### PR TITLE
feat(oidc): add optional key cache refresh on unknown kid

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/types.go
@@ -239,6 +239,17 @@ type Issuer struct {
 	Audiences            []string
 	AudienceMatchPolicy  AudienceMatchPolicyType
 	EgressSelectorType   EgressSelectorType
+	// jwksRefreshOnUnknownKeyID, if true, causes the JSON Web Key Set (JWKS) to be
+	// refetched from the issuer whenever a presented JWT is signed with a key ID (kid)
+	// that is not present in the currently cached JWKS, before failing authentication.
+	// This handles the case where the identity provider has rotated its signing keys
+	// but the locally cached JWKS has not yet expired.
+	//
+	// If unset or false, the JWKS is only refetched once the entire cached key set is
+	// close to expiring: a token signed with a newly rotated key may be rejected until
+	// the local cache naturally expires.
+	// +optional
+	JWKSRefreshOnUnknownKeyID bool
 }
 
 // AudienceMatchPolicyType is a set of valid values for Issuer.AudienceMatchPolicy

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/types.go
@@ -198,6 +198,18 @@ type Issuer struct {
 	//
 	// +optional
 	EgressSelectorType EgressSelectorType `json:"egressSelectorType,omitempty"`
+
+	// jwksRefreshOnUnknownKeyID, if true, causes the JSON Web Key Set (JWKS) to be
+	// refetched from the issuer whenever a presented JWT is signed with a key ID (kid)
+	// that is not present in the currently cached JWKS, before failing authentication.
+	// This handles the case where the identity provider has rotated its signing keys
+	// but the locally cached JWKS has not yet expired.
+	//
+	// If unset or false, the JWKS is only refetched once the entire cached key set is
+	// close to expiring: a token signed with a newly rotated key may be rejected until
+	// the local cache naturally expires.
+	// +optional
+	JWKSRefreshOnUnknownKeyID bool `json:"jwksRefreshOnUnknownKeyID,omitempty"`
 }
 
 // AudienceMatchPolicyType is a set of valid values for issuer.audienceMatchPolicy

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1/zz_generated.conversion.go
@@ -661,6 +661,7 @@ func autoConvert_v1_Issuer_To_apiserver_Issuer(in *Issuer, out *apiserver.Issuer
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = apiserver.AudienceMatchPolicyType(in.AudienceMatchPolicy)
 	out.EgressSelectorType = apiserver.EgressSelectorType(in.EgressSelectorType)
+	out.JWKSRefreshOnUnknownKeyID = in.JWKSRefreshOnUnknownKeyID
 	return nil
 }
 
@@ -678,6 +679,7 @@ func autoConvert_apiserver_Issuer_To_v1_Issuer(in *apiserver.Issuer, out *Issuer
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = AudienceMatchPolicyType(in.AudienceMatchPolicy)
 	out.EgressSelectorType = EgressSelectorType(in.EgressSelectorType)
+	out.JWKSRefreshOnUnknownKeyID = in.JWKSRefreshOnUnknownKeyID
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/types.go
@@ -311,6 +311,18 @@ type Issuer struct {
 	//
 	// +optional
 	EgressSelectorType EgressSelectorType `json:"egressSelectorType,omitempty"`
+
+	// jwksRefreshOnUnknownKeyID, if true, causes the JSON Web Key Set (JWKS) to be
+	// refetched from the issuer whenever a presented JWT is signed with a key ID (kid)
+	// that is not present in the currently cached JWKS, before failing authentication.
+	// This handles the case where the identity provider has rotated its signing keys
+	// but the locally cached JWKS has not yet expired.
+	//
+	// If unset or false, the JWKS is only refetched once the entire cached key set is
+	// close to expiring: a token signed with a newly rotated key may be rejected until
+	// the local cache naturally expires.
+	// +optional
+	JWKSRefreshOnUnknownKeyID bool `json:"jwksRefreshOnUnknownKeyID,omitempty"`
 }
 
 // AudienceMatchPolicyType is a set of valid values for issuer.audienceMatchPolicy

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
@@ -672,6 +672,7 @@ func autoConvert_v1alpha1_Issuer_To_apiserver_Issuer(in *Issuer, out *apiserver.
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = apiserver.AudienceMatchPolicyType(in.AudienceMatchPolicy)
 	out.EgressSelectorType = apiserver.EgressSelectorType(in.EgressSelectorType)
+	out.JWKSRefreshOnUnknownKeyID = in.JWKSRefreshOnUnknownKeyID
 	return nil
 }
 
@@ -689,6 +690,7 @@ func autoConvert_apiserver_Issuer_To_v1alpha1_Issuer(in *apiserver.Issuer, out *
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = AudienceMatchPolicyType(in.AudienceMatchPolicy)
 	out.EgressSelectorType = EgressSelectorType(in.EgressSelectorType)
+	out.JWKSRefreshOnUnknownKeyID = in.JWKSRefreshOnUnknownKeyID
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/types.go
@@ -282,6 +282,18 @@ type Issuer struct {
 	//
 	// +optional
 	EgressSelectorType EgressSelectorType `json:"egressSelectorType,omitempty"`
+
+	// jwksRefreshOnUnknownKeyID, if true, causes the JSON Web Key Set (JWKS) to be
+	// refetched from the issuer whenever a presented JWT is signed with a key ID (kid)
+	// that is not present in the currently cached JWKS, before failing authentication.
+	// This handles the case where the identity provider has rotated its signing keys
+	// but the locally cached JWKS has not yet expired.
+	//
+	// If unset or false, the JWKS is only refetched once the entire cached key set is
+	// close to expiring: a token signed with a newly rotated key may be rejected until
+	// the local cache naturally expires.
+	// +optional
+	JWKSRefreshOnUnknownKeyID bool `json:"jwksRefreshOnUnknownKeyID,omitempty"`
 }
 
 // AudienceMatchPolicyType is a set of valid values for issuer.audienceMatchPolicy

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1beta1/zz_generated.conversion.go
@@ -612,6 +612,7 @@ func autoConvert_v1beta1_Issuer_To_apiserver_Issuer(in *Issuer, out *apiserver.I
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = apiserver.AudienceMatchPolicyType(in.AudienceMatchPolicy)
 	out.EgressSelectorType = apiserver.EgressSelectorType(in.EgressSelectorType)
+	out.JWKSRefreshOnUnknownKeyID = in.JWKSRefreshOnUnknownKeyID
 	return nil
 }
 
@@ -629,6 +630,7 @@ func autoConvert_apiserver_Issuer_To_v1beta1_Issuer(in *apiserver.Issuer, out *I
 	out.Audiences = *(*[]string)(unsafe.Pointer(&in.Audiences))
 	out.AudienceMatchPolicy = AudienceMatchPolicyType(in.AudienceMatchPolicy)
 	out.EgressSelectorType = EgressSelectorType(in.EgressSelectorType)
+	out.JWKSRefreshOnUnknownKeyID = in.JWKSRefreshOnUnknownKeyID
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/validation/validation_test.go
@@ -2562,3 +2562,42 @@ func TestValidateAndCompileMatchConditions(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateIssuerJWKSRefreshOnUnknownKeyID confirms that
+// Issuer.JWKSRefreshOnUnknownKeyID is a plain opt-in boolean that never fails
+// validation, regardless of its value.
+func TestValidateIssuerJWKSRefreshOnUnknownKeyID(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		jwksRefreshOnUnknownKeyID bool
+	}{
+		{name: "false (default when unset)", jwksRefreshOnUnknownKeyID: false},
+		{name: "true", jwksRefreshOnUnknownKeyID: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := &api.AuthenticationConfiguration{
+				JWT: []api.JWTAuthenticator{
+					{
+						Issuer: api.Issuer{
+							URL:                       "https://issuer-url",
+							Audiences:                 []string{"audience"},
+							JWKSRefreshOnUnknownKeyID: tc.jwksRefreshOnUnknownKeyID,
+						},
+						ClaimMappings: api.ClaimMappings{
+							Username: api.PrefixedClaimOrExpression{
+								Claim:  "sub",
+								Prefix: ptr.To("prefix"),
+							},
+						},
+					},
+				},
+			}
+
+			if errs := ValidateAuthenticationConfiguration(authenticationcel.NewDefaultCompiler(), in, nil); len(errs) != 0 {
+				t.Fatalf("expected no validation errors for jwksRefreshOnUnknownKeyID=%v, got: %v", tc.jwksRefreshOnUnknownKeyID, errs.ToAggregate())
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -280,6 +280,9 @@ const jwksMinRefreshInterval = time.Second
 // the underlying key set (which forces a fresh fetch from jwksURL) and retries
 // once, rate limited by jwksMinRefreshInterval to bound the cost of repeated
 // bad tokens against the identity provider's JWKS endpoint.
+//
+// It is only used when the issuer opts in via Issuer.JWKSRefreshOnUnknownKeyID;
+// otherwise a bare oidc.RemoteKeySet is used, preserving the default behavior.
 type verifyingKeySet struct {
 	ctx     context.Context
 	client  *http.Client
@@ -539,12 +542,20 @@ func New(lifecycleCtx context.Context, opts Options) (AuthenticatorTokenWithHeal
 					jwksClient = &clientWithJWKSMetrics
 				}
 
-				// Use verifyingKeySet instead of the provider's own key set (or a
-				// bare oidc.NewRemoteKeySet) so that a token signed with a key ID
-				// the local JWKS cache doesn't yet recognize (e.g. right after the
-				// provider rotates its signing keys) triggers a fresh JWKS fetch
-				// before authentication fails, instead of failing immediately.
-				keySet := newVerifyingKeySet(lifecycleCtx, jwksClient, providerJSON.JWKSURL)
+				// Only use verifyingKeySet instead of a bare oidc.NewRemoteKeySet
+				// when opted in via Issuer.JWKSRefreshOnUnknownKeyID, so that a
+				// token signed with a key ID the local JWKS cache doesn't yet
+				// recognize (e.g. right after the provider rotates its signing
+				// keys) triggers a fresh JWKS fetch before authentication fails,
+				// instead of failing immediately. Unset/false preserves the
+				// default behavior: refresh only when the whole cache is near
+				// expiry.
+				var keySet oidc.KeySet
+				if opts.JWTAuthenticator.Issuer.JWKSRefreshOnUnknownKeyID {
+					keySet = newVerifyingKeySet(lifecycleCtx, jwksClient, providerJSON.JWKSURL)
+				} else {
+					keySet = oidc.NewRemoteKeySet(oidc.ClientContext(lifecycleCtx, jwksClient), providerJSON.JWKSURL)
+				}
 				authn.setVerifier(&idTokenVerifier{oidc.NewVerifier(issuerURL, keySet, verifierConfig), audiences})
 				return true, nil
 			})

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc.go
@@ -261,6 +261,88 @@ type AuthenticatorTokenWithHealthCheck interface {
 	HealthCheck() error
 }
 
+// jwksMinRefreshInterval bounds how often verifyingKeySet will force a fresh
+// JSON Web Key Set (JWKS) fetch in response to a verification failure, so that
+// a client presenting tokens with an unrecognized key ID cannot force
+// unbounded fetches against the identity provider's JWKS endpoint.
+const jwksMinRefreshInterval = time.Second
+
+// verifyingKeySet wraps an oidc.KeySet built from a JWKS URL. The vendored
+// go-oidc client's RemoteKeySet only refetches keys from the issuer once its
+// entire local cache is close to expiring; it does not refetch just because a
+// specific token's key ID is missing from an otherwise still-fresh cache, e.g.
+// right after the identity provider rotates its signing keys. That means a
+// legitimate token signed with a newly rotated key can be rejected with an
+// authentication error until the local JWKS cache happens to expire on its
+// own.
+//
+// verifyingKeySet works around this: whenever verification fails, it rebuilds
+// the underlying key set (which forces a fresh fetch from jwksURL) and retries
+// once, rate limited by jwksMinRefreshInterval to bound the cost of repeated
+// bad tokens against the identity provider's JWKS endpoint.
+type verifyingKeySet struct {
+	ctx     context.Context
+	client  *http.Client
+	jwksURL string
+
+	mu          sync.Mutex
+	current     oidc.KeySet
+	lastRefresh time.Time
+}
+
+func newVerifyingKeySet(ctx context.Context, client *http.Client, jwksURL string) *verifyingKeySet {
+	return &verifyingKeySet{
+		ctx:         ctx,
+		client:      client,
+		jwksURL:     jwksURL,
+		current:     oidc.NewRemoteKeySet(oidc.ClientContext(ctx, client), jwksURL),
+		lastRefresh: time.Now(),
+	}
+}
+
+func (k *verifyingKeySet) VerifySignature(ctx context.Context, jwt string) ([]byte, error) {
+	keySet := k.snapshot()
+
+	payload, err := keySet.VerifySignature(ctx, jwt)
+	if err == nil {
+		return payload, nil
+	}
+
+	refreshed := k.refresh(keySet)
+	if refreshed == nil {
+		return nil, err
+	}
+	return refreshed.VerifySignature(ctx, jwt)
+}
+
+func (k *verifyingKeySet) snapshot() oidc.KeySet {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.current
+}
+
+// refresh rebuilds the underlying key set if stale is still the active one and
+// at least jwksMinRefreshInterval has passed since the last rebuild. It
+// returns nil if the refresh was skipped because it was rate limited, or the
+// newly-active key set otherwise (either freshly built here, or built
+// concurrently by another caller while the lock was released).
+func (k *verifyingKeySet) refresh(stale oidc.KeySet) oidc.KeySet {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	if k.current != stale {
+		// Someone else already refreshed while we were verifying.
+		return k.current
+	}
+	if time.Since(k.lastRefresh) < jwksMinRefreshInterval {
+		return nil
+	}
+
+	k.current = oidc.NewRemoteKeySet(oidc.ClientContext(k.ctx, k.client), k.jwksURL)
+	k.lastRefresh = time.Now()
+	return k.current
+}
+
 // New returns an authenticator that is asynchronously initialized when opts.KeySet is not set.
 // The input lifecycleCtx is used to:
 // - terminate background goroutines that are needed for asynchronous initialization
@@ -435,33 +517,35 @@ func New(lifecycleCtx context.Context, opts Options) (AuthenticatorTokenWithHeal
 					return false, nil
 				}
 
-				if utilfeature.DefaultFeatureGate.Enabled(features.StructuredAuthenticationConfigurationJWKSMetrics) {
-					providerJSON := &struct {
-						JWKSURL string `json:"jwks_uri"`
-					}{}
+				providerJSON := &struct {
+					JWKSURL string `json:"jwks_uri"`
+				}{}
 
-					if err := provider.Claims(providerJSON); err != nil {
-						klog.Errorf("oidc authenticator: error getting JWKS URL: %v", err)
-						authn.healthCheck.Store(&errorHolder{err: err})
-						return false, nil
-					}
-					if len(providerJSON.JWKSURL) == 0 {
-						klog.Errorf("provider did not return JWKS URL")
-						authn.healthCheck.Store(&errorHolder{err: fmt.Errorf("provider did not return JWKS URL")})
-						return false, nil
-					}
-
-					clientWithJWKSMetrics := *client
-					clientWithJWKSMetrics.Transport = withMetricsRoundTripper(client.Transport, providerJSON.JWKSURL, issuerURL, opts.APIServerID, lifecycleCtx)
-					client = &clientWithJWKSMetrics
-
-					remoteKeySet := oidc.NewRemoteKeySet(oidc.ClientContext(lifecycleCtx, client), providerJSON.JWKSURL)
-					authn.setVerifier(&idTokenVerifier{oidc.NewVerifier(issuerURL, remoteKeySet, verifierConfig), audiences})
-					return true, nil
+				if err := provider.Claims(providerJSON); err != nil {
+					klog.Errorf("oidc authenticator: error getting JWKS URL: %v", err)
+					authn.healthCheck.Store(&errorHolder{err: err})
+					return false, nil
+				}
+				if len(providerJSON.JWKSURL) == 0 {
+					klog.Errorf("provider did not return JWKS URL")
+					authn.healthCheck.Store(&errorHolder{err: fmt.Errorf("provider did not return JWKS URL")})
+					return false, nil
 				}
 
-				verifier := provider.Verifier(verifierConfig)
-				authn.setVerifier(&idTokenVerifier{verifier, audiences})
+				jwksClient := client
+				if utilfeature.DefaultFeatureGate.Enabled(features.StructuredAuthenticationConfigurationJWKSMetrics) {
+					clientWithJWKSMetrics := *client
+					clientWithJWKSMetrics.Transport = withMetricsRoundTripper(client.Transport, providerJSON.JWKSURL, issuerURL, opts.APIServerID, lifecycleCtx)
+					jwksClient = &clientWithJWKSMetrics
+				}
+
+				// Use verifyingKeySet instead of the provider's own key set (or a
+				// bare oidc.NewRemoteKeySet) so that a token signed with a key ID
+				// the local JWKS cache doesn't yet recognize (e.g. right after the
+				// provider rotates its signing keys) triggers a fresh JWKS fetch
+				// before authentication fails, instead of failing immediately.
+				keySet := newVerifyingKeySet(lifecycleCtx, jwksClient, providerJSON.JWKSURL)
+				authn.setVerifier(&idTokenVerifier{oidc.NewVerifier(issuerURL, keySet, verifierConfig), audiences})
 				return true, nil
 			})
 		}()

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
@@ -5067,3 +5067,189 @@ func testContext(t *testing.T) context.Context {
 	t.Cleanup(cancel)
 	return ctx
 }
+
+type refreshTestServer struct {
+	*httptest.Server
+
+	mu   sync.RWMutex
+	keys jose.JSONWebKeySet
+}
+
+func (s *refreshTestServer) setKeys(keys jose.JSONWebKeySet) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.keys = keys
+}
+
+func (s *refreshTestServer) getKeys() jose.JSONWebKeySet {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.keys
+}
+
+func newRefreshTestServer(t *testing.T, initialKeys jose.JSONWebKeySet) *refreshTestServer {
+	s := &refreshTestServer{keys: initialKeys}
+	s.Server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"issuer": %q, "jwks_uri": %q}`, s.Server.URL, s.Server.URL+"/keys")
+		case "/keys":
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Cache-Control", "max-age=3600")
+			keyBytes, err := json.Marshal(s.getKeys())
+			if err != nil {
+				t.Fatalf("marshal keys: %v", err)
+			}
+			w.Write(keyBytes)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	return s
+}
+
+// TestJWKSRefreshOnUnknownKeyID verifies that a token signed with a key the
+// issuer has rotated to, but which the authenticator's local JWKS cache
+// hasn't observed yet (the cache is still within its Cache-Control lifetime),
+// is only accepted after a forced refresh when Issuer.JWKSRefreshOnUnknownKeyID
+// is set. Left unset, the pre-existing behavior is preserved: the token is
+// rejected until the cache naturally expires.
+func TestJWKSRefreshOnUnknownKeyID(t *testing.T) {
+	testCases := []struct {
+		name                      string
+		jwksRefreshOnUnknownKeyID bool
+		wantErr                   bool
+	}{
+		{
+			name:    "disabled by default: token signed with a not-yet-cached key is rejected",
+			wantErr: true,
+		},
+		{
+			name:                      "enabled: token signed with a not-yet-cached key succeeds after refresh",
+			jwksRefreshOnUnknownKeyID: true,
+			wantErr:                   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			signingKey := loadRSAPrivKey(t, "testdata/rsa_1.pem", jose.RS256)
+			pubKeys := []*jose.JSONWebKey{loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256)}
+			signer, err := jose.NewSigner(jose.SigningKey{
+				Algorithm: jose.SignatureAlgorithm(signingKey.Algorithm),
+				Key:       signingKey,
+			}, nil)
+			if err != nil {
+				t.Fatalf("initialize signer: %v", err)
+			}
+
+			ts := newRefreshTestServer(t, toKeySet(pubKeys))
+			defer ts.Close()
+
+			opts := Options{
+				JWTAuthenticator: apiserver.JWTAuthenticator{
+					Issuer: apiserver.Issuer{
+						URL:                       ts.URL,
+						Audiences:                 []string{"my-client"},
+						JWKSRefreshOnUnknownKeyID: tc.jwksRefreshOnUnknownKeyID,
+					},
+					ClaimMappings: apiserver.ClaimMappings{
+						Username: apiserver.PrefixedClaimOrExpression{
+							Claim:  "username",
+							Prefix: ptr.To(""),
+						},
+					},
+				},
+				now: func() time.Time { return now },
+			}
+
+			caBundle := pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: ts.Certificate().Raw,
+			})
+			caContent, err := dynamiccertificates.NewStaticCAContent("oidc-authenticator", caBundle)
+			if err != nil {
+				t.Fatalf("initialize ca: %v", err)
+			}
+			opts.CAContentProvider = caContent
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			a, err := New(ctx, opts)
+			if err != nil {
+				t.Fatalf("initialize authenticator: %v", err)
+			}
+
+			ia, ok := a.(*instrumentedAuthenticator)
+			if !ok {
+				t.Fatalf("expected authenticator to be instrumented")
+			}
+			authn, ok := ia.delegate.(*jwtAuthenticator)
+			if !ok {
+				t.Fatalf("expected delegate to be jwtAuthenticator")
+			}
+			if err := wait.PollUntilContextCancel(ctx, time.Millisecond, true, func(context.Context) (bool, error) {
+				v, _ := authn.idTokenVerifier()
+				return v != nil, nil
+			}); err != nil {
+				t.Fatalf("failed to initialize the authenticator: %v", err)
+			}
+
+			claims := fmt.Sprintf(`{"iss": %q, "aud": "my-client", "username": "jane", "exp": %d}`, ts.URL, valid.Unix())
+
+			jws, err := signer.Sign([]byte(claims))
+			if err != nil {
+				t.Fatalf("sign claims: %v", err)
+			}
+			token, err := jws.CompactSerialize()
+			if err != nil {
+				t.Fatalf("serialize token: %v", err)
+			}
+			// Prime the cache with the original key.
+			if _, _, err := a.AuthenticateToken(ctx, token); err != nil {
+				t.Fatalf("authenticate token with initial key: %v", err)
+			}
+
+			// Rotate the provider's signing key. The JWKS response's
+			// Cache-Control header keeps the cache "fresh" for an hour, so
+			// this simulates a key rotation the authenticator hasn't
+			// observed yet.
+			signingKey = loadRSAPrivKey(t, "testdata/rsa_2.pem", jose.RS256)
+			pubKeys = []*jose.JSONWebKey{
+				loadRSAKey(t, "testdata/rsa_1.pem", jose.RS256),
+				loadRSAKey(t, "testdata/rsa_2.pem", jose.RS256),
+			}
+			signer, err = jose.NewSigner(jose.SigningKey{
+				Algorithm: jose.SignatureAlgorithm(signingKey.Algorithm),
+				Key:       signingKey,
+			}, nil)
+			if err != nil {
+				t.Fatalf("initialize signer: %v", err)
+			}
+			ts.setKeys(toKeySet(pubKeys))
+
+			jws, err = signer.Sign([]byte(claims))
+			if err != nil {
+				t.Fatalf("sign claims: %v", err)
+			}
+			token, err = jws.CompactSerialize()
+			if err != nil {
+				t.Fatalf("serialize token: %v", err)
+			}
+
+			// verifyingKeySet rate limits forced refreshes; wait it out so the
+			// "enabled" case's refresh attempt isn't skipped.
+			time.Sleep(jwksMinRefreshInterval + 100*time.Millisecond)
+
+			_, _, err = a.AuthenticateToken(ctx, token)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected authentication to fail for a token signed with a not-yet-cached key, but it succeeded")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected authentication to succeed after JWKS refresh, got error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
#### What this PR does / why we need it:
Enable oidc keys cache refresh on auth attempt with unknown key id
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #139769 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
JWT issuers in AuthenticationConfiguration can now enable automatic JWKs cache refresh on kubeapi access attempt from a caller with unknown key id
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
