### PR TITLE
Fixing some unit test issues for k8s.io/client-go/tools/clientcmd on Windows

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/config_test.go
@@ -31,11 +31,11 @@ func TestModifyConfigWritesToFirstKubeconfigFile(t *testing.T) {
 	)
 
 	tempdir := t.TempDir()
-	configFile1, _ := os.Create(filepath.Join(tempdir, "kubeconfig-a"))
-	configFile2, _ := os.Create(filepath.Join(tempdir, "kubeconfig-b"))
+	configFile1 := filepath.Join(tempdir, "kubeconfig-a")
+	configFile2 := filepath.Join(tempdir, "kubeconfig-b")
 
 	// The first kubeconfig has everything.
-	err := os.WriteFile(configFile1.Name(), []byte(`
+	err := os.WriteFile(configFile1, []byte(`
 kind: Config
 apiVersion: v1
 clusters:
@@ -62,7 +62,7 @@ users:
 	}
 
 	// The second kubeconfig declares a new context and activates it.
-	err = os.WriteFile(configFile2.Name(), []byte(`
+	err = os.WriteFile(configFile2, []byte(`
 kind: Config
 apiVersion: v1
 contexts:
@@ -80,7 +80,7 @@ current-context: `+contextNameB+`
 
 	// Set KUBECONFIG to the files, in descending alphabetical order.
 	// This will be used to check that they don't get sorted.
-	envVarValue := fmt.Sprintf("%s%c%s", configFile2.Name(), filepath.ListSeparator, configFile1.Name())
+	envVarValue := fmt.Sprintf("%s%c%s", configFile2, filepath.ListSeparator, configFile1)
 	t.Setenv(RecommendedConfigPathEnvVar, envVarValue)
 
 	// Load the kubeconfigs, change the active context, and call ModifyConfig.
@@ -99,7 +99,7 @@ current-context: `+contextNameB+`
 	}
 
 	// Load the files again and check that only configFile2 was changed.
-	config1, err := LoadFromFile(configFile1.Name()) // file sorts first, but was specified last
+	config1, err := LoadFromFile(configFile1) // file sorts first, but was specified last
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -108,7 +108,7 @@ current-context: `+contextNameB+`
 		t.Errorf("Config should not be modified, but was. Expected %q, got %q", contextNameA, config1.CurrentContext)
 	}
 
-	config2, err := LoadFromFile(configFile2.Name()) // file sorts last, but was specified first
+	config2, err := LoadFromFile(configFile2) // file sorts last, but was specified first
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+	"k8s.io/client-go/util/homedir"
 	"k8s.io/klog/v2"
 )
 
@@ -514,27 +515,28 @@ extensions:
 }
 
 func TestResolveRelativePaths(t *testing.T) {
+	absoluteDir := filepath.Join(t.TempDir(), "absolute")
 	pathResolutionConfig1 := clientcmdapi.Config{
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"relative-user-1": {ClientCertificate: "relative/client/cert", ClientKey: "../relative/client/key"},
-			"absolute-user-1": {ClientCertificate: "/absolute/client/cert", ClientKey: "/absolute/client/key"},
-			"relative-cmd-1":  {Exec: &clientcmdapi.ExecConfig{Command: "../relative/client/cmd"}},
-			"absolute-cmd-1":  {Exec: &clientcmdapi.ExecConfig{Command: "/absolute/client/cmd"}},
+			"relative-user-1": {ClientCertificate: filepath.Join("relative", "client", "cert"), ClientKey: filepath.Join("..", "relative", "client", "key")},
+			"absolute-user-1": {ClientCertificate: filepath.Join(absoluteDir, "client", "cert"), ClientKey: filepath.Join(absoluteDir, "client", "key")},
+			"relative-cmd-1":  {Exec: &clientcmdapi.ExecConfig{Command: filepath.Join("..", "relative", "client", "cmd")}},
+			"absolute-cmd-1":  {Exec: &clientcmdapi.ExecConfig{Command: filepath.Join(absoluteDir, "client", "cmd")}},
 			"PATH-cmd-1":      {Exec: &clientcmdapi.ExecConfig{Command: "cmd"}},
 		},
 		Clusters: map[string]*clientcmdapi.Cluster{
-			"relative-server-1": {CertificateAuthority: "../relative/ca"},
-			"absolute-server-1": {CertificateAuthority: "/absolute/ca"},
+			"relative-server-1": {CertificateAuthority: filepath.Join("..", "relative", "ca")},
+			"absolute-server-1": {CertificateAuthority: filepath.Join(absoluteDir, "ca")},
 		},
 	}
 	pathResolutionConfig2 := clientcmdapi.Config{
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"relative-user-2": {ClientCertificate: "relative/client/cert2", ClientKey: "../relative/client/key2"},
-			"absolute-user-2": {ClientCertificate: "/absolute/client/cert2", ClientKey: "/absolute/client/key2"},
+			"relative-user-2": {ClientCertificate: filepath.Join("relative", "client", "cert2"), ClientKey: filepath.Join("..", "relative", "client", "key2")},
+			"absolute-user-2": {ClientCertificate: filepath.Join(absoluteDir, "client", "cert2"), ClientKey: filepath.Join(absoluteDir, "client", "key2")},
 		},
 		Clusters: map[string]*clientcmdapi.Cluster{
-			"relative-server-2": {CertificateAuthority: "../relative/ca2"},
-			"absolute-server-2": {CertificateAuthority: "/absolute/ca2"},
+			"relative-server-2": {CertificateAuthority: filepath.Join("..", "relative", "ca2")},
+			"absolute-server-2": {CertificateAuthority: filepath.Join(absoluteDir, "ca2")},
 		},
 	}
 
@@ -626,29 +628,26 @@ func TestResolveRelativePaths(t *testing.T) {
 }
 
 func TestMigratingFile(t *testing.T) {
-	sourceFile, _ := os.CreateTemp("", "")
-	defer utiltesting.CloseAndRemove(t, sourceFile)
-	destinationFile, _ := os.CreateTemp("", "")
-	// delete the file so that we'll write to it
-	os.Remove(destinationFile.Name())
+	tempDir := t.TempDir()
+	sourceFile := filepath.Join(tempDir, "source")
+	destinationFile := filepath.Join(tempDir, "destination")
 
-	WriteToFile(testConfigAlfa, sourceFile.Name())
+	if err := WriteToFile(testConfigAlfa, sourceFile); err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
 
 	loadingRules := ClientConfigLoadingRules{
-		MigrationRules: map[string]string{destinationFile.Name(): sourceFile.Name()},
+		MigrationRules: map[string]string{destinationFile: sourceFile},
 	}
 
 	if _, err := loadingRules.Load(); err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
-	// the load should have recreated this file
-	defer utiltesting.CloseAndRemove(t, destinationFile)
-
-	sourceContent, err := os.ReadFile(sourceFile.Name())
+	sourceContent, err := os.ReadFile(sourceFile)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
-	destinationContent, err := os.ReadFile(destinationFile.Name())
+	destinationContent, err := os.ReadFile(destinationFile)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -658,11 +657,11 @@ func TestMigratingFile(t *testing.T) {
 	}
 
 	// destination file permissions should be the same as the source file permissions
-	sourceInfo, err := os.Stat(sourceFile.Name())
+	sourceInfo, err := os.Stat(sourceFile)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
-	destinationInfo, err := os.Stat(destinationFile.Name())
+	destinationInfo, err := os.Stat(destinationFile)
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
@@ -949,7 +948,10 @@ func TestLoadingGetLoadingPrecedence(t *testing.T) {
 		precedence []string
 	}{
 		"default": {
-			precedence: []string{filepath.Join(os.Getenv("HOME"), ".kube/config")},
+			// Reconstruct the expected default path independently from the
+			// home directory so the assertion validates how RecommendedHomeFile
+			// is assembled rather than comparing it against itself.
+			precedence: []string{filepath.Join(homedir.HomeDir(), RecommendedHomeDir, RecommendedFileName)},
 		},
 		"explicit": {
 			rules: &ClientConfigLoadingRules{
@@ -962,7 +964,7 @@ func TestLoadingGetLoadingPrecedence(t *testing.T) {
 			precedence: []string{"/env/kubeconfig"},
 		},
 		"envvar-multiple": {
-			env:        "/env/kubeconfig:/other/kubeconfig",
+			env:        strings.Join([]string{"/env/kubeconfig", "/other/kubeconfig"}, string(filepath.ListSeparator)),
 			precedence: []string{"/env/kubeconfig", "/other/kubeconfig"},
 		},
 	}


### PR DESCRIPTION
…Windows

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:

/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This fixes some unit tests in the `k8s.io/clinet-go-tools/clientcmd` package so we can enable them to run on windows

For the changes in `config_test.go` os.CreateFile keeps an handle to the file open which we don't need and test cleanup sometimes files with

```bash
--- FAIL: TestModifyConfigWritesToFirstKubeconfigFile (1.98s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat ...\kubeconfig-a: The process cannot access the file because it is being used by another process.
```

THe changes to `loader_test.config` address these failures

```bash
Failed  === RUN   TestResolveRelativePaths
    client_config_test.go:998: Expected "/absolute/ca", got "C:\\Users\\azureuser\\AppData\\Local\\Temp\\229315489\\absolute\\ca"
    client_config_test.go:998: Expected "/absolute/ca2", got "C:\\Users\\azureuser\\AppData\\Local\\Temp\\3556952727\\1920850899\\absolute\\ca2"
    client_config_test.go:998: Expected "/absolute/client/cert", got "C:\\Users\\azureuser\\AppData\\Local\\Temp\\229315489\\absolute\\client\\cert"
    client_config_test.go:998: Expected "/absolute/client/key", got "C:\\Users\\azureuser\\AppData\\Local\\Temp\\229315489\\absolute\\client\\key"
    client_config_test.go:998: Expected "C:\\Users\\azureuser\\AppData\\Local\\Temp\\relative\\client\\cmd", got "../relative/client/cmd"
    client_config_test.go:998: Expected "/absolute/client/cert2", got "C:\\Users\\azureuser\\AppData\\Local\\Temp\\3556952727\\1920850899\\absolute\\client\\cert2"
    client_config_test.go:998: Expected "/absolute/client/key2", got "C:\\Users\\azureuser\\AppData\\Local\\Temp\\3556952727\\1920850899\\absolute\\client\\key2"
--- FAIL: TestResolveRelativePaths (0.04s)

=== RUN   TestMigratingFile
    loader_test.go:657: source and destination do not match
--- FAIL: TestMigratingFile (0.02s)

=== RUN   TestLoadingGetLoadingPrecedence/envvar-multiple
    loader_test.go:979: expect [/env/kubeconfig /other/kubeconfig], got [/env/kubeconfig:/other/kubeconfig]
--- FAIL: TestLoadingGetLoadingPrecedence/envvar-multiple (0.00s)

=== RUN   TestLoadingGetLoadingPrecedence
--- FAIL: TestLoadingGetLoadingPrecedence (0.00s)
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```