### PR TITLE
kubelet: fix CPU manager hang in distribute-across-NUMA with cpuGroupSize

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -61,14 +61,6 @@ func (m mapIntInt) Values(keys ...int) []int {
 	return values
 }
 
-func sum(xs []int) int {
-	var s int
-	for _, x := range xs {
-		s += x
-	}
-	return s
-}
-
 func mean(xs []int) float64 {
 	var sum float64
 	for _, x := range xs {
@@ -1030,8 +1022,14 @@ func takeByTopologyNUMADistributed(logger klog.Logger, topo *topology.CPUTopolog
 					availableAfterAllocation := availableAfterAllocation.Clone()
 
 					// If this subset is not capable of allocating all
-					// remainder CPUs, continue to the next one.
-					if sum(availableAfterAllocation.Values(subset...)) < remainder {
+					// remainder CPUs in whole groups of 'cpuGroupSize',
+					// continue to the next one. Leftover CPUs smaller than a
+					// group cannot be handed out, so a raw CPU sum overcounts.
+					availableGroups := 0
+					for _, numa := range subset {
+						availableGroups += availableAfterAllocation[numa] / cpuGroupSize
+					}
+					if availableGroups*cpuGroupSize < remainder {
 						return Continue
 					}
 

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -1042,6 +1042,15 @@ func TestTakeByTopologyNUMADistributed(t *testing.T) {
 			mustParseCPUSet(t, "0-7,10-16,20-27,30-37,40-47,50-56,60-67,70-77"),
 		},
 		{
+			"ensure allocation with cpuGroupSize 2 terminates when per-NUMA availability is not a multiple of the group size",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-4,10-14,20-24,30-34"),
+			14,
+			2,
+			"",
+			mustParseCPUSet(t, "0-3,10-13,20-23,30-31"),
+		},
+		{
 			"ensure bestRemainder chosen with NUMA nodes that have enough CPUs to satisfy the request",
 			topoDualSocketMultiNumaPerSocketHT,
 			mustParseCPUSet(t, "0-3,10-13,20-23,30-36,40-43,50-53,60-63,70-76"),

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -1042,6 +1042,37 @@ func TestTakeByTopologyNUMADistributed(t *testing.T) {
 			mustParseCPUSet(t, "0-7,10-16,20-27,30-37,40-47,50-56,60-67,70-77"),
 		},
 		{
+			"ensure allocation with cpuGroupSize 2 terminates when per-NUMA availability is not a multiple of the group size",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-4,10-14,20-24,30-34"),
+			14,
+			2,
+			"",
+			mustParseCPUSet(t, "0-3,10-13,20-23,30-31"),
+		},
+		{
+			// Feasible: whole-group capacity exactly covers the request, so
+			// the group accounting must not reject it.
+			"ensure allocation with cpuGroupSize 2 succeeds when whole-group capacity exactly satisfies the request",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-4,10-14,20-24,30-34"),
+			16,
+			2,
+			"",
+			mustParseCPUSet(t, "0-3,10-13,20-23,30-33"),
+		},
+		{
+			// Same fragmentation on 8 NUMA nodes with 31 CPUs free each, so
+			// the remainder search walks deeper subsets.
+			"ensure allocation with cpuGroupSize 2 terminates on 8 NUMA nodes with fragmented availability",
+			topoDualSocketMultiNumaPerSocketHTLarge,
+			mustParseCPUSet(t, "1-15,17-31,33-47,49-63,65-79,81-95,97-111,113-127,128-255"),
+			230,
+			2,
+			"",
+			mustParseCPUSet(t, "1-15,17-31,33-47,49-62,65-78,81-94,97-110,113-126,129-143,145-159,161-175,177-190,193-206,209-222,225-238,241-254"),
+		},
+		{
 			"ensure bestRemainder chosen with NUMA nodes that have enough CPUs to satisfy the request",
 			topoDualSocketMultiNumaPerSocketHT,
 			mustParseCPUSet(t, "0-3,10-13,20-23,30-36,40-43,50-53,60-63,70-76"),

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -2207,6 +2207,30 @@ func TestPolicyWithAlignBySocketAndDistributeCPUsAcrossNUMAEnabled(t *testing.T)
 	}
 }
 
+func TestPolicyWithDistributeCPUsAcrossNUMAAndFullPCPUsOnly(t *testing.T) {
+	testCases := []staticPolicyTest{
+		{
+			description: "DistributeCPUsAcrossNUMA and FullPCPUsOnly with fragmented per-NUMA availability",
+			topo:        topoDualSocketMultiNumaPerSocketHT,
+			options: map[string]string{
+				DistributeCPUsAcrossNUMAOption: "true",
+				FullPCPUsOnlyOption:            "true",
+			},
+			numReservedCPUs: 0,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stDefaultCPUSet: mustParseCPUSet(t, "0-4,10-14,20-24,30-34"),
+			pod:             makePod("fakePod", "fakeContainer", "14000m", "14000m"),
+			topologyHint:    &topologymanager.TopologyHint{},
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         mustParseCPUSet(t, "0-3,10-13,20-23,30-31"),
+		},
+	}
+	for _, testCase := range testCases {
+		runStaticPolicyTestCaseWithFeatureGate(t, testCase)
+	}
+}
+
 type staticPolicyAllocatePodTest struct {
 	description                     string
 	topo                            *topology.CPUTopology

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -2207,6 +2207,71 @@ func TestPolicyWithAlignBySocketAndDistributeCPUsAcrossNUMAEnabled(t *testing.T)
 	}
 }
 
+func TestPolicyWithDistributeCPUsAcrossNUMAAndFullPCPUsOnly(t *testing.T) {
+	testCases := []staticPolicyTest{
+		{
+			description: "DistributeCPUsAcrossNUMA and FullPCPUsOnly with fragmented per-NUMA availability",
+			topo:        topoDualSocketMultiNumaPerSocketHT,
+			options: map[string]string{
+				DistributeCPUsAcrossNUMAOption: "true",
+				FullPCPUsOnlyOption:            "true",
+			},
+			numReservedCPUs: 0,
+			stAssignments:   state.ContainerCPUAssignments{},
+			stDefaultCPUSet: mustParseCPUSet(t, "0-4,10-14,20-24,30-34"),
+			pod:             makePod("fakePod", "fakeContainer", "14000m", "14000m"),
+			topologyHint:    &topologymanager.TopologyHint{},
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         mustParseCPUSet(t, "0-3,10-13,20-23,30-31"),
+		},
+		{
+			// --reserved-cpus takes one thread of a core on each NUMA node,
+			// leaving 19 CPUs free per node.
+			description: "GuPodManyCores, DualSocketMultiNumaPerSocketHT, PartialCoreReserved, ExpectAllocDistributed",
+			topo:        topoDualSocketMultiNumaPerSocketHT,
+			options: map[string]string{
+				DistributeCPUsAcrossNUMAOption: "true",
+				FullPCPUsOnlyOption:            "true",
+			},
+			numReservedCPUs: 4,
+			reservedCPUs:    newCPUSetPtr(0, 10, 20, 30),
+			stAssignments:   state.ContainerCPUAssignments{},
+			stDefaultCPUSet: mustParseCPUSet(t, "1-9,11-19,21-29,31-39,40-79"),
+			pod:             makePod("fakePod", "fakeContainer", "70000m", "70000m"),
+			topologyHint:    &topologymanager.TopologyHint{},
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         mustParseCPUSet(t, "1-9,11-19,21-29,31-38,41-49,51-59,61-69,71-78"),
+		},
+		{
+			// Shared pool fragmented before FullPCPUsOnly was enabled: a
+			// container holding half cores leaves 17 CPUs free per NUMA node.
+			description: "GuPodManyCores, DualSocketMultiNumaPerSocketHT, PreexistingPartialCores, ExpectAllocDistributed",
+			topo:        topoDualSocketMultiNumaPerSocketHT,
+			options: map[string]string{
+				DistributeCPUsAcrossNUMAOption: "true",
+				FullPCPUsOnlyOption:            "true",
+			},
+			numReservedCPUs: 0,
+			stAssignments: state.ContainerCPUAssignments{
+				"legacyPod": map[string]cpuset.CPUSet{
+					"legacyContainer": mustParseCPUSet(t, "0-2,10-12,20-22,30-32"),
+				},
+			},
+			stDefaultCPUSet: mustParseCPUSet(t, "3-9,13-19,23-29,33-39,40-79"),
+			pod:             makePod("fakePod", "fakeContainer", "62000m", "62000m"),
+			topologyHint:    &topologymanager.TopologyHint{},
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         mustParseCPUSet(t, "3-9,13-19,23-29,33-41,43-51,53-61,63-69,73-79"),
+		},
+	}
+	for _, testCase := range testCases {
+		runStaticPolicyTestCaseWithFeatureGate(t, testCase)
+	}
+}
+
 type staticPolicyAllocatePodTest struct {
 	description                     string
 	topo                            *topology.CPUTopology


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes an infinite loop in `takeByTopologyNUMADistributed` when `distribute-cpus-across-numa` and `full-pcpus-only` are both enabled (`cpuGroupSize > 1`).

Remainder CPUs are allocated in whole groups of `cpuGroupSize`, but the feasibility check used a raw CPU sum. If each candidate NUMA node had a leftover smaller than the group size (e.g. leftovers `{1,1}` with `cpuGroupSize=2`), the check could pass while no group was placeable, so the loop never terminated. `Allocate` then hung holding the CPU manager lock during pod admission.

This is reachable when per-NUMA availability is not a multiple of `cpuGroupSize` (e.g. `--reserved-cpus` that does not cover whole cores).

The fix counts capacity in whole `cpuGroupSize` groups so infeasible subsets are skipped and the search terminates (falling back to packing).

##### When this may happen in the real world? 🤔 
With `full-pcpus-only` and `distribute-cpus-across-numa` both enabled (via `--cpu-manager-policy-options=full-pcpus-only=true,distribute-cpus-across-numa=true`), the distributed NUMA allocator could infinite-loop when per-NUMA free CPUs were not a multiple of the hardware thread count per core. That hung Guaranteed pod CPU allocation and wedged the kubelet on that node. The fix counts remainder capacity in whole core groups and skips infeasible NUMA subsets so the search always terminates (with packing fallback).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Only the `distribute-cpus-across-numa` + `full-pcpus-only` path is affected (`cpuGroupSize > 1`). Regression coverage:
- `TestTakeByTopologyNUMADistributed` (allocator unit)
- `TestPolicyWithDistributeCPUsAcrossNUMAAndFullPCPUsOnly` (`Allocate` path)

Both hang (timeout) without the fix and pass with it.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where the kubelet could hang during Pod admission when the CPU manager `distribute-cpus-across-numa` and `full-pcpus-only` policy options were both enabled and per-NUMA CPU availability was not a multiple of the hardware thread count per core.
```

#### Additional documentation e.g., KEPs, usage docs, etc.:

```docs

```