### PR TITLE
KEP-5491: scheduler_perf test for matchConstraint for list attributes

### DIFF
--- a/test/integration/scheduler_perf/dra/listattributes/listattributes_test.go
+++ b/test/integration/scheduler_perf/dra/listattributes/listattributes_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package listattributes
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	_ "k8s.io/component-base/logs/json/register"
+	"k8s.io/dynamic-resource-allocation/structured"
+	perf "k8s.io/kubernetes/test/integration/scheduler_perf"
+)
+
+func TestMain(m *testing.M) {
+	if err := perf.InitTests(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	m.Run()
+}
+
+func TestSchedulerPerf(t *testing.T) {
+	structured.EnableAllocators("experimental")
+	defer structured.EnableAllocators()
+
+	perf.RunIntegrationPerfScheduling(t, "performance-config.yaml")
+}
+
+func BenchmarkPerfScheduling(b *testing.B) {
+	structured.EnableAllocators("experimental")
+	defer structured.EnableAllocators()
+
+	perf.RunBenchmarkPerfScheduling(b, "performance-config.yaml", "dra_listattributes", nil)
+}

--- a/test/integration/scheduler_perf/dra/listattributes/performance-config.yaml
+++ b/test/integration/scheduler_perf/dra/listattributes/performance-config.yaml
@@ -1,0 +1,88 @@
+#
+# The following labels are used in this file. (listed in ascending order of the number of covered test cases)
+#
+# - integration-test: test cases to run as the integration test, usually to spot some issues in the scheduler implementation or scheduler-perf itself.
+# - performance: test cases to run in the performance test.
+# - short: supplemental label for the above two labels (must not used alone), which literally means short execution time test cases.
+#
+# Specifically, the CIs use labels like the following:
+# - `ci-kubernetes-integration-master` (`integration-test`): Test cases are chosen based on a tradeoff between code coverage and overall runtime.
+# It basically covers all test cases but with their smallest workload.
+# - `pull-kubernetes-integration` (`integration-test`,`short`): Test cases are chosen so that they should take less than total 5 min to complete.
+# - `ci-benchmark-scheduler-perf` (`performance`): Long enough test cases are chosen (ideally, longer than 10 seconds)
+# to provide meaningful samples for the pod scheduling rate.
+#
+# Also, `performance`+`short` isn't used in the CIs, but it's used to test the performance test locally.
+# (Sometimes, the test cases with `integration-test` are too small to spot issues.)
+#
+# Combining `performance` and `short` selects suitable workloads for a local
+# before/after comparisons with benchstat.
+
+# SchedulingWithResourceClaimTemplateListAttributes is a variant of
+# SchedulingWithResourceClaimTemplate that exercises MatchAttribute with
+# list-valued device attributes. Each device carries either a shared value
+# plus a device-specific suffix list, or only the device-specific suffix
+# list. The ResourceSlice layout keeps a contiguous block of non-matching
+# devices before the matching suffix, so each claim request has to work
+# through that block before it reaches enough compatible devices. This is
+# intended to stress the MatchAttribute search path by forcing repeated
+# incompatible checks before the allocator can complete an exact-fit
+# allocation from the matching suffix.
+- name: SchedulingWithResourceClaimTemplateListAttributes
+  featureGates:
+    DynamicResourceAllocation: true
+    DRAListTypeAttributes: true
+  workloadTemplate:
+  - opcode: createNodes
+    nodeTemplatePath: ../templates/node-with-dra-test-driver.yaml
+    countParam: $nodesWithDRA
+  - opcode: createAny
+    templatePath: ../templates/resourceslice-list-attributes-devices.yaml
+    countParam: $nodesWithDRA
+    templateParams:
+      numDevices: $numDevices|64
+      numNonMatchingDevices: $numNonMatchingDevices|32
+      numListValues: $numListValues|32
+  - opcode: createAny
+    templatePath: ../templates/deviceclass.yaml
+  - opcode: createAny
+    templatePath: ../templates/resourceclaimtemplate.yaml
+    namespace: test
+    templateParams:
+      numRequests: $numRequests|1
+      constraints: $constraints|
+  - opcode: createPods
+    namespace: test
+    countParam: $measurePods
+    steadyStateParam: $steadyState
+    durationParam: $duration
+    podTemplatePath: ../templates/pod-with-claim-template.yaml
+    collectMetrics: true
+  workloads:
+  - name: fast
+    labels: [integration-test, short]
+    params:
+      # This testcase runs through all code paths without
+      # taking too long overall.
+      nodesWithDRA: 1
+      measurePods: 1
+      steadyState: false
+      duration: 0s # unused
+      numDevices: 64
+      numNonMatchingDevices: 32
+      numRequests: 32
+      numListValues: 47
+      constraints:
+      - matchAttribute: dra.example.com/match
+  - name: empty_500nodes
+    params:
+      nodesWithDRA: 500
+      measurePods: 500
+      steadyState: true
+      duration: 10s
+      numDevices: 64
+      numNonMatchingDevices: 32
+      numRequests: 32
+      numListValues: 47
+      constraints:
+      - matchAttribute: dra.example.com/match

--- a/test/integration/scheduler_perf/dra/templates/resourceslice-list-attributes-devices.yaml
+++ b/test/integration/scheduler_perf/dra/templates/resourceslice-list-attributes-devices.yaml
@@ -1,0 +1,33 @@
+{{$numDevices := or .numDevices 64}}
+{{$numListValues := or .numListValues 32}}
+{{$sharedValue := or .sharedValue "shared-value"}}
+{{$numNonMatchingDevices := or .numNonMatchingDevices 32}}
+
+kind: ResourceSlice
+apiVersion: resource.k8s.io/v1
+metadata:
+  name: resourceslice-{{.Index}}
+spec:
+  pool:
+    name: resourceslice-{{.Index}}
+    generation: 1
+    resourceSliceCount: 1
+  driver: test-driver.cdi.k8s.io
+  nodeName: scheduler-perf-dra-{{.Index}}
+  devices:{{range $deviceIndex := ($numDevices | Int)}}
+  - name: device-{{$deviceIndex}}
+    attributes:
+      dra.example.com/match:
+        strings:
+        # Keep a contiguous block of non-matching devices before the matching
+        # suffix so claim requests must work through that block before they
+        # reach enough compatible devices. This is meant to stress the
+        # MatchAttribute search path with repeated incompatible checks before
+        # the allocator reaches the exact-fit matching suffix.
+        {{if ge $deviceIndex ($numNonMatchingDevices | Int)}}
+        - {{$sharedValue}}
+        {{end}}
+        {{range $valueIndex := ($numListValues | Int)}}
+        - device-{{$deviceIndex}}-value-{{$valueIndex}}
+        {{end}}
+{{end}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig scheduling
/wg device-management

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

As suggested in https://github.com/kubernetes/kubernetes/pull/140109#discussion_r3620010146, this PR implements the scheduler_perf scenario for `matchConstraint` with list type attributes so that it re-computes attributes to attributeSet in the allocator so many times.

#### Which issue(s) this PR is related to:

ref: https://github.com/kubernetes/kubernetes/pull/140109

<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
