### PR TITLE
test/integration: share API server across TestPreemption subtests

### DIFF
--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -689,6 +689,18 @@ func TestPreemption(t *testing.T) {
 	for _, asyncPreemptionEnabled := range []bool{true, false} {
 		for _, asyncAPICallsEnabled := range []bool{true, false} {
 			for _, clearingNominatedNodeNameAfterBinding := range []bool{true, false} {
+				// Start one API server per flag combination and share it across all
+				// test cases in this combo. GenericWorkload is always enabled so that
+				// both plain-pod and pod-group test cases can share the same server;
+				// the scheduler-side GenericWorkload gate is set per subtest below.
+				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+					features.SchedulerAsyncPreemption:              asyncPreemptionEnabled,
+					features.SchedulerAsyncAPICalls:                asyncAPICallsEnabled,
+					features.ClearingNominatedNodeNameAfterBinding: clearingNominatedNodeNameAfterBinding,
+					features.GenericWorkload:                       true,
+				})
+				sharedAPICtx := testutils.InitTestAPIServer(t, "preemption", nil)
+
 				for _, test := range tests {
 					t.Run(fmt.Sprintf("%s (Async preemption enabled: %v, Async API calls enabled: %v, ClearingNominatedNodeNameAfterBinding: %v)", test.name, asyncPreemptionEnabled, asyncAPICallsEnabled, clearingNominatedNodeNameAfterBinding), func(t *testing.T) {
 						featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
@@ -699,20 +711,32 @@ func TestPreemption(t *testing.T) {
 						})
 
 						testCtx := testutils.InitTestSchedulerWithOptions(t,
-							testutils.InitTestAPIServer(t, "preemption", nil),
+							testutils.WithNewNamespace(t, sharedAPICtx, "preemption"),
 							0,
 							scheduler.WithProfiles(cfg.Profiles...),
 							scheduler.WithFrameworkOutOfTreeRegistry(registry))
 						testutils.SyncSchedulerInformerFactory(testCtx)
-						go testCtx.Scheduler.Run(testCtx.Ctx)
+						go testCtx.Scheduler.Run(testCtx.SchedulerCtx)
+						defer testCtx.SchedulerCloseFn()
 
 						if _, err := createNode(testCtx.ClientSet, nodeObject); err != nil {
 							t.Fatalf("Error creating node: %v", err)
 						}
+						t.Cleanup(func() {
+							if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, nodeObject.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+								t.Errorf("Error deleting node %s: %v", nodeObject.Name, err)
+							}
+						})
 						for _, n := range test.extraNodes {
 							if _, err := createNode(testCtx.ClientSet, n); err != nil {
 								t.Fatalf("Error creating extra node %s: %v", n.Name, err)
 							}
+							n := n
+							t.Cleanup(func() {
+								if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, n.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+									t.Errorf("Error deleting node %s: %v", n.Name, err)
+								}
+							})
 						}
 
 						cs := testCtx.ClientSet

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -686,124 +686,129 @@ func TestPreemption(t *testing.T) {
 	}
 	nodeObject := st.MakeNode().Name("node1").Capacity(nodeRes).Label("node", "node1").Obj()
 
+	// Group test indexes by genericWorkloadEnabled so each group can share an
+	// API server started with the correct feature gate value.
+	testsByGW := make(map[bool][]int)
+	for i, test := range tests {
+		testsByGW[test.genericWorkloadEnabled] = append(testsByGW[test.genericWorkloadEnabled], i)
+	}
+
 	for _, asyncPreemptionEnabled := range []bool{true, false} {
 		for _, asyncAPICallsEnabled := range []bool{true, false} {
 			for _, clearingNominatedNodeNameAfterBinding := range []bool{true, false} {
-				// Start one API server per flag combination and share it across all
-				// test cases in this combo. GenericWorkload is always enabled so that
-				// both plain-pod and pod-group test cases can share the same server;
-				// the scheduler-side GenericWorkload gate is set per subtest below.
-				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-					features.SchedulerAsyncPreemption:              asyncPreemptionEnabled,
-					features.SchedulerAsyncAPICalls:                asyncAPICallsEnabled,
-					features.ClearingNominatedNodeNameAfterBinding: clearingNominatedNodeNameAfterBinding,
-					features.GenericWorkload:                       true,
-				})
-				sharedAPICtx := testutils.InitTestAPIServer(t, "preemption", nil)
+				for _, genericWorkloadEnabled := range []bool{true, false} {
+					gwIndexes := testsByGW[genericWorkloadEnabled]
+					if len(gwIndexes) == 0 {
+						continue
+					}
+					// One API server per full flag combination. All flags including
+					// GenericWorkload are consistent between API server and scheduler.
+					featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+						features.SchedulerAsyncPreemption:              asyncPreemptionEnabled,
+						features.SchedulerAsyncAPICalls:                asyncAPICallsEnabled,
+						features.ClearingNominatedNodeNameAfterBinding: clearingNominatedNodeNameAfterBinding,
+						features.GenericWorkload:                       genericWorkloadEnabled,
+					})
+					sharedAPICtx := testutils.InitTestAPIServer(t, "preemption", nil)
 
-				for _, test := range tests {
-					t.Run(fmt.Sprintf("%s (Async preemption enabled: %v, Async API calls enabled: %v, ClearingNominatedNodeNameAfterBinding: %v)", test.name, asyncPreemptionEnabled, asyncAPICallsEnabled, clearingNominatedNodeNameAfterBinding), func(t *testing.T) {
-						featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-							features.SchedulerAsyncPreemption:              asyncPreemptionEnabled,
-							features.SchedulerAsyncAPICalls:                asyncAPICallsEnabled,
-							features.ClearingNominatedNodeNameAfterBinding: clearingNominatedNodeNameAfterBinding,
-							features.GenericWorkload:                       test.genericWorkloadEnabled,
-						})
+					for _, i := range gwIndexes {
+						test := tests[i]
+						t.Run(fmt.Sprintf("%s (Async preemption enabled: %v, Async API calls enabled: %v, ClearingNominatedNodeNameAfterBinding: %v)", test.name, asyncPreemptionEnabled, asyncAPICallsEnabled, clearingNominatedNodeNameAfterBinding), func(t *testing.T) {
+							testCtx := testutils.InitTestSchedulerWithOptions(t,
+								testutils.WithNewNamespace(t, sharedAPICtx, "preemption"),
+								0,
+								scheduler.WithProfiles(cfg.Profiles...),
+								scheduler.WithFrameworkOutOfTreeRegistry(registry))
+							testutils.SyncSchedulerInformerFactory(testCtx)
+							go testCtx.Scheduler.Run(testCtx.SchedulerCtx)
+							defer testCtx.SchedulerCloseFn()
 
-						testCtx := testutils.InitTestSchedulerWithOptions(t,
-							testutils.WithNewNamespace(t, sharedAPICtx, "preemption"),
-							0,
-							scheduler.WithProfiles(cfg.Profiles...),
-							scheduler.WithFrameworkOutOfTreeRegistry(registry))
-						testutils.SyncSchedulerInformerFactory(testCtx)
-						go testCtx.Scheduler.Run(testCtx.SchedulerCtx)
-						defer testCtx.SchedulerCloseFn()
-
-						if _, err := createNode(testCtx.ClientSet, nodeObject); err != nil {
-							t.Fatalf("Error creating node: %v", err)
-						}
-						t.Cleanup(func() {
-							if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, nodeObject.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-								t.Errorf("Error deleting node %s: %v", nodeObject.Name, err)
+							if _, err := createNode(testCtx.ClientSet, nodeObject); err != nil {
+								t.Fatalf("Error creating node: %v", err)
 							}
-						})
-						for _, n := range test.extraNodes {
-							if _, err := createNode(testCtx.ClientSet, n); err != nil {
-								t.Fatalf("Error creating extra node %s: %v", n.Name, err)
-							}
-							n := n
 							t.Cleanup(func() {
-								if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, n.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-									t.Errorf("Error deleting node %s: %v", n.Name, err)
+								if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, nodeObject.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+									t.Errorf("Error deleting node %s: %v", nodeObject.Name, err)
 								}
 							})
-						}
-
-						cs := testCtx.ClientSet
-						ns := testCtx.NS.Name
-
-						for _, pg := range test.podGroups {
-							pg.Namespace = ns
-							if _, err := cs.SchedulingV1alpha3().PodGroups(ns).Create(testCtx.Ctx, pg, metav1.CreateOptions{}); err != nil {
-								t.Fatalf("Error creating PodGroup %s: %v", pg.Name, err)
+							for _, n := range test.extraNodes {
+								if _, err := createNode(testCtx.ClientSet, n); err != nil {
+									t.Fatalf("Error creating extra node %s: %v", n.Name, err)
+								}
+								n := n
+								t.Cleanup(func() {
+									if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, n.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+										t.Errorf("Error deleting node %s: %v", n.Name, err)
+									}
+								})
 							}
-						}
 
-						filter.Tokens = test.initTokens
-						filter.EnablePreFilter = test.enablePreFilter
-						filter.Unresolvable = test.unresolvable
-						pods := make([]*v1.Pod, len(test.existingPods))
-						// Create and run existingPods.
-						for i, p := range test.existingPods {
-							p.Namespace = ns
-							pods[i], err = runPausePod(cs, p)
+							cs := testCtx.ClientSet
+							ns := testCtx.NS.Name
+
+							for _, pg := range test.podGroups {
+								pg.Namespace = ns
+								if _, err := cs.SchedulingV1alpha3().PodGroups(ns).Create(testCtx.Ctx, pg, metav1.CreateOptions{}); err != nil {
+									t.Fatalf("Error creating PodGroup %s: %v", pg.Name, err)
+								}
+							}
+
+							filter.Tokens = test.initTokens
+							filter.EnablePreFilter = test.enablePreFilter
+							filter.Unresolvable = test.unresolvable
+							pods := make([]*v1.Pod, len(test.existingPods))
+							// Create and run existingPods.
+							for i, p := range test.existingPods {
+								p.Namespace = ns
+								pods[i], err = runPausePod(cs, p)
+								if err != nil {
+									t.Fatalf("Error running pause pod: %v", err)
+								}
+							}
+							// Create the "pod".
+							test.pod.Namespace = ns
+							preemptor, err := createPausePod(cs, test.pod)
 							if err != nil {
-								t.Fatalf("Error running pause pod: %v", err)
+								t.Errorf("Error while creating high priority pod: %v", err)
 							}
-						}
-						// Create the "pod".
-						test.pod.Namespace = ns
-						preemptor, err := createPausePod(cs, test.pod)
-						if err != nil {
-							t.Errorf("Error while creating high priority pod: %v", err)
-						}
-						// Wait for preemption of pods and make sure the other ones are not preempted.
-						for i, p := range pods {
-							if _, found := test.preemptedPodIndexes[i]; found {
-								if err = wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false,
-									podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
-									t.Errorf("Pod %v/%v is not getting evicted.", p.Namespace, p.Name)
-								}
-								pod, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
-								if err != nil {
-									t.Errorf("Error %v when getting the updated status for pod %v/%v ", err, p.Namespace, p.Name)
-								}
-								_, cond := podutil.GetPodCondition(&pod.Status, v1.DisruptionTarget)
-								if cond == nil {
-									t.Errorf("Pod %q does not have the expected condition: %q", klog.KObj(pod), v1.DisruptionTarget)
-								}
-							} else {
-								// Re-fetch to get current state; the pod object from runPausePod
-								// always has DeletionTimestamp=nil and cannot detect unexpected eviction.
-								current, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
-								if err != nil {
-									t.Errorf("Error getting pod %v: %v", p.Name, err)
-								} else if current.DeletionTimestamp != nil {
-									t.Errorf("Pod %v was unexpectedly preempted", p.Name)
+							// Wait for preemption of pods and make sure the other ones are not preempted.
+							for i, p := range pods {
+								if _, found := test.preemptedPodIndexes[i]; found {
+									if err = wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false,
+										podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
+										t.Errorf("Pod %v/%v is not getting evicted.", p.Namespace, p.Name)
+									}
+									pod, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
+									if err != nil {
+										t.Errorf("Error %v when getting the updated status for pod %v/%v ", err, p.Namespace, p.Name)
+									}
+									_, cond := podutil.GetPodCondition(&pod.Status, v1.DisruptionTarget)
+									if cond == nil {
+										t.Errorf("Pod %q does not have the expected condition: %q", klog.KObj(pod), v1.DisruptionTarget)
+									}
+								} else {
+									// Re-fetch to get current state; the pod object from runPausePod
+									// always has DeletionTimestamp=nil and cannot detect unexpected eviction.
+									current, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
+									if err != nil {
+										t.Errorf("Error getting pod %v: %v", p.Name, err)
+									} else if current.DeletionTimestamp != nil {
+										t.Errorf("Pod %v was unexpectedly preempted", p.Name)
+									}
 								}
 							}
-						}
-						// Also check that the preemptor pod gets the NominatedNodeName field set.
-						if len(test.preemptedPodIndexes) > 0 && !clearingNominatedNodeNameAfterBinding {
-							if err := testutils.WaitForNominatedNodeName(testCtx.Ctx, cs, preemptor); err != nil {
-								t.Errorf("NominatedNodeName field was not set for pod %v: %v", preemptor.Name, err)
+							// Also check that the preemptor pod gets the NominatedNodeName field set.
+							if len(test.preemptedPodIndexes) > 0 && !clearingNominatedNodeNameAfterBinding {
+								if err := testutils.WaitForNominatedNodeName(testCtx.Ctx, cs, preemptor); err != nil {
+									t.Errorf("NominatedNodeName field was not set for pod %v: %v", preemptor.Name, err)
+								}
 							}
-						}
 
-						// Cleanup
-						pods = append(pods, preemptor)
-						testutils.CleanupPods(testCtx.Ctx, cs, t, pods)
-					})
+							// Cleanup
+							pods = append(pods, preemptor)
+							testutils.CleanupPods(testCtx.Ctx, cs, t, pods)
+						})
+					}
 				}
 			}
 		}

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -575,6 +575,25 @@ func InitTestAPIServer(t *testing.T, nsPrefix string, admission admission.Interf
 	return testCtx
 }
 
+// WithNewNamespace creates a child TestContext that shares the API server from
+// parent but gets a fresh namespace. Only the namespace is deleted on t.Cleanup;
+// the API server lifecycle is managed by the caller. This is useful when
+// multiple subtests share one API server to avoid the per-subtest startup cost.
+func WithNewNamespace(t *testing.T, parent *TestContext, nsPrefix string) *TestContext {
+	t.Helper()
+	child := &TestContext{
+		ClientSet:  parent.ClientSet,
+		KubeConfig: parent.KubeConfig,
+		Ctx:        parent.Ctx,
+		CloseFn:    func() {}, // API server is owned by parent; do not tear it down here.
+	}
+	child.NS = framework.CreateNamespaceOrDie(child.ClientSet, nsPrefix+string(uuid.NewUUID()), t)
+	t.Cleanup(func() {
+		framework.DeleteNamespaceOrDie(child.ClientSet, child.NS, t)
+	})
+	return child
+}
+
 // WaitForSchedulerCacheCleanup waits for cleanup of scheduler's cache to complete
 func WaitForSchedulerCacheCleanup(ctx context.Context, sched *scheduler.Scheduler, t *testing.T) {
 	schedulerCacheIsEmpty := func(context.Context) (bool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

TestPreemption was starting a fresh API server for every subtest,
which is expensive. Share one API server per flag combination instead.
Each subtest still gets an isolated namespace, fresh scheduler, and nodes.

Testing:

Earlier without the enhancement :
```
# ./preemption.test -test.v -test.timeout=800s 2>&1 | grep -E "^(--- PASS|--- FAIL|FAIL|ok )"
--- PASS: TestPodGroupPreemption (146.35s)
--- PASS: TestPreemption (364.53s)
--- PASS: TestAsyncPreemption (57.74s)
--- PASS: TestPreemptionRespectsWaitingPod (5.32s)
--- PASS: TestPreemptionRespectsBindingPod (5.15s)
```

Now with the enhancement:
```
# ./preemption_new.test -test.v -test.timeout=520s 2>&1 | grep -E "^(--- PASS|--- FAIL|FAIL|ok )"
--- PASS: TestPodGroupPreemption (143.94s)
--- PASS: TestPreemption (72.73s)
--- PASS: TestAsyncPreemption (55.85s)
--- PASS: TestPreemptionRespectsWaitingPod (5.03s)
--- PASS: TestPreemptionRespectsBindingPod (5.09s)

```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
