### PR TITLE
controller/informers: migrate controllers to typed handlers

### DIFF
--- a/cmd/kube-controller-manager/app/batch.go
+++ b/cmd/kube-controller-manager/app/batch.go
@@ -46,8 +46,8 @@ func newJobController(ctx context.Context, controllerContext ControllerContext, 
 		return nil, err
 	}
 
-	var workloadInformer schedulinginformers.WorkloadInformer
-	var podGroupInformer schedulinginformers.PodGroupInformer
+	var workloadInformer schedulinginformers.TypedWorkloadInformer
+	var podGroupInformer schedulinginformers.TypedPodGroupInformer
 	if utilfeature.DefaultFeatureGate.Enabled(features.WorkloadWithJob) {
 		workloadInformer = controllerContext.InformerFactory.Scheduling().V1alpha3().Workloads()
 		podGroupInformer = controllerContext.InformerFactory.Scheduling().V1alpha3().PodGroups()

--- a/pkg/controller/bootstrap/bootstrapsigner.go
+++ b/pkg/controller/bootstrap/bootstrapsigner.go
@@ -24,8 +24,6 @@ import (
 
 	"k8s.io/klog/v2"
 
-	"fmt"
-
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -93,7 +91,7 @@ type Signer struct {
 }
 
 // NewSigner returns a new *Signer.
-func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configMaps informers.ConfigMapInformer, options SignerOptions) (*Signer, error) {
+func NewSigner(cl clientset.Interface, secrets informers.TypedSecretInformer, configMaps informers.TypedConfigMapInformer, options SignerOptions) (*Signer, error) {
 	e := &Signer{
 		client:             cl,
 		configMapKey:       options.ConfigMapNamespace + "/" + options.ConfigMapName,
@@ -112,44 +110,42 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 		),
 	}
 
-	configMaps.Informer().AddEventHandlerWithResyncPeriod(
-		cache.FilteringResourceEventHandler{
-			FilterFunc: func(obj interface{}) bool {
-				switch t := obj.(type) {
-				case *v1.ConfigMap:
-					return t.Name == options.ConfigMapName && t.Namespace == options.ConfigMapNamespace
-				default:
-					utilruntime.HandleError(fmt.Errorf("object passed to %T that is not expected: %T", e, obj))
-					return false
-				}
-			},
-			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc:    func(_ interface{}) { e.pokeConfigMapSync() },
-				UpdateFunc: func(_, _ interface{}) { e.pokeConfigMapSync() },
-			},
+	configMapMatches := func(cm *v1.ConfigMap) bool {
+		return cm.Name == options.ConfigMapName && cm.Namespace == options.ConfigMapNamespace
+	}
+	configMaps.TypedInformer().AddTypedEventHandler(informers.ConfigMapHandlerFuncs{
+		AddFunc: func(cm *v1.ConfigMap) {
+			if configMapMatches(cm) {
+				e.pokeConfigMapSync()
+			}
 		},
-		options.ConfigMapResync,
-	)
+		UpdateFunc: func(_, cm *v1.ConfigMap) {
+			if configMapMatches(cm) {
+				e.pokeConfigMapSync()
+			}
+		},
+	}, cache.HandlerOptions{ResyncPeriod: &options.ConfigMapResync})
 
-	secrets.Informer().AddEventHandlerWithResyncPeriod(
-		cache.FilteringResourceEventHandler{
-			FilterFunc: func(obj interface{}) bool {
-				switch t := obj.(type) {
-				case *v1.Secret:
-					return t.Type == bootstrapapi.SecretTypeBootstrapToken && t.Namespace == e.secretNamespace
-				default:
-					utilruntime.HandleError(fmt.Errorf("object passed to %T that is not expected: %T", e, obj))
-					return false
-				}
-			},
-			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc:    func(_ interface{}) { e.pokeConfigMapSync() },
-				UpdateFunc: func(_, _ interface{}) { e.pokeConfigMapSync() },
-				DeleteFunc: func(_ interface{}) { e.pokeConfigMapSync() },
-			},
+	secretMatches := func(secret *v1.Secret) bool {
+		return secret.Type == bootstrapapi.SecretTypeBootstrapToken && secret.Namespace == e.secretNamespace
+	}
+	secrets.TypedInformer().AddTypedEventHandler(informers.SecretHandlerFuncs{
+		AddFunc: func(secret *v1.Secret) {
+			if secretMatches(secret) {
+				e.pokeConfigMapSync()
+			}
 		},
-		options.SecretResync,
-	)
+		UpdateFunc: func(oldSecret, newSecret *v1.Secret) {
+			if secretMatches(oldSecret) || secretMatches(newSecret) {
+				e.pokeConfigMapSync()
+			}
+		},
+		DeleteFunc: func(deleted informers.DeletedSecret) {
+			if deleted.OptionalObj != nil && secretMatches(deleted.OptionalObj) {
+				e.pokeConfigMapSync()
+			}
+		},
+	}, cache.HandlerOptions{ResyncPeriod: &options.SecretResync})
 
 	return e, nil
 }

--- a/pkg/controller/bootstrap/bootstrapsigner.go
+++ b/pkg/controller/bootstrap/bootstrapsigner.go
@@ -113,7 +113,7 @@ func NewSigner(cl clientset.Interface, secrets informers.TypedSecretInformer, co
 	configMapMatches := func(cm *v1.ConfigMap) bool {
 		return cm.Name == options.ConfigMapName && cm.Namespace == options.ConfigMapNamespace
 	}
-	configMaps.TypedInformer().AddTypedEventHandler(informers.ConfigMapHandlerFuncs{
+	_, _ = configMaps.TypedInformer().AddTypedEventHandler(informers.ConfigMapHandlerFuncs{
 		AddFunc: func(cm *v1.ConfigMap) {
 			if configMapMatches(cm) {
 				e.pokeConfigMapSync()
@@ -129,7 +129,7 @@ func NewSigner(cl clientset.Interface, secrets informers.TypedSecretInformer, co
 	secretMatches := func(secret *v1.Secret) bool {
 		return secret.Type == bootstrapapi.SecretTypeBootstrapToken && secret.Namespace == e.secretNamespace
 	}
-	secrets.TypedInformer().AddTypedEventHandler(informers.SecretHandlerFuncs{
+	_, _ = secrets.TypedInformer().AddTypedEventHandler(informers.SecretHandlerFuncs{
 		AddFunc: func(secret *v1.Secret) {
 			if secretMatches(secret) {
 				e.pokeConfigMapSync()

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -73,7 +73,7 @@ type TokenCleaner struct {
 }
 
 // NewTokenCleaner returns a new *NewTokenCleaner.
-func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInformer, options TokenCleanerOptions) (*TokenCleaner, error) {
+func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.TypedSecretInformer, options TokenCleanerOptions) (*TokenCleaner, error) {
 	e := &TokenCleaner{
 		client:               cl,
 		secretLister:         secrets.Lister(),
@@ -87,24 +87,21 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 		),
 	}
 
-	secrets.Informer().AddEventHandlerWithResyncPeriod(
-		cache.FilteringResourceEventHandler{
-			FilterFunc: func(obj interface{}) bool {
-				switch t := obj.(type) {
-				case *v1.Secret:
-					return t.Type == bootstrapapi.SecretTypeBootstrapToken && t.Namespace == e.tokenSecretNamespace
-				default:
-					utilruntime.HandleError(fmt.Errorf("object passed to %T that is not expected: %T", e, obj))
-					return false
-				}
-			},
-			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc:    e.enqueueSecrets,
-				UpdateFunc: func(oldSecret, newSecret interface{}) { e.enqueueSecrets(newSecret) },
-			},
+	secretMatches := func(secret *v1.Secret) bool {
+		return secret.Type == bootstrapapi.SecretTypeBootstrapToken && secret.Namespace == e.tokenSecretNamespace
+	}
+	secrets.TypedInformer().AddTypedEventHandler(coreinformers.SecretHandlerFuncs{
+		AddFunc: func(secret *v1.Secret) {
+			if secretMatches(secret) {
+				e.enqueueSecrets(secret)
+			}
 		},
-		options.SecretResync,
-	)
+		UpdateFunc: func(_, secret *v1.Secret) {
+			if secretMatches(secret) {
+				e.enqueueSecrets(secret)
+			}
+		},
+	}, cache.HandlerOptions{ResyncPeriod: &options.SecretResync})
 
 	return e, nil
 }
@@ -133,7 +130,7 @@ func (tc *TokenCleaner) Run(ctx context.Context) {
 	<-ctx.Done()
 }
 
-func (tc *TokenCleaner) enqueueSecrets(obj interface{}) {
+func (tc *TokenCleaner) enqueueSecrets(obj *v1.Secret) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(err)

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -90,7 +90,7 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.TypedSecretIn
 	secretMatches := func(secret *v1.Secret) bool {
 		return secret.Type == bootstrapapi.SecretTypeBootstrapToken && secret.Namespace == e.tokenSecretNamespace
 	}
-	secrets.TypedInformer().AddTypedEventHandler(coreinformers.SecretHandlerFuncs{
+	_, _ = secrets.TypedInformer().AddTypedEventHandler(coreinformers.SecretHandlerFuncs{
 		AddFunc: func(secret *v1.Secret) {
 			if secretMatches(secret) {
 				e.enqueueSecrets(secret)

--- a/pkg/controller/certificates/approver/sarapprove.go
+++ b/pkg/controller/certificates/approver/sarapprove.go
@@ -45,7 +45,7 @@ type sarApprover struct {
 }
 
 // NewCSRApprovingController creates a new CSRApprovingController.
-func NewCSRApprovingController(ctx context.Context, client clientset.Interface, csrInformer certificatesinformers.CertificateSigningRequestInformer) *certificates.CertificateController {
+func NewCSRApprovingController(ctx context.Context, client clientset.Interface, csrInformer certificatesinformers.TypedCertificateSigningRequestInformer) *certificates.CertificateController {
 	approver := &sarApprover{
 		client:      client,
 		recognizers: recognizers(),

--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -77,7 +77,7 @@ func NewCertificateController(
 	}
 
 	// Manage the addition/update of certificate requests
-	csrInformer.TypedInformer().AddTypedEventHandler(certificatesinformers.CertificateSigningRequestHandlerFuncs{
+	_, _ = csrInformer.TypedInformer().AddTypedEventHandler(certificatesinformers.CertificateSigningRequestHandlerFuncs{
 		AddFunc: func(csr *certificates.CertificateSigningRequest) {
 			logger.V(4).Info("Adding certificate request", "csr", csr.Name)
 			cc.enqueueCertificateRequest(csr.Name)
@@ -90,7 +90,7 @@ func NewCertificateController(
 			logger.V(4).Info("Deleting certificate request", "csr", deletedCSR.GetName())
 			cc.enqueueCertificateRequest(deletedCSR.GetKey())
 		},
-	}, cache.HandlerOptions{})
+	})
 	cc.csrLister = csrInformer.Lister()
 	cc.csrsSynced = csrInformer.Informer().HasSynced
 	return cc

--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	"k8s.io/kubernetes/pkg/controller"
 )
 
 type CertificateController struct {
@@ -57,7 +56,7 @@ func NewCertificateController(
 	ctx context.Context,
 	name string,
 	kubeClient clientset.Interface,
-	csrInformer certificatesinformers.CertificateSigningRequestInformer,
+	csrInformer certificatesinformers.TypedCertificateSigningRequestInformer,
 	handler func(context.Context, *certificates.CertificateSigningRequest) error,
 ) *CertificateController {
 	logger := klog.FromContext(ctx)
@@ -78,35 +77,20 @@ func NewCertificateController(
 	}
 
 	// Manage the addition/update of certificate requests
-	csrInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			csr := obj.(*certificates.CertificateSigningRequest)
+	csrInformer.TypedInformer().AddTypedEventHandler(certificatesinformers.CertificateSigningRequestHandlerFuncs{
+		AddFunc: func(csr *certificates.CertificateSigningRequest) {
 			logger.V(4).Info("Adding certificate request", "csr", csr.Name)
-			cc.enqueueCertificateRequest(obj)
+			cc.enqueueCertificateRequest(csr.Name)
 		},
-		UpdateFunc: func(old, new interface{}) {
-			oldCSR := old.(*certificates.CertificateSigningRequest)
+		UpdateFunc: func(oldCSR, newCSR *certificates.CertificateSigningRequest) {
 			logger.V(4).Info("Updating certificate request", "old", oldCSR.Name)
-			cc.enqueueCertificateRequest(new)
+			cc.enqueueCertificateRequest(newCSR.Name)
 		},
-		DeleteFunc: func(obj interface{}) {
-			csr, ok := obj.(*certificates.CertificateSigningRequest)
-			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					logger.V(2).Info("Couldn't get object from tombstone", "object", obj)
-					return
-				}
-				csr, ok = tombstone.Obj.(*certificates.CertificateSigningRequest)
-				if !ok {
-					logger.V(2).Info("Tombstone contained object that is not a CSR", "object", obj)
-					return
-				}
-			}
-			logger.V(4).Info("Deleting certificate request", "csr", csr.Name)
-			cc.enqueueCertificateRequest(obj)
+		DeleteFunc: func(deletedCSR certificatesinformers.DeletedCertificateSigningRequest) {
+			logger.V(4).Info("Deleting certificate request", "csr", deletedCSR.GetName())
+			cc.enqueueCertificateRequest(deletedCSR.GetKey())
 		},
-	})
+	}, cache.HandlerOptions{})
 	cc.csrLister = csrInformer.Lister()
 	cc.csrsSynced = csrInformer.Informer().HasSynced
 	return cc
@@ -167,12 +151,7 @@ func (cc *CertificateController) processNextWorkItem(ctx context.Context) bool {
 
 }
 
-func (cc *CertificateController) enqueueCertificateRequest(obj interface{}) {
-	key, err := controller.KeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
-		return
-	}
+func (cc *CertificateController) enqueueCertificateRequest(key string) {
 	cc.queue.Add(key)
 }
 

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -52,7 +52,7 @@ func init() {
 // NewPublisher construct a new controller which would manage the configmap
 // which stores certificates in each namespace. It will make sure certificate
 // configmap exists in each namespace.
-func NewPublisher(cmInformer coreinformers.ConfigMapInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, rootCA []byte) (*Publisher, error) {
+func NewPublisher(cmInformer coreinformers.TypedConfigMapInformer, nsInformer coreinformers.TypedNamespaceInformer, cl clientset.Interface, rootCA []byte) (*Publisher, error) {
 	e := &Publisher{
 		client: cl,
 		rootCA: rootCA,
@@ -64,17 +64,17 @@ func NewPublisher(cmInformer coreinformers.ConfigMapInformer, nsInformer coreinf
 		),
 	}
 
-	cmInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	cmInformer.TypedInformer().AddTypedEventHandler(coreinformers.ConfigMapHandlerFuncs{
 		DeleteFunc: e.configMapDeleted,
 		UpdateFunc: e.configMapUpdated,
-	})
+	}, cache.HandlerOptions{})
 	e.cmLister = cmInformer.Lister()
 	e.cmListerSynced = cmInformer.Informer().HasSynced
 
-	nsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	nsInformer.TypedInformer().AddTypedEventHandler(coreinformers.NamespaceHandlerFuncs{
 		AddFunc:    e.namespaceAdded,
 		UpdateFunc: e.namespaceUpdated,
-	})
+	}, cache.HandlerOptions{})
 	e.nsListerSynced = nsInformer.Informer().HasSynced
 
 	e.syncHandler = e.syncNamespace
@@ -125,37 +125,25 @@ func (c *Publisher) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-func (c *Publisher) configMapDeleted(obj interface{}) {
-	cm, err := convertToCM(obj)
-	if err != nil {
-		utilruntime.HandleError(err)
+func (c *Publisher) configMapDeleted(deleted coreinformers.DeletedConfigMap) {
+	if deleted.GetName() != RootCACertConfigMapName {
 		return
 	}
+	c.queue.Add(deleted.GetNamespace())
+}
+
+func (c *Publisher) configMapUpdated(_, cm *v1.ConfigMap) {
 	if cm.Name != RootCACertConfigMapName {
 		return
 	}
 	c.queue.Add(cm.Namespace)
 }
 
-func (c *Publisher) configMapUpdated(_, newObj interface{}) {
-	cm, err := convertToCM(newObj)
-	if err != nil {
-		utilruntime.HandleError(err)
-		return
-	}
-	if cm.Name != RootCACertConfigMapName {
-		return
-	}
-	c.queue.Add(cm.Namespace)
-}
-
-func (c *Publisher) namespaceAdded(obj interface{}) {
-	namespace := obj.(*v1.Namespace)
+func (c *Publisher) namespaceAdded(namespace *v1.Namespace) {
 	c.queue.Add(namespace.Name)
 }
 
-func (c *Publisher) namespaceUpdated(oldObj interface{}, newObj interface{}) {
-	newNamespace := newObj.(*v1.Namespace)
+func (c *Publisher) namespaceUpdated(_, newNamespace *v1.Namespace) {
 	if newNamespace.Status.Phase != v1.NamespaceActive {
 		return
 	}
@@ -233,19 +221,4 @@ func (c *Publisher) syncNamespace(ctx context.Context, ns string) (err error) {
 
 	_, err = c.client.CoreV1().ConfigMaps(ns).Update(ctx, cm, metav1.UpdateOptions{})
 	return err
-}
-
-func convertToCM(obj interface{}) (*v1.ConfigMap, error) {
-	cm, ok := obj.(*v1.ConfigMap)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			return nil, fmt.Errorf("couldn't get object from tombstone %#v", obj)
-		}
-		cm, ok = tombstone.Obj.(*v1.ConfigMap)
-		if !ok {
-			return nil, fmt.Errorf("tombstone contained object that is not a ConfigMap %#v", obj)
-		}
-	}
-	return cm, nil
 }

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -64,17 +64,17 @@ func NewPublisher(cmInformer coreinformers.TypedConfigMapInformer, nsInformer co
 		),
 	}
 
-	cmInformer.TypedInformer().AddTypedEventHandler(coreinformers.ConfigMapHandlerFuncs{
+	_, _ = cmInformer.TypedInformer().AddTypedEventHandler(coreinformers.ConfigMapHandlerFuncs{
 		DeleteFunc: e.configMapDeleted,
 		UpdateFunc: e.configMapUpdated,
-	}, cache.HandlerOptions{})
+	})
 	e.cmLister = cmInformer.Lister()
 	e.cmListerSynced = cmInformer.Informer().HasSynced
 
-	nsInformer.TypedInformer().AddTypedEventHandler(coreinformers.NamespaceHandlerFuncs{
+	_, _ = nsInformer.TypedInformer().AddTypedEventHandler(coreinformers.NamespaceHandlerFuncs{
 		AddFunc:    e.namespaceAdded,
 		UpdateFunc: e.namespaceUpdated,
-	}, cache.HandlerOptions{})
+	})
 	e.nsListerSynced = nsInformer.Informer().HasSynced
 
 	e.syncHandler = e.syncNamespace

--- a/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	clienttesting "k8s.io/client-go/testing"
@@ -148,7 +149,7 @@ func TestConfigMapCreation(t *testing.T) {
 
 			if tc.DeletedConfigMap != nil {
 				cmStore.Delete(tc.DeletedConfigMap)
-				controller.configMapDeleted(tc.DeletedConfigMap)
+				controller.configMapDeleted(coreinformers.DeletedConfigMap{OptionalObj: tc.DeletedConfigMap})
 			}
 
 			if tc.UpdatedConfigMap != nil {

--- a/pkg/controller/certificates/signer/signer.go
+++ b/pkg/controller/certificates/signer/signer.go
@@ -47,7 +47,7 @@ type CSRSigningController struct {
 func NewKubeletServingCSRSigningController(
 	ctx context.Context,
 	client clientset.Interface,
-	csrInformer certificatesinformers.CertificateSigningRequestInformer,
+	csrInformer certificatesinformers.TypedCertificateSigningRequestInformer,
 	caFile, caKeyFile string,
 	certTTL time.Duration,
 ) (*CSRSigningController, error) {
@@ -57,7 +57,7 @@ func NewKubeletServingCSRSigningController(
 func NewKubeletClientCSRSigningController(
 	ctx context.Context,
 	client clientset.Interface,
-	csrInformer certificatesinformers.CertificateSigningRequestInformer,
+	csrInformer certificatesinformers.TypedCertificateSigningRequestInformer,
 	caFile, caKeyFile string,
 	certTTL time.Duration,
 ) (*CSRSigningController, error) {
@@ -67,7 +67,7 @@ func NewKubeletClientCSRSigningController(
 func NewKubeAPIServerClientCSRSigningController(
 	ctx context.Context,
 	client clientset.Interface,
-	csrInformer certificatesinformers.CertificateSigningRequestInformer,
+	csrInformer certificatesinformers.TypedCertificateSigningRequestInformer,
 	caFile, caKeyFile string,
 	certTTL time.Duration,
 ) (*CSRSigningController, error) {
@@ -77,7 +77,7 @@ func NewKubeAPIServerClientCSRSigningController(
 func NewLegacyUnknownCSRSigningController(
 	ctx context.Context,
 	client clientset.Interface,
-	csrInformer certificatesinformers.CertificateSigningRequestInformer,
+	csrInformer certificatesinformers.TypedCertificateSigningRequestInformer,
 	caFile, caKeyFile string,
 	certTTL time.Duration,
 ) (*CSRSigningController, error) {
@@ -89,7 +89,7 @@ func NewCSRSigningController(
 	controllerName string,
 	signerName string,
 	client clientset.Interface,
-	csrInformer certificatesinformers.CertificateSigningRequestInformer,
+	csrInformer certificatesinformers.TypedCertificateSigningRequestInformer,
 	caFile, caKeyFile string,
 	certTTL time.Duration,
 ) (*CSRSigningController, error) {

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -53,7 +53,7 @@ type ClusterRoleAggregationController struct {
 }
 
 // NewClusterRoleAggregation creates a new controller
-func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInformer, clusterRoleClient rbacclient.ClusterRolesGetter) *ClusterRoleAggregationController {
+func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.TypedClusterRoleInformer, clusterRoleClient rbacclient.ClusterRolesGetter) *ClusterRoleAggregationController {
 	c := &ClusterRoleAggregationController{
 		clusterRoleClient:  clusterRoleClient,
 		clusterRoleLister:  clusterRoleInformer.Lister(),
@@ -68,17 +68,17 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInfo
 	}
 	c.syncHandler = c.syncClusterRole
 
-	clusterRoleInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	clusterRoleInformer.TypedInformer().AddTypedEventHandler(rbacinformers.ClusterRoleHandlerFuncs{
+		AddFunc: func(_ *rbacv1.ClusterRole) {
 			c.enqueue()
 		},
-		UpdateFunc: func(old, cur interface{}) {
+		UpdateFunc: func(_, _ *rbacv1.ClusterRole) {
 			c.enqueue()
 		},
-		DeleteFunc: func(uncast interface{}) {
+		DeleteFunc: func(_ rbacinformers.DeletedClusterRole) {
 			c.enqueue()
 		},
-	})
+	}, cache.HandlerOptions{})
 	return c
 }
 

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -68,7 +68,7 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.TypedClusterRol
 	}
 	c.syncHandler = c.syncClusterRole
 
-	clusterRoleInformer.TypedInformer().AddTypedEventHandler(rbacinformers.ClusterRoleHandlerFuncs{
+	_, _ = clusterRoleInformer.TypedInformer().AddTypedEventHandler(rbacinformers.ClusterRoleHandlerFuncs{
 		AddFunc: func(_ *rbacv1.ClusterRole) {
 			c.enqueue()
 		},
@@ -78,7 +78,7 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.TypedClusterRol
 		DeleteFunc: func(_ rbacinformers.DeletedClusterRole) {
 			c.enqueue()
 		},
-	}, cache.HandlerOptions{})
+	})
 	return c
 }
 

--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -86,7 +86,7 @@ type ControllerV2 struct {
 }
 
 // NewControllerV2 creates and initializes a new Controller.
-func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInformer, cronJobsInformer batchv1informers.CronJobInformer, kubeClient clientset.Interface) (*ControllerV2, error) {
+func NewControllerV2(ctx context.Context, jobInformer batchv1informers.TypedJobInformer, cronJobsInformer batchv1informers.TypedCronJobInformer, kubeClient clientset.Interface) (*ControllerV2, error) {
 	logger := klog.FromContext(ctx)
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 
@@ -114,30 +114,26 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 		now: time.Now,
 	}
 
-	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = jobInformer.TypedInformer().AddTypedEventHandler(batchv1informers.JobHandlerFuncs{
 		AddFunc:    jm.addJob,
 		UpdateFunc: jm.updateJob,
 		DeleteFunc: jm.deleteJob,
 	})
 
-	cronJobsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = cronJobsInformer.TypedInformer().AddTypedEventHandler(batchv1informers.CronJobHandlerFuncs{
+		AddFunc: func(obj *batchv1.CronJob) {
 			jm.enqueueController(obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *batchv1.CronJob) {
 			jm.updateCronJob(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			jm.enqueueController(obj)
+		DeleteFunc: func(obj batchv1informers.DeletedCronJob) {
+			jm.queue.Add(obj.GetKey())
 		},
 	})
 
-	err := jobInformer.Informer().AddIndexers(cache.Indexers{
-		jobControllerUIDIndex: func(obj interface{}) ([]string, error) {
-			job, ok := obj.(*batchv1.Job)
-			if !ok {
-				return nil, nil
-			}
+	err := jobInformer.TypedInformer().AddTypedIndexers(batchv1informers.JobIndexers{
+		jobControllerUIDIndex: func(job *batchv1.Job) ([]string, error) {
 			if controllerRef := metav1.GetControllerOf(job); controllerRef != nil {
 				return []string{string(controllerRef.UID)}, nil
 			}
@@ -298,12 +294,11 @@ func (jm *ControllerV2) resolveControllerRef(namespace string, controllerRef *me
 }
 
 // When a job is created, enqueue the controller that manages it and update it's expectations.
-func (jm *ControllerV2) addJob(obj interface{}) {
-	job := obj.(*batchv1.Job)
+func (jm *ControllerV2) addJob(job *batchv1.Job) {
 	if job.DeletionTimestamp != nil {
 		// on a restart of the controller, it's possible a new job shows up in a state that
 		// is already pending deletion. Prevent the job from being a creation observation.
-		jm.deleteJob(job)
+		jm.deleteJob(batchv1informers.DeletedJob{OptionalObj: job})
 		return
 	}
 
@@ -322,9 +317,7 @@ func (jm *ControllerV2) addJob(obj interface{}) {
 // is updated and wake them up. If the anything of the Job have changed, we need to
 // awaken both the old and new CronJob. old and cur must be *batchv1.Job
 // types.
-func (jm *ControllerV2) updateJob(old, cur interface{}) {
-	curJob := cur.(*batchv1.Job)
-	oldJob := old.(*batchv1.Job)
+func (jm *ControllerV2) updateJob(oldJob, curJob *batchv1.Job) {
 	if curJob.ResourceVersion == oldJob.ResourceVersion {
 		// Periodic resync will send update events for all known jobs.
 		// Two different versions of the same jobs will always have different RVs.
@@ -352,23 +345,11 @@ func (jm *ControllerV2) updateJob(old, cur interface{}) {
 	}
 }
 
-func (jm *ControllerV2) deleteJob(obj interface{}) {
-	job, ok := obj.(*batchv1.Job)
-
-	// When a delete is dropped, the relist will notice a job in the store not
-	// in the list, leading to the insertion of a tombstone object which contains
-	// the deleted key/value. Note that this value might be stale.
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-			return
-		}
-		job, ok = tombstone.Obj.(*batchv1.Job)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Job %#v", obj))
-			return
-		}
+func (jm *ControllerV2) deleteJob(deleted batchv1informers.DeletedJob) {
+	job := deleted.OptionalObj
+	if job == nil {
+		utilruntime.HandleError(fmt.Errorf("deleted Job %q is unavailable", deleted.GetKey()))
+		return
 	}
 
 	controllerRef := metav1.GetControllerOf(job)
@@ -405,14 +386,7 @@ func (jm *ControllerV2) enqueueControllerAfter(obj interface{}, t time.Duration)
 
 // updateCronJob re-queues the CronJob for next scheduled time if there is a
 // change in spec.schedule otherwise it re-queues it now
-func (jm *ControllerV2) updateCronJob(logger klog.Logger, old interface{}, curr interface{}) {
-	oldCJ, okOld := old.(*batchv1.CronJob)
-	newCJ, okNew := curr.(*batchv1.CronJob)
-
-	if !okOld || !okNew {
-		// typecasting of one failed, handle this better, may be log entry
-		return
-	}
+func (jm *ControllerV2) updateCronJob(logger klog.Logger, oldCJ, newCJ *batchv1.CronJob) {
 	// if the change in schedule results in next requeue having to be sooner than it already was,
 	// it will be handled here by the queue. If the next requeue is further than previous schedule,
 	// the sync loop will essentially be a no-op for the already queued key with old schedule.
@@ -429,7 +403,7 @@ func (jm *ControllerV2) updateCronJob(logger klog.Logger, old interface{}, curr 
 		now := jm.now()
 		t := nextScheduleTimeDuration(newCJ, now, sched)
 
-		jm.enqueueControllerAfter(curr, *t)
+		jm.enqueueControllerAfter(newCJ, *t)
 		return
 	}
 
@@ -438,7 +412,7 @@ func (jm *ControllerV2) updateCronJob(logger klog.Logger, old interface{}, curr 
 	// during the next schedule
 	// TODO: need to handle the change of spec.JobTemplate.metadata.labels explicitly
 	//   to cleanup jobs with old labels
-	jm.enqueueController(curr)
+	jm.enqueueController(newCJ)
 }
 
 // syncCronJob reconciles a CronJob with a list of any Jobs that it created.

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -157,10 +157,10 @@ type DaemonSetsController struct {
 // NewDaemonSetsController creates a new DaemonSetsController
 func NewDaemonSetsController(
 	ctx context.Context,
-	daemonSetInformer appsinformers.DaemonSetInformer,
-	historyInformer appsinformers.ControllerRevisionInformer,
-	podInformer coreinformers.PodInformer,
-	nodeInformer coreinformers.NodeInformer,
+	daemonSetInformer appsinformers.TypedDaemonSetInformer,
+	historyInformer appsinformers.TypedControllerRevisionInformer,
+	podInformer coreinformers.TypedPodInformer,
+	nodeInformer coreinformers.TypedNodeInformer,
 	kubeClient clientset.Interface,
 	failedPodsBackoff *flowcontrol.Backoff,
 ) (*DaemonSetsController, error) {
@@ -221,29 +221,29 @@ func NewDaemonSetsController(
 		consistencyStore: consistencyStore,
 	}
 
-	daemonSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = daemonSetInformer.TypedInformer().AddTypedEventHandler(appsinformers.DaemonSetHandlerFuncs{
+		AddFunc: func(obj *apps.DaemonSet) {
 			dsc.addDaemonset(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *apps.DaemonSet) {
 			dsc.updateDaemonset(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			dsc.deleteDaemonset(logger, obj)
+		DeleteFunc: func(obj appsinformers.DeletedDaemonSet) {
+			dsc.deleteDaemonset(logger, obj.OptionalObj)
 		},
 	})
 	dsc.dsLister = daemonSetInformer.Lister()
 	dsc.dsStoreSynced = daemonSetInformer.Informer().HasSynced
 
-	historyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = historyInformer.TypedInformer().AddTypedEventHandler(appsinformers.ControllerRevisionHandlerFuncs{
+		AddFunc: func(obj *apps.ControllerRevision) {
 			dsc.addHistory(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *apps.ControllerRevision) {
 			dsc.updateHistory(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			dsc.deleteHistory(logger, obj)
+		DeleteFunc: func(obj appsinformers.DeletedControllerRevision) {
+			dsc.deleteHistory(logger, obj.OptionalObj)
 		},
 	})
 	dsc.historyLister = historyInformer.Lister()
@@ -252,15 +252,15 @@ func NewDaemonSetsController(
 	// Watch for creation/deletion of pods. The reason we watch is that we don't want a daemon set to create/delete
 	// more pods until all the effects (expectations) of a daemon set's create/delete have been observed.
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc: func(obj *v1.Pod) {
 			dsc.addPod(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *v1.Pod) {
 			dsc.updatePod(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			dsc.deletePod(logger, obj)
+		DeleteFunc: func(obj coreinformers.DeletedPod) {
+			dsc.deletePod(logger, obj.OptionalObj)
 		},
 	})
 	dsc.podLister = podInformer.Lister()
@@ -269,11 +269,11 @@ func NewDaemonSetsController(
 	controller.AddPodControllerIndexer(podInformer.Informer())
 	dsc.podIndexer = podInformer.Informer().GetIndexer()
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = nodeInformer.TypedInformer().AddTypedEventHandler(coreinformers.NodeHandlerFuncs{
+		AddFunc: func(obj *v1.Node) {
 			dsc.addNode(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *v1.Node) {
 			dsc.updateNode(logger, oldObj, newObj)
 		},
 	},

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -101,7 +101,7 @@ type DeploymentController struct {
 }
 
 // NewDeploymentController creates a new DeploymentController.
-func NewDeploymentController(ctx context.Context, dInformer appsinformers.DeploymentInformer, rsInformer appsinformers.ReplicaSetInformer, podInformer coreinformers.PodInformer, client clientset.Interface) (*DeploymentController, error) {
+func NewDeploymentController(ctx context.Context, dInformer appsinformers.TypedDeploymentInformer, rsInformer appsinformers.TypedReplicaSetInformer, podInformer coreinformers.TypedPodInformer, client clientset.Interface) (*DeploymentController, error) {
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	logger := klog.FromContext(ctx)
 	dc := &DeploymentController{
@@ -120,32 +120,32 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 		Recorder:   dc.eventRecorder,
 	}
 
-	dInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = dInformer.TypedInformer().AddTypedEventHandler(appsinformers.DeploymentHandlerFuncs{
+		AddFunc: func(obj *apps.Deployment) {
 			dc.addDeployment(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *apps.Deployment) {
 			dc.updateDeployment(logger, oldObj, newObj)
 		},
 		// This will enter the sync loop and no-op, because the deployment has been deleted from the store.
-		DeleteFunc: func(obj interface{}) {
-			dc.deleteDeployment(logger, obj)
+		DeleteFunc: func(deleted appsinformers.DeletedDeployment) {
+			dc.deleteDeployment(logger, deleted)
 		},
 	})
-	rsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = rsInformer.TypedInformer().AddTypedEventHandler(appsinformers.ReplicaSetHandlerFuncs{
+		AddFunc: func(obj *apps.ReplicaSet) {
 			dc.addReplicaSet(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *apps.ReplicaSet) {
 			dc.updateReplicaSet(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			dc.deleteReplicaSet(logger, obj)
+		DeleteFunc: func(deleted appsinformers.DeletedReplicaSet) {
+			dc.deleteReplicaSet(logger, deleted)
 		},
 	})
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		DeleteFunc: func(obj interface{}) {
-			dc.deletePod(logger, obj)
+	_, _ = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		DeleteFunc: func(deleted coreinformers.DeletedPod) {
+			dc.deletePod(logger, deleted)
 		},
 	})
 
@@ -198,45 +198,33 @@ func (dc *DeploymentController) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-func (dc *DeploymentController) addDeployment(logger klog.Logger, obj interface{}) {
-	d := obj.(*apps.Deployment)
+func (dc *DeploymentController) addDeployment(logger klog.Logger, d *apps.Deployment) {
 	logger.V(4).Info("Adding deployment", "deployment", klog.KObj(d))
 	dc.enqueueDeployment(d)
 }
 
-func (dc *DeploymentController) updateDeployment(logger klog.Logger, old, cur interface{}) {
-	oldD := old.(*apps.Deployment)
-	curD := cur.(*apps.Deployment)
+func (dc *DeploymentController) updateDeployment(logger klog.Logger, oldD, curD *apps.Deployment) {
 	logger.V(4).Info("Updating deployment", "deployment", klog.KObj(oldD))
 	dc.enqueueDeployment(curD)
 }
 
-func (dc *DeploymentController) deleteDeployment(logger klog.Logger, obj interface{}) {
-	d, ok := obj.(*apps.Deployment)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-			return
-		}
-		d, ok = tombstone.Obj.(*apps.Deployment)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Deployment %#v", obj))
-			return
-		}
+func (dc *DeploymentController) deleteDeployment(logger klog.Logger, deleted appsinformers.DeletedDeployment) {
+	if deleted.OptionalObj == nil {
+		utilruntime.HandleError(fmt.Errorf("deleted Deployment object %q is unavailable", deleted.GetKey()))
+		return
 	}
+	d := deleted.OptionalObj
 	logger.V(4).Info("Deleting deployment", "deployment", klog.KObj(d))
 	dc.enqueueDeployment(d)
 }
 
 // addReplicaSet enqueues the deployment that manages a ReplicaSet when the ReplicaSet is created.
-func (dc *DeploymentController) addReplicaSet(logger klog.Logger, obj interface{}) {
-	rs := obj.(*apps.ReplicaSet)
+func (dc *DeploymentController) addReplicaSet(logger klog.Logger, rs *apps.ReplicaSet) {
 
 	if rs.DeletionTimestamp != nil {
 		// On a restart of the controller manager, it's possible for an object to
 		// show up in a state that is already pending deletion.
-		dc.deleteReplicaSet(logger, rs)
+		dc.deleteReplicaSet(logger, appsinformers.DeletedReplicaSet{OptionalObj: rs})
 		return
 	}
 	// If it has a ControllerRef, that's all that matters.
@@ -286,9 +274,7 @@ func (dc *DeploymentController) getDeploymentsForReplicaSet(logger klog.Logger, 
 // is updated and wake them up. If the anything of the ReplicaSets have changed, we need to
 // awaken both the old and new deployments. old and cur must be *apps.ReplicaSet
 // types.
-func (dc *DeploymentController) updateReplicaSet(logger klog.Logger, old, cur interface{}) {
-	curRS := cur.(*apps.ReplicaSet)
-	oldRS := old.(*apps.ReplicaSet)
+func (dc *DeploymentController) updateReplicaSet(logger klog.Logger, oldRS, curRS *apps.ReplicaSet) {
 	if curRS.ResourceVersion == oldRS.ResourceVersion {
 		// Periodic resync will send update events for all known replica sets.
 		// Two different versions of the same replica set will always have different RVs.
@@ -333,25 +319,16 @@ func (dc *DeploymentController) updateReplicaSet(logger klog.Logger, old, cur in
 // deleteReplicaSet enqueues the deployment that manages a ReplicaSet when
 // the ReplicaSet is deleted. obj could be an *apps.ReplicaSet, or
 // a DeletionFinalStateUnknown marker item.
-func (dc *DeploymentController) deleteReplicaSet(logger klog.Logger, obj interface{}) {
-	rs, ok := obj.(*apps.ReplicaSet)
-
+func (dc *DeploymentController) deleteReplicaSet(logger klog.Logger, deleted appsinformers.DeletedReplicaSet) {
 	// When a delete is dropped, the relist will notice a pod in the store not
 	// in the list, leading to the insertion of a tombstone object which contains
 	// the deleted key/value. Note that this value might be stale. If the ReplicaSet
 	// changed labels the new deployment will not be woken up till the periodic resync.
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-			return
-		}
-		rs, ok = tombstone.Obj.(*apps.ReplicaSet)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ReplicaSet %#v", obj))
-			return
-		}
+	if deleted.OptionalObj == nil {
+		utilruntime.HandleError(fmt.Errorf("deleted ReplicaSet object %q is unavailable", deleted.GetKey()))
+		return
 	}
+	rs := deleted.OptionalObj
 
 	controllerRef := metav1.GetControllerOf(rs)
 	if controllerRef == nil {
@@ -367,25 +344,16 @@ func (dc *DeploymentController) deleteReplicaSet(logger klog.Logger, obj interfa
 }
 
 // deletePod will enqueue a Recreate Deployment once all of its pods have stopped running.
-func (dc *DeploymentController) deletePod(logger klog.Logger, obj interface{}) {
-	pod, ok := obj.(*v1.Pod)
-
+func (dc *DeploymentController) deletePod(logger klog.Logger, deleted coreinformers.DeletedPod) {
 	// When a delete is dropped, the relist will notice a pod in the store not
 	// in the list, leading to the insertion of a tombstone object which contains
 	// the deleted key/value. Note that this value might be stale. If the Pod
 	// changed labels the new deployment will not be woken up till the periodic resync.
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-			return
-		}
-		pod, ok = tombstone.Obj.(*v1.Pod)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", obj))
-			return
-		}
+	if deleted.OptionalObj == nil {
+		utilruntime.HandleError(fmt.Errorf("deleted Pod object %q is unavailable", deleted.GetKey()))
+		return
 	}
+	pod := deleted.OptionalObj
 	d := dc.getDeploymentForPod(logger, pod)
 	if d == nil {
 		return

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/informers"
+	appsinformers "k8s.io/client-go/informers/apps/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
@@ -425,7 +427,7 @@ func TestPodDeletionEnqueuesRecreateDeployment(t *testing.T) {
 				}
 			}
 
-			c.deletePod(logger, pod)
+			c.deletePod(logger, coreinformers.DeletedPod{OptionalObj: pod})
 
 			if !enqueued {
 				t.Errorf("expected deployment %q to be queued after pod deletion", foo.Name)
@@ -465,7 +467,7 @@ func TestPodDeletionPartialReplicaSetOwnershipEnqueueRecreateDeployment(t *testi
 		}
 	}
 
-	c.deletePod(logger, pod)
+	c.deletePod(logger, coreinformers.DeletedPod{OptionalObj: pod})
 
 	if !enqueued {
 		t.Errorf("expected deployment %q to be queued after pod deletion", foo.Name)
@@ -892,7 +894,7 @@ func TestDeleteReplicaSet(t *testing.T) {
 		t.Fatalf("error creating Deployment controller: %v", err)
 	}
 
-	dc.deleteReplicaSet(logger, rs1)
+	dc.deleteReplicaSet(logger, appsinformers.DeletedReplicaSet{OptionalObj: rs1})
 	if got, want := dc.queue.Len(), 1; got != want {
 		t.Fatalf("queue.Len() = %v, want %v", got, want)
 	}
@@ -905,7 +907,7 @@ func TestDeleteReplicaSet(t *testing.T) {
 		t.Errorf("queue.Get() = %v, want %v", got, want)
 	}
 
-	dc.deleteReplicaSet(logger, rs2)
+	dc.deleteReplicaSet(logger, appsinformers.DeletedReplicaSet{OptionalObj: rs2})
 	if got, want := dc.queue.Len(), 1; got != want {
 		t.Fatalf("queue.Len() = %v, want %v", got, want)
 	}
@@ -942,7 +944,7 @@ func TestDeleteReplicaSetOrphan(t *testing.T) {
 		t.Fatalf("error creating Deployment controller: %v", err)
 	}
 
-	dc.deleteReplicaSet(logger, rs)
+	dc.deleteReplicaSet(logger, appsinformers.DeletedReplicaSet{OptionalObj: rs})
 	if got, want := dc.queue.Len(), 0; got != want {
 		t.Fatalf("queue.Len() = %v, want %v", got, want)
 	}

--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -96,12 +96,12 @@ type Controller struct {
 
 	client        clientset.Interface
 	recorder      record.EventRecorder
-	podInformer   coreinformers.PodInformer
+	podInformer   coreinformers.TypedPodInformer
 	podLister     corelisters.PodLister
-	claimInformer resourceinformers.ResourceClaimInformer
-	sliceInformer resourceinformers.ResourceSliceInformer
-	ruleInformer  resourceinformers.DeviceTaintRuleInformer
-	classInformer resourceinformers.DeviceClassInformer
+	claimInformer resourceinformers.TypedResourceClaimInformer
+	sliceInformer resourceinformers.TypedResourceSliceInformer
+	ruleInformer  resourceinformers.TypedDeviceTaintRuleInformer
+	classInformer resourceinformers.TypedDeviceClassInformer
 	ruleLister    resourcelisters.DeviceTaintRuleLister
 	haveSynced    []cache.DoneChecker
 	hasSynced     atomic.Int32
@@ -731,11 +731,11 @@ func (tc *Controller) countTaintedDevices(rule *resourceapi.DeviceTaintRule) (nu
 
 // New creates a new Controller that will use passed clientset to communicate with the API server.
 // Spawns no goroutines. That happens in Run.
-func New(c clientset.Interface, podInformer coreinformers.PodInformer, claimInformer resourceinformers.ResourceClaimInformer, sliceInformer resourceinformers.ResourceSliceInformer, ruleInformer resourceinformers.DeviceTaintRuleInformer, classInformer resourceinformers.DeviceClassInformer, controllerName string) *Controller {
+func New(c clientset.Interface, podInformer coreinformers.TypedPodInformer, claimInformer resourceinformers.TypedResourceClaimInformer, sliceInformer resourceinformers.TypedResourceSliceInformer, ruleInformer resourceinformers.TypedDeviceTaintRuleInformer, classInformer resourceinformers.TypedDeviceClassInformer, controllerName string) *Controller {
 	return newWithFeatures(c, podInformer, claimInformer, sliceInformer, ruleInformer, classInformer, controllerName, utilfeature.DefaultFeatureGate.Enabled(features.DRAWorkloadResourceClaims))
 }
 
-func newWithFeatures(c clientset.Interface, podInformer coreinformers.PodInformer, claimInformer resourceinformers.ResourceClaimInformer, sliceInformer resourceinformers.ResourceSliceInformer, ruleInformer resourceinformers.DeviceTaintRuleInformer, classInformer resourceinformers.DeviceClassInformer, controllerName string, workloadResourceClaimsEnabled bool) *Controller {
+func newWithFeatures(c clientset.Interface, podInformer coreinformers.TypedPodInformer, claimInformer resourceinformers.TypedResourceClaimInformer, sliceInformer resourceinformers.TypedResourceSliceInformer, ruleInformer resourceinformers.TypedDeviceTaintRuleInformer, classInformer resourceinformers.TypedDeviceClassInformer, controllerName string, workloadResourceClaimsEnabled bool) *Controller {
 	metrics.Register() // It would be nicer to pass the controller name here, but that probably would break generating https://kubernetes.io/docs/reference/instrumentation/metrics.
 
 	tc := &Controller{
@@ -834,38 +834,21 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 		return err
 	}
 
-	claimHandler, err := tc.claimInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			claim, ok := obj.(*resourceapi.ResourceClaim)
-			if !ok {
-				logger.Error(nil, "Expected ResourceClaim", "actual", fmt.Sprintf("%T", obj))
-				return
-			}
+	claimHandler, err := tc.claimInformer.TypedInformer().AddTypedEventHandler(resourceinformers.ResourceClaimHandlerFuncs{
+		AddFunc: func(claim *resourceapi.ResourceClaim) {
 			tc.mutex.Lock()
 			defer tc.mutex.Unlock()
 			tc.handleClaimChange(nil, claim)
 		},
-		UpdateFunc: func(oldObj, newObj any) {
-			oldClaim, ok := oldObj.(*resourceapi.ResourceClaim)
-			if !ok {
-				logger.Error(nil, "Expected ResourceClaim", "actual", fmt.Sprintf("%T", oldObj))
-				return
-			}
-			newClaim, ok := newObj.(*resourceapi.ResourceClaim)
-			if !ok {
-				logger.Error(nil, "Expected ResourceClaim", "actual", fmt.Sprintf("%T", newObj))
-			}
+		UpdateFunc: func(oldClaim, newClaim *resourceapi.ResourceClaim) {
 			tc.mutex.Lock()
 			defer tc.mutex.Unlock()
 			tc.handleClaimChange(oldClaim, newClaim)
 		},
-		DeleteFunc: func(obj any) {
-			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-				obj = tombstone.Obj
-			}
-			claim, ok := obj.(*resourceapi.ResourceClaim)
-			if !ok {
-				logger.Error(nil, "Expected ResourceClaim", "actual", fmt.Sprintf("%T", obj))
+		DeleteFunc: func(deleted resourceinformers.DeletedResourceClaim) {
+			claim := deleted.OptionalObj
+			if claim == nil {
+				logger.Error(nil, "Deleted ResourceClaim object is unavailable", "claim", deleted.GetKey())
 				return
 			}
 			tc.mutex.Lock()
@@ -881,38 +864,21 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 	}()
 	tc.haveSynced = append(tc.haveSynced, claimHandler.HasSyncedChecker())
 
-	podHandler, err := tc.podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			pod, ok := obj.(*v1.Pod)
-			if !ok {
-				logger.Error(nil, "Expected Pod", "actual", fmt.Sprintf("%T", obj))
-				return
-			}
+	podHandler, err := tc.podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc: func(pod *v1.Pod) {
 			tc.mutex.Lock()
 			defer tc.mutex.Unlock()
 			tc.handlePodChange(nil, pod)
 		},
-		UpdateFunc: func(oldObj, newObj any) {
-			oldPod, ok := oldObj.(*v1.Pod)
-			if !ok {
-				logger.Error(nil, "Expected Pod", "actual", fmt.Sprintf("%T", oldObj))
-				return
-			}
-			newPod, ok := newObj.(*v1.Pod)
-			if !ok {
-				logger.Error(nil, "Expected Pod", "actual", fmt.Sprintf("%T", newObj))
-			}
+		UpdateFunc: func(oldPod, newPod *v1.Pod) {
 			tc.mutex.Lock()
 			defer tc.mutex.Unlock()
 			tc.handlePodChange(oldPod, newPod)
 		},
-		DeleteFunc: func(obj any) {
-			if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-				obj = tombstone.Obj
-			}
-			pod, ok := obj.(*v1.Pod)
-			if !ok {
-				logger.Error(nil, "Expected Pod", "actual", fmt.Sprintf("%T", obj))
+		DeleteFunc: func(deleted coreinformers.DeletedPod) {
+			pod := deleted.OptionalObj
+			if pod == nil {
+				logger.Error(nil, "Deleted Pod object is unavailable", "pod", deleted.GetKey())
 				return
 			}
 			tc.mutex.Lock()
@@ -929,38 +895,21 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 	tc.haveSynced = append(tc.haveSynced, podHandler.HasSyncedChecker())
 
 	if tc.ruleInformer != nil {
-		ruleHandler, err := tc.ruleInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj any) {
-				rule, ok := obj.(*resourceapi.DeviceTaintRule)
-				if !ok {
-					logger.Error(nil, "Expected DeviceTaintRule", "actual", fmt.Sprintf("%T", obj))
-					return
-				}
+		ruleHandler, err := tc.ruleInformer.TypedInformer().AddTypedEventHandler(resourceinformers.DeviceTaintRuleHandlerFuncs{
+			AddFunc: func(rule *resourceapi.DeviceTaintRule) {
 				tc.mutex.Lock()
 				defer tc.mutex.Unlock()
 				tc.handleRuleChange(nil, rule)
 			},
-			UpdateFunc: func(oldObj, newObj any) {
-				oldRule, ok := oldObj.(*resourceapi.DeviceTaintRule)
-				if !ok {
-					logger.Error(nil, "Expected DeviceTaintRule", "actual", fmt.Sprintf("%T", oldObj))
-					return
-				}
-				newRule, ok := newObj.(*resourceapi.DeviceTaintRule)
-				if !ok {
-					logger.Error(nil, "Expected DeviceTaintRule", "actual", fmt.Sprintf("%T", newObj))
-				}
+			UpdateFunc: func(oldRule, newRule *resourceapi.DeviceTaintRule) {
 				tc.mutex.Lock()
 				defer tc.mutex.Unlock()
 				tc.handleRuleChange(oldRule, newRule)
 			},
-			DeleteFunc: func(obj any) {
-				if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-					obj = tombstone.Obj
-				}
-				rule, ok := obj.(*resourceapi.DeviceTaintRule)
-				if !ok {
-					logger.Error(nil, "Expected DeviceTaintRule", "actual", fmt.Sprintf("%T", obj))
+			DeleteFunc: func(deleted resourceinformers.DeletedDeviceTaintRule) {
+				rule := deleted.OptionalObj
+				if rule == nil {
+					logger.Error(nil, "Deleted DeviceTaintRule object is unavailable", "rule", deleted.GetKey())
 					return
 				}
 				tc.mutex.Lock()
@@ -977,36 +926,21 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 		tc.haveSynced = append(tc.haveSynced, ruleHandler.HasSyncedChecker())
 	}
 
-	sliceHandler, err := tc.sliceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			slice, ok := obj.(*resourceapi.ResourceSlice)
-			if !ok {
-				logger.Error(nil, "Expected ResourceSlice", "actual", fmt.Sprintf("%T", obj))
-				return
-			}
+	sliceHandler, err := tc.sliceInformer.TypedInformer().AddTypedEventHandler(resourceinformers.ResourceSliceHandlerFuncs{
+		AddFunc: func(slice *resourceapi.ResourceSlice) {
 			tc.mutex.Lock()
 			defer tc.mutex.Unlock()
 			tc.handleSliceChange(nil, slice)
 		},
-		UpdateFunc: func(oldObj, newObj any) {
-			oldSlice, ok := oldObj.(*resourceapi.ResourceSlice)
-			if !ok {
-				logger.Error(nil, "Expected ResourceSlice", "actual", fmt.Sprintf("%T", oldObj))
-				return
-			}
-			newSlice, ok := newObj.(*resourceapi.ResourceSlice)
-			if !ok {
-				logger.Error(nil, "Expected ResourceSlice", "actual", fmt.Sprintf("%T", newObj))
-			}
+		UpdateFunc: func(oldSlice, newSlice *resourceapi.ResourceSlice) {
 			tc.mutex.Lock()
 			defer tc.mutex.Unlock()
 			tc.handleSliceChange(oldSlice, newSlice)
 		},
-		DeleteFunc: func(obj any) {
-			// No need to check for DeletedFinalStateUnknown here, the resourceslicetracker doesn't use that.
-			slice, ok := obj.(*resourceapi.ResourceSlice)
-			if !ok {
-				logger.Error(nil, "Expected ResourceSlice", "actual", fmt.Sprintf("%T", obj))
+		DeleteFunc: func(deleted resourceinformers.DeletedResourceSlice) {
+			slice := deleted.OptionalObj
+			if slice == nil {
+				logger.Error(nil, "Deleted ResourceSlice object is unavailable", "slice", deleted.GetKey())
 				return
 			}
 			tc.mutex.Lock()

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -133,12 +133,12 @@ type podControllerFinder func(ctx context.Context, controllerRef *metav1.OwnerRe
 
 func NewDisruptionController(
 	ctx context.Context,
-	podInformer coreinformers.PodInformer,
-	pdbInformer policyinformers.PodDisruptionBudgetInformer,
-	rcInformer coreinformers.ReplicationControllerInformer,
-	rsInformer appsv1informers.ReplicaSetInformer,
-	dInformer appsv1informers.DeploymentInformer,
-	ssInformer appsv1informers.StatefulSetInformer,
+	podInformer coreinformers.TypedPodInformer,
+	pdbInformer policyinformers.TypedPodDisruptionBudgetInformer,
+	rcInformer coreinformers.TypedReplicationControllerInformer,
+	rsInformer appsv1informers.TypedReplicaSetInformer,
+	dInformer appsv1informers.TypedDeploymentInformer,
+	ssInformer appsv1informers.TypedStatefulSetInformer,
 	kubeClient clientset.Interface,
 	restMapper apimeta.RESTMapper,
 	scaleNamespacer scaleclient.ScalesGetter,
@@ -164,12 +164,12 @@ func NewDisruptionController(
 // stalePodDisruptionTimeout
 // It is only supposed to be used by tests.
 func NewDisruptionControllerInternal(ctx context.Context,
-	podInformer coreinformers.PodInformer,
-	pdbInformer policyinformers.PodDisruptionBudgetInformer,
-	rcInformer coreinformers.ReplicationControllerInformer,
-	rsInformer appsv1informers.ReplicaSetInformer,
-	dInformer appsv1informers.DeploymentInformer,
-	ssInformer appsv1informers.StatefulSetInformer,
+	podInformer coreinformers.TypedPodInformer,
+	pdbInformer policyinformers.TypedPodDisruptionBudgetInformer,
+	rcInformer coreinformers.TypedReplicationControllerInformer,
+	rsInformer appsv1informers.TypedReplicaSetInformer,
+	dInformer appsv1informers.TypedDeploymentInformer,
+	ssInformer appsv1informers.TypedStatefulSetInformer,
 	kubeClient clientset.Interface,
 	restMapper apimeta.RESTMapper,
 	scaleNamespacer scaleclient.ScalesGetter,
@@ -212,29 +212,29 @@ func NewDisruptionControllerInternal(ctx context.Context,
 
 	dc.getUpdater = func() updater { return dc.writePdbStatus }
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc: func(obj *v1.Pod) {
 			dc.addPod(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *v1.Pod) {
 			dc.updatePod(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			dc.deletePod(logger, obj)
+		DeleteFunc: func(obj coreinformers.DeletedPod) {
+			dc.deletePod(logger, obj.OptionalObj)
 		},
 	})
 	dc.podLister = podInformer.Lister()
 	dc.podListerSynced = podInformer.Informer().HasSynced
 
-	pdbInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = pdbInformer.TypedInformer().AddTypedEventHandler(policyinformers.PodDisruptionBudgetHandlerFuncs{
+		AddFunc: func(obj *policy.PodDisruptionBudget) {
 			dc.addDB(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *policy.PodDisruptionBudget) {
 			dc.updateDB(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			dc.removeDB(logger, obj)
+		DeleteFunc: func(obj policyinformers.DeletedPodDisruptionBudget) {
+			dc.removeDB(logger, obj.OptionalObj)
 		},
 	})
 	dc.pdbLister = pdbInformer.Lister()

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -77,8 +77,8 @@ const (
 )
 
 // NewEndpointController returns a new *Controller.
-func NewEndpointController(ctx context.Context, podInformer coreinformers.PodInformer, serviceInformer coreinformers.ServiceInformer,
-	endpointsInformer coreinformers.EndpointsInformer, client clientset.Interface, endpointUpdatesBatchPeriod time.Duration) *Controller {
+func NewEndpointController(ctx context.Context, podInformer coreinformers.TypedPodInformer, serviceInformer coreinformers.TypedServiceInformer,
+	endpointsInformer coreinformers.TypedEndpointsInformer, client clientset.Interface, endpointUpdatesBatchPeriod time.Duration) *Controller {
 	broadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: ControllerName})
 
@@ -94,9 +94,9 @@ func NewEndpointController(ctx context.Context, podInformer coreinformers.PodInf
 		workerLoopPeriod: time.Second,
 	}
 
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceInformer.TypedInformer().AddTypedEventHandler(coreinformers.ServiceHandlerFuncs{
 		AddFunc: e.onServiceUpdate,
-		UpdateFunc: func(old, cur interface{}) {
+		UpdateFunc: func(old, cur *v1.Service) {
 			e.onServiceUpdate(cur)
 		},
 		DeleteFunc: e.onServiceDelete,
@@ -104,15 +104,15 @@ func NewEndpointController(ctx context.Context, podInformer coreinformers.PodInf
 	e.serviceLister = serviceInformer.Lister()
 	e.servicesSynced = serviceInformer.Informer().HasSynced
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { e.onPodUpdate(nil, obj) },
+	_, _ = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc:    func(obj *v1.Pod) { e.onPodUpdate(nil, obj) },
 		UpdateFunc: e.onPodUpdate,
-		DeleteFunc: func(obj interface{}) { e.onPodUpdate(obj, nil) },
+		DeleteFunc: func(obj coreinformers.DeletedPod) { e.onPodUpdate(obj.OptionalObj, nil) },
 	})
 	e.podLister = podInformer.Lister()
 	e.podsSynced = podInformer.Informer().HasSynced
 
-	endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = endpointsInformer.TypedInformer().AddTypedEventHandler(coreinformers.EndpointsHandlerFuncs{
 		DeleteFunc: e.onEndpointsDelete,
 	})
 	e.endpointsLister = endpointsInformer.Lister()
@@ -264,7 +264,7 @@ func podToEndpointAddressForService(svc *v1.Service, pod *v1.Pod) (*v1.EndpointA
 }
 
 // onServiceUpdate updates the Service Selector in the cache and queues the Service for processing.
-func (e *Controller) onServiceUpdate(obj interface{}) {
+func (e *Controller) onServiceUpdate(obj *v1.Service) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
@@ -274,30 +274,20 @@ func (e *Controller) onServiceUpdate(obj interface{}) {
 }
 
 // onServiceDelete removes the Service Selector from the cache and queues the Service for processing.
-func (e *Controller) onServiceDelete(obj interface{}) {
-	key, err := controller.KeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
-		return
-	}
-	e.queue.Add(key)
+func (e *Controller) onServiceDelete(obj coreinformers.DeletedService) {
+	e.queue.Add(obj.GetKey())
 }
 
 // onPodUpdate enqueues the pod's projection key on Add/Update/Delete events, to find matching services later.
-func (e *Controller) onPodUpdate(old, cur interface{}) {
+func (e *Controller) onPodUpdate(old, cur *v1.Pod) {
 	key := endpointsliceutil.GetPodUpdateProjectionKey(old, cur)
 	if key != nil {
 		e.podQueue.Add(key)
 	}
 }
 
-func (e *Controller) onEndpointsDelete(obj interface{}) {
-	key, err := controller.KeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
-		return
-	}
-	e.queue.Add(key)
+func (e *Controller) onEndpointsDelete(obj coreinformers.DeletedEndpoints) {
+	e.queue.Add(obj.GetKey())
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	clientscheme "k8s.io/client-go/kubernetes/scheme"
@@ -203,11 +204,11 @@ func makeBlockingEndpointTestServer(t *testing.T, controller *endpointController
 					// Delay the deletion of endpoints to make endpoints cache out of sync
 					<-blockDelete
 					_ = controller.endpointsStore.Delete(endpoint)
-					controller.onEndpointsDelete(endpoint)
+					controller.onEndpointsDelete(coreinformers.DeletedEndpoints{OptionalObj: endpoint})
 				}()
 			} else {
 				_ = controller.endpointsStore.Delete(endpoint)
-				controller.onEndpointsDelete(endpoint)
+				controller.onEndpointsDelete(coreinformers.DeletedEndpoints{OptionalObj: endpoint})
 			}
 			blockNextAction <- struct{}{}
 		}
@@ -2227,7 +2228,7 @@ func TestPodDeleteBatching(t *testing.T) {
 					t.Fatalf("Pod %q doesn't exist", update.podName)
 				}
 				endpoints.podStore.Delete(old)
-				endpoints.onPodUpdate(old, nil)
+				endpoints.onPodUpdate(old.(*v1.Pod), nil)
 			}
 
 			time.Sleep(tc.finalDelay)
@@ -2565,7 +2566,7 @@ func TestMultipleServiceChanges(t *testing.T) {
 	waitForChanReceive(t, 1*time.Second, blockNextAction, "Service Add should have caused a request to be sent to the test server")
 
 	controller.serviceStore.Delete(svc)
-	controller.onServiceDelete(svc)
+	controller.onServiceDelete(coreinformers.DeletedService{OptionalObj: svc})
 	waitForChanReceive(t, 1*time.Second, blockNextAction, "Service Delete should have caused a request to be sent to the test server")
 
 	// If endpoints cache has not updated before service update is registered
@@ -2914,7 +2915,7 @@ func TestEndpointsDeletionEvents(t *testing.T) {
 
 	// Test Unexpected and Expected Deletes
 	store.Delete(ep1)
-	controller.onEndpointsDelete(ep1)
+	controller.onEndpointsDelete(coreinformers.DeletedEndpoints{OptionalObj: ep1})
 
 	if controller.queue.Len() != 1 {
 		t.Errorf("Expected one service to be in the queue, found %d", controller.queue.Len())

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -82,10 +82,10 @@ const (
 )
 
 // NewController creates and initializes a new Controller
-func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
-	serviceInformer coreinformers.ServiceInformer,
-	nodeInformer coreinformers.NodeInformer,
-	endpointSliceInformer discoveryinformers.EndpointSliceInformer,
+func NewController(ctx context.Context, podInformer coreinformers.TypedPodInformer,
+	serviceInformer coreinformers.TypedServiceInformer,
+	nodeInformer coreinformers.TypedNodeInformer,
+	endpointSliceInformer discoveryinformers.TypedEndpointSliceInformer,
 	maxEndpointsPerSlice int32,
 	client clientset.Interface,
 	endpointUpdatesBatchPeriod time.Duration,
@@ -119,9 +119,9 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 		workerLoopPeriod: time.Second,
 	}
 
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceInformer.TypedInformer().AddTypedEventHandler(coreinformers.ServiceHandlerFuncs{
 		AddFunc: c.onServiceUpdate,
-		UpdateFunc: func(old, cur interface{}) {
+		UpdateFunc: func(old, cur *v1.Service) {
 			c.onServiceUpdate(cur)
 		},
 		DeleteFunc: c.onServiceDelete,
@@ -129,10 +129,10 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 	c.serviceLister = serviceInformer.Lister()
 	c.servicesSynced = serviceInformer.Informer().HasSynced
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.onPodUpdate(nil, obj) },
+	_, _ = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc:    func(obj *v1.Pod) { c.onPodUpdate(nil, obj) },
 		UpdateFunc: c.onPodUpdate,
-		DeleteFunc: func(obj interface{}) { c.onPodUpdate(obj, nil) },
+		DeleteFunc: func(obj coreinformers.DeletedPod) { c.onPodUpdate(obj.OptionalObj, nil) },
 	})
 	c.podLister = podInformer.Lister()
 	c.podsSynced = podInformer.Informer().HasSynced
@@ -141,9 +141,9 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 	c.nodesSynced = nodeInformer.Informer().HasSynced
 
 	logger := klog.FromContext(ctx)
-	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = endpointSliceInformer.TypedInformer().AddTypedEventHandler(discoveryinformers.EndpointSliceHandlerFuncs{
 		AddFunc: c.onEndpointSliceAdd,
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *discovery.EndpointSlice) {
 			c.onEndpointSliceUpdate(logger, oldObj, newObj)
 		},
 		DeleteFunc: c.onEndpointSliceDelete,
@@ -162,14 +162,14 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 
 	c.endpointUpdatesBatchPeriod = endpointUpdatesBatchPeriod
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(_ interface{}) {
+	_, _ = nodeInformer.TypedInformer().AddTypedEventHandler(coreinformers.NodeHandlerFuncs{
+		AddFunc: func(_ *v1.Node) {
 			c.addNode()
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *v1.Node) {
 			c.updateNode(oldObj, newObj)
 		},
-		DeleteFunc: func(_ interface{}) {
+		DeleteFunc: func(_ coreinformers.DeletedNode) {
 			c.deleteNode()
 		},
 	})
@@ -504,7 +504,7 @@ func (c *Controller) syncPod(logger klog.Logger, key *endpointsliceutil.PodProje
 }
 
 // onServiceUpdate updates the Service Selector in the cache and queues the Service for processing.
-func (c *Controller) onServiceUpdate(obj interface{}) {
+func (c *Controller) onServiceUpdate(obj *v1.Service) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
@@ -515,18 +515,12 @@ func (c *Controller) onServiceUpdate(obj interface{}) {
 }
 
 // onServiceDelete removes the Service Selector from the cache and queues the Service for processing.
-func (c *Controller) onServiceDelete(obj interface{}) {
-	key, err := controller.KeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %+v: %v", obj, err))
-		return
-	}
-
-	c.serviceQueue.Add(key)
+func (c *Controller) onServiceDelete(obj coreinformers.DeletedService) {
+	c.serviceQueue.Add(obj.GetKey())
 }
 
 // onPodUpdate enqueues the pod's projection key on Add/Update/Delete events, to find matching services later.
-func (c *Controller) onPodUpdate(old, cur interface{}) {
+func (c *Controller) onPodUpdate(old, cur *v1.Pod) {
 	key := endpointsliceutil.GetPodUpdateProjectionKey(old, cur)
 	if key != nil {
 		c.podQueue.Add(key)
@@ -536,8 +530,7 @@ func (c *Controller) onPodUpdate(old, cur interface{}) {
 // onEndpointSliceAdd queues a sync for the relevant Service for a sync if the
 // EndpointSlice resource version does not match the expected version in the
 // endpointSliceTracker.
-func (c *Controller) onEndpointSliceAdd(obj interface{}) {
-	endpointSlice := obj.(*discovery.EndpointSlice)
+func (c *Controller) onEndpointSliceAdd(endpointSlice *discovery.EndpointSlice) {
 	if endpointSlice == nil {
 		utilruntime.HandleError(fmt.Errorf("Invalid EndpointSlice provided to onEndpointSliceAdd()"))
 		return
@@ -551,9 +544,7 @@ func (c *Controller) onEndpointSliceAdd(obj interface{}) {
 // the EndpointSlice resource version does not match the expected version in the
 // endpointSliceTracker or the managed-by value of the EndpointSlice has changed
 // from or to this controller.
-func (c *Controller) onEndpointSliceUpdate(logger klog.Logger, prevObj, obj interface{}) {
-	prevEndpointSlice := prevObj.(*discovery.EndpointSlice)
-	endpointSlice := obj.(*discovery.EndpointSlice)
+func (c *Controller) onEndpointSliceUpdate(logger klog.Logger, prevEndpointSlice, endpointSlice *discovery.EndpointSlice) {
 	if endpointSlice == nil || prevEndpointSlice == nil {
 		utilruntime.HandleError(fmt.Errorf("Invalid EndpointSlice provided to onEndpointSliceUpdate()"))
 		return
@@ -577,8 +568,8 @@ func (c *Controller) onEndpointSliceUpdate(logger klog.Logger, prevObj, obj inte
 // onEndpointSliceDelete queues a sync for the relevant Service for a sync if the
 // EndpointSlice resource version does not match the expected version in the
 // endpointSliceTracker.
-func (c *Controller) onEndpointSliceDelete(obj interface{}) {
-	endpointSlice := getEndpointSliceFromDeleteAction(obj)
+func (c *Controller) onEndpointSliceDelete(obj discoveryinformers.DeletedEndpointSlice) {
+	endpointSlice := obj.OptionalObj
 	if endpointSlice != nil && c.reconciler.ManagedByController(endpointSlice) && c.endpointSliceTracker.Has(endpointSlice) {
 		// This returns false if we didn't expect the EndpointSlice to be
 		// deleted. If that is the case, we queue the Service for another sync.
@@ -610,10 +601,7 @@ func (c *Controller) addNode() {
 	c.topologyQueue.Add(topologyQueueItemKey)
 }
 
-func (c *Controller) updateNode(old, cur interface{}) {
-	oldNode := old.(*v1.Node)
-	curNode := cur.(*v1.Node)
-
+func (c *Controller) updateNode(oldNode, curNode *v1.Node) {
 	// LabelTopologyZone may be added by cloud provider asynchronously after the Node is created.
 	// The topology cache should be updated in this case.
 	if isNodeReady(oldNode) != isNodeReady(curNode) ||
@@ -667,27 +655,6 @@ func dropEndpointSlicesPendingDeletion(endpointSlices []*discovery.EndpointSlice
 		}
 	}
 	return endpointSlices[:n]
-}
-
-// getEndpointSliceFromDeleteAction parses an EndpointSlice from a delete action.
-func getEndpointSliceFromDeleteAction(obj interface{}) *discovery.EndpointSlice {
-	if endpointSlice, ok := obj.(*discovery.EndpointSlice); ok {
-		// Enqueue all the services that the pod used to be a member of.
-		// This is the same thing we do when we add a pod.
-		return endpointSlice
-	}
-	// If we reached here it means the pod was deleted but its final state is unrecorded.
-	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get object from tombstone %#v", obj))
-		return nil
-	}
-	endpointSlice, ok := tombstone.Obj.(*discovery.EndpointSlice)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("Tombstone contained object that is not a EndpointSlice: %#v", obj))
-		return nil
-	}
-	return endpointSlice
 }
 
 // isNodeReady returns true if a node is ready; false otherwise.

--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -1687,7 +1687,7 @@ func TestPodDeleteBatching(t *testing.T) {
 				require.NoError(t, err, "error while retrieving old value of %q: %v", update.podName, err)
 				assert.True(t, exists, "pod should exist")
 				esController.podStore.Delete(old)
-				esController.onPodUpdate(old, nil)
+				esController.onPodUpdate(old.(*v1.Pod), nil)
 			}
 
 			time.Sleep(tc.finalDelay)

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -69,9 +69,9 @@ const (
 )
 
 // NewController creates and initializes a new Controller
-func NewController(ctx context.Context, endpointsInformer coreinformers.EndpointsInformer,
-	endpointSliceInformer discoveryinformers.EndpointSliceInformer,
-	serviceInformer coreinformers.ServiceInformer,
+func NewController(ctx context.Context, endpointsInformer coreinformers.TypedEndpointsInformer,
+	endpointSliceInformer discoveryinformers.TypedEndpointSliceInformer,
+	serviceInformer coreinformers.TypedServiceInformer,
 	maxEndpointsPerSubset int32,
 	client clientset.Interface,
 	endpointUpdatesBatchPeriod time.Duration,
@@ -102,26 +102,26 @@ func NewController(ctx context.Context, endpointsInformer coreinformers.Endpoint
 		workerLoopPeriod: time.Second,
 	}
 
-	endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = endpointsInformer.TypedInformer().AddTypedEventHandler(coreinformers.EndpointsHandlerFuncs{
+		AddFunc: func(obj *v1.Endpoints) { //nolint:staticcheck // This controller intentionally mirrors the deprecated Endpoints API.
 			c.onEndpointsAdd(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *v1.Endpoints) { //nolint:staticcheck // This controller intentionally mirrors the deprecated Endpoints API.
 			c.onEndpointsUpdate(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			c.onEndpointsDelete(logger, obj)
+		DeleteFunc: func(obj coreinformers.DeletedEndpoints) {
+			c.onEndpointsDelete(logger, obj.OptionalObj)
 		},
 	})
 	c.endpointsLister = endpointsInformer.Lister()
 	c.endpointsSynced = endpointsInformer.Informer().HasSynced
 
-	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: c.onEndpointSliceAdd,
-		UpdateFunc: func(oldObj, newObj interface{}) {
+	_, _ = endpointSliceInformer.TypedInformer().AddTypedEventHandler(discoveryinformers.EndpointSliceHandlerFuncs{
+		AddFunc: func(obj *discovery.EndpointSlice) { c.onEndpointSliceAdd(obj) },
+		UpdateFunc: func(oldObj, newObj *discovery.EndpointSlice) {
 			c.onEndpointSliceUpdate(logger, oldObj, newObj)
 		},
-		DeleteFunc: c.onEndpointSliceDelete,
+		DeleteFunc: func(obj discoveryinformers.DeletedEndpointSlice) { c.onEndpointSliceDelete(obj.OptionalObj) },
 	})
 
 	c.endpointSliceLister = endpointSliceInformer.Lister()
@@ -130,10 +130,10 @@ func NewController(ctx context.Context, endpointsInformer coreinformers.Endpoint
 
 	c.serviceLister = serviceInformer.Lister()
 	c.servicesSynced = serviceInformer.Informer().HasSynced
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.onServiceAdd,
-		UpdateFunc: c.onServiceUpdate,
-		DeleteFunc: c.onServiceDelete,
+	_, _ = serviceInformer.TypedInformer().AddTypedEventHandler(coreinformers.ServiceHandlerFuncs{
+		AddFunc:    func(obj *v1.Service) { c.onServiceAdd(obj) },
+		UpdateFunc: func(oldObj, newObj *v1.Service) { c.onServiceUpdate(oldObj, newObj) },
+		DeleteFunc: func(obj coreinformers.DeletedService) { c.onServiceDelete(obj.OptionalObj) },
 	})
 
 	c.maxEndpointsPerSubset = maxEndpointsPerSubset

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -209,18 +209,18 @@ var (
 // workloadInformer and podGroupInformer may be nil when the WorkloadWithJob
 // feature gate is disabled; they are required when the gate is enabled.
 func NewController(ctx context.Context, kubeClient clientset.Interface,
-	podInformer coreinformers.PodInformer, jobInformer batchinformers.JobInformer,
-	workloadInformer schedulinginformers.WorkloadInformer,
-	podGroupInformer schedulinginformers.PodGroupInformer) (*Controller, error) {
+	podInformer coreinformers.TypedPodInformer, jobInformer batchinformers.TypedJobInformer,
+	workloadInformer schedulinginformers.TypedWorkloadInformer,
+	podGroupInformer schedulinginformers.TypedPodGroupInformer) (*Controller, error) {
 
 	return newControllerWithClock(ctx, kubeClient, &clock.RealClock{},
 		podInformer, jobInformer, workloadInformer, podGroupInformer)
 }
 
 func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface, clock clock.WithTicker,
-	podInformer coreinformers.PodInformer, jobInformer batchinformers.JobInformer,
-	workloadInformer schedulinginformers.WorkloadInformer,
-	podGroupInformer schedulinginformers.PodGroupInformer,
+	podInformer coreinformers.TypedPodInformer, jobInformer batchinformers.TypedJobInformer,
+	workloadInformer schedulinginformers.TypedWorkloadInformer,
+	podGroupInformer schedulinginformers.TypedPodGroupInformer,
 ) (*Controller, error) {
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	logger := klog.FromContext(ctx)
@@ -269,15 +269,15 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 		consistencyStore:        consistencyStore,
 	}
 
-	if _, err := jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	if _, err := jobInformer.TypedInformer().AddTypedEventHandler(batchinformers.JobHandlerFuncs{
+		AddFunc: func(obj *batch.Job) {
 			jm.addJob(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *batch.Job) {
 			jm.updateJob(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			jm.deleteJob(logger, obj)
+		DeleteFunc: func(obj batchinformers.DeletedJob) {
+			jm.deleteJob(logger, obj.OptionalObj)
 		},
 	}); err != nil {
 		return nil, fmt.Errorf("adding Job event handler: %w", err)
@@ -285,15 +285,15 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 	jm.jobLister = jobInformer.Lister()
 	jm.jobStoreSynced = jobInformer.Informer().HasSynced
 
-	if _, err := podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	if _, err := podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc: func(obj *v1.Pod) {
 			jm.addPod(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *v1.Pod) {
 			jm.updatePod(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			jm.deletePod(logger, obj, true)
+		DeleteFunc: func(obj coreinformers.DeletedPod) {
+			jm.deletePod(logger, obj.OptionalObj, true)
 		},
 	}); err != nil {
 		return nil, fmt.Errorf("adding Pod event handler: %w", err)

--- a/pkg/controller/job/job_scheduling_manager.go
+++ b/pkg/controller/job/job_scheduling_manager.go
@@ -688,7 +688,7 @@ func computePodGroupName(workloadName, templateName string) string {
 
 // addSchedulingInformers wires up Workload and PodGroup informers
 // and indexers so that changes to those objects re-enqueue the owning Job.
-func (jm *Controller) addSchedulingInformers(logger klog.Logger, workloadInformer schedulinginformers.WorkloadInformer, podGroupInformer schedulinginformers.PodGroupInformer) error {
+func (jm *Controller) addSchedulingInformers(logger klog.Logger, workloadInformer schedulinginformers.TypedWorkloadInformer, podGroupInformer schedulinginformers.TypedPodGroupInformer) error {
 	if workloadInformer == nil {
 		return fmt.Errorf("workload informer is required when the feature gate %q is enabled", features.WorkloadWithJob)
 	}

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -83,7 +83,7 @@ func NewNamespaceController(
 	}
 
 	// configure the namespace informer event handlers
-	namespaceInformer.TypedInformer().AddTypedEventHandler(
+	_, _ = namespaceInformer.TypedInformer().AddTypedEventHandler(
 		coreinformers.NamespaceHandlerFuncs{
 			AddFunc: func(namespace *v1.Namespace) {
 				namespaceController.enqueueNamespace(namespace)

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/namespace/deletion"
 
 	"k8s.io/klog/v2"
@@ -68,7 +67,7 @@ func NewNamespaceController(
 	kubeClient clientset.Interface,
 	metadataClient metadata.Interface,
 	discoverResourcesFn func() ([]*metav1.APIResourceList, error),
-	namespaceInformer coreinformers.NamespaceInformer,
+	namespaceInformer coreinformers.TypedNamespaceInformer,
 	resyncPeriod time.Duration,
 	finalizerToken v1.FinalizerName) *NamespaceController {
 
@@ -84,18 +83,16 @@ func NewNamespaceController(
 	}
 
 	// configure the namespace informer event handlers
-	namespaceInformer.Informer().AddEventHandlerWithResyncPeriod(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				namespace := obj.(*v1.Namespace)
-				namespaceController.enqueueNamespace(ctx, namespace)
+	namespaceInformer.TypedInformer().AddTypedEventHandler(
+		coreinformers.NamespaceHandlerFuncs{
+			AddFunc: func(namespace *v1.Namespace) {
+				namespaceController.enqueueNamespace(namespace)
 			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				namespace := newObj.(*v1.Namespace)
-				namespaceController.enqueueNamespace(ctx, namespace)
+			UpdateFunc: func(_, namespace *v1.Namespace) {
+				namespaceController.enqueueNamespace(namespace)
 			},
 		},
-		resyncPeriod,
+		cache.HandlerOptions{ResyncPeriod: &resyncPeriod},
 	)
 	namespaceController.lister = namespaceInformer.Lister()
 	namespaceController.listerSynced = namespaceInformer.Informer().HasSynced
@@ -116,15 +113,7 @@ func nsControllerRateLimiter() workqueue.TypedRateLimiter[string] {
 }
 
 // enqueueNamespace adds an object to the controller work queue
-// obj could be an *v1.Namespace, or a DeletionFinalStateUnknown item.
-func (nm *NamespaceController) enqueueNamespace(ctx context.Context, obj interface{}) {
-	key, err := controller.KeyFunc(obj)
-	if err != nil {
-		utilruntime.HandleErrorWithContext(ctx, err, "Couldn't get key for object", "object", obj)
-		return
-	}
-
-	namespace := obj.(*v1.Namespace)
+func (nm *NamespaceController) enqueueNamespace(namespace *v1.Namespace) {
 	// don't queue if we aren't deleted
 	if namespace.DeletionTimestamp == nil || namespace.DeletionTimestamp.IsZero() {
 		return
@@ -132,7 +121,7 @@ func (nm *NamespaceController) enqueueNamespace(ctx context.Context, obj interfa
 
 	// delay processing namespace events to allow HA api servers to observe namespace deletion,
 	// and HA etcd servers to observe last minute object creations inside the namespace
-	nm.queue.AddAfter(key, namespaceDeletionGracePeriod)
+	nm.queue.AddAfter(namespace.Name, namespaceDeletionGracePeriod)
 }
 
 // worker processes the queue of namespace objects.

--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -95,7 +95,7 @@ type CIDRAllocatorParams struct {
 }
 
 // New creates a new CIDR range allocator.
-func New(ctx context.Context, kubeClient clientset.Interface, cloud cloudprovider.Interface, nodeInformer informers.NodeInformer, allocatorType CIDRAllocatorType, allocatorParams CIDRAllocatorParams) (CIDRAllocator, error) {
+func New(ctx context.Context, kubeClient clientset.Interface, cloud cloudprovider.Interface, nodeInformer informers.TypedNodeInformer, allocatorType CIDRAllocatorType, allocatorParams CIDRAllocatorParams) (CIDRAllocator, error) {
 	nodeList, err := listNodes(ctx, kubeClient)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -69,7 +69,7 @@ var _ CIDRAllocator = &rangeAllocator{}
 // Caller must always pass in a list of existing nodes so the new allocator.
 // Caller must ensure that ClusterCIDRs are semantically correct e.g (1 for non DualStack, 2 for DualStack etc..)
 // can initialize its CIDR map. NodeList is only nil in testing.
-func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, nodeInformer informers.NodeInformer, allocatorParams CIDRAllocatorParams, nodeList *v1.NodeList) (CIDRAllocator, error) {
+func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, nodeInformer informers.TypedNodeInformer, allocatorParams CIDRAllocatorParams, nodeList *v1.NodeList) (CIDRAllocator, error) {
 	logger := klog.FromContext(ctx)
 	if client == nil {
 		logger.Error(nil, "kubeClient is nil when starting CIDRRangeAllocator")
@@ -130,40 +130,25 @@ func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, node
 		}
 	}
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			key, err := cache.MetaNamespaceKeyFunc(obj)
-			if err == nil {
-				ra.queue.Add(key)
-			}
+	nodeInformer.TypedInformer().AddTypedEventHandler(informers.NodeHandlerFuncs{
+		AddFunc: func(node *v1.Node) {
+			ra.queue.Add(node.Name)
 		},
-		UpdateFunc: func(old, new interface{}) {
-			key, err := cache.MetaNamespaceKeyFunc(new)
-			if err == nil {
-				ra.queue.Add(key)
-			}
+		UpdateFunc: func(_, node *v1.Node) {
+			ra.queue.Add(node.Name)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(deleted informers.DeletedNode) {
 			// The informer cache no longer has the object, and since Node doesn't have a finalizer,
 			// we don't see the Update with DeletionTimestamp != 0.
-			node, ok := obj.(*v1.Node)
-			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					utilruntime.HandleErrorWithContext(ctx, nil, "Could not get object from tombstone", "obj", obj)
-					return
-				}
-				node, ok = tombstone.Obj.(*v1.Node)
-				if !ok {
-					utilruntime.HandleErrorWithContext(ctx, nil, "Tombstone contained object that is not a node", "type", fmt.Sprintf("%T", obj))
-					return
-				}
+			if deleted.OptionalObj == nil {
+				utilruntime.HandleErrorWithContext(ctx, nil, "Deleted node object is unavailable", "node", deleted.GetName())
+				return
 			}
-			if err := ra.ReleaseCIDR(logger, node); err != nil {
+			if err := ra.ReleaseCIDR(logger, deleted.OptionalObj); err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Error while processing CIDR Release")
 			}
 		},
-	})
+	}, cache.HandlerOptions{})
 
 	return ra, nil
 }

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -130,7 +130,7 @@ func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, node
 		}
 	}
 
-	nodeInformer.TypedInformer().AddTypedEventHandler(informers.NodeHandlerFuncs{
+	_, _ = nodeInformer.TypedInformer().AddTypedEventHandler(informers.NodeHandlerFuncs{
 		AddFunc: func(node *v1.Node) {
 			ra.queue.Add(node.Name)
 		},
@@ -148,7 +148,7 @@ func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, node
 				utilruntime.HandleErrorWithContext(ctx, err, "Error while processing CIDR Release")
 			}
 		},
-	}, cache.HandlerOptions{})
+	})
 
 	return ra, nil
 }

--- a/pkg/controller/nodeipam/ipam/test/utils.go
+++ b/pkg/controller/nodeipam/ipam/test/utils.go
@@ -44,7 +44,7 @@ func MustParseCIDR(s string) *net.IPNet {
 }
 
 // FakeNodeInformer creates a fakeNodeInformer using the provided fakeNodeHandler.
-func FakeNodeInformer(fakeNodeHandler *testutil.FakeNodeHandler) coreinformers.NodeInformer {
+func FakeNodeInformer(fakeNodeHandler *testutil.FakeNodeHandler) coreinformers.TypedNodeInformer {
 	fakeClient := &fake.Clientset{}
 	fakeInformerFactory := informers.NewSharedInformerFactory(fakeClient, controller.NoResyncPeriodFunc())
 	fakeNodeInformer := fakeInformerFactory.Core().V1().Nodes()

--- a/pkg/controller/nodeipam/node_ipam_controller.go
+++ b/pkg/controller/nodeipam/node_ipam_controller.go
@@ -65,7 +65,7 @@ type Controller struct {
 // currently, this should be handled as a fatal error.
 func NewNodeIpamController(
 	ctx context.Context,
-	nodeInformer coreinformers.NodeInformer,
+	nodeInformer coreinformers.TypedNodeInformer,
 	cloud cloudprovider.Interface,
 	kubeClient clientset.Interface,
 	clusterCIDRs []*net.IPNet,

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -313,10 +313,10 @@ type Controller struct {
 // NewNodeLifecycleController returns a new taint controller.
 func NewNodeLifecycleController(
 	ctx context.Context,
-	leaseInformer coordinformers.LeaseInformer,
-	podInformer coreinformers.PodInformer,
-	nodeInformer coreinformers.NodeInformer,
-	daemonSetInformer appsv1informers.DaemonSetInformer,
+	leaseInformer coordinformers.TypedLeaseInformer,
+	podInformer coreinformers.TypedPodInformer,
+	nodeInformer coreinformers.TypedNodeInformer,
+	daemonSetInformer appsv1informers.TypedDaemonSetInformer,
 	kubeClient clientset.Interface,
 	nodeMonitorPeriod time.Duration,
 	nodeStartupGracePeriod time.Duration,
@@ -366,15 +366,12 @@ func NewNodeLifecycleController(
 	nc.enterFullDisruptionFunc = nc.HealthyQPSFunc
 	nc.computeZoneStateFunc = nc.ComputeZoneState
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			pod := obj.(*v1.Pod)
+	_, _ = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc: func(pod *v1.Pod) {
 			nc.podUpdated(nil, pod)
 		},
-		UpdateFunc: func(prev, obj interface{}) {
-			prevPod := prev.(*v1.Pod)
-			newPod := obj.(*v1.Pod)
-			nc.podUpdated(prevPod, newPod)
+		UpdateFunc: func(prev, pod *v1.Pod) {
+			nc.podUpdated(prev, pod)
 		},
 	})
 	nc.podInformerSynced = podInformer.Informer().HasSynced
@@ -408,19 +405,24 @@ func NewNodeLifecycleController(
 	}
 
 	logger.Info("Controller will reconcile labels")
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: controllerutil.CreateAddNodeHandler(func(node *v1.Node) error {
+	_, _ = nodeInformer.TypedInformer().AddTypedEventHandler(coreinformers.NodeHandlerFuncs{
+		AddFunc: func(node *v1.Node) {
+			node = node.DeepCopy()
 			nc.nodeUpdateQueue.Add(node.Name)
-			return nil
-		}),
-		UpdateFunc: controllerutil.CreateUpdateNodeHandler(func(_, newNode *v1.Node) error {
+		},
+		UpdateFunc: func(_, newNode *v1.Node) {
+			newNode = newNode.DeepCopy()
 			nc.nodeUpdateQueue.Add(newNode.Name)
-			return nil
-		}),
-		DeleteFunc: controllerutil.CreateDeleteNodeHandler(logger, func(node *v1.Node) error {
+		},
+		DeleteFunc: func(deleted coreinformers.DeletedNode) {
+			node := deleted.OptionalObj
+			if node == nil {
+				logger.Error(nil, "Deleted Node object is unavailable", "node", deleted.GetKey())
+				return
+			}
+			node = node.DeepCopy()
 			nc.nodesToRetry.Delete(node.Name)
-			return nil
-		}),
+		},
 	})
 
 	nc.leaseLister = leaseInformer.Lister()

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -142,8 +142,8 @@ func NewHorizontalController(
 	hpaNamespacer autoscalingclient.HorizontalPodAutoscalersGetter,
 	mapper apimeta.RESTMapper,
 	metricsClient metricsclient.MetricsClient,
-	hpaInformer autoscalinginformers.HorizontalPodAutoscalerInformer,
-	podInformer coreinformers.PodInformer,
+	hpaInformer autoscalinginformers.TypedHorizontalPodAutoscalerInformer,
+	podInformer coreinformers.TypedPodInformer,
 	resyncPeriod time.Duration,
 	downscaleStabilisationWindow time.Duration,
 	tolerance float64,
@@ -193,13 +193,15 @@ func NewHorizontalController(
 		hpaController.selectorTracker = newBiMultimapSelectorTracker()
 	}
 
-	hpaInformer.Informer().AddEventHandlerWithResyncPeriod(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    hpaController.enqueueHPA,
-			UpdateFunc: hpaController.updateHPA,
-			DeleteFunc: hpaController.deleteHPA,
+	_, _ = hpaInformer.TypedInformer().AddTypedEventHandler(
+		autoscalinginformers.HorizontalPodAutoscalerHandlerFuncs{
+			AddFunc:    func(hpa *autoscalingv2.HorizontalPodAutoscaler) { hpaController.enqueueHPA(hpa) },
+			UpdateFunc: func(oldHPA, newHPA *autoscalingv2.HorizontalPodAutoscaler) { hpaController.updateHPA(oldHPA, newHPA) },
+			DeleteFunc: func(hpa autoscalinginformers.DeletedHorizontalPodAutoscaler) {
+				hpaController.deleteHPA(hpa.OptionalObj)
+			},
 		},
-		resyncPeriod,
+		cache.HandlerOptions{ResyncPeriod: &resyncPeriod},
 	)
 	hpaController.hpaLister = hpaInformer.Lister()
 	hpaController.hpaListerSynced = hpaInformer.Informer().HasSynced

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -152,7 +152,7 @@ func DefaultReplicaSetControllerFeatures() ReplicaSetControllerFeatures {
 }
 
 // NewReplicaSetController configures a replica set controller with the specified event recorder
-func NewReplicaSetController(ctx context.Context, rsInformer appsinformers.ReplicaSetInformer, podInformer coreinformers.PodInformer, kubeClient clientset.Interface, burstReplicas int) *ReplicaSetController {
+func NewReplicaSetController(ctx context.Context, rsInformer appsinformers.TypedReplicaSetInformer, podInformer coreinformers.TypedPodInformer, kubeClient clientset.Interface, burstReplicas int) *ReplicaSetController {
 	logger := klog.FromContext(ctx)
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	if err := metrics.Register(legacyregistry.Register); err != nil {
@@ -201,7 +201,7 @@ func NewReplicaSetController(ctx context.Context, rsInformer appsinformers.Repli
 
 // NewBaseController is the implementation of NewReplicaSetController with additional injected
 // parameters so that it can also serve as the implementation of NewReplicationController.
-func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetInformer, podInformer coreinformers.PodInformer, kubeClient clientset.Interface, burstReplicas int,
+func NewBaseController(logger klog.Logger, rsInformer appsinformers.TypedReplicaSetInformer, podInformer coreinformers.TypedPodInformer, kubeClient clientset.Interface, burstReplicas int,
 	gvk schema.GroupVersionKind, metricOwnerName, queueName string, podControl controller.PodControlInterface, eventBroadcaster record.EventBroadcaster, controllerFeatures ReplicaSetControllerFeatures, consistencyStore consistencyutil.ConsistencyStore) *ReplicaSetController {
 
 	rsc := &ReplicaSetController{
@@ -220,15 +220,15 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 		consistencyStore:   consistencyStore,
 	}
 
-	rsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = rsInformer.TypedInformer().AddTypedEventHandler(appsinformers.ReplicaSetHandlerFuncs{
+		AddFunc: func(obj *apps.ReplicaSet) {
 			rsc.addRS(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *apps.ReplicaSet) {
 			rsc.updateRS(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			rsc.deleteRS(logger, obj)
+		DeleteFunc: func(deleted appsinformers.DeletedReplicaSet) {
+			rsc.deleteRS(logger, deleted)
 		},
 	})
 	rsInformer.Informer().AddIndexers(cache.Indexers{
@@ -248,18 +248,18 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 	rsc.rsLister = rsInformer.Lister()
 	rsc.rsListerSynced = rsInformer.Informer().HasSynced
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc: func(obj *v1.Pod) {
 			rsc.addPod(logger, obj)
 		},
 		// This invokes the ReplicaSet for every pod change, eg: host assignment. Though this might seem like
 		// overkill the most frequent pod update is status, and the associated ReplicaSet will only list from
 		// local storage, so it should be ok.
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *v1.Pod) {
 			rsc.updatePod(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			rsc.deletePod(logger, obj)
+		DeleteFunc: func(deleted coreinformers.DeletedPod) {
+			rsc.deletePod(logger, deleted)
 		},
 	})
 	rsc.podLister = podInformer.Lister()
@@ -384,16 +384,13 @@ func (rsc *ReplicaSetController) enqueueRSAfter(rs *apps.ReplicaSet, duration ti
 	rsc.queue.AddAfter(key, duration)
 }
 
-func (rsc *ReplicaSetController) addRS(logger klog.Logger, obj interface{}) {
-	rs := obj.(*apps.ReplicaSet)
+func (rsc *ReplicaSetController) addRS(logger klog.Logger, rs *apps.ReplicaSet) {
 	logger.V(4).Info("Adding", "replicaSet", klog.KObj(rs))
 	rsc.enqueueRS(rs)
 }
 
 // callback when RS is updated
-func (rsc *ReplicaSetController) updateRS(logger klog.Logger, old, cur interface{}) {
-	oldRS := old.(*apps.ReplicaSet)
-	curRS := cur.(*apps.ReplicaSet)
+func (rsc *ReplicaSetController) updateRS(logger klog.Logger, oldRS, curRS *apps.ReplicaSet) {
 
 	// TODO: make a KEP and fix informers to always call the delete event handler on re-create
 	if curRS.UID != oldRS.UID {
@@ -402,10 +399,7 @@ func (rsc *ReplicaSetController) updateRS(logger klog.Logger, old, cur interface
 			utilruntime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", oldRS, err))
 			return
 		}
-		rsc.deleteRS(logger, cache.DeletedFinalStateUnknown{
-			Key: key,
-			Obj: oldRS,
-		})
+		rsc.deleteRS(logger, appsinformers.DeletedReplicaSet{OptionalObj: oldRS, FinalStateUnknown: &cache.DeletedFinalStateUnknown{Key: key, Obj: oldRS}})
 	}
 
 	// You might imagine that we only really need to enqueue the
@@ -426,20 +420,12 @@ func (rsc *ReplicaSetController) updateRS(logger klog.Logger, old, cur interface
 	rsc.enqueueRS(curRS)
 }
 
-func (rsc *ReplicaSetController) deleteRS(logger klog.Logger, obj interface{}) {
-	rs, ok := obj.(*apps.ReplicaSet)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-			return
-		}
-		rs, ok = tombstone.Obj.(*apps.ReplicaSet)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a ReplicaSet %#v", obj))
-			return
-		}
+func (rsc *ReplicaSetController) deleteRS(logger klog.Logger, deleted appsinformers.DeletedReplicaSet) {
+	if deleted.OptionalObj == nil {
+		utilruntime.HandleError(fmt.Errorf("deleted ReplicaSet object %q is unavailable", deleted.GetKey()))
+		return
 	}
+	rs := deleted.OptionalObj
 
 	key, err := controller.KeyFunc(rs)
 	if err != nil {
@@ -460,13 +446,12 @@ func (rsc *ReplicaSetController) deleteRS(logger klog.Logger, obj interface{}) {
 }
 
 // When a pod is created, enqueue the replica set that manages it and update its expectations.
-func (rsc *ReplicaSetController) addPod(logger klog.Logger, obj interface{}) {
-	pod := obj.(*v1.Pod)
+func (rsc *ReplicaSetController) addPod(logger klog.Logger, pod *v1.Pod) {
 
 	if pod.DeletionTimestamp != nil {
 		// on a restart of the controller manager, it's possible a new pod shows up in a state that
 		// is already pending deletion. Prevent the pod from being a creation observation.
-		rsc.deletePod(logger, pod)
+		rsc.deletePod(logger, coreinformers.DeletedPod{OptionalObj: pod})
 		return
 	}
 
@@ -503,9 +488,7 @@ func (rsc *ReplicaSetController) addPod(logger klog.Logger, obj interface{}) {
 // When a pod is updated, figure out what replica set/s manage it and wake them
 // up. If the labels of the pod have changed we need to awaken both the old
 // and new replica set. old and cur must be *v1.Pod types.
-func (rsc *ReplicaSetController) updatePod(logger klog.Logger, old, cur interface{}) {
-	curPod := cur.(*v1.Pod)
-	oldPod := old.(*v1.Pod)
+func (rsc *ReplicaSetController) updatePod(logger klog.Logger, oldPod, curPod *v1.Pod) {
 	if curPod.ResourceVersion == oldPod.ResourceVersion {
 		// Periodic resync will send update events for all known pods.
 		// Two different versions of the same pod will always have different RVs.
@@ -519,10 +502,10 @@ func (rsc *ReplicaSetController) updatePod(logger klog.Logger, old, cur interfac
 		// for modification of the deletion timestamp and expect an rs to create more replicas asap, not wait
 		// until the kubelet actually deletes the pod. This is different from the Phase of a pod changing, because
 		// an rs never initiates a phase change, and so is never asleep waiting for the same.
-		rsc.deletePod(logger, curPod)
+		rsc.deletePod(logger, coreinformers.DeletedPod{OptionalObj: curPod})
 		if labelChanged {
 			// we don't need to check the oldPod.DeletionTimestamp because DeletionTimestamp cannot be unset.
-			rsc.deletePod(logger, oldPod)
+			rsc.deletePod(logger, coreinformers.DeletedPod{OptionalObj: oldPod})
 		}
 		return
 	}
@@ -578,25 +561,16 @@ func (rsc *ReplicaSetController) updatePod(logger klog.Logger, old, cur interfac
 
 // When a pod is deleted, enqueue the replica set that manages the pod and update its expectations.
 // obj could be an *v1.Pod, or a DeletionFinalStateUnknown marker item.
-func (rsc *ReplicaSetController) deletePod(logger klog.Logger, obj interface{}) {
-	pod, ok := obj.(*v1.Pod)
-
+func (rsc *ReplicaSetController) deletePod(logger klog.Logger, deleted coreinformers.DeletedPod) {
 	// When a delete is dropped, the relist will notice a pod in the store not
 	// in the list, leading to the insertion of a tombstone object which contains
 	// the deleted key/value. Note that this value might be stale. If the pod
 	// changed labels the new ReplicaSet will not be woken up till the periodic resync.
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %+v", obj))
-			return
-		}
-		pod, ok = tombstone.Obj.(*v1.Pod)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a pod %#v", obj))
-			return
-		}
+	if deleted.OptionalObj == nil {
+		utilruntime.HandleError(fmt.Errorf("deleted Pod object %q is unavailable", deleted.GetKey()))
+		return
 	}
+	pod := deleted.OptionalObj
 
 	controllerRef := metav1.GetControllerOf(pod)
 	if controllerRef == nil {

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -44,6 +44,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
+	appsinformers "k8s.io/client-go/informers/apps/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
@@ -261,7 +263,7 @@ func TestDeleteFinalStateUnknown(t *testing.T) {
 	rsSpec := newReplicaSet(1, labelMap)
 	informers.Apps().V1().ReplicaSets().Informer().GetIndexer().Add(rsSpec)
 	pods := newPodList(nil, 1, v1.PodRunning, labelMap, rsSpec, "pod")
-	manager.deletePod(logger, cache.DeletedFinalStateUnknown{Key: "foo", Obj: &pods.Items[0]})
+	manager.deletePod(logger, coreinformers.DeletedPod{OptionalObj: &pods.Items[0], FinalStateUnknown: &cache.DeletedFinalStateUnknown{Key: "foo", Obj: &pods.Items[0]}})
 
 	go manager.worker(ctx)
 
@@ -1032,7 +1034,7 @@ func doTestControllerBurstReplicas(t *testing.T, burstReplicas, numReplicas int)
 				// don't double delete.
 				for i := range podsToDelete[1:] {
 					informers.Core().V1().Pods().Informer().GetIndexer().Delete(podsToDelete[i])
-					manager.deletePod(logger, podsToDelete[i])
+					manager.deletePod(logger, coreinformers.DeletedPod{OptionalObj: podsToDelete[i]})
 				}
 				podExp, exists, err := manager.expectations.GetExpectations(rsKey)
 				if !exists || err != nil {
@@ -1075,7 +1077,7 @@ func doTestControllerBurstReplicas(t *testing.T, burstReplicas, numReplicas int)
 					},
 				}
 				informers.Core().V1().Pods().Informer().GetIndexer().Delete(lastPod)
-				manager.deletePod(logger, lastPod)
+				manager.deletePod(logger, coreinformers.DeletedPod{OptionalObj: lastPod})
 			}
 			pods.Items = pods.Items[expectedPods:]
 		}
@@ -1174,7 +1176,7 @@ func TestDeleteControllerAndExpectations(t *testing.T) {
 		t.Errorf("No expectations found for ReplicaSet")
 	}
 	informers.Apps().V1().ReplicaSets().Informer().GetIndexer().Delete(rs)
-	manager.deleteRS(logger, rs)
+	manager.deleteRS(logger, appsinformers.DeletedReplicaSet{OptionalObj: rs})
 	manager.syncReplicaSet(ctx, GetKey(rs, t))
 
 	_, exists, err = manager.expectations.GetExpectations(rsKey)
@@ -1485,14 +1487,14 @@ func TestDeletionTimestamp(t *testing.T) {
 
 	// A pod with a non-nil deletion timestamp should also be ignored by the
 	// delete handler, because it's already been counted in the update.
-	manager.deletePod(logger, &pod)
+	manager.deletePod(logger, coreinformers.DeletedPod{OptionalObj: &pod})
 	podExp, exists, err = manager.expectations.GetExpectations(rsKey)
 	if !exists || err != nil || podExp.Fulfilled() {
 		t.Fatalf("Wrong expectations %#v", podExp)
 	}
 
 	// Deleting the second pod should clear expectations.
-	manager.deletePod(logger, secondPod)
+	manager.deletePod(logger, coreinformers.DeletedPod{OptionalObj: secondPod})
 
 	queueRS, _ = manager.queue.Get()
 	if queueRS != rsKey {

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	appsv1apply "k8s.io/client-go/applyconfigurations/apps/v1"
 	appsv1autoscaling "k8s.io/client-go/applyconfigurations/autoscaling/v1"
+	appsinformers "k8s.io/client-go/informers/apps/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	appsv1client "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -54,11 +55,15 @@ import (
 // informerAdapter implements ReplicaSetInformer by wrapping ReplicationControllerInformer
 // and converting objects.
 type informerAdapter struct {
-	rcInformer coreinformers.ReplicationControllerInformer
+	rcInformer coreinformers.TypedReplicationControllerInformer
 }
 
 func (i informerAdapter) Informer() cache.SharedIndexInformer {
 	return conversionInformer{i.rcInformer.Informer()}
+}
+
+func (i informerAdapter) TypedInformer() appsinformers.ReplicaSetIndexInformer {
+	return cache.NewTypedSharedIndexInformer[*apps.ReplicaSet](i.Informer())
 }
 
 func (i informerAdapter) Lister() appslisters.ReplicaSetLister {
@@ -75,6 +80,10 @@ func (i conversionInformer) AddEventHandler(handler cache.ResourceEventHandler) 
 
 func (i conversionInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
 	return i.SharedIndexInformer.AddEventHandlerWithResyncPeriod(conversionEventHandler{handler}, resyncPeriod)
+}
+
+func (i conversionInformer) AddEventHandlerWithOptions(handler cache.ResourceEventHandler, options cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
+	return i.SharedIndexInformer.AddEventHandlerWithOptions(conversionEventHandler{handler}, options)
 }
 
 type conversionLister struct {

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -51,7 +51,7 @@ type ReplicationManager struct {
 }
 
 // NewReplicationManager configures a replication manager with the specified event recorder
-func NewReplicationManager(ctx context.Context, podInformer coreinformers.PodInformer, rcInformer coreinformers.ReplicationControllerInformer, kubeClient clientset.Interface, burstReplicas int) *ReplicationManager {
+func NewReplicationManager(ctx context.Context, podInformer coreinformers.TypedPodInformer, rcInformer coreinformers.TypedReplicationControllerInformer, kubeClient clientset.Interface, burstReplicas int) *ReplicationManager {
 	logger := klog.FromContext(ctx)
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	return &ReplicationManager{

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -196,10 +196,10 @@ type nonRetryableError struct {
 func NewController(
 	logger klog.Logger,
 	kubeClient clientset.Interface,
-	podInformer v1informers.PodInformer,
-	podGroupInformer schedulinginformers.PodGroupInformer,
-	claimInformer resourceinformers.ResourceClaimInformer,
-	templateInformer resourceinformers.ResourceClaimTemplateInformer) (*Controller, error) {
+	podInformer v1informers.TypedPodInformer,
+	podGroupInformer schedulinginformers.TypedPodGroupInformer,
+	claimInformer resourceinformers.TypedResourceClaimInformer,
+	templateInformer resourceinformers.TypedResourceClaimTemplateInformer) (*Controller, error) {
 	return newControllerWithFeatures(
 		logger,
 		kubeClient,
@@ -219,10 +219,10 @@ func NewController(
 func newControllerWithFeatures(
 	logger klog.Logger,
 	kubeClient clientset.Interface,
-	podInformer v1informers.PodInformer,
-	podGroupInformer schedulinginformers.PodGroupInformer,
-	claimInformer resourceinformers.ResourceClaimInformer,
-	templateInformer resourceinformers.ResourceClaimTemplateInformer,
+	podInformer v1informers.TypedPodInformer,
+	podGroupInformer schedulinginformers.TypedPodGroupInformer,
+	claimInformer resourceinformers.TypedResourceClaimInformer,
+	templateInformer resourceinformers.TypedResourceClaimTemplateInformer,
 	features controllerFeatures) (*Controller, error) {
 
 	ec := &Controller{
@@ -246,45 +246,45 @@ func newControllerWithFeatures(
 	resourceclaimmetrics.RegisterMetrics()
 	controllermetrics.RegisterMetrics(newCustomCollector(ec.claimLister, getAdminAccessMetricLabel, logger))
 
-	if _, err := podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
+	if _, err := podInformer.TypedInformer().AddTypedEventHandler(v1informers.PodHandlerFuncs{
+		AddFunc: func(obj *v1.Pod) {
 			ec.enqueuePod(logger, obj, false)
 		},
-		UpdateFunc: func(old, updated any) {
+		UpdateFunc: func(old, updated *v1.Pod) {
 			ec.enqueuePod(logger, updated, false)
 		},
-		DeleteFunc: func(obj any) {
-			ec.enqueuePod(logger, obj, true)
+		DeleteFunc: func(obj v1informers.DeletedPod) {
+			ec.enqueuePod(logger, obj.OptionalObj, true)
 		},
 	}, cache.HandlerOptions{Logger: &logger}); err != nil {
 		return nil, err
 	}
-	if _, err := claimInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
+	if _, err := claimInformer.TypedInformer().AddTypedEventHandler(resourceinformers.ResourceClaimHandlerFuncs{
+		AddFunc: func(obj *resourceapi.ResourceClaim) {
 			logger.V(6).Info("New claim", "claimDump", obj)
 			ec.enqueueResourceClaim(logger, nil, obj)
 		},
-		UpdateFunc: func(old, updated any) {
+		UpdateFunc: func(old, updated *resourceapi.ResourceClaim) {
 			logger.V(6).Info("Updated claim", "claimDump", updated)
 			ec.enqueueResourceClaim(logger, old, updated)
 		},
-		DeleteFunc: func(obj any) {
+		DeleteFunc: func(obj resourceinformers.DeletedResourceClaim) {
 			logger.V(6).Info("Deleted claim", "claimDump", obj)
-			ec.enqueueResourceClaim(logger, obj, nil)
+			ec.enqueueResourceClaim(logger, obj.OptionalObj, nil)
 		},
 	}, cache.HandlerOptions{Logger: &logger}); err != nil {
 		return nil, err
 	}
-	if _, err := templateInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
+	if _, err := templateInformer.TypedInformer().AddTypedEventHandler(resourceinformers.ResourceClaimTemplateHandlerFuncs{
+		AddFunc: func(obj *resourceapi.ResourceClaimTemplate) {
 			logger.V(6).Info("New claim template", "claimTemplateDump", obj)
 			ec.enqueueResourceClaimTemplate(logger, obj)
 		},
-		UpdateFunc: func(old, updated any) {
+		UpdateFunc: func(old, updated *resourceapi.ResourceClaimTemplate) {
 			logger.V(6).Info("Updated claim template", "claimTemplateDump", updated)
 			ec.enqueueResourceClaimTemplate(logger, updated)
 		},
-		DeleteFunc: func(obj any) {
+		DeleteFunc: func(obj resourceinformers.DeletedResourceClaimTemplate) {
 			logger.V(6).Info("Deleted claim template", "claimTemplateDump", obj)
 		},
 	}, cache.HandlerOptions{Logger: &logger}); err != nil {
@@ -306,18 +306,18 @@ func newControllerWithFeatures(
 		ec.podGroupSynced = podGroupInformer.Informer().HasSynced
 		ec.podGroupIndexer = podGroupInformer.Informer().GetIndexer()
 
-		if _, err := podGroupInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj any) {
+		if _, err := podGroupInformer.TypedInformer().AddTypedEventHandler(schedulinginformers.PodGroupHandlerFuncs{
+			AddFunc: func(obj *schedulingapi.PodGroup) {
 				logger.V(6).Info("New PodGroup", "podGroupDump", obj)
 				ec.enqueuePodGroup(logger, obj, false)
 			},
-			UpdateFunc: func(old, updated any) {
+			UpdateFunc: func(old, updated *schedulingapi.PodGroup) {
 				logger.V(6).Info("Updated PodGroup", "podGroupDump", updated)
 				ec.enqueuePodGroup(logger, updated, false)
 			},
-			DeleteFunc: func(obj any) {
+			DeleteFunc: func(obj schedulinginformers.DeletedPodGroup) {
 				logger.V(6).Info("Deleted PodGroup", "podGroupDump", obj)
-				ec.enqueuePodGroup(logger, obj, true)
+				ec.enqueuePodGroup(logger, obj.OptionalObj, true)
 			},
 		}, cache.HandlerOptions{Logger: &logger}); err != nil {
 			return nil, err

--- a/pkg/controller/resourcepoolstatusrequest/controller.go
+++ b/pkg/controller/resourcepoolstatusrequest/controller.go
@@ -89,9 +89,9 @@ type Controller struct {
 func NewController(
 	ctx context.Context,
 	client clientset.Interface,
-	requestInformer resourcev1alpha3informers.ResourcePoolStatusRequestInformer,
-	sliceInformer resourcev1informers.ResourceSliceInformer,
-	claimInformer resourcev1informers.ResourceClaimInformer,
+	requestInformer resourcev1alpha3informers.TypedResourcePoolStatusRequestInformer,
+	sliceInformer resourcev1informers.TypedResourceSliceInformer,
+	claimInformer resourcev1informers.TypedResourceClaimInformer,
 ) (*Controller, error) {
 	logger := klog.FromContext(ctx)
 
@@ -110,12 +110,12 @@ func NewController(
 	metrics.Register()
 
 	// Set up event handlers for ResourcePoolStatusRequests
-	_, err := requestInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, err := requestInformer.TypedInformer().AddTypedEventHandler(resourcev1alpha3informers.ResourcePoolStatusRequestHandlerFuncs{
+		AddFunc: func(obj *resourcev1alpha3.ResourcePoolStatusRequest) {
 			c.enqueueRequest(logger, obj)
 		},
-		UpdateFunc: func(old, new interface{}) {
-			c.enqueueRequest(logger, new)
+		UpdateFunc: func(_, newObj *resourcev1alpha3.ResourcePoolStatusRequest) {
+			c.enqueueRequest(logger, newObj)
 		},
 	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
@@ -496,13 +496,7 @@ func errorStatus(message string) resourcev1alpha3.ResourcePoolStatusRequestStatu
 }
 
 // enqueueRequest adds a request to the workqueue.
-func (c *Controller) enqueueRequest(logger klog.Logger, obj interface{}) {
-	request, ok := obj.(*resourcev1alpha3.ResourcePoolStatusRequest)
-	if !ok {
-		logger.Error(nil, "Failed to cast object to ResourcePoolStatusRequest")
-		return
-	}
-
+func (c *Controller) enqueueRequest(logger klog.Logger, request *resourcev1alpha3.ResourcePoolStatusRequest) {
 	// Skip if already processed (status is set)
 	if request.Status != nil {
 		return

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -57,7 +57,7 @@ type ControllerOptions struct {
 	// Must have authority to list all quotas, and update quota status
 	QuotaClient corev1client.ResourceQuotasGetter
 	// Shared informer for resource quotas
-	ResourceQuotaInformer coreinformers.ResourceQuotaInformer
+	ResourceQuotaInformer coreinformers.TypedResourceQuotaInformer
 	// Controls full recalculation of quota usage
 	ResyncPeriod controller.ResyncPeriodFunc
 	// Maintains evaluators that know how to calculate usage for group resource
@@ -125,12 +125,13 @@ func NewController(ctx context.Context, options *ControllerOptions) (*Controller
 
 	logger := klog.FromContext(ctx)
 
-	options.ResourceQuotaInformer.Informer().AddEventHandlerWithResyncPeriod(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+	resyncPeriod := rq.resyncPeriod()
+	_, _ = options.ResourceQuotaInformer.TypedInformer().AddTypedEventHandler(
+		coreinformers.ResourceQuotaHandlerFuncs{
+			AddFunc: func(obj *v1.ResourceQuota) {
 				rq.addQuota(logger, obj)
 			},
-			UpdateFunc: func(old, cur interface{}) {
+			UpdateFunc: func(oldResourceQuota, curResourceQuota *v1.ResourceQuota) {
 				// We are only interested in observing updates to quota.spec to drive updates to quota.status.
 				// We ignore all updates to quota.Status because they are all driven by this controller.
 				// IMPORTANT:
@@ -139,8 +140,6 @@ func NewController(ctx context.Context, options *ControllerOptions) (*Controller
 				// that cannot be backed by a cache and result in a full query of a namespace's content, we do not
 				// want to pay the price on spurious status updates.  As a result, we have a separate routine that is
 				// responsible for enqueue of all resource quotas when doing a full resync (enqueueAll)
-				oldResourceQuota := old.(*v1.ResourceQuota)
-				curResourceQuota := cur.(*v1.ResourceQuota)
 				if quota.Equals(oldResourceQuota.Spec.Hard, curResourceQuota.Spec.Hard) {
 					return
 				}
@@ -149,11 +148,11 @@ func NewController(ctx context.Context, options *ControllerOptions) (*Controller
 			// This will enter the sync loop and no-op, because the controller has been deleted from the store.
 			// Note that deleting a controller immediately after scaling it to 0 will not work. The recommended
 			// way of achieving this is by performing a `stop` operation on the controller.
-			DeleteFunc: func(obj interface{}) {
-				rq.enqueueResourceQuota(logger, obj)
+			DeleteFunc: func(obj coreinformers.DeletedResourceQuota) {
+				rq.queue.Add(obj.GetKey())
 			},
 		},
-		rq.resyncPeriod(),
+		cache.HandlerOptions{ResyncPeriod: &resyncPeriod},
 	)
 
 	if options.DiscoveryFunc != nil {

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
@@ -68,8 +68,8 @@ type Controller struct {
 // NewPodGroupProtectionController returns a new instance of the PodGroup protection controller.
 func NewPodGroupProtectionController(
 	logger klog.Logger,
-	podGroupInformer schedulinginformers.PodGroupInformer,
-	podInformer coreinformers.PodInformer,
+	podGroupInformer schedulinginformers.TypedPodGroupInformer,
+	podInformer coreinformers.TypedPodInformer,
 	kubeClient clientset.Interface,
 ) (*Controller, error) {
 	c := &Controller{
@@ -84,11 +84,11 @@ func NewPodGroupProtectionController(
 		),
 	}
 
-	if _, err := podGroupInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	if _, err := podGroupInformer.TypedInformer().AddTypedEventHandler(schedulinginformers.PodGroupHandlerFuncs{
+		AddFunc: func(obj *schedulingv1alpha3.PodGroup) {
 			c.handlePodGroupUpdate(logger, obj)
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new *schedulingv1alpha3.PodGroup) {
 			c.handlePodGroupUpdate(logger, new)
 		},
 	}, cache.HandlerOptions{Logger: &logger}); err != nil {
@@ -99,14 +99,14 @@ func NewPodGroupProtectionController(
 		return nil, fmt.Errorf("could not initialize PodGroup protection controller: %w", err)
 	}
 
-	if _, err := podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	if _, err := podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc: func(obj *v1.Pod) {
 			c.handlePodChange(logger, nil, obj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			c.handlePodChange(logger, obj, nil)
+		DeleteFunc: func(obj coreinformers.DeletedPod) {
+			c.handlePodChange(logger, obj.OptionalObj, nil)
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new *v1.Pod) {
 			c.handlePodChange(logger, old, new)
 		},
 	}, cache.HandlerOptions{Logger: &logger}); err != nil {

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -18,7 +18,6 @@ package serviceaccount
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -62,7 +61,7 @@ func DefaultServiceAccountsControllerOptions() ServiceAccountsControllerOptions 
 }
 
 // NewServiceAccountsController returns a new *ServiceAccountsController.
-func NewServiceAccountsController(logger klog.Logger, saInformer coreinformers.ServiceAccountInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, options ServiceAccountsControllerOptions) (*ServiceAccountsController, error) {
+func NewServiceAccountsController(logger klog.Logger, saInformer coreinformers.TypedServiceAccountInformer, nsInformer coreinformers.TypedNamespaceInformer, cl clientset.Interface, options ServiceAccountsControllerOptions) (*ServiceAccountsController, error) {
 	e := &ServiceAccountsController{
 		client:                  cl,
 		serviceAccountsToEnsure: options.ServiceAccounts,
@@ -72,18 +71,18 @@ func NewServiceAccountsController(logger klog.Logger, saInformer coreinformers.S
 		),
 	}
 
-	saHandler, _ := saInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
-		DeleteFunc: func(obj interface{}) {
-			e.serviceAccountDeleted(logger, obj)
+	saHandler, _ := saInformer.TypedInformer().AddTypedEventHandler(coreinformers.ServiceAccountHandlerFuncs{
+		DeleteFunc: func(deleted coreinformers.DeletedServiceAccount) {
+			e.serviceAccountDeleted(logger, deleted)
 		},
-	}, options.ServiceAccountResync)
+	}, cache.HandlerOptions{ResyncPeriod: &options.ServiceAccountResync})
 	e.saLister = saInformer.Lister()
 	e.saListerSynced = saHandler.HasSynced
 
-	nsHandler, _ := nsInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+	nsHandler, _ := nsInformer.TypedInformer().AddTypedEventHandler(coreinformers.NamespaceHandlerFuncs{
 		AddFunc:    e.namespaceAdded,
 		UpdateFunc: e.namespaceUpdated,
-	}, options.NamespaceResync)
+	}, cache.HandlerOptions{ResyncPeriod: &options.NamespaceResync})
 	e.nsLister = nsInformer.Lister()
 	e.nsListerSynced = nsHandler.HasSynced
 
@@ -136,32 +135,17 @@ func (c *ServiceAccountsController) Run(ctx context.Context, workers int) {
 }
 
 // serviceAccountDeleted reacts to a ServiceAccount deletion by recreating a default ServiceAccount in the namespace if needed
-func (c *ServiceAccountsController) serviceAccountDeleted(logger klog.Logger, obj interface{}) {
-	sa, ok := obj.(*v1.ServiceAccount)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleErrorWithLogger(logger, nil, "Couldn't get object from tombstone", "obj", obj)
-			return
-		}
-		sa, ok = tombstone.Obj.(*v1.ServiceAccount)
-		if !ok {
-			utilruntime.HandleErrorWithLogger(logger, nil, "Tombstone contained object that is not a ServiceAccount", "type", fmt.Sprintf("%T", obj))
-			return
-		}
-	}
-	c.queue.Add(sa.Namespace)
+func (c *ServiceAccountsController) serviceAccountDeleted(_ klog.Logger, deleted coreinformers.DeletedServiceAccount) {
+	c.queue.Add(deleted.GetNamespace())
 }
 
 // namespaceAdded reacts to a Namespace creation by creating a default ServiceAccount object
-func (c *ServiceAccountsController) namespaceAdded(obj interface{}) {
-	namespace := obj.(*v1.Namespace)
+func (c *ServiceAccountsController) namespaceAdded(namespace *v1.Namespace) {
 	c.queue.Add(namespace.Name)
 }
 
 // namespaceUpdated reacts to a Namespace update (or re-list) by creating a default ServiceAccount in the namespace if needed
-func (c *ServiceAccountsController) namespaceUpdated(oldObj interface{}, newObj interface{}) {
-	newNamespace := newObj.(*v1.Namespace)
+func (c *ServiceAccountsController) namespaceUpdated(_, newNamespace *v1.Namespace) {
 	c.queue.Add(newNamespace.Name)
 }
 

--- a/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/controller"
@@ -220,7 +221,7 @@ func TestServiceAccountCreation(t *testing.T) {
 				controller.namespaceUpdated(nil, tc.UpdatedNamespace)
 			}
 			if tc.DeletedServiceAccount != nil {
-				controller.serviceAccountDeleted(logger, tc.DeletedServiceAccount)
+				controller.serviceAccountDeleted(logger, coreinformers.DeletedServiceAccount{OptionalObj: tc.DeletedServiceAccount})
 			}
 
 			// wait to be called

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -71,7 +71,7 @@ type TokensControllerOptions struct {
 }
 
 // NewTokensController returns a new *TokensController.
-func NewTokensController(logger klog.Logger, serviceAccounts informers.ServiceAccountInformer, secrets informers.SecretInformer, cl clientset.Interface, options TokensControllerOptions) (*TokensController, error) {
+func NewTokensController(logger klog.Logger, serviceAccounts informers.TypedServiceAccountInformer, secrets informers.TypedSecretInformer, cl clientset.Interface, options TokensControllerOptions) (*TokensController, error) {
 	maxRetries := options.MaxRetries
 	if maxRetries == 0 {
 		maxRetries = 10
@@ -96,32 +96,39 @@ func NewTokensController(logger klog.Logger, serviceAccounts informers.ServiceAc
 
 	e.serviceAccounts = serviceAccounts.Lister()
 	e.serviceAccountSynced = serviceAccounts.Informer().HasSynced
-	serviceAccounts.Informer().AddEventHandlerWithResyncPeriod(
-		cache.ResourceEventHandlerFuncs{
+	serviceAccounts.TypedInformer().AddTypedEventHandler(
+		informers.ServiceAccountHandlerFuncs{
 			AddFunc:    e.queueServiceAccountSync,
 			UpdateFunc: e.queueServiceAccountUpdateSync,
-			DeleteFunc: e.queueServiceAccountSync,
+			DeleteFunc: e.queueDeletedServiceAccountSync,
 		},
-		options.ServiceAccountResync,
+		cache.HandlerOptions{ResyncPeriod: &options.ServiceAccountResync},
 	)
 
 	e.secrets = secrets.Lister()
 	e.secretSynced = secrets.Informer().HasSynced
-	secrets.Informer().AddEventHandlerWithOptions(
-		cache.FilteringResourceEventHandler{
-			FilterFunc: func(obj interface{}) bool {
-				switch t := obj.(type) {
-				case *v1.Secret:
-					return t.Type == v1.SecretTypeServiceAccountToken
-				default:
-					utilruntime.HandleErrorWithLogger(logger, nil, "Unexpected object type passed to tokens controller", "type", fmt.Sprintf("%T", obj))
-					return false
+	secretMatches := func(secret *v1.Secret) bool { return secret.Type == v1.SecretTypeServiceAccountToken }
+	secrets.TypedInformer().AddTypedEventHandler(
+		informers.SecretHandlerFuncs{
+			AddFunc: func(secret *v1.Secret) {
+				if secretMatches(secret) {
+					e.queueSecretSync(secret)
 				}
 			},
-			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc:    e.queueSecretSync,
-				UpdateFunc: e.queueSecretUpdateSync,
-				DeleteFunc: e.queueSecretSync,
+			UpdateFunc: func(oldSecret, newSecret *v1.Secret) {
+				switch oldMatches, newMatches := secretMatches(oldSecret), secretMatches(newSecret); {
+				case oldMatches && newMatches:
+					e.queueSecretUpdateSync(oldSecret, newSecret)
+				case oldMatches:
+					e.queueSecretSync(oldSecret)
+				case newMatches:
+					e.queueSecretSync(newSecret)
+				}
+			},
+			DeleteFunc: func(deleted informers.DeletedSecret) {
+				if deleted.OptionalObj != nil && secretMatches(deleted.OptionalObj) {
+					e.queueSecretSync(deleted.OptionalObj)
+				}
 			},
 		},
 		cache.HandlerOptions{
@@ -191,21 +198,20 @@ func (e *TokensController) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-func (e *TokensController) queueServiceAccountSync(obj interface{}) {
-	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		obj = tombstone.Obj
-	}
-	if serviceAccount, ok := obj.(*v1.ServiceAccount); ok {
-		e.syncServiceAccountQueue.Add(makeServiceAccountKey(serviceAccount))
-		return
-	}
-	utilruntime.HandleError(fmt.Errorf("error decoding object, invalid type: %T", obj))
+func (e *TokensController) queueServiceAccountSync(serviceAccount *v1.ServiceAccount) {
+	e.syncServiceAccountQueue.Add(makeServiceAccountKey(serviceAccount))
 }
 
-func (e *TokensController) queueServiceAccountUpdateSync(oldObj interface{}, newObj interface{}) {
-	if serviceAccount, ok := newObj.(*v1.ServiceAccount); ok {
-		e.syncServiceAccountQueue.Add(makeServiceAccountKey(serviceAccount))
+func (e *TokensController) queueDeletedServiceAccountSync(deleted informers.DeletedServiceAccount) {
+	if deleted.OptionalObj == nil {
+		utilruntime.HandleError(fmt.Errorf("deleted ServiceAccount object %q is unavailable", deleted.GetKey()))
+		return
 	}
+	e.queueServiceAccountSync(deleted.OptionalObj)
+}
+
+func (e *TokensController) queueServiceAccountUpdateSync(_, serviceAccount *v1.ServiceAccount) {
+	e.syncServiceAccountQueue.Add(makeServiceAccountKey(serviceAccount))
 }
 
 // complete optionally requeues key, then calls queue.Done(key)
@@ -225,16 +231,12 @@ func retryOrForget[T comparable](logger klog.Logger, queue workqueue.TypedRateLi
 	queue.Forget(key)
 }
 
-func (e *TokensController) queueSecretSync(obj interface{}) {
-	if secret, ok := obj.(*v1.Secret); ok {
-		e.syncSecretQueue.Add(makeSecretQueueKey(secret))
-	}
+func (e *TokensController) queueSecretSync(secret *v1.Secret) {
+	e.syncSecretQueue.Add(makeSecretQueueKey(secret))
 }
 
-func (e *TokensController) queueSecretUpdateSync(oldObj interface{}, newObj interface{}) {
-	if secret, ok := newObj.(*v1.Secret); ok {
-		e.syncSecretQueue.Add(makeSecretQueueKey(secret))
-	}
+func (e *TokensController) queueSecretUpdateSync(_, secret *v1.Secret) {
+	e.syncSecretQueue.Add(makeSecretQueueKey(secret))
 }
 
 func (e *TokensController) syncServiceAccount(ctx context.Context) {

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -96,7 +96,7 @@ func NewTokensController(logger klog.Logger, serviceAccounts informers.TypedServ
 
 	e.serviceAccounts = serviceAccounts.Lister()
 	e.serviceAccountSynced = serviceAccounts.Informer().HasSynced
-	serviceAccounts.TypedInformer().AddTypedEventHandler(
+	_, _ = serviceAccounts.TypedInformer().AddTypedEventHandler(
 		informers.ServiceAccountHandlerFuncs{
 			AddFunc:    e.queueServiceAccountSync,
 			UpdateFunc: e.queueServiceAccountUpdateSync,
@@ -108,7 +108,7 @@ func NewTokensController(logger klog.Logger, serviceAccounts informers.TypedServ
 	e.secrets = secrets.Lister()
 	e.secretSynced = secrets.Informer().HasSynced
 	secretMatches := func(secret *v1.Secret) bool { return secret.Type == v1.SecretTypeServiceAccountToken }
-	secrets.TypedInformer().AddTypedEventHandler(
+	_, _ = secrets.TypedInformer().AddTypedEventHandler(
 		informers.SecretHandlerFuncs{
 			AddFunc: func(secret *v1.Secret) {
 				if secretMatches(secret) {

--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -470,7 +471,7 @@ func TestTokenCreation(t *testing.T) {
 			}
 			if tc.DeletedServiceAccount != nil {
 				serviceAccounts.Delete(tc.DeletedServiceAccount)
-				controller.queueServiceAccountSync(tc.DeletedServiceAccount)
+				controller.queueDeletedServiceAccountSync(coreinformers.DeletedServiceAccount{OptionalObj: tc.DeletedServiceAccount})
 			}
 			if tc.AddedSecret != nil {
 				secrets.Add(tc.AddedSecret)
@@ -556,7 +557,7 @@ func TestTokenCreation(t *testing.T) {
 func TestQueueServiceAccountSync_Tombstone(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	sa := serviceAccount(emptySecretReferences())
-	tombstone := cache.DeletedFinalStateUnknown{
+	tombstone := &cache.DeletedFinalStateUnknown{
 		Key: "default/default",
 		Obj: sa,
 	}
@@ -568,7 +569,7 @@ func TestQueueServiceAccountSync_Tombstone(t *testing.T) {
 		t.Fatalf("error creating Tokens controller: %v", err)
 	}
 
-	tokenController.queueServiceAccountSync(tombstone)
+	tokenController.queueDeletedServiceAccountSync(coreinformers.DeletedServiceAccount{OptionalObj: sa, FinalStateUnknown: tombstone})
 	if tokenController.syncServiceAccountQueue.Len() != 1 {
 		t.Errorf("expected 1 item in queue, got %d", tokenController.syncServiceAccountQueue.Len())
 	}

--- a/pkg/controller/servicecidrs/servicecidrs_controller.go
+++ b/pkg/controller/servicecidrs/servicecidrs_controller.go
@@ -89,14 +89,14 @@ func NewController(
 		AddFunc:    c.addServiceCIDR,
 		UpdateFunc: c.updateServiceCIDR,
 		DeleteFunc: c.deleteServiceCIDR,
-	}, cache.HandlerOptions{})
+	})
 	c.serviceCIDRLister = serviceCIDRInformer.Lister()
 	c.serviceCIDRsSynced = serviceCIDRInformer.Informer().HasSynced
 
 	_, _ = ipAddressInformer.TypedInformer().AddTypedEventHandler(networkinginformers.IPAddressHandlerFuncs{
 		AddFunc:    c.addIPAddress,
 		DeleteFunc: c.deleteIPAddress,
-	}, cache.HandlerOptions{})
+	})
 
 	c.ipAddressLister = ipAddressInformer.Lister()
 	c.ipAddressSynced = ipAddressInformer.Informer().HasSynced

--- a/pkg/controller/servicecidrs/servicecidrs_controller.go
+++ b/pkg/controller/servicecidrs/servicecidrs_controller.go
@@ -70,8 +70,8 @@ const (
 // NewController returns a new *Controller.
 func NewController(
 	ctx context.Context,
-	serviceCIDRInformer networkinginformers.ServiceCIDRInformer,
-	ipAddressInformer networkinginformers.IPAddressInformer,
+	serviceCIDRInformer networkinginformers.TypedServiceCIDRInformer,
+	ipAddressInformer networkinginformers.TypedIPAddressInformer,
 	client clientset.Interface,
 ) *Controller {
 	broadcaster := record.NewBroadcaster(record.WithContext(ctx))
@@ -85,18 +85,18 @@ func NewController(
 		workerLoopPeriod: time.Second,
 	}
 
-	_, _ = serviceCIDRInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceCIDRInformer.TypedInformer().AddTypedEventHandler(networkinginformers.ServiceCIDRHandlerFuncs{
 		AddFunc:    c.addServiceCIDR,
 		UpdateFunc: c.updateServiceCIDR,
 		DeleteFunc: c.deleteServiceCIDR,
-	})
+	}, cache.HandlerOptions{})
 	c.serviceCIDRLister = serviceCIDRInformer.Lister()
 	c.serviceCIDRsSynced = serviceCIDRInformer.Informer().HasSynced
 
-	_, _ = ipAddressInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = ipAddressInformer.TypedInformer().AddTypedEventHandler(networkinginformers.IPAddressHandlerFuncs{
 		AddFunc:    c.addIPAddress,
 		DeleteFunc: c.deleteIPAddress,
-	})
+	}, cache.HandlerOptions{})
 
 	c.ipAddressLister = ipAddressInformer.Lister()
 	c.ipAddressSynced = ipAddressInformer.Informer().HasSynced
@@ -155,59 +155,35 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-func (c *Controller) addServiceCIDR(obj interface{}) {
-	cidr, ok := obj.(*networkingapiv1.ServiceCIDR)
-	if !ok {
-		return
-	}
+func (c *Controller) addServiceCIDR(cidr *networkingapiv1.ServiceCIDR) {
 	c.queue.Add(cidr.Name)
 	for _, key := range c.overlappingServiceCIDRs(cidr) {
 		c.queue.Add(key)
 	}
 }
 
-func (c *Controller) updateServiceCIDR(oldObj, obj interface{}) {
-	key, err := cache.MetaNamespaceKeyFunc(obj)
-	if err == nil {
-		c.queue.Add(key)
-	}
+func (c *Controller) updateServiceCIDR(_, cidr *networkingapiv1.ServiceCIDR) {
+	c.queue.Add(cidr.Name)
 }
 
 // deleteServiceCIDR
-func (c *Controller) deleteServiceCIDR(obj interface{}) {
-	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-	if err == nil {
-		c.queue.Add(key)
-	}
+func (c *Controller) deleteServiceCIDR(deleted networkinginformers.DeletedServiceCIDR) {
+	c.queue.Add(deleted.GetKey())
 }
 
 // addIPAddress may block a ServiceCIDR deletion
-func (c *Controller) addIPAddress(obj interface{}) {
-	ip, ok := obj.(*networkingapiv1.IPAddress)
-	if !ok {
-		return
-	}
-
+func (c *Controller) addIPAddress(ip *networkingapiv1.IPAddress) {
 	for _, cidr := range c.containingServiceCIDRs(ip) {
 		c.queue.Add(cidr)
 	}
 }
 
 // deleteIPAddress may unblock a ServiceCIDR deletion
-func (c *Controller) deleteIPAddress(obj interface{}) {
-	ip, ok := obj.(*networkingapiv1.IPAddress)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			return
-		}
-		ip, ok = tombstone.Obj.(*networkingapiv1.IPAddress)
-		if !ok {
-			return
-		}
+func (c *Controller) deleteIPAddress(deleted networkinginformers.DeletedIPAddress) {
+	if deleted.OptionalObj == nil {
+		return
 	}
-
-	for _, cidr := range c.containingServiceCIDRs(ip) {
+	for _, cidr := range c.containingServiceCIDRs(deleted.OptionalObj) {
 		c.queue.Add(cidr)
 	}
 }

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -112,10 +112,10 @@ var (
 // NewStatefulSetController creates a new statefulset controller.
 func NewStatefulSetController(
 	ctx context.Context,
-	podInformer coreinformers.PodInformer,
-	setInformer appsinformers.StatefulSetInformer,
-	pvcInformer coreinformers.PersistentVolumeClaimInformer,
-	revInformer appsinformers.ControllerRevisionInformer,
+	podInformer coreinformers.TypedPodInformer,
+	setInformer appsinformers.TypedStatefulSetInformer,
+	pvcInformer coreinformers.TypedPersistentVolumeClaimInformer,
+	revInformer appsinformers.TypedControllerRevisionInformer,
 	kubeClient clientset.Interface,
 ) *StatefulSetController {
 	logger := klog.FromContext(ctx)
@@ -178,39 +178,37 @@ func NewStatefulSetController(
 		consistencyStore: consistencyStore,
 	}
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
 		// lookup the statefulset and enqueue
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj *v1.Pod) {
 			ssc.addPod(logger, obj)
 		},
 		// lookup current and old statefulset if labels changed
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *v1.Pod) {
 			ssc.updatePod(logger, oldObj, newObj)
 		},
 		// lookup statefulset accounting for deletion tombstones
-		DeleteFunc: func(obj interface{}) {
-			ssc.deletePod(logger, obj)
+		DeleteFunc: func(obj coreinformers.DeletedPod) {
+			ssc.deletePod(logger, obj.OptionalObj)
 		},
 	})
 	ssc.podLister = podInformer.Lister()
 	ssc.podListerSynced = podInformer.Informer().HasSynced
 	controller.AddPodControllerIndexer(podInformer.Informer())
 	ssc.podIndexer = podInformer.Informer().GetIndexer()
-	setInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
+	_, _ = setInformer.TypedInformer().AddTypedEventHandler(
+		appsinformers.StatefulSetHandlerFuncs{
+			AddFunc: func(obj *apps.StatefulSet) {
 				ssc.enqueueStatefulSet(logger, obj)
 			},
-			UpdateFunc: func(old, cur interface{}) {
-				oldPS := old.(*apps.StatefulSet)
-				curPS := cur.(*apps.StatefulSet)
+			UpdateFunc: func(oldPS, curPS *apps.StatefulSet) {
 				if oldPS.Status.Replicas != curPS.Status.Replicas {
 					logger.V(4).Info("Observed updated replica count for StatefulSet", "statefulSet", klog.KObj(curPS), "oldReplicas", oldPS.Status.Replicas, "newReplicas", curPS.Status.Replicas)
 				}
-				ssc.enqueueStatefulSet(logger, cur)
+				ssc.enqueueStatefulSet(logger, curPS)
 			},
-			DeleteFunc: func(obj interface{}) {
-				ssc.enqueueStatefulSet(logger, obj)
+			DeleteFunc: func(obj appsinformers.DeletedStatefulSet) {
+				ssc.queue.Add(obj.GetKey())
 			},
 		},
 	)

--- a/pkg/controller/storageversiongc/gc_controller.go
+++ b/pkg/controller/storageversiongc/gc_controller.go
@@ -57,7 +57,7 @@ type Controller struct {
 }
 
 // NewStorageVersionGC creates a new Controller.
-func NewStorageVersionGC(ctx context.Context, clientset kubernetes.Interface, leaseInformer coordinformers.LeaseInformer, storageVersionInformer apiserverinternalinformers.StorageVersionInformer) *Controller {
+func NewStorageVersionGC(ctx context.Context, clientset kubernetes.Interface, leaseInformer coordinformers.TypedLeaseInformer, storageVersionInformer apiserverinternalinformers.TypedStorageVersionInformer) *Controller {
 	c := &Controller{
 		kubeclientset:        clientset,
 		leaseLister:          leaseInformer.Lister(),
@@ -73,18 +73,18 @@ func NewStorageVersionGC(ctx context.Context, clientset kubernetes.Interface, le
 		),
 	}
 	logger := klog.FromContext(ctx)
-	_, err := leaseInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		DeleteFunc: func(obj interface{}) {
-			c.onDeleteLease(logger, obj)
+	_, err := leaseInformer.TypedInformer().AddTypedEventHandler(coordinformers.LeaseHandlerFuncs{
+		DeleteFunc: func(deleted coordinformers.DeletedLease) {
+			c.onDeleteLease(logger, deleted)
 		},
 	}, cache.HandlerOptions{Logger: &logger})
 	utilruntime.Must(err)
 	// use the default resync period from the informer
-	_, err = storageVersionInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, err = storageVersionInformer.TypedInformer().AddTypedEventHandler(apiserverinternalinformers.StorageVersionHandlerFuncs{
+		AddFunc: func(obj *apiserverinternalv1alpha1.StorageVersion) {
 			c.onAddStorageVersion(logger, obj)
 		},
-		UpdateFunc: func(old, newObj interface{}) {
+		UpdateFunc: func(old, newObj *apiserverinternalv1alpha1.StorageVersion) {
 			c.onUpdateStorageVersion(logger, old, newObj)
 		},
 	}, cache.HandlerOptions{Logger: &logger})
@@ -240,14 +240,12 @@ func (c *Controller) syncStorageVersion(ctx context.Context, name string) error 
 	return c.updateOrDeleteStorageVersion(ctx, sv, serverStorageVersions)
 }
 
-func (c *Controller) onAddStorageVersion(logger klog.Logger, obj interface{}) {
-	castObj := obj.(*apiserverinternalv1alpha1.StorageVersion)
-	c.enqueueStorageVersion(logger, castObj)
+func (c *Controller) onAddStorageVersion(logger klog.Logger, obj *apiserverinternalv1alpha1.StorageVersion) {
+	c.enqueueStorageVersion(logger, obj)
 }
 
-func (c *Controller) onUpdateStorageVersion(logger klog.Logger, oldObj, newObj interface{}) {
-	castNewObj := newObj.(*apiserverinternalv1alpha1.StorageVersion)
-	c.enqueueStorageVersion(logger, castNewObj)
+func (c *Controller) onUpdateStorageVersion(logger klog.Logger, _, newObj *apiserverinternalv1alpha1.StorageVersion) {
+	c.enqueueStorageVersion(logger, newObj)
 }
 
 // enqueueStorageVersion enqueues the storage version if it has entry for invalid apiserver
@@ -264,26 +262,15 @@ func (c *Controller) enqueueStorageVersion(logger klog.Logger, obj *apiserverint
 	}
 }
 
-func (c *Controller) onDeleteLease(logger klog.Logger, obj interface{}) {
-	castObj, ok := obj.(*coordinationv1.Lease)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-			return
-		}
-		castObj, ok = tombstone.Obj.(*coordinationv1.Lease)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Lease %#v", obj))
-			return
-		}
+func (c *Controller) onDeleteLease(logger klog.Logger, deleted coordinformers.DeletedLease) {
+	if deleted.OptionalObj == nil {
+		return
 	}
-
-	if castObj.Namespace == metav1.NamespaceSystem &&
-		castObj.Labels != nil &&
-		castObj.Labels[controlplane.IdentityLeaseComponentLabelKey] == apiserver.KubeAPIServer {
-		logger.V(4).Info("Observed lease deleted", "castObjName", castObj.Name)
-		c.enqueueLease(castObj)
+	if deleted.OptionalObj.Namespace == metav1.NamespaceSystem &&
+		deleted.OptionalObj.Labels != nil &&
+		deleted.OptionalObj.Labels[controlplane.IdentityLeaseComponentLabelKey] == apiserver.KubeAPIServer {
+		logger.V(4).Info("Observed lease deleted", "leaseName", deleted.GetName())
+		c.enqueueLease(deleted.OptionalObj)
 	}
 }
 

--- a/pkg/controller/storageversionmigrator/migrationrunner.go
+++ b/pkg/controller/storageversionmigrator/migrationrunner.go
@@ -66,7 +66,7 @@ type MigrationRunnerController struct {
 func NewCustomResourceController(
 	ctx context.Context,
 	kubeClient clientset.Interface,
-	svmInformer svminformers.StorageVersionMigrationInformer,
+	svmInformer svminformers.TypedStorageVersionMigrationInformer,
 	crdClient apiextensionsclient.CustomResourceDefinitionInterface,
 ) *MigrationRunnerController {
 	logger := klog.FromContext(ctx)
@@ -82,15 +82,15 @@ func NewCustomResourceController(
 		),
 	}
 
-	_, err := svmInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, err := svmInformer.TypedInformer().AddTypedEventHandler(svminformers.StorageVersionMigrationHandlerFuncs{
+		AddFunc: func(obj *svmv1.StorageVersionMigration) {
 			crController.addSVM(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *svmv1.StorageVersionMigration) {
 			crController.updateSVM(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			crController.deleteSVM(logger, obj)
+		DeleteFunc: func(deleted svminformers.DeletedStorageVersionMigration) {
+			crController.deleteSVM(logger, deleted)
 		},
 	}, cache.HandlerOptions{Logger: &logger})
 	utilruntime.Must(err)
@@ -98,35 +98,23 @@ func NewCustomResourceController(
 	return crController
 }
 
-func (crc *MigrationRunnerController) addSVM(logger klog.Logger, obj interface{}) {
-	svm := obj.(*svmv1.StorageVersionMigration)
+func (crc *MigrationRunnerController) addSVM(logger klog.Logger, svm *svmv1.StorageVersionMigration) {
 	logger.V(4).Info("Adding", "svm", klog.KObj(svm))
 	crc.enqueue(svm)
 }
 
-func (crc *MigrationRunnerController) updateSVM(logger klog.Logger, oldObj, newObj interface{}) {
-	oldSVM := oldObj.(*svmv1.StorageVersionMigration)
-	newSVM := newObj.(*svmv1.StorageVersionMigration)
+func (crc *MigrationRunnerController) updateSVM(logger klog.Logger, oldSVM, newSVM *svmv1.StorageVersionMigration) {
 	logger.V(4).Info("Updating", "svm", klog.KObj(oldSVM))
 	crc.enqueue(newSVM)
 }
 
-func (crc *MigrationRunnerController) deleteSVM(logger klog.Logger, obj interface{}) {
-	svm, ok := obj.(*svmv1.StorageVersionMigration)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			logger.Info("could not cast obj to DeletedFinalStateUnknown", "object", obj)
-			return
-		}
-		svm, ok = tombstone.Obj.(*svmv1.StorageVersionMigration)
-		if !ok {
-			logger.Info("could not cast tombstone to SVM", "object", obj)
-			return
-		}
+func (crc *MigrationRunnerController) deleteSVM(logger klog.Logger, deleted svminformers.DeletedStorageVersionMigration) {
+	if deleted.OptionalObj == nil {
+		logger.Info("deleted StorageVersionMigration object is unavailable", "svm", deleted.GetKey())
+		return
 	}
-	logger.V(4).Info("Deleting", "svm", klog.KObj(svm))
-	crc.enqueue(svm)
+	logger.V(4).Info("Deleting", "svm", klog.KObj(deleted))
+	crc.enqueue(deleted.OptionalObj)
 }
 
 func (crc *MigrationRunnerController) enqueue(svm *svmv1.StorageVersionMigration) {

--- a/pkg/controller/storageversionmigrator/resourceversion.go
+++ b/pkg/controller/storageversionmigrator/resourceversion.go
@@ -72,7 +72,7 @@ func NewResourceVersionController(
 	kubeClient clientset.Interface,
 	discoveryClient discovery.DiscoveryInterface,
 	metadataClient metadata.Interface,
-	svmInformer svminformers.StorageVersionMigrationInformer,
+	svmInformer svminformers.TypedStorageVersionMigrationInformer,
 	mapper meta.ResettableRESTMapper,
 ) *ResourceVersionController {
 	logger := klog.FromContext(ctx)
@@ -90,11 +90,11 @@ func NewResourceVersionController(
 		),
 	}
 
-	_, err := svmInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, err := svmInformer.TypedInformer().AddTypedEventHandler(svminformers.StorageVersionMigrationHandlerFuncs{
+		AddFunc: func(obj *svmv1.StorageVersionMigration) {
 			rvController.addSVM(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *svmv1.StorageVersionMigration) {
 			rvController.updateSVM(logger, oldObj, newObj)
 		},
 	}, cache.HandlerOptions{Logger: &logger})
@@ -103,15 +103,12 @@ func NewResourceVersionController(
 	return rvController
 }
 
-func (rv *ResourceVersionController) addSVM(logger klog.Logger, obj interface{}) {
-	svm := obj.(*svmv1.StorageVersionMigration)
+func (rv *ResourceVersionController) addSVM(logger klog.Logger, svm *svmv1.StorageVersionMigration) {
 	logger.V(4).Info("Adding", "svm", klog.KObj(svm))
 	rv.enqueue(svm)
 }
 
-func (rv *ResourceVersionController) updateSVM(logger klog.Logger, oldObj, newObj interface{}) {
-	oldSVM := oldObj.(*svmv1.StorageVersionMigration)
-	newSVM := newObj.(*svmv1.StorageVersionMigration)
+func (rv *ResourceVersionController) updateSVM(logger klog.Logger, oldSVM, newSVM *svmv1.StorageVersionMigration) {
 	logger.V(4).Info("Updating", "svm", klog.KObj(oldSVM))
 	rv.enqueue(newSVM)
 }

--- a/pkg/controller/storageversionmigrator/storageversionmigrator.go
+++ b/pkg/controller/storageversionmigrator/storageversionmigrator.go
@@ -72,7 +72,7 @@ func NewSVMController(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,
 	dynamicClient *dynamic.DynamicClient,
-	svmInformer svminformers.StorageVersionMigrationInformer,
+	svmInformer svminformers.TypedStorageVersionMigrationInformer,
 	controllerName string,
 	mapper meta.ResettableRESTMapper,
 	dependencyGraphBuilder *garbagecollector.GraphBuilder,
@@ -95,11 +95,11 @@ func NewSVMController(
 		rateLimiter: rateLimiter,
 	}
 
-	_, err := svmInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, err := svmInformer.TypedInformer().AddTypedEventHandler(svminformers.StorageVersionMigrationHandlerFuncs{
+		AddFunc: func(obj *svmv1.StorageVersionMigration) {
 			svmController.addSVM(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *svmv1.StorageVersionMigration) {
 			svmController.updateSVM(logger, oldObj, newObj)
 		},
 	}, cache.HandlerOptions{Logger: &logger})

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/core/helper"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/controller/tainteviction/metrics"
-	controllerutil "k8s.io/kubernetes/pkg/controller/util/node"
 	utilpod "k8s.io/kubernetes/pkg/util/pod"
 )
 
@@ -182,7 +181,7 @@ func getMinTolerationTime(tolerations []v1.Toleration) time.Duration {
 }
 
 // New creates a new Controller that will use passed clientset to communicate with the API server.
-func New(ctx context.Context, c clientset.Interface, podInformer corev1informers.PodInformer, nodeInformer corev1informers.NodeInformer, controllerName string) (*Controller, error) {
+func New(ctx context.Context, c clientset.Interface, podInformer corev1informers.TypedPodInformer, nodeInformer corev1informers.TypedNodeInformer, controllerName string) (*Controller, error) {
 	logger := klog.FromContext(ctx)
 	metrics.Register()
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
@@ -222,30 +221,18 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 	}
 	tm.taintEvictionQueue = CreateWorkerQueue(deletePodHandler(c, tm.emitPodDeletionEvent, tm.name))
 
-	_, err := podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			pod := obj.(*v1.Pod)
+	_, err := podInformer.TypedInformer().AddTypedEventHandler(corev1informers.PodHandlerFuncs{
+		AddFunc: func(pod *v1.Pod) {
 			tm.PodUpdated(nil, pod)
 		},
-		UpdateFunc: func(prev, obj interface{}) {
-			prevPod := prev.(*v1.Pod)
-			newPod := obj.(*v1.Pod)
-			tm.PodUpdated(prevPod, newPod)
+		UpdateFunc: func(prev, pod *v1.Pod) {
+			tm.PodUpdated(prev, pod)
 		},
-		DeleteFunc: func(obj interface{}) {
-			pod, isPod := obj.(*v1.Pod)
-			// We can get DeletedFinalStateUnknown instead of *v1.Pod here and we need to handle that correctly.
-			if !isPod {
-				deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					logger.Error(nil, "Received unexpected object", "object", obj)
-					return
-				}
-				pod, ok = deletedState.Obj.(*v1.Pod)
-				if !ok {
-					logger.Error(nil, "DeletedFinalStateUnknown contained non-Pod object", "object", deletedState.Obj)
-					return
-				}
+		DeleteFunc: func(deleted corev1informers.DeletedPod) {
+			pod := deleted.OptionalObj
+			if pod == nil {
+				logger.Error(nil, "Deleted Pod object is unavailable", "pod", deleted.GetKey())
+				return
 			}
 			tm.PodUpdated(pod, nil)
 		},
@@ -254,19 +241,25 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 		return nil, fmt.Errorf("unable to add pod event handler: %w", err)
 	}
 
-	_, err = nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: controllerutil.CreateAddNodeHandler(func(node *v1.Node) error {
+	_, err = nodeInformer.TypedInformer().AddTypedEventHandler(corev1informers.NodeHandlerFuncs{
+		AddFunc: func(node *v1.Node) {
+			node = node.DeepCopy()
 			tm.NodeUpdated(nil, node)
-			return nil
-		}),
-		UpdateFunc: controllerutil.CreateUpdateNodeHandler(func(oldNode, newNode *v1.Node) error {
+		},
+		UpdateFunc: func(oldNode, newNode *v1.Node) {
+			oldNode = oldNode.DeepCopy()
+			newNode = newNode.DeepCopy()
 			tm.NodeUpdated(oldNode, newNode)
-			return nil
-		}),
-		DeleteFunc: controllerutil.CreateDeleteNodeHandler(logger, func(node *v1.Node) error {
+		},
+		DeleteFunc: func(deleted corev1informers.DeletedNode) {
+			node := deleted.OptionalObj
+			if node == nil {
+				logger.Error(nil, "Deleted Node object is unavailable", "node", deleted.GetKey())
+				return
+			}
+			node = node.DeepCopy()
 			tm.NodeUpdated(node, nil)
-			return nil
-		}),
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to add node event handler: %w", err)

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -86,7 +86,7 @@ func NewTTLController(ctx context.Context, nodeInformer informers.TypedNodeInfor
 		),
 	}
 	logger := klog.FromContext(ctx)
-	nodeInformer.TypedInformer().AddTypedEventHandler(informers.NodeHandlerFuncs{
+	_, _ = nodeInformer.TypedInformer().AddTypedEventHandler(informers.NodeHandlerFuncs{
 		AddFunc: func(obj *v1.Node) {
 			ttlc.addNode(logger, obj)
 		},
@@ -94,7 +94,7 @@ func NewTTLController(ctx context.Context, nodeInformer informers.TypedNodeInfor
 			ttlc.updateNode(logger, old, newObj)
 		},
 		DeleteFunc: ttlc.deleteNode,
-	}, cache.HandlerOptions{})
+	})
 
 	ttlc.nodeStore = listers.NewNodeLister(nodeInformer.Informer().GetIndexer())
 	ttlc.hasSynced = nodeInformer.Informer().HasSynced

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -28,7 +28,6 @@ package ttl
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strconv"
 	"sync"
@@ -78,7 +77,7 @@ type Controller struct {
 }
 
 // NewTTLController creates a new TTLController
-func NewTTLController(ctx context.Context, nodeInformer informers.NodeInformer, kubeClient clientset.Interface) *Controller {
+func NewTTLController(ctx context.Context, nodeInformer informers.TypedNodeInformer, kubeClient clientset.Interface) *Controller {
 	ttlc := &Controller{
 		kubeClient: kubeClient,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -87,15 +86,15 @@ func NewTTLController(ctx context.Context, nodeInformer informers.NodeInformer, 
 		),
 	}
 	logger := klog.FromContext(ctx)
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	nodeInformer.TypedInformer().AddTypedEventHandler(informers.NodeHandlerFuncs{
+		AddFunc: func(obj *v1.Node) {
 			ttlc.addNode(logger, obj)
 		},
-		UpdateFunc: func(old, newObj interface{}) {
+		UpdateFunc: func(old, newObj *v1.Node) {
 			ttlc.updateNode(logger, old, newObj)
 		},
 		DeleteFunc: ttlc.deleteNode,
-	})
+	}, cache.HandlerOptions{})
 
 	ttlc.nodeStore = listers.NewNodeLister(nodeInformer.Informer().GetIndexer())
 	ttlc.hasSynced = nodeInformer.Informer().HasSynced
@@ -145,13 +144,7 @@ func (ttlc *Controller) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-func (ttlc *Controller) addNode(logger klog.Logger, obj interface{}) {
-	node, ok := obj.(*v1.Node)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
-		return
-	}
-
+func (ttlc *Controller) addNode(logger klog.Logger, node *v1.Node) {
 	func() {
 		ttlc.lock.Lock()
 		defer ttlc.lock.Unlock()
@@ -164,12 +157,7 @@ func (ttlc *Controller) addNode(logger klog.Logger, obj interface{}) {
 	ttlc.enqueueNode(logger, node)
 }
 
-func (ttlc *Controller) updateNode(logger klog.Logger, _, newObj interface{}) {
-	node, ok := newObj.(*v1.Node)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", newObj))
-		return
-	}
+func (ttlc *Controller) updateNode(logger klog.Logger, _, node *v1.Node) {
 	// Processing all updates of nodes guarantees that we will update
 	// the ttl annotation, when cluster size changes.
 	// We are relying on the fact that Kubelet is updating node status
@@ -178,21 +166,7 @@ func (ttlc *Controller) updateNode(logger klog.Logger, _, newObj interface{}) {
 	ttlc.enqueueNode(logger, node)
 }
 
-func (ttlc *Controller) deleteNode(obj interface{}) {
-	_, ok := obj.(*v1.Node)
-	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object type: %v", obj))
-			return
-		}
-		_, ok = tombstone.Obj.(*v1.Node)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("unexpected object types: %v", obj))
-			return
-		}
-	}
-
+func (ttlc *Controller) deleteNode(_ informers.DeletedNode) {
 	func() {
 		ttlc.lock.Lock()
 		defer ttlc.lock.Unlock()

--- a/pkg/controller/ttl/ttl_controller_test.go
+++ b/pkg/controller/ttl/ttl_controller_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	listers "k8s.io/client-go/listers/core/v1"
 	core "k8s.io/client-go/testing"
@@ -240,7 +241,7 @@ func TestDesiredTTL(t *testing.T) {
 			ttlController.addNode(logger, &v1.Node{})
 		}
 		if testCase.deleteNode {
-			ttlController.deleteNode(&v1.Node{})
+			ttlController.deleteNode(coreinformers.DeletedNode{OptionalObj: &v1.Node{}})
 		}
 		assert.Equal(t, testCase.expectedTTL, ttlController.getDesiredTTLSeconds(),
 			"%d: unexpected ttl: %d", i, ttlController.getDesiredTTLSeconds())

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -87,14 +87,14 @@ func New(ctx context.Context, jobInformer batchinformers.TypedJobInformer, clien
 	}
 
 	logger := klog.FromContext(ctx)
-	jobInformer.TypedInformer().AddTypedEventHandler(batchinformers.JobHandlerFuncs{
+	_, _ = jobInformer.TypedInformer().AddTypedEventHandler(batchinformers.JobHandlerFuncs{
 		AddFunc: func(obj *batch.Job) {
 			tc.addJob(logger, obj)
 		},
 		UpdateFunc: func(oldObj, newObj *batch.Job) {
 			tc.updateJob(logger, oldObj, newObj)
 		},
-	}, cache.HandlerOptions{})
+	})
 
 	tc.jLister = jobInformer.Lister()
 	tc.jListerSynced = jobInformer.Informer().HasSynced

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -70,7 +70,7 @@ type Controller struct {
 }
 
 // New creates an instance of Controller
-func New(ctx context.Context, jobInformer batchinformers.JobInformer, client clientset.Interface) *Controller {
+func New(ctx context.Context, jobInformer batchinformers.TypedJobInformer, client clientset.Interface) *Controller {
 	eventBroadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	eventBroadcaster.StartStructuredLogging(3)
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: client.CoreV1().Events("")})
@@ -87,14 +87,14 @@ func New(ctx context.Context, jobInformer batchinformers.JobInformer, client cli
 	}
 
 	logger := klog.FromContext(ctx)
-	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	jobInformer.TypedInformer().AddTypedEventHandler(batchinformers.JobHandlerFuncs{
+		AddFunc: func(obj *batch.Job) {
 			tc.addJob(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *batch.Job) {
 			tc.updateJob(logger, oldObj, newObj)
 		},
-	})
+	}, cache.HandlerOptions{})
 
 	tc.jLister = jobInformer.Lister()
 	tc.jListerSynced = jobInformer.Informer().HasSynced
@@ -130,8 +130,7 @@ func (tc *Controller) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-func (tc *Controller) addJob(logger klog.Logger, obj interface{}) {
-	job := obj.(*batch.Job)
+func (tc *Controller) addJob(logger klog.Logger, job *batch.Job) {
 	logger.V(4).Info("Adding job", "job", klog.KObj(job))
 
 	if job.DeletionTimestamp == nil && needsCleanup(job) {
@@ -140,8 +139,7 @@ func (tc *Controller) addJob(logger klog.Logger, obj interface{}) {
 
 }
 
-func (tc *Controller) updateJob(logger klog.Logger, old, cur interface{}) {
-	job := cur.(*batch.Job)
+func (tc *Controller) updateJob(logger klog.Logger, _, job *batch.Job) {
 	logger.V(4).Info("Updating job", "job", klog.KObj(job))
 
 	if job.DeletionTimestamp == nil && needsCleanup(job) {

--- a/pkg/controller/validatingadmissionpolicystatus/controller.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller.go
@@ -41,7 +41,7 @@ const ControllerName = "validatingadmissionpolicy-status"
 // Controller is the ValidatingAdmissionPolicy Status controller that reconciles the Status field of each policy object.
 // This controller runs type checks against referred types for each policy definition.
 type Controller struct {
-	policyInformer informerv1.ValidatingAdmissionPolicyInformer
+	policyInformer informerv1.TypedValidatingAdmissionPolicyInformer
 	policyQueue    workqueue.TypedRateLimitingInterface[string]
 	policySynced   cache.InformerSynced
 	policyClient   admissionregistrationv1.ValidatingAdmissionPolicyInterface
@@ -73,7 +73,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-func NewController(policyInformer informerv1.ValidatingAdmissionPolicyInformer, policyClient admissionregistrationv1.ValidatingAdmissionPolicyInterface, typeChecker *validatingadmissionpolicy.TypeChecker) (*Controller, error) {
+func NewController(policyInformer informerv1.TypedValidatingAdmissionPolicyInformer, policyClient admissionregistrationv1.ValidatingAdmissionPolicyInterface, typeChecker *validatingadmissionpolicy.TypeChecker) (*Controller, error) {
 	c := &Controller{
 		policyInformer: policyInformer,
 		policyQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -83,14 +83,14 @@ func NewController(policyInformer informerv1.ValidatingAdmissionPolicyInformer, 
 		policyClient: policyClient,
 		typeChecker:  typeChecker,
 	}
-	reg, err := policyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	reg, err := policyInformer.TypedInformer().AddTypedEventHandler(informerv1.ValidatingAdmissionPolicyHandlerFuncs{
+		AddFunc: func(obj *v1.ValidatingAdmissionPolicy) {
 			c.enqueuePolicy(obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(_, newObj *v1.ValidatingAdmissionPolicy) {
 			c.enqueuePolicy(newObj)
 		},
-	})
+	}, cache.HandlerOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -98,15 +98,13 @@ func NewController(policyInformer informerv1.ValidatingAdmissionPolicyInformer, 
 	return c, nil
 }
 
-func (c *Controller) enqueuePolicy(policy any) {
-	if policy, ok := policy.(*v1.ValidatingAdmissionPolicy); ok {
-		// policy objects are cluster-scoped, no point include its namespace.
-		key := policy.ObjectMeta.Name
-		if key == "" {
-			utilruntime.HandleError(fmt.Errorf("cannot get name of object %v", policy))
-		}
-		c.policyQueue.Add(key)
+func (c *Controller) enqueuePolicy(policy *v1.ValidatingAdmissionPolicy) {
+	// Policy objects are cluster-scoped, so their name is the queue key.
+	key := policy.Name
+	if key == "" {
+		utilruntime.HandleError(fmt.Errorf("cannot get name of object %v", policy))
 	}
+	c.policyQueue.Add(key)
 }
 
 func (c *Controller) runWorker(ctx context.Context) {

--- a/pkg/controller/validatingadmissionpolicystatus/controller.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller.go
@@ -90,7 +90,7 @@ func NewController(policyInformer informerv1.TypedValidatingAdmissionPolicyInfor
 		UpdateFunc: func(_, newObj *v1.ValidatingAdmissionPolicy) {
 			c.enqueuePolicy(newObj)
 		},
-	}, cache.HandlerOptions{})
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -103,10 +103,10 @@ type AttachDetachController interface {
 func NewAttachDetachController(
 	ctx context.Context,
 	kubeClient clientset.Interface,
-	podInformer coreinformers.PodInformer,
-	nodeInformer coreinformers.NodeInformer,
-	pvcInformer coreinformers.PersistentVolumeClaimInformer,
-	pvInformer coreinformers.PersistentVolumeInformer,
+	podInformer coreinformers.TypedPodInformer,
+	nodeInformer coreinformers.TypedNodeInformer,
+	pvcInformer coreinformers.TypedPersistentVolumeClaimInformer,
+	pvInformer coreinformers.TypedPersistentVolumeInformer,
 	csiNodeInformer storageinformersv1.CSINodeInformer,
 	csiDriverInformer storageinformersv1.CSIDriverInformer,
 	volumeAttachmentInformer storageinformersv1.VolumeAttachmentInformer,
@@ -193,15 +193,15 @@ func NewAttachDetachController(
 		adc.csiMigratedPluginManager,
 		adc.intreeToCSITranslator)
 
-	podInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc: func(obj *v1.Pod) {
 			adc.podAdd(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *v1.Pod) {
 			adc.podUpdate(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			adc.podDelete(logger, obj)
+		DeleteFunc: func(obj coreinformers.DeletedPod) {
+			adc.podDelete(logger, obj.OptionalObj)
 		},
 	})
 
@@ -211,23 +211,23 @@ func NewAttachDetachController(
 		return nil, fmt.Errorf("could not initialize attach detach controller: %w", err)
 	}
 
-	nodeInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = nodeInformer.TypedInformer().AddTypedEventHandler(coreinformers.NodeHandlerFuncs{
+		AddFunc: func(obj *v1.Node) {
 			adc.nodeAdd(logger, obj)
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj *v1.Node) {
 			adc.nodeUpdate(logger, oldObj, newObj)
 		},
-		DeleteFunc: func(obj interface{}) {
-			adc.nodeDelete(logger, obj)
+		DeleteFunc: func(obj coreinformers.DeletedNode) {
+			adc.nodeDelete(logger, obj.OptionalObj)
 		},
 	})
 
-	pvcInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = pvcInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeClaimHandlerFuncs{
+		AddFunc: func(obj *v1.PersistentVolumeClaim) {
 			adc.enqueuePVC(obj)
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new *v1.PersistentVolumeClaim) {
 			adc.enqueuePVC(new)
 		},
 	})

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -102,17 +102,17 @@ func NewController(
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	ec.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "ephemeral_volume"})
 
-	podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+	_, _ = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
 		AddFunc: ec.enqueuePod,
 		// The pod spec is immutable. Therefore the controller can ignore pod updates
 		// because there cannot be any changes that have to be copied into the generated
 		// PVC.
 		// Deletion of the PVC is handled through the owner reference and garbage collection.
 		// Therefore pod deletions also can be ignored.
-	}, cache.HandlerOptions{})
-	pvcInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeClaimHandlerFuncs{
+	})
+	_, _ = pvcInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeClaimHandlerFuncs{
 		DeleteFunc: ec.onPVCDelete,
-	}, cache.HandlerOptions{})
+	})
 	if err := common.AddPodPVCIndexerIfNotPresent(podInformer.Informer().GetIndexer()); err != nil {
 		return nil, fmt.Errorf("could not initialize ephemeral volume controller: %w", err)
 	}

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -67,7 +67,7 @@ type ephemeralController struct {
 
 	// podIndexer has the common PodPVC indexer indexer installed To
 	// limit iteration over pods to those of interest.
-	podIndexer cache.Indexer
+	podIndexer cache.TypedIndexer[*v1.Pod]
 
 	// recorder is used to record events in the API server
 	recorder record.EventRecorder
@@ -79,13 +79,13 @@ type ephemeralController struct {
 func NewController(
 	ctx context.Context,
 	kubeClient clientset.Interface,
-	podInformer coreinformers.PodInformer,
-	pvcInformer coreinformers.PersistentVolumeClaimInformer) (Controller, error) {
+	podInformer coreinformers.TypedPodInformer,
+	pvcInformer coreinformers.TypedPersistentVolumeClaimInformer) (Controller, error) {
 
 	ec := &ephemeralController{
 		kubeClient: kubeClient,
 		podLister:  podInformer.Lister(),
-		podIndexer: podInformer.Informer().GetIndexer(),
+		podIndexer: podInformer.TypedInformer().GetTypedIndexer(),
 		podSynced:  podInformer.Informer().HasSynced,
 		pvcLister:  pvcInformer.Lister(),
 		pvcsSynced: pvcInformer.Informer().HasSynced,
@@ -102,30 +102,25 @@ func NewController(
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	ec.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "ephemeral_volume"})
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
 		AddFunc: ec.enqueuePod,
 		// The pod spec is immutable. Therefore the controller can ignore pod updates
 		// because there cannot be any changes that have to be copied into the generated
 		// PVC.
 		// Deletion of the PVC is handled through the owner reference and garbage collection.
 		// Therefore pod deletions also can be ignored.
-	})
-	pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	}, cache.HandlerOptions{})
+	pvcInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeClaimHandlerFuncs{
 		DeleteFunc: ec.onPVCDelete,
-	})
-	if err := common.AddPodPVCIndexerIfNotPresent(ec.podIndexer); err != nil {
+	}, cache.HandlerOptions{})
+	if err := common.AddPodPVCIndexerIfNotPresent(podInformer.Informer().GetIndexer()); err != nil {
 		return nil, fmt.Errorf("could not initialize ephemeral volume controller: %w", err)
 	}
 
 	return ec, nil
 }
 
-func (ec *ephemeralController) enqueuePod(obj interface{}) {
-	pod, ok := obj.(*v1.Pod)
-	if !ok {
-		return
-	}
-
+func (ec *ephemeralController) enqueuePod(pod *v1.Pod) {
 	// Ignore pods which are already getting deleted.
 	if pod.DeletionTimestamp != nil {
 		return
@@ -134,36 +129,26 @@ func (ec *ephemeralController) enqueuePod(obj interface{}) {
 	for _, vol := range pod.Spec.Volumes {
 		if vol.Ephemeral != nil {
 			// It has at least one ephemeral inline volume, work on it.
-			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(pod)
-			if err != nil {
-				runtime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", pod, err))
-				return
-			}
-			ec.queue.Add(key)
+			ec.queue.Add(pod.Namespace + "/" + pod.Name)
 			break
 		}
 	}
 }
 
-func (ec *ephemeralController) onPVCDelete(obj interface{}) {
-	pvc, ok := obj.(*v1.PersistentVolumeClaim)
-	if !ok {
-		return
-	}
-
+func (ec *ephemeralController) onPVCDelete(deleted coreinformers.DeletedPersistentVolumeClaim) {
 	// Someone deleted a PVC, either intentionally or
 	// accidentally. If there is a pod referencing it because of
 	// an ephemeral volume, then we should re-create the PVC.
 	// The common indexer does some prefiltering for us by
 	// limiting the list to those pods which reference
 	// the PVC.
-	objs, err := ec.podIndexer.ByIndex(common.PodPVCIndex, fmt.Sprintf("%s/%s", pvc.Namespace, pvc.Name))
+	pods, err := ec.podIndexer.ByTypedIndex(common.PodPVCIndex, deleted.GetKey())
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("listing pods from cache: %v", err))
 		return
 	}
-	for _, obj := range objs {
-		ec.enqueuePod(obj)
+	for _, pod := range pods {
+		ec.enqueuePod(pod)
 	}
 }
 

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -100,7 +100,7 @@ type expandController struct {
 func NewExpandController(
 	ctx context.Context,
 	kubeClient clientset.Interface,
-	pvcInformer coreinformers.PersistentVolumeClaimInformer,
+	pvcInformer coreinformers.TypedPersistentVolumeClaimInformer,
 	plugins []volume.VolumePlugin,
 	translator CSINameTranslator,
 	csiMigratedPluginManager csimigration.PluginManager) (ExpandController, error) {
@@ -133,30 +133,21 @@ func NewExpandController(
 		expc.recorder,
 		blkutil)
 
-	pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: expc.enqueuePVC,
-		UpdateFunc: func(old, new interface{}) {
-			oldPVC, ok := old.(*v1.PersistentVolumeClaim)
-			if !ok {
-				return
-			}
-
+	_, _ = pvcInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeClaimHandlerFuncs{
+		AddFunc: func(pvc *v1.PersistentVolumeClaim) { expc.enqueuePVC(pvc) },
+		UpdateFunc: func(oldPVC, newPVC *v1.PersistentVolumeClaim) {
 			oldReq := oldPVC.Spec.Resources.Requests[v1.ResourceStorage]
 			oldCap := oldPVC.Status.Capacity[v1.ResourceStorage]
-			newPVC, ok := new.(*v1.PersistentVolumeClaim)
-			if !ok {
-				return
-			}
 			newReq := newPVC.Spec.Resources.Requests[v1.ResourceStorage]
 			newCap := newPVC.Status.Capacity[v1.ResourceStorage]
 			// PVC will be enqueued under 2 circumstances
 			// 1. User has increased PVC's request capacity --> volume needs to be expanded
 			// 2. PVC status capacity has been expanded --> claim's bound PV has likely recently gone through filesystem resize, so remove AnnPreResizeCapacity annotation from PV
 			if newReq.Cmp(oldReq) > 0 || newCap.Cmp(oldCap) > 0 {
-				expc.enqueuePVC(new)
+				expc.enqueuePVC(newPVC)
 			}
 		},
-		DeleteFunc: expc.enqueuePVC,
+		DeleteFunc: func(pvc coreinformers.DeletedPersistentVolumeClaim) { expc.enqueuePVC(pvc.OptionalObj) },
 	})
 
 	return expc, nil

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -65,11 +65,11 @@ type ControllerParameters struct {
 	KubeClient                clientset.Interface
 	SyncPeriod                time.Duration
 	VolumePlugins             []vol.VolumePlugin
-	VolumeInformer            coreinformers.PersistentVolumeInformer
-	ClaimInformer             coreinformers.PersistentVolumeClaimInformer
-	ClassInformer             storageinformers.StorageClassInformer
-	PodInformer               coreinformers.PodInformer
-	NodeInformer              coreinformers.NodeInformer
+	VolumeInformer            coreinformers.TypedPersistentVolumeInformer
+	ClaimInformer             coreinformers.TypedPersistentVolumeClaimInformer
+	ClassInformer             storageinformers.TypedStorageClassInformer
+	PodInformer               coreinformers.TypedPodInformer
+	NodeInformer              coreinformers.TypedNodeInformer
 	EnableDynamicProvisioning bool
 }
 
@@ -105,21 +105,23 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 		return nil, fmt.Errorf("could not initialize volume plugins for PersistentVolume Controller: %w", err)
 	}
 
-	p.VolumeInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, obj) },
-			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, newObj) },
-			DeleteFunc: func(obj interface{}) { controller.enqueueWork(ctx, controller.volumeQueue, obj) },
+	_, _ = p.VolumeInformer.TypedInformer().AddTypedEventHandler(
+		coreinformers.PersistentVolumeHandlerFuncs{
+			AddFunc:    func(obj *v1.PersistentVolume) { controller.enqueueWork(ctx, controller.volumeQueue, obj) },
+			UpdateFunc: func(oldObj, newObj *v1.PersistentVolume) { controller.enqueueWork(ctx, controller.volumeQueue, newObj) },
+			DeleteFunc: func(obj coreinformers.DeletedPersistentVolume) { controller.volumeQueue.Add(obj.GetKey()) },
 		},
 	)
 	controller.volumeLister = p.VolumeInformer.Lister()
 	controller.volumeListerSynced = p.VolumeInformer.Informer().HasSynced
 
-	p.ClaimInformer.Informer().AddEventHandler(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, obj) },
-			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, newObj) },
-			DeleteFunc: func(obj interface{}) { controller.enqueueWork(ctx, controller.claimQueue, obj) },
+	_, _ = p.ClaimInformer.TypedInformer().AddTypedEventHandler(
+		coreinformers.PersistentVolumeClaimHandlerFuncs{
+			AddFunc: func(obj *v1.PersistentVolumeClaim) { controller.enqueueWork(ctx, controller.claimQueue, obj) },
+			UpdateFunc: func(oldObj, newObj *v1.PersistentVolumeClaim) {
+				controller.enqueueWork(ctx, controller.claimQueue, newObj)
+			},
+			DeleteFunc: func(obj coreinformers.DeletedPersistentVolumeClaim) { controller.claimQueue.Add(obj.GetKey()) },
 		},
 	)
 	controller.claimLister = p.ClaimInformer.Lister()

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -122,7 +122,7 @@ var unusedSinceNowFunc = metav1.Now
 type podUsageCheckFunc func(logger klog.Logger, pod *v1.Pod, pvc *v1.PersistentVolumeClaim) bool
 
 // NewPVCProtectionController returns a new instance of PVCProtectionController.
-func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.PersistentVolumeClaimInformer, podInformer coreinformers.PodInformer, cl clientset.Interface) (*Controller, error) {
+func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.TypedPersistentVolumeClaimInformer, podInformer coreinformers.TypedPodInformer, cl clientset.Interface) (*Controller, error) {
 	e := &Controller{
 		client: cl,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -134,11 +134,11 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 
 	e.pvcLister = pvcInformer.Lister()
 	e.pvcListerSynced = pvcInformer.Informer().HasSynced
-	pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = pvcInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeClaimHandlerFuncs{
+		AddFunc: func(obj *v1.PersistentVolumeClaim) {
 			e.pvcAddedUpdated(logger, obj)
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new *v1.PersistentVolumeClaim) {
 			e.pvcAddedUpdated(logger, new)
 		},
 	})
@@ -149,14 +149,14 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 	if err := common.AddIndexerIfNotPresent(e.podIndexer, common.PodPVCIndex, common.PodPVCIndexFunc()); err != nil {
 		return nil, fmt.Errorf("could not initialize pvc protection controller: %w", err)
 	}
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc: func(obj *v1.Pod) {
 			e.podAddedDeletedUpdated(logger, nil, obj, false)
 		},
-		DeleteFunc: func(obj interface{}) {
-			e.podAddedDeletedUpdated(logger, nil, obj, true)
+		DeleteFunc: func(obj coreinformers.DeletedPod) {
+			e.podAddedDeletedUpdated(logger, nil, obj.OptionalObj, true)
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new *v1.Pod) {
 			e.podAddedDeletedUpdated(logger, old, new, false)
 		},
 	})

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -61,14 +61,14 @@ func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.Type
 
 	e.pvLister = pvInformer.Lister()
 	e.pvListerSynced = pvInformer.Informer().HasSynced
-	pvInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeHandlerFuncs{
+	_, _ = pvInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeHandlerFuncs{
 		AddFunc: func(obj *v1.PersistentVolume) {
 			e.pvAddedUpdated(logger, obj)
 		},
 		UpdateFunc: func(_, newObj *v1.PersistentVolume) {
 			e.pvAddedUpdated(logger, newObj)
 		},
-	}, cache.HandlerOptions{})
+	})
 
 	return e
 }

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -50,7 +50,7 @@ type Controller struct {
 }
 
 // NewPVProtectionController returns a new *Controller.
-func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.PersistentVolumeInformer, cl clientset.Interface) *Controller {
+func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.TypedPersistentVolumeInformer, cl clientset.Interface) *Controller {
 	e := &Controller{
 		client: cl,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -61,14 +61,14 @@ func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.Pers
 
 	e.pvLister = pvInformer.Lister()
 	e.pvListerSynced = pvInformer.Informer().HasSynced
-	pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	pvInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeHandlerFuncs{
+		AddFunc: func(obj *v1.PersistentVolume) {
 			e.pvAddedUpdated(logger, obj)
 		},
-		UpdateFunc: func(old, new interface{}) {
-			e.pvAddedUpdated(logger, new)
+		UpdateFunc: func(_, newObj *v1.PersistentVolume) {
+			e.pvAddedUpdated(logger, newObj)
 		},
-	})
+	}, cache.HandlerOptions{})
 
 	return e
 }
@@ -201,12 +201,7 @@ func (c *Controller) isBeingUsed(pv *v1.PersistentVolume) bool {
 }
 
 // pvAddedUpdated reacts to pv added/updated events
-func (c *Controller) pvAddedUpdated(logger klog.Logger, obj interface{}) {
-	pv, ok := obj.(*v1.PersistentVolume)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("PV informer returned non-PV object: %#v", obj))
-		return
-	}
+func (c *Controller) pvAddedUpdated(logger klog.Logger, pv *v1.PersistentVolume) {
 	logger.V(4).Info("Got event on PV", "PV", klog.KObj(pv))
 
 	if protectionutil.NeedToAddFinalizer(pv, volumeutil.PVProtectionFinalizer) || protectionutil.IsDeletionCandidate(pv, volumeutil.PVProtectionFinalizer) {

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
@@ -86,10 +86,10 @@ type Controller struct {
 func NewController(
 	ctx context.Context,
 	kubeClient clientset.Interface,
-	podInformer coreinformers.PodInformer,
-	pvcInformer coreinformers.PersistentVolumeClaimInformer,
-	pvInformer coreinformers.PersistentVolumeInformer,
-	csiDriverInformer storageinformersv1.CSIDriverInformer,
+	podInformer coreinformers.TypedPodInformer,
+	pvcInformer coreinformers.TypedPersistentVolumeClaimInformer,
+	pvInformer coreinformers.TypedPersistentVolumeInformer,
+	csiDriverInformer storageinformersv1.TypedCSIDriverInformer,
 	plugins []volume.VolumePlugin,
 	prober volume.DynamicPluginProber,
 ) (*Controller, error) {
@@ -139,35 +139,35 @@ func NewController(
 	}
 
 	logger := klog.FromContext(ctx)
-	_, err = podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.enqueuePod(logger, obj) },
-		UpdateFunc: func(oldObj, newObj interface{}) { c.updatePod(logger, oldObj, newObj) },
-		DeleteFunc: func(obj interface{}) { c.enqueuePod(logger, obj) },
+	_, err = podInformer.TypedInformer().AddTypedEventHandler(coreinformers.PodHandlerFuncs{
+		AddFunc:    func(obj *v1.Pod) { c.enqueuePod(logger, obj) },
+		UpdateFunc: func(oldObj, newObj *v1.Pod) { c.updatePod(logger, oldObj, newObj) },
+		DeleteFunc: func(obj coreinformers.DeletedPod) { c.enqueuePod(logger, obj.OptionalObj) },
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.addPVC(logger, obj) },
-		UpdateFunc: func(oldObj, newObj interface{}) { c.updatePVC(logger, oldObj, newObj) },
+	_, err = pvcInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeClaimHandlerFuncs{
+		AddFunc:    func(obj *v1.PersistentVolumeClaim) { c.addPVC(logger, obj) },
+		UpdateFunc: func(oldObj, newObj *v1.PersistentVolumeClaim) { c.updatePVC(logger, oldObj, newObj) },
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.addPV(logger, obj) },
-		UpdateFunc: func(oldObj, newObj interface{}) { c.updatePV(logger, oldObj, newObj) },
+	_, err = pvInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeHandlerFuncs{
+		AddFunc:    func(obj *v1.PersistentVolume) { c.addPV(logger, obj) },
+		UpdateFunc: func(oldObj, newObj *v1.PersistentVolume) { c.updatePV(logger, oldObj, newObj) },
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = csiDriverInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { c.addCSIDriver(logger, obj) },
-		UpdateFunc: func(oldObj, newObj interface{}) { c.updateCSIDriver(logger, oldObj, newObj) },
-		DeleteFunc: func(obj interface{}) { c.deleteCSIDriver(logger, obj) },
+	_, err = csiDriverInformer.TypedInformer().AddTypedEventHandler(storageinformersv1.CSIDriverHandlerFuncs{
+		AddFunc:    func(obj *storagev1.CSIDriver) { c.addCSIDriver(logger, obj) },
+		UpdateFunc: func(oldObj, newObj *storagev1.CSIDriver) { c.updateCSIDriver(logger, oldObj, newObj) },
+		DeleteFunc: func(obj storageinformersv1.DeletedCSIDriver) { c.deleteCSIDriver(logger, obj.OptionalObj) },
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/controller/volume/vacprotection/vac_protection_controller.go
+++ b/pkg/controller/volume/vacprotection/vac_protection_controller.go
@@ -96,9 +96,9 @@ type Controller struct {
 // NewVACProtectionController returns a new *Controller.
 func NewVACProtectionController(logger klog.Logger,
 	client clientset.Interface,
-	pvcInformer coreinformers.PersistentVolumeClaimInformer,
-	pvInformer coreinformers.PersistentVolumeInformer,
-	vacInformer storageinformers.VolumeAttributesClassInformer) (*Controller, error) {
+	pvcInformer coreinformers.TypedPersistentVolumeClaimInformer,
+	pvInformer coreinformers.TypedPersistentVolumeInformer,
+	vacInformer storageinformers.TypedVolumeAttributesClassInformer) (*Controller, error) {
 	c := &Controller{
 		client:    client,
 		pvcSynced: pvcInformer.Informer().HasSynced,
@@ -113,20 +113,16 @@ func NewVACProtectionController(logger klog.Logger,
 		),
 	}
 
-	_, _ = vacInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+	_, _ = vacInformer.TypedInformer().AddTypedEventHandler(storageinformers.VolumeAttributesClassHandlerFuncs{
+		AddFunc: func(obj *storagev1.VolumeAttributesClass) {
 			c.vacAddedUpdated(logger, obj)
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new *storagev1.VolumeAttributesClass) {
 			c.vacAddedUpdated(logger, new)
 		},
 	})
 
-	err := pvInformer.Informer().AddIndexers(cache.Indexers{vacNameKeyIndex: func(obj interface{}) ([]string, error) {
-		pv, ok := obj.(*v1.PersistentVolume)
-		if !ok {
-			return []string{}, nil
-		}
+	err := pvInformer.TypedInformer().AddTypedIndexers(coreinformers.PersistentVolumeIndexers{vacNameKeyIndex: func(pv *v1.PersistentVolume) ([]string, error) {
 		return getPVReferencedVACNames(pv), nil
 	}})
 	if err != nil {
@@ -150,11 +146,7 @@ func NewVACProtectionController(logger klog.Logger,
 		return pvcs, nil
 	}
 
-	err = pvcInformer.Informer().AddIndexers(cache.Indexers{vacNameKeyIndex: func(obj interface{}) ([]string, error) {
-		pvc, ok := obj.(*v1.PersistentVolumeClaim)
-		if !ok {
-			return []string{}, nil
-		}
+	err = pvcInformer.TypedInformer().AddTypedIndexers(coreinformers.PersistentVolumeClaimIndexers{vacNameKeyIndex: func(pvc *v1.PersistentVolumeClaim) ([]string, error) {
 		return getPVCReferencedVACNames(pvc), nil
 	}})
 	if err != nil {
@@ -178,21 +170,21 @@ func NewVACProtectionController(logger klog.Logger,
 		return pvcs, nil
 	}
 
-	_, _ = pvcInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(old, new interface{}) {
+	_, _ = pvcInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeClaimHandlerFuncs{
+		UpdateFunc: func(old, new *v1.PersistentVolumeClaim) {
 			c.pvcUpdated(logger, old, new)
 		},
-		DeleteFunc: func(obj interface{}) {
-			c.pvcDeleted(logger, obj)
+		DeleteFunc: func(obj coreinformers.DeletedPersistentVolumeClaim) {
+			c.pvcDeleted(logger, obj.OptionalObj)
 		},
 	})
 
-	_, _ = pvInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(old, new interface{}) {
+	_, _ = pvInformer.TypedInformer().AddTypedEventHandler(coreinformers.PersistentVolumeHandlerFuncs{
+		UpdateFunc: func(old, new *v1.PersistentVolume) {
 			c.pvUpdated(logger, old, new)
 		},
-		DeleteFunc: func(obj interface{}) {
-			c.pvDeleted(logger, obj)
+		DeleteFunc: func(obj coreinformers.DeletedPersistentVolume) {
+			c.pvDeleted(logger, obj.OptionalObj)
 		},
 	})
 	return c, nil

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -56,9 +56,9 @@ type Tracker struct {
 	enableDeviceTaintRules bool
 
 	resourceSliceLister   resourcelisters.ResourceSliceLister
-	resourceSlices        cache.SharedIndexInformer
+	resourceSlices        resourceinformers.ResourceSliceIndexInformer
 	resourceSlicesHandle  cache.ResourceEventHandlerRegistration
-	deviceTaints          cache.SharedIndexInformer
+	deviceTaints          resourceinformers.DeviceTaintRuleIndexInformer
 	deviceTaintsHandle    cache.ResourceEventHandlerRegistration
 	patchedResourceSlices cache.Store
 	broadcaster           record.EventBroadcaster
@@ -114,8 +114,8 @@ type Options struct {
 	// EnableConsumableCapacity defines whether the CEL compiler supports the DRAConsumableCapacity feature.
 	EnableConsumableCapacity bool
 
-	SliceInformer resourceinformers.ResourceSliceInformer
-	TaintInformer resourceinformers.DeviceTaintRuleInformer
+	SliceInformer resourceinformers.TypedResourceSliceInformer
+	TaintInformer resourceinformers.TypedDeviceTaintRuleInformer
 
 	// KubeClient is used to generate Events when CEL expressions
 	// encounter runtime errors.
@@ -128,7 +128,7 @@ func StartTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr 
 		// Minimal wrapper. All public methods shortcut by calling the underlying informer.
 		return &Tracker{
 			resourceSliceLister: opts.SliceInformer.Lister(),
-			resourceSlices:      opts.SliceInformer.Informer(),
+			resourceSlices:      opts.SliceInformer.TypedInformer(),
 		}, nil
 	}
 
@@ -153,8 +153,8 @@ func newTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr er
 	t := &Tracker{
 		enableDeviceTaintRules: opts.EnableDeviceTaintRules,
 		resourceSliceLister:    opts.SliceInformer.Lister(),
-		resourceSlices:         opts.SliceInformer.Informer(),
-		deviceTaints:           opts.TaintInformer.Informer(),
+		resourceSlices:         opts.SliceInformer.TypedInformer(),
+		deviceTaints:           opts.TaintInformer.TypedInformer(),
 		patchedResourceSlices:  cache.NewStore(cache.MetaNamespaceKeyFunc),
 		handleError:            utilruntime.HandleErrorWithContext,
 		synced:                 make(chan struct{}),
@@ -167,7 +167,7 @@ func newTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr er
 			t.Stop()
 		}
 	}()
-	err := t.resourceSlices.AddIndexers(cache.Indexers{driverPoolDeviceIndexName: sliceDriverPoolDeviceIndexFunc})
+	err := t.resourceSlices.AddTypedIndexers(resourceinformers.ResourceSliceIndexers{driverPoolDeviceIndexName: sliceDriverPoolDeviceIndexFunc})
 	if err != nil {
 		return nil, fmt.Errorf("failed to add %s index to ResourceSlice informer: %w", driverPoolDeviceIndexName, err)
 	}
@@ -185,23 +185,25 @@ func newTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr er
 // initInformers adds event handlers to a tracker constructed with newTracker.
 func (t *Tracker) initInformers(ctx context.Context) error {
 	var err error
+	logger := klog.FromContext(ctx)
+	options := cache.HandlerOptions{Logger: &logger}
 
-	sliceHandler := cache.ResourceEventHandlerFuncs{
+	sliceHandler := resourceinformers.ResourceSliceHandlerFuncs{
 		AddFunc:    t.resourceSliceAdd(ctx),
 		UpdateFunc: t.resourceSliceUpdate(ctx),
 		DeleteFunc: t.resourceSliceDelete(ctx),
 	}
-	t.resourceSlicesHandle, err = t.resourceSlices.AddEventHandler(sliceHandler)
+	t.resourceSlicesHandle, err = t.resourceSlices.AddTypedEventHandler(sliceHandler, options)
 	if err != nil {
 		return fmt.Errorf("add event handler for ResourceSlices: %w", err)
 	}
 
-	taintHandler := cache.ResourceEventHandlerFuncs{
+	taintHandler := resourceinformers.DeviceTaintRuleHandlerFuncs{
 		AddFunc:    t.deviceTaintAdd(ctx),
 		UpdateFunc: t.deviceTaintUpdate(ctx),
 		DeleteFunc: t.deviceTaintDelete(ctx),
 	}
-	t.deviceTaintsHandle, err = t.deviceTaints.AddEventHandler(taintHandler)
+	t.deviceTaintsHandle, err = t.deviceTaints.AddTypedEventHandler(taintHandler, options)
 	if err != nil {
 		return fmt.Errorf("add event handler for DeviceTaintRules: %w", err)
 	}
@@ -356,8 +358,7 @@ func (t *Tracker) pushEvent(oldObj, newObj any) {
 	}
 }
 
-func sliceDriverPoolDeviceIndexFunc(obj any) ([]string, error) {
-	slice := obj.(*resourceapi.ResourceSlice)
+func sliceDriverPoolDeviceIndexFunc(slice *resourceapi.ResourceSlice) ([]string, error) {
 	drivers := []string{
 		anyDriver,
 		slice.Spec.Driver,
@@ -396,13 +397,9 @@ func (t *Tracker) sliceNamesForPatch(ctx context.Context, patch *resourceapi.Dev
 	return sliceNames
 }
 
-func (t *Tracker) resourceSliceAdd(ctx context.Context) func(obj any) {
+func (t *Tracker) resourceSliceAdd(ctx context.Context) func(*resourceapi.ResourceSlice) {
 	logger := klog.FromContext(ctx)
-	return func(obj any) {
-		slice, ok := obj.(*resourceapi.ResourceSlice)
-		if !ok {
-			return
-		}
+	return func(slice *resourceapi.ResourceSlice) {
 		if loggerV := logger.V(6); loggerV.Enabled() {
 			loggerV.Info("ResourceSlice added", "slice", klog.Format(slice))
 		} else {
@@ -412,17 +409,9 @@ func (t *Tracker) resourceSliceAdd(ctx context.Context) func(obj any) {
 	}
 }
 
-func (t *Tracker) resourceSliceUpdate(ctx context.Context) func(oldObj, newObj any) {
+func (t *Tracker) resourceSliceUpdate(ctx context.Context) func(_, _ *resourceapi.ResourceSlice) {
 	logger := klog.FromContext(ctx)
-	return func(oldObj, newObj any) {
-		oldSlice, ok := oldObj.(*resourceapi.ResourceSlice)
-		if !ok {
-			return
-		}
-		newSlice, ok := newObj.(*resourceapi.ResourceSlice)
-		if !ok {
-			return
-		}
+	return func(oldSlice, newSlice *resourceapi.ResourceSlice) {
 		if loggerV := logger.V(6); loggerV.Enabled() {
 			// While debugging, one needs a full dump of the objects for context *and*
 			// a diff because otherwise small changes would be hard to spot.
@@ -434,28 +423,17 @@ func (t *Tracker) resourceSliceUpdate(ctx context.Context) func(oldObj, newObj a
 	}
 }
 
-func (t *Tracker) resourceSliceDelete(ctx context.Context) func(obj any) {
+func (t *Tracker) resourceSliceDelete(ctx context.Context) func(resourceinformers.DeletedResourceSlice) {
 	logger := klog.FromContext(ctx)
-	return func(obj any) {
-		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-			obj = tombstone.Obj
-		}
-		slice, ok := obj.(*resourceapi.ResourceSlice)
-		if !ok {
-			return
-		}
-		logger.V(5).Info("ResourceSlice deleted", "slice", klog.KObj(slice))
-		t.syncSlice(ctx, slice.Name, true)
+	return func(deletedSlice resourceinformers.DeletedResourceSlice) {
+		logger.V(5).Info("ResourceSlice deleted", "slice", klog.KObj(deletedSlice))
+		t.syncSlice(ctx, deletedSlice.GetName(), true)
 	}
 }
 
-func (t *Tracker) deviceTaintAdd(ctx context.Context) func(obj any) {
+func (t *Tracker) deviceTaintAdd(ctx context.Context) func(*resourceapi.DeviceTaintRule) {
 	logger := klog.FromContext(ctx)
-	return func(obj any) {
-		rule, ok := obj.(*resourceapi.DeviceTaintRule)
-		if !ok {
-			return
-		}
+	return func(rule *resourceapi.DeviceTaintRule) {
 		if loggerV := logger.V(6); loggerV.Enabled() {
 			loggerV.Info("DeviceTaintRule added", "deviceTaintRule", klog.Format(rule))
 		} else {
@@ -467,17 +445,9 @@ func (t *Tracker) deviceTaintAdd(ctx context.Context) func(obj any) {
 	}
 }
 
-func (t *Tracker) deviceTaintUpdate(ctx context.Context) func(oldObj, newObj any) {
+func (t *Tracker) deviceTaintUpdate(ctx context.Context) func(_, _ *resourceapi.DeviceTaintRule) {
 	logger := klog.FromContext(ctx)
-	return func(oldObj, newObj any) {
-		oldRule, ok := oldObj.(*resourceapi.DeviceTaintRule)
-		if !ok {
-			return
-		}
-		newRule, ok := newObj.(*resourceapi.DeviceTaintRule)
-		if !ok {
-			return
-		}
+	return func(oldRule, newRule *resourceapi.DeviceTaintRule) {
 		if loggerV := logger.V(6); loggerV.Enabled() {
 			loggerV.Info("DeviceTaintRule updated", "diff", diff.Diff(oldRule, newRule), "deviceTaintRule", klog.KObj(newRule))
 		} else {
@@ -496,18 +466,15 @@ func (t *Tracker) deviceTaintUpdate(ctx context.Context) func(oldObj, newObj any
 	}
 }
 
-func (t *Tracker) deviceTaintDelete(ctx context.Context) func(obj any) {
+func (t *Tracker) deviceTaintDelete(ctx context.Context) func(resourceinformers.DeletedDeviceTaintRule) {
 	logger := klog.FromContext(ctx)
-	return func(obj any) {
-		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-			obj = tombstone.Obj
-		}
-		patch, ok := obj.(*resourceapi.DeviceTaintRule)
-		if !ok {
+	return func(deletedRule resourceinformers.DeletedDeviceTaintRule) {
+		logger.V(5).Info("DeviceTaintRule deleted", "deviceTaintRule", klog.KObj(deletedRule))
+		if deletedRule.OptionalObj == nil {
+			// TODO: what... ? Sync all?
 			return
 		}
-		logger.V(5).Info("DeviceTaintRule deleted", "patch", klog.KObj(patch))
-		for _, sliceName := range t.sliceNamesForPatch(ctx, patch) {
+		for _, sliceName := range t.sliceNamesForPatch(ctx, deletedRule.OptionalObj) {
 			t.syncSlice(ctx, sliceName, false)
 		}
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
@@ -32,6 +32,7 @@ import (
 	resourceapi "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
+	resourceinformers "k8s.io/client-go/informers/resource/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -109,7 +110,7 @@ func applyEventPair(tCtx *testContext, event any) {
 		case pair[0] != nil:
 			err := store.Delete(pair[0])
 			require.NoError(tCtx, err)
-			tCtx.resourceSliceDelete(tCtx.Context)(pair[0])
+			tCtx.resourceSliceDelete(tCtx.Context)(resourceinformers.DeletedResourceSlice{OptionalObj: pair[0]})
 		default:
 			err := store.Add(pair[1])
 			require.NoError(tCtx, err)
@@ -125,7 +126,7 @@ func applyEventPair(tCtx *testContext, event any) {
 		case pair[0] != nil:
 			err := store.Delete(pair[0])
 			require.NoError(tCtx, err)
-			tCtx.deviceTaintDelete(tCtx.Context)(pair[0])
+			tCtx.deviceTaintDelete(tCtx.Context)(resourceinformers.DeletedDeviceTaintRule{OptionalObj: pair[0]})
 		default:
 			err := store.Add(pair[1])
 			require.NoError(tCtx, err)

--- a/test/integration/dra/device_taints.go
+++ b/test/integration/dra/device_taints.go
@@ -142,7 +142,7 @@ func testEvictCluster(tCtx ktesting.TContext, useRule useRuleMode) {
 	// Create a new factory and sync it so that when the controller starts, it is up-to-date.
 	// This works as long as this is the only test running it.
 	informerFactory := informers.NewSharedInformerFactory(tCtx.Client(), 0)
-	var ruleInformer resourceinformers.DeviceTaintRuleInformer
+	var ruleInformer resourceinformers.TypedDeviceTaintRuleInformer
 	if utilfeature.DefaultFeatureGate.Enabled(features.DRADeviceTaintRules) {
 		ruleInformer = informerFactory.Resource().V1().DeviceTaintRules()
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This applies the typed informer API introduced by #139821 throughout `pkg/controller`.

All controllers backed by generated, statically typed informers now:

- accept the generated `Typed*Informer` interfaces;
- register generated typed handler aliases through `TypedInformer().AddTypedEventHandler`;
- use typed indexers where the cache and event object types match; and
- use `Deleted*` wrappers or their stable keys instead of open-coded tombstone assertions.

The two remaining untyped registrations in `pkg/controller` are intentionally dynamic:

- `garbagecollector/graph_builder.go` registers handlers on GVR-selected shared informers;
- `resourcequota/resource_quota_monitor.go` does the same for discovered resources.

Besides exercising the API broadly, this found several useful edge cases for the typed informer design:

- delete handlers often need the old object, while `DeletedObject.OptionalObj` is intentionally nullable;
- the ReplicationController reuses the ReplicaSet controller through an event-converting informer adapter, so the adapter must also intercept `AddEventHandlerWithOptions`;
- that adapter cannot use the ReplicaSet typed indexer because its underlying cache stores ReplicationControllers, even though its event stream exposes ReplicaSets; and
- existing controller-local handler helpers can hide untyped callbacks and tombstone handling, so some call sites become clearer when expressed directly as typed handlers.

The diff deliberately keeps the ReplicationController's legacy indexer untyped for the cache/event-type mismatch above.

#### Which issue(s) this PR is related to:

#139821

#### Special notes for your reviewer:

This is a broad trial migration intended to expose ergonomics and missing cases in the new API. The net diff removes more code than it adds, primarily type assertions and tombstone plumbing.

Tested with:

```
make test WHAT=./pkg/controller/...
```

This ran 6040 tests with the race detector enabled.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
