### PR TITLE
Propagate TokenReview request context deadline

### DIFF
--- a/pkg/registry/authentication/tokenreview/storage.go
+++ b/pkg/registry/authentication/tokenreview/storage.go
@@ -34,6 +34,16 @@ import (
 
 var badAuthenticatorAuds = apierrors.NewInternalError(errors.New("error validating audiences"))
 
+// valuelessContext preserves cancellation and deadline propagation without
+// exposing unrelated context values to token authenticators.
+type valuelessContext struct {
+	context.Context
+}
+
+func (valuelessContext) Value(any) any {
+	return nil
+}
+
 type REST struct {
 	tokenAuthenticator authenticator.Request
 	apiAudiences       []string
@@ -90,8 +100,10 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		return tokenReview, nil
 	}
 
+	reqCtx := valuelessContext{Context: ctx}
+
 	// create a header that contains nothing but the token
-	fakeReq := &http.Request{Header: http.Header{}}
+	fakeReq := (&http.Request{Header: http.Header{}}).WithContext(reqCtx)
 	fakeReq.Header.Add("Authorization", "Bearer "+tokenReview.Spec.Token)
 
 	auds := tokenReview.Spec.Audiences

--- a/pkg/registry/authentication/tokenreview/storage_test.go
+++ b/pkg/registry/authentication/tokenreview/storage_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenreview
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/kubernetes/pkg/apis/authentication"
+)
+
+type contextKey string
+
+func TestCreatePropagatesCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	storage := NewREST(authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		if err := req.Context().Err(); !errors.Is(err, context.Canceled) {
+			return nil, false, fmt.Errorf("expected canceled request context, got %v", err)
+		}
+
+		return nil, false, req.Context().Err()
+	}), nil)
+
+	obj, err := storage.Create(ctx, newTokenReview("test-token", nil), nil, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	status := obj.(*authentication.TokenReview).Status
+	if status.Authenticated {
+		t.Fatal("expected unauthenticated TokenReview")
+	}
+	if status.Error != context.Canceled.Error() {
+		t.Fatalf("expected status error %q, got %q", context.Canceled.Error(), status.Error)
+	}
+}
+
+func TestCreatePropagatesContextDeadline(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	storage := NewREST(authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		if err := req.Context().Err(); !errors.Is(err, context.DeadlineExceeded) {
+			return nil, false, fmt.Errorf("expected deadline exceeded request context, got %v", err)
+		}
+
+		return nil, false, req.Context().Err()
+	}), nil)
+
+	obj, err := storage.Create(ctx, newTokenReview("test-token", nil), nil, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	status := obj.(*authentication.TokenReview).Status
+	if status.Authenticated {
+		t.Fatal("expected unauthenticated TokenReview")
+	}
+	if status.Error != context.DeadlineExceeded.Error() {
+		t.Fatalf("expected status error %q, got %q", context.DeadlineExceeded.Error(), status.Error)
+	}
+}
+
+func TestCreateStripsParentContextValuesAndPreservesAudiences(t *testing.T) {
+	parentKey := contextKey("request-value")
+	ctx := context.WithValue(context.Background(), parentKey, "value")
+	wantAuds := []string{"api", "kubernetes"}
+
+	storage := NewREST(authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		if got := req.Context().Value(parentKey); got != nil {
+			return nil, false, fmt.Errorf("expected parent context value to be hidden, got %v", got)
+		}
+
+		auds, ok := authenticator.AudiencesFrom(req.Context())
+		if !ok {
+			return nil, false, errors.New("expected request audiences")
+		}
+		if !reflect.DeepEqual(auds, authenticator.Audiences(wantAuds)) {
+			return nil, false, fmt.Errorf("expected audiences %v, got %v", wantAuds, auds)
+		}
+
+		return &authenticator.Response{
+			Audiences: auds,
+			User:      &user.DefaultInfo{Name: "test-user"},
+		}, true, nil
+	}), wantAuds)
+
+	obj, err := storage.Create(ctx, newTokenReview("test-token", nil), nil, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	status := obj.(*authentication.TokenReview).Status
+	if !status.Authenticated {
+		t.Fatal("expected authenticated TokenReview")
+	}
+	if status.Error != "" {
+		t.Fatalf("expected no status error, got %q", status.Error)
+	}
+	if status.User.Username != "test-user" {
+		t.Fatalf("expected username %q, got %q", "test-user", status.User.Username)
+	}
+	if !reflect.DeepEqual(status.Audiences, wantAuds) {
+		t.Fatalf("expected status audiences %v, got %v", wantAuds, status.Audiences)
+	}
+}
+
+func newTokenReview(token string, audiences []string) *authentication.TokenReview {
+	return &authentication.TokenReview{
+		Spec: authentication.TokenReviewSpec{
+			Token:     token,
+			Audiences: audiences,
+		},
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig auth
/priority important-soon

#### What this PR does / why we need it:

TokenReview builds a synthetic HTTP request before invoking request-based token authenticators. That synthetic request previously used a background context, so cancellation and deadline signals from the original API request were not visible to authenticators.

This change builds the synthetic request from a valueless wrapper around the original context. That preserves cancellation and deadline behavior while avoiding propagation of unrelated request-scoped context values. TokenReview audiences are then added explicitly to the wrapped context before authentication.

#### Which issue(s) this PR fixes:

Fixes #89702

#### Special notes for your reviewer:

This follows the prior review direction on #89702 to preserve cancellation/deadline propagation without forwarding arbitrary context values. Unit tests cover canceled contexts, exceeded deadlines, and context-value isolation while preserving audiences.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

#### Validation:

```text
docker run --rm -v "$PWD":/workspace -w /workspace -e GOTOOLCHAIN=local golang:1.26.5 go test ./pkg/registry/authentication/tokenreview
docker run --rm -v "$PWD":/workspace -w /workspace -e GOTOOLCHAIN=local golang:1.26.5 go test ./pkg/registry/authentication/...
```
