### PR TITLE
DRA: add more DistinctAttribute tests

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -6166,6 +6166,109 @@ func TestAllocator(t *testing.T,
 				deviceRequestAllocationResult(req3, driverA, pool1, device4).withConsumedCapacity(&fixedShareID, nil),
 			)},
 		},
+		"distinct-constraint-single-request-count-3-not-distinct": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(
+				claim0,
+				[]resourceapi.DeviceConstraint{{DistinctAttribute: &stringAttribute}},
+				request(req0, classA, 3)),
+			),
+			classes: objects(class(classA, driverA)),
+			// req0 asks for 3 devices under a DistinctAttribute(stringAttribute)
+			// constraint. Three devices exist with stringAttribute values
+			// value1, value2, value1 -- only two distinct values.
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value1")},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value2")},
+				}),
+				device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value1")},
+				}),
+			)),
+			node: node(node1, region1),
+			// Expected results:
+			//   - [req0] No allocation. Satisfying req0 requires 3 devices with
+			//     distinct stringAttribute values, but device1 and device3 both
+			//     have "value1", so no set of 3 distinct-valued devices exists.
+			expectResults: nil,
+		},
+		"distinct-constraint-single-request-count-3-all-distinct": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(
+				claim0,
+				[]resourceapi.DeviceConstraint{{DistinctAttribute: &stringAttribute}},
+				request(req0, classA, 3)),
+			),
+			classes: objects(class(classA, driverA)),
+			// req0 asks for 3 devices under a DistinctAttribute(stringAttribute)
+			// constraint. Three devices exist with distinct values
+			// value1, value2, value3.
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value1")},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value2")},
+				}),
+				device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value3")},
+				}),
+			)),
+			node: node(node1, region1),
+			// Expected results:
+			//   - [req0] All three devices are allocated: their stringAttribute
+			//     values (value1, value2, value3) are pairwise distinct, so the
+			//     constraint holds.
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, false),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+				deviceAllocationResult(req0, driverA, pool1, device3, false),
+			)},
+		},
+		"distinct-constraint-two-requests-with-count-not-distinct": {
+			features: Features{
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(
+				claim(claim0).withConstraints(
+					resourceapi.DeviceConstraint{DistinctAttribute: &stringAttribute, Requests: []string{req0, req1}},
+				).withRequests(
+					deviceRequest(req0, classA, 2),
+					deviceRequest(req1, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			// req0 asks for 2 devices and req1 for 1 device; a single
+			// DistinctAttribute(stringAttribute) constraint covers both requests,
+			// so all 3 allocated devices must be distinct. Three devices exist
+			// with values value1, value2, value1 -- only two distinct values.
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value1")},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value2")},
+				}),
+				device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value1")},
+				}),
+			)),
+			node: node(node1, region1),
+			// Expected results:
+			//   - No allocation. The constraint spans req0 and req1, so the 3
+			//     devices across both requests must be pairwise distinct. Because
+			//     device1 and device3 share "value1", 3 distinct-valued devices
+			//     cannot be chosen.
+			expectResults: nil,
+		},
 		"with-distinct-constraints-attribute-not-set": {
 			features: Features{
 				ConsumableCapacity: true,
@@ -6835,6 +6938,75 @@ func TestAllocator(t *testing.T,
 			node: node(node1, region1),
 
 			expectResults: nil,
+		},
+		"list-attributes-distinct-constraint-single-request-count-3-not-distinct": {
+			features: Features{
+				ListTypeAttributes: true,
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(
+				claim0,
+				[]resourceapi.DeviceConstraint{{DistinctAttribute: &stringAttribute}},
+				request(req0, classA, 3)),
+			),
+			classes: objects(class(classA, driverA)),
+			// Same scenario as distinct-constraint-single-request-count-3-not-distinct
+			// but with the ListTypeAttributes feature enabled: req0 asks for 3
+			// devices under a DistinctAttribute constraint, and the 3 devices carry
+			// values value1, value2, value1 -- only two distinct values.
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value1")},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value2")},
+				}),
+				device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value1")},
+				}),
+			)),
+			node: node(node1, region1),
+			// Expected results:
+			//   - [req0] No allocation. device1 and device3 both have "value1",
+			//     so 3 devices with distinct stringAttribute values cannot be found.
+			expectResults: nil,
+		},
+		"list-attributes-distinct-constraint-single-request-count-3-all-distinct": {
+			features: Features{
+				ListTypeAttributes: true,
+				ConsumableCapacity: true,
+			},
+			claimsToAllocate: objects(claimWithRequests(
+				claim0,
+				[]resourceapi.DeviceConstraint{{DistinctAttribute: &stringAttribute}},
+				request(req0, classA, 3)),
+			),
+			classes: objects(class(classA, driverA)),
+			// Same scenario as distinct-constraint-single-request-count-3-all-distinct
+			// but with the ListTypeAttributes feature enabled: req0 asks for 3
+			// devices under a DistinctAttribute constraint, and the 3 devices carry
+			// distinct values value1, value2, value3.
+			slices: unwrapResourceSlices(sliceWithDevices(slice1, node1, pool1, driverA,
+				device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value1")},
+				}),
+				device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value2")},
+				}),
+				device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					"stringAttribute": {StringValue: new("value3")},
+				}),
+			)),
+			node: node(node1, region1),
+			// Expected results:
+			//   - [req0] All three devices are allocated: their stringAttribute
+			//     values (value1, value2, value3) are pairwise distinct.
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, false),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+				deviceAllocationResult(req0, driverA, pool1, device3, false),
+			)},
 		},
 		"list-attributes-distinct-constraint-list-of-string-values-all-distinct": {
 			features: Features{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds regression tests to the shared structured DRA allocator test suite (`TestAllocator`) for `DistinctAttribute` claim constraints when a single request allocates more than one device.

Background: `distinctAttributeConstraint` previously tracked each chosen device's attribute in a map keyed by request name. When a request allocated multiple devices (`count > 1`), each device overwrote the previous one, so the distinctness check only compared a candidate against the most recent device of that request. The allocator could return, for example, `[red, blue, red]` for a request requiring distinct values.

The code has since been fixed upstream (the constraint now tracks every chosen device in a slice rather than a map keyed by request name). However, the existing distinct-constraint tests only used `count=2`, which cannot trigger the
overwrite. This PR adds cases with `count>=3` and a multi-request constraint scope, for both scalar and list-type attributes, including positive controls, so the regression stays covered! 🟢 

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Tests only; no production code changes. The cases require the `DRAConsumableCapacity` feature (and `DRAListTypeAttributes` for the list-type variants). They pass against the current slice-based `distinctAttributeConstraint` implementation and fail against the earlier map-keyed-by-request-name version.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
