### PR TITLE
Use assumecache in the PV controller to fix storeObjectUpdate races

### DIFF
--- a/pkg/controller/volume/persistentvolume/delete_test.go
+++ b/pkg/controller/volume/persistentvolume/delete_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	storage "k8s.io/api/storage/v1"
 	"k8s.io/component-helpers/storage/volume"
@@ -124,7 +125,7 @@ func TestDeleteSync(t *testing.T) {
 				// happen)
 				claim := newClaim("claim8-7", "uid8-7", "10Gi", "volume8-7", v1.ClaimBound, nil)
 				reactor.AddClaimBoundToVolume(claim)
-				ctrl.claims.Add(claim)
+				require.NoError(t, ctrl.claims.Indexer().Add(claim))
 			}),
 		},
 		{

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/klog/v2"
 
 	v1 "k8s.io/api/core/v1"
@@ -768,13 +769,13 @@ func runSyncTests(t *testing.T, ctx context.Context, tests []controllerTest, sto
 			if metav1.HasAnnotation(claim.ObjectMeta, annSkipLocalStore) {
 				continue
 			}
-			ctrl.claims.Add(claim)
+			require.NoError(t, ctrl.claims.Indexer().Add(claim))
 		}
 		for _, volume := range test.initialVolumes {
 			if metav1.HasAnnotation(volume.ObjectMeta, annSkipLocalStore) {
 				continue
 			}
-			ctrl.volumes.store.Add(volume)
+			require.NoError(t, ctrl.volumes.Indexer().Add(volume))
 		}
 		reactor.AddClaims(test.initialClaims)
 		reactor.AddVolumes(test.initialVolumes)
@@ -851,10 +852,10 @@ func runMultisyncTests(t *testing.T, ctx context.Context, tests []controllerTest
 
 		reactor := newVolumeReactor(ctx, client, ctrl, nil, nil, test.errors)
 		for _, claim := range test.initialClaims {
-			ctrl.claims.Add(claim)
+			require.NoError(t, ctrl.claims.Indexer().Add(claim))
 		}
 		for _, volume := range test.initialVolumes {
-			ctrl.volumes.store.Add(volume)
+			require.NoError(t, ctrl.volumes.Indexer().Add(volume))
 		}
 		reactor.AddClaims(test.initialClaims)
 		reactor.AddVolumes(test.initialVolumes)
@@ -901,12 +902,11 @@ func runMultisyncTests(t *testing.T, ctx context.Context, tests []controllerTest
 			time.Sleep(600 * time.Millisecond)
 
 			// There were some changes, process them
-			switch obj.(type) {
+			switch obj := obj.(type) {
 			case *v1.PersistentVolumeClaim:
-				claim := obj.(*v1.PersistentVolumeClaim)
 				// Simulate "claim updated" event
-				ctrl.claims.Update(claim)
-				err = ctrl.syncClaim(context.TODO(), claim)
+				require.NoError(t, ctrl.claims.Indexer().Update(obj))
+				err = ctrl.syncClaim(context.TODO(), obj)
 				if err != nil {
 					if err == pvtesting.ErrVersionConflict {
 						// Ignore version errors
@@ -920,10 +920,9 @@ func runMultisyncTests(t *testing.T, ctx context.Context, tests []controllerTest
 				// Process generated changes
 				continue
 			case *v1.PersistentVolume:
-				volume := obj.(*v1.PersistentVolume)
 				// Simulate "volume updated" event
-				ctrl.volumes.store.Update(volume)
-				err = ctrl.syncVolume(context.TODO(), volume)
+				require.NoError(t, ctrl.volumes.Indexer().Update(obj))
+				err = ctrl.syncVolume(context.TODO(), obj)
 				if err != nil {
 					if err == pvtesting.ErrVersionConflict {
 						// Ignore version errors

--- a/pkg/controller/volume/persistentvolume/index.go
+++ b/pkg/controller/volume/persistentvolume/index.go
@@ -22,21 +22,21 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/component-helpers/storage/volume"
+	"k8s.io/component-helpers/storage/volume/assumecache"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume/util"
 )
 
-// persistentVolumeOrderedIndex is a cache.Store that keeps persistent volumes
-// indexed by AccessModes and ordered by storage capacity.
-type persistentVolumeOrderedIndex struct {
-	store cache.Indexer
-}
+const accessModesIndex = "accessmodes"
 
-func newPersistentVolumeOrderedIndex() persistentVolumeOrderedIndex {
-	return persistentVolumeOrderedIndex{cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{"accessmodes": accessModesIndexFunc})}
+// persistentVolumeOrderedIndex keeps persistent volumes indexed by AccessModes
+// and ordered by storage capacity. It is backed by an assume cache layered on
+// top of the PV shared informer, so lookups observe the controller's own writes
+// before the informer delivers them.
+type persistentVolumeOrderedIndex struct {
+	*assumecache.AssumeCache[*v1.PersistentVolume]
 }
 
 // accessModesIndexFunc is an indexing function that returns a persistent
@@ -52,23 +52,7 @@ func accessModesIndexFunc(obj interface{}) ([]string, error) {
 // listByAccessModes returns all volumes with the given set of
 // AccessModeTypes. The list is unsorted!
 func (pvIndex *persistentVolumeOrderedIndex) listByAccessModes(modes []v1.PersistentVolumeAccessMode) ([]*v1.PersistentVolume, error) {
-	pv := &v1.PersistentVolume{
-		Spec: v1.PersistentVolumeSpec{
-			AccessModes: modes,
-		},
-	}
-
-	objs, err := pvIndex.store.Index("accessmodes", pv)
-	if err != nil {
-		return nil, err
-	}
-
-	volumes := make([]*v1.PersistentVolume, len(objs))
-	for i, obj := range objs {
-		volumes[i] = obj.(*v1.PersistentVolume)
-	}
-
-	return volumes, nil
+	return pvIndex.ByIndex(accessModesIndex, v1helper.GetAccessModesAsString(modes))
 }
 
 // find returns the nearest PV from the ordered list or nil if a match is not found
@@ -151,7 +135,7 @@ func (pvIndex *persistentVolumeOrderedIndex) findBestMatchForClaim(claim *v1.Per
 // what is closest to what they actually asked for.
 func (pvIndex *persistentVolumeOrderedIndex) allPossibleMatchingAccessModes(requestedModes []v1.PersistentVolumeAccessMode) [][]v1.PersistentVolumeAccessMode {
 	matchedModes := [][]v1.PersistentVolumeAccessMode{}
-	keys := pvIndex.store.ListIndexFuncValues("accessmodes")
+	keys := pvIndex.ListIndexFuncValues(accessModesIndex)
 	for _, key := range keys {
 		indexedModes := v1helper.GetAccessModesFromString(key)
 		if util.ContainsAllAccessModes(indexedModes, requestedModes) {

--- a/pkg/controller/volume/persistentvolume/index_test.go
+++ b/pkg/controller/volume/persistentvolume/index_test.go
@@ -20,14 +20,45 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/component-helpers/storage/volume"
+	"k8s.io/component-helpers/storage/volume/assumecache"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume/util"
 )
+
+// fakePVInformer is a minimal assumecache.Informer for unit tests that only
+// need a standalone persistentVolumeOrderedIndex over an in-memory indexer.
+type fakePVInformer struct {
+	indexer cache.Indexer
+}
+
+func (f *fakePVInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	return nil, nil
+}
+
+func (f *fakePVInformer) GetIndexer() cache.Indexer {
+	return f.indexer
+}
+
+// newPersistentVolumeOrderedIndex builds a persistentVolumeOrderedIndex backed
+// by a standalone assume cache, for tests that exercise the matching logic
+// without a running informer.
+func newPersistentVolumeOrderedIndex() persistentVolumeOrderedIndex {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{accessModesIndex: accessModesIndexFunc})
+	c, err := assumecache.NewAssumeCache[*v1.PersistentVolume](klog.Background(), &fakePVInformer{indexer: indexer}, schema.GroupResource{Resource: "persistentvolumes"})
+	if err != nil {
+		panic(err)
+	}
+	return persistentVolumeOrderedIndex{c}
+}
 
 func makePVC(size string, modfn func(*v1.PersistentVolumeClaim)) *v1.PersistentVolumeClaim {
 	fs := v1.PersistentVolumeFilesystem
@@ -77,7 +108,7 @@ func makeVolumeModePVC(size string, mode *v1.PersistentVolumeMode, modfn func(*v
 func TestMatchVolume(t *testing.T) {
 	volList := newPersistentVolumeOrderedIndex()
 	for _, pv := range createTestVolumes() {
-		volList.store.Add(pv)
+		require.NoError(t, volList.Indexer().Add(pv))
 	}
 
 	scenarios := map[string]struct {
@@ -259,8 +290,8 @@ func TestMatchingWithBoundVolumes(t *testing.T) {
 		},
 	}
 
-	volumeIndex.store.Add(pv1)
-	volumeIndex.store.Add(pv2)
+	require.NoError(t, volumeIndex.Indexer().Add(pv1))
+	require.NoError(t, volumeIndex.Indexer().Add(pv2))
 
 	claim := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
@@ -293,7 +324,7 @@ func TestMatchingWithBoundVolumes(t *testing.T) {
 func TestListByAccessModes(t *testing.T) {
 	volList := newPersistentVolumeOrderedIndex()
 	for _, pv := range createTestVolumes() {
-		volList.store.Add(pv)
+		require.NoError(t, volList.Indexer().Add(pv))
 	}
 
 	volumes, err := volList.listByAccessModes([]v1.PersistentVolumeAccessMode{v1.ReadWriteOnce, v1.ReadOnlyMany})
@@ -324,7 +355,7 @@ func TestListByAccessModes(t *testing.T) {
 func TestAllPossibleAccessModes(t *testing.T) {
 	index := newPersistentVolumeOrderedIndex()
 	for _, pv := range createTestVolumes() {
-		index.store.Add(pv)
+		require.NoError(t, index.Indexer().Add(pv))
 	}
 
 	// the mock PVs creates contain 2 types of accessmodes:   RWO+ROX and RWO+ROW+RWX
@@ -411,9 +442,9 @@ func TestFindingVolumeWithDifferentAccessModes(t *testing.T) {
 	}
 
 	index := newPersistentVolumeOrderedIndex()
-	index.store.Add(gce)
-	index.store.Add(ebs)
-	index.store.Add(nfs)
+	require.NoError(t, index.Indexer().Add(gce))
+	require.NoError(t, index.Indexer().Add(ebs))
+	require.NoError(t, index.Indexer().Add(nfs))
 
 	volume, _ := index.findBestMatchForClaim(claim, false)
 	if volume.Name != ebs.Name {
@@ -1102,7 +1133,7 @@ func createVolumeModeNilTestVolume() *v1.PersistentVolume {
 
 func createTestVolOrderedIndex(pv *v1.PersistentVolume) persistentVolumeOrderedIndex {
 	volFile := newPersistentVolumeOrderedIndex()
-	volFile.store.Add(pv)
+	_ = volFile.Indexer().Add(pv)
 	return volFile
 }
 
@@ -1376,11 +1407,11 @@ func TestFindingPreboundVolumes(t *testing.T) {
 	pvBadMode.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}
 
 	index := newPersistentVolumeOrderedIndex()
-	index.store.Add(pv1)
-	index.store.Add(pv5)
-	index.store.Add(pv8)
-	index.store.Add(pvBadSize)
-	index.store.Add(pvBadMode)
+	require.NoError(t, index.Indexer().Add(pv1))
+	require.NoError(t, index.Indexer().Add(pv5))
+	require.NoError(t, index.Indexer().Add(pv8))
+	require.NoError(t, index.Indexer().Add(pvBadSize))
+	require.NoError(t, index.Indexer().Add(pvBadMode))
 
 	// expected exact match on size
 	volume, _ := index.findBestMatchForClaim(claim, false)
@@ -1423,7 +1454,7 @@ func TestFindingPreboundVolumes(t *testing.T) {
 func TestBestMatchDelayed(t *testing.T) {
 	volList := newPersistentVolumeOrderedIndex()
 	for _, pv := range createTestVolumes() {
-		volList.store.Add(pv)
+		require.NoError(t, volList.Indexer().Add(pv))
 	}
 
 	// binding through PV controller should be delayed

--- a/pkg/controller/volume/persistentvolume/metrics/metrics.go
+++ b/pkg/controller/volume/persistentvolume/metrics/metrics.go
@@ -55,12 +55,12 @@ var registerMetrics sync.Once
 
 // PVLister used to list persistent volumes.
 type PVLister interface {
-	List() []interface{}
+	List() []*v1.PersistentVolume
 }
 
 // PVCLister used to list persistent volume claims.
 type PVCLister interface {
-	List() []interface{}
+	List() []*v1.PersistentVolumeClaim
 }
 
 // Register all metrics for pv controller.
@@ -204,11 +204,7 @@ func (collector *pvAndPVCCountCollector) pvCollect(ch chan<- metrics.Metric) {
 	boundNumberByStorageClass := make(map[string]int)
 	unboundNumberByStorageClass := make(map[string]int)
 	totalCount := make(volumeCount)
-	for _, pvObj := range collector.pvLister.List() {
-		pv, ok := pvObj.(*v1.PersistentVolume)
-		if !ok {
-			continue
-		}
+	for _, pv := range collector.pvLister.List() {
 		pluginName := collector.getPVPluginName(pv)
 		totalCount.add(pluginName, string(*pv.Spec.VolumeMode))
 		if pv.Status.Phase == v1.VolumeBound {
@@ -246,11 +242,7 @@ func (collector *pvAndPVCCountCollector) pvCollect(ch chan<- metrics.Metric) {
 func (collector *pvAndPVCCountCollector) pvcCollect(ch chan<- metrics.Metric) {
 	boundNumber := make(map[pvcBindingMetricDimensions]int)
 	unboundNumber := make(map[pvcBindingMetricDimensions]int)
-	for _, pvcObj := range collector.pvcLister.List() {
-		pvc, ok := pvcObj.(*v1.PersistentVolumeClaim)
-		if !ok {
-			continue
-		}
+	for _, pvc := range collector.pvcLister.List() {
 		if pvc.Status.Phase == v1.ClaimBound {
 			boundNumber[getPVCMetricDimensions(pvc)]++
 		} else {

--- a/pkg/controller/volume/persistentvolume/provision_test.go
+++ b/pkg/controller/volume/persistentvolume/provision_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/klog/v2/ktesting"
 
 	v1 "k8s.io/api/core/v1"
@@ -627,7 +628,7 @@ func TestProvisionMultiSync(t *testing.T) {
 				// operationTimestamps. Rely on the existences of the start time stamp to create a PV for binding
 				if ctrl.operationTimestamps.Has("default/claim12-2") {
 					volume := newVolume("pvc-uid12-2", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimRetain, classExternal)
-					ctrl.volumes.store.Add(volume) // add the volume to controller
+					require.NoError(t, ctrl.volumes.Indexer().Add(volume)) // add the volume to controller
 					reactor.AddVolume(volume)
 				}
 			}),
@@ -666,7 +667,7 @@ func TestProvisionMultiSync(t *testing.T) {
 				// operationTimestamps. Rely on the existences of the start time stamp to create a PV for binding
 				if ctrl.operationTimestamps.Has("default/claim12-4") {
 					volume := newVolume("pvc-uid12-4", "1Gi", "uid12-4", "claim12-4", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classExternal, volume.AnnBoundByController)
-					ctrl.volumes.store.Add(volume) // add the volume to controller
+					require.NoError(t, ctrl.volumes.Indexer().Add(volume)) // add the volume to controller
 					reactor.AddVolume(volume)
 				}
 			}),

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	volerr "k8s.io/cloud-provider/volume/errors"
 	storagehelpers "k8s.io/component-helpers/storage/volume"
+	"k8s.io/component-helpers/storage/volume/assumecache"
 	"k8s.io/kubernetes/pkg/controller/volume/common"
 	"k8s.io/kubernetes/pkg/controller/volume/events"
 	"k8s.io/kubernetes/pkg/controller/volume/persistentvolume/metrics"
@@ -181,7 +182,7 @@ type PersistentVolumeController struct {
 	// Any write to API server would fail with version conflict - these objects
 	// have been already written.
 	volumes persistentVolumeOrderedIndex
-	claims  cache.Store
+	claims  *assumecache.AssumeCache[*v1.PersistentVolumeClaim]
 
 	// Work queues of claims and volumes to process. Every queue should have
 	// exactly one worker thread, especially syncClaim() is not reentrant.
@@ -412,11 +413,11 @@ func (ctrl *PersistentVolumeController) syncUnboundClaim(ctx context.Context, cl
 		// [Unit test set 2]
 		// User asked for a specific PV.
 		logger.V(4).Info("Synchronizing unbound PersistentVolumeClaim, volume requested", "PVC", klog.KObj(claim), "volumeName", claim.Spec.VolumeName)
-		obj, found, err := ctrl.volumes.store.GetByKey(claim.Spec.VolumeName)
-		if err != nil {
+		volume, err := ctrl.volumes.Get(claim.Spec.VolumeName)
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
-		if !found {
+		if apierrors.IsNotFound(err) {
 			// User asked for a PV that does not exist.
 			// OBSERVATION: pvc is "Pending"
 			// Retry later.
@@ -426,10 +427,6 @@ func (ctrl *PersistentVolumeController) syncUnboundClaim(ctx context.Context, cl
 			}
 			return nil
 		} else {
-			volume, ok := obj.(*v1.PersistentVolume)
-			if !ok {
-				return fmt.Errorf("cannot convert object from volume cache to volume %q!?: %+v", claim.Spec.VolumeName, obj)
-			}
 			logger.V(4).Info("Synchronizing unbound PersistentVolumeClaim, volume requested and found", "PVC", klog.KObj(claim), "volumeName", claim.Spec.VolumeName, "volumeStatus", getVolumeStatusForLogging(volume))
 			if volume.Spec.ClaimRef == nil {
 				// User asked for a PV that is not claimed
@@ -505,22 +502,17 @@ func (ctrl *PersistentVolumeController) syncBoundClaim(ctx context.Context, clai
 		}
 		return nil
 	}
-	obj, found, err := ctrl.volumes.store.GetByKey(claim.Spec.VolumeName)
-	if err != nil {
+	volume, err := ctrl.volumes.Get(claim.Spec.VolumeName)
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if !found {
+	if apierrors.IsNotFound(err) {
 		// Claim is bound to a non-existing volume.
 		if _, err = ctrl.updateClaimStatusWithEvent(ctx, claim, v1.ClaimLost, nil, v1.EventTypeWarning, "ClaimLost", "Bound claim has lost its PersistentVolume. Data on the volume is lost!"); err != nil {
 			return err
 		}
 		return nil
 	} else {
-		volume, ok := obj.(*v1.PersistentVolume)
-		if !ok {
-			return fmt.Errorf("cannot convert object from volume cache to volume %q!?: %#v", claim.Spec.VolumeName, obj)
-		}
-
 		logger.V(4).Info("Synchronizing bound PersistentVolumeClaim, volume found", "PVC", klog.KObj(claim), "volumeName", claim.Spec.VolumeName, "volumeStatus", getVolumeStatusForLogging(volume))
 		if volume.Spec.ClaimRef == nil {
 			// Claim is bound but volume has come unbound.
@@ -598,46 +590,33 @@ func (ctrl *PersistentVolumeController) syncVolume(ctx context.Context, volume *
 		}
 		logger.V(4).Info("Synchronizing PersistentVolume, volume is bound to claim", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
 		// Get the PVC by _name_
-		var claim *v1.PersistentVolumeClaim
 		claimName := claimrefToClaimKey(volume.Spec.ClaimRef)
-		obj, found, err := ctrl.claims.GetByKey(claimName)
-		if err != nil {
+		claim, err := ctrl.claims.Get(claimName)
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
+		found := err == nil
 		if !found {
 			// If the PV was created by an external PV provisioner or
 			// bound by external PV binder (e.g. kube-scheduler), it's
 			// possible under heavy load that the corresponding PVC is not synced to
-			// controller local cache yet. So we need to double-check PVC in
-			//   1) informer cache
-			//   2) apiserver if not found in informer cache
+			// controller local cache yet. So we need to double-check PVC in apiserver
 			// to make sure we will not reclaim a PV wrongly.
 			// Note that only non-released and non-failed volumes will be
 			// updated to Released state when PVC does not exist.
 			if volume.Status.Phase != v1.VolumeReleased && volume.Status.Phase != v1.VolumeFailed {
-				obj, err = ctrl.claimLister.PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(volume.Spec.ClaimRef.Name)
+				claim, err = ctrl.kubeClient.CoreV1().PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(ctx, volume.Spec.ClaimRef.Name, metav1.GetOptions{})
 				if err != nil && !apierrors.IsNotFound(err) {
 					return err
 				}
 				found = !apierrors.IsNotFound(err)
-				if !found {
-					obj, err = ctrl.kubeClient.CoreV1().PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(ctx, volume.Spec.ClaimRef.Name, metav1.GetOptions{})
-					if err != nil && !apierrors.IsNotFound(err) {
-						return err
-					}
-					found = !apierrors.IsNotFound(err)
-				}
 			}
 		}
 		if !found {
 			logger.V(4).Info("Synchronizing PersistentVolume, claim not found", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
+			claim = nil
 			// Fall through with claim = nil
 		} else {
-			var ok bool
-			claim, ok = obj.(*v1.PersistentVolumeClaim)
-			if !ok {
-				return fmt.Errorf("cannot convert object from volume cache to volume %q!?: %#v", claim.Spec.VolumeName, obj)
-			}
 			logger.V(4).Info("Synchronizing PersistentVolume, claim found", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "claimStatus", getClaimStatusForLogging(claim), "volumeName", volume.Name)
 		}
 		if claim != nil && claim.UID != volume.Spec.ClaimRef.UID {
@@ -869,7 +848,7 @@ func (ctrl *PersistentVolumeController) updateClaimStatus(ctx context.Context, c
 		logger.V(4).Info("Updating PersistentVolumeClaim status, set phase failed", "PVC", klog.KObj(claim), "phase", phase, "err", err)
 		return newClaim, err
 	}
-	_, err = ctrl.storeClaimUpdate(logger, newClaim)
+	err = ctrl.claims.AssumeWritten(newClaim)
 	if err != nil {
 		logger.V(4).Info("Updating PersistentVolumeClaim status: cannot update internal cache", "PVC", klog.KObj(claim), "err", err)
 		return newClaim, err
@@ -928,7 +907,7 @@ func (ctrl *PersistentVolumeController) updateVolumePhase(ctx context.Context, v
 		logger.V(4).Info("Updating PersistentVolume: set phase failed", "volumeName", volume.Name, "phase", phase, "err", err)
 		return newVol, err
 	}
-	_, err = ctrl.storeVolumeUpdate(logger, newVol)
+	err = ctrl.volumes.AssumeWritten(newVol)
 	if err != nil {
 		logger.V(4).Info("Updating PersistentVolume: cannot update internal cache", "volumeName", volume.Name, "err", err)
 		return newVol, err
@@ -1023,7 +1002,7 @@ func (ctrl *PersistentVolumeController) updateBindVolumeToClaim(ctx context.Cont
 		return newVol, err
 	}
 	if updateCache {
-		_, err = ctrl.storeVolumeUpdate(logger, newVol)
+		err = ctrl.volumes.AssumeWritten(newVol)
 		if err != nil {
 			logger.V(4).Info("Updating PersistentVolume: cannot update internal cache", "volumeName", volumeClone.Name, "err", err)
 			return newVol, err
@@ -1075,7 +1054,7 @@ func (ctrl *PersistentVolumeController) bindClaimToVolume(ctx context.Context, c
 			logger.V(4).Info("Updating PersistentVolumeClaim: binding to volume failed", "PVC", klog.KObj(claim), "volumeName", volume.Name, "err", err)
 			return newClaim, err
 		}
-		_, err = ctrl.storeClaimUpdate(logger, newClaim)
+		err = ctrl.claims.AssumeWritten(newClaim)
 		if err != nil {
 			logger.V(4).Info("Updating PersistentVolumeClaim: cannot update internal cache", "PVC", klog.KObj(claim), "err", err)
 			return newClaim, err
@@ -1164,7 +1143,7 @@ func (ctrl *PersistentVolumeController) unbindVolume(ctx context.Context, volume
 		logger.V(4).Info("Updating PersistentVolume: rollback failed", "volumeName", volume.Name, "err", err)
 		return err
 	}
-	_, err = ctrl.storeVolumeUpdate(logger, newVol)
+	err = ctrl.volumes.AssumeWritten(newVol)
 	if err != nil {
 		logger.V(4).Info("Updating PersistentVolume: cannot update internal cache", "volumeName", volume.Name, "err", err)
 		return err
@@ -1257,11 +1236,12 @@ func (ctrl *PersistentVolumeController) recycleVolumeOperation(ctx context.Conte
 	// a different PV -- we checked that the PV is unused in isVolumeReleased.
 	// So the old PV is safe to be recycled.
 	claimName := claimrefToClaimKey(volume.Spec.ClaimRef)
-	_, claimCached, err := ctrl.claims.GetByKey(claimName)
-	if err != nil {
+	_, err = ctrl.claims.Get(claimName)
+	if err != nil && !apierrors.IsNotFound(err) {
 		logger.V(3).Info("Error getting the claim from cache", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name))
 		return
 	}
+	claimCached := err == nil
 
 	if used && !claimCached {
 		msg := fmt.Sprintf("Volume is used by pods: %s", strings.Join(pods, ","))
@@ -1413,22 +1393,12 @@ func (ctrl *PersistentVolumeController) isVolumeReleased(logger klog.Logger, vol
 		return false, nil
 	}
 
-	var claim *v1.PersistentVolumeClaim
 	claimName := claimrefToClaimKey(volume.Spec.ClaimRef)
-	obj, found, err := ctrl.claims.GetByKey(claimName)
-	if err != nil {
+	claim, err := ctrl.claims.Get(claimName)
+	if err != nil && !apierrors.IsNotFound(err) {
 		return false, err
 	}
-	if !found {
-		// Fall through with claim = nil
-	} else {
-		var ok bool
-		claim, ok = obj.(*v1.PersistentVolumeClaim)
-		if !ok {
-			return false, fmt.Errorf("cannot convert object from claim cache to claim!?: %#v", obj)
-		}
-	}
-	if claim != nil && claim.UID == volume.Spec.ClaimRef.UID {
+	if err == nil && claim.UID == volume.Spec.ClaimRef.UID {
 		// the claim still exists and has the right UID
 
 		if len(claim.Spec.VolumeName) > 0 && claim.Spec.VolumeName != volume.Name {
@@ -1547,8 +1517,7 @@ func (ctrl *PersistentVolumeController) removeDeletionProtectionFinalizer(ctx co
 		if err != nil {
 			return fmt.Errorf("persistent volume controller can't update finalizer: %v", err)
 		}
-		_, err = ctrl.storeVolumeUpdate(logger, volumeClone)
-		if err != nil {
+		if err = ctrl.volumes.AssumeWritten(volumeClone); err != nil {
 			return fmt.Errorf("persistent Volume Controller can't anneal migration finalizer: %v", err)
 		}
 		logger.V(2).Info("PV in-tree protection finalizer removed from volume", "volumeName", volume.Name)
@@ -1742,7 +1711,7 @@ func (ctrl *PersistentVolumeController) provisionClaimOperation(
 			} else {
 				logger.V(3).Info("Volume for claim saved", "PVC", klog.KObj(claim), "volumeName", volume.Name)
 
-				_, updateErr := ctrl.storeVolumeUpdate(logger, newVol)
+				updateErr := ctrl.volumes.AssumeWritten(newVol)
 				if updateErr != nil {
 					// We will get an "volume added" event soon, this is not a big error
 					logger.V(4).Info("provisionClaimOperation: cannot update internal cache", "volumeName", volume.Name, "err", updateErr)
@@ -1863,7 +1832,7 @@ func (ctrl *PersistentVolumeController) rescheduleProvisioning(ctx context.Conte
 		logger.V(4).Info("Failed to delete annotation 'storagehelpers.AnnSelectedNode' for PersistentVolumeClaim", "PVC", klog.KObj(newClaim), "err", err)
 		return
 	}
-	if _, err := ctrl.storeClaimUpdate(logger, newClaim); err != nil {
+	if err := ctrl.claims.AssumeWritten(newClaim); err != nil {
 		// We will get an "claim updated" event soon, this is not a big error
 		logger.V(4).Info("Updating PersistentVolumeClaim: cannot update internal cache", "PVC", klog.KObj(newClaim), "err", err)
 	}

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -1534,21 +1534,21 @@ func (ctrl *PersistentVolumeController) doDeleteVolume(ctx context.Context, plug
 func (ctrl *PersistentVolumeController) removeDeletionProtectionFinalizer(ctx context.Context, volume *v1.PersistentVolume) error {
 	// Retrieve latest version
 	logger := klog.FromContext(ctx)
-	newVolume, err := ctrl.kubeClient.CoreV1().PersistentVolumes().Get(ctx, volume.Name, metav1.GetOptions{})
+	latestVolume, err := ctrl.kubeClient.CoreV1().PersistentVolumes().Get(ctx, volume.Name, metav1.GetOptions{})
 	if err != nil {
 		logger.Error(err, "Error reading persistent volume", "volumeName", volume.Name)
 		return err
 	}
-	volume = newVolume
+	volume = latestVolume
 	volumeClone := volume.DeepCopy()
 	pvFinalizers := volumeClone.Finalizers
 	if pvFinalizers != nil && slices.Contains(pvFinalizers, storagehelpers.PVDeletionInTreeProtectionFinalizer) {
 		volumeClone.SetFinalizers(slice.RemoveString(pvFinalizers, storagehelpers.PVDeletionInTreeProtectionFinalizer, nil))
-		_, err = ctrl.kubeClient.CoreV1().PersistentVolumes().Update(ctx, volumeClone, metav1.UpdateOptions{})
+		newVol, err := ctrl.kubeClient.CoreV1().PersistentVolumes().Update(ctx, volumeClone, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("persistent volume controller can't update finalizer: %v", err)
 		}
-		_, err = ctrl.storeVolumeUpdate(logger, volumeClone)
+		_, err = ctrl.storeVolumeUpdate(logger, newVol)
 		if err != nil {
 			return fmt.Errorf("persistent Volume Controller can't anneal migration finalizer: %v", err)
 		}
@@ -1856,12 +1856,13 @@ func (ctrl *PersistentVolumeController) rescheduleProvisioning(ctx context.Conte
 
 	// The claim from method args can be pointing to watcher cache. We must not
 	// modify these, therefore create a copy.
-	newClaim := claim.DeepCopy()
-	delete(newClaim.Annotations, storagehelpers.AnnSelectedNode)
+	claimClone := claim.DeepCopy()
+	delete(claimClone.Annotations, storagehelpers.AnnSelectedNode)
 	// Try to update the PVC object
 	logger := klog.FromContext(ctx)
-	if _, err := ctrl.kubeClient.CoreV1().PersistentVolumeClaims(newClaim.Namespace).Update(ctx, newClaim, metav1.UpdateOptions{}); err != nil {
-		logger.V(4).Info("Failed to delete annotation 'storagehelpers.AnnSelectedNode' for PersistentVolumeClaim", "PVC", klog.KObj(newClaim), "err", err)
+	newClaim, err := ctrl.kubeClient.CoreV1().PersistentVolumeClaims(claimClone.Namespace).Update(ctx, claimClone, metav1.UpdateOptions{})
+	if err != nil {
+		logger.V(4).Info("Failed to delete annotation 'storagehelpers.AnnSelectedNode' for PersistentVolumeClaim", "PVC", klog.KObj(claimClone), "err", err)
 		return
 	}
 	if _, err := ctrl.storeClaimUpdate(logger, newClaim); err != nil {

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	volerr "k8s.io/cloud-provider/volume/errors"
 	storagehelpers "k8s.io/component-helpers/storage/volume"
+	"k8s.io/component-helpers/storage/volume/assumecache"
 	"k8s.io/kubernetes/pkg/controller/volume/common"
 	"k8s.io/kubernetes/pkg/controller/volume/events"
 	"k8s.io/kubernetes/pkg/controller/volume/persistentvolume/metrics"
@@ -182,7 +183,7 @@ type PersistentVolumeController struct {
 	// Any write to API server would fail with version conflict - these objects
 	// have been already written.
 	volumes persistentVolumeOrderedIndex
-	claims  cache.Store
+	claims  *assumecache.AssumeCache[*v1.PersistentVolumeClaim]
 
 	// Work queues of claims and volumes to process. Every queue should have
 	// exactly one worker thread, especially syncClaim() is not reentrant.
@@ -413,11 +414,11 @@ func (ctrl *PersistentVolumeController) syncUnboundClaim(ctx context.Context, cl
 		// [Unit test set 2]
 		// User asked for a specific PV.
 		logger.V(4).Info("Synchronizing unbound PersistentVolumeClaim, volume requested", "PVC", klog.KObj(claim), "volumeName", claim.Spec.VolumeName)
-		obj, found, err := ctrl.volumes.store.GetByKey(claim.Spec.VolumeName)
-		if err != nil {
+		volume, err := ctrl.volumes.Get(claim.Spec.VolumeName)
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
-		if !found {
+		if apierrors.IsNotFound(err) {
 			// User asked for a PV that does not exist.
 			// OBSERVATION: pvc is "Pending"
 			// Retry later.
@@ -427,10 +428,6 @@ func (ctrl *PersistentVolumeController) syncUnboundClaim(ctx context.Context, cl
 			}
 			return nil
 		} else {
-			volume, ok := obj.(*v1.PersistentVolume)
-			if !ok {
-				return fmt.Errorf("cannot convert object from volume cache to volume %q!?: %+v", claim.Spec.VolumeName, obj)
-			}
 			logger.V(4).Info("Synchronizing unbound PersistentVolumeClaim, volume requested and found", "PVC", klog.KObj(claim), "volumeName", claim.Spec.VolumeName, "volumeStatus", getVolumeStatusForLogging(volume))
 			if volume.Spec.ClaimRef == nil {
 				// User asked for a PV that is not claimed
@@ -506,22 +503,17 @@ func (ctrl *PersistentVolumeController) syncBoundClaim(ctx context.Context, clai
 		}
 		return nil
 	}
-	obj, found, err := ctrl.volumes.store.GetByKey(claim.Spec.VolumeName)
-	if err != nil {
+	volume, err := ctrl.volumes.Get(claim.Spec.VolumeName)
+	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	if !found {
+	if apierrors.IsNotFound(err) {
 		// Claim is bound to a non-existing volume.
 		if _, err = ctrl.updateClaimStatusWithEvent(ctx, claim, v1.ClaimLost, nil, v1.EventTypeWarning, "ClaimLost", "Bound claim has lost its PersistentVolume. Data on the volume is lost!"); err != nil {
 			return err
 		}
 		return nil
 	} else {
-		volume, ok := obj.(*v1.PersistentVolume)
-		if !ok {
-			return fmt.Errorf("cannot convert object from volume cache to volume %q!?: %#v", claim.Spec.VolumeName, obj)
-		}
-
 		logger.V(4).Info("Synchronizing bound PersistentVolumeClaim, volume found", "PVC", klog.KObj(claim), "volumeName", claim.Spec.VolumeName, "volumeStatus", getVolumeStatusForLogging(volume))
 		if volume.Spec.ClaimRef == nil {
 			// Claim is bound but volume has come unbound.
@@ -599,46 +591,33 @@ func (ctrl *PersistentVolumeController) syncVolume(ctx context.Context, volume *
 		}
 		logger.V(4).Info("Synchronizing PersistentVolume, volume is bound to claim", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
 		// Get the PVC by _name_
-		var claim *v1.PersistentVolumeClaim
 		claimName := claimrefToClaimKey(volume.Spec.ClaimRef)
-		obj, found, err := ctrl.claims.GetByKey(claimName)
-		if err != nil {
+		claim, err := ctrl.claims.Get(claimName)
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
+		found := err == nil
 		if !found {
 			// If the PV was created by an external PV provisioner or
 			// bound by external PV binder (e.g. kube-scheduler), it's
 			// possible under heavy load that the corresponding PVC is not synced to
-			// controller local cache yet. So we need to double-check PVC in
-			//   1) informer cache
-			//   2) apiserver if not found in informer cache
+			// controller local cache yet. So we need to double-check PVC in apiserver
 			// to make sure we will not reclaim a PV wrongly.
 			// Note that only non-released and non-failed volumes will be
 			// updated to Released state when PVC does not exist.
 			if volume.Status.Phase != v1.VolumeReleased && volume.Status.Phase != v1.VolumeFailed {
-				obj, err = ctrl.claimLister.PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(volume.Spec.ClaimRef.Name)
+				claim, err = ctrl.kubeClient.CoreV1().PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(ctx, volume.Spec.ClaimRef.Name, metav1.GetOptions{})
 				if err != nil && !apierrors.IsNotFound(err) {
 					return err
 				}
 				found = !apierrors.IsNotFound(err)
-				if !found {
-					obj, err = ctrl.kubeClient.CoreV1().PersistentVolumeClaims(volume.Spec.ClaimRef.Namespace).Get(ctx, volume.Spec.ClaimRef.Name, metav1.GetOptions{})
-					if err != nil && !apierrors.IsNotFound(err) {
-						return err
-					}
-					found = !apierrors.IsNotFound(err)
-				}
 			}
 		}
 		if !found {
 			logger.V(4).Info("Synchronizing PersistentVolume, claim not found", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
+			claim = nil
 			// Fall through with claim = nil
 		} else {
-			var ok bool
-			claim, ok = obj.(*v1.PersistentVolumeClaim)
-			if !ok {
-				return fmt.Errorf("cannot convert object from volume cache to volume %q!?: %#v", claim.Spec.VolumeName, obj)
-			}
 			logger.V(4).Info("Synchronizing PersistentVolume, claim found", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "claimStatus", getClaimStatusForLogging(claim), "volumeName", volume.Name)
 		}
 		if claim != nil && claim.UID != volume.Spec.ClaimRef.UID {
@@ -870,7 +849,7 @@ func (ctrl *PersistentVolumeController) updateClaimStatus(ctx context.Context, c
 		logger.V(4).Info("Updating PersistentVolumeClaim status, set phase failed", "PVC", klog.KObj(claim), "phase", phase, "err", err)
 		return newClaim, err
 	}
-	_, err = ctrl.storeClaimUpdate(logger, newClaim)
+	err = ctrl.claims.AssumeWritten(newClaim)
 	if err != nil {
 		logger.V(4).Info("Updating PersistentVolumeClaim status: cannot update internal cache", "PVC", klog.KObj(claim), "err", err)
 		return newClaim, err
@@ -929,7 +908,7 @@ func (ctrl *PersistentVolumeController) updateVolumePhase(ctx context.Context, v
 		logger.V(4).Info("Updating PersistentVolume: set phase failed", "volumeName", volume.Name, "phase", phase, "err", err)
 		return newVol, err
 	}
-	_, err = ctrl.storeVolumeUpdate(logger, newVol)
+	err = ctrl.volumes.AssumeWritten(newVol)
 	if err != nil {
 		logger.V(4).Info("Updating PersistentVolume: cannot update internal cache", "volumeName", volume.Name, "err", err)
 		return newVol, err
@@ -1024,7 +1003,7 @@ func (ctrl *PersistentVolumeController) updateBindVolumeToClaim(ctx context.Cont
 		return newVol, err
 	}
 	if updateCache {
-		_, err = ctrl.storeVolumeUpdate(logger, newVol)
+		err = ctrl.volumes.AssumeWritten(newVol)
 		if err != nil {
 			logger.V(4).Info("Updating PersistentVolume: cannot update internal cache", "volumeName", volumeClone.Name, "err", err)
 			return newVol, err
@@ -1076,7 +1055,7 @@ func (ctrl *PersistentVolumeController) bindClaimToVolume(ctx context.Context, c
 			logger.V(4).Info("Updating PersistentVolumeClaim: binding to volume failed", "PVC", klog.KObj(claim), "volumeName", volume.Name, "err", err)
 			return newClaim, err
 		}
-		_, err = ctrl.storeClaimUpdate(logger, newClaim)
+		err = ctrl.claims.AssumeWritten(newClaim)
 		if err != nil {
 			logger.V(4).Info("Updating PersistentVolumeClaim: cannot update internal cache", "PVC", klog.KObj(claim), "err", err)
 			return newClaim, err
@@ -1165,7 +1144,7 @@ func (ctrl *PersistentVolumeController) unbindVolume(ctx context.Context, volume
 		logger.V(4).Info("Updating PersistentVolume: rollback failed", "volumeName", volume.Name, "err", err)
 		return err
 	}
-	_, err = ctrl.storeVolumeUpdate(logger, newVol)
+	err = ctrl.volumes.AssumeWritten(newVol)
 	if err != nil {
 		logger.V(4).Info("Updating PersistentVolume: cannot update internal cache", "volumeName", volume.Name, "err", err)
 		return err
@@ -1258,11 +1237,12 @@ func (ctrl *PersistentVolumeController) recycleVolumeOperation(ctx context.Conte
 	// a different PV -- we checked that the PV is unused in isVolumeReleased.
 	// So the old PV is safe to be recycled.
 	claimName := claimrefToClaimKey(volume.Spec.ClaimRef)
-	_, claimCached, err := ctrl.claims.GetByKey(claimName)
-	if err != nil {
+	_, err = ctrl.claims.Get(claimName)
+	if err != nil && !apierrors.IsNotFound(err) {
 		logger.V(3).Info("Error getting the claim from cache", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name))
 		return
 	}
+	claimCached := err == nil
 
 	if used && !claimCached {
 		msg := fmt.Sprintf("Volume is used by pods: %s", strings.Join(pods, ","))
@@ -1414,34 +1394,21 @@ func (ctrl *PersistentVolumeController) isVolumeReleased(logger klog.Logger, vol
 		return false, nil
 	}
 
-	var claim *v1.PersistentVolumeClaim
 	claimName := claimrefToClaimKey(volume.Spec.ClaimRef)
-	obj, found, err := ctrl.claims.GetByKey(claimName)
-	if err != nil {
+	claim, err := ctrl.claims.Get(claimName)
+	switch {
+	case apierrors.IsNotFound(err):
+		logger.V(2).Info("isVolumeReleased: claim gone, volume is released", "volumeName", volume.Name)
+	case err != nil:
 		return false, err
-	}
-	if !found {
-		// Fall through with claim = nil
-	} else {
-		var ok bool
-		claim, ok = obj.(*v1.PersistentVolumeClaim)
-		if !ok {
-			return false, fmt.Errorf("cannot convert object from claim cache to claim!?: %#v", obj)
-		}
-	}
-	if claim != nil && claim.UID == volume.Spec.ClaimRef.UID {
-		// the claim still exists and has the right UID
-
-		if len(claim.Spec.VolumeName) > 0 && claim.Spec.VolumeName != volume.Name {
-			// the claim is bound to another PV, this PV *is* released
-			return true, nil
-		}
-
+	case claim.UID != volume.Spec.ClaimRef.UID:
+		logger.V(2).Info("isVolumeReleased: claim replaced, volume is released", "volumeName", volume.Name)
+	case len(claim.Spec.VolumeName) > 0 && claim.Spec.VolumeName != volume.Name:
+		logger.V(2).Info("isVolumeReleased: claim bound to another volume, volume is released", "volumeName", volume.Name)
+	default:
 		logger.V(4).Info("isVolumeReleased: ClaimRef is still valid, volume is not released", "volumeName", volume.Name)
 		return false, nil
 	}
-
-	logger.V(2).Info("isVolumeReleased: volume is released", "volumeName", volume.Name)
 	return true, nil
 }
 
@@ -1548,8 +1515,7 @@ func (ctrl *PersistentVolumeController) removeDeletionProtectionFinalizer(ctx co
 		if err != nil {
 			return fmt.Errorf("persistent volume controller can't update finalizer: %v", err)
 		}
-		_, err = ctrl.storeVolumeUpdate(logger, newVol)
-		if err != nil {
+		if err = ctrl.volumes.AssumeWritten(newVol); err != nil {
 			return fmt.Errorf("persistent Volume Controller can't anneal migration finalizer: %v", err)
 		}
 		logger.V(2).Info("PV in-tree protection finalizer removed from volume", "volumeName", volume.Name)
@@ -1743,7 +1709,7 @@ func (ctrl *PersistentVolumeController) provisionClaimOperation(
 			} else {
 				logger.V(3).Info("Volume for claim saved", "PVC", klog.KObj(claim), "volumeName", volume.Name)
 
-				_, updateErr := ctrl.storeVolumeUpdate(logger, newVol)
+				updateErr := ctrl.volumes.AssumeWritten(newVol)
 				if updateErr != nil {
 					// We will get an "volume added" event soon, this is not a big error
 					logger.V(4).Info("provisionClaimOperation: cannot update internal cache", "volumeName", volume.Name, "err", updateErr)
@@ -1865,7 +1831,7 @@ func (ctrl *PersistentVolumeController) rescheduleProvisioning(ctx context.Conte
 		logger.V(4).Info("Failed to delete annotation 'storagehelpers.AnnSelectedNode' for PersistentVolumeClaim", "PVC", klog.KObj(claimClone), "err", err)
 		return
 	}
-	if _, err := ctrl.storeClaimUpdate(logger, newClaim); err != nil {
+	if err := ctrl.claims.AssumeWritten(newClaim); err != nil {
 		// We will get an "claim updated" event soon, this is not a big error
 		logger.V(4).Info("Updating PersistentVolumeClaim: cannot update internal cache", "PVC", klog.KObj(newClaim), "err", err)
 	}

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -20,16 +20,15 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -37,11 +36,11 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	storagehelpers "k8s.io/component-helpers/storage/volume"
+	"k8s.io/component-helpers/storage/volume/assumecache"
 	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/volume/common"
@@ -79,8 +78,6 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "persistentvolume-controller"})
 
 	controller := &PersistentVolumeController{
-		volumes:                       newPersistentVolumeOrderedIndex(),
-		claims:                        cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc),
 		kubeClient:                    p.KubeClient,
 		eventBroadcaster:              eventBroadcaster,
 		eventRecorder:                 eventRecorder,
@@ -106,11 +103,26 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 	}
 
 	logger := klog.FromContext(ctx)
-	_, err := p.VolumeInformer.Informer().AddEventHandlerWithOptions(
+
+	if err := p.VolumeInformer.Informer().AddIndexers(cache.Indexers{accessModesIndex: accessModesIndexFunc}); err != nil {
+		return nil, fmt.Errorf("could not add accessmodes indexer to the PV informer: %w", err)
+	}
+	pvCache, err := assumecache.NewAssumeCache[*v1.PersistentVolume](logger, p.VolumeInformer.Informer(), schema.GroupResource{Resource: "persistentvolumes"})
+	if err != nil {
+		return nil, fmt.Errorf("could not create the PV assume cache: %w", err)
+	}
+	controller.volumes = persistentVolumeOrderedIndex{pvCache}
+	pvcCache, err := assumecache.NewAssumeCache[*v1.PersistentVolumeClaim](logger, p.ClaimInformer.Informer(), schema.GroupResource{Resource: "persistentvolumeclaims"})
+	if err != nil {
+		return nil, fmt.Errorf("could not create the PVC assume cache: %w", err)
+	}
+	controller.claims = pvcCache
+
+	_, err = p.VolumeInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    func(obj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, obj) },
 			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, newObj) },
-			DeleteFunc: func(obj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, obj) },
+			DeleteFunc: func(obj interface{}) { controller.volumeDeleted(ctx, obj) },
 		},
 		cache.HandlerOptions{Logger: &logger},
 	)
@@ -124,7 +136,7 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    func(obj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, obj) },
 			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, newObj) },
-			DeleteFunc: func(obj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, obj) },
+			DeleteFunc: func(obj interface{}) { controller.claimDeleted(ctx, obj) },
 		},
 		cache.HandlerOptions{Logger: &logger},
 	)
@@ -155,35 +167,6 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 	return controller, nil
 }
 
-// initializeCaches fills all controller caches with initial data from etcd in
-// order to have the caches already filled when first addClaim/addVolume to
-// perform initial synchronization of the controller.
-func (ctrl *PersistentVolumeController) initializeCaches(logger klog.Logger, volumeLister corelisters.PersistentVolumeLister, claimLister corelisters.PersistentVolumeClaimLister) {
-	volumeList, err := volumeLister.List(labels.Everything())
-	if err != nil {
-		logger.Error(err, "PersistentVolumeController can't initialize caches")
-		return
-	}
-	for _, volume := range volumeList {
-		volumeClone := volume.DeepCopy()
-		if _, err = ctrl.storeVolumeUpdate(logger, volumeClone); err != nil {
-			logger.Error(err, "Error updating volume cache")
-		}
-	}
-
-	claimList, err := claimLister.List(labels.Everything())
-	if err != nil {
-		logger.Error(err, "PersistentVolumeController can't initialize caches")
-		return
-	}
-	for _, claim := range claimList {
-		if _, err = ctrl.storeClaimUpdate(logger, claim.DeepCopy()); err != nil {
-			logger.Error(err, "Error updating claim cache")
-		}
-	}
-	logger.V(4).Info("Controller initialized")
-}
-
 // enqueueWork adds volume or claim to given work queue.
 func (ctrl *PersistentVolumeController) enqueueWork(ctx context.Context, queue workqueue.TypedInterface[string], obj interface{}) {
 	// Beware of "xxx deleted" events
@@ -200,30 +183,11 @@ func (ctrl *PersistentVolumeController) enqueueWork(ctx context.Context, queue w
 	queue.Add(objName)
 }
 
-func (ctrl *PersistentVolumeController) storeVolumeUpdate(logger klog.Logger, volume interface{}) (bool, error) {
-	return storeObjectUpdate(logger, ctrl.volumes.store, volume, "volume")
-}
-
-func (ctrl *PersistentVolumeController) storeClaimUpdate(logger klog.Logger, claim interface{}) (bool, error) {
-	return storeObjectUpdate(logger, ctrl.claims, claim, "claim")
-}
-
 // updateVolume runs in worker thread and handles "volume added",
 // "volume updated" and "periodic sync" events.
 func (ctrl *PersistentVolumeController) updateVolume(ctx context.Context, volume *v1.PersistentVolume) error {
-	// Store the new volume version in the cache and do not process it if this
-	// is an old version.
 	logger := klog.FromContext(ctx)
-	new, err := ctrl.storeVolumeUpdate(logger, volume)
-	if err != nil {
-		logger.Error(err, "Error storing volume update")
-		return err
-	}
-	if !new {
-		return nil
-	}
-
-	err = ctrl.syncVolume(ctx, volume)
+	err := ctrl.syncVolume(ctx, volume)
 	if err != nil {
 		if errors.IsConflict(err) {
 			// Version conflict error happens quite often and the controller
@@ -237,14 +201,23 @@ func (ctrl *PersistentVolumeController) updateVolume(ctx context.Context, volume
 	return nil
 }
 
-// deleteVolume runs in worker thread and handles "volume deleted" event.
-func (ctrl *PersistentVolumeController) deleteVolume(ctx context.Context, volume *v1.PersistentVolume) {
+// volumeDeleted handles the informer "volume deleted" event.
+func (ctrl *PersistentVolumeController) volumeDeleted(ctx context.Context, obj interface{}) {
 	logger := klog.FromContext(ctx)
-	if err := ctrl.volumes.store.Delete(volume); err != nil {
-		logger.Error(err, "Volume deletion encountered", "volumeName", volume.Name)
-	} else {
-		logger.V(4).Info("volume deleted", "volumeName", volume.Name)
+	volume, ok := obj.(*v1.PersistentVolume)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Couldn't get object from tombstone", "obj", obj)
+			return
+		}
+		volume, ok = tombstone.Obj.(*v1.PersistentVolume)
+		if !ok {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Tombstone contained object that is not a volume", "obj", tombstone.Obj)
+			return
+		}
 	}
+	logger.V(4).Info("volume deleted", "volumeName", volume.Name)
 	// record deletion metric if a deletion start timestamp is in the cache
 	// the following calls will be a no-op if there is nothing for this volume in the cache
 	// end of timestamp cache entry lifecycle, "RecordMetric" will do the clean
@@ -257,25 +230,15 @@ func (ctrl *PersistentVolumeController) deleteVolume(ctx context.Context, volume
 	// claim here in response to volume deletion prevents the claim from
 	// waiting until the next sync period for its Lost status.
 	claimKey := claimrefToClaimKey(volume.Spec.ClaimRef)
-	logger.V(5).Info("deleteVolume: scheduling sync of claim", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
+	logger.V(5).Info("volumeDeleted: scheduling sync of claim", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
 	ctrl.claimQueue.Add(claimKey)
 }
 
 // updateClaim runs in worker thread and handles "claim added",
 // "claim updated" and "periodic sync" events.
 func (ctrl *PersistentVolumeController) updateClaim(ctx context.Context, claim *v1.PersistentVolumeClaim) error {
-	// Store the new claim version in the cache and do not process it if this is
-	// an old version.
 	logger := klog.FromContext(ctx)
-	new, err := ctrl.storeClaimUpdate(logger, claim)
-	if err != nil {
-		logger.Error(err, "Error storing claim update")
-		return err
-	}
-	if !new {
-		return nil
-	}
-	err = ctrl.syncClaim(ctx, claim)
+	err := ctrl.syncClaim(ctx, claim)
 	if err != nil {
 		if errors.IsConflict(err) {
 			// Version conflict error happens quite often and the controller
@@ -290,11 +253,21 @@ func (ctrl *PersistentVolumeController) updateClaim(ctx context.Context, claim *
 }
 
 // Unit test [5-5] [5-6] [5-7]
-// deleteClaim runs in worker thread and handles "claim deleted" event.
-func (ctrl *PersistentVolumeController) deleteClaim(ctx context.Context, claim *v1.PersistentVolumeClaim) {
+// claimDeleted handles the informer "claim deleted" event.
+func (ctrl *PersistentVolumeController) claimDeleted(ctx context.Context, obj interface{}) {
 	logger := klog.FromContext(ctx)
-	if err := ctrl.claims.Delete(claim); err != nil {
-		logger.Error(err, "Claim deletion encountered", "PVC", klog.KObj(claim))
+	claim, ok := obj.(*v1.PersistentVolumeClaim)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Couldn't get object from tombstone", "obj", obj)
+			return
+		}
+		claim, ok = tombstone.Obj.(*v1.PersistentVolumeClaim)
+		if !ok {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Tombstone contained object that is not a claim", "obj", tombstone.Obj)
+			return
+		}
 	}
 	claimKey := claimToClaimKey(claim)
 	logger.V(4).Info("Claim deleted", "PVC", klog.KObj(claim))
@@ -304,14 +277,14 @@ func (ctrl *PersistentVolumeController) deleteClaim(ctx context.Context, claim *
 
 	volumeName := claim.Spec.VolumeName
 	if volumeName == "" {
-		logger.V(5).Info("deleteClaim: volume not bound", "PVC", klog.KObj(claim))
+		logger.V(5).Info("claimDeleted: volume not bound", "PVC", klog.KObj(claim))
 		return
 	}
 
 	// sync the volume when its claim is deleted.  Explicitly sync'ing the
 	// volume here in response to claim deletion prevents the volume from
 	// waiting until the next sync period for its Release.
-	logger.V(5).Info("deleteClaim: scheduling sync of volume", "PVC", klog.KObj(claim), "volumeName", volumeName)
+	logger.V(5).Info("claimDeleted: scheduling sync of volume", "PVC", klog.KObj(claim), "volumeName", volumeName)
 	ctrl.volumeQueue.Add(volumeName)
 }
 
@@ -339,8 +312,7 @@ func (ctrl *PersistentVolumeController) Run(ctx context.Context) {
 		return
 	}
 
-	ctrl.initializeCaches(logger, ctrl.volumeLister, ctrl.claimLister)
-	metrics.Register(ctrl.volumes.store, ctrl.claims, &ctrl.volumePluginMgr)
+	metrics.Register(ctrl.volumes, ctrl.claims, &ctrl.volumePluginMgr)
 	volumeutil.RegisterMetrics()
 
 	wg.Go(func() {
@@ -373,8 +345,7 @@ func (ctrl *PersistentVolumeController) updateClaimMigrationAnnotations(ctx cont
 	if err != nil {
 		return nil, fmt.Errorf("persistent Volume Controller can't anneal migration annotations: %v", err)
 	}
-	_, err = ctrl.storeClaimUpdate(logger, newClaim)
-	if err != nil {
+	if err = ctrl.claims.AssumeWritten(newClaim); err != nil {
 		return nil, fmt.Errorf("persistent Volume Controller can't anneal migration annotations: %v", err)
 	}
 	return newClaim, nil
@@ -396,8 +367,7 @@ func (ctrl *PersistentVolumeController) updateVolumeMigrationAnnotationsAndFinal
 	if err != nil {
 		return nil, fmt.Errorf("persistent Volume Controller can't anneal migration annotations or finalizer: %v", err)
 	}
-	_, err = ctrl.storeVolumeUpdate(logger, newVol)
-	if err != nil {
+	if err = ctrl.volumes.AssumeWritten(newVol); err != nil {
 		return nil, fmt.Errorf("persistent Volume Controller can't anneal migration annotations or finalizer: %v", err)
 	}
 	return newVol, nil
@@ -542,43 +512,23 @@ func (ctrl *PersistentVolumeController) syncVolumeByKey(ctx context.Context, key
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("syncVolumeByKey", "volumeKey", key)
 
-	_, name, err := cache.SplitMetaNamespaceKey(key)
+	volume, assumed, err := ctrl.volumes.GetAssumed(key)
 	if err != nil {
-		logger.V(4).Info("Error getting name of volume to get volume from informer", "volumeKey", key, "err", err)
-		return nil
-	}
-
-	volume, err := ctrl.volumeLister.Get(name)
-	if err == nil {
-		// The volume still exists in informer cache, the event must have
-		// been add/update/sync
-		return ctrl.updateVolume(ctx, volume)
-	}
-	if !errors.IsNotFound(err) {
-		logger.V(2).Info("Error getting volume from informer", "volumeKey", key, "err", err)
-		return err
-	}
-
-	// The volume is not in informer cache, the event must have been "delete"
-	volumeObj, found, err := ctrl.volumes.store.GetByKey(key)
-	if err != nil {
+		if errors.IsNotFound(err) {
+			// The volume no longer exists; its deletion (and any follow-up
+			// work) was already handled by the informer delete handler.
+			logger.V(4).Info("Volume deleted", "volumeKey", key)
+			return nil
+		}
 		logger.V(2).Info("Error getting volume from cache", "volumeKey", key, "err", err)
 		return err
 	}
-	if !found {
-		// The controller has already processed the delete event and
-		// deleted the volume from its cache
-		logger.V(2).Info("Deletion of volume was already processed", "volumeKey", key)
+	if assumed {
+		// Serving our own write not yet observed by the informer.
+		// The informer catching up will re-enqueue.
 		return nil
 	}
-	volume, ok := volumeObj.(*v1.PersistentVolume)
-	if !ok {
-		logger.Error(nil, "Expected volume, got", "obj", volumeObj)
-		// Don't retry on type assertion failure
-		return nil
-	}
-	ctrl.deleteVolume(ctx, volume)
-	return nil
+	return ctrl.updateVolume(ctx, volume)
 }
 
 // claimWorker runs a worker thread that just dequeues items, processes them, and marks them done.
@@ -612,43 +562,23 @@ func (ctrl *PersistentVolumeController) syncClaimByKey(ctx context.Context, key 
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("syncClaimByKey", "claimKey", key)
 
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	claim, assumed, err := ctrl.claims.GetAssumed(key)
 	if err != nil {
-		logger.V(4).Info("Error getting namespace & name of claim to get claim from informer", "claimKey", key, "err", err)
-		return nil
-	}
-
-	claim, err := ctrl.claimLister.PersistentVolumeClaims(namespace).Get(name)
-	if err == nil {
-		// The claim still exists in informer cache, the event must have
-		// been add/update/sync
-		return ctrl.updateClaim(ctx, claim)
-	}
-	if !errors.IsNotFound(err) {
-		logger.V(2).Info("Error getting claim from informer", "claimKey", key, "err", err)
-		return err
-	}
-
-	// The claim is not in informer cache, the event must have been "delete"
-	claimObj, found, err := ctrl.claims.GetByKey(key)
-	if err != nil {
+		if errors.IsNotFound(err) {
+			// The claim no longer exists; its deletion (and any follow-up
+			// work) was already handled by the informer delete handler.
+			logger.V(4).Info("Claim deleted", "claimKey", key)
+			return nil
+		}
 		logger.V(2).Info("Error getting claim from cache", "claimKey", key, "err", err)
 		return err
 	}
-	if !found {
-		// The controller has already processed the delete event and
-		// deleted the claim from its cache
-		logger.V(2).Info("Deletion of claim was already processed", "claimKey", key)
+	if assumed {
+		// Serving our own write not yet observed by the informer.
+		// The informer catching up will re-enqueue.
 		return nil
 	}
-	claim, ok := claimObj.(*v1.PersistentVolumeClaim)
-	if !ok {
-		logger.Error(nil, "Expected claim, got", "obj", claimObj)
-		// Don't retry on type assertion failure
-		return nil
-	}
-	ctrl.deleteClaim(ctx, claim)
-	return nil
+	return ctrl.updateClaim(ctx, claim)
 }
 
 // resync supplements short resync period of shared informers - we don't want
@@ -697,8 +627,7 @@ func (ctrl *PersistentVolumeController) setClaimProvisioner(ctx context.Context,
 	if err != nil {
 		return newClaim, err
 	}
-	_, err = ctrl.storeClaimUpdate(logger, newClaim)
-	if err != nil {
+	if err = ctrl.claims.AssumeWritten(newClaim); err != nil {
 		return newClaim, err
 	}
 	return newClaim, nil
@@ -720,59 +649,4 @@ func getVolumeStatusForLogging(volume *v1.PersistentVolume) string {
 		claimName = fmt.Sprintf("%s/%s (uid: %s)", volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name, volume.Spec.ClaimRef.UID)
 	}
 	return fmt.Sprintf("phase: %s, bound to: %q, boundByController: %v", volume.Status.Phase, claimName, boundByController)
-}
-
-// storeObjectUpdate updates given cache with a new object version from Informer
-// callback (i.e. with events from etcd) or with an object modified by the
-// controller itself. Returns "true", if the cache was updated, false if the
-// object is an old version and should be ignored.
-func storeObjectUpdate(logger klog.Logger, store cache.Store, obj interface{}, className string) (bool, error) {
-	objName, err := controller.KeyFunc(obj)
-	if err != nil {
-		return false, fmt.Errorf("couldn't get key for object %+v: %w", obj, err)
-	}
-	oldObj, found, err := store.Get(obj)
-	if err != nil {
-		return false, fmt.Errorf("error finding %s %q in controller cache: %w", className, objName, err)
-	}
-
-	objAccessor, err := meta.Accessor(obj)
-	if err != nil {
-		return false, err
-	}
-	if !found {
-		// This is a new object
-		logger.V(4).Info("storeObjectUpdate, adding obj", "storageClassName", className, "objName", objName, "resourceVersion", objAccessor.GetResourceVersion())
-		if err = store.Add(obj); err != nil {
-			return false, fmt.Errorf("error adding %s %q to controller cache: %w", className, objName, err)
-		}
-		return true, nil
-	}
-
-	oldObjAccessor, err := meta.Accessor(oldObj)
-	if err != nil {
-		return false, err
-	}
-
-	objResourceVersion, err := strconv.ParseInt(objAccessor.GetResourceVersion(), 10, 64)
-	if err != nil {
-		return false, fmt.Errorf("error parsing ResourceVersion %q of %s %q: %s", objAccessor.GetResourceVersion(), className, objName, err)
-	}
-	oldObjResourceVersion, err := strconv.ParseInt(oldObjAccessor.GetResourceVersion(), 10, 64)
-	if err != nil {
-		return false, fmt.Errorf("error parsing old ResourceVersion %q of %s %q: %s", oldObjAccessor.GetResourceVersion(), className, objName, err)
-	}
-
-	// Throw away only older version, let the same version pass - we do want to
-	// get periodic sync events.
-	if oldObjResourceVersion > objResourceVersion {
-		logger.V(4).Info("storeObjectUpdate: ignoring obj", "storageClassName", className, "objName", objName, "resourceVersion", objAccessor.GetResourceVersion())
-		return false, nil
-	}
-
-	logger.V(4).Info("storeObjectUpdate updating obj with version", "storageClassName", className, "objName", objName, "resourceVersion", objAccessor.GetResourceVersion())
-	if err = store.Update(obj); err != nil {
-		return false, fmt.Errorf("error updating %s %q in controller cache: %w", className, objName, err)
-	}
-	return true, nil
 }

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -20,16 +20,15 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -37,11 +36,11 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	storagehelpers "k8s.io/component-helpers/storage/volume"
+	"k8s.io/component-helpers/storage/volume/assumecache"
 	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/volume/common"
@@ -80,8 +79,6 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "persistentvolume-controller"})
 
 	controller := &PersistentVolumeController{
-		volumes:                       newPersistentVolumeOrderedIndex(),
-		claims:                        cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc),
 		kubeClient:                    p.KubeClient,
 		eventBroadcaster:              eventBroadcaster,
 		eventRecorder:                 eventRecorder,
@@ -111,11 +108,26 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 	}
 
 	logger := klog.FromContext(ctx)
-	_, err := p.VolumeInformer.Informer().AddEventHandlerWithOptions(
+
+	if err := p.VolumeInformer.Informer().AddIndexers(cache.Indexers{accessModesIndex: accessModesIndexFunc}); err != nil {
+		return nil, fmt.Errorf("could not add accessmodes indexer to the PV informer: %w", err)
+	}
+	pvCache, err := assumecache.NewAssumeCache[*v1.PersistentVolume](logger, p.VolumeInformer.Informer(), schema.GroupResource{Resource: "persistentvolumes"})
+	if err != nil {
+		return nil, fmt.Errorf("could not create the PV assume cache: %w", err)
+	}
+	controller.volumes = persistentVolumeOrderedIndex{pvCache}
+	pvcCache, err := assumecache.NewAssumeCache[*v1.PersistentVolumeClaim](logger, p.ClaimInformer.Informer(), schema.GroupResource{Resource: "persistentvolumeclaims"})
+	if err != nil {
+		return nil, fmt.Errorf("could not create the PVC assume cache: %w", err)
+	}
+	controller.claims = pvcCache
+
+	_, err = p.VolumeInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    func(obj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, obj) },
 			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, newObj) },
-			DeleteFunc: func(obj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, obj) },
+			DeleteFunc: func(obj interface{}) { controller.volumeDeleted(ctx, obj) },
 		},
 		cache.HandlerOptions{Logger: &logger},
 	)
@@ -129,7 +141,7 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    func(obj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, obj) },
 			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, newObj) },
-			DeleteFunc: func(obj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, obj) },
+			DeleteFunc: func(obj interface{}) { controller.claimDeleted(ctx, obj) },
 		},
 		cache.HandlerOptions{Logger: &logger},
 	)
@@ -160,35 +172,6 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 	return controller, nil
 }
 
-// initializeCaches fills all controller caches with initial data from etcd in
-// order to have the caches already filled when first addClaim/addVolume to
-// perform initial synchronization of the controller.
-func (ctrl *PersistentVolumeController) initializeCaches(logger klog.Logger, volumeLister corelisters.PersistentVolumeLister, claimLister corelisters.PersistentVolumeClaimLister) {
-	volumeList, err := volumeLister.List(labels.Everything())
-	if err != nil {
-		logger.Error(err, "PersistentVolumeController can't initialize caches")
-		return
-	}
-	for _, volume := range volumeList {
-		volumeClone := volume.DeepCopy()
-		if _, err = ctrl.storeVolumeUpdate(logger, volumeClone); err != nil {
-			logger.Error(err, "Error updating volume cache")
-		}
-	}
-
-	claimList, err := claimLister.List(labels.Everything())
-	if err != nil {
-		logger.Error(err, "PersistentVolumeController can't initialize caches")
-		return
-	}
-	for _, claim := range claimList {
-		if _, err = ctrl.storeClaimUpdate(logger, claim.DeepCopy()); err != nil {
-			logger.Error(err, "Error updating claim cache")
-		}
-	}
-	logger.V(4).Info("Controller initialized")
-}
-
 // enqueueWork adds volume or claim to given work queue.
 func (ctrl *PersistentVolumeController) enqueueWork(ctx context.Context, queue workqueue.TypedInterface[string], obj interface{}) {
 	// Beware of "xxx deleted" events
@@ -205,30 +188,11 @@ func (ctrl *PersistentVolumeController) enqueueWork(ctx context.Context, queue w
 	queue.Add(objName)
 }
 
-func (ctrl *PersistentVolumeController) storeVolumeUpdate(logger klog.Logger, volume interface{}) (bool, error) {
-	return storeObjectUpdate(logger, ctrl.volumes.store, volume, "volume")
-}
-
-func (ctrl *PersistentVolumeController) storeClaimUpdate(logger klog.Logger, claim interface{}) (bool, error) {
-	return storeObjectUpdate(logger, ctrl.claims, claim, "claim")
-}
-
 // updateVolume runs in worker thread and handles "volume added",
 // "volume updated" and "periodic sync" events.
 func (ctrl *PersistentVolumeController) updateVolume(ctx context.Context, volume *v1.PersistentVolume) error {
-	// Store the new volume version in the cache and do not process it if this
-	// is an old version.
 	logger := klog.FromContext(ctx)
-	new, err := ctrl.storeVolumeUpdate(logger, volume)
-	if err != nil {
-		logger.Error(err, "Error storing volume update")
-		return err
-	}
-	if !new {
-		return nil
-	}
-
-	err = ctrl.syncVolume(ctx, volume)
+	err := ctrl.syncVolume(ctx, volume)
 	if err != nil {
 		if errors.IsConflict(err) {
 			// Version conflict error happens quite often and the controller
@@ -242,14 +206,23 @@ func (ctrl *PersistentVolumeController) updateVolume(ctx context.Context, volume
 	return nil
 }
 
-// deleteVolume runs in worker thread and handles "volume deleted" event.
-func (ctrl *PersistentVolumeController) deleteVolume(ctx context.Context, volume *v1.PersistentVolume) {
+// volumeDeleted handles the informer "volume deleted" event.
+func (ctrl *PersistentVolumeController) volumeDeleted(ctx context.Context, obj interface{}) {
 	logger := klog.FromContext(ctx)
-	if err := ctrl.volumes.store.Delete(volume); err != nil {
-		logger.Error(err, "Volume deletion encountered", "volumeName", volume.Name)
-	} else {
-		logger.V(4).Info("volume deleted", "volumeName", volume.Name)
+	volume, ok := obj.(*v1.PersistentVolume)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Couldn't get object from tombstone", "obj", obj)
+			return
+		}
+		volume, ok = tombstone.Obj.(*v1.PersistentVolume)
+		if !ok {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Tombstone contained object that is not a volume", "obj", tombstone.Obj)
+			return
+		}
 	}
+	logger.V(4).Info("volume deleted", "volumeName", volume.Name)
 	// record deletion metric if a deletion start timestamp is in the cache
 	// the following calls will be a no-op if there is nothing for this volume in the cache
 	// end of timestamp cache entry lifecycle, "RecordMetric" will do the clean
@@ -262,25 +235,15 @@ func (ctrl *PersistentVolumeController) deleteVolume(ctx context.Context, volume
 	// claim here in response to volume deletion prevents the claim from
 	// waiting until the next sync period for its Lost status.
 	claimKey := claimrefToClaimKey(volume.Spec.ClaimRef)
-	logger.V(5).Info("deleteVolume: scheduling sync of claim", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
+	logger.V(5).Info("volumeDeleted: scheduling sync of claim", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "volumeName", volume.Name)
 	ctrl.claimQueue.Add(claimKey)
 }
 
 // updateClaim runs in worker thread and handles "claim added",
 // "claim updated" and "periodic sync" events.
 func (ctrl *PersistentVolumeController) updateClaim(ctx context.Context, claim *v1.PersistentVolumeClaim) error {
-	// Store the new claim version in the cache and do not process it if this is
-	// an old version.
 	logger := klog.FromContext(ctx)
-	new, err := ctrl.storeClaimUpdate(logger, claim)
-	if err != nil {
-		logger.Error(err, "Error storing claim update")
-		return err
-	}
-	if !new {
-		return nil
-	}
-	err = ctrl.syncClaim(ctx, claim)
+	err := ctrl.syncClaim(ctx, claim)
 	if err != nil {
 		if errors.IsConflict(err) {
 			// Version conflict error happens quite often and the controller
@@ -295,11 +258,21 @@ func (ctrl *PersistentVolumeController) updateClaim(ctx context.Context, claim *
 }
 
 // Unit test [5-5] [5-6] [5-7]
-// deleteClaim runs in worker thread and handles "claim deleted" event.
-func (ctrl *PersistentVolumeController) deleteClaim(ctx context.Context, claim *v1.PersistentVolumeClaim) {
+// claimDeleted handles the informer "claim deleted" event.
+func (ctrl *PersistentVolumeController) claimDeleted(ctx context.Context, obj interface{}) {
 	logger := klog.FromContext(ctx)
-	if err := ctrl.claims.Delete(claim); err != nil {
-		logger.Error(err, "Claim deletion encountered", "PVC", klog.KObj(claim))
+	claim, ok := obj.(*v1.PersistentVolumeClaim)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Couldn't get object from tombstone", "obj", obj)
+			return
+		}
+		claim, ok = tombstone.Obj.(*v1.PersistentVolumeClaim)
+		if !ok {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Tombstone contained object that is not a claim", "obj", tombstone.Obj)
+			return
+		}
 	}
 	claimKey := claimToClaimKey(claim)
 	logger.V(4).Info("Claim deleted", "PVC", klog.KObj(claim))
@@ -309,14 +282,14 @@ func (ctrl *PersistentVolumeController) deleteClaim(ctx context.Context, claim *
 
 	volumeName := claim.Spec.VolumeName
 	if volumeName == "" {
-		logger.V(5).Info("deleteClaim: volume not bound", "PVC", klog.KObj(claim))
+		logger.V(5).Info("claimDeleted: volume not bound", "PVC", klog.KObj(claim))
 		return
 	}
 
 	// sync the volume when its claim is deleted.  Explicitly sync'ing the
 	// volume here in response to claim deletion prevents the volume from
 	// waiting until the next sync period for its Release.
-	logger.V(5).Info("deleteClaim: scheduling sync of volume", "PVC", klog.KObj(claim), "volumeName", volumeName)
+	logger.V(5).Info("claimDeleted: scheduling sync of volume", "PVC", klog.KObj(claim), "volumeName", volumeName)
 	ctrl.volumeQueue.Add(volumeName)
 }
 
@@ -344,8 +317,7 @@ func (ctrl *PersistentVolumeController) Run(ctx context.Context) {
 		return
 	}
 
-	ctrl.initializeCaches(logger, ctrl.volumeLister, ctrl.claimLister)
-	metrics.Register(ctrl.volumes.store, ctrl.claims, &ctrl.metricsPluginMgr)
+	metrics.Register(ctrl.volumes, ctrl.claims, &ctrl.metricsPluginMgr)
 	volumeutil.RegisterMetrics()
 
 	wg.Go(func() {
@@ -378,8 +350,7 @@ func (ctrl *PersistentVolumeController) updateClaimMigrationAnnotations(ctx cont
 	if err != nil {
 		return nil, fmt.Errorf("persistent Volume Controller can't anneal migration annotations: %v", err)
 	}
-	_, err = ctrl.storeClaimUpdate(logger, newClaim)
-	if err != nil {
+	if err = ctrl.claims.AssumeWritten(newClaim); err != nil {
 		return nil, fmt.Errorf("persistent Volume Controller can't anneal migration annotations: %v", err)
 	}
 	return newClaim, nil
@@ -401,8 +372,7 @@ func (ctrl *PersistentVolumeController) updateVolumeMigrationAnnotationsAndFinal
 	if err != nil {
 		return nil, fmt.Errorf("persistent Volume Controller can't anneal migration annotations or finalizer: %v", err)
 	}
-	_, err = ctrl.storeVolumeUpdate(logger, newVol)
-	if err != nil {
+	if err = ctrl.volumes.AssumeWritten(newVol); err != nil {
 		return nil, fmt.Errorf("persistent Volume Controller can't anneal migration annotations or finalizer: %v", err)
 	}
 	return newVol, nil
@@ -547,43 +517,23 @@ func (ctrl *PersistentVolumeController) syncVolumeByKey(ctx context.Context, key
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("syncVolumeByKey", "volumeKey", key)
 
-	_, name, err := cache.SplitMetaNamespaceKey(key)
+	volume, assumed, err := ctrl.volumes.GetAssumed(key)
 	if err != nil {
-		logger.V(4).Info("Error getting name of volume to get volume from informer", "volumeKey", key, "err", err)
-		return nil
-	}
-
-	volume, err := ctrl.volumeLister.Get(name)
-	if err == nil {
-		// The volume still exists in informer cache, the event must have
-		// been add/update/sync
-		return ctrl.updateVolume(ctx, volume)
-	}
-	if !errors.IsNotFound(err) {
-		logger.V(2).Info("Error getting volume from informer", "volumeKey", key, "err", err)
-		return err
-	}
-
-	// The volume is not in informer cache, the event must have been "delete"
-	volumeObj, found, err := ctrl.volumes.store.GetByKey(key)
-	if err != nil {
+		if errors.IsNotFound(err) {
+			// The volume no longer exists; its deletion (and any follow-up
+			// work) was already handled by the informer delete handler.
+			logger.V(4).Info("Volume deleted", "volumeKey", key)
+			return nil
+		}
 		logger.V(2).Info("Error getting volume from cache", "volumeKey", key, "err", err)
 		return err
 	}
-	if !found {
-		// The controller has already processed the delete event and
-		// deleted the volume from its cache
-		logger.V(2).Info("Deletion of volume was already processed", "volumeKey", key)
+	if assumed {
+		// Serving our own write not yet observed by the informer.
+		// The informer catching up will re-enqueue.
 		return nil
 	}
-	volume, ok := volumeObj.(*v1.PersistentVolume)
-	if !ok {
-		logger.Error(nil, "Expected volume, got", "obj", volumeObj)
-		// Don't retry on type assertion failure
-		return nil
-	}
-	ctrl.deleteVolume(ctx, volume)
-	return nil
+	return ctrl.updateVolume(ctx, volume)
 }
 
 // claimWorker runs a worker thread that just dequeues items, processes them, and marks them done.
@@ -617,43 +567,23 @@ func (ctrl *PersistentVolumeController) syncClaimByKey(ctx context.Context, key 
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("syncClaimByKey", "claimKey", key)
 
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	claim, assumed, err := ctrl.claims.GetAssumed(key)
 	if err != nil {
-		logger.V(4).Info("Error getting namespace & name of claim to get claim from informer", "claimKey", key, "err", err)
-		return nil
-	}
-
-	claim, err := ctrl.claimLister.PersistentVolumeClaims(namespace).Get(name)
-	if err == nil {
-		// The claim still exists in informer cache, the event must have
-		// been add/update/sync
-		return ctrl.updateClaim(ctx, claim)
-	}
-	if !errors.IsNotFound(err) {
-		logger.V(2).Info("Error getting claim from informer", "claimKey", key, "err", err)
-		return err
-	}
-
-	// The claim is not in informer cache, the event must have been "delete"
-	claimObj, found, err := ctrl.claims.GetByKey(key)
-	if err != nil {
+		if errors.IsNotFound(err) {
+			// The claim no longer exists; its deletion (and any follow-up
+			// work) was already handled by the informer delete handler.
+			logger.V(4).Info("Claim deleted", "claimKey", key)
+			return nil
+		}
 		logger.V(2).Info("Error getting claim from cache", "claimKey", key, "err", err)
 		return err
 	}
-	if !found {
-		// The controller has already processed the delete event and
-		// deleted the claim from its cache
-		logger.V(2).Info("Deletion of claim was already processed", "claimKey", key)
+	if assumed {
+		// Serving our own write not yet observed by the informer.
+		// The informer catching up will re-enqueue.
 		return nil
 	}
-	claim, ok := claimObj.(*v1.PersistentVolumeClaim)
-	if !ok {
-		logger.Error(nil, "Expected claim, got", "obj", claimObj)
-		// Don't retry on type assertion failure
-		return nil
-	}
-	ctrl.deleteClaim(ctx, claim)
-	return nil
+	return ctrl.updateClaim(ctx, claim)
 }
 
 // resync supplements short resync period of shared informers - we don't want
@@ -702,8 +632,7 @@ func (ctrl *PersistentVolumeController) setClaimProvisioner(ctx context.Context,
 	if err != nil {
 		return newClaim, err
 	}
-	_, err = ctrl.storeClaimUpdate(logger, newClaim)
-	if err != nil {
+	if err = ctrl.claims.AssumeWritten(newClaim); err != nil {
 		return newClaim, err
 	}
 	return newClaim, nil
@@ -725,59 +654,4 @@ func getVolumeStatusForLogging(volume *v1.PersistentVolume) string {
 		claimName = fmt.Sprintf("%s/%s (uid: %s)", volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name, volume.Spec.ClaimRef.UID)
 	}
 	return fmt.Sprintf("phase: %s, bound to: %q, boundByController: %v", volume.Status.Phase, claimName, boundByController)
-}
-
-// storeObjectUpdate updates given cache with a new object version from Informer
-// callback (i.e. with events from etcd) or with an object modified by the
-// controller itself. Returns "true", if the cache was updated, false if the
-// object is an old version and should be ignored.
-func storeObjectUpdate(logger klog.Logger, store cache.Store, obj interface{}, className string) (bool, error) {
-	objName, err := controller.KeyFunc(obj)
-	if err != nil {
-		return false, fmt.Errorf("couldn't get key for object %+v: %w", obj, err)
-	}
-	oldObj, found, err := store.Get(obj)
-	if err != nil {
-		return false, fmt.Errorf("error finding %s %q in controller cache: %w", className, objName, err)
-	}
-
-	objAccessor, err := meta.Accessor(obj)
-	if err != nil {
-		return false, err
-	}
-	if !found {
-		// This is a new object
-		logger.V(4).Info("storeObjectUpdate, adding obj", "storageClassName", className, "objName", objName, "resourceVersion", objAccessor.GetResourceVersion())
-		if err = store.Add(obj); err != nil {
-			return false, fmt.Errorf("error adding %s %q to controller cache: %w", className, objName, err)
-		}
-		return true, nil
-	}
-
-	oldObjAccessor, err := meta.Accessor(oldObj)
-	if err != nil {
-		return false, err
-	}
-
-	objResourceVersion, err := strconv.ParseInt(objAccessor.GetResourceVersion(), 10, 64)
-	if err != nil {
-		return false, fmt.Errorf("error parsing ResourceVersion %q of %s %q: %s", objAccessor.GetResourceVersion(), className, objName, err)
-	}
-	oldObjResourceVersion, err := strconv.ParseInt(oldObjAccessor.GetResourceVersion(), 10, 64)
-	if err != nil {
-		return false, fmt.Errorf("error parsing old ResourceVersion %q of %s %q: %s", oldObjAccessor.GetResourceVersion(), className, objName, err)
-	}
-
-	// Throw away only older version, let the same version pass - we do want to
-	// get periodic sync events.
-	if oldObjResourceVersion > objResourceVersion {
-		logger.V(4).Info("storeObjectUpdate: ignoring obj", "storageClassName", className, "objName", objName, "resourceVersion", objAccessor.GetResourceVersion())
-		return false, nil
-	}
-
-	logger.V(4).Info("storeObjectUpdate updating obj with version", "storageClassName", className, "objName", objName, "resourceVersion", objAccessor.GetResourceVersion())
-	if err = store.Update(obj); err != nil {
-		return false, fmt.Errorf("error updating %s %q in controller cache: %w", className, objName, err)
-	}
-	return true, nil
 }

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -108,8 +108,7 @@ func TestControllerSync(t *testing.T) {
 			errors:          noerrors,
 			// Custom test function that generates a delete event
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-				obj := ctrl.claims.List()[0]
-				claim := obj.(*v1.PersistentVolumeClaim)
+				claim := ctrl.claims.List()[0]
 				reactor.DeleteClaimEvent(claim)
 				return nil
 			},
@@ -125,8 +124,7 @@ func TestControllerSync(t *testing.T) {
 			errors:          noerrors,
 			// Custom test function that generates a delete event
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-				obj := ctrl.volumes.store.List()[0]
-				volume := obj.(*v1.PersistentVolume)
+				volume := ctrl.volumes.List()[0]
 				reactor.DeleteVolumeEvent(volume)
 				return nil
 			},
@@ -148,17 +146,16 @@ func TestControllerSync(t *testing.T) {
 			// event will be generated to trigger "deleteVolume" call for metric reporting
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
 				test.initialVolumes[0].Annotations[volume.AnnDynamicallyProvisioned] = "gcr.io/vendor-csi"
-				obj := ctrl.claims.List()[0]
-				claim := obj.(*v1.PersistentVolumeClaim)
+				claim := ctrl.claims.List()[0]
 				reactor.DeleteClaimEvent(claim)
 				err := wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					return len(ctrl.claims.ListKeys()) == 0, nil
+					return len(ctrl.claims.List()) == 0, nil
 				})
 				if err != nil {
 					return err
 				}
 				// claim has been removed from controller's cache, generate a volume deleted event
-				volume := ctrl.volumes.store.List()[0].(*v1.PersistentVolume)
+				volume := ctrl.volumes.List()[0]
 				reactor.DeleteVolumeEvent(volume)
 				return nil
 			},
@@ -178,12 +175,11 @@ func TestControllerSync(t *testing.T) {
 			// "deleteClaim" to remove the claim from controller's cache and mark bound volume to be released
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
 				// should have been provisioned by external provisioner
-				obj := ctrl.claims.List()[0]
-				claim := obj.(*v1.PersistentVolumeClaim)
+				claim := ctrl.claims.List()[0]
 				reactor.DeleteClaimEvent(claim)
 				// wait until claim is cleared from cache, i.e., deleteClaim is called
 				err := wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					return len(ctrl.claims.ListKeys()) == 0, nil
+					return len(ctrl.claims.List()) == 0, nil
 				})
 				if err != nil {
 					return err
@@ -213,10 +209,10 @@ func TestControllerSync(t *testing.T) {
 			// Custom test function that generates a delete claim event which should have been caught by
 			// "deleteClaim" to remove the claim from controller's cache and mark bound volume to be released
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-				volume := ctrl.volumes.store.List()[0].(*v1.PersistentVolume)
+				volume := ctrl.volumes.List()[0]
 				reactor.DeleteVolumeEvent(volume)
 				err := wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					return len(ctrl.volumes.store.ListKeys()) == 0, nil
+					return len(ctrl.volumes.List()) == 0, nil
 				})
 				if err != nil {
 					return err
@@ -225,8 +221,7 @@ func TestControllerSync(t *testing.T) {
 				// Wait for the PVC to get fully processed. This avoids races between PV controller and DeleteClaimEvent
 				// below.
 				err = wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					obj := ctrl.claims.List()[0]
-					claim := obj.(*v1.PersistentVolumeClaim)
+					claim := ctrl.claims.List()[0]
 					return claim.Status.Phase == v1.ClaimLost, nil
 				})
 				if err != nil {
@@ -234,12 +229,11 @@ func TestControllerSync(t *testing.T) {
 				}
 
 				// trying to remove the claim as well
-				obj := ctrl.claims.List()[0]
-				claim := obj.(*v1.PersistentVolumeClaim)
+				claim := ctrl.claims.List()[0]
 				reactor.DeleteClaimEvent(claim)
 				// wait until claim is cleared from cache, i.e., deleteClaim is called
 				err = wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					return len(ctrl.claims.ListKeys()) == 0, nil
+					return len(ctrl.claims.List()) == 0, nil
 				})
 				if err != nil {
 					return err
@@ -272,12 +266,11 @@ func TestControllerSync(t *testing.T) {
 					return err
 				}
 				// delete the claim
-				obj := ctrl.claims.List()[0]
-				claim := obj.(*v1.PersistentVolumeClaim)
+				claim := ctrl.claims.List()[0]
 				reactor.DeleteClaimEvent(claim)
 				// wait until claim is cleared from cache, i.e., deleteClaim is called
 				err = wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					return len(ctrl.claims.ListKeys()) == 0, nil
+					return len(ctrl.claims.List()) == 0, nil
 				})
 				if err != nil {
 					return err
@@ -370,8 +363,8 @@ func TestControllerSync(t *testing.T) {
 
 		// Wait for the controller to pass initial sync and fill its caches.
 		err = wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-			return len(ctrl.claims.ListKeys()) >= len(test.initialClaims) &&
-				len(ctrl.volumes.store.ListKeys()) >= len(test.initialVolumes), nil
+			return len(ctrl.claims.List()) >= len(test.initialClaims) &&
+				len(ctrl.volumes.List()) >= len(test.initialVolumes), nil
 		})
 		if err != nil {
 			t.Errorf("Test %q controller sync failed: %v", test.name, err)
@@ -399,76 +392,6 @@ func TestControllerSync(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			doit(test)
 		})
-	}
-}
-
-func storeVersion(t *testing.T, prefix string, c cache.Store, version string, expectedReturn bool) {
-	pv := newVolume("pvName", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimDelete, classEmpty)
-	pv.ResourceVersion = version
-	logger, _ := ktesting.NewTestContext(t)
-	ret, err := storeObjectUpdate(logger, c, pv, "volume")
-	if err != nil {
-		t.Errorf("%s: expected storeObjectUpdate to succeed, got: %v", prefix, err)
-	}
-	if expectedReturn != ret {
-		t.Errorf("%s: expected storeObjectUpdate to return %v, got: %v", prefix, expectedReturn, ret)
-	}
-
-	// find the stored version
-
-	pvObj, found, err := c.GetByKey("pvName")
-	if err != nil {
-		t.Errorf("expected volume 'pvName' in the cache, got error instead: %v", err)
-	}
-	if !found {
-		t.Errorf("expected volume 'pvName' in the cache but it was not found")
-	}
-	pv, ok := pvObj.(*v1.PersistentVolume)
-	if !ok {
-		t.Errorf("expected volume in the cache, got different object instead: %#v", pvObj)
-	}
-
-	if ret {
-		if pv.ResourceVersion != version {
-			t.Errorf("expected volume with version %s in the cache, got %s instead", version, pv.ResourceVersion)
-		}
-	} else {
-		if pv.ResourceVersion == version {
-			t.Errorf("expected volume with version other than %s in the cache, got %s instead", version, pv.ResourceVersion)
-		}
-	}
-}
-
-// TestControllerCache tests func storeObjectUpdate()
-func TestControllerCache(t *testing.T) {
-	// Cache under test
-	c := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-
-	// Store new PV
-	storeVersion(t, "Step1", c, "1", true)
-	// Store the same PV
-	storeVersion(t, "Step2", c, "1", true)
-	// Store newer PV
-	storeVersion(t, "Step3", c, "2", true)
-	// Store older PV - simulating old "PV updated" event or periodic sync with
-	// old data
-	storeVersion(t, "Step4", c, "1", false)
-	// Store newer PV - test integer parsing ("2" > "10" as string,
-	// while 2 < 10 as integers)
-	storeVersion(t, "Step5", c, "10", true)
-}
-
-func TestControllerCacheParsingError(t *testing.T) {
-	c := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-	// There must be something in the cache to compare with
-	storeVersion(t, "Step1", c, "1", true)
-
-	pv := newVolume("pvName", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimDelete, classEmpty)
-	pv.ResourceVersion = "xxx"
-	logger, _ := ktesting.NewTestContext(t)
-	_, err := storeObjectUpdate(logger, c, pv, "volume")
-	if err == nil {
-		t.Errorf("Expected parsing error, got nil instead")
 	}
 }
 

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,8 +110,7 @@ func TestControllerSync(t *testing.T) {
 			errors:          noerrors,
 			// Custom test function that generates a delete event
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-				obj := ctrl.claims.List()[0]
-				claim := obj.(*v1.PersistentVolumeClaim)
+				claim := ctrl.claims.List()[0]
 				reactor.DeleteClaimEvent(claim)
 				return nil
 			},
@@ -125,8 +126,7 @@ func TestControllerSync(t *testing.T) {
 			errors:          noerrors,
 			// Custom test function that generates a delete event
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-				obj := ctrl.volumes.store.List()[0]
-				volume := obj.(*v1.PersistentVolume)
+				volume := ctrl.volumes.List()[0]
 				reactor.DeleteVolumeEvent(volume)
 				return nil
 			},
@@ -148,17 +148,16 @@ func TestControllerSync(t *testing.T) {
 			// event will be generated to trigger "deleteVolume" call for metric reporting
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
 				test.initialVolumes[0].Annotations[volume.AnnDynamicallyProvisioned] = "gcr.io/vendor-csi"
-				obj := ctrl.claims.List()[0]
-				claim := obj.(*v1.PersistentVolumeClaim)
+				claim := ctrl.claims.List()[0]
 				reactor.DeleteClaimEvent(claim)
 				err := wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					return len(ctrl.claims.ListKeys()) == 0, nil
+					return len(ctrl.claims.List()) == 0, nil
 				})
 				if err != nil {
 					return err
 				}
 				// claim has been removed from controller's cache, generate a volume deleted event
-				volume := ctrl.volumes.store.List()[0].(*v1.PersistentVolume)
+				volume := ctrl.volumes.List()[0]
 				reactor.DeleteVolumeEvent(volume)
 				return nil
 			},
@@ -178,12 +177,11 @@ func TestControllerSync(t *testing.T) {
 			// "deleteClaim" to remove the claim from controller's cache and mark bound volume to be released
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
 				// should have been provisioned by external provisioner
-				obj := ctrl.claims.List()[0]
-				claim := obj.(*v1.PersistentVolumeClaim)
+				claim := ctrl.claims.List()[0]
 				reactor.DeleteClaimEvent(claim)
 				// wait until claim is cleared from cache, i.e., deleteClaim is called
 				err := wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					return len(ctrl.claims.ListKeys()) == 0, nil
+					return len(ctrl.claims.List()) == 0, nil
 				})
 				if err != nil {
 					return err
@@ -213,10 +211,10 @@ func TestControllerSync(t *testing.T) {
 			// Custom test function that generates a delete claim event which should have been caught by
 			// "deleteClaim" to remove the claim from controller's cache and mark bound volume to be released
 			test: func(ctrl *PersistentVolumeController, reactor *pvtesting.VolumeReactor, test controllerTest) error {
-				volume := ctrl.volumes.store.List()[0].(*v1.PersistentVolume)
+				volume := ctrl.volumes.List()[0]
 				reactor.DeleteVolumeEvent(volume)
 				err := wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					return len(ctrl.volumes.store.ListKeys()) == 0, nil
+					return len(ctrl.volumes.List()) == 0, nil
 				})
 				if err != nil {
 					return err
@@ -225,8 +223,7 @@ func TestControllerSync(t *testing.T) {
 				// Wait for the PVC to get fully processed. This avoids races between PV controller and DeleteClaimEvent
 				// below.
 				err = wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					obj := ctrl.claims.List()[0]
-					claim := obj.(*v1.PersistentVolumeClaim)
+					claim := ctrl.claims.List()[0]
 					return claim.Status.Phase == v1.ClaimLost, nil
 				})
 				if err != nil {
@@ -234,12 +231,11 @@ func TestControllerSync(t *testing.T) {
 				}
 
 				// trying to remove the claim as well
-				obj := ctrl.claims.List()[0]
-				claim := obj.(*v1.PersistentVolumeClaim)
+				claim := ctrl.claims.List()[0]
 				reactor.DeleteClaimEvent(claim)
 				// wait until claim is cleared from cache, i.e., deleteClaim is called
 				err = wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					return len(ctrl.claims.ListKeys()) == 0, nil
+					return len(ctrl.claims.List()) == 0, nil
 				})
 				if err != nil {
 					return err
@@ -272,12 +268,11 @@ func TestControllerSync(t *testing.T) {
 					return err
 				}
 				// delete the claim
-				obj := ctrl.claims.List()[0]
-				claim := obj.(*v1.PersistentVolumeClaim)
+				claim := ctrl.claims.List()[0]
 				reactor.DeleteClaimEvent(claim)
 				// wait until claim is cleared from cache, i.e., deleteClaim is called
 				err = wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-					return len(ctrl.claims.ListKeys()) == 0, nil
+					return len(ctrl.claims.List()) == 0, nil
 				})
 				if err != nil {
 					return err
@@ -370,8 +365,8 @@ func TestControllerSync(t *testing.T) {
 
 		// Wait for the controller to pass initial sync and fill its caches.
 		err = wait.Poll(10*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-			return len(ctrl.claims.ListKeys()) >= len(test.initialClaims) &&
-				len(ctrl.volumes.store.ListKeys()) >= len(test.initialVolumes), nil
+			return len(ctrl.claims.List()) >= len(test.initialClaims) &&
+				len(ctrl.volumes.List()) >= len(test.initialVolumes), nil
 		})
 		if err != nil {
 			t.Errorf("Test %q controller sync failed: %v", test.name, err)
@@ -399,76 +394,6 @@ func TestControllerSync(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			doit(test)
 		})
-	}
-}
-
-func storeVersion(t *testing.T, prefix string, c cache.Store, version string, expectedReturn bool) {
-	pv := newVolume("pvName", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimDelete, classEmpty)
-	pv.ResourceVersion = version
-	logger, _ := ktesting.NewTestContext(t)
-	ret, err := storeObjectUpdate(logger, c, pv, "volume")
-	if err != nil {
-		t.Errorf("%s: expected storeObjectUpdate to succeed, got: %v", prefix, err)
-	}
-	if expectedReturn != ret {
-		t.Errorf("%s: expected storeObjectUpdate to return %v, got: %v", prefix, expectedReturn, ret)
-	}
-
-	// find the stored version
-
-	pvObj, found, err := c.GetByKey("pvName")
-	if err != nil {
-		t.Errorf("expected volume 'pvName' in the cache, got error instead: %v", err)
-	}
-	if !found {
-		t.Errorf("expected volume 'pvName' in the cache but it was not found")
-	}
-	pv, ok := pvObj.(*v1.PersistentVolume)
-	if !ok {
-		t.Errorf("expected volume in the cache, got different object instead: %#v", pvObj)
-	}
-
-	if ret {
-		if pv.ResourceVersion != version {
-			t.Errorf("expected volume with version %s in the cache, got %s instead", version, pv.ResourceVersion)
-		}
-	} else {
-		if pv.ResourceVersion == version {
-			t.Errorf("expected volume with version other than %s in the cache, got %s instead", version, pv.ResourceVersion)
-		}
-	}
-}
-
-// TestControllerCache tests func storeObjectUpdate()
-func TestControllerCache(t *testing.T) {
-	// Cache under test
-	c := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-
-	// Store new PV
-	storeVersion(t, "Step1", c, "1", true)
-	// Store the same PV
-	storeVersion(t, "Step2", c, "1", true)
-	// Store newer PV
-	storeVersion(t, "Step3", c, "2", true)
-	// Store older PV - simulating old "PV updated" event or periodic sync with
-	// old data
-	storeVersion(t, "Step4", c, "1", false)
-	// Store newer PV - test integer parsing ("2" > "10" as string,
-	// while 2 < 10 as integers)
-	storeVersion(t, "Step5", c, "10", true)
-}
-
-func TestControllerCacheParsingError(t *testing.T) {
-	c := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-	// There must be something in the cache to compare with
-	storeVersion(t, "Step1", c, "1", true)
-
-	pv := newVolume("pvName", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimDelete, classEmpty)
-	pv.ResourceVersion = "xxx"
-	logger, _ := ktesting.NewTestContext(t)
-	_, err := storeObjectUpdate(logger, c, pv, "volume")
-	if err == nil {
-		t.Errorf("Expected parsing error, got nil instead")
 	}
 }
 
@@ -887,4 +812,46 @@ func TestRetroactiveStorageClassAssignment(t *testing.T) {
 	for _, test := range tests {
 		runSyncTests(t, ctx, test.tests, test.storageClasses, nil)
 	}
+}
+
+// The controller must be able to read back its own writes before the informer
+// catches up. That only works if the object handed to AssumeWritten is the one
+// returned by the API call, carrying the server-assigned ResourceVersion.
+func TestAssumeOwnWrites(t *testing.T) {
+	newCtrl := func(t *testing.T, ctx context.Context) (*PersistentVolumeController, *volumeReactor) {
+		client := &fake.Clientset{}
+		ctrl, err := newTestController(ctx, client, nil, true)
+		require.NoError(t, err)
+		return ctrl, newVolumeReactor(ctx, client, ctrl, nil, nil, noerrors)
+	}
+
+	t.Run("removeDeletionProtectionFinalizer", func(t *testing.T) {
+		_, ctx := ktesting.NewTestContext(t)
+		ctrl, reactor := newCtrl(t, ctx)
+		pv := newVolumeWithFinalizers("volume-1", "1Gi", "", "", v1.VolumeAvailable, v1.PersistentVolumeReclaimDelete, classEmpty,
+			[]string{volume.PVDeletionInTreeProtectionFinalizer}, volume.AnnDynamicallyProvisioned)
+		require.NoError(t, ctrl.volumes.Indexer().Add(pv))
+		reactor.AddVolume(pv)
+
+		require.NoError(t, ctrl.removeDeletionProtectionFinalizer(ctx, pv))
+
+		cached, err := ctrl.volumes.Get(pv.Name)
+		require.NoError(t, err)
+		assert.NotContains(t, cached.Finalizers, volume.PVDeletionInTreeProtectionFinalizer)
+	})
+
+	t.Run("rescheduleProvisioning", func(t *testing.T) {
+		_, ctx := ktesting.NewTestContext(t)
+		ctrl, reactor := newCtrl(t, ctx)
+		claim := claimWithAnnotation(volume.AnnSelectedNode, "node1",
+			newClaimArray("claim-1", "uid-1", "1Gi", "", v1.ClaimPending, &classGold))[0]
+		require.NoError(t, ctrl.claims.Indexer().Add(claim))
+		reactor.AddClaim(claim)
+
+		ctrl.rescheduleProvisioning(ctx, claim)
+
+		cached, err := ctrl.claims.Get(cache.MetaObjectToName(claim).String())
+		require.NoError(t, err)
+		assert.NotContains(t, cached.Annotations, volume.AnnSelectedNode)
+	})
 }

--- a/pkg/scheduler/framework/plugins/volumebinding/assume_cache.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/assume_cache.go
@@ -23,12 +23,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 	storagehelpers "k8s.io/component-helpers/storage/volume"
+	"k8s.io/component-helpers/storage/volume/assumecache"
 	"k8s.io/klog/v2"
 )
 
 // PVAssumeCache is a AssumeCache for PersistentVolume objects
 type PVAssumeCache struct {
-	*passiveAssumeCache[*v1.PersistentVolume]
+	*assumecache.AssumeCache[*v1.PersistentVolume]
 }
 
 func pvStorageClassIndexFunc(obj interface{}) ([]string, error) {
@@ -41,7 +42,7 @@ func pvStorageClassIndexFunc(obj interface{}) ([]string, error) {
 const storageClassIndex = "storageclass"
 
 // NewPVAssumeCache creates a PV assume cache.
-func NewPVAssumeCache(logger klog.Logger, informer informer) (PVAssumeCache, error) {
+func NewPVAssumeCache(logger klog.Logger, informer assumecache.Informer) (PVAssumeCache, error) {
 	logger = klog.LoggerWithName(logger, "pv-cache")
 	err := informer.GetIndexer().AddIndexers(map[string]cache.IndexFunc{
 		storageClassIndex: pvStorageClassIndexFunc,
@@ -53,7 +54,7 @@ func NewPVAssumeCache(logger klog.Logger, informer informer) (PVAssumeCache, err
 			return PVAssumeCache{}, err
 		}
 	}
-	cache, err := newAssumeCache[*v1.PersistentVolume](logger, informer, schema.GroupResource{Resource: "persistentvolumes"})
+	cache, err := assumecache.NewAssumeCache[*v1.PersistentVolume](logger, informer, schema.GroupResource{Resource: "persistentvolumes"})
 	return PVAssumeCache{cache}, err
 }
 
@@ -65,12 +66,12 @@ func (c PVAssumeCache) ListPVs(storageClassName string) ([]*v1.PersistentVolume,
 
 // PVCAssumeCache is a AssumeCache for PersistentVolumeClaim objects
 type PVCAssumeCache struct {
-	*passiveAssumeCache[*v1.PersistentVolumeClaim]
+	*assumecache.AssumeCache[*v1.PersistentVolumeClaim]
 }
 
 // NewPVCAssumeCache creates a PVC assume cache.
-func NewPVCAssumeCache(logger klog.Logger, informer informer) (PVCAssumeCache, error) {
+func NewPVCAssumeCache(logger klog.Logger, informer assumecache.Informer) (PVCAssumeCache, error) {
 	logger = klog.LoggerWithName(logger, "pvc-cache")
-	cache, err := newAssumeCache[*v1.PersistentVolumeClaim](logger, informer, schema.GroupResource{Resource: "persistentvolumeclaims"})
+	cache, err := assumecache.NewAssumeCache[*v1.PersistentVolumeClaim](logger, informer, schema.GroupResource{Resource: "persistentvolumeclaims"})
 	return PVCAssumeCache{cache}, err
 }

--- a/pkg/scheduler/framework/plugins/volumebinding/assume_cache_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/assume_cache_test.go
@@ -23,6 +23,31 @@ import (
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
+// testInformer is a minimal fake informer for unit tests.
+type testInformer struct {
+	handler cache.ResourceEventHandler
+	indexer cache.Indexer
+	t       *testing.T
+}
+
+func (i *testInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
+	i.handler = handler
+	return nil, nil
+}
+
+func (i *testInformer) GetIndexer() cache.Indexer {
+	return i.indexer
+}
+
+func (i *testInformer) add(obj any) {
+	if err := i.indexer.Add(obj); err != nil {
+		i.t.Fatalf("failed to add object into indexer: %v", err)
+	}
+	if i.handler != nil {
+		i.handler.OnAdd(obj, false)
+	}
+}
+
 func TestPVAssumeCache(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	informer := &testInformer{

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -139,6 +139,8 @@ type testEnv struct {
 	internalPodInformer     coreinformers.PodInformer
 	internalNodeInformer    coreinformers.NodeInformer
 	internalCSINodeInformer storageinformers.CSINodeInformer
+	internalPVInformer      coreinformers.PersistentVolumeInformer
+	internalPVCInformer     coreinformers.PersistentVolumeClaimInformer
 
 	// For CSIStorageCapacity feature testing:
 	internalCSIDriverInformer          storageinformers.CSIDriverInformer
@@ -165,6 +167,7 @@ func newTestBinder(t *testing.T, ctx context.Context) *testEnv {
 	nodeInformer := informerFactory.Core().V1().Nodes()
 	csiNodeInformer := informerFactory.Storage().V1().CSINodes()
 	pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
+	pvInformer := informerFactory.Core().V1().PersistentVolumes()
 	classInformer := informerFactory.Storage().V1().StorageClasses()
 	csiDriverInformer := informerFactory.Storage().V1().CSIDrivers()
 	csiStorageCapacityInformer := informerFactory.Storage().V1().CSIStorageCapacities()
@@ -180,7 +183,7 @@ func newTestBinder(t *testing.T, ctx context.Context) *testEnv {
 		nodeInformer,
 		csiNodeInformer,
 		pvcInformer,
-		informerFactory.Core().V1().PersistentVolumes(),
+		pvInformer,
 		classInformer,
 		capacityCheck,
 		10*time.Second)
@@ -269,6 +272,8 @@ func newTestBinder(t *testing.T, ctx context.Context) *testEnv {
 		internalPodInformer:     podInformer,
 		internalNodeInformer:    nodeInformer,
 		internalCSINodeInformer: csiNodeInformer,
+		internalPVInformer:      pvInformer,
+		internalPVCInformer:     pvcInformer,
 
 		internalCSIDriverInformer:          csiDriverInformer,
 		internalCSIStorageCapacityInformer: csiStorageCapacityInformer,
@@ -303,7 +308,7 @@ func (env *testEnv) addCSIStorageCapacities(capacities []*storagev1.CSIStorageCa
 
 func (env *testEnv) initClaims(t *testing.T, cachedPVCs []*v1.PersistentVolumeClaim, apiPVCs []*v1.PersistentVolumeClaim) {
 	for _, pvc := range cachedPVCs {
-		if err := env.internalBinder.pvcCache.store.Add(pvc); err != nil {
+		if err := env.internalPVCInformer.Informer().GetIndexer().Add(pvc); err != nil {
 			t.Fatalf("error adding PVC %s/%s to cache: %v", pvc.Namespace, pvc.Name, err)
 		}
 		if apiPVCs == nil {
@@ -317,7 +322,7 @@ func (env *testEnv) initClaims(t *testing.T, cachedPVCs []*v1.PersistentVolumeCl
 
 func (env *testEnv) initVolumes(t *testing.T, cachedPVs []*v1.PersistentVolume, apiPVs []*v1.PersistentVolume) {
 	for _, pv := range cachedPVs {
-		if err := env.internalBinder.pvCache.store.Add(pv); err != nil {
+		if err := env.internalPVInformer.Informer().GetIndexer().Add(pv); err != nil {
 			t.Fatalf("error adding PV %s to cache: %v", pv.Name, err)
 		}
 		if apiPVs == nil {
@@ -375,7 +380,7 @@ func (env *testEnv) updateClaims(ctx context.Context, pvcs []*v1.PersistentVolum
 
 func (env *testEnv) deleteVolumes(t *testing.T, pvs []*v1.PersistentVolume) {
 	for _, pv := range pvs {
-		if err := env.internalBinder.pvCache.store.Delete(pv); err != nil {
+		if err := env.internalPVInformer.Informer().GetIndexer().Delete(pv); err != nil {
 			t.Fatalf("Error deleting PV %s: %v", pv.Name, err)
 		}
 	}
@@ -383,7 +388,7 @@ func (env *testEnv) deleteVolumes(t *testing.T, pvs []*v1.PersistentVolume) {
 
 func (env *testEnv) deleteClaims(t *testing.T, pvcs []*v1.PersistentVolumeClaim) {
 	for _, pvc := range pvcs {
-		if err := env.internalBinder.pvcCache.store.Delete(pvc); err != nil {
+		if err := env.internalPVCInformer.Informer().GetIndexer().Delete(pvc); err != nil {
 			t.Fatalf("Error deleting PVC %s/%s: %v", pvc.Namespace, pvc.Name, err)
 		}
 	}

--- a/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache.go
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package volumebinding
+// Package assumecache provides a cache layered on top of a shared informer that
+// lets a client observe its own writes ("assumptions") before the informer
+// delivers them, while always deferring to the informer as the source of truth.
+package assumecache
 
 import (
 	"fmt"
@@ -29,13 +32,13 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// informer is the subset of [cache.SharedInformer] that newAssumeCache depends upon.
-type informer interface {
+// Informer is the subset of [cache.SharedInformer] that NewAssumeCache depends upon.
+type Informer interface {
 	AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error)
 	GetIndexer() cache.Indexer
 }
 
-// passiveAssumeCache is a cache on top of the informer that allows for updating
+// AssumeCache is a cache on top of the informer that allows for updating
 // objects outside of informer events and also restoring the informer
 // cache's version of the object.
 //
@@ -46,7 +49,7 @@ type informer interface {
 //   - this is always up-to-date with the informer
 //   - this only allow assuming objects yet to be sent to the apiserver,
 //     not the ones returned from the apiserver
-type passiveAssumeCache[T v1.Object] struct {
+type AssumeCache[T v1.Object] struct {
 	// The logger that was chosen when setting up the cache.
 	// Will be used for all operations.
 	logger klog.Logger
@@ -63,9 +66,9 @@ type passiveAssumeCache[T v1.Object] struct {
 	assumed map[string]T
 }
 
-// newAssumeCache creates an assume cache for objects of type T.
-func newAssumeCache[T v1.Object](logger klog.Logger, informer informer, gr schema.GroupResource) (*passiveAssumeCache[T], error) {
-	c := &passiveAssumeCache[T]{
+// NewAssumeCache creates an assume cache for objects of type T.
+func NewAssumeCache[T v1.Object](logger klog.Logger, informer Informer, gr schema.GroupResource) (*AssumeCache[T], error) {
+	c := &AssumeCache[T]{
 		logger:  logger,
 		gr:      gr,
 		store:   informer.GetIndexer(),
@@ -83,7 +86,7 @@ func newAssumeCache[T v1.Object](logger klog.Logger, informer informer, gr schem
 }
 
 // Receives events from informer. May expire the assumed object if it is older.
-func (c *passiveAssumeCache[T]) mayExpire(key string) {
+func (c *AssumeCache[T]) mayExpire(key string) {
 	c.rwMutex.Lock()
 	defer c.rwMutex.Unlock()
 
@@ -123,7 +126,7 @@ func (c *passiveAssumeCache[T]) mayExpire(key string) {
 	}
 }
 
-func (c *passiveAssumeCache[T]) add(obj any) {
+func (c *AssumeCache[T]) add(obj any) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleErrorWithLogger(c.logger, err, "Add object get key")
@@ -132,11 +135,11 @@ func (c *passiveAssumeCache[T]) add(obj any) {
 	c.mayExpire(key)
 }
 
-func (c *passiveAssumeCache[T]) update(_, obj any) {
+func (c *AssumeCache[T]) update(_, obj any) {
 	c.add(obj)
 }
 
-func (c *passiveAssumeCache[T]) delete(obj any) {
+func (c *AssumeCache[T]) delete(obj any) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleErrorWithLogger(c.logger, err, "Delete object get key")
@@ -148,7 +151,7 @@ func (c *passiveAssumeCache[T]) delete(obj any) {
 // ByIndex returns the stored objects whose set of indexed values for the named index includes the given indexed value
 //
 // The index is evaluated on the object from store. Objects from [Assume] will present in the result but will not affect the index.
-func (c *passiveAssumeCache[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
+func (c *AssumeCache[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
 
@@ -160,7 +163,7 @@ func (c *passiveAssumeCache[T]) ByIndex(indexName, indexedValue string) ([]T, er
 }
 
 // Get the object by its key.
-func (c *passiveAssumeCache[T]) Get(key string) (T, error) {
+func (c *AssumeCache[T]) Get(key string) (T, error) {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
 
@@ -177,7 +180,7 @@ func (c *passiveAssumeCache[T]) Get(key string) (T, error) {
 }
 
 // GetAPIObj gets the informer cache's version by its key.
-func (c *passiveAssumeCache[T]) GetAPIObj(key string) (T, error) {
+func (c *AssumeCache[T]) GetAPIObj(key string) (T, error) {
 	obj, ok, err := c.store.GetByKey(key)
 	var zero T
 	if err != nil {
@@ -197,7 +200,7 @@ func keyOf[T v1.Object](obj T) string {
 	return cache.MetaObjectToName(obj).String()
 }
 
-func (c *passiveAssumeCache[T]) replaceAssumed(objs []any) []T {
+func (c *AssumeCache[T]) replaceAssumed(objs []any) []T {
 	allObjs := make([]T, 0, len(objs))
 	for _, obj := range objs {
 		v, ok := obj.(T)
@@ -222,7 +225,7 @@ func (c *passiveAssumeCache[T]) replaceAssumed(objs []any) []T {
 // If an update is received via the informer while such an
 // object is assumed, it gets dropped in favor of the
 // newer object from the apiserver.
-func (c *passiveAssumeCache[T]) Assume(obj T) error {
+func (c *AssumeCache[T]) Assume(obj T) error {
 	key := keyOf(obj)
 
 	c.rwMutex.Lock()
@@ -242,7 +245,7 @@ func (c *passiveAssumeCache[T]) Assume(obj T) error {
 }
 
 // Restore the informer cache's version of the object.
-func (c *passiveAssumeCache[T]) Restore(obj T) {
+func (c *AssumeCache[T]) Restore(obj T) {
 	key := keyOf(obj)
 
 	c.rwMutex.Lock()

--- a/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache.go
@@ -170,6 +170,32 @@ func (c *AssumeCache[T]) delete(obj any) {
 	c.mayExpire(key)
 }
 
+// Indexer returns the underlying informer indexer that backs the cache. It is
+// the raw source of truth and does NOT apply the assumption overlay.
+// Only use for test.
+func (c *AssumeCache[T]) Indexer() cache.Indexer {
+	return c.store
+}
+
+// List returns all objects in the cache, with any active assumption applied in
+// place of the informer's version. The returned objects are shared; callers
+// must not mutate them.
+func (c *AssumeCache[T]) List() []T {
+	c.rwMutex.RLock()
+	defer c.rwMutex.RUnlock()
+
+	return c.replaceAssumed(c.store.List())
+}
+
+// ListIndexFuncValues returns the distinct values of the named index across the
+// informer's objects. Assumptions do not affect the index (see [AssumeCache.ByIndex]).
+func (c *AssumeCache[T]) ListIndexFuncValues(indexName string) []string {
+	c.rwMutex.RLock()
+	defer c.rwMutex.RUnlock()
+
+	return c.store.ListIndexFuncValues(indexName)
+}
+
 // ByIndex returns the stored objects whose set of indexed values for the named index includes the given indexed value
 //
 // The index is evaluated on the object from store. Objects from [Assume] will present in the result but will not affect the index.
@@ -186,20 +212,27 @@ func (c *AssumeCache[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
 
 // Get the object by its key.
 func (c *AssumeCache[T]) Get(key string) (T, error) {
+	obj, _, err := c.GetAssumed(key)
+	return obj, err
+}
+
+// GetAssumed behaves like Get but also reports whether the returned object came
+// from an in-memory assumption rather than the informer store.
+func (c *AssumeCache[T]) GetAssumed(key string) (obj T, assumed bool, err error) {
 	c.rwMutex.RLock()
 	defer c.rwMutex.RUnlock()
 
-	obj, err := c.GetAPIObj(key)
+	obj, err = c.GetAPIObj(key)
 	if err != nil {
-		return obj, err
+		return obj, false, err
 	}
 
-	assumed, ok := c.assumed[key]
-	if !ok || !assumed.preferOver(obj.GetResourceVersion()) {
-		// not assumed, or the informer object is preferred
-		return obj, nil
+	a, ok := c.assumed[key]
+	if ok && a.preferOver(obj.GetResourceVersion()) {
+		return a.object, true, nil
 	}
-	return assumed.object, nil
+	// not assumed, or the informer object is preferred
+	return obj, false, nil
 }
 
 // GetAPIObj gets the informer cache's version by its key.

--- a/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -47,8 +48,6 @@ type Informer interface {
 // This is different from pkg/scheduler/util/assumecache in:
 //   - this does not dispatch events
 //   - this is always up-to-date with the informer
-//   - this only allow assuming objects yet to be sent to the apiserver,
-//     not the ones returned from the apiserver
 type AssumeCache[T v1.Object] struct {
 	// The logger that was chosen when setting up the cache.
 	// Will be used for all operations.
@@ -63,7 +62,33 @@ type AssumeCache[T v1.Object] struct {
 
 	// Objects from informer
 	store   cache.Indexer
-	assumed map[string]T
+	assumed map[string]assumedObject[T]
+}
+
+// assumedObject is an object assumed into the cache together with how it should
+// be reconciled against the informer.
+type assumedObject[T v1.Object] struct {
+	object T
+	// Whether object was already written to the apiserver.
+	persisted bool
+}
+
+// preferOver reports whether the assumed object should be served instead of the
+// informer object with the given resource version, i.e. the assumption has not
+// yet been superseded by the informer.
+func (a assumedObject[T]) preferOver(storeRV string) bool {
+	assumedRV := a.object.GetResourceVersion()
+	if !a.persisted {
+		// Keep the optimistic object, skip resync.
+		return assumedRV == storeRV
+	}
+	cmp, err := resourceversion.CompareResourceVersion(assumedRV, storeRV)
+	if err != nil {
+		// Non-conformant apiserver. Drop assumption to avoid leaks.
+		return false
+	}
+	// Keep the written object until the informer reaches its version.
+	return cmp > 0
 }
 
 // NewAssumeCache creates an assume cache for objects of type T.
@@ -72,7 +97,7 @@ func NewAssumeCache[T v1.Object](logger klog.Logger, informer Informer, gr schem
 		logger:  logger,
 		gr:      gr,
 		store:   informer.GetIndexer(),
-		assumed: make(map[string]T),
+		assumed: make(map[string]assumedObject[T]),
 	}
 
 	_, err := informer.AddEventHandler(
@@ -85,7 +110,8 @@ func NewAssumeCache[T v1.Object](logger klog.Logger, informer Informer, gr schem
 	return c, err
 }
 
-// Receives events from informer. May expire the assumed object if it is older.
+// Receives events from informer. May expire the assumed object once the
+// informer has caught up to (or past) it.
 func (c *AssumeCache[T]) mayExpire(key string) {
 	c.rwMutex.Lock()
 	defer c.rwMutex.Unlock()
@@ -102,7 +128,6 @@ func (c *AssumeCache[T]) mayExpire(key string) {
 		return
 	}
 
-	expire := true
 	if exists {
 		newMeta, err := meta.Accessor(obj)
 		if err != nil {
@@ -110,20 +135,17 @@ func (c *AssumeCache[T]) mayExpire(key string) {
 			return
 		}
 
-		// Only overwrite assumed object if version is newer (not resync).
-		if assumed.GetResourceVersion() == newMeta.GetResourceVersion() {
-			c.logger.V(10).Info("ignoring resync of assumed object", "key", key, "version", assumed.GetResourceVersion())
-			expire = false
-		} else {
-			c.logger.V(4).Info("assumed object expired", "newVersion", newMeta.GetResourceVersion(),
-				"key", key, "version", assumed.GetResourceVersion())
+		if assumed.preferOver(newMeta.GetResourceVersion()) {
+			c.logger.V(10).Info("keeping assumed object", "key", key,
+				"version", assumed.object.GetResourceVersion(), "informerVersion", newMeta.GetResourceVersion())
+			return
 		}
+		c.logger.V(4).Info("assumed object expired", "key", key,
+			"version", assumed.object.GetResourceVersion(), "newVersion", newMeta.GetResourceVersion())
 	} else {
-		c.logger.V(4).Info("assumed object expired", "key", key, "version", assumed.GetResourceVersion())
+		c.logger.V(4).Info("assumed object expired", "key", key, "version", assumed.object.GetResourceVersion())
 	}
-	if expire {
-		delete(c.assumed, key)
-	}
+	delete(c.assumed, key)
 }
 
 func (c *AssumeCache[T]) add(obj any) {
@@ -173,10 +195,11 @@ func (c *AssumeCache[T]) Get(key string) (T, error) {
 	}
 
 	assumed, ok := c.assumed[key]
-	if !ok || assumed.GetResourceVersion() != obj.GetResourceVersion() { // not assumed or Informer object is newer
+	if !ok || !assumed.preferOver(obj.GetResourceVersion()) {
+		// not assumed, or the informer object is preferred
 		return obj, nil
 	}
-	return assumed, nil
+	return assumed.object, nil
 }
 
 // GetAPIObj gets the informer cache's version by its key.
@@ -208,23 +231,22 @@ func (c *AssumeCache[T]) replaceAssumed(objs []any) []T {
 			utilruntime.HandleErrorWithLogger(c.logger, nil, "listed object has wrong type", "type", fmt.Sprintf("%T", obj))
 			continue
 		}
-		assumed, ok := c.assumed[keyOf(v)]
-		if ok && assumed.GetResourceVersion() == v.GetResourceVersion() {
-			// assumed object is not in informer yet
-			v = assumed
+		if assumed, ok := c.assumed[keyOf(v)]; ok && assumed.preferOver(v.GetResourceVersion()) {
+			// the assumed object is newer than (or not yet in) the informer
+			v = assumed.object
 		}
 		allObjs = append(allObjs, v)
 	}
 	return allObjs
 }
 
-// Assume updates the object in-memory only.
+// Assume optimistically records an in-memory change to an object before it is
+// written to the apiserver. The object's ResourceVersion must equal the
+// informer's current version, otherwise an error is returned. The assumption is
+// dropped as soon as the informer observes any newer version.
 //
-// The version of the object must be equal to
-// the current object, otherwise an error is returned.
-// If an update is received via the informer while such an
-// object is assumed, it gets dropped in favor of the
-// newer object from the apiserver.
+// For an object that has already been written to the apiserver, use
+// [AssumeCache.AssumeWritten] instead.
 func (c *AssumeCache[T]) Assume(obj T) error {
 	key := keyOf(obj)
 
@@ -239,8 +261,49 @@ func (c *AssumeCache[T]) Assume(obj T) error {
 	if stored.GetResourceVersion() != obj.GetResourceVersion() {
 		return fmt.Errorf("%q is out of sync (stored: %s, assume: %s)", key, stored.GetResourceVersion(), obj.GetResourceVersion())
 	}
-	c.assumed[key] = obj
+	c.assumed[key] = assumedObject[T]{object: obj, persisted: false}
 	c.logger.V(4).Info("Assumed object", "key", key, "version", obj.GetResourceVersion())
+	return nil
+}
+
+// AssumeWritten records an object that has already been written to the
+// apiserver, i.e. obj carries the server-assigned ResourceVersion returned by
+// the write. Reads observe obj until the informer delivers that version or a
+// newer one, so a sequence of writes (e.g. spec then status) is not transiently
+// reverted to an intermediate version while the informer catches up.
+//
+// It is a no-op (returning nil) when:
+//   - obj is not present in the informer — either a creation whose event has
+//     not been delivered yet, or an object that has already been deleted;
+//     leaving these to the informer is what prevents a deleted object from
+//     being resurrected; or
+//   - the informer already holds the same or a newer version, or the
+//     ResourceVersions are not comparable (a non-conformant apiserver).
+func (c *AssumeCache[T]) AssumeWritten(obj T) error {
+	key := keyOf(obj)
+
+	c.rwMutex.Lock()
+	defer c.rwMutex.Unlock()
+
+	stored, exists, err := c.store.GetByKey(key)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	storedMeta, err := meta.Accessor(stored)
+	if err != nil {
+		return err
+	}
+	assumed := assumedObject[T]{object: obj, persisted: true}
+	if assumed.preferOver(storedMeta.GetResourceVersion()) {
+		c.assumed[key] = assumed
+		c.logger.V(4).Info("Assumed written object", "key", key, "version", obj.GetResourceVersion())
+	} else {
+		c.logger.V(4).Info("Reject expired assumption",
+			"key", key, "version", obj.GetResourceVersion(), "informerVersion", storedMeta.GetResourceVersion())
+	}
 	return nil
 }
 
@@ -252,7 +315,7 @@ func (c *AssumeCache[T]) Restore(obj T) {
 	defer c.rwMutex.Unlock()
 
 	assumed, ok := c.assumed[key]
-	if ok && assumed.GetResourceVersion() == obj.GetResourceVersion() {
+	if ok && assumed.object.GetResourceVersion() == obj.GetResourceVersion() {
 		delete(c.assumed, key)
 		c.logger.V(4).Info("Restored object", "key", key, "version", obj.GetResourceVersion())
 	}

--- a/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache_test.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache_test.go
@@ -225,6 +225,8 @@ func TestAssume(t *testing.T) {
 			shouldSucceed: true,
 		},
 		"fail-new-higher-version": {
+			// A higher ResourceVersion is a written object; it must go through
+			// AssumeWritten, not the optimistic Assume.
 			old:           makeObj("pvc1", "5", "ns1"),
 			new:           makeObj("pvc1", "6", "ns1"),
 			shouldSucceed: false,
@@ -401,5 +403,101 @@ func TestDelayedInformerEvent(t *testing.T) {
 	// Expect assumed version not overwritten
 	if err := verifyObj(cache, keyOf(newObj), newObj); err != nil {
 		t.Fatalf("failed to get after assume: %v", err)
+	}
+}
+
+// TestAssumeWritten verifies the no-op paths and the basic behavior of
+// assuming an object that was already written to the apiserver.
+func TestAssumeWritten(t *testing.T) {
+	informer, cache := newTestCache(t)
+
+	// Object absent from the informer: no-op, and must not create a phantom.
+	if err := cache.AssumeWritten(makeObj("pvc1", "5", "ns1")); err != nil {
+		t.Fatalf("AssumeWritten(absent) returned error: %v", err)
+	}
+	if _, err := cache.Get(keyOf(makeObj("pvc1", "5", "ns1"))); err == nil {
+		t.Fatalf("AssumeWritten created a phantom for an object absent from the informer")
+	}
+
+	base := makeObj("pvc1", "5", "ns1")
+	informer.add(base)
+
+	// Informer already holds the same version: no-op, informer object is served.
+	if err := cache.AssumeWritten(makeObj("pvc1", "5", "ns1")); err != nil {
+		t.Fatalf("AssumeWritten(same) returned error: %v", err)
+	}
+	if err := verifyObj(cache, keyOf(base), base); err != nil {
+		t.Fatalf("expected informer object after no-op AssumeWritten: %v", err)
+	}
+
+	// Newer written version: assumed and served until the informer catches up.
+	newer := makeObj("pvc1", "7", "ns1")
+	if err := cache.AssumeWritten(newer); err != nil {
+		t.Fatalf("AssumeWritten(newer) returned error: %v", err)
+	}
+	if err := verifyObj(cache, keyOf(newer), newer); err != nil {
+		t.Fatalf("expected assumed written object: %v", err)
+	}
+}
+
+// TestAssumeWrittenNotRevertedByIntermediateEvent verifies that when the
+// controller writes an object several times in a row (e.g. spec then status)
+// and assumes each server-returned version, a later informer event for an
+// intermediate version does not revert the assumed newer version.
+func TestAssumeWrittenNotRevertedByIntermediateEvent(t *testing.T) {
+	informer, cache := newTestCache(t)
+
+	// Base object at RV 100.
+	informer.add(makeObj("pvc1", "100", "ns1"))
+
+	// Two consecutive writes 100 -> 105 -> 106, each assumed while the informer
+	// is still behind.
+	if err := cache.AssumeWritten(makeObj("pvc1", "105", "ns1")); err != nil {
+		t.Fatalf("AssumeWritten(105) failed: %v", err)
+	}
+	obj106 := makeObj("pvc1", "106", "ns1")
+	if err := cache.AssumeWritten(obj106); err != nil {
+		t.Fatalf("AssumeWritten(106) failed: %v", err)
+	}
+	if err := verifyObj(cache, keyOf(obj106), obj106); err != nil {
+		t.Fatalf("Get after Assume(106): %v", err)
+	}
+
+	// The informer now delivers the intermediate version 105 first. The assumed
+	// 106 must not be reverted to 105.
+	informer.add(makeObj("pvc1", "105", "ns1"))
+	if err := verifyObj(cache, keyOf(obj106), obj106); err != nil {
+		t.Fatalf("assumed 106 was reverted by intermediate informer event: %v", err)
+	}
+
+	// Once the informer catches up to 106, the assumption expires and the
+	// informer object is served.
+	final106 := makeObj("pvc1", "106", "ns1")
+	informer.add(final106)
+	if err := verifyObj(cache, keyOf(final106), final106); err != nil {
+		t.Fatalf("Get after informer caught up to 106: %v", err)
+	}
+}
+
+// TestAssumeWrittenExpiredOnDelete verifies that a written (post-write)
+// assumption does not resurrect an object that has been deleted from the
+// informer.
+func TestAssumeWrittenExpiredOnDelete(t *testing.T) {
+	informer, cache := newTestCache(t)
+
+	base := makeObj("pvc1", "100", "ns1")
+	informer.add(base)
+
+	// Assume a written version newer than the informer's.
+	if err := cache.AssumeWritten(makeObj("pvc1", "105", "ns1")); err != nil {
+		t.Fatalf("AssumeWritten(105) failed: %v", err)
+	}
+
+	// The object is deleted from the informer.
+	informer.delete(base)
+
+	// The assumed object must not survive the delete.
+	if _, err := cache.Get(keyOf(base)); err == nil {
+		t.Fatalf("Get() returned success after delete; assumed object was resurrected")
 	}
 }

--- a/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache_test.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package volumebinding
+package assumecache
 
 import (
 	"fmt"
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/component-helpers/storage/volume"
 	"k8s.io/klog/v2/ktesting"
 )
 
@@ -180,7 +179,7 @@ func makeObj(name, version, namespace string) *testObj {
 	}
 }
 
-type testCache = *passiveAssumeCache[*testObj]
+type testCache = *AssumeCache[*testObj]
 
 func verifyObj(cache testCache, key string, expected *testObj) error {
 	obj, err := cache.Get(key)
@@ -195,6 +194,8 @@ func verifyObj(cache testCache, key string, expected *testObj) error {
 
 const testIndex = "testIndex"
 
+const testAnnotationKey = "volume.kubernetes.io/selected-node"
+
 func newTestCache(t *testing.T) (*testInformer, testCache) {
 	logger, _ := ktesting.NewTestContext(t)
 	informer := &testInformer{
@@ -205,9 +206,9 @@ func newTestCache(t *testing.T) (*testInformer, testCache) {
 		}),
 		t: t,
 	}
-	cache, err := newAssumeCache[*testObj](logger, informer, schema.GroupResource{Resource: "tests"})
+	cache, err := NewAssumeCache[*testObj](logger, informer, schema.GroupResource{Resource: "tests"})
 	if err != nil {
-		t.Fatalf("newAssumeCache() failed: %v", err)
+		t.Fatalf("NewAssumeCache() failed: %v", err)
 	}
 	return informer, cache
 }
@@ -362,7 +363,7 @@ func TestAssumeUpdateCache(t *testing.T) {
 
 	// Assume
 	newObj := obj.DeepCopy()
-	newObj.Annotations[volume.AnnSelectedNode] = "test-node"
+	newObj.Annotations[testAnnotationKey] = "test-node"
 	if err := cache.Assume(newObj); err != nil {
 		t.Fatalf("failed to assume: %v", err)
 	}
@@ -388,7 +389,7 @@ func TestDelayedInformerEvent(t *testing.T) {
 	}
 
 	newObj := obj2.DeepCopy()
-	newObj.Annotations[volume.AnnSelectedNode] = "test-node"
+	newObj.Annotations[testAnnotationKey] = "test-node"
 	if err := cache.Assume(newObj); err != nil {
 		t.Fatalf("failed to assume: %v", err)
 	}

--- a/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache_test.go
+++ b/staging/src/k8s.io/component-helpers/storage/volume/assumecache/assume_cache_test.go
@@ -440,6 +440,35 @@ func TestAssumeWritten(t *testing.T) {
 	}
 }
 
+// TestGetAssumed verifies that GetAssumed reports whether the served object
+// came from an assumption or from the informer store.
+func TestGetAssumed(t *testing.T) {
+	informer, cache := newTestCache(t)
+
+	base := makeObj("pvc1", "5", "ns1")
+	informer.add(base)
+
+	// Informer object: assumed is false.
+	if obj, assumed, err := cache.GetAssumed(keyOf(base)); err != nil || assumed || obj != base {
+		t.Fatalf("GetAssumed(informer) = (%v, %v, %v), want (%v, false, nil)", obj, assumed, err, base)
+	}
+
+	// Written object not yet observed by the informer: assumed is true.
+	newer := makeObj("pvc1", "7", "ns1")
+	if err := cache.AssumeWritten(newer); err != nil {
+		t.Fatalf("AssumeWritten(newer) returned error: %v", err)
+	}
+	if obj, assumed, err := cache.GetAssumed(keyOf(newer)); err != nil || !assumed || obj != newer {
+		t.Fatalf("GetAssumed(assumed) = (%v, %v, %v), want (%v, true, nil)", obj, assumed, err, newer)
+	}
+
+	// Informer catches up: the assumption expires, assumed is false again.
+	informer.add(newer)
+	if obj, assumed, err := cache.GetAssumed(keyOf(newer)); err != nil || assumed || obj != newer {
+		t.Fatalf("GetAssumed(caught up) = (%v, %v, %v), want (%v, false, nil)", obj, assumed, err, newer)
+	}
+}
+
 // TestAssumeWrittenNotRevertedByIntermediateEvent verifies that when the
 // controller writes an object several times in a row (e.g. spec then status)
 // and assumes each server-returned version, a later informer event for an


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The PV controller kept its own PV/PVC caches (`ctrl.volumes`, `ctrl.claims`) separate from the shared informers, reconciled via `storeObjectUpdate()`. That split brain caused #124224:

- an in-flight controller update could re-add an object the informer had already observed as deleted, resurrecting a phantom PV/PVC; and
- concurrent read-compare-write of the separate store could overwrite a newer version with a stale one.

This PR replaces both caches and `storeObjectUpdate()` with a single `assumecache.AssumeCache[T]` layered on each shared informer. The informer indexer is the source of truth; the controller's own writes are recorded with `AssumeWritten()` (using comparable ResourceVersions, KEP-5504) so reads observe them until the informer catches up, and never resurrect a deleted object.

Done in three commits:
1. Move `AssumeCache` to a shared `component-helpers` package.
2. Add `AssumeWritten` so a cache can assume objects it has already written to the apiserver (which carry a newer, server-assigned ResourceVersion).
3. Rewire the PV controller onto the assume cache.

#### Which issue(s) this PR is related to:

Fixes #124224
KEP: https://github.com/kubernetes/enhancements/issues/5504

#### Special notes for your reviewer:

No behavior change intended. The old `storeObjectUpdate()` "skip older ResourceVersion" guard is preserved via `AssumeCache.GetAssumed()`: `syncVolumeByKey`/`syncClaimByKey` skip the sync while the object is still served from the controller's own not-yet-observed write (it already reflects that write; the informer catching up re-enqueues and expires the assumption, so state is reconciled exactly once). Because a written assumption expires at RV-equality, the "let the same version pass" behavior that periodic resync relies on is kept as well; the 15s resync is unchanged. The RV-ordering logic previously covered via `storeObjectUpdate()` tests is now covered by the assumecache package tests.

##### Why `AssumeCache` and not `ConsistencyStore`

`ConsistencyStore` is introduced recently and is used by the Job/ReplicaSet controllers, etc. They share the idea of comparing RVs at read time to determine freshness.
`ConsistencyStore` records the RVs an owner has written, and its `EnsureReady(owner)` gates a sync until the informer has caught up to those writes. Each worker then reads the plain informer. But we still use `AssumeCache`:

- The PV controller is a bidirectional 1:1 binder: both `syncVolume` and `syncClaim` read *and* write both object types, so there is no single "owner" a write naturally belongs to. `ConsistencyStore` is designed for owner -> children reconcilers. It could be bent to fit the PV controller by recording on each object's own identity and check every object separately when read. That seems correct, but does not feel right.
- A single PV is written from three places concurrently: the claim worker (during `bind`), the volume worker (phase updates / `unbindVolume`), and async reclaim/delete goroutines. `ConsistencyStore` documents that `EnsureReady` must not run concurrently with `WroteAt` for the same key. Job/RS satisfy this for free (one owner, one goroutine); the PV controller does not.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a rare race in the PersistentVolume controller that could leave a PV stuck in the `Bound` phase and never released after concurrent updates.
```
