### PR TITLE
fix: kubectl cp should support resource/name format

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -62,6 +62,12 @@ var (
 		# Copy /tmp/foo local file to /tmp/bar in a remote pod in namespace <some-namespace>
 		kubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
 
+		# Copy /tmp/foo local file to /tmp/bar using the resource/name format
+		kubectl cp /tmp/foo pod/<some-pod>:/tmp/bar
+
+		# Copy /tmp/foo local file to /tmp/bar using the resource/name format with a namespace
+		kubectl cp /tmp/foo <some-namespace>/pod/<some-pod>:/tmp/bar
+
 		# Copy /tmp/foo from a remote pod to /tmp/bar locally
 		kubectl cp <some-namespace>/<some-pod>:/tmp/foo /tmp/bar`))
 )
@@ -190,14 +196,33 @@ func extractFileSpec(arg string) (fileSpec, error) {
 			File:    newRemotePath(file),
 		}, nil
 	case 2:
+		if isPodResource(pieces[0]) {
+			return fileSpec{
+				PodName: pieces[1],
+				File:    newRemotePath(file),
+			}, nil
+		}
 		return fileSpec{
 			PodNamespace: pieces[0],
 			PodName:      pieces[1],
 			File:         newRemotePath(file),
 		}, nil
+	case 3:
+		if !isPodResource(pieces[1]) {
+			return fileSpec{}, errFileSpecDoesntMatchFormat
+		}
+		return fileSpec{
+			PodNamespace: pieces[0],
+			PodName:      pieces[2],
+			File:         newRemotePath(file),
+		}, nil
 	default:
 		return fileSpec{}, errFileSpecDoesntMatchFormat
 	}
+}
+
+func isPodResource(resource string) bool {
+	return resource == "pod" || resource == "pods"
 }
 
 // Complete completes all the required options

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
@@ -70,6 +70,28 @@ func TestExtractFileSpec(t *testing.T) {
 			expectedFile:      "/some/file",
 		},
 		{
+			spec:         "pod/pod:/some/file",
+			expectedPod:  "pod",
+			expectedFile: "/some/file",
+		},
+		{
+			spec:         "pods/pod:/some/file",
+			expectedPod:  "pod",
+			expectedFile: "/some/file",
+		},
+		{
+			spec:              "namespace/pod/pod:/some/file",
+			expectedPod:       "pod",
+			expectedNamespace: "namespace",
+			expectedFile:      "/some/file",
+		},
+		{
+			spec:              "namespace/pods/pod:/some/file",
+			expectedPod:       "pod",
+			expectedNamespace: "namespace",
+			expectedFile:      "/some/file",
+		},
+		{
 			spec:         "pod:/some/file",
 			expectedPod:  "pod",
 			expectedFile: "/some/file",
@@ -83,7 +105,11 @@ func TestExtractFileSpec(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			spec:      "namespace/pod/invalid:/some/file",
+			spec:      "namespace/deployment/invalid:/some/file",
+			expectErr: true,
+		},
+		{
+			spec:      "namespace/pod/pod/invalid:/some/file",
 			expectErr: true,
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR adds support for Pod references in `resource/name` format to `kubectl cp`.

The following remote file specifications are now supported:

- `pod/<pod-name>:<path>`
- `pods/<pod-name>:<path>`
- `<namespace>/pod/<pod-name>:<path>`
- `<namespace>/pods/<pod-name>:<path>`

This allows output from commands such as `kubectl get pods -o name` to be passed directly to `kubectl cp`.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1325

#### Special notes for your reviewer:

Kubernetes PR #73664 added `resource/name` resolution to `kubectl exec`, but it did not change `kubectl cp` parsing. `kubectl cp` parses its remote file specification before creating `ExecOptions` and deliberately uses exec's legacy direct-Pod path.

/cc @soltysh
/cc @ardaguclu
/cc @brianpursley

#### Does this PR introduce a user-facing change?

```release-note
`kubectl cp` now accepts Pod references using resource/name syntax, including `pod/<name>`, `pods/<name>`, and namespace-prefixed forms.