### PR TITLE
Add podautoscalers category to HorizontalPodAutoscaler

### DIFF
--- a/api/discovery/aggregated_v2.json
+++ b/api/discovery/aggregated_v2.json
@@ -438,7 +438,8 @@
           "resources": [
             {
               "categories": [
-                "all"
+                "all",
+                "podautoscalers"
               ],
               "resource": "horizontalpodautoscalers",
               "responseKind": {
@@ -485,7 +486,8 @@
           "resources": [
             {
               "categories": [
-                "all"
+                "all",
+                "podautoscalers"
               ],
               "resource": "horizontalpodautoscalers",
               "responseKind": {

--- a/api/discovery/apis__autoscaling__v1.json
+++ b/api/discovery/apis__autoscaling__v1.json
@@ -5,7 +5,8 @@
   "resources": [
     {
       "categories": [
-        "all"
+        "all",
+        "podautoscalers"
       ],
       "kind": "HorizontalPodAutoscaler",
       "name": "horizontalpodautoscalers",

--- a/api/discovery/apis__autoscaling__v2.json
+++ b/api/discovery/apis__autoscaling__v2.json
@@ -5,7 +5,8 @@
   "resources": [
     {
       "categories": [
-        "all"
+        "all",
+        "podautoscalers"
       ],
       "kind": "HorizontalPodAutoscaler",
       "name": "horizontalpodautoscalers",

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -76,7 +76,7 @@ var _ rest.CategoriesProvider = &REST{}
 
 // Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
 func (r *REST) Categories() []string {
-	return []string{"all"}
+	return []string{"all", "podautoscalers"}
 }
 
 // StatusREST implements the REST endpoint for changing the status of a daemonset

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
@@ -172,7 +172,7 @@ func TestCategories(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	expected := []string{"all"}
+	expected := []string{"all", "podautoscalers"}
 	registrytest.AssertCategories(t, storage, expected)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds the `podautoscalers` category to `HorizontalPodAutoscaler` so that HPAs are included when running `kubectl get podautoscalers`. This is the upstream counterpart to adding the same category to the VerticalPodAutoscaler CRD (https://github.com/kubernetes/autoscaler/issues/9995)
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
HorizontalPodAutoscaler now belongs to the "podautoscalers" category, allowing `kubectl get podautoscalers`
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
