### PR TITLE
Automated cherry pick of #139162: Fix case where preemptor may be stuck in unschedulable queue
#139330: Unset WasFlushedFromUnschedulable for gated pods
#139331: Make sure gated pods are flushed with the same frequency as non-gated

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -693,6 +693,9 @@ func (p *PriorityQueue) moveToActiveQ(logger klog.Logger, pInfo *framework.Queue
 			if p.unschedulablePods.get(pInfo.Pod) == nil {
 				logger.V(5).Info("Pod moved to an internal scheduling queue, because the pod is gated", "pod", klog.KObj(pInfo.Pod), "event", event, "queue", unschedulableQ)
 			}
+			// Clearing WasFlushedFromUnschedulable is typically done on scheduling failure, but in case the flushed pod was gated, it never attempts scheduling.
+			// We clear it here to ensure it's not set the next time the pod is woken up by a non-flush event.
+			pInfo.WasFlushedFromUnschedulable = false
 			p.unschedulablePods.addOrUpdate(pInfo, gatedBefore, event)
 			return
 		}
@@ -726,6 +729,9 @@ func (p *PriorityQueue) moveToBackoffQ(logger klog.Logger, pInfo *framework.Queu
 			if p.unschedulablePods.get(pInfo.Pod) == nil {
 				logger.V(5).Info("Pod moved to an internal scheduling queue", "pod", klog.KObj(pInfo.Pod), "event", event, "queue", unschedulableQ)
 			}
+			// Clearing WasFlushedFromUnschedulable is typically done on scheduling failure, but in case the flushed pod was gated, it never attempts scheduling.
+			// We clear it here to ensure it's not set the next time the pod is woken up by a non-flush event.
+			pInfo.WasFlushedFromUnschedulable = false
 			p.unschedulablePods.addOrUpdate(pInfo, gatedBefore, event)
 			return false
 		}

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1313,7 +1313,10 @@ func (p *PriorityQueue) movePodsToActiveOrBackoffQueue(logger klog.Logger, podIn
 
 	activated := false
 	for _, pInfo := range podInfoList {
-		if pInfo.Gated() && !framework.MatchAnyClusterEvent(event, pInfo.GatingPluginEvents) {
+		// As an optimization, we avoid re-evaluating gated pods for events unrelated to their gating plugin.
+		// However, wildcard events (e.g., periodic flushes) always trigger re-evaluation to ensure pods don't
+		// get stuck due to incomplete or incorrect queueing hints.
+		if pInfo.Gated() && !framework.ClusterEventIsWildCard(event) && !framework.MatchAnyClusterEvent(event, pInfo.GatingPluginEvents) {
 			// This event doesn't interest the gating plugin of this Pod,
 			// which means this event never moves this Pod to activeQ.
 			continue

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -943,6 +943,7 @@ func (p *PriorityQueue) AddUnschedulableIfNotPresent(logger klog.Logger, pInfo *
 	pInfo.BackoffExpiration = time.Time{}
 	// Clear the flush flag since the pod is returning to the queue after a scheduling attempt.
 	pInfo.WasFlushedFromUnschedulable = false
+	pInfo.FlushTimestamp = time.Time{}
 
 	if !p.isSchedulingQueueHintEnabled {
 		// fall back to the old behavior which doesn't depend on the queueing hint.
@@ -996,9 +997,13 @@ func (p *PriorityQueue) flushUnschedulablePodsLeftover(logger klog.Logger) {
 	currentTime := p.clock.Now()
 	for _, pInfo := range p.unschedulablePods.podInfoMap {
 		lastScheduleTime := pInfo.Timestamp
+		if flushTime := pInfo.GetFlushTimestamp(); flushTime.After(lastScheduleTime) {
+			lastScheduleTime = flushTime
+		}
 		if currentTime.Sub(lastScheduleTime) > p.podMaxInUnschedulablePodsDuration {
 			// Mark this pod as flushed so we can detect if it schedules soon after
 			pInfo.WasFlushedFromUnschedulable = true
+			pInfo.SetFlushTimestamp(currentTime)
 			podsToMove = append(podsToMove, pInfo)
 		}
 	}

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -2053,12 +2053,15 @@ func BenchmarkMoveAllToActiveOrBackoffQueue(b *testing.B) {
 func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithQueueingHint(t *testing.T) {
 	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	p := st.MakePod().Name("pod1").Namespace("ns1").UID("1").Label("foo", "bar").Obj()
+	gatedPod := st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()
 	tests := []struct {
 		name    string
 		podInfo *framework.QueuedPodInfo
 		hint    fwk.QueueingHintFn
 		// duration is the duration that the Pod has been in the unschedulable queue.
 		duration time.Duration
+		// triggerEvent is the event to trigger the move. If unset, defaults to nodeAdd.
+		triggerEvent *fwk.ClusterEvent
 		// expectedQ is the queue name (activeQ, backoffQ, or unschedulablePods) that this Pod should be quened to.
 		expectedQ string
 	}{
@@ -2090,6 +2093,33 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithQueueingHint(t *testing.
 			name:      "Skip queues pod to unschedulablePods",
 			podInfo:   &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(p), UnschedulablePlugins: sets.New("foo")},
 			hint:      queueHintReturnSkip,
+			expectedQ: unschedulableQ,
+		},
+		{
+			name:         "Queue queues pod to backoffQ if Pod is not gated and the event is wildcard",
+			podInfo:      &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(p), UnschedulablePlugins: sets.New("foo")},
+			triggerEvent: &framework.EventUnschedulableTimeout,
+			hint: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+				return fwk.Queue, fmt.Errorf("QueueingHintFn should not be called as trigger event is wildcard")
+			},
+			expectedQ: backoffQ,
+		},
+		{
+			name:         "Queue queues pod to backoffQ when Pod is no longer gated and the event is wildcard",
+			podInfo:      setQueuedPodInfoGated(&framework.QueuedPodInfo{PodInfo: mustNewPodInfo(p)}, "foo", []fwk.ClusterEvent{framework.EventUnscheduledPodUpdate}),
+			triggerEvent: &framework.EventUnschedulableTimeout,
+			hint: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+				return fwk.Queue, fmt.Errorf("QueueingHintFn should not be called as trigger event is wildcard")
+			},
+			expectedQ: backoffQ,
+		},
+		{
+			name:         "Queue queues pod to unschedulableQ when Pod is gated and the event is wildcard",
+			podInfo:      setQueuedPodInfoGated(&framework.QueuedPodInfo{PodInfo: mustNewPodInfo(gatedPod)}, "foo", []fwk.ClusterEvent{framework.EventUnscheduledPodUpdate}),
+			triggerEvent: &framework.EventUnschedulableTimeout,
+			hint: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+				return fwk.Queue, fmt.Errorf("QueueingHintFn should not be called as trigger event is wildcard")
+			},
 			expectedQ: unschedulableQ,
 		},
 		{
@@ -2137,19 +2167,29 @@ func TestPriorityQueue_MoveAllToActiveOrBackoffQueueWithQueueingHint(t *testing.
 			}}
 			q := NewTestQueue(ctx, newDefaultQueueSort(), WithQueueingHintMapPerProfile(m), WithClock(cl), WithPreEnqueuePluginMap(preEnqM))
 			q.Add(ctx, test.podInfo.Pod)
-			if p, err := q.Pop(logger); err != nil {
-				t.Errorf("Pop failed: %v", err)
-			} else if diff := cmp.Diff(test.podInfo.Pod, p.Pod); diff != "" {
-				t.Errorf("Unexpected pod after Pop (-want, +got):\n%s", diff)
-			}
-			// add to unsched pod pool
-			err := q.AddUnschedulableIfNotPresent(logger, test.podInfo, q.SchedulingCycle())
-			if err != nil {
-				t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+			if q.activeQ.len() > 0 {
+				if p, err := q.Pop(logger); err != nil {
+					t.Errorf("Pop failed: %v", err)
+				} else if diff := cmp.Diff(test.podInfo.Pod, p.Pod); diff != "" {
+					t.Errorf("Unexpected pod after Pop (-want, +got):\n%s", diff)
+				}
+				// add to unsched pod pool
+				err := q.AddUnschedulableIfNotPresent(logger, test.podInfo, q.SchedulingCycle())
+				if err != nil {
+					t.Fatalf("unexpected error from AddUnschedulableIfNotPresent: %v", err)
+				}
+			} else {
+				// The pod was already moved to unschedulablePods because it's gated.
+				// Update it with the test's configured podInfo to ensure custom test fields are set.
+				q.unschedulablePods.addOrUpdate(test.podInfo, test.podInfo.Gated(), "test-setup")
 			}
 			cl.Step(test.duration)
 
-			q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, nil, nil)
+			event := nodeAdd
+			if test.triggerEvent != nil {
+				event = *test.triggerEvent
+			}
+			q.MoveAllToActiveOrBackoffQueue(logger, event, nil, nil, nil)
 
 			if q.backoffQ.len() == 0 && test.expectedQ == backoffQ {
 				t.Fatalf("expected pod to be queued to backoffQ, but it was not")

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -3303,6 +3303,137 @@ func TestFlushUnschedulablePodsLeftoverSetsFlag(t *testing.T) {
 	}
 }
 
+func TestFlushUnschedulablePodsLeftoverSetsFlag_GatedPod(t *testing.T) {
+	tests := []struct {
+		name                            string
+		gatedBeforeFlush                bool
+		gatedAfterFlush                 bool
+		backingOff                      bool
+		wantWasFlushedFromUnschedulable bool
+		wantQ                           string
+	}{
+		{
+			name:                            "flag is set when pod is not gated",
+			wantWasFlushedFromUnschedulable: true,
+			wantQ:                           activeQ,
+		},
+		{
+			name:                            "flag is set when pod is no longer gated",
+			gatedBeforeFlush:                true,
+			wantWasFlushedFromUnschedulable: true,
+			wantQ:                           activeQ,
+		},
+		{
+			name:                            "flag is unset when pod is newly gated",
+			gatedAfterFlush:                 true,
+			wantWasFlushedFromUnschedulable: false,
+			wantQ:                           unschedulableQ,
+		},
+		{
+			name:                            "flag is unset when pod is still gated",
+			gatedBeforeFlush:                true,
+			gatedAfterFlush:                 true,
+			wantWasFlushedFromUnschedulable: false,
+			wantQ:                           unschedulableQ,
+		},
+		{
+			name:                            "flag is set when pod is not gated and backoff is not complete",
+			backingOff:                      true,
+			wantWasFlushedFromUnschedulable: true,
+			wantQ:                           backoffQ,
+		},
+		{
+			name:                            "flag is set when pod is no longer gated and backoff is not complete",
+			gatedBeforeFlush:                true,
+			backingOff:                      true,
+			wantWasFlushedFromUnschedulable: true,
+			wantQ:                           backoffQ,
+		},
+		{
+			name:                            "flag is unset when pod is newly gated and backoff is not complete",
+			gatedAfterFlush:                 true,
+			backingOff:                      true,
+			wantWasFlushedFromUnschedulable: false,
+			wantQ:                           unschedulableQ,
+		},
+		{
+			name:                            "flag is unset when pod is still gated and backoff is not complete",
+			gatedBeforeFlush:                true,
+			gatedAfterFlush:                 true,
+			backingOff:                      true,
+			wantWasFlushedFromUnschedulable: false,
+			wantQ:                           unschedulableQ,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const allowedLabel = "allow"
+			const preEnqueuePluginName = "preEnqueuePlugin"
+
+			var backoffDuration time.Duration
+			if tt.backingOff {
+				backoffDuration = DefaultPodMaxInUnschedulablePodsDuration + time.Minute
+			}
+
+			c := testingclock.NewFakeClock(time.Now())
+			m := makeEmptyQueueingHintMapPerProfile()
+			preEnqM := map[string]map[string]fwk.PreEnqueuePlugin{
+				"": {
+					preEnqueuePluginName: &preEnqueuePlugin{allowlists: []string{allowedLabel}},
+				},
+			}
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithQueueingHintMapPerProfile(m), WithPreEnqueuePluginMap(preEnqM),
+				WithPodInitialBackoffDuration(backoffDuration), WithPodMaxBackoffDuration(backoffDuration))
+
+			pod := st.MakePod().Name("pod1").Namespace("ns1").UID("1").Label(allowedLabel, "").Obj()
+			podInfo := &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(pod), UnschedulablePlugins: sets.New("foo")}
+			if tt.gatedBeforeFlush {
+				podInfo = setQueuedPodInfoGated(podInfo, preEnqueuePluginName, []fwk.ClusterEvent{})
+			}
+
+			q.Add(ctx, podInfo.Pod)
+			_, err := q.Pop(logger)
+			if err != nil {
+				t.Fatalf("Failed to pop from active queue: %v", err)
+			}
+
+			if tt.gatedAfterFlush {
+				delete(pod.Labels, allowedLabel)
+			}
+
+			err = q.AddUnschedulableIfNotPresent(logger, podInfo, q.SchedulingCycle())
+			if err != nil {
+				t.Fatalf("Failed to add pod to unschedulable: %v", err)
+			}
+
+			// Advance time past the flush duration and flush
+			c.Step(DefaultPodMaxInUnschedulablePodsDuration + time.Second)
+			q.flushUnschedulablePodsLeftover(logger)
+
+			queueSizes := map[string]int{
+				unschedulableQ: len(q.UnschedulablePods()),
+				backoffQ:       len(q.PodsInBackoffQ()),
+				activeQ:        len(q.PodsInActiveQ()),
+			}
+
+			if queueSizes[tt.wantQ] == 0 {
+				t.Errorf("Pod not found in %s", tt.wantQ)
+			}
+			actualPod, ok := q.GetPod(podInfo.Pod.Name, podInfo.Pod.Namespace)
+			if !ok {
+				t.Fatalf("Pod not found in scheduling queue")
+			}
+			if actualPod.WasFlushedFromUnschedulable != tt.wantWasFlushedFromUnschedulable {
+				t.Errorf("Unexpected WasFlushedFromUnschedulable value: %v", actualPod.WasFlushedFromUnschedulable)
+			}
+		})
+	}
+}
+
 func TestPriorityQueue_initPodMaxInUnschedulablePodsDuration(t *testing.T) {
 	pod1 := st.MakePod().Name("test-pod-1").Namespace("ns1").UID("tp-1").NominatedNodeName("node1").Obj()
 	pod2 := st.MakePod().Name("test-pod-2").Namespace("ns2").UID("tp-2").NominatedNodeName("node2").Obj()

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -3434,6 +3434,79 @@ func TestFlushUnschedulablePodsLeftoverSetsFlag_GatedPod(t *testing.T) {
 	}
 }
 
+// TestGatedPodFlushFrequency verifies that a gated pod is only flushed once every
+// podMaxInUnschedulablePodsDuration, and not on every periodic flush execution.
+func TestGatedPodFlushFrequency(t *testing.T) {
+	gatedPod := mustNewPodInfo(st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj())
+
+	podInfo := &framework.QueuedPodInfo{
+		PodInfo:              gatedPod,
+		UnschedulablePlugins: sets.New("foo"),
+	}
+
+	c := testingclock.NewFakeClock(time.Now())
+	m := makeEmptyQueueingHintMapPerProfile()
+	preEnqueuePluginName := "preEnqueuePlugin"
+	preEnqM := map[string]map[string]fwk.PreEnqueuePlugin{
+		"": {
+			preEnqueuePluginName: &preEnqueuePlugin{}, // Empty allowlist, gates all pods
+		},
+	}
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Use a user-defined 5-minute duration for clarity
+	flushDuration := 5 * time.Minute
+	q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c), WithQueueingHintMapPerProfile(m), WithPreEnqueuePluginMap(preEnqM),
+		WithPodMaxInUnschedulablePodsDuration(flushDuration))
+
+	getPodFromAnyQueue := func() *framework.QueuedPodInfo {
+		pInfo, ok := q.GetPod(podInfo.Pod.Name, podInfo.Pod.Namespace)
+		if !ok {
+			t.Fatalf("Failed to find pod in any queue")
+		}
+		return pInfo
+	}
+
+	// Add gated pod directly to unschedulablePods
+	q.unschedulablePods.addOrUpdate(podInfo, false, "test-setup")
+
+	// Step clock past the flush duration and trigger flush
+	// (T=5:01)
+	c.Step(flushDuration + time.Second)
+
+	q.flushUnschedulablePodsLeftover(logger)
+
+	actualPod := getPodFromAnyQueue()
+	// Verify that flush happened
+	firstFlushTime := actualPod.GetFlushTimestamp()
+	if firstFlushTime.IsZero() {
+		t.Errorf("Expected FlushTimestamp to be set after the first leftover flush")
+	}
+
+	// Step clock by less than the flush duration and trigger flush
+	// T=9:01
+	c.Step(4 * time.Minute)
+	q.flushUnschedulablePodsLeftover(logger)
+
+	actualPod = getPodFromAnyQueue()
+	if actualPod.GetFlushTimestamp() != firstFlushTime {
+		t.Errorf("Expected FlushTimestamp to remain %v, but was updated to %v (pod was flushed prematurely)", firstFlushTime, actualPod.GetFlushTimestamp())
+	}
+
+	// Step clock past the duration since the last flush
+	// T=10:02
+	c.Step(time.Minute + time.Second)
+	q.flushUnschedulablePodsLeftover(logger)
+
+	actualPod = getPodFromAnyQueue()
+	// Verify that flush happened
+	if !actualPod.GetFlushTimestamp().After(firstFlushTime) {
+		t.Errorf("Expected FlushTimestamp to be updated to a newer time after 5 minutes elapsed, but remained %v", actualPod.GetFlushTimestamp())
+	}
+}
+
 func TestPriorityQueue_initPodMaxInUnschedulablePodsDuration(t *testing.T) {
 	pod1 := st.MakePod().Name("test-pod-1").Namespace("ns1").UID("tp-1").NominatedNodeName("node1").Obj()
 	pod2 := st.MakePod().Name("test-pod-2").Namespace("ns2").UID("tp-2").NominatedNodeName("node2").Obj()
@@ -3480,6 +3553,8 @@ func TestPriorityQueue_initPodMaxInUnschedulablePodsDuration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			pInfo1.FlushTimestamp = time.Time{}
+			pInfo2.FlushTimestamp = time.Time{}
 			tCtx := ktesting.Init(t)
 			logger := klog.FromContext(tCtx)
 			var queue *PriorityQueue

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -587,6 +587,8 @@ type QueuedPodInfo struct {
 	// indicate queueing hint misconfigurations or event handling bugs.
 	// This flag is cleared when the pod returns to the queue for any reason.
 	WasFlushedFromUnschedulable bool
+	// FlushTimestamp tracks the last time this pod was flushed from the unschedulable queue.
+	FlushTimestamp time.Time
 	// The time when the pod is added to the queue for the first time. The pod may be added
 	// back to the queue multiple times before it's successfully scheduled.
 	// It shouldn't be updated once initialized. It's used to record the e2e scheduling
@@ -659,11 +661,16 @@ func (pqi *QueuedPodInfo) Gated() bool {
 	return pqi.GatingPlugin != ""
 }
 
+func (qp *QueuedPodInfo) GetFlushTimestamp() time.Time {
+	return qp.FlushTimestamp
+}
+
 // DeepCopy returns a deep copy of the QueuedPodInfo object.
 func (pqi *QueuedPodInfo) DeepCopy() *QueuedPodInfo {
 	return &QueuedPodInfo{
 		PodInfo:                 pqi.PodInfo.DeepCopy(),
 		Timestamp:               pqi.Timestamp,
+		FlushTimestamp:          pqi.FlushTimestamp,
 		Attempts:                pqi.Attempts,
 		UnschedulableCount:      pqi.UnschedulableCount,
 		InitialAttemptTimestamp: pqi.InitialAttemptTimestamp,
@@ -691,6 +698,10 @@ func (pqi *QueuedPodInfo) ClearRejectorPlugins() {
 	pqi.PendingPlugins.Clear()
 	pqi.GatingPlugin = ""
 	pqi.GatingPluginEvents = nil
+}
+
+func (pqi *QueuedPodInfo) SetFlushTimestamp(t time.Time) {
+	pqi.FlushTimestamp = t
 }
 
 // QueuedPodGroupInfo is a PodGroupInfo wrapper with additional information related to

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -445,6 +445,8 @@ type Plugin interface {
 type PreEnqueuePlugin interface {
 	Plugin
 	// PreEnqueue is called prior to adding Pods to activeQ or backoffQ.
+	// An unsuccessful status marks the pod as gated and moves it to unschedulableQ.
+	// Gated pods are only re-evaluated on events registered by the gating plugin or wildcard events.
 	PreEnqueue(ctx context.Context, p *v1.Pod) *Status
 }
 

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	configtesting "k8s.io/kubernetes/pkg/scheduler/apis/config/testing"
 	"k8s.io/kubernetes/pkg/scheduler/backend/queue"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpreemption"
 	plfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
@@ -486,6 +487,7 @@ func TestPreemption(t *testing.T) {
 func TestAsyncPreemption(t *testing.T) {
 	const podBlockedInBindingName = "pod-blocked-in-binding"
 	const reservingPodName = "reserving-pod"
+	const blockingPodName = "blocking-pod"
 
 	type createPod struct {
 		pod *v1.Pod
@@ -533,6 +535,11 @@ func TestAsyncPreemption(t *testing.T) {
 		// verifyPodInUnschedulable waits for some time and confirms that the given pod is in the unschedulable pool.
 		// The value is the name of the checked pod.
 		verifyPodInUnschedulable string
+		// flushUnschedulable flushes the unschedulable queue.
+		flushUnschedulable bool
+		// waitForPodsDeleted waits for the specified pods to be deleted from the cluster.
+		// The value is the array of Pod indexes representing the order of Pod creation.
+		waitForPodsDeleted []int
 	}
 
 	tests := []struct {
@@ -1058,6 +1065,62 @@ func TestAsyncPreemption(t *testing.T) {
 			},
 		},
 		{
+			name: "gated preemptor is eventually scheduled even if victim deletion doesn't raise queue hints",
+			scenarios: []scenario{
+				{
+					name: "create victim pods",
+					createPod: &createPod{
+						pod:   st.MakePod().GenerateName(fmt.Sprintf("victim-%s-", blockingPodName)).Node("node").Priority(1).Container("image").ZeroTerminationGracePeriod().Obj(),
+						count: new(2),
+					},
+				},
+				{
+					name: "create preemptor",
+					createPod: &createPod{
+						pod: st.MakePod().Name("preemptor").Priority(100).Container("image").Obj(),
+					},
+				},
+				{
+					name: "schedule preemptor",
+					schedulePod: &schedulePod{
+						podName:             "preemptor",
+						expectUnschedulable: true,
+					},
+				},
+				{
+					name:                 "verify preemptor running preemption",
+					podRunningPreemption: new(2),
+				},
+				{
+					name:            "gate preemptor",
+					podGatedInQueue: "preemptor",
+				},
+				{
+					name:               "complete preemption",
+					completePreemption: "preemptor",
+				},
+				{
+					name:               "wait for victims to be deleted",
+					waitForPodsDeleted: []int{0, 1},
+				},
+				{
+					name:                     "verify preemptor is still in unschedulable queue",
+					verifyPodInUnschedulable: "preemptor",
+				},
+				{
+					name:               "flush scheduling queue",
+					flushUnschedulable: true,
+				},
+				{
+					name: "verify preemptor scheduled",
+					schedulePod: &schedulePod{
+						podName:       "preemptor",
+						expectSuccess: true,
+					},
+				},
+			},
+		},
+		{
 			// This scenario verifies the fix for https://github.com/kubernetes/kubernetes/issues/134217
 			// Scenario reproduces the issue, but with a victim that is under graceful termination and sis reserving some resources required by the preemptor:
 			// Victim pod takes long in binding. Preemptor pod attempts preemption, goes to unschedulable, then the victim's graceful termination is initiated.
@@ -1299,6 +1362,19 @@ func TestAsyncPreemption(t *testing.T) {
 					t.Fatalf("Error registering a reserving plugin: %v", err)
 				}
 
+				// Register fake plugin that will filter nodes with a specific name.
+				// Importantly, this plugin always returns QueueSkip as the queue hint, simulating faulty queue hint implementation.
+				queueSkipFilterPluginName := "queueSkipFilterPlugin"
+				err = registry.Register(queueSkipFilterPluginName, func(ctx context.Context, o runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
+					return &queueSkipFilterPlugin{
+						name:              queueSkipFilterPluginName,
+						nameOfBlockingPod: blockingPodName,
+					}, nil
+				})
+				if err != nil {
+					t.Fatalf("Error registering a queueSkipFilterPlugin plugin: %v", err)
+				}
+
 				cfg := configtesting.V1ToInternalWithDefaults(t, configv1.KubeSchedulerConfiguration{
 					Profiles: []configv1.KubeSchedulerProfile{{
 						SchedulerName: ptr.To(v1.DefaultSchedulerName),
@@ -1308,6 +1384,7 @@ func TestAsyncPreemption(t *testing.T) {
 									{Name: blockingBindPluginName},
 									{Name: delayedPreemptionPluginName},
 									{Name: reservingPluginName},
+									{Name: queueSkipFilterPluginName},
 								},
 								Disabled: []configv1.Plugin{
 									{Name: names.DefaultPreemption},
@@ -1447,6 +1524,9 @@ func TestAsyncPreemption(t *testing.T) {
 						if !podInUnschedulablePodPool(t, testCtx.Scheduler.SchedulingQueue, scenario.podGatedInQueue) {
 							t.Fatalf("Expected the pod %s to be in the queue even after the activation", scenario.podGatedInQueue)
 						}
+						if pInfo, _ := testCtx.Scheduler.SchedulingQueue.GetPod(scenario.podGatedInQueue, testCtx.NS.Name); pInfo == nil || !pInfo.Gated() {
+							t.Fatalf("Expected the pod %s to be gated", scenario.podGatedInQueue)
+						}
 					case scenario.podRunningPreemption != nil:
 						if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 							return preemptionPlugin.Executor.IsPodRunningPreemption(createdPods[*scenario.podRunningPreemption].GetUID()), nil
@@ -1466,6 +1546,15 @@ func TestAsyncPreemption(t *testing.T) {
 							// If timeout was reached or context was cancelled without finding that vanished from unschedulable, it means the state is as expected.
 							// If a different error occurred, it means that the pod got unexpectedly activated, or something else went wrong.
 							t.Fatalf("Error in scenario verifyPodInUnschedulable: %v", err)
+						}
+					case scenario.flushUnschedulable:
+						testCtx.Scheduler.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+					case len(scenario.waitForPodsDeleted) != 0:
+						for _, podIndex := range scenario.waitForPodsDeleted {
+							podName := createdPods[podIndex].Name
+							if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodDeleted(testCtx.Ctx, cs, testCtx.NS.Name, podName)); err != nil {
+								t.Fatalf("Failed to wait for pod %s to be deleted: %v", podName, err)
+							}
 						}
 					}
 				}
@@ -1504,6 +1593,38 @@ func unschedulablePod(t *testing.T, queue queue.SchedulingQueue, podName string)
 	}
 	return nil
 }
+
+type queueSkipFilterPlugin struct {
+	name              string
+	nameOfBlockingPod string
+}
+
+func (fp *queueSkipFilterPlugin) EventsToRegister(context.Context) ([]fwk.ClusterEventWithHint, error) {
+	return []fwk.ClusterEventWithHint{
+		{
+			Event: fwk.ClusterEvent{Resource: fwk.Pod, ActionType: fwk.Delete},
+			QueueingHintFn: func(_ klog.Logger, _ *v1.Pod, _, _ interface{}) (fwk.QueueingHint, error) {
+				return fwk.QueueSkip, nil
+			},
+		},
+	}, nil
+}
+
+func (fp *queueSkipFilterPlugin) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
+	for _, scheduledPod := range nodeInfo.GetPods() {
+		if strings.Contains(scheduledPod.GetPod().Name, fp.nameOfBlockingPod) {
+			return fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("node %s has blocking pod %s", nodeInfo.Node().Name, scheduledPod.GetPod().Name))
+		}
+	}
+	return nil
+}
+
+func (fp *queueSkipFilterPlugin) Name() string {
+	return fp.name
+}
+
+var _ fwk.FilterPlugin = &queueSkipFilterPlugin{}
+var _ fwk.EnqueueExtensions = &queueSkipFilterPlugin{}
 
 // blockingBindPlugin is a fake plugin that simulates a long binding operation.
 // Underneath it calls realPlugin.Bind(), after receiving a signal that binding can be unblocked.


### PR DESCRIPTION
Cherry pick of #139162 #139330 #139331 on release-1.36.

#139162: Fix case where preemptor may be stuck in unschedulable queue
#139330: Unset WasFlushedFromUnschedulable for gated pods
#139331: Make sure gated pods are flushed with the same frequency as non-gated

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Fixed a race condition in preemption, where a preemptor pod could get stuck in unschedulable state.
NONE
NONE
```