### PR TITLE
fix(client-go): close response body for non-ErrBadHandshake websocket errors

### DIFF
--- a/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
+++ b/staging/src/k8s.io/client-go/transport/websocket/roundtripper.go
@@ -155,6 +155,9 @@ func (rt *RoundTripper) RoundTrip(request *http.Request) (retResp *http.Response
 			}
 			return nil, &httpstream.UpgradeFailureError{Cause: cause}
 		}
+		if resp != nil {
+			resp.Body.Close()
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- Fix HTTP response body leak for non-ErrBadHandshake websocket upgrade errors

## Bug
In the websocket roundtripper, when `dialer.DialContext` returns an error that is not `ErrBadHandshake` (e.g., `errInvalidCompression`), the response body is not closed. The `ErrBadHandshake` path correctly closes it, but the fallthrough does not.

## Fix
Add `if resp != nil { resp.Body.Close() }` before the fallthrough return.
