### PR TITLE
Fix links in kubectl get website documentation

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_flags.go
@@ -131,7 +131,7 @@ func (f *PrintFlags) AddFlags(cmd *cobra.Command) {
 	f.CustomColumnsFlags.AddFlags(cmd)
 
 	if f.OutputFormat != nil {
-		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, fmt.Sprintf(`Output format. One of: (%s). See custom columns [https://kubernetes.io/docs/reference/kubectl/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [https://kubernetes.io/docs/reference/kubectl/jsonpath/].`, strings.Join(f.AllowedFormats(), ", ")))
+		cmd.Flags().StringVarP(f.OutputFormat, "output", "o", *f.OutputFormat, fmt.Sprintf(`Output format. One of: (%s). See [custom columns](https://kubernetes.io/docs/reference/kubectl/#custom-columns), [golang template](http://golang.org/pkg/text/template/#pkg-overview) and [jsonpath template](https://kubernetes.io/docs/reference/kubectl/jsonpath/).`, strings.Join(f.AllowedFormats(), ", ")))
 		util.CheckErr(cmd.RegisterFlagCompletionFunc(
 			"output",
 			func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
Incorrect links in page https://kubernetes.io/docs/reference/kubectl/generated/kubectl_get/ Fixed markdown.

/sig cli
/sig docs
/kind documentation

