### PR TITLE
etcd3: add apiserver_storage_list_duration_seconds metric

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -1908,6 +1908,43 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
+- name: storage_list_duration_seconds
+  namespace: apiserver
+  help: Latency of the storage layer GetList call in seconds, including object decode,
+    split by whether etcd RangeStream was used.
+  type: Histogram
+  stabilityLevel: ALPHA
+  labels:
+  - group
+  - resource
+  - streamed
+  buckets:
+  - 0.005
+  - 0.025
+  - 0.05
+  - 0.1
+  - 0.2
+  - 0.4
+  - 0.6
+  - 0.8
+  - 1
+  - 1.25
+  - 1.5
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 8
+  - 10
+  - 15
+  - 20
+  - 30
+  - 45
+  - 60
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: apiserver_storage_list_evaluated_objects_total
   help: Number of objects tested in the course of serving a LIST request from storage
   type: Counter

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -142,6 +142,17 @@ var (
 		},
 		[]string{"group", "resource"},
 	)
+	listLatency = compbasemetrics.NewHistogramVec(
+		&compbasemetrics.HistogramOpts{
+			Namespace: "apiserver",
+			Name:      "storage_list_duration_seconds",
+			Help:      "Latency of the storage layer GetList call in seconds, including object decode, split by whether etcd RangeStream was used.",
+			Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
+				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
+			StabilityLevel: compbasemetrics.ALPHA,
+		},
+		[]string{"streamed", "group", "resource"},
+	)
 )
 
 var registerMetrics sync.Once
@@ -162,6 +173,7 @@ func Register() {
 		legacyregistry.MustRegister(etcdBookmarkTotal)
 		legacyregistry.MustRegister(etcdLeaseObjectCounts)
 		legacyregistry.MustRegister(decodeErrorCounts)
+		legacyregistry.MustRegister(listLatency)
 	})
 }
 
@@ -203,6 +215,15 @@ func RecordEtcdRequest(verb string, groupResource schema.GroupResource, err erro
 	if err != nil {
 		etcdRequestErrorCounts.WithLabelValues(verb, groupResource.Group, groupResource.Resource).Inc()
 	}
+}
+
+// RecordListLatency sets the storage_list_duration_seconds metric.
+func RecordListLatency(groupResource schema.GroupResource, streamed bool, startTime time.Time) {
+	streamedLabel := "false"
+	if streamed {
+		streamedLabel = "true"
+	}
+	listLatency.WithLabelValues(streamedLabel, groupResource.Group, groupResource.Resource).Observe(sinceInSeconds(startTime))
 }
 
 // RecordEtcdEvent updated the etcd_events_received_total metric.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -783,11 +783,14 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 	var count int64
 	var numFetched int
 	var numEvald int
+	var streamed bool
+	startTime := time.Now()
 	// Because these metrics are for understanding the costs of handling LIST requests,
 	// get them recorded even in error cases.
 	defer func() {
 		numReturn := v.Len()
 		metrics.RecordStorageListMetrics(s.groupResource, "", numFetched, numEvald, numReturn)
+		metrics.RecordListLatency(s.groupResource, streamed, startTime)
 	}()
 
 	aggregator := s.listErrAggrFactory()
@@ -797,6 +800,7 @@ func (s *store) GetList(ctx context.Context, key string, opts storage.ListOption
 		streamChunks, supported := s.streamChunks(ctx, keyPrefix, withRev)
 		if supported {
 			chunks = streamChunks
+			streamed = true
 		} else {
 			etcdfeature.DefaultFeatureSupportChecker.MarkUnsupported(storage.RangeStream)
 			klog.V(4).Infof("etcd server does not support RangeStream for %v; falling back to paginated list", s.groupResource)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds `apiserver_storage_list_duration_seconds`, a histogram wrapping the whole `GetList` call (etcd read plus decode) labelled `streamed="true"|"false"`, so streamed and non-streamed list latency are comparable (unlike `etcd_request_duration_seconds`, where `list` excludes decode but `listStream` includes it).

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Added `apiserver_storage_list_duration_seconds`, a metric measuring end-to-end apiserver list latency (etcd read plus object decode), labelled by whether etcd RangeStream was used, so streamed and non-streamed lists can be compared directly.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE