### PR TITLE
fix: validate PodTopologySpread plugin args for constraint fields

### DIFF
--- a/pkg/scheduler/apis/config/validation/validation_pluginargs.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs.go
@@ -40,6 +40,11 @@ var supportedScoringStrategyTypes = sets.New(
 	string(config.RequestedToCapacityRatio),
 )
 
+var supportedPodTopologySpreadNodePolicies = sets.New(
+	v1.NodeInclusionPolicyHonor,
+	v1.NodeInclusionPolicyIgnore,
+)
+
 // ValidateDefaultPreemptionArgs validates that DefaultPreemptionArgs are correct.
 func ValidateDefaultPreemptionArgs(path *field.Path, args *config.DefaultPreemptionArgs) error {
 	var allErrs field.ErrorList
@@ -116,6 +121,13 @@ func ValidatePodTopologySpreadArgs(path *field.Path, args *config.PodTopologySpr
 		if err := validateWhenUnsatisfiable(p.Child("whenUnsatisfiable"), c.WhenUnsatisfiable); err != nil {
 			allErrs = append(allErrs, err)
 		}
+		allErrs = append(allErrs, validateMinDomains(p.Child("minDomains"), c.MinDomains, c.WhenUnsatisfiable)...)
+		if err := validateNodeInclusionPolicy(p.Child("nodeAffinityPolicy"), c.NodeAffinityPolicy); err != nil {
+			allErrs = append(allErrs, err)
+		}
+		if err := validateNodeInclusionPolicy(p.Child("nodeTaintsPolicy"), c.NodeTaintsPolicy); err != nil {
+			allErrs = append(allErrs, err)
+		}
 		if c.LabelSelector != nil {
 			f := field.Forbidden(p.Child("labelSelector"), "constraint must not define a selector, as they deduced for each pod")
 			allErrs = append(allErrs, f)
@@ -158,6 +170,31 @@ func validateWhenUnsatisfiable(p *field.Path, v v1.UnsatisfiableConstraintAction
 	}
 	if !supportedScheduleActions.Has(string(v)) {
 		return field.NotSupported(p, v, sets.List(supportedScheduleActions))
+	}
+	return nil
+}
+
+func validateMinDomains(p *field.Path, minDomains *int32, action v1.UnsatisfiableConstraintAction) field.ErrorList {
+	if minDomains == nil {
+		return nil
+	}
+
+	var allErrs field.ErrorList
+	if *minDomains <= 0 {
+		allErrs = append(allErrs, field.Invalid(p, *minDomains, "not in valid range (0, inf)"))
+	}
+	if action != v1.DoNotSchedule {
+		allErrs = append(allErrs, field.Invalid(p, *minDomains, fmt.Sprintf("can only use minDomains if whenUnsatisfiable=%s, not %s", v1.DoNotSchedule, action)))
+	}
+	return allErrs
+}
+
+func validateNodeInclusionPolicy(p *field.Path, policy *v1.NodeInclusionPolicy) *field.Error {
+	if policy == nil {
+		return nil
+	}
+	if !supportedPodTopologySpreadNodePolicies.Has(*policy) {
+		return field.NotSupported(p, *policy, sets.List(supportedPodTopologySpreadNodePolicies))
 	}
 	return nil
 }

--- a/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_pluginargs_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	schedfeature "k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -189,6 +190,124 @@ func TestValidatePodTopologySpreadArgs(t *testing.T) {
 					},
 				},
 				DefaultingType: config.ListDefaulting,
+			},
+		},
+		"valid config with minDomains and node inclusion policies": {
+			args: &config.PodTopologySpreadArgs{
+				DefaultConstraints: []v1.TopologySpreadConstraint{
+					{
+						MaxSkew:            1,
+						TopologyKey:        "node",
+						WhenUnsatisfiable:  v1.DoNotSchedule,
+						MinDomains:         ptr.To[int32](1),
+						NodeAffinityPolicy: ptr.To(v1.NodeInclusionPolicyHonor),
+						NodeTaintsPolicy:   ptr.To(v1.NodeInclusionPolicyIgnore),
+					},
+					{
+						MaxSkew:            2,
+						TopologyKey:        "zone",
+						WhenUnsatisfiable:  v1.DoNotSchedule,
+						MinDomains:         ptr.To[int32](2),
+						NodeAffinityPolicy: ptr.To(v1.NodeInclusionPolicyIgnore),
+						NodeTaintsPolicy:   ptr.To(v1.NodeInclusionPolicyHonor),
+					},
+				},
+				DefaultingType: config.ListDefaulting,
+			},
+		},
+		"minDomains less than zero": {
+			args: &config.PodTopologySpreadArgs{
+				DefaultConstraints: []v1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "node",
+						WhenUnsatisfiable: v1.DoNotSchedule,
+						MinDomains:        ptr.To[int32](-1),
+					},
+				},
+				DefaultingType: config.ListDefaulting,
+			},
+			wantErrs: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "defaultConstraints[0].minDomains",
+				},
+			},
+		},
+		"minDomains equal to zero": {
+			args: &config.PodTopologySpreadArgs{
+				DefaultConstraints: []v1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "node",
+						WhenUnsatisfiable: v1.DoNotSchedule,
+						MinDomains:        ptr.To[int32](0),
+					},
+				},
+				DefaultingType: config.ListDefaulting,
+			},
+			wantErrs: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "defaultConstraints[0].minDomains",
+				},
+			},
+		},
+		"minDomains with schedule anyway": {
+			args: &config.PodTopologySpreadArgs{
+				DefaultConstraints: []v1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "node",
+						WhenUnsatisfiable: v1.ScheduleAnyway,
+						MinDomains:        ptr.To[int32](1),
+					},
+				},
+				DefaultingType: config.ListDefaulting,
+			},
+			wantErrs: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "defaultConstraints[0].minDomains",
+				},
+			},
+		},
+		"unsupported nodeAffinityPolicy": {
+			args: &config.PodTopologySpreadArgs{
+				DefaultConstraints: []v1.TopologySpreadConstraint{
+					{
+						MaxSkew:            1,
+						TopologyKey:        "node",
+						WhenUnsatisfiable:  v1.DoNotSchedule,
+						NodeAffinityPolicy: ptr.To[v1.NodeInclusionPolicy]("unknown policy"),
+					},
+				},
+				DefaultingType: config.ListDefaulting,
+			},
+			wantErrs: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeNotSupported,
+					Field: "defaultConstraints[0].nodeAffinityPolicy",
+				},
+			},
+		},
+		"unsupported nodeTaintsPolicy": {
+			args: &config.PodTopologySpreadArgs{
+				DefaultConstraints: []v1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "node",
+						WhenUnsatisfiable: v1.DoNotSchedule,
+						NodeTaintsPolicy:  ptr.To[v1.NodeInclusionPolicy]("unknown policy"),
+					},
+				},
+				DefaultingType: config.ListDefaulting,
+			},
+			wantErrs: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeNotSupported,
+					Field: "defaultConstraints[0].nodeTaintsPolicy",
+				},
 			},
 		},
 		"maxSkew less than zero": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR extends scheduler config validation for `PodTopologySpreadArgs.defaultConstraints` to reject invalid newer `TopologySpreadConstraint` fields.

  It adds validation for:

  - `minDomains` must be positive when set
  - `minDomains` may only be set with `whenUnsatisfiable: DoNotSchedule`
  - `nodeAffinityPolicy` and `nodeTaintsPolicy` must be either `Honor` or `Ignore` when set

  This prevents kube-scheduler from accepting invalid plugin args that should fail during config validation.

#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
N/A
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Scheduler now rejects invalid `PodTopologySpreadArgs.defaultConstraints` entries. Users must to remove `matchLabelKeys` and correct non-positive `minDomains`, `minDomains` used with `ScheduleAnyway`, and unsupported `nodeAffinityPolicy` or `nodeTaintsPolicy` values before upgrading.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
