### PR TITLE
cli-runtime: include group in resource-not-found error message

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -807,6 +807,9 @@ func (b *Builder) mappingFor(resourceOrKindArg string) (*meta.RESTMapping, error
 		// if the error is _not_ a *meta.NoKindMatchError, then we had trouble doing discovery,
 		// so we should return the original error since it may help a user diagnose what is actually wrong
 		if meta.IsNoMatchError(err) {
+			if len(groupResource.Group) > 0 {
+				return nil, fmt.Errorf("the server doesn't have a resource type %q in group %q", groupResource.Resource, groupResource.Group)
+			}
 			return nil, fmt.Errorf("the server doesn't have a resource type %q", groupResource.Resource)
 		}
 		return nil, err

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -807,10 +807,16 @@ func (b *Builder) mappingFor(resourceOrKindArg string) (*meta.RESTMapping, error
 		// if the error is _not_ a *meta.NoKindMatchError, then we had trouble doing discovery,
 		// so we should return the original error since it may help a user diagnose what is actually wrong
 		if meta.IsNoMatchError(err) {
-			if len(groupResource.Group) > 0 {
+			switch {
+			case len(groupResource.Group) > 0 && len(gvk.Version) > 0:
+				return nil, fmt.Errorf("the server doesn't have a resource type %q in group %q and version %q", groupResource.Resource, groupResource.Group, gvk.Version)
+			case len(groupResource.Group) > 0:
 				return nil, fmt.Errorf("the server doesn't have a resource type %q in group %q", groupResource.Resource, groupResource.Group)
+			case len(gvk.Version) > 0:
+				return nil, fmt.Errorf("the server doesn't have a resource type %q in version %q", groupResource.Resource, gvk.Version)
+			default:
+				return nil, fmt.Errorf("the server doesn't have a resource type %q", groupResource.Resource)
 			}
-			return nil, fmt.Errorf("the server doesn't have a resource type %q", groupResource.Resource)
 		}
 		return nil, err
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -46,6 +46,7 @@ import (
 	restclientwatch "k8s.io/client-go/rest/watch"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/utils/dump"
+
 	// TODO we need to remove this linkage and create our own scheme
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -1361,6 +1362,21 @@ func TestNoSelectorUnknowResourceType(t *testing.T) {
 		}
 	}
 }
+
+func TestNoSelectorUnknownResourceTypeWithGroup(t *testing.T) {
+	b := newDefaultBuilder().
+		NamespaceParam("test").
+		ResourceTypeOrNameArgs(false, "foo.bar")
+
+	err := b.Do().Err()
+	if err == nil {
+		t.Fatalf("expected error, got none")
+	}
+	if !strings.Contains(err.Error(), "server doesn't have a resource type \"foo\" in group \"bar\"") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestSingleResourceType(t *testing.T) {
 	b := newDefaultBuilder().
 		LabelSelectorParam("a=b").

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -46,7 +46,6 @@ import (
 	restclientwatch "k8s.io/client-go/rest/watch"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/utils/dump"
-
 	// TODO we need to remove this linkage and create our own scheme
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -1362,7 +1361,6 @@ func TestNoSelectorUnknowResourceType(t *testing.T) {
 		}
 	}
 }
-
 func TestSingleResourceType(t *testing.T) {
 	b := newDefaultBuilder().
 		LabelSelectorParam("a=b").

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -1363,20 +1363,6 @@ func TestNoSelectorUnknowResourceType(t *testing.T) {
 	}
 }
 
-func TestNoSelectorUnknownResourceTypeWithGroup(t *testing.T) {
-	b := newDefaultBuilder().
-		NamespaceParam("test").
-		ResourceTypeOrNameArgs(false, "foo.bar")
-
-	err := b.Do().Err()
-	if err == nil {
-		t.Fatalf("expected error, got none")
-	}
-	if !strings.Contains(err.Error(), "server doesn't have a resource type \"foo\" in group \"bar\"") {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
 func TestSingleResourceType(t *testing.T) {
 	b := newDefaultBuilder().
 		LabelSelectorParam("a=b").


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kubectl` drops the group name from the error when a resource type is requested with a group qualifier it doesn't belong to. For example, `kubectl get pdb.hpa` prints `the server doesn't have a resource type "pdb"`, which is wrong. `pdb` exists, it just doesn't exist in the `hpa` group. The error reads as if the resource type itself is unknown, when the real problem is the group.

```
$ kubectl get pdb.hpa
error: the server doesn't have a resource type "pdb"
```
This PR includes the group in the error message when one is present, so the same command now reports 
```
the server doesn't have a resource type "pdb" in group "hpa"`.
```

Root cause: in `staging/src/k8s.io/cli-runtime/pkg/resource/builder.go`, `mappingFor` parses the resource arg into a `schema.GroupResource{Resource, Group}`, but on a `NoMatchError` builds the error from `.Resource` only, discarding `.Group`.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubectl/issues/1865

#### Special notes for your reviewer:

Added `TestNoSelectorUnknownResourceTypeWithGroup` in `builder_test.go` covering the group case, alongside the existing `TestNoSelectorUnknowResourceType`.

#### Does this PR introduce a user-facing change?

```release-note
kubectl now includes the group name in the error message when a resource type is not found under the specified group, e.g. "the server doesn't have a resource type \"pdb\" in group \"hpa\"".
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
