### PR TITLE
ttlafterfinished: use contextual informer logging

### DIFF
--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -87,14 +87,15 @@ func New(ctx context.Context, jobInformer batchinformers.JobInformer, client cli
 	}
 
 	logger := klog.FromContext(ctx)
-	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := jobInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			tc.addJob(logger, obj)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			tc.updateJob(logger, oldObj, newObj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
+	utilruntime.Must(err)
 
 	tc.jLister = jobInformer.Lister()
 	tc.jListerSynced = jobInformer.Informer().HasSynced


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig apps
/wg structured-logging

#### What this PR does / why we need it:

Passes the TTL-after-finished controller's contextual logger to its Job informer event handler registration. This lets informer internals use the controller's logger instead of a background logger.

#### Which issue(s) this PR is related to:

Related to #126379

#### Special notes for your reviewer:

Local validation:
- `make test WHAT=./pkg/controller/ttlafterfinished GOFLAGS=-v`
- `./hack/verify-gofmt.sh`
- `./hack/verify-golangci-lint.sh -r upstream/master ./pkg/controller/ttlafterfinished/...`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```
