### PR TITLE
Automated cherry pick of #140437: DRA: skip the counter check for a persisted shared device

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -5790,6 +5790,42 @@ func TestAllocator(t *testing.T,
 			node:          node(node1, region1),
 			expectResults: []any{},
 		},
+		"partitionable-consumable-capacity-shared-device-counter-not-recharged": {
+			features: Features{
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			// device1 already has a persisted shared allocation. It is represented
+			// only by a share ID, with no AggregatedCapacity entry.
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+			),
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, request(req0, classA, 1)),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil).
+						withAllowMultipleAllocations().
+						withDeviceCounterConsumption(
+							deviceCounterConsumption(counterSet1, map[string]resource.Quantity{
+								"c": resource.MustParse("1"),
+							}),
+						),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1, map[string]resource.Quantity{
+						"c": resource.MustParse("1"),
+					}),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceRequestAllocationResult(req0, driverA, pool1, device1).withConsumedCapacity(&fixedShareID, nil),
+			)},
+		},
 		"consumable-capacity-with-partitionable-device-multiple-capacity-pools": {
 			// This test case combines integration of PrioritizedList, PartitionableDevices, and ConsumableCapacity features.
 			features: Features{

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -1459,7 +1459,8 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		return false, nil, nil
 	}
 
-	// Skip counter availability check for devices that allow multiple allocation and some capacity has already in-use.
+	// Skip the counter check for an allow-multiple device in use: its counters are already
+	// accounted for, so a further share must not charge them again.
 	skipCounterCheck := allowMultipleAllocations && alloc.deviceCapacityInUse(device.id)
 
 	// The API validation logic has checked the ConsumesCounters referred should exist inside SharedCounters.
@@ -1787,8 +1788,17 @@ func (alloc *allocator) deviceInUse(deviceID DeviceID) bool {
 }
 
 func (alloc *allocator) deviceCapacityInUse(deviceID DeviceID) bool {
-	_, found := alloc.allocatedState.AggregatedCapacity[deviceID]
-	return found || alloc.allocatingCapacityForAnyClaim(deviceID)
+	if _, found := alloc.allocatedState.AggregatedCapacity[deviceID]; found {
+		return true
+	}
+	// A persisted allow-multiple allocation with no per-share capacity is recorded
+	// only in AllocatedSharedDeviceIDs (with no AggregatedCapacity entry).
+	for sharedDeviceID := range alloc.allocatedState.AllocatedSharedDeviceIDs {
+		if sharedDeviceID.GetDeviceID() == deviceID {
+			return true
+		}
+	}
+	return alloc.allocatingCapacityForAnyClaim(deviceID)
 }
 
 func (alloc *allocator) allocatingDeviceForAnyClaim(deviceID DeviceID) bool {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -1331,7 +1331,8 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		return false, nil, nil
 	}
 
-	// Skip counter availability check for devices that allow multiple allocation and some capacity has already in-use.
+	// Skip the counter check for an allow-multiple device in use: its counters are already
+	// accounted for, so a further share must not charge them again.
 	skipCounterCheck := allowMultipleAllocations && alloc.deviceCapacityInUse(device.id)
 
 	// The API validation logic has checked the ConsumesCounters referred should exist inside SharedCounters.
@@ -1659,8 +1660,17 @@ func (alloc *allocator) deviceInUse(deviceID DeviceID) bool {
 }
 
 func (alloc *allocator) deviceCapacityInUse(deviceID DeviceID) bool {
-	_, found := alloc.allocatedState.AggregatedCapacity[deviceID]
-	return found || alloc.allocatingCapacityForAnyClaim(deviceID)
+	if _, found := alloc.allocatedState.AggregatedCapacity[deviceID]; found {
+		return true
+	}
+	// A persisted allow-multiple allocation with no per-share capacity is recorded
+	// only in AllocatedSharedDeviceIDs (with no AggregatedCapacity entry).
+	for sharedDeviceID := range alloc.allocatedState.AllocatedSharedDeviceIDs {
+		if sharedDeviceID.GetDeviceID() == deviceID {
+			return true
+		}
+	}
+	return alloc.allocatingCapacityForAnyClaim(deviceID)
 }
 
 func (alloc *allocator) allocatingDeviceForAnyClaim(deviceID DeviceID) bool {


### PR DESCRIPTION
Cherry pick of #140437 on release-1.36.

#140437: DRA: skip the counter check for a persisted shared device

/kind bug
/priority important-soon
/sig node
/wg device-management

#### What this PR does / why we need it

This backports the persisted shared-device counter-accounting fix from #140437 to `release-1.36`.

When a device both allows multiple allocations (`DRAConsumableCapacity`) and consumes shared counters (`DRAPartitionableDevices`), an existing allocation may be persisted with a `ShareID` but no `ConsumedCapacity`. In that case the device is present in `AllocatedSharedDeviceIDs` but has no entry in `AggregatedCapacity`.

Counter availability is reconstructed through `IsDeviceAllocated`, which already recognizes `AllocatedSharedDeviceIDs`, so the persisted device has its counters subtracted from the available counter pool. However `deviceCapacityInUse`, which decides whether an allow-multiple device should skip the counter check, only recognizes `AggregatedCapacity` and capacity reserved during the current allocation search.

As a result, a later claim sharing the same device can charge the device's physical counters a second time and be rejected with a false `Insufficient counters` result, leaving an otherwise schedulable pod pending.

This change makes `deviceCapacityInUse` also recognize persisted shares in `AllocatedSharedDeviceIDs`, matching the persisted-state semantics already used by `IsDeviceAllocated`. It applies to the incubating and experimental allocators. The stable allocator does not support `ConsumableCapacity` and is unaffected.

`DRAConsumableCapacity` and `DRAPartitionableDevices` are both beta and enabled by default in Kubernetes 1.36, and the affected incubating allocator is selected by the default feature configuration, so the issue is reachable on a default 1.36 cluster.

#### Which issue(s) this PR fixes

Backport of #140437. The master-side change resolved #140433.

#### Special notes for your reviewer

This is intentionally a narrow backport of the single master commit `acf342bdcaba4c5ac3489e4c41394ba683a315f7`.

The backport changes exactly three files: the shared allocator regression-test table, the incubating allocator, and the experimental allocator.

The production change keeps every existing form of the in-use check: persisted aggregated capacity, a persisted shared allocation recorded only by `ShareID`, and capacity reserved during the current allocation search. The lookup compares the underlying `DeviceID`, so a persisted share of another device cannot cause this device's counter check to be skipped.

The implementation scans `AllocatedSharedDeviceIDs` rather than introducing a second precomputed `Set[DeviceID]`. This matches the existing `IsDeviceAllocated` approach and avoids a second copy of persisted shared-device state. The scan is limited to allow-multiple candidates; a derived index can be considered separately if profiling shows this lookup to be significant.

Only `release-1.36` is targeted. The bug requires both `DRAConsumableCapacity` and `DRAPartitionableDevices`; these are beta and on by default in 1.36 but alpha and off by default in 1.35 and earlier, so the issue is not reachable by default on the older supported release branches and a backport there is not warranted under the cherry-pick policy.

The scope is limited to the double-count of a persisted allow-multiple share. It does not change how a device that already carries a persisted share is handled if it is later requested as a dedicated allocation; that is a separate correctness question, left as a follow-up on master rather than widened into this backport.

The related rollback fix from #140431 is already in `release-1.36` via #140663. That one addresses state leaked during rejection and backtracking within a single allocation search, whereas this PR addresses persisted shared state reconstructed across scheduling cycles. The two are related but independent.

The PoolID counter-cache fix from #140435 is being backported separately in #140504. It is not a prerequisite for this change, and keeping the two fixes in separate PRs preserves narrow review and rollback boundaries.

#### Validation

Validated locally against `release-1.36` (go1.26, workspace mode):

- [x] `git diff --check` is clean, and the changed-file set is exactly the shared allocator test file plus the incubating and experimental allocator files (`+62/-6`).
- [x] `go test ./structured/... -run 'TestAllocator/partitionable-consumable-capacity-shared-device-counter-not-recharged'` passes on the incubating and experimental allocators.
- [x] `go test -race ./structured/...` passes.
- [x] `go test ./structured/... -count=10` passes across 10 repetitions.
- [x] With the regression test kept and the two production hunks temporarily reverted to their `release-1.36` versions, the targeted test fails on the incubating allocator with `Insufficient counters device="driver-a/pool-1/device-1"`.
- [x] With the production fix restored, the targeted test passes.

Happy to re-run any additional branch-specific validation the release team prefers.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a DRA consumable-capacity scheduling bug: a device that consumes shared counters could have them counted twice when it already had a persisted shared allocation with no consumed capacity, wrongly rejecting a later claim for the same device and leaving the pod pending.
```
