### PR TITLE
kubelet: clean residual CSI vol_data.json during orphaned pod volume cleanup

### DIFF
--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -154,19 +154,9 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(logger klog.Logger, uid types.UID
 		}
 	}
 
-	// Remove residual CSI metadata (e.g. vol_data.json) for unmounted CSI volumes.
-	// After hard reboots, mounts are gone but CSI metadata files often remain and
-	// block rmdir-only cleanup of the volumes tree ("not a directory" errors).
-	// See https://github.com/kubernetes/kubernetes/issues/105536.
-	//
-	// Safety (must stay aligned with #102576):
-	//   - This runs only after cleanupOrphanedPodDirs has verified podVolumesExist
-	//     is false (volume manager has no possibly-mounted volumes; disk mount
-	//     check did not find mounts). Do not call cleanOrphanedCSIVolumeDirs from
-	//     other paths without that gate.
-	//   - Only well-known CSI metadata is removed, and only when IsMountPoint says
-	//     the CSI mount path is not mounted (bind mounts included on Linux).
-	//   - Arbitrary files under the volume dir are never deleted.
+	// Remove residual CSI metadata (vol_data.json) for unmounted CSI volumes so
+	// rmdir-only volumes cleanup is not blocked after reboot (#105536).
+	// Only safe after podVolumesExist is false (see cleanupOrphanedPodDirs).
 	orphanVolumeErrors = append(orphanVolumeErrors, kl.cleanOrphanedCSIVolumeDirs(logger, uid)...)
 
 	// Remove any remaining subdirectories along with the volumes directory itself.
@@ -181,10 +171,9 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(logger klog.Logger, uid types.UID
 	return orphanVolumeErrors
 }
 
-// cleanOrphanedCSIVolumeDirs removes residual CSI volume metadata for orphaned pods
-// when the corresponding CSI volume is no longer mounted.
-//
-// Must only be called when podVolumesExist(uid) is false (see removeOrphanedPodVolumeDirs).
+// cleanOrphanedCSIVolumeDirs removes residual CSI volume metadata for orphaned
+// pods when the corresponding CSI volume is no longer mounted.
+// Must only be called when podVolumesExist(uid) is false.
 func (kl *Kubelet) cleanOrphanedCSIVolumeDirs(logger klog.Logger, uid types.UID) []error {
 	pluginDir := filepath.Join(kl.getPodVolumesDir(uid), utilstrings.EscapeQualifiedName(csi.CSIPluginName))
 	entries, err := os.ReadDir(pluginDir)

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -158,7 +158,15 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(logger klog.Logger, uid types.UID
 	// After hard reboots, mounts are gone but CSI metadata files often remain and
 	// block rmdir-only cleanup of the volumes tree ("not a directory" errors).
 	// See https://github.com/kubernetes/kubernetes/issues/105536.
-	// Safety: only well-known CSI metadata is removed, and only when not mounted.
+	//
+	// Safety (must stay aligned with #102576):
+	//   - This runs only after cleanupOrphanedPodDirs has verified podVolumesExist
+	//     is false (volume manager has no possibly-mounted volumes; disk mount
+	//     check did not find mounts). Do not call cleanOrphanedCSIVolumeDirs from
+	//     other paths without that gate.
+	//   - Only well-known CSI metadata is removed, and only when IsMountPoint says
+	//     the CSI mount path is not mounted (bind mounts included on Linux).
+	//   - Arbitrary files under the volume dir are never deleted.
 	orphanVolumeErrors = append(orphanVolumeErrors, kl.cleanOrphanedCSIVolumeDirs(logger, uid)...)
 
 	// Remove any remaining subdirectories along with the volumes directory itself.
@@ -175,6 +183,8 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(logger klog.Logger, uid types.UID
 
 // cleanOrphanedCSIVolumeDirs removes residual CSI volume metadata for orphaned pods
 // when the corresponding CSI volume is no longer mounted.
+//
+// Must only be called when podVolumesExist(uid) is false (see removeOrphanedPodVolumeDirs).
 func (kl *Kubelet) cleanOrphanedCSIVolumeDirs(logger klog.Logger, uid types.UID) []error {
 	pluginDir := filepath.Join(kl.getPodVolumesDir(uid), utilstrings.EscapeQualifiedName(csi.CSIPluginName))
 	entries, err := os.ReadDir(pluginDir)
@@ -191,11 +201,14 @@ func (kl *Kubelet) cleanOrphanedCSIVolumeDirs(logger klog.Logger, uid types.UID)
 			continue
 		}
 		volumeDir := filepath.Join(pluginDir, entry.Name())
-		if err := csi.CleanupUnmountedVolumeArtifacts(kl.mounter, volumeDir); err != nil {
+		cleaned, err := csi.CleanupUnmountedVolumeArtifacts(kl.mounter, volumeDir)
+		if err != nil {
 			errs = append(errs, fmt.Errorf("orphaned pod %q found, but failed to clean residual CSI volume artifacts at %s: %w", uid, volumeDir, err))
 			continue
 		}
-		logger.V(4).Info("Cleaned residual CSI volume artifacts for orphaned pod", "podUID", uid, "path", volumeDir)
+		if cleaned {
+			logger.V(4).Info("Cleaned residual CSI volume artifacts for orphaned pod", "podUID", uid, "path", volumeDir)
+		}
 	}
 	return errs
 }

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -31,7 +31,9 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/util/removeall"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/csi"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
+	utilstrings "k8s.io/utils/strings"
 )
 
 // ListVolumesForPod returns a map of the mounted volumes for the given pod.
@@ -152,6 +154,13 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(logger klog.Logger, uid types.UID
 		}
 	}
 
+	// Remove residual CSI metadata (e.g. vol_data.json) for unmounted CSI volumes.
+	// After hard reboots, mounts are gone but CSI metadata files often remain and
+	// block rmdir-only cleanup of the volumes tree ("not a directory" errors).
+	// See https://github.com/kubernetes/kubernetes/issues/105536.
+	// Safety: only well-known CSI metadata is removed, and only when not mounted.
+	orphanVolumeErrors = append(orphanVolumeErrors, kl.cleanOrphanedCSIVolumeDirs(logger, uid)...)
+
 	// Remove any remaining subdirectories along with the volumes directory itself.
 	// Fail if any regular files are encountered.
 	podVolDir := kl.getPodVolumesDir(uid)
@@ -162,6 +171,33 @@ func (kl *Kubelet) removeOrphanedPodVolumeDirs(logger klog.Logger, uid types.UID
 	}
 
 	return orphanVolumeErrors
+}
+
+// cleanOrphanedCSIVolumeDirs removes residual CSI volume metadata for orphaned pods
+// when the corresponding CSI volume is no longer mounted.
+func (kl *Kubelet) cleanOrphanedCSIVolumeDirs(logger klog.Logger, uid types.UID) []error {
+	pluginDir := filepath.Join(kl.getPodVolumesDir(uid), utilstrings.EscapeQualifiedName(csi.CSIPluginName))
+	entries, err := os.ReadDir(pluginDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return []error{fmt.Errorf("orphaned pod %q found, but error occurred during reading CSI volume plugin dir: %v", uid, err)}
+	}
+
+	var errs []error
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		volumeDir := filepath.Join(pluginDir, entry.Name())
+		if err := csi.CleanupUnmountedVolumeArtifacts(kl.mounter, volumeDir); err != nil {
+			errs = append(errs, fmt.Errorf("orphaned pod %q found, but failed to clean residual CSI volume artifacts at %s: %w", uid, volumeDir, err))
+			continue
+		}
+		logger.V(4).Info("Cleaned residual CSI volume artifacts for orphaned pod", "podUID", uid, "path", volumeDir)
+	}
+	return errs
 }
 
 // cleanupOrphanedPodDirs removes the volumes of pods that should not be

--- a/pkg/kubelet/kubelet_volumes_linux_test.go
+++ b/pkg/kubelet/kubelet_volumes_linux_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -211,6 +212,81 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				return nil
 			},
 		},
+
+		// CSI plugin path exists as a file: ReadDir fails and is reported.
+		"pod-csi-plugin-dir-is-file": {
+			prepareFunc: func(kubelet *Kubelet) error {
+				podDir := kubelet.getPodDir("pod1uid")
+				pluginPath := filepath.Join(podDir, "volumes/kubernetes.io~csi")
+				if err := os.MkdirAll(filepath.Dir(pluginPath), 0750); err != nil {
+					return err
+				}
+				return os.WriteFile(pluginPath, []byte("not-a-dir"), 0640)
+			},
+			// cleanup still runs; errors are rolled up for volume cleanup (not always returned as top-level err)
+			validateFunc: func(kubelet *Kubelet) error {
+				// plugin path remains as file
+				pluginPath := filepath.Join(kubelet.getPodDir("pod1uid"), "volumes/kubernetes.io~csi")
+				fi, err := os.Stat(pluginPath)
+				if err != nil {
+					return err
+				}
+				if fi.IsDir() {
+					return fmt.Errorf("expected plugin path to remain a file")
+				}
+				return nil
+			},
+		},
+		// Non-directory entry under CSI plugin dir is skipped safely.
+		"pod-csi-plugin-has-file-entry-skipped": {
+			prepareFunc: func(kubelet *Kubelet) error {
+				podDir := kubelet.getPodDir("pod1uid")
+				pluginPath := filepath.Join(podDir, "volumes/kubernetes.io~csi")
+				if err := os.MkdirAll(pluginPath, 0750); err != nil {
+					return err
+				}
+				// file entry + a cleanable volume dir
+				if err := os.WriteFile(filepath.Join(pluginPath, "not-a-volume"), []byte("x"), 0640); err != nil {
+					return err
+				}
+				volumePath := filepath.Join(pluginPath, "pvc-ok")
+				if err := os.MkdirAll(volumePath, 0750); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(volumePath, "vol_data.json"), []byte(`{}`), 0640)
+			},
+			validateFunc: func(kubelet *Kubelet) error {
+				// residual metadata cleaned; file entry may remain and block full volumes dir removal
+				dataPath := filepath.Join(kubelet.getPodDir("pod1uid"), "volumes/kubernetes.io~csi/pvc-ok/vol_data.json")
+				if _, err := os.Stat(dataPath); !os.IsNotExist(err) {
+					return fmt.Errorf("expected vol_data cleaned, err=%v", err)
+				}
+				return nil
+			},
+		},
+		// Mount path non-empty: CSI cleanup fails for that volume; userdata path keeps erroring remove.
+		"pod-csi-nonempty-mount-blocks-cleanup": {
+			prepareFunc: func(kubelet *Kubelet) error {
+				podDir := kubelet.getPodDir("pod1uid")
+				volumePath := filepath.Join(podDir, "volumes/kubernetes.io~csi/pvc-fake")
+				mountPath := filepath.Join(volumePath, "mount")
+				if err := os.MkdirAll(mountPath, 0750); err != nil {
+					return err
+				}
+				if err := os.WriteFile(filepath.Join(mountPath, "stuck"), []byte("x"), 0640); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(volumePath, "vol_data.json"), []byte(`{}`), 0640)
+			},
+			validateFunc: func(kubelet *Kubelet) error {
+				// vol_data must remain because mount removal failed first
+				dataPath := filepath.Join(kubelet.getPodDir("pod1uid"), "volumes/kubernetes.io~csi/pvc-fake/vol_data.json")
+				if _, err := os.Stat(dataPath); err != nil {
+					return fmt.Errorf("expected vol_data to remain when mount dir non-empty: %v", err)
+				}
+				return nil
+			},
+		},
 		// TODO: test volume in volume-manager
 	}
 
@@ -356,4 +432,70 @@ func TestPodVolumesExistWithMount(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCleanOrphanedCSIVolumeDirs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	logger, _ := ktesting.NewTestContext(t)
+
+	t.Run("plugin-dir-missing", func(t *testing.T) {
+		testKubelet := newTestKubelet(t, false)
+		defer testKubelet.Cleanup()
+		kl := testKubelet.kubelet
+		errs := kl.cleanOrphanedCSIVolumeDirs(logger, "pod-missing")
+		if len(errs) != 0 {
+			t.Fatalf("expected no errors, got %v", errs)
+		}
+	})
+
+	t.Run("plugin-dir-is-file", func(t *testing.T) {
+		testKubelet := newTestKubelet(t, false)
+		defer testKubelet.Cleanup()
+		kl := testKubelet.kubelet
+		uid := types.UID("pod-file")
+		pluginPath := filepath.Join(kl.getPodVolumesDir(uid), "kubernetes.io~csi")
+		if err := os.MkdirAll(filepath.Dir(pluginPath), 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(pluginPath, []byte("x"), 0640); err != nil {
+			t.Fatal(err)
+		}
+		errs := kl.cleanOrphanedCSIVolumeDirs(logger, uid)
+		if len(errs) != 1 {
+			t.Fatalf("expected 1 error, got %v", errs)
+		}
+		if !strings.Contains(errs[0].Error(), "reading CSI volume plugin dir") {
+			t.Fatalf("unexpected error: %v", errs[0])
+		}
+	})
+
+	t.Run("cleanup-artifact-error-propagates", func(t *testing.T) {
+		testKubelet := newTestKubelet(t, false)
+		defer testKubelet.Cleanup()
+		kl := testKubelet.kubelet
+		uid := types.UID("pod-block")
+		volumePath := filepath.Join(kl.getPodVolumesDir(uid), "kubernetes.io~csi", "pvc-x")
+		mountPath := filepath.Join(volumePath, "mount")
+		if err := os.MkdirAll(mountPath, 0750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(mountPath, "stuck"), []byte("x"), 0640); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(volumePath, "vol_data.json"), []byte(`{}`), 0640); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(filepath.Dir(volumePath), "not-dir"), []byte("x"), 0640); err != nil {
+			t.Fatal(err)
+		}
+		errs := kl.cleanOrphanedCSIVolumeDirs(logger, uid)
+		if len(errs) != 1 {
+			t.Fatalf("expected 1 error from nonempty mount, got %v", errs)
+		}
+		if !strings.Contains(errs[0].Error(), "failed to clean residual CSI volume artifacts") {
+			t.Fatalf("unexpected error: %v", errs[0])
+		}
+	})
 }

--- a/pkg/kubelet/kubelet_volumes_linux_test.go
+++ b/pkg/kubelet/kubelet_volumes_linux_test.go
@@ -166,6 +166,51 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				return validateDirExists(filepath.Join(podDir, "volume-subpaths/volume/container/index"))
 			},
 		},
+
+		// Residual CSI vol_data.json after unmount/reboot must not block orphan cleanup.
+		// https://github.com/kubernetes/kubernetes/issues/105536
+		"pod-doesnot-exist-with-csi-vol-data-json": {
+			prepareFunc: func(kubelet *Kubelet) error {
+				podDir := kubelet.getPodDir("pod1uid")
+				// Escaped CSI plugin name on disk is kubernetes.io~csi
+				volumePath := filepath.Join(podDir, "volumes/kubernetes.io~csi/pvc-fake")
+				if err := os.MkdirAll(filepath.Join(volumePath, "mount"), 0750); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(volumePath, "vol_data.json"), []byte(`{"driverName":"test.csi"}`), 0640)
+			},
+			validateFunc: func(kubelet *Kubelet) error {
+				podDir := kubelet.getPodDir("pod1uid")
+				return validateDirNotExists(podDir)
+			},
+		},
+		// Arbitrary non-metadata content under a volume path must still be preserved.
+		"pod-doesnot-exist-with-csi-userdata-preserved": {
+			prepareFunc: func(kubelet *Kubelet) error {
+				podDir := kubelet.getPodDir("pod1uid")
+				volumePath := filepath.Join(podDir, "volumes/kubernetes.io~csi/pvc-fake")
+				if err := os.MkdirAll(volumePath, 0750); err != nil {
+					return err
+				}
+				if err := os.WriteFile(filepath.Join(volumePath, "vol_data.json"), []byte(`{"driverName":"test.csi"}`), 0640); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(volumePath, "userdata.txt"), []byte("keep-me"), 0640)
+			},
+			validateFunc: func(kubelet *Kubelet) error {
+				podDir := kubelet.getPodDir("pod1uid")
+				// volumes dir remains because of userdata; vol_data.json should be gone
+				dataPath := filepath.Join(podDir, "volumes/kubernetes.io~csi/pvc-fake/vol_data.json")
+				if _, err := os.Stat(dataPath); !os.IsNotExist(err) {
+					return fmt.Errorf("expected vol_data.json removed, stat err=%v", err)
+				}
+				userPath := filepath.Join(podDir, "volumes/kubernetes.io~csi/pvc-fake/userdata.txt")
+				if _, err := os.Stat(userPath); err != nil {
+					return fmt.Errorf("expected userdata.txt preserved: %v", err)
+				}
+				return nil
+			},
+		},
 		// TODO: test volume in volume-manager
 	}
 

--- a/pkg/kubelet/kubelet_volumes_linux_test.go
+++ b/pkg/kubelet/kubelet_volumes_linux_test.go
@@ -168,12 +168,10 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 			},
 		},
 
-		// Residual CSI vol_data.json after unmount/reboot must not block orphan cleanup.
-		// https://github.com/kubernetes/kubernetes/issues/105536
+		// #105536: residual CSI vol_data.json after reboot must not block orphan cleanup.
 		"pod-doesnot-exist-with-csi-vol-data-json": {
 			prepareFunc: func(kubelet *Kubelet) error {
 				podDir := kubelet.getPodDir("pod1uid")
-				// Escaped CSI plugin name on disk is kubernetes.io~csi
 				volumePath := filepath.Join(podDir, "volumes/kubernetes.io~csi/pvc-fake")
 				if err := os.MkdirAll(filepath.Join(volumePath, "mount"), 0750); err != nil {
 					return err
@@ -185,7 +183,7 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				return validateDirNotExists(podDir)
 			},
 		},
-		// Arbitrary non-metadata content under a volume path must still be preserved.
+		// Non-metadata content under a CSI volume path must be preserved.
 		"pod-doesnot-exist-with-csi-userdata-preserved": {
 			prepareFunc: func(kubelet *Kubelet) error {
 				podDir := kubelet.getPodDir("pod1uid")
@@ -200,7 +198,6 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 			},
 			validateFunc: func(kubelet *Kubelet) error {
 				podDir := kubelet.getPodDir("pod1uid")
-				// volumes dir remains because of userdata; vol_data.json should be gone
 				dataPath := filepath.Join(podDir, "volumes/kubernetes.io~csi/pvc-fake/vol_data.json")
 				if _, err := os.Stat(dataPath); !os.IsNotExist(err) {
 					return fmt.Errorf("expected vol_data.json removed, stat err=%v", err)
@@ -213,7 +210,7 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 			},
 		},
 
-		// CSI plugin path exists as a file: ReadDir fails and is reported.
+		// CSI plugin path as a file: ReadDir fails and is reported.
 		"pod-csi-plugin-dir-is-file": {
 			prepareFunc: func(kubelet *Kubelet) error {
 				podDir := kubelet.getPodDir("pod1uid")
@@ -223,9 +220,7 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				}
 				return os.WriteFile(pluginPath, []byte("not-a-dir"), 0640)
 			},
-			// cleanup still runs; errors are rolled up for volume cleanup (not always returned as top-level err)
 			validateFunc: func(kubelet *Kubelet) error {
-				// plugin path remains as file
 				pluginPath := filepath.Join(kubelet.getPodDir("pod1uid"), "volumes/kubernetes.io~csi")
 				fi, err := os.Stat(pluginPath)
 				if err != nil {
@@ -237,7 +232,7 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				return nil
 			},
 		},
-		// Non-directory entry under CSI plugin dir is skipped safely.
+		// Non-directory entry under CSI plugin dir is skipped.
 		"pod-csi-plugin-has-file-entry-skipped": {
 			prepareFunc: func(kubelet *Kubelet) error {
 				podDir := kubelet.getPodDir("pod1uid")
@@ -245,7 +240,6 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				if err := os.MkdirAll(pluginPath, 0750); err != nil {
 					return err
 				}
-				// file entry + a cleanable volume dir
 				if err := os.WriteFile(filepath.Join(pluginPath, "not-a-volume"), []byte("x"), 0640); err != nil {
 					return err
 				}
@@ -256,7 +250,6 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				return os.WriteFile(filepath.Join(volumePath, "vol_data.json"), []byte(`{}`), 0640)
 			},
 			validateFunc: func(kubelet *Kubelet) error {
-				// residual metadata cleaned; file entry may remain and block full volumes dir removal
 				dataPath := filepath.Join(kubelet.getPodDir("pod1uid"), "volumes/kubernetes.io~csi/pvc-ok/vol_data.json")
 				if _, err := os.Stat(dataPath); !os.IsNotExist(err) {
 					return fmt.Errorf("expected vol_data cleaned, err=%v", err)
@@ -264,7 +257,7 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				return nil
 			},
 		},
-		// Mount path non-empty: CSI cleanup fails for that volume; userdata path keeps erroring remove.
+		// Non-empty mount path blocks CSI metadata cleanup for that volume.
 		"pod-csi-nonempty-mount-blocks-cleanup": {
 			prepareFunc: func(kubelet *Kubelet) error {
 				podDir := kubelet.getPodDir("pod1uid")
@@ -279,7 +272,6 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				return os.WriteFile(filepath.Join(volumePath, "vol_data.json"), []byte(`{}`), 0640)
 			},
 			validateFunc: func(kubelet *Kubelet) error {
-				// vol_data must remain because mount removal failed first
 				dataPath := filepath.Join(kubelet.getPodDir("pod1uid"), "volumes/kubernetes.io~csi/pvc-fake/vol_data.json")
 				if _, err := os.Stat(dataPath); err != nil {
 					return fmt.Errorf("expected vol_data to remain when mount dir non-empty: %v", err)

--- a/pkg/volume/csi/csi_orphan_cleanup.go
+++ b/pkg/volume/csi/csi_orphan_cleanup.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog/v2"
+	"k8s.io/mount-utils"
+)
+
+// CleanupUnmountedVolumeArtifacts removes residual CSI volume directory content when
+// the volume is not mounted.
+//
+// After a hard node reboot, CSI mount points are typically gone while the per-volume
+// metadata file (vol_data.json) remains under:
+//
+//	.../volumes/kubernetes.io~csi/<volume>/vol_data.json
+//
+// Orphaned-pod cleanup intentionally uses rmdir-only traversal on the volumes tree
+// (see kubelet removeOrphanedPodVolumeDirs / pkg/util/removeall.RemoveDirsOneFilesystem)
+// so that real mount contents are never recursively deleted. Residual vol_data.json
+// therefore blocks cleanup and produces perpetual "not a directory" errors.
+//
+// Safety:
+//   - If the CSI mount path is still a mount point, this is a no-op.
+//   - Only the well-known CSI metadata file (vol_data.json) and empty directories are removed.
+//   - Arbitrary files under the volume path are left untouched.
+func CleanupUnmountedVolumeArtifacts(mounter mount.Interface, volumeDir string) error {
+	if mounter == nil {
+		return fmt.Errorf("mounter is required")
+	}
+
+	exists, err := mount.PathExists(volumeDir)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	mountPath := GetCSIMounterPath(volumeDir)
+	mountExists, err := mount.PathExists(mountPath)
+	if err != nil {
+		return err
+	}
+	if mountExists {
+		notMnt, err := mounter.IsLikelyNotMountPoint(mountPath)
+		if err != nil {
+			// Path may race; treat missing path as unmounted.
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to check mount point %q: %w", mountPath, err)
+			}
+			notMnt = true
+		}
+		if !notMnt {
+			// Still mounted: never touch metadata or the volume directory.
+			return nil
+		}
+		// Unmounted local directory left after reboot / successful unmount.
+		if err := os.Remove(mountPath); err != nil && !os.IsNotExist(err) {
+			// Non-empty mount dir may still hold data; do not delete vol_data.json yet.
+			return fmt.Errorf("failed to remove unmounted CSI mount path %q: %w", mountPath, err)
+		}
+	}
+
+	dataFile := filepath.Join(volumeDir, volDataFileName)
+	if err := os.Remove(dataFile); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove CSI volume data file %q: %w", dataFile, err)
+	}
+	klog.V(4).InfoS("Removed residual CSI volume metadata", "path", dataFile)
+
+	// Best-effort: remove the volume directory if it is now empty.
+	if err := os.Remove(volumeDir); err != nil && !os.IsNotExist(err) {
+		// Directory still has residual content that is not safe for this helper to delete.
+		klog.V(4).InfoS("CSI volume directory not empty after metadata cleanup", "path", volumeDir, "err", err)
+	}
+	return nil
+}

--- a/pkg/volume/csi/csi_orphan_cleanup.go
+++ b/pkg/volume/csi/csi_orphan_cleanup.go
@@ -25,32 +25,22 @@ import (
 	"k8s.io/mount-utils"
 )
 
-// CleanupUnmountedVolumeArtifacts removes residual CSI volume directory content when
-// the volume is not mounted.
+// CleanupUnmountedVolumeArtifacts removes residual CSI volume directory content
+// when the volume is not mounted.
 //
-// After a hard node reboot, CSI mount points are typically gone while the per-volume
-// metadata file (vol_data.json) remains under:
+// Orphaned-pod volume cleanup uses rmdir-only traversal of the volumes tree
+// (see removeall.RemoveDirsOneFilesystem). After a hard reboot, CSI mounts are
+// typically gone while vol_data.json remains under
+// volumes/kubernetes.io~csi/<volume>/, which blocks cleanup.
 //
-//	.../volumes/kubernetes.io~csi/<volume>/vol_data.json
+// Callers must only invoke this after verifying the pod has no remaining
+// mounted volumes (kubelet podVolumesExist == false). That gate preserves CSI
+// metadata needed for reconstruction / NodeUnstage.
 //
-// Orphaned-pod cleanup intentionally uses rmdir-only traversal on the volumes tree
-// (see kubelet removeOrphanedPodVolumeDirs / pkg/util/removeall.RemoveDirsOneFilesystem)
-// so that real mount contents are never recursively deleted. Residual vol_data.json
-// therefore blocks cleanup and produces perpetual "not a directory" errors.
-//
-// Prerequisites / safety (review notes for #102576 / reconstruction):
-//   - Callers must only invoke this after determining the pod has no remaining
-//     mounted/uncertain volumes (kubelet podVolumesExist == false). That gate
-//     is what prevents deleting CSI metadata while volume manager still needs it
-//     for NodeUnstage / reconstruction.
-//   - This uses mounter.IsMountPoint (not only IsLikelyNotMountPoint) so bind
-//     mounts are detected on Linux when the mount table is available.
-//   - If the CSI mount path is still a mount point, this is a no-op.
-//   - Only the well-known CSI metadata file (vol_data.json) and empty dirs under
-//     the pod volume path are removed. Arbitrary files are left untouched.
-//   - Scope: filesystem CSI pod volume dirs under volumes/kubernetes.io~csi/.
-//     Global plugin staging/publish paths and block volumeDevices layouts are
-//     intentionally out of scope for this helper.
+// Only the well-known CSI metadata file (vol_data.json) and empty directories under
+// the pod volume path are removed. Arbitrary files are left untouched.
+// Filesystem CSI pod volume dirs only; staging/publish and block volumeDevices
+// paths are out of scope.
 //
 // Returns cleaned=true only when vol_data.json was successfully removed.
 func CleanupUnmountedVolumeArtifacts(mounter mount.Interface, volumeDir string) (cleaned bool, err error) {
@@ -72,44 +62,35 @@ func CleanupUnmountedVolumeArtifacts(mounter mount.Interface, volumeDir string) 
 		return false, err
 	}
 	if mountExists {
-		// Prefer IsMountPoint: detects bind mounts; more expensive but safer for CSI.
+		// IsMountPoint detects bind mounts; safer than IsLikelyNotMountPoint for CSI.
 		isMnt, err := mounter.IsMountPoint(mountPath)
 		if err != nil {
-			// Path may race; treat missing path as unmounted.
 			if !os.IsNotExist(err) {
 				return false, fmt.Errorf("failed to check mount point %q: %w", mountPath, err)
 			}
 			isMnt = false
 		}
 		if isMnt {
-			// Still mounted: never touch metadata or the volume directory.
-			// Preserves vol_data.json for any remaining unstage/unpublish work.
 			return false, nil
 		}
-		// Unmounted local directory left after reboot / successful unmount.
 		if err := os.Remove(mountPath); err != nil && !os.IsNotExist(err) {
-			// Non-empty mount dir may still hold data; do not delete vol_data.json yet.
+			// Non-empty mount dir may still hold data; leave vol_data.json alone.
 			return false, fmt.Errorf("failed to remove unmounted CSI mount path %q: %w", mountPath, err)
 		}
 	}
 
 	dataFile := filepath.Join(volumeDir, volDataFileName)
 	if err := os.Remove(dataFile); err != nil {
-		if os.IsNotExist(err) {
-			// Nothing to clean; try empty volumeDir removal below.
-			if remErr := os.Remove(volumeDir); remErr != nil && !os.IsNotExist(remErr) {
-				klog.V(4).InfoS("CSI volume directory not empty after metadata cleanup", "path", volumeDir, "err", remErr)
-			}
-			return false, nil
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("failed to remove CSI volume data file %q: %w", dataFile, err)
 		}
-		return false, fmt.Errorf("failed to remove CSI volume data file %q: %w", dataFile, err)
+	} else {
+		klog.V(4).InfoS("Removed residual CSI volume metadata", "path", dataFile)
+		cleaned = true
 	}
-	klog.V(4).InfoS("Removed residual CSI volume metadata", "path", dataFile)
-	cleaned = true
 
 	// Best-effort: remove the volume directory if it is now empty.
 	if err := os.Remove(volumeDir); err != nil && !os.IsNotExist(err) {
-		// Directory still has residual content that is not safe for this helper to delete.
 		klog.V(4).InfoS("CSI volume directory not empty after metadata cleanup", "path", volumeDir, "err", err)
 	}
 	return cleaned, nil

--- a/pkg/volume/csi/csi_orphan_cleanup.go
+++ b/pkg/volume/csi/csi_orphan_cleanup.go
@@ -38,58 +38,79 @@ import (
 // so that real mount contents are never recursively deleted. Residual vol_data.json
 // therefore blocks cleanup and produces perpetual "not a directory" errors.
 //
-// Safety:
+// Prerequisites / safety (review notes for #102576 / reconstruction):
+//   - Callers must only invoke this after determining the pod has no remaining
+//     mounted/uncertain volumes (kubelet podVolumesExist == false). That gate
+//     is what prevents deleting CSI metadata while volume manager still needs it
+//     for NodeUnstage / reconstruction.
+//   - This uses mounter.IsMountPoint (not only IsLikelyNotMountPoint) so bind
+//     mounts are detected on Linux when the mount table is available.
 //   - If the CSI mount path is still a mount point, this is a no-op.
-//   - Only the well-known CSI metadata file (vol_data.json) and empty directories are removed.
-//   - Arbitrary files under the volume path are left untouched.
-func CleanupUnmountedVolumeArtifacts(mounter mount.Interface, volumeDir string) error {
+//   - Only the well-known CSI metadata file (vol_data.json) and empty dirs under
+//     the pod volume path are removed. Arbitrary files are left untouched.
+//   - Scope: filesystem CSI pod volume dirs under volumes/kubernetes.io~csi/.
+//     Global plugin staging/publish paths and block volumeDevices layouts are
+//     intentionally out of scope for this helper.
+//
+// Returns cleaned=true only when vol_data.json was successfully removed.
+func CleanupUnmountedVolumeArtifacts(mounter mount.Interface, volumeDir string) (cleaned bool, err error) {
 	if mounter == nil {
-		return fmt.Errorf("mounter is required")
+		return false, fmt.Errorf("mounter is required")
 	}
 
 	exists, err := mount.PathExists(volumeDir)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if !exists {
-		return nil
+		return false, nil
 	}
 
 	mountPath := GetCSIMounterPath(volumeDir)
 	mountExists, err := mount.PathExists(mountPath)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if mountExists {
-		notMnt, err := mounter.IsLikelyNotMountPoint(mountPath)
+		// Prefer IsMountPoint: detects bind mounts; more expensive but safer for CSI.
+		isMnt, err := mounter.IsMountPoint(mountPath)
 		if err != nil {
 			// Path may race; treat missing path as unmounted.
 			if !os.IsNotExist(err) {
-				return fmt.Errorf("failed to check mount point %q: %w", mountPath, err)
+				return false, fmt.Errorf("failed to check mount point %q: %w", mountPath, err)
 			}
-			notMnt = true
+			isMnt = false
 		}
-		if !notMnt {
+		if isMnt {
 			// Still mounted: never touch metadata or the volume directory.
-			return nil
+			// Preserves vol_data.json for any remaining unstage/unpublish work.
+			return false, nil
 		}
 		// Unmounted local directory left after reboot / successful unmount.
 		if err := os.Remove(mountPath); err != nil && !os.IsNotExist(err) {
 			// Non-empty mount dir may still hold data; do not delete vol_data.json yet.
-			return fmt.Errorf("failed to remove unmounted CSI mount path %q: %w", mountPath, err)
+			return false, fmt.Errorf("failed to remove unmounted CSI mount path %q: %w", mountPath, err)
 		}
 	}
 
 	dataFile := filepath.Join(volumeDir, volDataFileName)
-	if err := os.Remove(dataFile); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to remove CSI volume data file %q: %w", dataFile, err)
+	if err := os.Remove(dataFile); err != nil {
+		if os.IsNotExist(err) {
+			// Nothing to clean; try empty volumeDir removal below.
+			if remErr := os.Remove(volumeDir); remErr != nil && !os.IsNotExist(remErr) {
+				klog.V(4).InfoS("CSI volume directory not empty after metadata cleanup", "path", volumeDir, "err", remErr)
+			}
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to remove CSI volume data file %q: %w", dataFile, err)
 	}
 	klog.V(4).InfoS("Removed residual CSI volume metadata", "path", dataFile)
+	cleaned = true
 
 	// Best-effort: remove the volume directory if it is now empty.
 	if err := os.Remove(volumeDir); err != nil && !os.IsNotExist(err) {
 		// Directory still has residual content that is not safe for this helper to delete.
 		klog.V(4).InfoS("CSI volume directory not empty after metadata cleanup", "path", volumeDir, "err", err)
 	}
-	return nil
+	return cleaned, nil
 }

--- a/pkg/volume/csi/csi_orphan_cleanup_test.go
+++ b/pkg/volume/csi/csi_orphan_cleanup_test.go
@@ -31,22 +31,22 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		mounter      mount.Interface
+		nilMounter   bool
+		volumeDir    func(root string) string
 		prepare      func(t *testing.T, volumeDir string, mounter *mount.FakeMounter)
-		volumeDir    func(root string) string // optional override of volumeDir path
+		wantCleaned  bool
 		wantDataGone bool
 		wantDirGone  bool
 		wantErr      bool
 		errContains  string
+		skipFSAssert bool
 	}{
 		{
-			name: "nil mounter",
-			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
-				t.Helper()
-			},
-			mounter:     nil,
-			wantErr:     true,
-			errContains: "mounter is required",
+			name:         "nil mounter",
+			nilMounter:   true,
+			wantErr:      true,
+			errContains:  "mounter is required",
+			skipFSAssert: true,
 		},
 		{
 			name: "missing volume dir is ok",
@@ -70,6 +70,7 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
+			wantCleaned:  true,
 			wantDataGone: true,
 			wantDirGone:  true,
 		},
@@ -81,6 +82,7 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
+			wantCleaned:  true,
 			wantDataGone: true,
 			wantDirGone:  true,
 		},
@@ -97,11 +99,9 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 				}
 				mounter.MountPoints = []mount.MountPoint{{Device: "/dev/sdb", Path: mountPath}}
 			},
-			wantDataGone: false,
-			wantDirGone:  false,
 		},
 		{
-			name: "IsLikelyNotMountPoint non-ENOENT error",
+			name: "IsMountPoint non-ENOENT error",
 			prepare: func(t *testing.T, volumeDir string, mounter *mount.FakeMounter) {
 				t.Helper()
 				mountPath := filepath.Join(volumeDir, "mount")
@@ -115,13 +115,11 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 					mountPath: errors.New("injected mount check failure"),
 				}
 			},
-			wantDataGone: false,
-			wantDirGone:  false,
-			wantErr:      true,
-			errContains:  "failed to check mount point",
+			wantErr:     true,
+			errContains: "failed to check mount point",
 		},
 		{
-			name: "IsLikelyNotMountPoint ENOENT treated as unmounted",
+			name: "IsMountPoint ENOENT treated as unmounted",
 			prepare: func(t *testing.T, volumeDir string, mounter *mount.FakeMounter) {
 				t.Helper()
 				mountPath := filepath.Join(volumeDir, "mount")
@@ -131,11 +129,11 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 				if err := os.WriteFile(filepath.Join(volumeDir, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
 					t.Fatal(err)
 				}
-				// FakeMounter returns this error before Stat; os.IsNotExist makes code treat as unmounted.
 				mounter.MountCheckErrors = map[string]error{
 					mountPath: os.ErrNotExist,
 				}
 			},
+			wantCleaned:  true,
 			wantDataGone: true,
 			wantDirGone:  true,
 		},
@@ -147,7 +145,6 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 				if err := os.MkdirAll(mountPath, 0750); err != nil {
 					t.Fatal(err)
 				}
-				// Make mount dir non-empty so os.Remove(mountPath) fails.
 				if err := os.WriteFile(filepath.Join(mountPath, "leftover"), []byte("x"), 0640); err != nil {
 					t.Fatal(err)
 				}
@@ -155,10 +152,8 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantDataGone: false,
-			wantDirGone:  false,
-			wantErr:      true,
-			errContains:  "failed to remove unmounted CSI mount path",
+			wantErr:     true,
+			errContains: "failed to remove unmounted CSI mount path",
 		},
 		{
 			name: "leaves arbitrary content after removing metadata",
@@ -171,18 +166,16 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
+			wantCleaned:  true,
 			wantDataGone: true,
-			wantDirGone:  false,
 		},
 		{
 			name: "PathExists error when volumeDir parent is a file",
-			// Stat(volumeDir) fails with ENOTDIR-style error when a path component is a file.
 			volumeDir: func(root string) string {
 				return filepath.Join(root, "not-a-dir", "volume")
 			},
 			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
 				t.Helper()
-				// volumeDir = root/not-a-dir/volume; make not-a-dir a file.
 				parent := filepath.Dir(volumeDir)
 				grand := filepath.Dir(parent)
 				if err := os.MkdirAll(grand, 0750); err != nil {
@@ -192,15 +185,13 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantErr:     true,
-			errContains: "", // OS-dependent message; just require error
+			wantErr:      true,
+			skipFSAssert: true,
 		},
 		{
 			name: "PathExists error for mount path when volumeDir is a file",
 			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
 				t.Helper()
-				// Replace volumeDir directory with a file so PathExists(volumeDir) succeeds
-				// (file exists) but PathExists(volumeDir/mount) fails.
 				if err := os.RemoveAll(volumeDir); err != nil {
 					t.Fatal(err)
 				}
@@ -208,14 +199,11 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			wantErr: true,
+			wantErr:      true,
+			skipFSAssert: true,
 		},
 		{
-			name: "no vol_data empty dir removes dir",
-			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
-				t.Helper()
-				// empty volume dir, no metadata
-			},
+			name:         "no vol_data empty dir removes dir",
 			wantDataGone: true,
 			wantDirGone:  true,
 		},
@@ -228,7 +216,6 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 				}
 			},
 			wantDataGone: true,
-			wantDirGone:  false,
 		},
 		{
 			name: "unreadable vol_data.json removal fails",
@@ -237,7 +224,6 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 				if err := os.WriteFile(filepath.Join(volumeDir, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
 					t.Fatal(err)
 				}
-				// Remove write permission on the directory so os.Remove(dataFile) fails.
 				if err := os.Chmod(volumeDir, 0500); err != nil {
 					t.Fatal(err)
 				}
@@ -245,17 +231,15 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 					_ = os.Chmod(volumeDir, 0750)
 				})
 			},
-			wantDataGone: false,
-			wantDirGone:  false,
-			wantErr:      true,
-			errContains:  "failed to remove CSI volume data file",
+			wantErr:     true,
+			errContains: "failed to remove CSI volume data file",
 		},
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
 			root := t.TempDir()
 			volumeDir := filepath.Join(root, "pvc-test")
 			if tc.volumeDir != nil {
@@ -266,10 +250,9 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 
 			fake := mount.NewFakeMounter(nil)
 			var mounter mount.Interface = fake
-			if tc.name == "nil mounter" {
+			if tc.nilMounter {
 				mounter = nil
 			}
-
 			if tc.prepare != nil {
 				tc.prepare(t, volumeDir, fake)
 			}
@@ -277,51 +260,39 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 			cleaned, err := CleanupUnmountedVolumeArtifacts(mounter, volumeDir)
 			if tc.wantErr {
 				if err == nil {
-					t.Fatalf("expected error, got nil")
+					t.Fatal("expected error, got nil")
 				}
 				if cleaned {
-					t.Fatalf("expected cleaned=false on error")
+					t.Fatal("expected cleaned=false on error")
 				}
-				if tc.errContains != "" && !contains(err.Error(), tc.errContains) {
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
 					t.Fatalf("error %q does not contain %q", err.Error(), tc.errContains)
 				}
 			} else if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			} else if cleaned != tc.wantCleaned {
+				t.Fatalf("cleaned=%v, want %v", cleaned, tc.wantCleaned)
 			}
 
-			if !tc.wantErr || tc.wantDataGone || tc.wantDirGone {
-				// Only assert filesystem outcomes when meaningful.
-			}
-			if tc.name == "nil mounter" || tc.name == "PathExists error when volumeDir parent is a file" || tc.name == "PathExists error for mount path when volumeDir is a file" {
+			if tc.skipFSAssert {
 				return
 			}
 
 			_, dataErr := os.Stat(filepath.Join(volumeDir, volDataFileName))
-			if tc.wantDataGone && !os.IsNotExist(dataErr) {
-				// Permission cases may leave the file; only assert when we expect success path.
-				if !tc.wantErr {
-					t.Fatalf("expected %s gone, stat err=%v", volDataFileName, dataErr)
+			dataGone := os.IsNotExist(dataErr)
+			if !tc.wantErr {
+				if tc.wantDataGone != dataGone {
+					t.Fatalf("vol_data gone=%v, want %v (stat err=%v)", dataGone, tc.wantDataGone, dataErr)
 				}
-			}
-			if !tc.wantDataGone && !tc.wantErr && os.IsNotExist(dataErr) {
-				t.Fatalf("expected %s to remain", volDataFileName)
+			} else if !tc.wantDataGone && dataGone {
+				t.Fatalf("expected %s to remain on error", volDataFileName)
 			}
 
 			_, dirErr := os.Stat(volumeDir)
-			if tc.wantDirGone && !tc.wantErr && !os.IsNotExist(dirErr) {
-				t.Fatalf("expected volume dir gone, stat err=%v", dirErr)
-			}
-			if !tc.wantDirGone && !tc.wantErr && os.IsNotExist(dirErr) {
-				t.Fatalf("expected volume dir to remain")
-			}
-
-			if _, err := os.Stat(filepath.Join(volumeDir, "userdata.txt")); err == nil {
-				// preserved if present
+			dirGone := os.IsNotExist(dirErr)
+			if !tc.wantErr && tc.wantDirGone != dirGone {
+				t.Fatalf("volume dir gone=%v, want %v (stat err=%v)", dirGone, tc.wantDirGone, dirErr)
 			}
 		})
 	}
-}
-
-func contains(s, sub string) bool {
-	return sub == "" || strings.Contains(s, sub)
 }

--- a/pkg/volume/csi/csi_orphan_cleanup_test.go
+++ b/pkg/volume/csi/csi_orphan_cleanup_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package csi
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"k8s.io/mount-utils"
@@ -29,19 +31,53 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		prepare      func(t *testing.T, root string, mounter *mount.FakeMounter)
+		mounter      mount.Interface
+		prepare      func(t *testing.T, volumeDir string, mounter *mount.FakeMounter)
+		volumeDir    func(root string) string // optional override of volumeDir path
 		wantDataGone bool
 		wantDirGone  bool
 		wantErr      bool
+		errContains  string
 	}{
 		{
-			name: "removes vol_data.json when unmounted",
-			prepare: func(t *testing.T, root string, _ *mount.FakeMounter) {
+			name: "nil mounter",
+			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
 				t.Helper()
-				if err := os.MkdirAll(filepath.Join(root, "mount"), 0750); err != nil {
+			},
+			mounter:     nil,
+			wantErr:     true,
+			errContains: "mounter is required",
+		},
+		{
+			name: "missing volume dir is ok",
+			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
+				t.Helper()
+				if err := os.RemoveAll(volumeDir); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(root, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+			},
+			wantDataGone: true,
+			wantDirGone:  true,
+		},
+		{
+			name: "removes vol_data.json when unmounted empty mount",
+			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(volumeDir, "mount"), 0750); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(volumeDir, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantDataGone: true,
+			wantDirGone:  true,
+		},
+		{
+			name: "removes vol_data.json when mount subdir absent",
+			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(volumeDir, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -50,13 +86,13 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 		},
 		{
 			name: "no-op when still mounted",
-			prepare: func(t *testing.T, root string, mounter *mount.FakeMounter) {
+			prepare: func(t *testing.T, volumeDir string, mounter *mount.FakeMounter) {
 				t.Helper()
-				mountPath := filepath.Join(root, "mount")
+				mountPath := filepath.Join(volumeDir, "mount")
 				if err := os.MkdirAll(mountPath, 0750); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(root, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+				if err := os.WriteFile(filepath.Join(volumeDir, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
 					t.Fatal(err)
 				}
 				mounter.MountPoints = []mount.MountPoint{{Device: "/dev/sdb", Path: mountPath}}
@@ -65,13 +101,73 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 			wantDirGone:  false,
 		},
 		{
-			name: "leaves arbitrary content untouched",
-			prepare: func(t *testing.T, root string, _ *mount.FakeMounter) {
+			name: "IsLikelyNotMountPoint non-ENOENT error",
+			prepare: func(t *testing.T, volumeDir string, mounter *mount.FakeMounter) {
 				t.Helper()
-				if err := os.WriteFile(filepath.Join(root, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+				mountPath := filepath.Join(volumeDir, "mount")
+				if err := os.MkdirAll(mountPath, 0750); err != nil {
 					t.Fatal(err)
 				}
-				if err := os.WriteFile(filepath.Join(root, "userdata.txt"), []byte("keep"), 0640); err != nil {
+				if err := os.WriteFile(filepath.Join(volumeDir, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+					t.Fatal(err)
+				}
+				mounter.MountCheckErrors = map[string]error{
+					mountPath: errors.New("injected mount check failure"),
+				}
+			},
+			wantDataGone: false,
+			wantDirGone:  false,
+			wantErr:      true,
+			errContains:  "failed to check mount point",
+		},
+		{
+			name: "IsLikelyNotMountPoint ENOENT treated as unmounted",
+			prepare: func(t *testing.T, volumeDir string, mounter *mount.FakeMounter) {
+				t.Helper()
+				mountPath := filepath.Join(volumeDir, "mount")
+				if err := os.MkdirAll(mountPath, 0750); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(volumeDir, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+					t.Fatal(err)
+				}
+				// FakeMounter returns this error before Stat; os.IsNotExist makes code treat as unmounted.
+				mounter.MountCheckErrors = map[string]error{
+					mountPath: os.ErrNotExist,
+				}
+			},
+			wantDataGone: true,
+			wantDirGone:  true,
+		},
+		{
+			name: "non-empty mount path blocks metadata deletion",
+			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
+				t.Helper()
+				mountPath := filepath.Join(volumeDir, "mount")
+				if err := os.MkdirAll(mountPath, 0750); err != nil {
+					t.Fatal(err)
+				}
+				// Make mount dir non-empty so os.Remove(mountPath) fails.
+				if err := os.WriteFile(filepath.Join(mountPath, "leftover"), []byte("x"), 0640); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(volumeDir, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantDataGone: false,
+			wantDirGone:  false,
+			wantErr:      true,
+			errContains:  "failed to remove unmounted CSI mount path",
+		},
+		{
+			name: "leaves arbitrary content after removing metadata",
+			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(volumeDir, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(volumeDir, "userdata.txt"), []byte("keep"), 0640); err != nil {
 					t.Fatal(err)
 				}
 			},
@@ -79,15 +175,60 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 			wantDirGone:  false,
 		},
 		{
-			name: "missing volume dir is ok",
-			prepare: func(t *testing.T, root string, _ *mount.FakeMounter) {
+			name: "PathExists error when volumeDir parent is a file",
+			// Stat(volumeDir) fails with ENOTDIR-style error when a path component is a file.
+			volumeDir: func(root string) string {
+				return filepath.Join(root, "not-a-dir", "volume")
+			},
+			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
 				t.Helper()
-				if err := os.RemoveAll(root); err != nil {
+				// volumeDir = root/not-a-dir/volume; make not-a-dir a file.
+				parent := filepath.Dir(volumeDir)
+				grand := filepath.Dir(parent)
+				if err := os.MkdirAll(grand, 0750); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(parent, []byte("file"), 0640); err != nil {
 					t.Fatal(err)
 				}
 			},
-			wantDataGone: true,
-			wantDirGone:  true,
+			wantErr:     true,
+			errContains: "", // OS-dependent message; just require error
+		},
+		{
+			name: "PathExists error for mount path when volumeDir is a file",
+			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
+				t.Helper()
+				// Replace volumeDir directory with a file so PathExists(volumeDir) succeeds
+				// (file exists) but PathExists(volumeDir/mount) fails.
+				if err := os.RemoveAll(volumeDir); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(volumeDir, []byte("not-a-directory"), 0640); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "unreadable vol_data.json removal fails",
+			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(volumeDir, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+					t.Fatal(err)
+				}
+				// Remove write permission on the directory so os.Remove(dataFile) fails.
+				if err := os.Chmod(volumeDir, 0500); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() {
+					_ = os.Chmod(volumeDir, 0750)
+				})
+			},
+			wantDataGone: false,
+			wantDirGone:  false,
+			wantErr:      true,
+			errContains:  "failed to remove CSI volume data file",
 		},
 	}
 
@@ -96,40 +237,68 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			root := t.TempDir()
-			// Use a nested volume dir so we can delete the whole tree in "missing" case.
 			volumeDir := filepath.Join(root, "pvc-test")
-			if err := os.MkdirAll(volumeDir, 0750); err != nil {
+			if tc.volumeDir != nil {
+				volumeDir = tc.volumeDir(root)
+			} else if err := os.MkdirAll(volumeDir, 0750); err != nil {
 				t.Fatal(err)
 			}
-			mounter := mount.NewFakeMounter(nil)
-			tc.prepare(t, volumeDir, mounter)
+
+			fake := mount.NewFakeMounter(nil)
+			var mounter mount.Interface = fake
+			if tc.name == "nil mounter" {
+				mounter = nil
+			}
+
+			if tc.prepare != nil {
+				tc.prepare(t, volumeDir, fake)
+			}
 
 			err := CleanupUnmountedVolumeArtifacts(mounter, volumeDir)
-			if tc.wantErr && err == nil {
-				t.Fatalf("expected error, got nil")
-			}
-			if !tc.wantErr && err != nil {
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tc.errContains != "" && !contains(err.Error(), tc.errContains) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+			} else if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !tc.wantErr || tc.wantDataGone || tc.wantDirGone {
+				// Only assert filesystem outcomes when meaningful.
+			}
+			if tc.name == "nil mounter" || tc.name == "PathExists error when volumeDir parent is a file" || tc.name == "PathExists error for mount path when volumeDir is a file" {
+				return
 			}
 
 			_, dataErr := os.Stat(filepath.Join(volumeDir, volDataFileName))
 			if tc.wantDataGone && !os.IsNotExist(dataErr) {
-				t.Fatalf("expected %s gone, stat err=%v", volDataFileName, dataErr)
+				// Permission cases may leave the file; only assert when we expect success path.
+				if !tc.wantErr {
+					t.Fatalf("expected %s gone, stat err=%v", volDataFileName, dataErr)
+				}
 			}
-			if !tc.wantDataGone && os.IsNotExist(dataErr) {
+			if !tc.wantDataGone && !tc.wantErr && os.IsNotExist(dataErr) {
 				t.Fatalf("expected %s to remain", volDataFileName)
 			}
 
 			_, dirErr := os.Stat(volumeDir)
-			if tc.wantDirGone && !os.IsNotExist(dirErr) {
+			if tc.wantDirGone && !tc.wantErr && !os.IsNotExist(dirErr) {
 				t.Fatalf("expected volume dir gone, stat err=%v", dirErr)
 			}
-			if !tc.wantDirGone && os.IsNotExist(dirErr) {
+			if !tc.wantDirGone && !tc.wantErr && os.IsNotExist(dirErr) {
 				t.Fatalf("expected volume dir to remain")
 			}
+
 			if _, err := os.Stat(filepath.Join(volumeDir, "userdata.txt")); err == nil {
-				// ensure we did not delete arbitrary content when present
+				// preserved if present
 			}
 		})
 	}
+}
+
+func contains(s, sub string) bool {
+	return sub == "" || strings.Contains(s, sub)
 }

--- a/pkg/volume/csi/csi_orphan_cleanup_test.go
+++ b/pkg/volume/csi/csi_orphan_cleanup_test.go
@@ -211,6 +211,26 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "no vol_data empty dir removes dir",
+			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
+				t.Helper()
+				// empty volume dir, no metadata
+			},
+			wantDataGone: true,
+			wantDirGone:  true,
+		},
+		{
+			name: "no vol_data with leftover file keeps dir",
+			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(volumeDir, "userdata.txt"), []byte("keep"), 0640); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantDataGone: true,
+			wantDirGone:  false,
+		},
+		{
 			name: "unreadable vol_data.json removal fails",
 			prepare: func(t *testing.T, volumeDir string, _ *mount.FakeMounter) {
 				t.Helper()

--- a/pkg/volume/csi/csi_orphan_cleanup_test.go
+++ b/pkg/volume/csi/csi_orphan_cleanup_test.go
@@ -254,10 +254,13 @@ func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
 				tc.prepare(t, volumeDir, fake)
 			}
 
-			err := CleanupUnmountedVolumeArtifacts(mounter, volumeDir)
+			cleaned, err := CleanupUnmountedVolumeArtifacts(mounter, volumeDir)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error, got nil")
+				}
+				if cleaned {
+					t.Fatalf("expected cleaned=false on error")
 				}
 				if tc.errContains != "" && !contains(err.Error(), tc.errContains) {
 					t.Fatalf("error %q does not contain %q", err.Error(), tc.errContains)

--- a/pkg/volume/csi/csi_orphan_cleanup_test.go
+++ b/pkg/volume/csi/csi_orphan_cleanup_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/mount-utils"
+)
+
+func TestCleanupUnmountedVolumeArtifacts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		prepare      func(t *testing.T, root string, mounter *mount.FakeMounter)
+		wantDataGone bool
+		wantDirGone  bool
+		wantErr      bool
+	}{
+		{
+			name: "removes vol_data.json when unmounted",
+			prepare: func(t *testing.T, root string, _ *mount.FakeMounter) {
+				t.Helper()
+				if err := os.MkdirAll(filepath.Join(root, "mount"), 0750); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(root, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantDataGone: true,
+			wantDirGone:  true,
+		},
+		{
+			name: "no-op when still mounted",
+			prepare: func(t *testing.T, root string, mounter *mount.FakeMounter) {
+				t.Helper()
+				mountPath := filepath.Join(root, "mount")
+				if err := os.MkdirAll(mountPath, 0750); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(root, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+					t.Fatal(err)
+				}
+				mounter.MountPoints = []mount.MountPoint{{Device: "/dev/sdb", Path: mountPath}}
+			},
+			wantDataGone: false,
+			wantDirGone:  false,
+		},
+		{
+			name: "leaves arbitrary content untouched",
+			prepare: func(t *testing.T, root string, _ *mount.FakeMounter) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(root, volDataFileName), []byte(`{"vol":"x"}`), 0640); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(root, "userdata.txt"), []byte("keep"), 0640); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantDataGone: true,
+			wantDirGone:  false,
+		},
+		{
+			name: "missing volume dir is ok",
+			prepare: func(t *testing.T, root string, _ *mount.FakeMounter) {
+				t.Helper()
+				if err := os.RemoveAll(root); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantDataGone: true,
+			wantDirGone:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			root := t.TempDir()
+			// Use a nested volume dir so we can delete the whole tree in "missing" case.
+			volumeDir := filepath.Join(root, "pvc-test")
+			if err := os.MkdirAll(volumeDir, 0750); err != nil {
+				t.Fatal(err)
+			}
+			mounter := mount.NewFakeMounter(nil)
+			tc.prepare(t, volumeDir, mounter)
+
+			err := CleanupUnmountedVolumeArtifacts(mounter, volumeDir)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			_, dataErr := os.Stat(filepath.Join(volumeDir, volDataFileName))
+			if tc.wantDataGone && !os.IsNotExist(dataErr) {
+				t.Fatalf("expected %s gone, stat err=%v", volDataFileName, dataErr)
+			}
+			if !tc.wantDataGone && os.IsNotExist(dataErr) {
+				t.Fatalf("expected %s to remain", volDataFileName)
+			}
+
+			_, dirErr := os.Stat(volumeDir)
+			if tc.wantDirGone && !os.IsNotExist(dirErr) {
+				t.Fatalf("expected volume dir gone, stat err=%v", dirErr)
+			}
+			if !tc.wantDirGone && os.IsNotExist(dirErr) {
+				t.Fatalf("expected volume dir to remain")
+			}
+			if _, err := os.Stat(filepath.Join(volumeDir, "userdata.txt")); err == nil {
+				// ensure we did not delete arbitrary content when present
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig storage

#### What this PR does / why we need it

After a hard node reboot, CSI mount points under the pod volumes tree are usually gone, but the CSI metadata file often remains:

`.../volumes/kubernetes.io~csi/<volume>/vol_data.json`

Orphaned pod volume cleanup deliberately walks that tree with rmdir only (see `removeall.RemoveDirsOneFilesystem` and the data safety work around #102576). That is intentional so we never recursively delete through a real mount. The downside is that a leftover regular file makes rmdir fail forever with "not a directory", so the orphaned pod directory never goes away and the kubelet keeps logging the same error.

This change removes that residual CSI metadata only when it is safe:

1. Called from `removeOrphanedPodVolumeDirs` only after `cleanupOrphanedPodDirs` has already seen `podVolumesExist == false`. That is the same gate that protects reconstruction and NodeUnstage work. Do not call this helper from other paths without that check.
2. Uses `mounter.IsMountPoint` on the CSI mount path (bind mount aware on Linux). If the path is still a mount, we leave metadata alone.
3. If the mount path exists but is not a mount, we try to remove the empty mount directory first. If that fails (for example non empty content), we leave `vol_data.json` in place and return an error.
4. Only the well known CSI metadata file `vol_data.json` is deleted. Arbitrary files under the volume directory are never removed.
5. Scope is filesystem CSI pod volume dirs under `volumes/kubernetes.io~csi/`. Global plugin staging/publish paths and block `volumeDevices` layouts are out of scope.

Helper lives in `pkg/volume/csi` (`CleanupUnmountedVolumeArtifacts`). Kubelet iterates CSI volume dirs for the orphaned pod and logs at V(4) only when metadata was actually removed (`cleaned == true`).

#### Which issue(s) this PR fixes

Fixes #105536

#### Special notes for your reviewer

I kept the rmdir only volumes cleanup path intact. This is a narrow pre step that matches what CSI unmount already does for `vol_data.json`, just applied when the pod is already orphaned and volumes are known unmounted.

Safety notes worth double checking:

1. `podVolumesExist` gate is required. Without it, deleting `vol_data.json` too early can break reconstruction / unstage after reboot.
2. Prefer `IsMountPoint` over only `IsLikelyNotMountPoint` so bind mounts are not treated as plain directories.
3. Logging uses the `cleaned` return value so we do not claim success when there was nothing to remove.

#### Does this PR introduce a user facing change?

```release-note
NONE
```

#### Additional documentation e.g. KEPs (optional)

None

#### Test plan

Local verification on WSL Linux:

1. Full unit suite for `pkg/volume/csi` (pass, 307 tests)
2. Full unit suite for `pkg/kubelet` (pass, 707 tests)
3. Focused coverage run for `TestCleanupUnmountedVolumeArtifacts` (helper at 100% on covered statements)

Unit coverage includes:

1. Residual `vol_data.json` with empty unmounted mount dir is removed and empty dirs collapse
2. Still mounted volume is a no op (metadata kept)
3. Non empty mount path blocks metadata deletion and returns error
4. Mount check failures, PathExists failures, nil mounter
5. Arbitrary userdata next to metadata is preserved
6. Missing plugin dir, plugin path as file, file entries under plugin dir
7. Integration through `cleanupOrphanedPodDirs` on Linux (`pkg/kubelet/kubelet_volumes_linux_test.go`)

Not run here: full e2e suite or full tree verify. Happy to follow up if reviewers want a targeted storage e2e.
