### PR TITLE
Bump DefaultKubeBinaryVersion to 1.38

### DIFF
--- a/staging/src/k8s.io/component-base/version/base.go
+++ b/staging/src/k8s.io/component-base/version/base.go
@@ -60,5 +60,5 @@ const (
 	// DefaultKubeBinaryVersion is the hard coded k8 binary version based on the latest K8s release.
 	// It is supposed to be consistent with gitMajor and gitMinor, except for local tests, where gitMajor and gitMinor are "".
 	// Should update for each minor release!
-	DefaultKubeBinaryVersion = "1.37"
+	DefaultKubeBinaryVersion = "1.38"
 )

--- a/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/cel/compile_test.go
@@ -258,13 +258,6 @@ var testcases = map[string]struct {
 		expectMatch: true,
 		expectCost:  5 + ((2 + 4) * maxElementsListTypeEnabled /* (cost(loopCondition=="not_strictly_false(accu)") + cost(loopStep=="accu && (x.isGreaterThan(semver("0.0.1"))")) * maxElementsListTypeEnabled */),
 	},
-	"includes-function-compilation-error": {
-		features:           &Features{EnableListTypeAttributes: false},
-		envType:            ptr.To(environment.NewExpressions),
-		expression:         `device.attributes["dra.example.com"].attr.includes("fish")`,
-		driver:             "dra.example.com",
-		expectCompileError: "undeclared reference to 'includes'",
-	},
 	"includes-function-compilation-and-eval-success": {
 		features:    &Features{EnableListTypeAttributes: true},
 		expression:  `device.attributes["dra.example.com"].attr.includes("fish")`,

--- a/test/integration/dra/api/api_test.go
+++ b/test/integration/dra/api/api_test.go
@@ -24,5 +24,5 @@ import (
 
 func TestDRA(t *testing.T) {
 	// Various special configurations with few tests.
-	dra.Run(t, "^(disabled|v1beta1|v1beta2|slice-taints|GA-opt-out|GA-1.*|compatibility-groups-without-consumable-capacity)$")
+	dra.Run(t, "^(disabled|v1beta2|slice-taints|GA-opt-out|GA-1.*|compatibility-groups-without-consumable-capacity)$")
 }

--- a/test/integration/dra/core.go
+++ b/test/integration/dra/core.go
@@ -33,7 +33,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	resourcev1beta1 "k8s.io/api/resource/v1beta1"
 	resourcev1beta2 "k8s.io/api/resource/v1beta2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -113,14 +112,6 @@ func testResourceSliceFieldSelectors(tCtx ktesting.TContext) {
 			poolNameField: resourceapi.ResourceSliceSelectorPoolName,
 			list: func(tCtx ktesting.TContext, options metav1.ListOptions) (runtime.Object, error) {
 				return tCtx.Client().ResourceV1().ResourceSlices().List(tCtx, options)
-			},
-		},
-		"v1beta1": {
-			driverField:   resourcev1beta1.ResourceSliceSelectorDriver,
-			nodeNameField: resourcev1beta1.ResourceSliceSelectorNodeName,
-			poolNameField: resourcev1beta1.ResourceSliceSelectorPoolName,
-			list: func(tCtx ktesting.TContext, options metav1.ListOptions) (runtime.Object, error) {
-				return tCtx.Client().ResourceV1beta1().ResourceSlices().List(tCtx, options)
 			},
 		},
 		"v1beta2": {

--- a/test/integration/dra/dra.go
+++ b/test/integration/dra/dra.go
@@ -28,7 +28,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	resourcealphaapi "k8s.io/api/resource/v1alpha3"
-	resourcev1beta1 "k8s.io/api/resource/v1beta1"
 	resourcev1beta2 "k8s.io/api/resource/v1beta2"
 	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -262,21 +261,6 @@ func run(tCtx ktesting.TContext, whatRE string) {
 				runSubTest(tCtx, "PrioritizedList", func(tCtx ktesting.TContext) { testPrioritizedList(tCtx, false) })
 			},
 		},
-		"v1beta1": {
-			apis: map[schema.GroupVersion]bool{
-				resourceapi.SchemeGroupVersion:     false,
-				resourcev1beta1.SchemeGroupVersion: true,
-			},
-			features: map[featuregate.Feature]bool{
-				features.DynamicResourceAllocation:    true,
-				features.DRADeviceCompatibilityGroups: true,
-			},
-			f: func(tCtx ktesting.TContext) {
-				runSubTest(tCtx, "PublishResourceSlices", func(tCtx ktesting.TContext) {
-					testPublishResourceSlices(tCtx, false, features.DRAOptionalNodeOperations)
-				})
-			},
-		},
 		"v1beta2": {
 			apis: map[schema.GroupVersion]bool{
 				resourceapi.SchemeGroupVersion:     false,
@@ -295,7 +279,6 @@ func run(tCtx ktesting.TContext, whatRE string) {
 		},
 		"all": {
 			apis: map[schema.GroupVersion]bool{
-				resourcev1beta1.SchemeGroupVersion:  true,
 				resourcev1beta2.SchemeGroupVersion:  true,
 				resourcealphaapi.SchemeGroupVersion: true,
 				schedulingapi.SchemeGroupVersion:    true,

--- a/test/integration/metrics/metrics_test.go
+++ b/test/integration/metrics/metrics_test.go
@@ -31,8 +31,8 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	v1 "k8s.io/api/core/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/features"
@@ -119,7 +119,7 @@ func TestAPIServerMetrics(t *testing.T) {
 	t.Setenv("KUBE_APISERVER_SERVE_REMOVED_APIS_FOR_ONE_RELEASE", "true")
 
 	flags := framework.DefaultTestServerFlags()
-	flags = append(flags, fmt.Sprintf("--runtime-config=%s=true", networkingv1beta1.SchemeGroupVersion))
+	flags = append(flags, fmt.Sprintf("--runtime-config=%s=true", certificatesv1beta1.SchemeGroupVersion))
 	s := kubeapiservertesting.StartTestServerOrDie(t, nil, flags, framework.SharedEtcd())
 	defer s.TearDownFn()
 
@@ -131,7 +131,7 @@ func TestAPIServerMetrics(t *testing.T) {
 	}
 
 	// Make a request to a deprecated API to ensure there's at least one data point
-	if _, err := client.NetworkingV1beta1().ServiceCIDRs().List(context.TODO(), metav1.ListOptions{}); err != nil {
+	if _, err := client.CertificatesV1beta1().ClusterTrustBundles().List(context.TODO(), metav1.ListOptions{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Bumps the hard-coded `DefaultKubeBinaryVersion` to 1.38 for the new minor release.

Do not merge until after 1.37 code freeze.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```