### PR TITLE
WIP: suspend pod relists while syncing pod

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -910,6 +910,13 @@ func NewMainKubelet(ctx context.Context,
 		klet.pleg = pleg.NewGenericPLEG(klet.containerRuntime, eventChannel, genericRelistDuration, podCache, clock.RealClock{})
 	}
 
+	if pleg := klet.pleg; pleg != nil {
+		if pw, ok := klet.podWorkers.(*podWorkers); ok {
+			pw.pleg = pleg
+		}
+	}
+
+
 	klet.runtimeState = newRuntimeState(maxWaitForContainerRuntime)
 	klet.runtimeState.addHealthCheck("PLEG", klet.pleg.Healthy)
 	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
@@ -2052,7 +2059,7 @@ func (kl *Kubelet) Run(ctx context.Context, updates <-chan kubetypes.PodUpdate) 
 // This operation writes all events that are dispatched in order to provide
 // the most accurate information possible about an error situation to aid debugging.
 // Callers should not write an event if this operation returns an error.
-func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (isTerminal bool, postSync func(), err error) {
+func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (isTerminal bool, requestRelist bool, err error) {
 	ctx, otelSpan := kl.tracer.Start(ctx, "syncPod", trace.WithAttributes(
 		semconv.K8SPodUIDKey.String(string(pod.UID)),
 		attribute.String("k8s.pod", klog.KObj(pod).String()),
@@ -2123,7 +2130,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	if apiPodStatus.Phase == v1.PodSucceeded || apiPodStatus.Phase == v1.PodFailed {
 		kl.statusManager.SetPodStatus(logger, pod, apiPodStatus)
 		isTerminal = true
-		return isTerminal, nil, nil
+		return isTerminal, false, nil
 	}
 
 	// Record the time it takes for the pod to become running
@@ -2139,7 +2146,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	// If the network plugin is not ready, only start the pod if it uses the host network
 	if err := kl.runtimeState.networkErrors(); err != nil && !kubecontainer.IsHostNetworkPod(pod) {
 		kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.NetworkNotReady, "%s: %v", NetworkNotReadyErrorMsg, err)
-		return false, nil, fmt.Errorf("%s: %v", NetworkNotReadyErrorMsg, err)
+		return false, false, fmt.Errorf("%s: %v", NetworkNotReadyErrorMsg, err)
 	}
 
 	// ensure the kubelet knows about referenced secrets or configmaps used by the pod
@@ -2180,7 +2187,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 				podKilled = true
 			} else {
 				if wait.Interrupted(err) {
-					return false, nil, nil
+					return false, false, nil
 				}
 				logger.Error(err, "KillPod failed", "pod", klog.KObj(pod), "podStatus", podStatus)
 			}
@@ -2208,11 +2215,11 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 				}
 				if err := pcm.EnsureExists(logger, pod); err != nil {
 					kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.FailedToCreatePodContainer, "unable to ensure pod container exists: %v", err)
-					return false, nil, fmt.Errorf("failed to ensure that the pod: %v cgroups exist and are correctly applied: %v", pod.UID, err)
+					return false, false, fmt.Errorf("failed to ensure that the pod: %v cgroups exist and are correctly applied: %v", pod.UID, err)
 				}
 
 				if err = kl.containerRuntime.UpdateActuatedPodLevelResources(logger, pod); err != nil {
-					return false, nil, fmt.Errorf("failed to update the state of pod-level resources for the pod %v : %w", pod.UID, err)
+					return false, false, fmt.Errorf("failed to update the state of pod-level resources for the pod %v : %w", pod.UID, err)
 				}
 			}
 		}
@@ -2225,7 +2232,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	if err := kl.makePodDataDirs(pod); err != nil {
 		kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.FailedToMakePodDataDirectories, "error making pod data directories: %v", err)
 		logger.Error(err, "Unable to make pod data directories for pod", "pod", klog.KObj(pod))
-		return false, nil, err
+		return false, false, err
 	}
 
 	// Wait for volumes to attach/mount
@@ -2234,13 +2241,13 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 		if errors.As(err, &volumeAttachLimitErr) {
 			kl.rejectPod(ctx, pod, volumemanager.VolumeAttachmentLimitExceededReason, volumeAttachLimitErr.Error())
 			recordAdmissionRejection(volumemanager.VolumeAttachmentLimitExceededReason)
-			return true, nil, nil
+			return true, false, nil
 		}
 		if !wait.Interrupted(err) {
 			kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, events.FailedMountVolume, "Unable to attach or mount volumes: %v", err)
 			logger.Error(err, "Unable to attach or mount volumes for pod; skipping pod", "pod", klog.KObj(pod))
 		}
-		return false, nil, err
+		return false, false, err
 	}
 
 	// Fetch the pull secrets for the pod
@@ -2319,14 +2326,11 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	}
 
 	err = result.Error()
-	if len(result.SyncResults) > 0 && err == nil {
-		postSync = func() {
-			kl.RequestPodRelist(klog.FromContext(ctx), pod.UID)
-		}
-	}
+	requestRelist = len(result.SyncResults) > 0 && err == nil
 
-	return false, postSync, err
+	return false, requestRelist, err
 }
+
 
 // SyncTerminatingPod is expected to terminate all running containers in a pod. Once this method
 // returns without error, the pod is considered to be terminated and it will be safe to clean up any

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -668,9 +668,9 @@ func TestDispatchWorkOfCompletedPod(t *testing.T) {
 	kubelet := testKubelet.kubelet
 	var got bool
 	kubelet.podWorkers = &fakePodWorkers{
-		syncPodFn: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, func(), error) {
+		syncPodFn: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, bool, error) {
 			got = true
-			return false, nil, nil
+			return false, false, nil
 		},
 		cache: kubelet.podCache,
 		t:     t,
@@ -752,9 +752,9 @@ func TestDispatchWorkOfActivePod(t *testing.T) {
 	kubelet := testKubelet.kubelet
 	var got bool
 	kubelet.podWorkers = &fakePodWorkers{
-		syncPodFn: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, func(), error) {
+		syncPodFn: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, bool, error) {
 			got = true
-			return false, nil, nil
+			return false, false, nil
 		},
 		cache: kubelet.podCache,
 		t:     t,
@@ -2800,8 +2800,8 @@ func TestPodResourceAllocationReset(t *testing.T) {
 	// fakePodWorkers triggers syncPodFn synchronously on update. We overwrite it here to
 	// avoid calling kubelet.SyncPod, which performs resize resource allocation.
 	kubelet.podWorkers.(*fakePodWorkers).syncPodFn =
-		func(_ context.Context, _ kubetypes.SyncPodType, _, _ *v1.Pod, _ *kubecontainer.PodStatus) (bool, func(), error) {
-			return false, nil, nil
+		func(_ context.Context, _ kubetypes.SyncPodType, _, _ *v1.Pod, _ *kubecontainer.PodStatus) (bool, bool, error) {
+			return false, false, nil
 		}
 
 	nodes := []*v1.Node{
@@ -5323,7 +5323,7 @@ func TestSyncPodRestartAllContainersRequeue(t *testing.T) {
 
 	callCount := 0
 	kubelet.podWorkers = &fakePodWorkers{
-		syncPodFn: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, func(), error) {
+		syncPodFn: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, bool, error) {
 			callCount++
 			if callCount > 1 {
 				// In the second call the SyncResult will not include the RemoveContainer.

--- a/pkg/kubelet/pleg/evented.go
+++ b/pkg/kubelet/pleg/evented.go
@@ -119,6 +119,14 @@ func (e *EventedPLEG) RequestRelist(logger klog.Logger, podUID types.UID) {
 	e.genericPleg.RequestRelist(logger, podUID)
 }
 
+func (e *EventedPLEG) SuspendPodRelist(podUID types.UID) {
+	e.genericPleg.SuspendPodRelist(podUID)
+}
+
+func (e *EventedPLEG) ResumePodRelist(logger klog.Logger, podUID types.UID, alwaysRelist bool) {
+	e.genericPleg.ResumePodRelist(logger, podUID, alwaysRelist)
+}
+
 // Start starts the Evented PLEG
 func (e *EventedPLEG) Start(ctx context.Context) {
 	e.runningMu.Lock()

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -80,6 +80,14 @@ type GenericPLEG struct {
 	relistRequests chan relistRequest
 	// globalRelistTimer controls the periodic global relist.
 	globalRelistTimer clock.Timer
+	// podRelistStates maps podUID to its relist suspension state.
+	podRelistStates sync.Map
+}
+
+type podRelistState struct {
+	mu           sync.Mutex
+	suspended    bool
+	relistNeeded bool
 }
 
 // Empty placeholder value for podsToReinspect (shared pointer reduces allocations).
@@ -342,12 +350,24 @@ func (g *GenericPLEG) reconcilePodRecord(ctx context.Context, pid types.UID) {
 		events = append(events, containerEvents...)
 	}
 
-	_, reinspect := g.podsToReinspect.LoadAndDelete(pid)
+	_, reinspect := g.podsToReinspect.Load(pid)
 
 	if len(events) == 0 && !reinspect {
 		// Nothing else needed for this pod.
 		return
 	}
+
+	state := g.getPodRelistState(pid)
+	state.mu.Lock()
+	if state.suspended {
+		logger.V(4).Info("GenericPLEG: Pod is suspended during global relist reconciliation, queueing relist request", "podUID", pid)
+		state.relistNeeded = true
+		state.mu.Unlock()
+		return
+	}
+	state.mu.Unlock()
+
+	g.podsToReinspect.Delete(pid)
 
 	// updateCache() will inspect the pod and update the cache. If an
 	// error occurs during the inspection, we want PLEG to retry again
@@ -380,6 +400,10 @@ func (g *GenericPLEG) reconcilePodRecord(ctx context.Context, pid types.UID) {
 
 	// Update the internal storage and send out the events.
 	g.podRecords.update(pid)
+	if _, exists := g.podRecords[pid]; !exists {
+		logger.V(4).Info("GenericPLEG: Pod is deleted, cleaning up relist state", "podUID", pid)
+		g.podRelistStates.Delete(pid)
+	}
 
 	// Map from containerId to exit code; used as a temporary cache for lookup
 	containerExitCode := make(map[string]int)
@@ -415,9 +439,19 @@ func (g *GenericPLEG) reconcilePodRecord(ctx context.Context, pid types.UID) {
 }
 
 func (g *GenericPLEG) relistPod(ctx context.Context, podUID types.UID) {
+	logger := klog.FromContext(ctx)
+	state := g.getPodRelistState(podUID)
+	state.mu.Lock()
+	if state.suspended {
+		logger.V(4).Info("GenericPLEG: Relists are suspended, queueing relist request", "podUID", podUID)
+		state.relistNeeded = true
+		state.mu.Unlock()
+		return
+	}
+	state.mu.Unlock()
+
 	g.relistLock.Lock()
 	defer g.relistLock.Unlock()
-	logger := klog.FromContext(ctx)
 
 	logger.V(5).Info("GenericPLEG: Relisting Pod", "podUID", podUID)
 
@@ -567,13 +601,53 @@ func (g *GenericPLEG) RequestReinspect(podUID types.UID) {
 	g.podsToReinspect.Store(podUID, empty)
 }
 
+func (g *GenericPLEG) getPodRelistState(uid types.UID) *podRelistState {
+	val, _ := g.podRelistStates.LoadOrStore(uid, &podRelistState{})
+	return val.(*podRelistState)
+}
+
+func (g *GenericPLEG) SuspendPodRelist(podUID types.UID) {
+	state := g.getPodRelistState(podUID)
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	state.suspended = true
+}
+
+func (g *GenericPLEG) ResumePodRelist(logger klog.Logger, podUID types.UID, alwaysRelist bool) {
+	state := g.getPodRelistState(podUID)
+	state.mu.Lock()
+	state.suspended = false
+	needed := state.relistNeeded || alwaysRelist
+	state.relistNeeded = false
+	state.mu.Unlock()
+
+	if needed {
+		logger.V(4).Info("GenericPLEG: Resuming relists, triggering queued relist request", "podUID", podUID, "alwaysRelist", alwaysRelist)
+		select {
+		case g.relistRequests <- relistRequest{podUID, g.clock.Now()}:
+		default:
+			logger.Error(nil, "Relist request channel full; dropping queued relist request", "podUID", podUID)
+		}
+	}
+}
+
 func (g *GenericPLEG) RequestRelist(logger klog.Logger, podUID types.UID) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.PLEGOnDemandRelist) {
 		return
 	}
 
+	state := g.getPodRelistState(podUID)
+	state.mu.Lock()
+	if state.suspended {
+		logger.V(4).Info("GenericPLEG: Relists are suspended, queueing request", "podUID", podUID)
+		state.relistNeeded = true
+		state.mu.Unlock()
+		return
+	}
+	state.mu.Unlock()
+
 	select {
-	case g.relistRequests <- relistRequest{podUID, time.Now()}:
+	case g.relistRequests <- relistRequest{podUID, g.clock.Now()}:
 	default:
 		logger.Error(nil, "Relist request channel full; dropping relist request", "podUID", podUID)
 	}

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -980,3 +980,171 @@ func requireUnblocked[T any](t *testing.T, ch <-chan T) (received T) {
 		return
 	}
 }
+
+func TestSuspendResumeRelist(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.PLEGOnDemandRelist, true)
+	synctest.Test(t, func(t *testing.T) {
+		tCtx := ktesting.Init(t)
+		runtimeMock := containertest.NewMockRuntime(t)
+		cache := kubecontainer.NewCache()
+		pleg := NewGenericPLEG(
+			runtimeMock,
+			make(chan *PodLifecycleEvent, 100),
+			&RelistDuration{RelistPeriod: 2 * time.Second},
+			cache,
+			clock.RealClock{},
+		).(*GenericPLEG)
+
+		pod1 := &kubecontainer.Pod{ID: "pod1", Name: "pod1", Containers: []*kubecontainer.Container{{ID: kubecontainer.ContainerID{Type: "test", ID: "c1"}, State: kubecontainer.ContainerStateRunning}}}
+		pleg.globalRelistTimer = pleg.clock.NewTimer(2 * time.Second)
+
+		t.Log("1a. Suspend pod1 relist, and request relist. It should be queued in state but not channel.")
+		pleg.SuspendPodRelist(pod1.ID)
+		pleg.RequestRelist(tCtx.Logger(), pod1.ID)
+
+		// Verify it is queued in state
+		state := pleg.getPodRelistState(pod1.ID)
+		state.mu.Lock()
+		assert.True(t, state.suspended)
+		assert.True(t, state.relistNeeded)
+		state.mu.Unlock()
+
+		t.Log("1b. Resume pod1 relist (queues it) and suspend again. Worker should dequeue and return early.")
+		pleg.ResumePodRelist(tCtx.Logger(), pod1.ID, false)
+		pleg.SuspendPodRelist(pod1.ID)
+
+		// workerLoopIteration should dequeue and call relistPod, which should return early because suspended.
+		// We do NOT expect GetPod to be called.
+		pleg.workerLoopIteration(tCtx)
+
+		// Verify it is queued in state again
+		state.mu.Lock()
+		assert.True(t, state.suspended)
+		assert.True(t, state.relistNeeded)
+		state.mu.Unlock()
+
+		t.Log("2. Resume pod1 relist. It should queue the request to the channel.")
+		call := runtimeMock.EXPECT().GetPod(mock.Anything, pod1.ID).RunAndReturn(func(ctx context.Context, uid types.UID) (*kubecontainer.Pod, error) {
+			assert.Equal(t, pod1.ID, uid)
+			pod1.Timestamp = time.Now()
+			return pod1, nil
+		}).Once()
+		runtimeMock.EXPECT().GetPodStatus(mock.Anything, pod1).RunAndReturn(func(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
+			assert.Equal(t, pod1, pod)
+			return &kubecontainer.PodStatus{ID: pod1.ID, TimeStamp: time.Now()}, nil
+		}).NotBefore(call).Once()
+
+		pleg.ResumePodRelist(tCtx.Logger(), pod1.ID, false)
+
+		// Now run worker loop to process the queued request
+		pleg.workerLoopIteration(tCtx)
+
+		t.Log("3. Suspend pod1 relist, and run global relist. It should skip reconciliation for pod1.")
+		pleg.SuspendPodRelist(pod1.ID)
+
+		pod1_changed := &kubecontainer.Pod{ID: "pod1", Name: "pod1", Containers: []*kubecontainer.Container{
+			{ID: kubecontainer.ContainerID{Type: "test", ID: "c1"}, State: kubecontainer.ContainerStateExited},
+		}}
+
+		runtimeMock.EXPECT().GetPods(mock.Anything, true).RunAndReturn(func(_ context.Context, _ bool) ([]*kubecontainer.Pod, error) {
+			pod1_changed.Timestamp = time.Now()
+			return []*kubecontainer.Pod{pod1_changed}, nil
+		}).Once()
+
+		pleg.globalRelistTimer.Reset(0)
+		pleg.workerLoopIteration(tCtx)
+
+		// Verify that a relist is queued in state because global relist saw changes but was suspended.
+		state.mu.Lock()
+		assert.True(t, state.relistNeeded)
+		state.mu.Unlock()
+
+		t.Log("4. Resume pod1. It should trigger the queued relist which will update the cache.")
+		call = runtimeMock.EXPECT().GetPod(mock.Anything, pod1.ID).RunAndReturn(func(ctx context.Context, uid types.UID) (*kubecontainer.Pod, error) {
+			assert.Equal(t, pod1.ID, uid)
+			pod1_changed.Timestamp = time.Now()
+			return pod1_changed, nil
+		}).Once()
+		runtimeMock.EXPECT().GetPodStatus(mock.Anything, pod1_changed).RunAndReturn(func(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
+			assert.Equal(t, pod1_changed, pod)
+			return &kubecontainer.PodStatus{ID: pod1_changed.ID, TimeStamp: time.Now()}, nil
+		}).NotBefore(call).Once()
+
+		time.Sleep(10 * time.Millisecond) // Advance fake time to ensure T_now > T_global
+		pleg.ResumePodRelist(tCtx.Logger(), pod1.ID, false)
+		pleg.workerLoopIteration(tCtx)
+
+		t.Log("5. Suspend and flag for reinspect. Global relist should queue relist and preserve reinspect.")
+		runtimeMock.EXPECT().GetPods(mock.Anything, true).RunAndReturn(func(_ context.Context, _ bool) ([]*kubecontainer.Pod, error) {
+			pod1_changed.Timestamp = time.Now()
+			return []*kubecontainer.Pod{pod1_changed}, nil
+		}).Once()
+
+		pleg.RequestReinspect(pod1.ID)
+		pleg.SuspendPodRelist(pod1.ID)
+		pleg.globalRelistTimer.Reset(0)
+		pleg.workerLoopIteration(tCtx)
+
+		// Verify queued
+		state.mu.Lock()
+		assert.True(t, state.relistNeeded)
+		state.mu.Unlock()
+
+		// Verify reinspect still in map
+		_, reinspectExists := pleg.podsToReinspect.Load(pod1.ID)
+		assert.True(t, reinspectExists)
+
+		t.Log("6. Resume pod1 after reinspect suspend. It should trigger relist and clean reinspect.")
+		call = runtimeMock.EXPECT().GetPod(mock.Anything, pod1.ID).RunAndReturn(func(ctx context.Context, uid types.UID) (*kubecontainer.Pod, error) {
+			assert.Equal(t, pod1.ID, uid)
+			pod1_changed.Timestamp = time.Now()
+			return pod1_changed, nil
+		}).Once()
+		runtimeMock.EXPECT().GetPodStatus(mock.Anything, pod1_changed).RunAndReturn(func(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
+			assert.Equal(t, pod1_changed, pod)
+			return &kubecontainer.PodStatus{ID: pod1_changed.ID, TimeStamp: time.Now()}, nil
+		}).NotBefore(call).Once()
+
+		time.Sleep(10 * time.Millisecond) // Advance fake time to ensure T_now > T_global_2
+		pleg.ResumePodRelist(tCtx.Logger(), pod1.ID, false)
+		pleg.workerLoopIteration(tCtx)
+
+		// Verify reinspect is now gone
+		_, reinspectExists = pleg.podsToReinspect.Load(pod1.ID)
+		assert.False(t, reinspectExists)
+
+		t.Log("8. Suspend and resume with alwaysRelist=true when not needed. It should trigger relist.")
+		pleg.SuspendPodRelist(pod1.ID)
+		// relistNeeded is false.
+		// We expect GetPod and GetPodStatus because we return a changed pod.
+		pod1_changed_2 := &kubecontainer.Pod{ID: "pod1", Name: "pod1", Containers: []*kubecontainer.Container{
+			{ID: kubecontainer.ContainerID{Type: "test", ID: "c1"}, State: kubecontainer.ContainerStateRunning},
+		}}
+		call = runtimeMock.EXPECT().GetPod(mock.Anything, pod1.ID).RunAndReturn(func(ctx context.Context, uid types.UID) (*kubecontainer.Pod, error) {
+			assert.Equal(t, pod1.ID, uid)
+			pod1_changed_2.Timestamp = time.Now()
+			return pod1_changed_2, nil
+		}).Once()
+		runtimeMock.EXPECT().GetPodStatus(mock.Anything, pod1_changed_2).RunAndReturn(func(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
+			assert.Equal(t, pod1_changed_2, pod)
+			return &kubecontainer.PodStatus{ID: pod1_changed_2.ID, TimeStamp: time.Now()}, nil
+		}).NotBefore(call).Once()
+
+		time.Sleep(10 * time.Millisecond) // Advance fake time
+		pleg.ResumePodRelist(tCtx.Logger(), pod1.ID, true) // alwaysRelist = true
+		pleg.workerLoopIteration(tCtx)
+
+		t.Log("7. Verify cleanup on deletion.")
+		runtimeMock.EXPECT().GetPods(mock.Anything, true).RunAndReturn(func(_ context.Context, _ bool) ([]*kubecontainer.Pod, error) {
+			return nil, nil
+		}).Once()
+
+		pleg.globalRelistTimer.Reset(0)
+		pleg.workerLoopIteration(tCtx)
+
+		// The pod should be removed from podRelistStates.
+		_, exists := pleg.podRelistStates.Load(pod1.ID)
+		assert.False(t, exists)
+	})
+}
+

--- a/pkg/kubelet/pleg/pleg.go
+++ b/pkg/kubelet/pleg/pleg.go
@@ -71,6 +71,11 @@ type PodLifecycleEventGenerator interface {
 	RequestReinspect(podUID types.UID)
 	// RequestRelist queues up the pod for an on-demand relist.
 	RequestRelist(logger klog.Logger, podUID types.UID)
+	// SuspendPodRelist suspends on-demand relists for the pod.
+	SuspendPodRelist(podUID types.UID)
+	// ResumePodRelist resumes on-demand relists for the pod and triggers any queued relist.
+	// If alwaysRelist is true, it forces a relist even if none was queued.
+	ResumePodRelist(logger klog.Logger, podUID types.UID, alwaysRelist bool)
 }
 
 // podLifecycleEventGeneratorHandler contains functions that are useful for different PLEGs

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -256,6 +256,11 @@ type PodWorkers interface {
 	IsPodForMirrorPodTerminatingByFullName(podFullname string) bool
 }
 
+type PodRelistSuspender interface {
+	SuspendPodRelist(podUID types.UID)
+	ResumePodRelist(logger klog.Logger, podUID types.UID, alwaysRelist bool)
+}
+
 // podSyncer describes the core lifecyle operations of the pod state machine. A pod is first
 // synced until it naturally reaches termination (true is returned) or an external agent decides
 // the pod should be terminated. Once a pod should be terminating, SyncTerminatingPod is invoked
@@ -267,7 +272,7 @@ type podSyncer interface {
 	// pod has reached a terminal state and the presence of the error indicates succeeded or failed.
 	// If an error is returned, the sync was not successful and should be rerun in the future. This
 	// is a long running method and should exit early with context.Canceled if the context is canceled.
-	SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod *v1.Pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, func(), error)
+	SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod *v1.Pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, bool, error)
 	// SyncTerminatingPod attempts to ensure the pod's containers are no longer running and to collect
 	// any final status. This method is repeatedly invoked with diminishing grace periods until it exits
 	// without error. Once this method exits with no error other components are allowed to tear down
@@ -285,7 +290,7 @@ type podSyncer interface {
 	SyncTerminatedPod(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus) error
 }
 
-type syncPodFnType func(ctx context.Context, updateType kubetypes.SyncPodType, pod *v1.Pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, func(), error)
+type syncPodFnType func(ctx context.Context, updateType kubetypes.SyncPodType, pod *v1.Pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, bool, error)
 type syncTerminatingPodFnType func(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus, gracePeriod *int64, podStatusFn func(*v1.PodStatus)) error
 type syncTerminatingRuntimePodFnType func(ctx context.Context, runningPod *kubecontainer.Pod) error
 type syncTerminatedPodFnType func(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus) error
@@ -309,7 +314,7 @@ func newPodSyncerFuncs(s podSyncer) podSyncerFuncs {
 
 var _ podSyncer = podSyncerFuncs{}
 
-func (f podSyncerFuncs) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod *v1.Pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, func(), error) {
+func (f podSyncerFuncs) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod *v1.Pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, bool, error) {
 	return f.syncPod(ctx, updateType, pod, mirrorPod, podStatus)
 }
 func (f podSyncerFuncs) SyncTerminatingPod(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus, gracePeriod *int64, podStatusFn func(*v1.PodStatus)) error {
@@ -596,6 +601,7 @@ type podWorkers struct {
 	// NOTE: This function has to be thread-safe - it can be called for
 	// different pods at the same time.
 	podSyncer podSyncer
+	pleg      PodRelistSuspender
 
 	// workerChannelFn is exposed for testing to allow unit tests to impose delays
 	// in channel communication. The function is invoked once each time a new worker
@@ -1296,7 +1302,7 @@ func (p *podWorkers) podWorkerLoop(parentCtx context.Context, podUID types.UID, 
 			}
 
 			// Take the appropriate action (illegal phases are prevented by UpdatePod)
-			var postSync func()
+			var relistSuspended, requestRelist bool
 			switch {
 			case update.WorkType == TerminatedPod:
 				err = p.podSyncer.SyncTerminatedPod(ctx, update.Options.Pod, status)
@@ -1316,12 +1322,14 @@ func (p *podWorkers) podWorkerLoop(parentCtx context.Context, podUID types.UID, 
 				}
 
 			default:
-				isTerminal, postSync, err = p.podSyncer.SyncPod(ctx, update.Options.UpdateType, update.Options.Pod, update.Options.MirrorPod, status)
+				p.pleg.SuspendPodRelist(podUID)
+				relistSuspended = true
+				isTerminal, requestRelist, err = p.podSyncer.SyncPod(ctx, update.Options.UpdateType, update.Options.Pod, update.Options.MirrorPod, status)
 			}
 
 			lastSyncTime = p.clock.Now()
-			if postSync != nil {
-				postSync()
+			if relistSuspended {
+				p.pleg.ResumePodRelist(logger, podUID, requestRelist)
 			}
 
 			return err

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -407,7 +407,7 @@ func createPodWorkersWithLogger(logger klog.Logger) (*podWorkers, *containertest
 	clock := clocktesting.NewFakePassiveClock(time.Unix(1, 0))
 	w := newPodWorkers(
 		&podSyncerFuncs{
-			syncPod: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, func(), error) {
+			syncPod: func(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, bool, error) {
 				func() {
 					lock.Lock()
 					defer lock.Unlock()
@@ -417,7 +417,7 @@ func createPodWorkersWithLogger(logger klog.Logger) (*podWorkers, *containertest
 						updateType: updateType,
 					})
 				}()
-				return false, nil, nil
+				return false, false, nil
 			},
 			syncTerminatingPod: func(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus, gracePeriod *int64, podStatusFn func(*v1.PodStatus)) error {
 				func() {
@@ -1205,17 +1205,17 @@ type terminalPhaseSync struct {
 	terminal sets.Set[string]
 }
 
-func (s *terminalPhaseSync) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod *v1.Pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, func(), error) {
+func (s *terminalPhaseSync) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod *v1.Pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, bool, error) {
 	isTerminal, _, err := s.fn(ctx, updateType, pod, mirrorPod, podStatus)
 	if err != nil {
-		return false, nil, err
+		return false, false, err
 	}
 	if !isTerminal {
 		s.lock.Lock()
 		defer s.lock.Unlock()
 		isTerminal = s.terminal.Has(string(pod.UID))
 	}
-	return isTerminal, nil, nil
+	return isTerminal, false, nil
 }
 
 func (s *terminalPhaseSync) SetTerminal(uid types.UID) {
@@ -2126,16 +2126,17 @@ type simpleFakeKubelet struct {
 	wg        sync.WaitGroup
 }
 
-func (kl *simpleFakeKubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, func(), error) {
+func (kl *simpleFakeKubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, bool, error) {
 	kl.pod, kl.mirrorPod, kl.podStatus = pod, mirrorPod, podStatus
-	return false, nil, nil
+	return false, false, nil
 }
 
-func (kl *simpleFakeKubelet) SyncPodWithWaitGroup(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, func(), error) {
+func (kl *simpleFakeKubelet) SyncPodWithWaitGroup(ctx context.Context, updateType kubetypes.SyncPodType, pod, mirrorPod *v1.Pod, podStatus *kubecontainer.PodStatus) (bool, bool, error) {
 	kl.pod, kl.mirrorPod, kl.podStatus = pod, mirrorPod, podStatus
 	kl.wg.Done()
-	return false, nil, nil
+	return false, false, nil
 }
+
 
 func (kl *simpleFakeKubelet) SyncTerminatingPod(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus, gracePeriod *int64, podStatusFn func(*v1.PodStatus)) error {
 	return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

SyncPod is always called in a single pod worker thread, and SyncPod is the only thing that processes events from the PLEG relist. Therefore, any relists that happen while SyncPod is running may be waisted effort. 

This PR introduces a way to suspend and resume relists for a pod, and queues up any relists requested while suspended to be triggered on resume.

#### Which issue(s) this PR is related to:

See https://github.com/kubernetes/kubernetes/pull/139262#issuecomment-5005543888

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig node