### PR TITLE
DV:migrate ManagedFieldsEntry manager and subresource length validations

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
@@ -734,6 +734,22 @@ func TestValidateObjectMetaDeclaratively(t *testing.T) {
 				field.TooLong(fldPath.Child("annotations"), "", TotalAnnotationSizeLimitB).MarkFromImperative(),
 			},
 		},
+		{
+			name:              "managedFields manager too long",
+			obj:               mkMeta(tweakManagedFields(metav1.ManagedFieldsEntry{Operation: metav1.ManagedFieldsOperationUpdate, Manager: strings.Repeat("a", 129)})),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("manager"), "", 128).WithOrigin("maxBytes").MarkAlpha(),
+			},
+		},
+		{
+			name:              "managedFields subresource too long",
+			obj:               mkMeta(tweakManagedFields(metav1.ManagedFieldsEntry{Operation: metav1.ManagedFieldsOperationUpdate, Subresource: strings.Repeat("a", 257)})),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 256).WithOrigin("maxBytes").MarkAlpha(),
+			},
+		},
 	}
 
 	matcher := field.ErrorMatcher{}.ByField().ByType().BySource().ByOrigin()
@@ -894,6 +910,24 @@ func TestValidateObjectMetaDeclaratively(t *testing.T) {
 			requiresNamespace: true,
 			expectedErrs: field.ErrorList{
 				field.Invalid(fldPath.Child("deletionGracePeriodSeconds"), &gracePeriod40, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		{
+			name:              "managedFields manager too long on update",
+			obj:               mkMeta(tweakResourceVersion("2"), tweakManagedFields(metav1.ManagedFieldsEntry{Operation: metav1.ManagedFieldsOperationUpdate, Manager: strings.Repeat("a", 129)})),
+			oldObj:            mkMeta(tweakResourceVersion("1")),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("manager"), "", 128).WithOrigin("maxBytes").MarkAlpha(),
+			},
+		},
+		{
+			name:              "managedFields subresource too long on update",
+			obj:               mkMeta(tweakResourceVersion("2"), tweakManagedFields(metav1.ManagedFieldsEntry{Operation: metav1.ManagedFieldsOperationUpdate, Subresource: strings.Repeat("a", 257)})),
+			oldObj:            mkMeta(tweakResourceVersion("1")),
+			requiresNamespace: true,
+			expectedErrs: field.ErrorList{
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 256).WithOrigin("maxBytes").MarkAlpha(),
 			},
 		},
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -706,6 +706,8 @@ message ListOptions {
 // that the fieldset applies to.
 message ManagedFieldsEntry {
   // Manager is an identifier of the workflow managing these fields.
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:maxBytes=128
   optional string manager = 1;
 
   // Operation is the type of operation which lead to this ManagedFieldsEntry being created.
@@ -742,6 +744,8 @@ message ManagedFieldsEntry {
   // regular update using the same manager name.
   // Note that the APIVersion field is not related to the Subresource field and
   // it always corresponds to the version of the main resource.
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:maxBytes=256
   optional string subresource = 8;
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -710,6 +710,8 @@ message ListOptions {
 // that the fieldset applies to.
 message ManagedFieldsEntry {
   // Manager is an identifier of the workflow managing these fields.
+  // +k8s:alpha(since: "1.38")=+k8s:optional
+  // +k8s:alpha(since: "1.38")=+k8s:maxBytes=128
   optional string manager = 1;
 
   // Operation is the type of operation which lead to this ManagedFieldsEntry being created.
@@ -746,6 +748,8 @@ message ManagedFieldsEntry {
   // regular update using the same manager name.
   // Note that the APIVersion field is not related to the Subresource field and
   // it always corresponds to the version of the main resource.
+  // +k8s:alpha(since: "1.38")=+k8s:optional
+  // +k8s:alpha(since: "1.38")=+k8s:maxBytes=256
   optional string subresource = 8;
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1406,6 +1406,8 @@ const (
 // that the fieldset applies to.
 type ManagedFieldsEntry struct {
 	// Manager is an identifier of the workflow managing these fields.
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:maxBytes=128
 	Manager string `json:"manager,omitempty" protobuf:"bytes,1,opt,name=manager"`
 	// Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 	// The only valid values for this field are 'Apply' and 'Update'.
@@ -1441,6 +1443,8 @@ type ManagedFieldsEntry struct {
 	// regular update using the same manager name.
 	// Note that the APIVersion field is not related to the Subresource field and
 	// it always corresponds to the version of the main resource.
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:maxBytes=256
 	Subresource string `json:"subresource,omitempty" protobuf:"bytes,8,opt,name=subresource"`
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1413,6 +1413,8 @@ const (
 // that the fieldset applies to.
 type ManagedFieldsEntry struct {
 	// Manager is an identifier of the workflow managing these fields.
+	// +k8s:alpha(since: "1.38")=+k8s:optional
+	// +k8s:alpha(since: "1.38")=+k8s:maxBytes=128
 	Manager string `json:"manager,omitempty" protobuf:"bytes,1,opt,name=manager"`
 	// Operation is the type of operation which lead to this ManagedFieldsEntry being created.
 	// The only valid values for this field are 'Apply' and 'Update'.
@@ -1448,6 +1450,8 @@ type ManagedFieldsEntry struct {
 	// regular update using the same manager name.
 	// Note that the APIVersion field is not related to the Subresource field and
 	// it always corresponds to the version of the main resource.
+	// +k8s:alpha(since: "1.38")=+k8s:optional
+	// +k8s:alpha(since: "1.38")=+k8s:maxBytes=256
 	Subresource string `json:"subresource,omitempty" protobuf:"bytes,8,opt,name=subresource"`
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -218,7 +218,7 @@ func ValidateFieldManager(fieldManager string, fldPath *field.Path) field.ErrorL
 	// considered as not set and is defaulted by the rest of the process
 	// (unless apply is used, in which case it is required).
 	if len(fieldManager) > FieldManagerMaxLength {
-		allErrs = append(allErrs, field.TooLong(fldPath, "" /*unused*/, FieldManagerMaxLength))
+		allErrs = append(allErrs, field.TooLong(fldPath, "" /*unused*/, FieldManagerMaxLength).WithOrigin("maxBytes").MarkCoveredByDeclarative())
 	}
 	// Verify that all characters are printable.
 	for i, r := range fieldManager {
@@ -308,7 +308,7 @@ func ValidateManagedFields(fieldsList []metav1.ManagedFieldsEntry, fldPath *fiel
 		allErrs = append(allErrs, ValidateFieldManager(fields.Manager, fldPath.Child("manager"))...)
 
 		if len(fields.Subresource) > MaxSubresourceNameLength {
-			allErrs = append(allErrs, field.TooLong(fldPath.Child("subresource"), "" /*unused*/, MaxSubresourceNameLength))
+			allErrs = append(allErrs, field.TooLong(fldPath.Child("subresource"), "" /*unused*/, MaxSubresourceNameLength).WithOrigin("maxBytes").MarkCoveredByDeclarative())
 		}
 	}
 	return allErrs

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -218,7 +218,7 @@ func ValidateFieldManager(fieldManager string, fldPath *field.Path) field.ErrorL
 	// considered as not set and is defaulted by the rest of the process
 	// (unless apply is used, in which case it is required).
 	if len(fieldManager) > FieldManagerMaxLength {
-		allErrs = append(allErrs, field.TooLong(fldPath, "" /*unused*/, FieldManagerMaxLength))
+		allErrs = append(allErrs, field.TooLong(fldPath, "" /*unused*/, FieldManagerMaxLength).WithOrigin("maxBytes"))
 	}
 	// Verify that all characters are printable.
 	for i, r := range fieldManager {
@@ -305,10 +305,22 @@ func ValidateManagedFields(fieldsList []metav1.ManagedFieldsEntry, fldPath *fiel
 		if len(fields.FieldsType) > 0 && fields.FieldsType != "FieldsV1" {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("fieldsType"), fields.FieldsType, "must be `FieldsV1`"))
 		}
-		allErrs = append(allErrs, ValidateFieldManager(fields.Manager, fldPath.Child("manager"))...)
+		managerErrs := ValidateFieldManager(fields.Manager, fldPath.Child("manager"))
+		if coveredByDeclarative {
+			for _, err := range managerErrs {
+				if err.Type == field.ErrorTypeTooLong {
+					_ = err.MarkCoveredByDeclarative()
+				}
+			}
+		}
+		allErrs = append(allErrs, managerErrs...)
 
 		if len(fields.Subresource) > MaxSubresourceNameLength {
-			allErrs = append(allErrs, field.TooLong(fldPath.Child("subresource"), "" /*unused*/, MaxSubresourceNameLength))
+			err := field.TooLong(fldPath.Child("subresource"), "" /*unused*/, MaxSubresourceNameLength).WithOrigin("maxBytes")
+			if coveredByDeclarative {
+				_ = err.MarkCoveredByDeclarative()
+			}
+			allErrs = append(allErrs, err)
 		}
 	}
 	return allErrs

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation_test.go
@@ -343,6 +343,55 @@ func TestValidateFieldManagerInvalid(t *testing.T) {
 	}
 }
 
+// TestValidateFieldManagerTooLongErrorShape verifies that the too-long error
+// carries the "maxBytes" origin and is marked as covered by declarative
+// validation, so the DV migration framework can suppress it once enforced.
+func TestValidateFieldManagerTooLongErrorShape(t *testing.T) {
+	// 129 characters — one over the 128-byte limit
+	tooLong := strings.Repeat("a", FieldManagerMaxLength+1)
+	errs := ValidateFieldManager(tooLong, field.NewPath("fieldManager"))
+	if len(errs) == 0 {
+		t.Fatal("expected a TooLong error, got none")
+	}
+	err := errs[0]
+	if err.Type != field.ErrorTypeTooLong {
+		t.Errorf("expected ErrorTypeTooLong, got %v", err.Type)
+	}
+	if err.Origin != "maxBytes" {
+		t.Errorf("expected origin \"maxBytes\", got %q", err.Origin)
+	}
+	if !err.CoveredByDeclarative {
+		t.Errorf("expected CoveredByDeclarative=true")
+	}
+}
+
+// TestValidateManagedFieldsSubresourceTooLongErrorShape verifies that the
+// subresource too-long error carries the "maxBytes" origin and is marked as
+// covered by declarative validation.
+func TestValidateManagedFieldsSubresourceTooLongErrorShape(t *testing.T) {
+	// 257 characters — one over the 256-byte limit
+	entry := metav1.ManagedFieldsEntry{
+		Operation:   metav1.ManagedFieldsOperationUpdate,
+		FieldsType:  "FieldsV1",
+		APIVersion:  "v1",
+		Subresource: strings.Repeat("a", MaxSubresourceNameLength+1),
+	}
+	errs := ValidateManagedFields([]metav1.ManagedFieldsEntry{entry}, field.NewPath("managedFields"))
+	if len(errs) == 0 {
+		t.Fatal("expected a TooLong error, got none")
+	}
+	err := errs[0]
+	if err.Type != field.ErrorTypeTooLong {
+		t.Errorf("expected ErrorTypeTooLong, got %v", err.Type)
+	}
+	if err.Origin != "maxBytes" {
+		t.Errorf("expected origin \"maxBytes\", got %q", err.Origin)
+	}
+	if !err.CoveredByDeclarative {
+		t.Errorf("expected CoveredByDeclarative=true")
+	}
+}
+
 func TestValidateManagedFieldsInvalid(t *testing.T) {
 	tests := []metav1.ManagedFieldsEntry{{
 		Operation:  metav1.ManagedFieldsOperationUpdate,

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -213,7 +213,36 @@ func Validate_ManagedFieldsEntry(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *v1.ManagedFieldsEntry) (errs field.ErrorList) {
 
-	// field v1.ManagedFieldsEntry.Manager has no validation
+	{ // field v1.ManagedFieldsEntry.Manager
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 128).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.ManagedFieldsEntry) *string {
+				return &oldObj.Manager
+			})
+		errs = append(errs, fn(fldPath.Child("manager"), &obj.Manager, oldVal, oldObj != nil)...)
+	}
 
 	{ // field v1.ManagedFieldsEntry.Operation
 		fn := func(
@@ -250,7 +279,38 @@ func Validate_ManagedFieldsEntry(
 	// field v1.ManagedFieldsEntry.Time has no validation
 	// field v1.ManagedFieldsEntry.FieldsType has no validation
 	// field v1.ManagedFieldsEntry.FieldsV1 has no validation
-	// field v1.ManagedFieldsEntry.Subresource has no validation
+
+	{ // field v1.ManagedFieldsEntry.Subresource
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.ManagedFieldsEntry) *string {
+				return &oldObj.Subresource
+			})
+		errs = append(errs, fn(fldPath.Child("subresource"), &obj.Subresource, oldVal, oldObj != nil)...)
+	}
+
 	return errs
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/zz_generated.validations.go
@@ -239,7 +239,36 @@ func Validate_ManagedFieldsEntry(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *v1.ManagedFieldsEntry) (errs field.ErrorList) {
 
-	// field v1.ManagedFieldsEntry.Manager has no validation
+	{ // field v1.ManagedFieldsEntry.Manager
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 128).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.ManagedFieldsEntry) *string {
+				return &oldObj.Manager
+			})
+		errs = append(errs, fn(fldPath.Child("manager"), &obj.Manager, oldVal, oldObj != nil)...)
+	}
 
 	{ // field v1.ManagedFieldsEntry.Operation
 		fn := func(
@@ -276,7 +305,38 @@ func Validate_ManagedFieldsEntry(
 	// field v1.ManagedFieldsEntry.Time has no validation
 	// field v1.ManagedFieldsEntry.FieldsType has no validation
 	// field v1.ManagedFieldsEntry.FieldsV1 has no validation
-	// field v1.ManagedFieldsEntry.Subresource has no validation
+
+	{ // field v1.ManagedFieldsEntry.Subresource
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.MaxBytes(ctx, op, fldPath, obj, oldObj, 256).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *v1.ManagedFieldsEntry) *string {
+				return &oldObj.Subresource
+			})
+		errs = append(errs, fn(fldPath.Child("subresource"), &obj.Subresource, oldVal, oldObj != nil)...)
+	}
+
 	return errs
 }
 

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/mutatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicy/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingadmissionpolicybinding/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/admissionregistration/validatingwebhookconfiguration/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/controllerrevision/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/daemonset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/daemonset/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/daemonset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/daemonset/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/replicaset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/replicaset/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/replicaset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/replicaset/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v2_test.go
+++ b/test/declarative_validation/autoscaling/horizontalpodautoscaler/zz_generated.validations.v2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/certificatesigningrequest/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/clustertrustbundle/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/certificates/podcertificaterequest/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/coordination/lease/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/coordination/lease/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/coordination/lease/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/coordination/lease/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/configmap/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/configmap/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/endpoints/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/endpoints/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/event/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/event/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/limitrange/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/limitrange/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/namespace/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/namespace/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/node/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/node/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/persistentvolume/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/persistentvolume/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/persistentvolumeclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/persistentvolumeclaim/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/pod/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/pod/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/podtemplate/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/podtemplate/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/replicationcontroller/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/replicationcontroller/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},

--- a/test/declarative_validation/core/resourcequota/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/resourcequota/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/secret/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/secret/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/service/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/service/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/core/serviceaccount/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/serviceaccount/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1_test.go
@@ -51,9 +51,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/discovery/endpointslice/zz_generated.validations.v1beta1_test.go
@@ -51,9 +51,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/events/event/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/events/event/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta3_test.go
+++ b/test/declarative_validation/flowcontrol/flowschema/zz_generated.validations.v1beta3_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta3_test.go
+++ b/test/declarative_validation/flowcontrol/prioritylevelconfiguration/zz_generated.validations.v1beta3_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/internal/storageversion/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/internal/storageversion/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/lifecycle/eviction/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/lifecycle/eviction/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},

--- a/test/declarative_validation/lifecycle/evictionrequest/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/lifecycle/evictionrequest/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},

--- a/test/declarative_validation/meta/objectmeta.go
+++ b/test/declarative_validation/meta/objectmeta.go
@@ -291,7 +291,7 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.TooLong(fldPath.Child("managedFields").Index(0).Child("manager"), "", 128).MarkFromImperative(),
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("manager"), "", 128).WithOrigin("maxBytes").MarkAlpha(),
 			},
 		},
 		{
@@ -311,7 +311,7 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 0).MarkFromImperative(),
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 256).WithOrigin("maxBytes").MarkAlpha(),
 			},
 		},
 		{
@@ -611,7 +611,7 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 0).MarkFromImperative(),
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 256).WithOrigin("maxBytes").MarkAlpha(),
 			},
 		},
 		{

--- a/test/declarative_validation/meta/objectmeta.go
+++ b/test/declarative_validation/meta/objectmeta.go
@@ -291,7 +291,7 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.TooLong(fldPath.Child("managedFields").Index(0).Child("manager"), "", 128).MarkFromImperative(),
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("manager"), "", 128).WithOrigin("maxBytes").MarkAlpha(),
 			},
 		},
 		{
@@ -311,7 +311,7 @@ func RunObjectMetaTestCases[T runtime.Object](t *testing.T, ctx context.Context,
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 0).MarkFromImperative(),
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 256).WithOrigin("maxBytes").MarkAlpha(),
 			},
 		},
 		{
@@ -604,6 +604,17 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 			}(),
 		},
 		{
+			Name: "update: managedFields: manager too long",
+			Modify: func(old, new metav1.Object) {
+				new.SetManagedFields([]metav1.ManagedFieldsEntry{
+					mkManagedFieldsEntry(tweakManager(strings.Repeat("a", 129))),
+				})
+			},
+			ExpectedErrs: field.ErrorList{
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("manager"), "", 128).WithOrigin("maxBytes").MarkAlpha(),
+			},
+		},
+		{
 			Name: "update: managedFields: subresource too long",
 			Modify: func(old, new metav1.Object) {
 				new.SetManagedFields([]metav1.ManagedFieldsEntry{
@@ -611,7 +622,7 @@ func RunObjectMetaUpdateTestCases[T runtime.Object](t *testing.T, ctx context.Co
 				})
 			},
 			ExpectedErrs: field.ErrorList{
-				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 0).MarkFromImperative(),
+				field.TooLong(fldPath.Child("managedFields").Index(0).Child("subresource"), "", 256).WithOrigin("maxBytes").MarkAlpha(),
 			},
 		},
 		{

--- a/test/declarative_validation/networking/ingress/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ingress/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/ingress/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ingress/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ipaddress/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/networkpolicy/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/networkpolicy/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/servicecidr/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1_test.go
@@ -47,9 +47,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/node/runtimeclass/zz_generated.validations.v1beta1_test.go
@@ -47,9 +47,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/policy/poddisruptionbudget/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/clusterrole/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/clusterrolebinding/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/role/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/role/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/rbac/rolebinding/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},

--- a/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/deviceclass/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1alpha3_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/devicetaintrule/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta2_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1alpha3_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/podgroup/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/priorityclass/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/scheduling/workload/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/workload/zz_generated.validations.v1alpha3_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/scheduling/workload/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/scheduling/workload/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csidriver/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csidriver/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csidriver/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csidriver/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csinode/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csinode/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csinode/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csinode/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/csistoragecapacity/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/storageclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/storageclass/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/storageclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/storageclass/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/volumeattachment/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1alpha1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1alpha1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storage/volumeattributesclass/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/storagemigration/storageversionmigration/zz_generated.validations.v1beta1_test.go
@@ -42,9 +42,15 @@ func init() {
 			"metadata.generation": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"metadata.managedFields[*].manager": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
+			},
 			"metadata.managedFields[*].operation": {
 				{ErrorType: "FieldValueNotSupported"},
 				{ErrorType: "FieldValueRequired"},
+			},
+			"metadata.managedFields[*].subresource": {
+				{ErrorType: "FieldValueTooLong", Origin: "maxBytes"},
 			},
 			"metadata.ownerReferences[*].apiVersion": {
 				{ErrorType: "FieldValueRequired"},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR migrates `ManagedFieldsEntry.manager` and `ManagedFieldsEntry.Subresource` fields inside objectMeta from handwritten to declarative validation.

- +k8s:maxBytes -> `ManagedFieldsEntry.manager`
- +k8s:maxBytes -> `ManagedFieldsEntry.Subresource`
- Configures HV to attach maxBytes and `.MarkCoveredByDeclarative()`
- Updated DV integration tests.(test/declarative_validation/meta/objectmeta.go) to expect `MarkAlpha` errors.


#### Which issue(s) this PR is related to:

part of https://github.com/kubernetes/kubernetes/issues/141634

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```