### PR TITLE
scheduler: record queue incoming metrics asynchronously

### DIFF
--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -346,7 +346,7 @@ func (aq *activeQueue) unlockedPop(logger klog.Logger) (framework.QueuedEntityIn
 		if err != nil {
 			return nil, err
 		}
-		recordIncomingEntitiesMetrics("active", entity, framework.PopFromBackoffQ, nil)
+		recordIncomingEntitiesMetrics(aq.metricsRecorder, "active", entity, framework.PopFromBackoffQ, nil)
 	}
 	err = aq.unlockedMoveEntityToInFlight(logger, entity)
 	if err != nil {
@@ -410,7 +410,7 @@ func (aq *activeQueue) add(logger klog.Logger, entity framework.QueuedEntityInfo
 	defer aq.lock.Unlock()
 
 	aq.queue.AddOrUpdate(entity)
-	recordIncomingEntitiesMetrics("active", entity, event, strategy)
+	recordIncomingEntitiesMetrics(aq.metricsRecorder, "active", entity, event, strategy)
 	logger.V(5).Info("Entity moved to an internal scheduling queue", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", activeQ)
 }
 

--- a/pkg/scheduler/backend/queue/backoff_queue.go
+++ b/pkg/scheduler/backend/queue/backoff_queue.go
@@ -310,7 +310,7 @@ func (bq *backoffQueue) add(logger klog.Logger, entity framework.QueuedEntityInf
 			logger.Error(nil, "BackoffQueue add() was called with an entity that was already in the entityBackoffQ", "type", entity.Type(), "entity", klog.KObj(entity))
 			return
 		}
-		recordIncomingEntitiesMetrics("backoff", entity, event, strategy)
+		recordIncomingEntitiesMetrics(nil, "backoff", entity, event, strategy)
 		logger.V(5).Info("Entity moved to an internal scheduling queue", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", backoffQ)
 		return
 	}
@@ -320,7 +320,7 @@ func (bq *backoffQueue) add(logger klog.Logger, entity framework.QueuedEntityInf
 		logger.Error(nil, "BackoffQueue add() was called with an entity that was already in the entityErrorBackoffQ", "type", entity.Type(), "entity", klog.KObj(entity))
 		return
 	}
-	recordIncomingEntitiesMetrics("backoff", entity, event, strategy)
+	recordIncomingEntitiesMetrics(nil, "backoff", entity, event, strategy)
 	logger.V(5).Info("Entity moved to an internal scheduling queue", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", backoffQ)
 }
 

--- a/pkg/scheduler/backend/queue/backoff_queue.go
+++ b/pkg/scheduler/backend/queue/backoff_queue.go
@@ -107,15 +107,17 @@ type backoffQueue struct {
 
 	// isPopFromBackoffQEnabled indicates whether the feature gate SchedulerPopFromBackoffQ is enabled.
 	isPopFromBackoffQEnabled bool
+	metricsRecorder          *metrics.MetricAsyncRecorder
 }
 
-func newBackoffQueue(clock clock.WithTicker, podInitialBackoffDuration time.Duration, podMaxBackoffDuration time.Duration, activeQLessFn func(entity1, entity2 framework.QueuedEntityInfo) bool, popFromBackoffQEnabled bool) *backoffQueue {
+func newBackoffQueue(clock clock.WithTicker, podInitialBackoffDuration time.Duration, podMaxBackoffDuration time.Duration, activeQLessFn func(entity1, entity2 framework.QueuedEntityInfo) bool, popFromBackoffQEnabled bool, metricsRecorder *metrics.MetricAsyncRecorder) *backoffQueue {
 	bq := &backoffQueue{
 		clock:                    clock,
 		podInitialBackoff:        podInitialBackoffDuration,
 		podMaxBackoff:            podMaxBackoffDuration,
 		isPopFromBackoffQEnabled: popFromBackoffQEnabled,
 		activeQLessFn:            activeQLessFn,
+		metricsRecorder:          metricsRecorder,
 	}
 	entityBackoffQLessFn := bq.lessBackoffCompleted
 	if popFromBackoffQEnabled {
@@ -310,7 +312,7 @@ func (bq *backoffQueue) add(logger klog.Logger, entity framework.QueuedEntityInf
 			logger.Error(nil, "BackoffQueue add() was called with an entity that was already in the entityBackoffQ", "type", entity.Type(), "entity", klog.KObj(entity))
 			return
 		}
-		recordIncomingEntitiesMetrics(nil, "backoff", entity, event, strategy)
+		recordIncomingEntitiesMetrics(bq.metricsRecorder, "backoff", entity, event, strategy)
 		logger.V(5).Info("Entity moved to an internal scheduling queue", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", backoffQ)
 		return
 	}
@@ -320,7 +322,7 @@ func (bq *backoffQueue) add(logger klog.Logger, entity framework.QueuedEntityInf
 		logger.Error(nil, "BackoffQueue add() was called with an entity that was already in the entityErrorBackoffQ", "type", entity.Type(), "entity", klog.KObj(entity))
 		return
 	}
-	recordIncomingEntitiesMetrics(nil, "backoff", entity, event, strategy)
+	recordIncomingEntitiesMetrics(bq.metricsRecorder, "backoff", entity, event, strategy)
 	logger.V(5).Info("Entity moved to an internal scheduling queue", "type", entity.Type(), "entity", klog.KObj(entity), "event", event, "queue", backoffQ)
 }
 

--- a/pkg/scheduler/backend/queue/backoff_queue_test.go
+++ b/pkg/scheduler/backend/queue/backoff_queue_test.go
@@ -104,7 +104,7 @@ func TestBackoffQueue_getBackoffTime(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bq := newBackoffQueue(clock.RealClock{}, tt.initialBackoffDuration, tt.maxBackoffDuration, convertLessFn(newDefaultQueueSort()), true)
+			bq := newBackoffQueue(clock.RealClock{}, tt.initialBackoffDuration, tt.maxBackoffDuration, convertLessFn(newDefaultQueueSort()), true, nil)
 			if got := bq.getBackoffTime(tt.podInfo); got != tt.want {
 				t.Errorf("backoffQueue.getBackoffTime() = %v, want %v", got, tt.want)
 			}
@@ -180,7 +180,7 @@ func TestBackoffQueue_calculateBackoffDuration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bq := newBackoffQueue(clock.RealClock{}, tt.initialBackoffDuration, tt.maxBackoffDuration, convertLessFn(newDefaultQueueSort()), true)
+			bq := newBackoffQueue(clock.RealClock{}, tt.initialBackoffDuration, tt.maxBackoffDuration, convertLessFn(newDefaultQueueSort()), true, nil)
 			if got := bq.calculateBackoffDuration(tt.count, tt.entitySize); got != tt.want {
 				t.Errorf("backoffQueue.calculateBackoffDuration() = %v, want %v", got, tt.want)
 			}
@@ -270,7 +270,7 @@ func TestBackoffQueue_popAllBackoffCompleted(t *testing.T) {
 		for _, popFromBackoffQEnabled := range []bool{true, false} {
 			t.Run(fmt.Sprintf("%s popFromBackoffQEnabled(%v)", tt.name, popFromBackoffQEnabled), func(t *testing.T) {
 				logger, _ := ktesting.NewTestContext(t)
-				bq := newBackoffQueue(fakeClock, DefaultPodInitialBackoffDuration, DefaultPodMaxBackoffDuration, convertLessFn(newDefaultQueueSort()), popFromBackoffQEnabled)
+				bq := newBackoffQueue(fakeClock, DefaultPodInitialBackoffDuration, DefaultPodMaxBackoffDuration, convertLessFn(newDefaultQueueSort()), popFromBackoffQEnabled, nil)
 				for _, podName := range tt.podsInBackoff {
 					bq.add(logger, podInfos[podName], framework.EventUnscheduledPodAdd.Label(), nil)
 				}
@@ -381,7 +381,7 @@ func TestBackoffQueueOrdering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
-			bq := newBackoffQueue(fakeClock, DefaultPodInitialBackoffDuration, DefaultPodMaxBackoffDuration, convertLessFn(newDefaultQueueSort()), tt.popFromBackoffQEnabled)
+			bq := newBackoffQueue(fakeClock, DefaultPodInitialBackoffDuration, DefaultPodMaxBackoffDuration, convertLessFn(newDefaultQueueSort()), tt.popFromBackoffQEnabled, nil)
 			for _, podInfo := range podInfos {
 				bq.add(logger, podInfo, framework.EventUnscheduledPodAdd.Label(), nil)
 			}

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -2137,17 +2137,26 @@ func (p *PriorityQueue) newQueuedPodInfo(ctx context.Context, pod *v1.Pod, plugi
 }
 
 // recordIncomingEntitiesMetrics records incoming queue metrics for pod-level and entity-level (individual pod or podgroup).
+// 'recorder' is used to record the metrics asynchronously if non-nil; otherwise the metrics are recorded synchronously.
 // 'strategy' is the previous queuing strategy, helps determine if the entity moved into a different
 // queue or newly added to correctly maintain incoming entities metrics.
 // If strategy is 'nil' it means that entity is newly added.
 // If queue label defined by previous strategy is different from next queue label, it means that entity moved into a different queue.
 // In both cases, we increment the incoming entities metric for the new queue.
-func recordIncomingEntitiesMetrics(targetQueueLabel string, entity framework.QueuedEntityInfo, event string, strategy *queueingStrategy) {
-	metrics.SchedulerQueueIncomingPods.WithLabelValues(targetQueueLabel, event).Add(float64(entity.Size()))
+func recordIncomingEntitiesMetrics(recorder *metrics.MetricAsyncRecorder, targetQueueLabel string, entity framework.QueuedEntityInfo, event string, strategy *queueingStrategy) {
+	if recorder != nil {
+		recorder.AddCounterVecAsync(metrics.SchedulerQueueIncomingPods, float64(entity.Size()), targetQueueLabel, event)
+	} else {
+		metrics.SchedulerQueueIncomingPods.WithLabelValues(targetQueueLabel, event).Add(float64(entity.Size()))
+	}
 
 	if strategy == nil || targetQueueLabel != strategyToQueueLabel(*strategy) {
 		if entityLabel, ok := metrics.EntityToLabel(entity); ok {
-			metrics.SchedulerQueueIncomingEntities.WithLabelValues(targetQueueLabel, event, entityLabel).Inc()
+			if recorder != nil {
+				recorder.IncCounterVecAsync(metrics.SchedulerQueueIncomingEntities, targetQueueLabel, event, entityLabel)
+			} else {
+				metrics.SchedulerQueueIncomingEntities.WithLabelValues(targetQueueLabel, event, entityLabel).Inc()
+			}
 		}
 	}
 }

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -439,13 +439,13 @@ func NewPriorityQueue(
 	isCompositePodGroupEnabled := utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup)
 	lessConverted := convertLessFn(lessFn)
 
-	backoffQ := newBackoffQueue(options.clock, options.podInitialBackoffDuration, options.podMaxBackoffDuration, lessConverted, isPopFromBackoffQEnabled)
+	backoffQ := newBackoffQueue(options.clock, options.podInitialBackoffDuration, options.podMaxBackoffDuration, lessConverted, isPopFromBackoffQEnabled, options.metricsRecorder)
 	pq := &PriorityQueue{
 		clock:                             options.clock,
 		stop:                              make(chan struct{}),
 		podMaxInUnschedulablePodsDuration: options.podMaxInUnschedulablePodsDuration,
 		backoffQ:                          backoffQ,
-		unschedulableEntities:             newUnschedulableEntities(metrics.NewUnschedulableEntitiesRecorder(), metrics.NewGatedEntitiesRecorder()),
+		unschedulableEntities:             newUnschedulableEntities(metrics.NewUnschedulableEntitiesRecorder(), metrics.NewGatedEntitiesRecorder(), options.metricsRecorder),
 		pendingPodGroupPods:               newPodGroupMemberPods(metrics.PendingPodGroupPods()),
 		incompletePodGroupPods:            newPodGroupMemberPods(metrics.IncompletePodGroupPods()),
 		workloadForest:                    newWorkloadForest(isCompositePodGroupEnabled),

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -5118,16 +5118,31 @@ func TestIncomingEntitiesMetrics(t *testing.T) {
 				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="active",type="pod"} 1
 			`,
 		},
+		{
+			name: "add individual pod to unschedulable queue",
+			run: func(_ ktesting.TContext, queue *PriorityQueue) {
+				queue.unschedulableEntities.addOrUpdate(pInfos[0], false, framework.EventUnscheduledPodAdd.Label(), nil)
+			},
+			want: `
+				scheduler_queue_incoming_entities_total{event="UnscheduledPodAdd",queue="unschedulable",type="pod"} 1
+			`,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			metrics.SchedulerQueueIncomingEntities.Reset()
-			recorder := metrics.NewMetricsAsyncRecorder(10, 20*time.Microsecond, tCtx.Done())
+			stopCh := make(chan struct{})
+			recorder := metrics.NewMetricsAsyncRecorder(10, time.Millisecond, stopCh)
+			close(stopCh)
+			<-recorder.IsStoppedCh
 			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)), WithMetricsRecorder(recorder))
 			queue.AddPodGroup(logger, st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj())
 			test.run(tCtx, queue)
+			if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingEntities, strings.NewReader(queueIncomingEntitiesMetricMetadata), metricName); err != nil {
+				t.Errorf("incoming entity metrics were recorded synchronously:\n%s", err)
+			}
 			recorder.FlushMetrics()
 			if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingEntities, strings.NewReader(queueIncomingEntitiesMetricMetadata+test.want), metricName); err != nil {
 				t.Errorf("unexpected collecting result:\n%s", err)

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -5024,12 +5024,14 @@ func TestIncomingPodsMetrics(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			metrics.SchedulerQueueIncomingPods.Reset()
-			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
+			recorder := metrics.NewMetricsAsyncRecorder(10, 20*time.Microsecond, tCtx.Done())
+			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)), WithMetricsRecorder(recorder))
 			for _, op := range test.operations {
 				for _, pInfo := range pInfos {
 					op(tCtx, queue, pInfo)
 				}
 			}
+			recorder.FlushMetrics()
 			metricName := metrics.SchedulerSubsystem + "_" + metrics.SchedulerQueueIncomingPods.Name
 			if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingPods, strings.NewReader(queueMetricMetadata+test.want), metricName); err != nil {
 				t.Errorf("unexpected collecting result:\n%s", err)
@@ -5122,9 +5124,11 @@ func TestIncomingEntitiesMetrics(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			metrics.SchedulerQueueIncomingEntities.Reset()
-			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
+			recorder := metrics.NewMetricsAsyncRecorder(10, 20*time.Microsecond, tCtx.Done())
+			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)), WithMetricsRecorder(recorder))
 			queue.AddPodGroup(logger, st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj())
 			test.run(tCtx, queue)
+			recorder.FlushMetrics()
 			if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingEntities, strings.NewReader(queueIncomingEntitiesMetricMetadata+test.want), metricName); err != nil {
 				t.Errorf("unexpected collecting result:\n%s", err)
 			}

--- a/pkg/scheduler/backend/queue/unschedulable_entities.go
+++ b/pkg/scheduler/backend/queue/unschedulable_entities.go
@@ -30,15 +30,17 @@ type unschedulableEntities struct {
 	// unschedulableRecorder tracks standard unschedulable entities, while gatedRecorder tracks entities
 	// that are specifically blocked by scheduling gates.
 	unschedulableRecorder, gatedRecorder metrics.MetricRecorder
+	metricsRecorder                      *metrics.MetricAsyncRecorder
 }
 
 // newUnschedulableEntities initializes a new object of unschedulableEntities.
-func newUnschedulableEntities(unschedulableRecorder, gatedRecorder metrics.MetricRecorder) *unschedulableEntities {
+func newUnschedulableEntities(unschedulableRecorder, gatedRecorder metrics.MetricRecorder, metricsRecorder *metrics.MetricAsyncRecorder) *unschedulableEntities {
 	return &unschedulableEntities{
 		entityInfoMap:         make(map[string]framework.QueuedEntityInfo),
 		keyFunc:               queuedEntityKeyFunc,
 		unschedulableRecorder: unschedulableRecorder,
 		gatedRecorder:         gatedRecorder,
+		metricsRecorder:       metricsRecorder,
 	}
 }
 
@@ -74,7 +76,7 @@ func (u *unschedulableEntities) addOrUpdate(entity framework.QueuedEntityInfo, g
 		} else {
 			u.unschedulableRecorder.Add(entity)
 		}
-		recordIncomingEntitiesMetrics(nil, "unschedulable", entity, event, strategy)
+		recordIncomingEntitiesMetrics(u.metricsRecorder, "unschedulable", entity, event, strategy)
 	}
 	u.entityInfoMap[entityKey] = entity
 }

--- a/pkg/scheduler/backend/queue/unschedulable_entities.go
+++ b/pkg/scheduler/backend/queue/unschedulable_entities.go
@@ -74,7 +74,7 @@ func (u *unschedulableEntities) addOrUpdate(entity framework.QueuedEntityInfo, g
 		} else {
 			u.unschedulableRecorder.Add(entity)
 		}
-		recordIncomingEntitiesMetrics("unschedulable", entity, event, strategy)
+		recordIncomingEntitiesMetrics(nil, "unschedulable", entity, event, strategy)
 	}
 	u.entityInfoMap[entityKey] = entity
 }

--- a/pkg/scheduler/backend/queue/unschedulable_entities_test.go
+++ b/pkg/scheduler/backend/queue/unschedulable_entities_test.go
@@ -197,7 +197,7 @@ func TestUnschedulableEntities(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			unschedulableRecorder := &mockMetricRecorder{}
 			gatedRecorder := &mockMetricRecorder{}
-			ue := newUnschedulableEntities(unschedulableRecorder, gatedRecorder)
+			ue := newUnschedulableEntities(unschedulableRecorder, gatedRecorder, nil)
 			assertMetrics := func(expectedPods []*framework.QueuedPodInfo, action string) {
 				t.Helper()
 
@@ -242,7 +242,7 @@ func TestUnschedulableEntities(t *testing.T) {
 func TestUnschedulablePodGroups_Unified(t *testing.T) {
 	unschedulableRecorder := &mockMetricRecorder{}
 	gatedRecorder := &mockMetricRecorder{}
-	ue := newUnschedulableEntities(unschedulableRecorder, gatedRecorder)
+	ue := newUnschedulableEntities(unschedulableRecorder, gatedRecorder, nil)
 
 	pgInfo := &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{

--- a/pkg/scheduler/metrics/metric_recorder.go
+++ b/pkg/scheduler/metrics/metric_recorder.go
@@ -151,6 +151,14 @@ type gaugeVecMetricKey struct {
 	labelValue string
 }
 
+// counterVecMetric is the data structure passed in the buffer channel between the main framework thread
+// and the metricsRecorder goroutine.
+type counterVecMetric struct {
+	metric      *metrics.CounterVec
+	labelValues []string
+	valueToAdd  float64
+}
+
 // MetricAsyncRecorder records metric in a separate goroutine to avoid overhead in the critical path.
 type MetricAsyncRecorder struct {
 	// bufferCh is a channel that serves as a metrics buffer before the metricsRecorder goroutine reports it.
@@ -167,6 +175,8 @@ type MetricAsyncRecorder struct {
 	aggregatedInflightEventMetric              map[gaugeVecMetricKey]int
 	aggregatedInflightEventMetricLastFlushTime time.Time
 	aggregatedInflightEventMetricBufferCh      chan *gaugeVecMetric
+	// counterVecBufferCh keeps counter updates off the scheduling critical path.
+	counterVecBufferCh chan *counterVecMetric
 
 	// stopCh is used to stop the goroutine which periodically flushes metrics.
 	stopCh <-chan struct{}
@@ -184,6 +194,7 @@ func NewMetricsAsyncRecorder(bufferSize int, interval time.Duration, stopCh <-ch
 		aggregatedInflightEventMetric: make(map[gaugeVecMetricKey]int),
 		aggregatedInflightEventMetricLastFlushTime: time.Now(),
 		aggregatedInflightEventMetricBufferCh:      make(chan *gaugeVecMetric, bufferSize),
+		counterVecBufferCh:                         make(chan *counterVecMetric, bufferSize),
 		IsStoppedCh:                                make(chan struct{}),
 	}
 	go recorder.run()
@@ -206,6 +217,27 @@ func (r *MetricAsyncRecorder) ObservePluginDurationAsync(extensionPoint, pluginN
 // The metric will be flushed to Prometheus asynchronously.
 func (r *MetricAsyncRecorder) ObserveQueueingHintDurationAsync(pluginName, event, hint string, value float64) {
 	r.observeMetricAsync(queueingHintExecutionDuration, value, pluginName, event, hint)
+}
+
+// AddCounterVecAsync increments a CounterVec metric by valueToAdd, with the given label values.
+// The metric will be flushed to Prometheus asynchronously.
+func (r *MetricAsyncRecorder) AddCounterVecAsync(m *metrics.CounterVec, valueToAdd float64, labelsValues ...string) {
+	newMetric := &counterVecMetric{
+		metric:      m,
+		labelValues: labelsValues,
+		valueToAdd:  valueToAdd,
+	}
+	select {
+	case r.counterVecBufferCh <- newMetric:
+	default:
+		// Drop the update rather than block the scheduling critical path.
+	}
+}
+
+// IncCounterVecAsync increments a CounterVec metric by 1, with the given label values.
+// The metric will be flushed to Prometheus asynchronously.
+func (r *MetricAsyncRecorder) IncCounterVecAsync(m *metrics.CounterVec, labelsValues ...string) {
+	r.AddCounterVecAsync(m, 1, labelsValues...)
 }
 
 // ObserveInFlightEventsAsync observes the in_flight_events metric.
@@ -274,6 +306,13 @@ func (r *MetricAsyncRecorder) FlushMetrics() {
 
 		select {
 		case m := <-r.aggregatedInflightEventMetricBufferCh:
+			m.metric.WithLabelValues(m.labelValues...).Add(m.valueToAdd)
+		default:
+			// no more value
+		}
+
+		select {
+		case m := <-r.counterVecBufferCh:
 			m.metric.WithLabelValues(m.labelValues...).Add(m.valueToAdd)
 		default:
 			// no more value

--- a/pkg/scheduler/metrics/metric_recorder_test.go
+++ b/pkg/scheduler/metrics/metric_recorder_test.go
@@ -196,6 +196,29 @@ func TestInFlightEventAsync(t *testing.T) {
 	}
 }
 
+func TestCounterVecAsync(t *testing.T) {
+	SchedulerQueueIncomingPods.Reset()
+	t.Cleanup(SchedulerQueueIncomingPods.Reset)
+
+	r := &MetricAsyncRecorder{
+		bufferSize:         2,
+		counterVecBufferCh: make(chan *counterVecMetric, 2),
+	}
+	r.AddCounterVecAsync(SchedulerQueueIncomingPods, 2, "active", "test")
+	r.IncCounterVecAsync(SchedulerQueueIncomingPods, "active", "test")
+	r.FlushMetrics()
+
+	metricName := SchedulerSubsystem + "_" + SchedulerQueueIncomingPods.Name
+	want := `
+# HELP scheduler_queue_incoming_pods_total [STABLE] Number of pods added to scheduling queues by event and queue type.
+# TYPE scheduler_queue_incoming_pods_total counter
+scheduler_queue_incoming_pods_total{event="test",queue="active"} 3
+`
+	if err := testutil.CollectAndCompare(SchedulerQueueIncomingPods, strings.NewReader(want), metricName); err != nil {
+		t.Fatalf("unexpected collected metrics: %v", err)
+	}
+}
+
 func TestEntityToLabel(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## What this PR does

This PR extends `MetricAsyncRecorder` to support asynchronous recording of `CounterVec` metrics.

It updates the scheduler to record the following metrics asynchronously when a `MetricAsyncRecorder` is available:

- `scheduler_queue_incoming_pods_total`
- `scheduler_queue_incoming_entities_total`

The `MetricAsyncRecorder` is now wired through all scheduling queue implementations (`activeQueue`, `backoffQueue`, and `unschedulableEntities`), enabling asynchronous recording of incoming queue metrics across all scheduling queue paths. Existing synchronous metric recording is retained only as a fallback when a recorder is not configured (for example, in tests).

Fixes #140709

## Testing

```sh
go build ./pkg/scheduler/...
go test ./pkg/scheduler/... -count=1
go vet ./pkg/scheduler/...