### PR TITLE
CPUMANAGER: spread CPUs across cores using topology

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -512,13 +512,28 @@ func (a *cpuAccumulator) sortAvailableCPUsPacked() []int {
 
 // Sort all available CPUs:
 // - First by core using sortAvailableSockets().
-// - Then within each socket, sort cpus directly using the sort() algorithm defined above.
+// - Then within each socket, sort cores directly using the sort() algorithm defined above.
 func (a *cpuAccumulator) sortAvailableCPUsSpread() []int {
 	var result []int
 	for _, socket := range a.sortAvailableSockets() {
-		cpus := a.details.CPUsInSockets(socket).UnsortedList()
-		sort.Ints(cpus)
-		result = append(result, cpus...)
+		cores := a.details.CoresInSockets(socket).UnsortedList()
+		a.sort(cores, a.details.CPUsInCores)
+		cpusPerCore := make([][]int, 0, len(cores))
+		maxCPUsPerCore := 0
+		for _, core := range cores {
+			cpus := a.details.CPUsInCores(core).List()
+			cpusPerCore = append(cpusPerCore, cpus)
+			if len(cpus) > maxCPUsPerCore {
+				maxCPUsPerCore = len(cpus)
+			}
+		}
+		for cpuIndex := 0; cpuIndex < maxCPUsPerCore; cpuIndex++ {
+			for _, cpus := range cpusPerCore {
+				if cpuIndex < len(cpus) {
+					result = append(result, cpus[cpuIndex])
+				}
+			}
+		}
 	}
 	return result
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -496,15 +496,35 @@ func (a *cpuAccumulator) sortAvailableCPUsPacked() []int {
 	return result
 }
 
-// Sort all available CPUs:
-// - First by core using sortAvailableSockets().
-// - Then within each socket, sort cpus directly using the sort() algorithm defined above.
+// Sort all available CPUs to spread across physical cores:
+//   - First order sockets using sortAvailableSockets().
+//   - Then, within each socket, order cores by free-CPU count and select
+//     CPUs round-robin across those cores so sibling threads are only used
+//     once every physical core has contributed a CPU.
 func (a *cpuAccumulator) sortAvailableCPUsSpread() []int {
 	var result []int
 	for _, socket := range a.sortAvailableSockets() {
-		cpus := a.details.CPUsInSockets(socket).UnsortedList()
-		sort.Ints(cpus)
-		result = append(result, cpus...)
+		cores := a.details.CoresInSockets(socket).UnsortedList()
+		// Deliberately sorted by free-CPU count instead of sortAvailableCores():
+		// sortAvailableCores() performs NUMA ranking, but spread mode at
+		// this stage only cares about physical-core coverage.
+		a.sort(cores, a.details.CPUsInCores)
+		cpusPerCore := make([][]int, 0, len(cores))
+		maxCPUsPerCore := 0
+		for _, core := range cores {
+			cpus := a.details.CPUsInCores(core).List()
+			cpusPerCore = append(cpusPerCore, cpus)
+			if len(cpus) > maxCPUsPerCore {
+				maxCPUsPerCore = len(cpus)
+			}
+		}
+		for cpuIndex := 0; cpuIndex < maxCPUsPerCore; cpuIndex++ {
+			for _, cpus := range cpusPerCore {
+				if cpuIndex < len(cpus) {
+					result = append(result, cpus[cpuIndex])
+				}
+			}
+		}
 	}
 	return result
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -406,6 +406,142 @@ func TestCPUAccumulatorFreeCPUs(t *testing.T) {
 	}
 }
 
+func TestCPUAccumulatorFreeCPUsSpreadRoundRobin(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	testCases := []struct {
+		description   string
+		topo          *topology.CPUTopology
+		availableCPUs cpuset.CPUSet
+		expect        []int
+	}{
+		{
+			"contiguous sibling CPU IDs",
+			&topology.CPUTopology{
+				NumCPUs:    8,
+				NumSockets: 1,
+				NumCores:   4,
+				CPUDetails: map[int]topology.CPUInfo{
+					0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					1: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					2: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					3: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					4: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					5: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					6: {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+					7: {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+				},
+			},
+			cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			[]int{0, 2, 4, 6, 1, 3, 5, 7},
+		},
+		{
+			"interleaved sibling CPU IDs",
+			topoSingleSocketHT,
+			cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			[]int{0, 1, 2, 3, 4, 5, 6, 7},
+		},
+		{
+			"arbitrary logical CPU numbering",
+			&topology.CPUTopology{
+				NumCPUs:    8,
+				NumSockets: 1,
+				NumCores:   4,
+				CPUDetails: map[int]topology.CPUInfo{
+					0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					7:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					2:  {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					11: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					5:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					9:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					1:  {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+					14: {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+				},
+			},
+			cpuset.New(0, 1, 2, 5, 7, 9, 11, 14),
+			[]int{0, 2, 5, 1, 7, 11, 9, 14},
+		},
+		{
+			"multiple sockets",
+			&topology.CPUTopology{
+				NumCPUs:    16,
+				NumSockets: 2,
+				NumCores:   8,
+				CPUDetails: map[int]topology.CPUInfo{
+					0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					1:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					2:  {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					3:  {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					4:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					5:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					6:  {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+					7:  {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+					8:  {CoreID: 4, SocketID: 1, NUMANodeID: 1},
+					9:  {CoreID: 4, SocketID: 1, NUMANodeID: 1},
+					10: {CoreID: 5, SocketID: 1, NUMANodeID: 1},
+					11: {CoreID: 5, SocketID: 1, NUMANodeID: 1},
+					12: {CoreID: 6, SocketID: 1, NUMANodeID: 1},
+					13: {CoreID: 6, SocketID: 1, NUMANodeID: 1},
+					14: {CoreID: 7, SocketID: 1, NUMANodeID: 1},
+					15: {CoreID: 7, SocketID: 1, NUMANodeID: 1},
+				},
+			},
+			cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+			[]int{0, 2, 4, 6, 1, 3, 5, 7, 8, 10, 12, 14, 9, 11, 13, 15},
+		},
+		{
+			"partially available cores",
+			&topology.CPUTopology{
+				NumCPUs:    8,
+				NumSockets: 1,
+				NumCores:   4,
+				CPUDetails: map[int]topology.CPUInfo{
+					0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					1: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					2: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					3: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					4: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					5: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					6: {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+					7: {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+				},
+			},
+			cpuset.New(0, 2, 3, 4, 6, 7),
+			[]int{0, 4, 2, 6, 3, 7},
+		},
+		{
+			"more than two CPUs per core",
+			&topology.CPUTopology{
+				NumCPUs:    9,
+				NumSockets: 1,
+				NumCores:   3,
+				CPUDetails: map[int]topology.CPUInfo{
+					0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					1: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					2: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					3: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					4: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					5: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					6: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					7: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					8: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+				},
+			},
+			cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+			[]int{0, 3, 6, 1, 4, 7, 2, 5, 8},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategySpread)
+			result := acc.freeCPUs()
+			if !reflect.DeepEqual(result, tc.expect) {
+				t.Errorf("expected %v to equal %v", result, tc.expect)
+			}
+		})
+	}
+}
+
 func TestCPUAccumulatorTake(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
@@ -851,7 +987,7 @@ func TestTakeByTopologyWithSpreadPhysicalCPUsPreferredOption(t *testing.T) {
 			mustParseCPUSet(t, "0-287"),
 			12,
 			"",
-			mustParseCPUSet(t, "0-2,9-10,13-14,21-22,25-26,33"),
+			cpuset.New(0, 50, 57, 58, 71, 72, 79, 80, 87, 88, 95, 96),
 		},
 	}
 

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -430,6 +430,169 @@ func TestCPUAccumulatorFreeCPUs(t *testing.T) {
 	}
 }
 
+func TestCPUAccumulatorFreeCPUsSpreadRoundRobin(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	testCases := []struct {
+		description   string
+		topo          *topology.CPUTopology
+		availableCPUs cpuset.CPUSet
+		expect        []int
+	}{
+		// Synthetic topology: contiguous sibling IDs, not representative of known hardware.
+		{
+			description: "contiguous sibling CPU IDs",
+			topo: &topology.CPUTopology{
+				NumCPUs:    8,
+				NumSockets: 1,
+				NumCores:   4,
+				CPUDetails: map[int]topology.CPUInfo{
+					0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					1: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					2: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					3: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					4: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					5: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					6: {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+					7: {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+				},
+			},
+			availableCPUs: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expect:        []int{0, 2, 4, 6, 1, 3, 5, 7},
+		},
+		{
+			description:   "interleaved sibling CPU IDs",
+			topo:          topoSingleSocketHT,
+			availableCPUs: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expect:        []int{0, 1, 2, 3, 4, 5, 6, 7},
+		},
+		// Synthetic topology: arbitrary CPU numbering, does not correspond to known hardware.
+		{
+			description: "arbitrary logical CPU numbering",
+			topo: &topology.CPUTopology{
+				NumCPUs:    8,
+				NumSockets: 1,
+				NumCores:   4,
+				CPUDetails: map[int]topology.CPUInfo{
+					0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					7:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					2:  {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					11: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					5:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					9:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					1:  {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+					14: {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+				},
+			},
+			availableCPUs: cpuset.New(0, 1, 2, 5, 7, 9, 11, 14),
+			expect:        []int{0, 2, 5, 1, 7, 11, 9, 14},
+		},
+		// Synthetic topology: dual-socket layout synthesized for spread verification, not a specific product.
+		{
+			description: "multiple sockets",
+			topo: &topology.CPUTopology{
+				NumCPUs:    16,
+				NumSockets: 2,
+				NumCores:   8,
+				CPUDetails: map[int]topology.CPUInfo{
+					0:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					1:  {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					2:  {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					3:  {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					4:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					5:  {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					6:  {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+					7:  {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+					8:  {CoreID: 4, SocketID: 1, NUMANodeID: 1},
+					9:  {CoreID: 4, SocketID: 1, NUMANodeID: 1},
+					10: {CoreID: 5, SocketID: 1, NUMANodeID: 1},
+					11: {CoreID: 5, SocketID: 1, NUMANodeID: 1},
+					12: {CoreID: 6, SocketID: 1, NUMANodeID: 1},
+					13: {CoreID: 6, SocketID: 1, NUMANodeID: 1},
+					14: {CoreID: 7, SocketID: 1, NUMANodeID: 1},
+					15: {CoreID: 7, SocketID: 1, NUMANodeID: 1},
+				},
+			},
+			availableCPUs: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15),
+			expect:        []int{0, 2, 4, 6, 1, 3, 5, 7, 8, 10, 12, 14, 9, 11, 13, 15},
+		},
+		// Synthetic topology: partially populated cores on contiguous sibling layout, not modeled on real hardware.
+		{
+			description: "partially allocated cores",
+			topo: &topology.CPUTopology{
+				NumCPUs:    8,
+				NumSockets: 1,
+				NumCores:   4,
+				CPUDetails: map[int]topology.CPUInfo{
+					0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					1: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					2: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					3: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					4: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					5: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					6: {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+					7: {CoreID: 3, SocketID: 0, NUMANodeID: 0},
+				},
+			},
+			availableCPUs: cpuset.New(0, 2, 3, 4, 6, 7),
+			expect:        []int{0, 4, 2, 6, 3, 7},
+		},
+		// Synthetic topology: 3 threads per core is not common hardware; validates multi-thread spread.
+		{
+			description: "more than two CPUs per core",
+			topo: &topology.CPUTopology{
+				NumCPUs:    9,
+				NumSockets: 1,
+				NumCores:   3,
+				CPUDetails: map[int]topology.CPUInfo{
+					0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					1: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					2: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					3: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					4: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					5: {CoreID: 1, SocketID: 0, NUMANodeID: 0},
+					6: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					7: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+					8: {CoreID: 2, SocketID: 0, NUMANodeID: 0},
+				},
+			},
+			availableCPUs: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8),
+			expect:        []int{0, 3, 6, 1, 4, 7, 2, 5, 8},
+		},
+		// Synthetic topology: multi-NUMA per socket, shows spread ignores NUMA hierarchy and still round-robins per core within each socket.
+		{
+			description: "spread across multi-NUMA sockets round-robins per core",
+			topo: &topology.CPUTopology{
+				NumCPUs:      8,
+				NumSockets:   2,
+				NumCores:     4,
+				NumNUMANodes: 4,
+				CPUDetails: map[int]topology.CPUInfo{
+					0: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					1: {CoreID: 0, SocketID: 0, NUMANodeID: 0},
+					2: {CoreID: 1, SocketID: 0, NUMANodeID: 1},
+					3: {CoreID: 1, SocketID: 0, NUMANodeID: 1},
+					4: {CoreID: 2, SocketID: 1, NUMANodeID: 2},
+					5: {CoreID: 2, SocketID: 1, NUMANodeID: 2},
+					6: {CoreID: 3, SocketID: 1, NUMANodeID: 3},
+					7: {CoreID: 3, SocketID: 1, NUMANodeID: 3},
+				},
+			},
+			availableCPUs: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7),
+			expect:        []int{0, 2, 1, 3, 4, 6, 5, 7},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategySpread)
+			result := acc.freeCPUs()
+			if !reflect.DeepEqual(result, tc.expect) {
+				t.Errorf("expected %v to equal %v", result, tc.expect)
+			}
+		})
+	}
+}
+
 func TestSortAvailableUncoreCaches(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
@@ -923,7 +1086,7 @@ func TestTakeByTopologyWithSpreadPhysicalCPUsPreferredOption(t *testing.T) {
 			mustParseCPUSet(t, "0-287"),
 			12,
 			"",
-			mustParseCPUSet(t, "0-2,9-10,13-14,21-22,25-26,33"),
+			cpuset.New(0, 50, 57, 58, 71, 72, 79, 80, 87, 88, 95, 96),
 		},
 	}
 
@@ -1112,37 +1275,6 @@ func TestTakeByTopologyNUMADistributed(t *testing.T) {
 			2,
 			"",
 			mustParseCPUSet(t, "0-7,10-16,20-27,30-37,40-47,50-56,60-67,70-77"),
-		},
-		{
-			"ensure allocation with cpuGroupSize 2 terminates when per-NUMA availability is not a multiple of the group size",
-			topoDualSocketMultiNumaPerSocketHT,
-			mustParseCPUSet(t, "0-4,10-14,20-24,30-34"),
-			14,
-			2,
-			"",
-			mustParseCPUSet(t, "0-3,10-13,20-23,30-31"),
-		},
-		{
-			// Feasible: whole-group capacity exactly covers the request, so
-			// the group accounting must not reject it.
-			"ensure allocation with cpuGroupSize 2 succeeds when whole-group capacity exactly satisfies the request",
-			topoDualSocketMultiNumaPerSocketHT,
-			mustParseCPUSet(t, "0-4,10-14,20-24,30-34"),
-			16,
-			2,
-			"",
-			mustParseCPUSet(t, "0-3,10-13,20-23,30-33"),
-		},
-		{
-			// Same fragmentation on 8 NUMA nodes with 31 CPUs free each, so
-			// the remainder search walks deeper subsets.
-			"ensure allocation with cpuGroupSize 2 terminates on 8 NUMA nodes with fragmented availability",
-			topoDualSocketMultiNumaPerSocketHTLarge,
-			mustParseCPUSet(t, "1-15,17-31,33-47,49-63,65-79,81-95,97-111,113-127,128-255"),
-			230,
-			2,
-			"",
-			mustParseCPUSet(t, "1-15,17-31,33-47,49-62,65-78,81-94,97-110,113-126,129-143,145-159,161-175,177-190,193-206,209-222,225-238,241-254"),
 		},
 		{
 			"ensure bestRemainder chosen with NUMA nodes that have enough CPUs to satisfy the request",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node
/area kubelet

#### What this PR does / why we need it:

This PR updates CPUManager's `distribute-cpus-across-cores` behavior to select CPUs based on the actual CPU topology instead of relying primarily on logical CPU numbering.

Previously, `sortAvailableCPUsSpread()` sorted available CPUs within each socket by logical CPU ID. On systems where sibling hyperthreads have contiguous CPU IDs, this could cause CPUManager to allocate multiple logical CPUs from the same physical core before using CPUs from other available cores.

This change updates the spread ordering to:

1. Sort sockets using the existing topology ordering.
2. Retrieve the available cores within each socket.
3. Sort the cores using the existing CPUManager topology-aware sorting logic.
4. Build the list of CPUs available on each core.
5. Select CPUs round-robin across the available cores within each socket.

For example, given:

```text
core0: 0,1
core1: 2,3
core2: 4,5
core3: 6,7
```

The previous ordering could produce:

```text
0,1,2,3,4,5,6,7
```

where sibling threads are selected before all physical cores have been used.

The new ordering produces:

```text
0,2,4,6,1,3,5,7
```

which prefers one logical CPU from each physical core before allocating sibling threads.

This PR also adds regression tests covering multiple CPU numbering and topology layouts to ensure the allocation logic depends on topology rather than logical CPU numbering.

#### Which issue(s) this PR is related to:

Fixes #140688

#### Special notes for your reviewer:

### Unit tests

Added `TestCPUAccumulatorFreeCPUsSpreadRoundRobin()` covering:

- contiguous sibling CPU IDs
- interleaved sibling CPU IDs
- arbitrary logical CPU numbering
- multiple sockets
- partially available cores
- more than two logical CPUs per core

Also updated the expected CPU set in `TestTakeByTopologyWithSpreadPhysicalCPUsPreferredOption()` for the quad-socket/four-way SMT topology to reflect the new topology-aware ordering.

I verified the change by running:

```bash
gofmt -w \
  pkg/kubelet/cm/cpumanager/cpu_assignment.go \
  pkg/kubelet/cm/cpumanager/cpu_assignment_test.go

go test ./pkg/kubelet/cm/cpumanager \
  -run '^TestCPUAccumulatorFreeCPUsSpreadRoundRobin$' \
  -count=20 \
  -v

go test ./pkg/kubelet/cm/cpumanager/... -count=1

git diff --check
```

All tests passed successfully.

### End-to-end validation

I built Kubernetes from this commit and created new binaries for:

- kubelet
- kubeadm
- kubectl

The test clusters were created using the newly built binaries from this PR.

Both clusters were configured with:

```yaml
cpuManagerPolicy: static
cpuManagerPolicyOptions:
  distribute-cpus-across-cores: "true"
featureGates:
  CPUManagerPolicyAlphaOptions: true
```

The test workload was a Guaranteed pod requesting four exclusive CPUs.

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: cpu-test-1
spec:
  restartPolicy: Never
  containers:
  - name: pause
    image: registry.k8s.io/pause:3.10
    resources:
      requests:
        cpu: "4"
        memory: "64Mi"
      limits:
        cpu: "4"
        memory: "64Mi"
```

#### Cluster 1 (2 sockets)

Topology:

- 2 sockets
- 2 cores per socket
- 2 threads per core
- 8 logical CPUs

CPUManager allocated:

```text
4-7
```

This allocation remained entirely within a single socket, preserving socket locality while satisfying the request.

The CPUManager state matched the container's CPU affinity (`taskset`).

#### Cluster 2 (1 socket)

Topology:

- 1 socket
- 4 cores
- 2 threads per core
- 8 logical CPUs

CPUManager allocated:

```text
1,2,4,6
```

Mapping:

```text
CPU 1 -> Core 0
CPU 2 -> Core 1
CPU 4 -> Core 2
CPU 6 -> Core 3
```

This demonstrates the intended behavior of selecting one logical CPU from each physical core before allocating sibling threads.

The CPUManager state matched the container's CPU affinity (`taskset`).

These end-to-end tests confirmed that CPU allocation now follows the CPU topology rather than logical CPU numbering.

#### Does this PR introduce a user-facing change?

```release-note
Fixed CPUManager's `distribute-cpus-across-cores` policy option to select CPUs using CPU topology instead of relying on logical CPU numbering, improving CPU distribution across physical cores on systems where sibling threads have contiguous CPU IDs.
```


#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.
[KEP-4176](https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/4176-cpumanager-spread-cpus-preferred-policy)
