### PR TITLE
Fix flaky TestExternalJWTSigningAndAuth race condition

### DIFF
--- a/test/integration/serviceaccount/external_jwt_signer_test.go
+++ b/test/integration/serviceaccount/external_jwt_signer_test.go
@@ -207,6 +207,9 @@ func TestExternalJWTSigningAndAuth(t *testing.T) {
 				t.Fatalf("failed to reset signer for the test %q: %v", tc.desc, err)
 			}
 			mockSigner.WaitForSupportedKeysFetch()
+			// Wait for the apiserver to process the refreshed keys so that
+			// token signing and verification use a consistent key set.
+			waitForDataTimestamp(t, client, time.Now())
 
 			// Adjust parameters on mock signer for the test.
 			tc.preTestSignerUpdate(t)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

WaitForSupportedKeysFetch() signals as soon as the mock signer's FetchKeys handler runs, but before the apiserver has processed the gRPC response and updated its key cache. This caused a race where tokens were signed with a new private key (from Reset) but verified against stale public keys still in the apiserver cache, producing "go-jose: error in cryptographic primitive".

Add waitForDataTimestamp() after WaitForSupportedKeysFetch() to ensure the apiserver has processed the refreshed keys before generating and validating tokens, matching the pattern already used in the "change of supported keys picked up after periodic sync" test case.

#### Which issue(s) this PR is related to:

Fixes #140760

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
