### PR TITLE
fix(apiserver): close response body when ResponseChecker fails in REST streamer

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/rest/streamer.go
@@ -93,6 +93,7 @@ func (s *LocationStreamer) InputStream(ctx context.Context, apiVersion, acceptHe
 
 	if s.ResponseChecker != nil {
 		if err = s.ResponseChecker.Check(resp); err != nil {
+			resp.Body.Close()
 			return nil, false, "", err
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix HTTP response body leak when ResponseChecker fails in REST streamer

## Bug
In `streamer.go`, when `ResponseChecker.Check(resp)` returns an error, the function returns without closing `resp.Body`. While the built-in `GenericHttpResponseChecker` closes the body internally, custom implementations of the `HttpResponseChecker` interface are not required to do so, creating a resource leak.

## Fix
Add `resp.Body.Close()` before returning the error.
