### PR TITLE
kubelet: add namespace/pod/container labels to CRI metrics collector

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3481,6 +3481,16 @@ func (kl *Kubelet) ListPodSandboxMetrics(ctx context.Context) ([]*runtimeapi.Pod
 	return kl.containerRuntime.ListPodSandboxMetrics(ctx)
 }
 
+// ListPodSandbox returns a list of pod sandboxes matching the filter.
+func (kl *Kubelet) ListPodSandbox(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
+	return kl.runtimeService.ListPodSandbox(ctx, filter)
+}
+
+// ListContainers lists all containers matching the filter.
+func (kl *Kubelet) ListContainers(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+	return kl.runtimeService.ListContainers(ctx, filter)
+}
+
 func (kl *Kubelet) supportLocalStorageCapacityIsolation() bool {
 	return kl.GetConfiguration().LocalStorageCapacityIsolation
 }

--- a/pkg/kubelet/metrics/collectors/cri_metrics.go
+++ b/pkg/kubelet/metrics/collectors/cri_metrics.go
@@ -26,29 +26,45 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// kubernetesLabelKeys are the Kubernetes-level labels appended to every CRI metric
+// to match the labels produced by the cadvisor metrics path.
+var kubernetesLabelKeys = []string{"namespace", "pod", "container"}
+
 type criMetricsCollector struct {
 	metrics.BaseStableCollector
 	// The descriptors structure will be populated by one call to ListMetricDescriptors from the runtime.
 	// They will be saved in this map, where the key is the Name and the value is the Desc.
 	descriptors             map[string]*metrics.Desc
 	listPodSandboxMetricsFn func(context.Context) ([]*runtimeapi.PodSandboxMetrics, error)
+	listPodSandboxFn        func(context.Context, *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error)
+	listContainersFn        func(context.Context, *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error)
 }
 
 // Check if criMetricsCollector implements necessary interface
 var _ metrics.StableCollector = &criMetricsCollector{}
 
 // NewCRIMetricsCollector implements the metrics.Collector interface
-func NewCRIMetricsCollector(ctx context.Context, listPodSandboxMetricsFn func(context.Context) ([]*runtimeapi.PodSandboxMetrics, error), listMetricDescriptorsFn func(context.Context) ([]*runtimeapi.MetricDescriptor, error)) metrics.StableCollector {
+func NewCRIMetricsCollector(
+	ctx context.Context,
+	listPodSandboxMetricsFn func(context.Context) ([]*runtimeapi.PodSandboxMetrics, error),
+	listMetricDescriptorsFn func(context.Context) ([]*runtimeapi.MetricDescriptor, error),
+	listPodSandboxFn func(context.Context, *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error),
+	listContainersFn func(context.Context, *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error),
+) metrics.StableCollector {
 	descs, err := listMetricDescriptorsFn(ctx)
 	if err != nil {
 		logger := klog.FromContext(ctx)
 		logger.Error(err, "Error reading MetricDescriptors")
 		return &criMetricsCollector{
 			listPodSandboxMetricsFn: listPodSandboxMetricsFn,
+			listPodSandboxFn:        listPodSandboxFn,
+			listContainersFn:        listContainersFn,
 		}
 	}
 	c := &criMetricsCollector{
 		listPodSandboxMetricsFn: listPodSandboxMetricsFn,
+		listPodSandboxFn:        listPodSandboxFn,
+		listContainersFn:        listContainersFn,
 		descriptors:             make(map[string]*metrics.Desc, len(descs)),
 	}
 
@@ -79,16 +95,22 @@ func (c *criMetricsCollector) CollectWithStability(ch chan<- metrics.Metric) {
 		return
 	}
 
+	podSandboxMap, containerMap := c.getPodAndContainerMaps(ctx)
+
 	for _, podMetric := range podMetrics {
+		sandbox := podSandboxMap[podMetric.PodSandboxId]
+		podName, namespace := podSandboxLabels(sandbox)
+
 		for _, metric := range podMetric.GetMetrics() {
-			promMetric, err := c.criMetricToProm(logger, metric)
+			promMetric, err := c.criMetricToProm(logger, metric, namespace, podName, "POD")
 			if err == nil {
 				ch <- promMetric
 			}
 		}
 		for _, ctrMetric := range podMetric.GetContainerMetrics() {
+			containerName := containerLabel(containerMap[ctrMetric.ContainerId])
 			for _, metric := range ctrMetric.GetMetrics() {
-				promMetric, err := c.criMetricToProm(logger, metric)
+				promMetric, err := c.criMetricToProm(logger, metric, namespace, podName, containerName)
 				if err == nil {
 					ch <- promMetric
 				}
@@ -100,10 +122,15 @@ func (c *criMetricsCollector) CollectWithStability(ch chan<- metrics.Metric) {
 func criDescToProm(m *runtimeapi.MetricDescriptor) *metrics.Desc {
 	// Labels in the translation are variableLabels, as opposed to constant labels.
 	// This is because the values of the labels will be different for each container.
-	return metrics.NewDesc(m.Name, m.Help, m.LabelKeys, nil, metrics.INTERNAL, "")
+	// Append Kubernetes-level labels (namespace, pod, container) that the CRI runtime
+	// does not provide but that consumers expect on /metrics/cadvisor.
+	labelKeys := make([]string, 0, len(m.LabelKeys)+len(kubernetesLabelKeys))
+	labelKeys = append(labelKeys, m.LabelKeys...)
+	labelKeys = append(labelKeys, kubernetesLabelKeys...)
+	return metrics.NewDesc(m.Name, m.Help, labelKeys, nil, metrics.INTERNAL, "")
 }
 
-func (c *criMetricsCollector) criMetricToProm(logger klog.Logger, m *runtimeapi.Metric) (metrics.Metric, error) {
+func (c *criMetricsCollector) criMetricToProm(logger klog.Logger, m *runtimeapi.Metric, namespace, podName, containerName string) (metrics.Metric, error) {
 	desc, ok := c.descriptors[m.Name]
 	if !ok {
 		err := fmt.Errorf("error converting CRI Metric to prometheus format")
@@ -113,7 +140,11 @@ func (c *criMetricsCollector) criMetricToProm(logger klog.Logger, m *runtimeapi.
 
 	typ := criTypeToProm[m.MetricType]
 
-	pm, err := metrics.NewConstMetric(desc, typ, float64(m.GetValue().Value), m.LabelValues...)
+	labelValues := make([]string, 0, len(m.LabelValues)+len(kubernetesLabelKeys))
+	labelValues = append(labelValues, m.LabelValues...)
+	labelValues = append(labelValues, namespace, podName, containerName)
+
+	pm, err := metrics.NewConstMetric(desc, typ, float64(m.GetValue().Value), labelValues...)
 	if err != nil {
 		logger.Error(err, "Error getting CRI prometheus metric", "descriptor", desc.String())
 		return nil, err
@@ -126,6 +157,53 @@ func (c *criMetricsCollector) criMetricToProm(logger klog.Logger, m *runtimeapi.
 		return pm, nil
 	}
 	return metrics.NewLazyMetricWithTimestamp(time.Unix(0, m.Timestamp), pm), nil
+}
+
+// getPodAndContainerMaps builds ID-to-metadata maps by calling the CRI RPCs.
+// Unlike criStatsProvider.getPodAndContainerMaps, it does not filter out
+// terminated pods/containers to avoid missing metrics for recently-stopped workloads.
+func (c *criMetricsCollector) getPodAndContainerMaps(ctx context.Context) (map[string]*runtimeapi.PodSandbox, map[string]*runtimeapi.Container) {
+	logger := klog.FromContext(ctx)
+	podSandboxMap := make(map[string]*runtimeapi.PodSandbox)
+	containerMap := make(map[string]*runtimeapi.Container)
+
+	if c.listPodSandboxFn != nil {
+		podSandboxes, err := c.listPodSandboxFn(ctx, &runtimeapi.PodSandboxFilter{})
+		if err != nil {
+			logger.Error(err, "Failed to list pod sandboxes for label resolution")
+		} else {
+			for _, s := range podSandboxes {
+				podSandboxMap[s.Id] = s
+			}
+		}
+	}
+
+	if c.listContainersFn != nil {
+		containers, err := c.listContainersFn(ctx, &runtimeapi.ContainerFilter{})
+		if err != nil {
+			logger.Error(err, "Failed to list containers for label resolution")
+		} else {
+			for _, ctr := range containers {
+				containerMap[ctr.Id] = ctr
+			}
+		}
+	}
+
+	return podSandboxMap, containerMap
+}
+
+func podSandboxLabels(sandbox *runtimeapi.PodSandbox) (podName, namespace string) {
+	if sandbox != nil && sandbox.Metadata != nil {
+		return sandbox.Metadata.Name, sandbox.Metadata.Namespace
+	}
+	return "", ""
+}
+
+func containerLabel(container *runtimeapi.Container) string {
+	if container != nil && container.Metadata != nil {
+		return container.Metadata.Name
+	}
+	return ""
 }
 
 var criTypeToProm = map[runtimeapi.MetricType]metrics.ValueType{

--- a/pkg/kubelet/metrics/collectors/cri_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/cri_metrics_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics/testutil"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+func TestCRIMetricsCollectorLabels(t *testing.T) {
+	sandboxID := "sandbox-abc"
+	containerID := "container-xyz"
+
+	descriptors := []*runtimeapi.MetricDescriptor{
+		{
+			Name:      "container_cpu_usage_seconds_total",
+			Help:      "CPU usage",
+			LabelKeys: []string{"id", "name", "image"},
+		},
+	}
+
+	podMetrics := []*runtimeapi.PodSandboxMetrics{
+		{
+			PodSandboxId: sandboxID,
+			Metrics: []*runtimeapi.Metric{
+				{
+					Name:        "container_cpu_usage_seconds_total",
+					MetricType:  runtimeapi.MetricType_COUNTER,
+					LabelValues: []string{sandboxID, "POD", ""},
+					Value:       &runtimeapi.UInt64Value{Value: 100},
+				},
+			},
+			ContainerMetrics: []*runtimeapi.ContainerMetrics{
+				{
+					ContainerId: containerID,
+					Metrics: []*runtimeapi.Metric{
+						{
+							Name:        "container_cpu_usage_seconds_total",
+							MetricType:  runtimeapi.MetricType_COUNTER,
+							LabelValues: []string{containerID, "k8s_nginx_my-pod_default_uid_0", "nginx:latest"},
+							Value:       &runtimeapi.UInt64Value{Value: 200},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	podSandboxes := []*runtimeapi.PodSandbox{
+		{
+			Id: sandboxID,
+			Metadata: &runtimeapi.PodSandboxMetadata{
+				Name:      "my-pod",
+				Namespace: "default",
+				Uid:       "uid-123",
+			},
+		},
+	}
+
+	containers := []*runtimeapi.Container{
+		{
+			Id:           containerID,
+			PodSandboxId: sandboxID,
+			Metadata: &runtimeapi.ContainerMetadata{
+				Name: "nginx",
+			},
+		},
+	}
+
+	collector := NewCRIMetricsCollector(
+		context.Background(),
+		func(ctx context.Context) ([]*runtimeapi.PodSandboxMetrics, error) {
+			return podMetrics, nil
+		},
+		func(ctx context.Context) ([]*runtimeapi.MetricDescriptor, error) {
+			return descriptors, nil
+		},
+		func(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
+			return podSandboxes, nil
+		},
+		func(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+			return containers, nil
+		},
+	)
+
+	err := testutil.CustomCollectAndCompare(collector, strings.NewReader(`
+		# HELP container_cpu_usage_seconds_total [INTERNAL] CPU usage
+		# TYPE container_cpu_usage_seconds_total counter
+		container_cpu_usage_seconds_total{container="POD", id="sandbox-abc", image="", name="POD", namespace="default", pod="my-pod"} 100
+		container_cpu_usage_seconds_total{container="nginx", id="container-xyz", image="nginx:latest", name="k8s_nginx_my-pod_default_uid_0", namespace="default", pod="my-pod"} 200
+	`), "container_cpu_usage_seconds_total")
+	if err != nil {
+		t.Fatalf("unexpected metrics:\n%s", err)
+	}
+}
+
+func TestCRIMetricsCollectorMissingMapping(t *testing.T) {
+	descriptors := []*runtimeapi.MetricDescriptor{
+		{
+			Name:      "container_cpu_usage_seconds_total",
+			Help:      "CPU usage",
+			LabelKeys: []string{"id", "name", "image"},
+		},
+	}
+
+	podMetrics := []*runtimeapi.PodSandboxMetrics{
+		{
+			PodSandboxId: "unknown-sandbox",
+			ContainerMetrics: []*runtimeapi.ContainerMetrics{
+				{
+					ContainerId: "unknown-container",
+					Metrics: []*runtimeapi.Metric{
+						{
+							Name:        "container_cpu_usage_seconds_total",
+							MetricType:  runtimeapi.MetricType_COUNTER,
+							LabelValues: []string{"unknown-container", "some-name", "some-image"},
+							Value:       &runtimeapi.UInt64Value{Value: 1024},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	collector := NewCRIMetricsCollector(
+		context.Background(),
+		func(ctx context.Context) ([]*runtimeapi.PodSandboxMetrics, error) {
+			return podMetrics, nil
+		},
+		func(ctx context.Context) ([]*runtimeapi.MetricDescriptor, error) {
+			return descriptors, nil
+		},
+		func(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
+			return nil, nil
+		},
+		func(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+			return nil, nil
+		},
+	)
+
+	err := testutil.CustomCollectAndCompare(collector, strings.NewReader(`
+		# HELP container_cpu_usage_seconds_total [INTERNAL] CPU usage
+		# TYPE container_cpu_usage_seconds_total counter
+		container_cpu_usage_seconds_total{container="", id="unknown-container", image="some-image", name="some-name", namespace="", pod=""} 1024
+	`), "container_cpu_usage_seconds_total")
+	if err != nil {
+		t.Fatalf("unexpected metrics:\n%s", err)
+	}
+}

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -323,6 +323,8 @@ type HostInterface interface {
 	GetPortForward(ctx context.Context, podName, podNamespace string, podUID types.UID, portForwardOpts portforward.V4Options) (*url.URL, error)
 	ListMetricDescriptors(ctx context.Context) ([]*runtimeapi.MetricDescriptor, error)
 	ListPodSandboxMetrics(ctx context.Context) ([]*runtimeapi.PodSandboxMetrics, error)
+	ListPodSandbox(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error)
+	ListContainers(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error)
 }
 
 // NewServer initializes and configures a kubelet.Server object to handle HTTP requests.
@@ -523,7 +525,7 @@ func (s *Server) InstallAuthNotRequiredHandlers(ctx context.Context) {
 	r := compbasemetrics.NewKubeRegistry()
 	r.RawMustRegister(metrics.NewPrometheusMachineCollector(prometheusHostAdapter{s.host}, includedMetrics))
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodAndContainerStatsFromCRI) {
-		r.CustomRegister(collectors.NewCRIMetricsCollector(context.TODO(), s.host.ListPodSandboxMetrics, s.host.ListMetricDescriptors))
+		r.CustomMustRegister(collectors.NewCRIMetricsCollector(context.TODO(), s.host.ListPodSandboxMetrics, s.host.ListMetricDescriptors, s.host.ListPodSandbox, s.host.ListContainers))
 		servermetrics.SetMetricsProvider(servermetrics.CRIMetricsProvider)
 	} else {
 		cadvisorOpts := cadvisorapi.RequestOptions{

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -167,6 +167,14 @@ func (fk *fakeKubelet) ListPodSandboxMetrics(ctx context.Context) ([]*runtimeapi
 	return nil, nil
 }
 
+func (fk *fakeKubelet) ListPodSandbox(ctx context.Context, filter *runtimeapi.PodSandboxFilter) ([]*runtimeapi.PodSandbox, error) {
+	return nil, nil
+}
+
+func (fk *fakeKubelet) ListContainers(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+	return nil, nil
+}
+
 func (fk *fakeKubelet) SyncLoopHealthCheck(req *http.Request) error {
 	duration := fk.resyncInterval * 2
 	minDuration := time.Minute * 5


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When the PodAndContainerStatsFromCRI feature gate is enabled, the
/metrics/cadvisor endpoint uses the CRI metrics collector which passes
through the CRI runtime's metric labels verbatim. CRI runtimes like
CRI-O only provide id, name, and image labels — they do not include
the Kubernetes-level namespace, pod, and container labels that
monitoring tooling expects.

This PR resolves this by calling ListPodSandbox and ListContainers at
scrape time to build ID-to-metadata maps, then appending namespace,
pod, and container labels to each metric. This follows the same pattern
that criStatsProvider.getPodAndContainerMaps already uses for
/stats/summary.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/2371
Fixes https://github.com/kubernetes/kubernetes/issues/140778

#### Special notes for your reviewer:

An alternative approach that would avoid the 2 extra RPC calls per scrape is documented in https://github.com/kubernetes/kubernetes/issues/140778.

#### Does this PR introduce a user-facing change?

```release-note
kubelet: add namespace, pod, and container labels to CRI metrics exposed on the /metrics/cadvisor endpoint when the PodAndContainerStatsFromCRI feature gate is enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

---

This PR was written in part with the assistance of generative AI.