### PR TITLE
Fix selectableFields hoisting when schemas differ

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/conversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/conversion.go
@@ -172,7 +172,7 @@ func Convert_v1_CustomResourceDefinitionSpec_To_apiextensions_CustomResourceDefi
 	if additionalPrinterColumnsIdentical {
 		out.AdditionalPrinterColumns = additionalPrinterColumns
 	}
-	if selectableFieldsIdentical {
+	if validationIdentical && selectableFieldsIdentical {
 		out.SelectableFields = selectableFields
 	}
 	for i := range out.Versions {
@@ -185,7 +185,7 @@ func Convert_v1_CustomResourceDefinitionSpec_To_apiextensions_CustomResourceDefi
 		if additionalPrinterColumnsIdentical {
 			out.Versions[i].AdditionalPrinterColumns = nil
 		}
-		if selectableFieldsIdentical {
+		if validationIdentical && selectableFieldsIdentical {
 			out.Versions[i].SelectableFields = nil
 		}
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/conversion_test.go
@@ -462,6 +462,80 @@ func TestConversion(t *testing.T) {
 			},
 		},
 		{
+			Name: "v1 to internal, identical selectable fields with distinct schemas remain per-version",
+			In: &CustomResourceDefinition{
+				Spec: CustomResourceDefinitionSpec{
+					Versions: []CustomResourceDefinitionVersion{
+						{
+							Name:    "v1",
+							Served:  true,
+							Storage: true,
+							SelectableFields: []SelectableField{
+								{JSONPath: ".spec.name"},
+							},
+							Schema: &CustomResourceValidation{
+								OpenAPIV3Schema: &JSONSchemaProps{
+									Type:        "object",
+									Description: "v1",
+								},
+							},
+						},
+						{
+							Name:    "v2",
+							Served:  true,
+							Storage: false,
+							SelectableFields: []SelectableField{
+								{JSONPath: ".spec.name"},
+							},
+							Schema: &CustomResourceValidation{
+								OpenAPIV3Schema: &JSONSchemaProps{
+									Type:        "object",
+									Description: "v2",
+								},
+							},
+						},
+					},
+				},
+			},
+			Out: &apiextensions.CustomResourceDefinition{},
+			ExpectOut: &apiextensions.CustomResourceDefinition{
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Version: "v1",
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{
+							Name:    "v1",
+							Served:  true,
+							Storage: true,
+							SelectableFields: []apiextensions.SelectableField{
+								{JSONPath: ".spec.name"},
+							},
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "v1",
+								},
+							},
+						},
+						{
+							Name:    "v2",
+							Served:  true,
+							Storage: false,
+							SelectableFields: []apiextensions.SelectableField{
+								{JSONPath: ".spec.name"},
+							},
+							Schema: &apiextensions.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+									Type:        "object",
+									Description: "v2",
+								},
+							},
+						},
+					},
+					PreserveUnknownFields: new(bool),
+				},
+			},
+		},
+		{
 			Name: "v1 to internal, distinct selectable fields remains per-version",
 			In: &CustomResourceDefinition{
 				Spec: CustomResourceDefinitionSpec{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When converting a `v1.CustomResourceDefinition` to the internal representation,
`spec.selectableFields` are currently hoisted to the top level whenever they are
identical across versions, regardless of whether the corresponding validation
schemas are also identical.

If the validation schemas differ, they correctly remain per-version, but
`selectableFields` are still hoisted. This produces an invalid internal
representation because top-level `spec.selectableFields` require a top-level
validation schema.

This PR updates the conversion logic to hoist `spec.selectableFields` only when
both the validation schema and selectable fields are identical across all
versions. It also adds a regression test covering this scenario.

#### Which issue(s) this PR is related to:

Fixes #140689
#### Special notes for your reviewer:

The added regression test verifies that when validation schemas differ but
`selectableFields` are identical across versions, both fields remain
per-version after conversion.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```