### PR TITLE
Migrate ObjectMeta finalizers validation to declarative validation

### DIFF
--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -805,7 +805,7 @@ func TestValidateStatefulSet(t *testing.T) {
 	},
 	}
 
-	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail", "Origin"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
+	cmpOpts := []cmp.Option{cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail", "Origin", "CoveredByDeclarative"), cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() })}
 	for _, testCase := range append(successCases, errorCases...) {
 		name := testCase.name
 		var testTitle string
@@ -1327,7 +1327,7 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 	}
 
 	cmpOpts := []cmp.Option{
-		cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail", "Origin"),
+		cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail", "Origin", "CoveredByDeclarative"),
 		cmpopts.SortSlices(func(a, b *field.Error) bool { return a.Error() < b.Error() }),
 		cmpopts.EquateEmpty(),
 	}

--- a/pkg/apis/resource/validation/validation_common_test.go
+++ b/pkg/apis/resource/validation/validation_common_test.go
@@ -34,7 +34,7 @@ import (
 // is informative.
 func assertFailures(tb testing.TB, want, got field.ErrorList) bool {
 	tb.Helper()
-	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(field.Error{}, "Origin"), cmp.AllowUnexported(api.UniqueString{})); diff != "" {
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreFields(field.Error{}, "Origin", "CoveredByDeclarative"), cmp.AllowUnexported(api.UniqueString{})); diff != "" {
 		tb.Errorf("unexpected field errors (-want, +got):\n%s", diff)
 		return false
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -118,10 +118,10 @@ func ValidateOwnerReferences(ownerReferences []metav1.OwnerReference, fldPath *f
 func ValidateFinalizerName(stringValue string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for _, msg := range validation.IsQualifiedName(stringValue) {
-		allErrs = append(allErrs, field.Invalid(fldPath, stringValue, msg))
+		allErrs = append(allErrs, field.Invalid(fldPath, stringValue, msg).WithOrigin("format=k8s-label-key"))
 	}
 
-	return allErrs
+	return allErrs.MarkCoveredByDeclarative()
 }
 
 // ValidateNoNewFinalizers validates the new finalizers has no new finalizers compare to old finalizers.
@@ -162,6 +162,10 @@ func ValidateObjectMetaDeclaratively(ctx context.Context, op operation.Type, obj
 		{
 			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("labels").String()) + `\[.*\]`),
 			Replacement: fldPath.Child("labels").String(),
+		},
+		{
+			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("finalizers").String()) + `\[.*\]`),
+			Replacement: fldPath.Child("finalizers").String(),
 		},
 	}
 	errs = validate.FilterCoveredHandwrittenErrors(ctx, errs, enforcedDVErrs, betaEnabled, rules...)

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -19,6 +19,7 @@ package validation
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -157,7 +158,13 @@ func ValidateObjectMetaDeclaratively(ctx context.Context, op operation.Type, obj
 	dvErrs := v1validation.Validate_ObjectMeta(ctx, operation.Operation{Type: op}, fldPath, obj, oldObj)
 	enforcedDVErrs := validate.FilterEnforcedDeclarativeErrors(ctx, dvErrs, betaEnabled)
 	errs = errs.MarkFromImperative()
-	errs = validate.FilterCoveredHandwrittenErrors(ctx, errs, enforcedDVErrs, betaEnabled)
+	rules := []field.NormalizationRule{
+		{
+			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("labels").String()) + `\[.*\]`),
+			Replacement: fldPath.Child("labels").String(),
+		},
+	}
+	errs = validate.FilterCoveredHandwrittenErrors(ctx, errs, enforcedDVErrs, betaEnabled, rules...)
 	return append(errs, enforcedDVErrs...)
 }
 
@@ -288,7 +295,7 @@ func validateObjectMetaAccessorWithOptsCommon(meta metav1.Object, isNamespaced b
 	}
 
 	allErrs = append(allErrs, ValidateNonnegativeField(meta.GetGeneration(), fldPath.Child("generation")).MarkCoveredByDeclarative()...)
-	allErrs = append(allErrs, v1validation.ValidateLabels(meta.GetLabels(), fldPath.Child("labels"))...)
+	allErrs = append(allErrs, v1validation.ValidateLabels(meta.GetLabels(), fldPath.Child("labels")).MarkCoveredByDeclarative()...)
 	allErrs = append(allErrs, ValidateAnnotations(meta.GetAnnotations(), fldPath.Child("annotations"))...)
 	allErrs = append(allErrs, ValidateOwnerReferences(meta.GetOwnerReferences(), fldPath.Child("ownerReferences"))...)
 	allErrs = append(allErrs, ValidateFinalizers(meta.GetFinalizers(), fldPath.Child("finalizers"))...)
@@ -360,7 +367,7 @@ func ValidateObjectMetaAccessorUpdate(newMeta, oldMeta metav1.Object, fldPath *f
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetDeletionTimestamp(), oldMeta.GetDeletionTimestamp(), fldPath.Child("deletionTimestamp")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 	allErrs = append(allErrs, ValidateImmutableField(newMeta.GetDeletionGracePeriodSeconds(), oldMeta.GetDeletionGracePeriodSeconds(), fldPath.Child("deletionGracePeriodSeconds")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 
-	allErrs = append(allErrs, v1validation.ValidateLabels(newMeta.GetLabels(), fldPath.Child("labels"))...)
+	allErrs = append(allErrs, v1validation.ValidateLabels(newMeta.GetLabels(), fldPath.Child("labels")).MarkCoveredByDeclarative()...)
 	allErrs = append(allErrs, ValidateAnnotations(newMeta.GetAnnotations(), fldPath.Child("annotations"))...)
 	allErrs = append(allErrs, ValidateOwnerReferences(newMeta.GetOwnerReferences(), fldPath.Child("ownerReferences"))...)
 	allErrs = append(allErrs, v1validation.ValidateManagedFields(newMeta.GetManagedFields(), fldPath.Child("managedFields"), v1validation.CoveredByDeclarative)...)

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -734,9 +735,46 @@ func TestValidateObjectMetaDeclaratively(t *testing.T) {
 				field.TooLong(fldPath.Child("annotations"), "", TotalAnnotationSizeLimitB).MarkFromImperative(),
 			},
 		},
+		{
+			name:              "invalid label key",
+			obj:               mkMeta(tweakLabels(map[string]string{"a/b/c": "val"})),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		{
+			name:              "label key too long",
+			obj:               mkMeta(tweakLabels(map[string]string{strings.Repeat("a", 64): "val"})),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), strings.Repeat("a", 64), "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		{
+			name:              "invalid label value",
+			obj:               mkMeta(tweakLabels(map[string]string{"key": "a!"})),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "a!", "").WithOrigin("format=k8s-label-value").MarkAlpha(),
+			},
+		},
+		{
+			name:              "label value too long",
+			obj:               mkMeta(tweakLabels(map[string]string{"key": strings.Repeat("a", 64)})),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), strings.Repeat("a", 64), "").WithOrigin("format=k8s-label-value").MarkAlpha(),
+			},
+		},
 	}
 
-	matcher := field.ErrorMatcher{}.ByField().ByType().BySource().ByOrigin()
+	matcher := field.ErrorMatcher{}.ByFieldNormalized([]field.NormalizationRule{
+		{
+			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("labels").String()) + `\[.*\]`),
+			Replacement: fldPath.Child("labels").String(),
+		},
+	}).ByType().BySource().ByOrigin()
 
 	toExpectedErrs := func(allDeclarativeEnforced bool, betaEnabled bool, errs field.ErrorList) field.ErrorList {
 		expected := make(field.ErrorList, 0, len(errs))
@@ -896,6 +934,42 @@ func TestValidateObjectMetaDeclaratively(t *testing.T) {
 				field.Invalid(fldPath.Child("deletionGracePeriodSeconds"), &gracePeriod40, "").WithOrigin("immutable").MarkAlpha(),
 			},
 		},
+		{
+			name:              "invalid label key on update",
+			obj:               mkMeta(tweakResourceVersion("2"), tweakLabels(map[string]string{"a/b/c": "val"})),
+			oldObj:            mkMeta(tweakResourceVersion("1")),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "a/b/c", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		{
+			name:              "label key too long on update",
+			obj:               mkMeta(tweakResourceVersion("2"), tweakLabels(map[string]string{strings.Repeat("a", 64): "val"})),
+			oldObj:            mkMeta(tweakResourceVersion("1")),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), strings.Repeat("a", 64), "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
+		{
+			name:              "invalid label value on update",
+			obj:               mkMeta(tweakResourceVersion("2"), tweakLabels(map[string]string{"key": "a!"})),
+			oldObj:            mkMeta(tweakResourceVersion("1")),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), "a!", "").WithOrigin("format=k8s-label-value").MarkAlpha(),
+			},
+		},
+		{
+			name:              "label value too long on update",
+			obj:               mkMeta(tweakResourceVersion("2"), tweakLabels(map[string]string{"key": strings.Repeat("a", 64)})),
+			oldObj:            mkMeta(tweakResourceVersion("1")),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("labels"), strings.Repeat("a", 64), "").WithOrigin("format=k8s-label-value").MarkAlpha(),
+			},
+		},
 	}
 
 	for _, tc := range updateCases {
@@ -997,3 +1071,8 @@ func mkOwnerRef(tweaks ...func(*metav1.OwnerReference)) metav1.OwnerReference {
 	}
 	return *r
 }
+
+func tweakLabels(labels map[string]string) func(*metav1.ObjectMeta) {
+	return func(o *metav1.ObjectMeta) { o.Labels = labels }
+}
+

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
@@ -767,6 +767,14 @@ func TestValidateObjectMetaDeclaratively(t *testing.T) {
 				field.Invalid(fldPath.Child("labels"), strings.Repeat("a", 64), "").WithOrigin("format=k8s-label-value").MarkAlpha(),
 			},
 		},
+		{
+			name:              "invalid finalizer format",
+			obj:               mkMeta(tweakFinalizers([]string{"invalid/format/slash"})),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("finalizers"), "invalid/format/slash", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
 	}
 
 	matcher := field.ErrorMatcher{}.ByFieldNormalized([]field.NormalizationRule{
@@ -774,13 +782,20 @@ func TestValidateObjectMetaDeclaratively(t *testing.T) {
 			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("labels").String()) + `\[.*\]`),
 			Replacement: fldPath.Child("labels").String(),
 		},
+		{
+			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("finalizers").String()) + `\[.*\]`),
+			Replacement: fldPath.Child("finalizers").String(),
+		},
 	}).ByType().BySource().ByOrigin()
 
-	toExpectedErrs := func(allDeclarativeEnforced bool, betaEnabled bool, errs field.ErrorList) field.ErrorList {
+	toExpectedErrs := func(allDeclarativeEnforced bool, betaEnabled bool, errs field.ErrorList, isUpdate bool) field.ErrorList {
 		expected := make(field.ErrorList, 0, len(errs))
 		for _, err := range errs {
 			e := *err
 			if !allDeclarativeEnforced && (e.IsAlpha() || (!betaEnabled && e.IsBeta())) {
+				if isUpdate && strings.HasPrefix(e.Field, "metadata.finalizers") {
+					continue
+				}
 				_ = e.MarkFromImperative()
 				e.ValidationStabilityLevel = 0
 			}
@@ -798,7 +813,7 @@ func TestValidateObjectMetaDeclaratively(t *testing.T) {
 						testCtx = validate.WithAllDeclarativeEnforcedForTest(ctx)
 					}
 					errs := ValidateObjectMetaDeclaratively(testCtx, operation.Create, tc.obj, nil, tc.requiresNamespace, NameIsDNSSubdomain, fldPath, betaEnabled)
-					matcher.Test(t, toExpectedErrs(allDeclarativeEnforced, betaEnabled, tc.expectedErrs), errs)
+					matcher.Test(t, toExpectedErrs(allDeclarativeEnforced, betaEnabled, tc.expectedErrs, false), errs)
 				})
 			}
 		}
@@ -970,6 +985,15 @@ func TestValidateObjectMetaDeclaratively(t *testing.T) {
 				field.Invalid(fldPath.Child("labels"), strings.Repeat("a", 64), "").WithOrigin("format=k8s-label-value").MarkAlpha(),
 			},
 		},
+		{
+			name:              "invalid finalizer format on update",
+			obj:               mkMeta(tweakResourceVersion("2"), tweakFinalizers([]string{"invalid/format/slash"})),
+			oldObj:            mkMeta(tweakResourceVersion("1")),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(fldPath.Child("finalizers"), "invalid/format/slash", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+			},
+		},
 	}
 
 	for _, tc := range updateCases {
@@ -981,7 +1005,7 @@ func TestValidateObjectMetaDeclaratively(t *testing.T) {
 						testCtx = validate.WithAllDeclarativeEnforcedForTest(ctx)
 					}
 					errs := ValidateObjectMetaDeclaratively(testCtx, operation.Update, tc.obj, tc.oldObj, tc.requiresNamespace, NameIsDNSSubdomain, fldPath, betaEnabled)
-					matcher.Test(t, toExpectedErrs(allDeclarativeEnforced, betaEnabled, tc.expectedErrs), errs)
+					matcher.Test(t, toExpectedErrs(allDeclarativeEnforced, betaEnabled, tc.expectedErrs, true), errs)
 				})
 			}
 		}
@@ -1076,3 +1100,6 @@ func tweakLabels(labels map[string]string) func(*metav1.ObjectMeta) {
 	return func(o *metav1.ObjectMeta) { o.Labels = labels }
 }
 
+func tweakFinalizers(finalizers []string) func(*metav1.ObjectMeta) {
+	return func(o *metav1.ObjectMeta) { o.Finalizers = finalizers }
+}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -884,6 +884,9 @@ message ObjectMeta {
   // and services.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
   // +optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-label-key
+  // +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:format=k8s-label-value
   map<string, string> labels = 11;
 
   // Annotations is an unstructured key value map stored with a resource that may be
@@ -921,6 +924,8 @@ message ObjectMeta {
   // +optional
   // +patchStrategy=merge
   // +listType=set
+  // +k8s:alpha(since:"1.37")=+k8s:optional
+  // +k8s:alpha(since:"1.37")=+k8s:eachVal=+k8s:format=k8s-label-key
   repeated string finalizers = 14;
 
   // ManagedFields maps workflow-id and version to the set of fields

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -249,6 +249,9 @@ type ObjectMeta struct {
 	// and services.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
 	// +optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:eachKey=+k8s:format=k8s-label-key
+	// +k8s:alpha(since: "1.37")=+k8s:eachVal=+k8s:format=k8s-label-value
 	Labels map[string]string `json:"labels,omitempty" protobuf:"bytes,11,rep,name=labels"`
 
 	// Annotations is an unstructured key value map stored with a resource that may be

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -289,6 +289,8 @@ type ObjectMeta struct {
 	// +optional
 	// +patchStrategy=merge
 	// +listType=set
+	// +k8s:alpha(since:"1.37")=+k8s:optional
+	// +k8s:alpha(since:"1.37")=+k8s:eachVal=+k8s:format=k8s-label-key
 	Finalizers []string `json:"finalizers,omitempty" patchStrategy:"merge" protobuf:"bytes,14,rep,name=finalizers"`
 
 	// Tombstone: ClusterName was a legacy field that was always cleared by

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -475,7 +475,36 @@ func Validate_ObjectMeta(
 		errs = append(errs, fn(fldPath.Child("ownerReferences"), obj.OwnerReferences, oldVal, oldObj != nil)...)
 	}
 
-	// field v1.ObjectMeta.Finalizers has no validation
+	{ // field v1.ObjectMeta.Finalizers
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj []string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.EachValSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, validate.LabelKey).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.ObjectMeta) []string {
+				return oldObj.Finalizers
+			})
+		errs = append(errs, fn(fldPath.Child("finalizers"), obj.Finalizers, oldVal, oldObj != nil)...)
+	}
 
 	{ // field v1.ObjectMeta.ManagedFields
 		fn := func(

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -407,7 +407,40 @@ func Validate_ObjectMeta(
 		errs = append(errs, fn(fldPath.Child("deletionGracePeriodSeconds"), obj.DeletionGracePeriodSeconds, oldVal, oldObj != nil)...)
 	}
 
-	// field v1.ObjectMeta.Labels has no validation
+	{ // field v1.ObjectMeta.Labels
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj map[string]string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalMap(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.EachMapKey(ctx, op, fldPath, obj, oldObj, validate.LabelKey).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if e := validate.EachMapVal(ctx, op, fldPath, obj, oldObj, validate.DirectEqual, validate.LabelValue).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.ObjectMeta) map[string]string {
+				return oldObj.Labels
+			})
+		errs = append(errs, fn(fldPath.Child("labels"), obj.Labels, oldVal, oldObj != nil)...)
+	}
+
 	// field v1.ObjectMeta.Annotations has no validation
 
 	{ // field v1.ObjectMeta.OwnerReferences

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -386,6 +387,10 @@ func WithAllDeclarativeEnforcedForTest(ctx context.Context) context.Context {
 // For testing purposes, WithAllDeclarativeEnforcedForTest enforces all declarative validations regardless
 // of lifecycle and filters all covered handwritten validations.
 func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runtime.Scheme, obj, oldObj runtime.Object, errs field.ErrorList, opType operation.Type, config DeclarativeValidationConfig) field.ErrorList {
+	config.NormalizationRules = append(config.NormalizationRules, field.NormalizationRule{
+		Regexp:      regexp.MustCompile(`metadata\.labels\[.*\]`),
+		Replacement: "metadata.labels",
+	})
 	// These errors must be errors returned by the handwritten validation.
 	errs = errs.MarkFromImperative()
 	validationIdentifier, err := metricIdentifier(ctx, scheme, obj, opType)

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/validate.go
@@ -390,6 +390,9 @@ func ValidateDeclarativelyWithMigrationChecks(ctx context.Context, scheme *runti
 	config.NormalizationRules = append(config.NormalizationRules, field.NormalizationRule{
 		Regexp:      regexp.MustCompile(`metadata\.labels\[.*\]`),
 		Replacement: "metadata.labels",
+	}, field.NormalizationRule{
+		Regexp:      regexp.MustCompile(`metadata\.finalizers\[.*\]`),
+		Replacement: "metadata.finalizers",
 	})
 	// These errors must be errors returned by the handwritten validation.
 	errs = errs.MarkFromImperative()

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/daemonset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/daemonset/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/daemonset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/daemonset/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/daemonset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/daemonset/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/daemonset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/daemonset/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/replicaset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/replicaset/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/replicaset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/replicaset/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/replicaset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/replicaset/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/replicaset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/replicaset/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v2_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v2_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1_test.go
@@ -39,8 +39,17 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
 			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/coordination/lease/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/coordination/lease/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/coordination/lease/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/coordination/lease/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/coordination/lease/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/coordination/lease/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/coordination/lease/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/coordination/lease/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/configmap/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/configmap/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/configmap/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/configmap/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/endpoints/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/endpoints/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/endpoints/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/endpoints/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/event/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/event/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/event/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/event/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/limitrange/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/limitrange/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/limitrange/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/limitrange/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/namespace/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/namespace/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/namespace/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/namespace/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/node/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/node/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/node/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/node/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/persistentvolume/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/persistentvolume/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/persistentvolume/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/persistentvolume/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/persistentvolumeclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/persistentvolumeclaim/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/persistentvolumeclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/persistentvolumeclaim/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/pod/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/pod/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/pod/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/pod/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/podtemplate/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/podtemplate/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/podtemplate/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/podtemplate/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/replicationcontroller/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/replicationcontroller/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/replicationcontroller/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/replicationcontroller/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/resourcequota/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/resourcequota/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/resourcequota/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/resourcequota/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/secret/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/secret/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/secret/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/secret/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/service/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/service/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/service/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/service/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/core/serviceaccount/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/serviceaccount/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/serviceaccount/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/serviceaccount/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1_test.go
@@ -48,6 +48,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1_test.go
@@ -51,6 +51,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1beta1_test.go
@@ -48,6 +48,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1beta1_test.go
@@ -51,6 +51,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/events/event/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/events/event/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/events/event/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/events/event/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta3_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta3_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta3_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta3_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta3_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta3_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta3_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta3_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/internal/storageversion/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/internal/storageversion/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/internal/storageversion/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/internal/storageversion/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/meta/objectmeta.go
+++ b/test/declarative_validation/meta/objectmeta.go
@@ -18,6 +18,7 @@ package meta
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -59,6 +60,12 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 		opt(o)
 	}
 	fldPath := field.NewPath("metadata")
+	o.validationConfigs = append(o.validationConfigs, apitesting.WithNormalizationRules(
+		field.NormalizationRule{
+			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("labels").String()) + `\[.*\]`),
+			Replacement: fldPath.Child("labels").String(),
+		},
+	))
 	trueVar := true
 
 	// TODO: Remove MarkFromImperative from expected errors after adding corresponding declarative validation tags on ObjectMeta.
@@ -331,7 +338,7 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkFromImperative(),
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 			},
 		},
 		{
@@ -342,7 +349,7 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkFromImperative(),
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 			},
 		},
 		{
@@ -353,7 +360,7 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkFromImperative(),
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkAlpha(),
 			},
 		},
 		{
@@ -364,7 +371,7 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkFromImperative(),
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkAlpha(),
 			},
 		},
 		{
@@ -448,6 +455,12 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 		opt(o)
 	}
 	fldPath := field.NewPath("metadata")
+	o.validationConfigs = append(o.validationConfigs, apitesting.WithNormalizationRules(
+		field.NormalizationRule{
+			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("labels").String()) + `\[.*\]`),
+			Replacement: fldPath.Child("labels").String(),
+		},
+	))
 	t1 := metav1.NewTime(time.Unix(1000, 0).UTC())
 	t2 := metav1.NewTime(time.Unix(2000, 0).UTC())
 
@@ -622,7 +635,7 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkFromImperative(),
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 			},
 		},
 		{
@@ -633,7 +646,7 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkFromImperative(),
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 			},
 		},
 		{
@@ -644,7 +657,7 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkFromImperative(),
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkAlpha(),
 			},
 		},
 		{
@@ -655,7 +668,7 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkFromImperative(),
+				field.Invalid(fldPath.Child("labels"), "", "").WithOrigin("format=k8s-label-value").MarkAlpha(),
 			},
 		},
 	}

--- a/test/declarative_validation/meta/objectmeta.go
+++ b/test/declarative_validation/meta/objectmeta.go
@@ -65,6 +65,10 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("labels").String()) + `\[.*\]`),
 			Replacement: fldPath.Child("labels").String(),
 		},
+		field.NormalizationRule{
+			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("finalizers").String()) + `\[.*\]`),
+			Replacement: fldPath.Child("finalizers").String(),
+		},
 	))
 	trueVar := true
 
@@ -239,7 +243,7 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 				meta.SetFinalizers([]string{"invalid/format/slash"})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+				field.Invalid(fldPath.Child("finalizers"), "", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 			},
 		},
 		{
@@ -249,7 +253,7 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 			},
 			ExpectedErrs: func() field.ErrorList {
 				errs := field.ErrorList{
-					field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+					field.Invalid(fldPath.Child("finalizers"), "", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 				}
 				if o.stringentFinalizerValidation {
 					errs = append(errs, field.Invalid(fldPath.Child("finalizers").Index(0), strings.Repeat("a", 317), "name is neither a standard finalizer name nor is it fully qualified").MarkFromImperative())
@@ -460,6 +464,10 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("labels").String()) + `\[.*\]`),
 			Replacement: fldPath.Child("labels").String(),
 		},
+		field.NormalizationRule{
+			Regexp:      regexp.MustCompile(regexp.QuoteMeta(fldPath.Child("finalizers").String()) + `\[.*\]`),
+			Replacement: fldPath.Child("finalizers").String(),
+		},
 	))
 	t1 := metav1.NewTime(time.Unix(1000, 0).UTC())
 	t2 := metav1.NewTime(time.Unix(2000, 0).UTC())
@@ -608,7 +616,7 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 			},
 			ExpectedErrs: func() field.ErrorList {
 				errs := field.ErrorList{
-					field.Invalid(fldPath.Child("finalizers"), "", "").MarkFromImperative(),
+					field.Invalid(fldPath.Child("finalizers"), "", "").WithOrigin("format=k8s-label-key").MarkAlpha(),
 				}
 				if o.stringentFinalizerValidation {
 					errs = append(errs, field.Invalid(fldPath.Child("finalizers").Index(0), strings.Repeat("a", 317), "name is neither a standard finalizer name nor is it fully qualified").MarkFromImperative())

--- a/test/declarative_validation/networking/ingress/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ingress/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/ingress/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ingress/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/networking/ingress/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ingress/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/ingress/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ingress/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/networking/networkpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/networkpolicy/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/networkpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/networkpolicy/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1_test.go
@@ -44,6 +44,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1_test.go
@@ -47,6 +47,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1beta1_test.go
@@ -44,6 +44,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1beta1_test.go
@@ -47,6 +47,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta2_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta2_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
@@ -39,8 +39,17 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
 			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/scheduling/workload/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/workload/zz_generated.validations.v1alpha3_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/scheduling/workload/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/workload/zz_generated.validations.v1alpha3_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/csidriver/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csidriver/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csidriver/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csidriver/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/csidriver/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csidriver/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csidriver/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csidriver/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/csinode/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csinode/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csinode/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csinode/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/csinode/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csinode/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csinode/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csinode/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/storageclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/storageclass/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/storageclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/storageclass/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/storageclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/storageclass/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/storageclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/storageclass/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1alpha1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1alpha1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
@@ -42,6 +42,12 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.labels": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"metadata.labels[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-value"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
@@ -39,6 +39,9 @@ func init() {
 			"metadata.deletionTimestamp": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"metadata.finalizers[*]": {
+				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

This PR migrates `metav1.ObjectMeta.finalizers` format validation to Declarative Validation.

#### Which issue(s) this PR is related to:

Part of  #141634

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
