### PR TITLE
e2e_node: gate restartable init container start on PostStart hook

### DIFF
--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -2202,6 +2202,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 							Delay:    600,
 							ExitCode: 0,
 						}),
+						Lifecycle: &v1.Lifecycle{
+							PostStart: startedPostStartGate(),
+						},
 						RestartPolicy: &containerRestartPolicyAlways,
 					},
 					{
@@ -2219,6 +2222,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Containers Lifecycle", fun
 							Delay:    600,
 							ExitCode: 0,
 						}),
+						Lifecycle: &v1.Lifecycle{
+							PostStart: startedPostStartGate(),
+						},
 						RestartPolicy: &containerRestartPolicyAlways,
 					},
 					{


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

The "restartable-init-containers-start-serially" NodeConformance test occasionally fails the check that `restartable-init-2` starts before `init-3`. The test infers container ordering from the "Started" line each container's own script echoes to its log, but the kubelet doesn't wait for that echo — it considers a sidecar container "started" (and safe to proceed to the next init container) as soon as the container process is reported running by the container runtime. Under CI load, the kubelet can start `init-3` in the small window between the sidecar's process starting and its script actually reaching the `echo '... Started'` line, which the test then misreads as `init-3` starting before `restartable-init-2`.

This same race was already fixed for other test blocks in this file (see the `startedPostStartGate()` helper introduced to gate a container's "started" state on its own `started` marker file via a `PostStart` hook), but that fix was never applied to this particular test group. This PR adds the same `PostStart` gate to `restartable-init-1` and `restartable-init-2` in the "restartable-init-containers-start-serially" pod spec, so the kubelet's view of "started" is synchronized with the log line the test reads.

#### Which issue(s) this PR is related to:

#140272

#### Special notes for your reviewer:

Test-only change (`test/e2e_node/container_lifecycle_test.go`), no production code touched. Mirrors the pattern already used elsewhere in this file for the same class of race.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
