### PR TITLE
Fix error message in RunPodGroupPostFilterPlugins

### DIFF
--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -1245,7 +1245,7 @@ func (f *frameworkImpl) RunPodGroupPostFilterPlugins(ctx context.Context, state 
 			}
 		} else {
 			// Any status other than Success, Unschedulable or UnschedulableAndUnresolvable is Error.
-			return nil, fwk.AsStatus(fmt.Errorf("error in %q PostFilter plugins: %s", pl.Name(), status.Message())).WithPlugin(pl.Name())
+			return nil, fwk.AsStatus(fmt.Errorf("error in %q PodGroupPostFilter plugins: %s", pl.Name(), status.Message())).WithPlugin(pl.Name())
 		}
 	}
 

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -946,7 +946,7 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 				},
 			},
 			featureFlagEnabeled: true,
-			expectedStatus:      fwk.NewStatus(fwk.Error, "error in \"plugin1\" PostFilter plugins: "+injectReason).WithPlugin("plugin1"),
+			expectedStatus:      fwk.NewStatus(fwk.Error, "error in \"plugin1\" PodGroupPostFilter plugins: "+injectReason).WithPlugin("plugin1"),
 		},
 		{
 			name: "first plugin returns non supported status: Skip",
@@ -962,7 +962,7 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 				},
 			},
 			featureFlagEnabeled: true,
-			expectedStatus:      fwk.NewStatus(fwk.Error, "error in \"plugin1\" PostFilter plugins: "+injectReason).WithPlugin("plugin1"),
+			expectedStatus:      fwk.NewStatus(fwk.Error, "error in \"plugin1\" PodGroupPostFilter plugins: "+injectReason).WithPlugin("plugin1"),
 		},
 		{
 			name: "first plugin returns success",


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

This PR fixes an error message in PodGroupPostFilter. Right now it says "error in PostFilter plugins" instead of "error in PodGroupPostFilter plugins".

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/enhancements/issues/5710

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
The error message from PodGroupPostFilter now contains correct extension point name.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

