### PR TITLE
Add ObjectDefaulter support to generic testing helpers

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester.go
@@ -38,8 +38,9 @@ import (
 )
 
 type Tester struct {
-	tester  *resttest.Tester
-	storage *genericregistry.Store
+	tester   *resttest.Tester
+	storage  *genericregistry.Store
+	defaulter runtime.ObjectDefaulter
 }
 type UpdateFunc func(runtime.Object) runtime.Object
 
@@ -169,6 +170,16 @@ func (t *Tester) SetRequestInfo(requestInfo *genericapirequest.RequestInfo) *Tes
 	return t
 }
 
+// WithDefaulter sets the ObjectDefaulter used to apply defaults to objects
+// before they are stored. This ensures that objects created through the
+// test helpers have the same defaults applied as they would through the
+// normal API server creation path (where defaults are applied during
+// decode by the versioning codec).
+func (t *Tester) WithDefaulter(d runtime.ObjectDefaulter) *Tester {
+	t.defaulter = d
+	return t
+}
+
 func (t *Tester) TestCreate(valid runtime.Object, invalid ...runtime.Object) {
 	t.tester.TestCreate(
 		valid,
@@ -250,6 +261,9 @@ func (t *Tester) getObject(ctx context.Context, obj runtime.Object) (runtime.Obj
 }
 
 func (t *Tester) createObject(ctx context.Context, obj runtime.Object) error {
+	if t.defaulter != nil {
+		t.defaulter.Default(obj)
+	}
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return err
@@ -266,6 +280,11 @@ func (t *Tester) setObjectsForList(objects []runtime.Object) []runtime.Object {
 	if _, err := t.storage.DeleteCollection(t.tester.TestContext(), rest.ValidateAllObjectFunc, nil, nil); err != nil {
 		t.tester.Errorf("unable to clear collection: %v", err)
 		return nil
+	}
+	if t.defaulter != nil {
+		for i := range objects {
+			t.defaulter.Default(objects[i])
+		}
 	}
 	if err := storagetesting.CreateObjList(key, t.storage.Storage.Storage, objects); err != nil {
 		t.tester.Errorf("unexpected error: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester.go
@@ -38,8 +38,8 @@ import (
 )
 
 type Tester struct {
-	tester   *resttest.Tester
-	storage  *genericregistry.Store
+	tester    *resttest.Tester
+	storage   *genericregistry.Store
 	defaulter runtime.ObjectDefaulter
 }
 type UpdateFunc func(runtime.Object) runtime.Object

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tester
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type testObject struct {
+	runtime.TypeMeta
+	DefaultedField string
+}
+
+func (obj *testObject) DeepCopyObject() runtime.Object {
+	ret := *obj
+	return &ret
+}
+
+type testDefaulter struct{}
+
+func (d *testDefaulter) Default(obj runtime.Object) {
+	if t, ok := obj.(*testObject); ok {
+		if t.DefaultedField == "" {
+			t.DefaultedField = "defaulted"
+		}
+	}
+}
+
+func TestWithDefaulter(t *testing.T) {
+	defaulter := &testDefaulter{}
+
+	tester := &Tester{}
+	tester.WithDefaulter(defaulter)
+
+	if tester.defaulter == nil {
+		t.Fatal("expected defaulter to be set")
+	}
+
+	result := tester.WithDefaulter(defaulter)
+	if result != tester {
+		t.Fatal("expected WithDefaulter to return the same Tester instance for chaining")
+	}
+}
+
+func TestCreateObjectAppliesDefaults(t *testing.T) {
+	defaulter := &testDefaulter{}
+	tester := &Tester{defaulter: defaulter}
+
+	obj := &testObject{}
+
+	if obj.DefaultedField != "" {
+		t.Fatalf("expected DefaultedField to be empty, got %q", obj.DefaultedField)
+	}
+
+	if tester.defaulter != nil {
+		tester.defaulter.Default(obj)
+	}
+
+	if obj.DefaultedField != "defaulted" {
+		t.Fatalf("expected DefaultedField to be %q, got %q", "defaulted", obj.DefaultedField)
+	}
+}
+
+func TestSetObjectsForListAppliesDefaults(t *testing.T) {
+	defaulter := &testDefaulter{}
+	tester := &Tester{defaulter: defaulter}
+
+	objects := []runtime.Object{
+		&testObject{},
+		&testObject{DefaultedField: "kept"},
+	}
+
+	if tester.defaulter != nil {
+		for i := range objects {
+			tester.defaulter.Default(objects[i])
+		}
+	}
+
+	expected := []string{"defaulted", "kept"}
+	for i, obj := range objects {
+		tObj := obj.(*testObject)
+		if tObj.DefaultedField != expected[i] {
+			t.Errorf("object %d: expected DefaultedField to be %q, got %q", i, expected[i], tObj.DefaultedField)
+		}
+	}
+}
+
+func TestNoDefaulterDoesNotApplyDefaults(t *testing.T) {
+	tester := &Tester{}
+
+	obj := &testObject{}
+
+	if tester.defaulter != nil {
+		tester.defaulter.Default(obj)
+	}
+
+	if obj.DefaultedField != "" {
+		t.Fatalf("expected DefaultedField to be empty when no defaulter is set, got %q", obj.DefaultedField)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester_test.go
@@ -17,100 +17,248 @@ limitations under the License.
 package tester
 
 import (
+	"context"
+	"fmt"
+	"path"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/apitesting"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/apis/example"
+	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/generic"
+	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/storage"
+	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
+	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/storage/storagebackend/factory"
 )
 
-type testObject struct {
-	runtime.TypeMeta
-	DefaultedField string
+var scheme = runtime.NewScheme()
+var codecs = serializer.NewCodecFactory(scheme)
+
+func init() {
+	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
+	utilruntime.Must(example.AddToScheme(scheme))
+	utilruntime.Must(examplev1.AddToScheme(scheme))
 }
 
-func (obj *testObject) DeepCopyObject() runtime.Object {
-	ret := *obj
-	return &ret
+type testRESTStrategy struct {
+	runtime.ObjectTyper
+	names.NameGenerator
+	namespaceScoped          bool
+	allowCreateOnUpdate      bool
+	allowUnconditionalUpdate bool
 }
 
-type testDefaulter struct{}
+func (t *testRESTStrategy) NamespaceScoped() bool { return t.namespaceScoped }
+func (t *testRESTStrategy) AllowCreateOnUpdate(ctx context.Context) bool {
+	return t.allowCreateOnUpdate
+}
+func (t *testRESTStrategy) AllowUnconditionalUpdate(ctx context.Context) bool {
+	return t.allowUnconditionalUpdate
+}
+func (t *testRESTStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {}
+func (t *testRESTStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
+}
+func (t *testRESTStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
+	return nil
+}
+func (t *testRESTStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	return nil
+}
+func (t *testRESTStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+	return nil
+}
+func (t *testRESTStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+	return nil
+}
+func (t *testRESTStrategy) Canonicalize(obj runtime.Object) {}
 
-func (d *testDefaulter) Default(obj runtime.Object) {
-	if t, ok := obj.(*testObject); ok {
-		if t.DefaultedField == "" {
-			t.DefaultedField = "defaulted"
+// podDefaulter defaults the node name of pods without one, mirroring the
+// defaulting that the API server would apply through the normal create path.
+type podDefaulter struct{}
+
+func (d *podDefaulter) Default(obj runtime.Object) {
+	if pod, ok := obj.(*example.Pod); ok {
+		if pod.Spec.NodeName == "" {
+			pod.Spec.NodeName = "machine"
 		}
 	}
 }
 
-func TestWithDefaulter(t *testing.T) {
-	defaulter := &testDefaulter{}
+func newTestStore(t *testing.T) (factory.DestroyFunc, *genericregistry.Store) {
+	podPrefix := "/pods/"
+	server, sc := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
+	strategy := &testRESTStrategy{scheme, names.SimpleNameGenerator, true, false, true}
 
-	tester := &Tester{}
-	tester.WithDefaulter(defaulter)
+	newFunc := func() runtime.Object { return &example.Pod{} }
+	newListFunc := func() runtime.Object { return &example.PodList{} }
 
-	if tester.defaulter == nil {
-		t.Fatal("expected defaulter to be set")
+	sc.Codec = apitesting.TestStorageCodec(codecs, examplev1.SchemeGroupVersion)
+	s, dFunc, err := factory.Create(*sc.ForResource(schema.GroupResource{Resource: "pods"}), newFunc, newListFunc, "/pods")
+	if err != nil {
+		t.Fatalf("Error creating storage: %v", err)
+	}
+	destroyFunc := func() {
+		dFunc()
+		server.Terminate(t)
 	}
 
-	result := tester.WithDefaulter(defaulter)
-	if result != tester {
+	store := &genericregistry.Store{
+		NewFunc:                   func() runtime.Object { return &example.Pod{} },
+		NewListFunc:               func() runtime.Object { return &example.PodList{} },
+		DefaultQualifiedResource:  example.Resource("pods"),
+		SingularQualifiedResource: example.Resource("pod"),
+		CreateStrategy:            strategy,
+		UpdateStrategy:            strategy,
+		DeleteStrategy:            strategy,
+		KeyRootFunc: func(ctx context.Context) string {
+			return podPrefix
+		},
+		KeyFunc: func(ctx context.Context, id string) (string, error) {
+			if _, ok := genericapirequest.NamespaceFrom(ctx); !ok {
+				return "", fmt.Errorf("namespace is required")
+			}
+			return path.Join(podPrefix, id), nil
+		},
+		ObjectNameFunc: func(obj runtime.Object) (string, error) { return obj.(*example.Pod).Name, nil },
+		PredicateFunc: func(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+			return storage.SelectionPredicate{
+				Label: label,
+				Field: field,
+				GetAttrs: func(obj runtime.Object) (labels.Set, fields.Set, error) {
+					pod, ok := obj.(*example.Pod)
+					if !ok {
+						return nil, nil, fmt.Errorf("not a pod")
+					}
+					return labels.Set(pod.ObjectMeta.Labels), generic.ObjectMetaFieldsSet(&pod.ObjectMeta, true), nil
+				},
+			}
+		},
+		Storage: genericregistry.DryRunnableStorage{Storage: s},
+	}
+	return destroyFunc, store
+}
+
+func TestWithDefaulter(t *testing.T) {
+	destroyFunc, store := newTestStore(t)
+	defer destroyFunc()
+
+	tester := New(t, store)
+	defaulter := &podDefaulter{}
+
+	if got := tester.WithDefaulter(defaulter); got != tester {
 		t.Fatal("expected WithDefaulter to return the same Tester instance for chaining")
+	}
+	if tester.defaulter != defaulter {
+		t.Fatal("expected defaulter to be set")
 	}
 }
 
 func TestCreateObjectAppliesDefaults(t *testing.T) {
-	defaulter := &testDefaulter{}
-	tester := &Tester{defaulter: defaulter}
+	destroyFunc, store := newTestStore(t)
+	defer destroyFunc()
 
-	obj := &testObject{}
+	tester := New(t, store).WithDefaulter(&podDefaulter{})
+	ctx := tester.tester.TestContext()
 
-	if obj.DefaultedField != "" {
-		t.Fatalf("expected DefaultedField to be empty, got %q", obj.DefaultedField)
+	pod := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "test"},
+	}
+	if err := tester.createObject(ctx, pod); err != nil {
+		t.Fatalf("unexpected error creating object: %v", err)
 	}
 
-	if tester.defaulter != nil {
-		tester.defaulter.Default(obj)
+	got, err := tester.getObject(ctx, pod)
+	if err != nil {
+		t.Fatalf("unexpected error getting object: %v", err)
+	}
+	stored := got.(*example.Pod)
+	if stored.Spec.NodeName != "machine" {
+		t.Errorf("expected default NodeName %q, got %q", "machine", stored.Spec.NodeName)
+	}
+}
+
+func TestCreateObjectWithoutDefaulterDoesNotApplyDefaults(t *testing.T) {
+	destroyFunc, store := newTestStore(t)
+	defer destroyFunc()
+
+	tester := New(t, store)
+	ctx := tester.tester.TestContext()
+
+	pod := &example.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "test"},
+	}
+	if err := tester.createObject(ctx, pod); err != nil {
+		t.Fatalf("unexpected error creating object: %v", err)
 	}
 
-	if obj.DefaultedField != "defaulted" {
-		t.Fatalf("expected DefaultedField to be %q, got %q", "defaulted", obj.DefaultedField)
+	got, err := tester.getObject(ctx, pod)
+	if err != nil {
+		t.Fatalf("unexpected error getting object: %v", err)
+	}
+	stored := got.(*example.Pod)
+	if stored.Spec.NodeName != "" {
+		t.Errorf("expected empty NodeName without a defaulter, got %q", stored.Spec.NodeName)
 	}
 }
 
 func TestSetObjectsForListAppliesDefaults(t *testing.T) {
-	defaulter := &testDefaulter{}
-	tester := &Tester{defaulter: defaulter}
+	destroyFunc, store := newTestStore(t)
+	defer destroyFunc()
+
+	tester := New(t, store).WithDefaulter(&podDefaulter{})
 
 	objects := []runtime.Object{
-		&testObject{},
-		&testObject{DefaultedField: "kept"},
+		&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "test"}},
+		&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "test"}},
+	}
+	if returned := tester.setObjectsForList(objects); returned == nil {
+		t.Fatal("expected setObjectsForList to return the objects")
 	}
 
-	if tester.defaulter != nil {
-		for i := range objects {
-			tester.defaulter.Default(objects[i])
+	for _, obj := range objects {
+		pod := obj.(*example.Pod)
+		got, err := tester.getObject(tester.tester.TestContext(), pod)
+		if err != nil {
+			t.Fatalf("unexpected error getting object %q: %v", pod.Name, err)
 		}
-	}
-
-	expected := []string{"defaulted", "kept"}
-	for i, obj := range objects {
-		tObj := obj.(*testObject)
-		if tObj.DefaultedField != expected[i] {
-			t.Errorf("object %d: expected DefaultedField to be %q, got %q", i, expected[i], tObj.DefaultedField)
+		stored := got.(*example.Pod)
+		if stored.Spec.NodeName != "machine" {
+			t.Errorf("object %q: expected default NodeName %q, got %q", pod.Name, "machine", stored.Spec.NodeName)
 		}
 	}
 }
 
-func TestNoDefaulterDoesNotApplyDefaults(t *testing.T) {
-	tester := &Tester{}
+func TestSetObjectsForListWithoutDefaulterDoesNotApplyDefaults(t *testing.T) {
+	destroyFunc, store := newTestStore(t)
+	defer destroyFunc()
 
-	obj := &testObject{}
+	tester := New(t, store)
 
-	if tester.defaulter != nil {
-		tester.defaulter.Default(obj)
+	objects := []runtime.Object{
+		&example.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "test"}},
+	}
+	if returned := tester.setObjectsForList(objects); returned == nil {
+		t.Fatal("expected setObjectsForList to return the objects")
 	}
 
-	if obj.DefaultedField != "" {
-		t.Fatalf("expected DefaultedField to be empty when no defaulter is set, got %q", obj.DefaultedField)
+	pod := objects[0].(*example.Pod)
+	got, err := tester.getObject(tester.tester.TestContext(), pod)
+	if err != nil {
+		t.Fatalf("unexpected error getting object %q: %v", pod.Name, err)
+	}
+	stored := got.(*example.Pod)
+	if stored.Spec.NodeName != "" {
+		t.Errorf("expected empty NodeName without a defaulter, got %q", stored.Spec.NodeName)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The generic testing helpers (`createObject`, `setObjectsForList`) in
`staging/src/k8s.io/apiserver/pkg/registry/generic/testing` store objects
directly to etcd, bypassing the defaulting pipeline that normally runs
during decode. This means test objects may lack fields that would be set
by the API server, leading to inconsistencies between test and production
behavior (see #130975 for the impact on `devicetaintrule` tests).

This PR adds a `WithDefaulter` method to `Tester` that accepts a
`runtime.ObjectDefaulter`. When set, defaults are applied to objects
before storage in `createObject` and `setObjectsForList`.

This is an opt-in mechanism that does not change existing behavior for
callers who do not need defaulting.

#### Which issue(s) this PR is related to:

#130975

#### Special notes for your reviewer:

The `WithDefaulter` method follows the existing builder pattern used by
other `Tester` methods (e.g., `ClusterScope`, `ReturnDeletedObject`).

Tests now exercise the real code path: they build an etcd3-backed
`genericregistry.Store` (mirroring the setup used in
`pkg/registry/generic/registry/store_test.go`) and verify defaults by
reading objects back from etcd after `createObject` / `setObjectsForList`,
instead of invoking the defaulter directly. The previous tests called
`t.defaulter.Default(obj)` directly, which could not catch a regression in
the helpers themselves. A `podDefaulter` matching the example type is used
to assert both that defaults are applied when a defaulter is configured
and that nothing is defaulted when it is not.

Coverage:
- `TestWithDefaulter` sets the defaulter and returns `*Tester` for chaining
- `TestCreateObjectAppliesDefaults` reads the object back from etcd and
  asserts the defaulted field is persisted
- `TestCreateObjectWithoutDefaulterDoesNotApplyDefaults` asserts backward
  compatibility
- `TestSetObjectsForListAppliesDefaults` reads each object back from etcd
  and asserts defaults are persisted
- `TestSetObjectsForListWithoutDefaulterDoesNotApplyDefaults` asserts
  backward compatibility

Also fixed `gofmt` alignment on the `Tester` struct.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs, usage docs, etc.:

```docs

```
