### PR TITLE
Fix DRA AdminAccess counter checks

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -1678,6 +1678,31 @@ func TestAllocator(t *testing.T,
 				deviceAllocationResult(req0, driverA, pool1, device2, true),
 			)},
 		},
+		"admin-access-allocated-partitionable-device": {
+			features: Features{AdminAccess: true, PartitionableDevices: true},
+			claimsToAllocate: func() []wrapResourceClaim {
+				c := claimWithRequest(claim0, req0, classA)
+				c.Spec.Devices.Requests[0].Exactly.AdminAccess = ptr.To(true)
+				return []wrapResourceClaim{c}
+			}(),
+			allocatedDevices: []DeviceID{MakeDeviceID(driverA, pool1, device1)},
+			classes:          objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{capacity0: one}),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1, map[string]resource.Quantity{capacity0: one}),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, true),
+			)},
+		},
 		"separate-claims-share-device-admin-access": {
 			features: Features{
 				AdminAccess: true,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -1491,8 +1491,9 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		return false, nil, nil
 	}
 
-	// Skip counter availability check for devices that allow multiple allocation and some capacity has already in-use.
-	skipCounterCheck := allowMultipleAllocations && alloc.deviceCapacityInUse(device.id)
+	// Admin access does not consume device resources, including counters. Also
+	// skip the check when a repeatable device already has capacity in use.
+	skipCounterCheck := request.adminAccess() || (allowMultipleAllocations && alloc.deviceCapacityInUse(device.id))
 
 	// The API validation logic has checked the ConsumesCounters referred should exist inside SharedCounters.
 	// countersReserved records whether checkAvailableCounters actually reserved


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
DRA AdminAccess requests do not consume device resources, but the allocator still checks and reserves their device counters. When counters are fully consumed by an existing allocation, a valid AdminAccess request is rejected. This change skips counter availability checks for AdminAccess requests.

A regression test covers an AdminAccess request for an already allocated partitionable device whose counters are fully consumed.

#### Which issue(s) this PR is related to:
Fixes #140729

#### Special notes for your reviewer:
The existing repeatable-device counter behavior is unchanged. `countersReserved` remains false for AdminAccess because no counter reservation is made.

#### Does this PR introduce a user-facing change?
No.

```release-note
NONE
```

#### Additional documentation e.g., KEPs, usage docs, etc.:

```docs
NONE
```