### PR TITLE
DRA: fail All requests when a matching device is capacity-exhausted

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -5926,13 +5926,8 @@ func TestAllocator(t *testing.T,
 					device(device2, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}, nil).withAllowMultipleAllocations(),
 				),
 			),
-			node: node(node1, region1),
-			expectResults: []any{
-				allocationResult(
-					localNodeSelector(node1),
-					deviceRequestAllocationResult(req0, driverA, pool1, device2).withConsumedCapacity(&fixedShareID, map[resourceapi.QualifiedName]resource.Quantity{capacity0: one}),
-				),
-			},
+			node:          node(node1, region1),
+			expectResults: []any{}, // device-1 capacity-exhausted but still matches; All fails, not device-2 only
 		},
 		"consumable-capacity-dedicated-device-with-consumable-capacity-request": {
 			features: Features{

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -573,6 +573,7 @@ func (alloc *allocator) validateDeviceRequest(request requestAccessor, parentReq
 		// better to wait. This does not matter yet as long the incomplete pool
 		// has some matching device.
 		requestData.allDevices = make([]deviceWithID, 0, resourceapi.AllocationResultsMaxSize)
+		emptyConsumedCapacity := NewConsumedCapacity() // reusable: CmpRequestOverCapacity clones/reads only
 		for _, pool := range pools {
 			if pool.IsIncomplete {
 				return requestData, fmt.Errorf("claim %s, request %s: asks for all devices, but resource pool %s is currently being updated", klog.KObj(claim), request.name(), pool.PoolID)
@@ -594,14 +595,16 @@ func (alloc *allocator) validateDeviceRequest(request requestAccessor, parentReq
 							pool:   pool,
 						}
 						if alloc.features.ConsumableCapacity {
-							// Next validate whether resource request over capacity
-							device := slice.Spec.Devices[deviceIndex]
-							success, err := alloc.CmpRequestOverCapacity(requestData.request, slice, device)
+							// Static capacity only: remaining capacity is checked in allocateDevice
+							// so capacity-blocked matching devices stay in allDevices and All fails.
+							apiDevice := slice.Spec.Devices[deviceIndex]
+							success, err := CmpRequestOverCapacity(emptyConsumedCapacity, requestData.request.capacities(),
+								apiDevice.AllowMultipleAllocations, apiDevice.Capacity, emptyConsumedCapacity, alloc.features.FractionalCapacityRange)
 							if err != nil {
-								return requestData, fmt.Errorf("claim %s, request %s: checking capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), device.Name, err)
+								return requestData, fmt.Errorf("claim %s, request %s: checking capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), apiDevice.Name, err)
 							}
 							if !success {
-								alloc.logger.V(7).Info("Device capacity not enough", "device", device)
+								alloc.logger.V(7).Info("Device static capacity insufficient", "device", apiDevice)
 								continue
 							}
 						}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -570,6 +570,7 @@ func (alloc *allocator) validateDeviceRequest(request requestAccessor, parentReq
 		// better to wait. This does not matter yet as long the incomplete pool
 		// has some matching device.
 		requestData.allDevices = make([]deviceWithID, 0, resourceapi.AllocationResultsMaxSize)
+		emptyConsumedCapacity := NewConsumedCapacity() // reusable: CmpRequestOverCapacity clones/reads only
 		for _, pool := range pools {
 			if pool.IsIncomplete {
 				return requestData, fmt.Errorf("claim %s, request %s: asks for all devices, but resource pool %s is currently being updated", klog.KObj(claim), request.name(), pool.PoolID)
@@ -591,14 +592,16 @@ func (alloc *allocator) validateDeviceRequest(request requestAccessor, parentReq
 							pool:   pool,
 						}
 						if alloc.features.ConsumableCapacity {
-							// Next validate whether resource request over capacity
-							device := slice.Spec.Devices[deviceIndex]
-							success, err := alloc.CmpRequestOverCapacity(requestData.request, slice, device)
+							// Static capacity only: remaining capacity is checked in allocateDevice
+							// so capacity-blocked matching devices stay in allDevices and All fails.
+							apiDevice := slice.Spec.Devices[deviceIndex]
+							success, err := CmpRequestOverCapacity(emptyConsumedCapacity, requestData.request.capacities(),
+								apiDevice.AllowMultipleAllocations, apiDevice.Capacity, emptyConsumedCapacity, alloc.features.FractionalCapacityRange)
 							if err != nil {
-								return requestData, fmt.Errorf("claim %s, request %s: checking capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), device.Name, err)
+								return requestData, fmt.Errorf("claim %s, request %s: checking capacity for device %s: %w", klog.KObj(claim), requestData.request.name(), apiDevice.Name, err)
 							}
 							if !success {
-								alloc.logger.V(7).Info("Device capacity not enough", "device", device)
+								alloc.logger.V(7).Info("Device static capacity insufficient", "device", apiDevice)
 								continue
 							}
 						}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes structured DRA allocator behavior for `allocationMode: All` with consumable capacity (`DRAConsumableCapacity`).

Per `CapacityRequirements` godoc, an All request must fail when a device otherwise matches the request and advertises sufficient static capacity, but cannot be allocated (for example, because remaining capacity is exhausted on a multi-alloc device).

When gathering devices for All, the allocator incorrectly used `alloc.CmpRequestOverCapacity`, which includes pre-consumed remaining capacity. Capacity-exhausted matching devices were filtered out of `allDevices`, so All
could succeed with only the still-free subset.

##### Example
Two multi-alloc devices each with `capacity0=1`; device-1 is fully consumed by another allocation. An All request for `capacity0=1` must fail, not return device-2 alone.

The fix uses a static-capacity-only check at All gather time (empty consumed state). Remaining capacity continues to be enforced in `allocateDevice`, so a blocked matching device causes the whole All request to fail, consistent with
exclusive in-use devices, which were already handled correctly.

Also reverts the `consumable-capacity-multi-allocatable-device-allocation-mode-all-in-use-insufficient` allocator table case to expect no allocation. That case originally expected failure (KEP 5075) and was later flipped to partial success alongside an ExactCount multi-device fix.

```yaml
apiVersion: resource.k8s.io/v1
kind: ResourceClaim
metadata:
  name: all-gpus
spec:
  devices:
    requests:
    - name: req0
      exactly:
        allocationMode: All
        deviceClassName: gpu-class
        capacity:
          requests:
            memory: 4Gi
```

If another pod already consumed all capacity on one matching device, the claim must stay unallocated rather than succeeding with the remaining device(s) only.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- Change is limited to All-mode gather in experimental and incubating allocators.
- Other All+capacity table cases are unchanged (`filter-out-*`, `in-use-sufficient`, `allocating-insufficient`).
- Requires `DRAConsumableCapacity`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where ResourceClaims using `allocationMode: All` with consumable capacity could be partially allocated when a matching device had insufficient remaining capacity. Such claims now correctly fail to allocate until all matching devices can be satisfied.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
