### PR TITLE
Fix hugepage reporting e2e test assertion for disabled feature gate

### DIFF
--- a/test/e2e_node/hugepages_reporting_test.go
+++ b/test/e2e_node/hugepages_reporting_test.go
@@ -140,17 +140,20 @@ var _ = SIGDescribe("HugepageAwareMemoryReporting", framework.WithSlow(), framew
 			framework.Logf("disabled: availableBefore=%d availableAfter=%d hugepages=%d",
 				availableBefore, availableAfter, expectedHugepageBytes)
 
-			// With the feature gate disabled, hugepage reservation is NOT subtracted
-			// from memory.available. The cgroup-based calculation still counts hugepage
-			// memory as available, so the drop should be much smaller than the
-			// hugepage reservation.
+			// With the feature gate disabled, hugepage reservation is NOT explicitly
+			// subtracted from memory.available via adjustForHugePages. However, the
+			// cgroup-based WorkingSet already reflects some of the hugepage reservation
+			// because the kernel removes hugepages from the free pool, so AvailableBytes
+			// (= Limit - WorkingSet) drops naturally. The drop should still be smaller
+			// than the full hugepage reservation, since adjustForHugePages is not
+			// applied (it would subtract the entire hugepage capacity on top).
 			drop := uint64(0)
 			if availableBefore > availableAfter {
 				drop = availableBefore - availableAfter
 			}
 			gomega.Expect(drop).To(
-				gomega.BeNumerically("<", expectedHugepageBytes-margin),
-				"memory.available should NOT decrease by the hugepage reservation when feature gate is disabled")
+				gomega.BeNumerically("<", expectedHugepageBytes),
+				"memory.available should NOT decrease by the full hugepage reservation when feature gate is disabled")
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind failing-test

#### What this PR does / why we need it:
The 'disabled' test case asserted that the drop in memory.available after reserving 32x2Mi hugepages should be less than expectedHugepageBytes - margin (64MiB - 50MiB = 14MiB). This threshold is too strict because the cgroup-based WorkingSet for the root cgroup already reflects most of the hugepage reservation: the kernel removes hugepages from the free pool, so MemFree drops and WorkingSet rises, causing AvailableBytes (= Limit - WorkingSet) to decrease naturally even without adjustForHugePages.

In the failing run the natural drop was ~47MiB, exceeding the 14MiB threshold.

Change the assertion to compare against expectedHugepageBytes (64MiB) instead of expectedHugepageBytes - margin. This still distinguishes the disabled case (drop < 64MiB, natural WorkingSet increase only) from the enabled case (drop >= 64MiB - 50MiB = 14MiB, adjustForHugePages subtracts full capacity).

Introduced in df355236d58 ('Make the eviction signal hugepages aware.').

#### Which issue(s) this PR is related to:

Fixes #140644

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
