### PR TITLE
kubelet: don't report OOMKilled for containers that exited with SIGTERM

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -761,6 +761,22 @@ func (m *kubeGenericRuntimeManager) toKubeContainerStatus(ctx context.Context, p
 		cStatus.Message = status.Message
 		cStatus.ExitCode = int(status.ExitCode)
 		cStatus.FinishedAt = time.Unix(0, status.FinishedAt)
+
+		if cStatus.Reason == "OOMKilled" && cStatus.ExitCode == 143 {
+			// The kernel OOM killer terminates processes with SIGKILL, so a
+			// container whose main process was OOM-killed exits with 137,
+			// never 143 (SIGTERM). Runtimes derive OOMKilled from the
+			// container cgroup's cumulative oom_kill counter, so a child
+			// process OOM-killed earlier in the container's life marks every
+			// later exit as OOMKilled — including a graceful SIGTERM
+			// termination from a node drain, an eviction, or a
+			// probe-triggered restart. Keep the termination reason consistent
+			// with the signal that actually ended the container so OOMKilled
+			// reliably means the terminated process was OOM-killed.
+			klog.FromContext(ctx).V(2).Info("Runtime reported OOMKilled for a container that exited with SIGTERM, reporting termination reason as Error",
+				"podUID", podUID, "containerName", labeledInfo.ContainerName, "exitCode", cStatus.ExitCode)
+			cStatus.Reason = "Error"
+		}
 	}
 
 	for _, mount := range status.Mounts {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -301,6 +301,79 @@ func TestToKubeContainerStatus(t *testing.T) {
 				StartedAt: time.Unix(0, startedAt),
 			},
 		},
+		"oom-killed container keeps the OOMKilled reason": {
+			input: &runtimeapi.ContainerStatus{
+				Id:         cid.ID,
+				Metadata:   meta,
+				Image:      imageSpec,
+				State:      runtimeapi.ContainerState_CONTAINER_EXITED,
+				CreatedAt:  createdAt,
+				StartedAt:  startedAt,
+				FinishedAt: finishedAt,
+				ExitCode:   int32(137),
+				Reason:     "OOMKilled",
+			},
+			expected: &kubecontainer.Status{
+				ID:         *cid,
+				Image:      imageSpec.Image,
+				State:      kubecontainer.ContainerStateExited,
+				CreatedAt:  time.Unix(0, createdAt),
+				StartedAt:  time.Unix(0, startedAt),
+				FinishedAt: time.Unix(0, finishedAt),
+				ExitCode:   137,
+				Reason:     "OOMKilled",
+			},
+		},
+		"sigterm exit is not reported as OOMKilled": {
+			// A runtime can report OOMKilled from the cgroup's cumulative
+			// oom_kill counter (e.g. a child process OOM-killed earlier) even
+			// though the container's main process exited from SIGTERM during a
+			// drain, eviction, or probe-triggered restart.
+			input: &runtimeapi.ContainerStatus{
+				Id:         cid.ID,
+				Metadata:   meta,
+				Image:      imageSpec,
+				State:      runtimeapi.ContainerState_CONTAINER_EXITED,
+				CreatedAt:  createdAt,
+				StartedAt:  startedAt,
+				FinishedAt: finishedAt,
+				ExitCode:   int32(143),
+				Reason:     "OOMKilled",
+			},
+			expected: &kubecontainer.Status{
+				ID:         *cid,
+				Image:      imageSpec.Image,
+				State:      kubecontainer.ContainerStateExited,
+				CreatedAt:  time.Unix(0, createdAt),
+				StartedAt:  time.Unix(0, startedAt),
+				FinishedAt: time.Unix(0, finishedAt),
+				ExitCode:   143,
+				Reason:     "Error",
+			},
+		},
+		"sigterm exit without an OOM claim is passed through": {
+			input: &runtimeapi.ContainerStatus{
+				Id:         cid.ID,
+				Metadata:   meta,
+				Image:      imageSpec,
+				State:      runtimeapi.ContainerState_CONTAINER_EXITED,
+				CreatedAt:  createdAt,
+				StartedAt:  startedAt,
+				FinishedAt: finishedAt,
+				ExitCode:   int32(143),
+				Reason:     "Error",
+			},
+			expected: &kubecontainer.Status{
+				ID:         *cid,
+				Image:      imageSpec.Image,
+				State:      kubecontainer.ContainerStateExited,
+				CreatedAt:  time.Unix(0, createdAt),
+				StartedAt:  time.Unix(0, startedAt),
+				FinishedAt: time.Unix(0, finishedAt),
+				ExitCode:   143,
+				Reason:     "Error",
+			},
+		},
 	} {
 		t.Run(desc, func(t *testing.T) {
 			actual := m.toKubeContainerStatus(tCtx, podUID, test.input, cid.Type)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

Container runtimes derive the `OOMKilled` termination reason from the container cgroup's **cumulative** `oom_kill` counter. A child process OOM-killed at any earlier point in the container's life therefore marks every later exit as `OOMKilled` — including a graceful SIGTERM termination (exit code 143) from a node drain, an eviction, or a probe-triggered restart. The kernel OOM killer terminates processes with SIGKILL, so a container whose main process was actually OOM-killed exits with 137, never 143.

This PR makes the kubelet reclassify the termination reason to `Error` when the runtime reports `OOMKilled` together with exit code 143, logging the runtime's original claim at `V(2)`. `containerStatuses[*].state.terminated.reason` then stays consistent with the signal that actually ended the container, so alerting and observability tooling can rely on `OOMKilled` meaning a real OOM kill.

The change is deliberately narrow: an `OOMKilled` report with exit code 137 (or any other code) is passed through unchanged, since only the 143 case is unambiguous — the main process demonstrably exited from SIGTERM, not the OOM killer.

#### Which issue(s) this PR fixes:

Fixes #140716

#### Special notes for your reviewer:

- The reclassification sits in `toKubeContainerStatus`, the single point where the CRI status enters the kubelet's internal `kubecontainer.Status`, so downstream consumers (`isInitContainerFailed`, pod status generation, backoff) all see the corrected reason.
- Table tests cover: real OOM kill (137 + OOMKilled → unchanged), stale cgroup OOM flag (143 + OOMKilled → Error), and plain SIGTERM exit (143 + Error → unchanged).
- An alternative would be fixing the counter semantics in the runtimes themselves; that is a larger cross-project change, while this keeps the API surface consistent regardless of runtime behavior.

#### Does this PR introduce a user-facing change?

```release-note
kubelet no longer reports `OOMKilled` as a container's termination reason when the container's main process exited with SIGTERM (exit code 143), for example during node drain or eviction. Previously, a child process OOM-killed earlier in the container's lifetime caused the runtime's cgroup-level OOM flag to override the actual termination cause.
```
