### PR TITLE
Unify span handling in watch cache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -686,6 +686,10 @@ func (c *Cacher) Watch(ctx context.Context, key string, opts storage.ListOptions
 }
 
 func (c *Cacher) Get(ctx context.Context, key string, opts storage.GetOptions, objPtr runtime.Object) error {
+	ctx, span := tracing.Start(ctx, "cacher.Get",
+		attribute.String("audit-id", audit.GetAuditIDTruncated(ctx)),
+		attribute.String("key", key),
+		attribute.String("resource-version", opts.ResourceVersion))
 	key, err := c.prepareKey(key, false)
 	if err != nil {
 		return err
@@ -704,6 +708,8 @@ func (c *Cacher) Get(ctx context.Context, key string, opts storage.GetOptions, o
 	if err != nil {
 		return err
 	}
+	// Get long processing is >500ms, however wait for fresh cache timeout is 3s so want to avoid traces just showing waits.
+	defer span.End(500 * time.Millisecond)
 
 	if exists {
 		elem, ok := obj.(*store.Element)
@@ -1325,10 +1331,17 @@ func (c *Cacher) waitUntilWatchCacheFreshAndForceAllEvents(ctx context.Context, 
 		//
 		// In this very rare scenario, the worst case will be that this
 		// request will wait for 3 seconds before it fails.
+		span := tracing.SpanFromContext(ctx)
 		consistentReadSupported := delegator.ConsistentReadSupported()
 		c.watchCache.RLock()
+		span.AddEvent("watchCache locked acquired")
 		defer c.watchCache.RUnlock()
-		return c.watchCache.waitUntilFreshLocked(ctx, consistentReadSupported, requestedWatchRV)
+		err := c.watchCache.waitUntilFreshLocked(ctx, consistentReadSupported, requestedWatchRV)
+		if err != nil {
+			return err
+		}
+		span.AddEvent("watchCache fresh enough")
+		return nil
 	}
 	return nil
 }
@@ -1359,10 +1372,14 @@ func (c *Cacher) setInitialEventsEndBookmarkIfRequested(cacheInterval *watchCach
 }
 
 func (c *Cacher) getKeys(ctx context.Context) ([]string, error) {
+	ctx, span := tracing.Start(ctx, "cacher.getKeys",
+		attribute.String("audit-id", audit.GetAuditIDTruncated(ctx)))
+	defer span.End(500 * time.Millisecond)
 	rev, err := c.storage.GetCurrentResourceVersion(ctx)
 	if err != nil {
 		return nil, err
 	}
+	span.AddEvent("GetCurrentResourceVersion succeed", attribute.Int64("resource-version", int64(rev)))
 	return c.watchCache.WaitUntilFreshAndGetKeys(ctx, rev)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/delegator.go
@@ -19,13 +19,10 @@ package cacher
 import (
 	"context"
 	"sync"
-	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/cacher/consistency"
@@ -33,7 +30,6 @@ import (
 	"k8s.io/apiserver/pkg/storage/cacher/metrics"
 	"k8s.io/apiserver/pkg/storage/cacher/store"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/component-base/tracing"
 	"k8s.io/klog/v2"
 )
 
@@ -112,22 +108,15 @@ func (c *CacheDelegator) Watch(ctx context.Context, key string, opts storage.Lis
 }
 
 func (c *CacheDelegator) Get(ctx context.Context, key string, opts storage.GetOptions, objPtr runtime.Object) error {
-	ctx, span := tracing.Start(ctx, "cacher.Get",
-		attribute.String("audit-id", audit.GetAuditIDTruncated(ctx)),
-		attribute.String("key", key),
-		attribute.String("resource-version", opts.ResourceVersion))
-	defer span.End(500 * time.Millisecond)
 	if opts.ResourceVersion == "" {
 		// If resourceVersion is not specified, serve it from underlying
 		// storage (for backward compatibility).
-		span.AddEvent("About to Get from underlying storage")
 		return c.storage.Get(ctx, key, opts, objPtr)
 	}
 
 	if !c.cacher.Ready() {
 		// If Cache is not initialized, delegator Get requests to storage
 		// as described in https://kep.k8s.io/4568
-		span.AddEvent("About to Get from underlying storage - cache not initialized")
 		return c.storage.Get(ctx, key, opts, objPtr)
 	}
 	// If resourceVersion is specified, serve it from cache.
@@ -136,7 +125,6 @@ func (c *CacheDelegator) Get(ctx context.Context, key string, opts storage.GetOp
 	if _, err := c.cacher.versioner.ParseResourceVersion(opts.ResourceVersion); err != nil {
 		return err
 	}
-	span.AddEvent("About to fetch object from cache")
 	return c.cacher.Get(ctx, key, opts, objPtr)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -340,8 +341,6 @@ func (w *watchCache) waitUntilFreshLocked(ctx context.Context, consistentReadSup
 		}()
 	}
 
-	span := tracing.SpanFromContext(ctx)
-	span.AddEvent("watchCache locked acquired")
 	for w.resourceVersion < resourceVersion {
 		if w.config.clock.Since(startTime) >= blockTimeout {
 			// Request that the client retry after 'resourceVersionTooHighRetrySeconds' seconds.
@@ -349,7 +348,6 @@ func (w *watchCache) waitUntilFreshLocked(ctx context.Context, consistentReadSup
 		}
 		w.cond.Wait()
 	}
-	span.AddEvent("watchCache fresh enough")
 	return nil
 }
 
@@ -387,15 +385,20 @@ func (c *watchCache) waitUntilFreshAndGetList(ctx context.Context, key string, o
 
 // WaitUntilFreshAndList returns list of pointers to `storeElement` objects along
 // with their ResourceVersion and the name of the index, if any, that was used.
-func (w *watchCache) WaitUntilFreshAndGetKeys(ctx context.Context, resourceVersion uint64) (keys []string, err error) {
+func (w *watchCache) WaitUntilFreshAndGetKeys(ctx context.Context, resourceVersion uint64) ([]string, error) {
+	span := tracing.SpanFromContext(ctx)
 	consistentReadSupported := delegator.ConsistentReadSupported()
 	w.RLock()
+	span.AddEvent("watchCache locked acquired")
 	defer w.RUnlock()
-	err = w.waitUntilFreshLocked(ctx, consistentReadSupported, resourceVersion)
+	err := w.waitUntilFreshLocked(ctx, consistentReadSupported, resourceVersion)
 	if err != nil {
 		return nil, err
 	}
-	return w.storage.ListKeys(), nil
+	span.AddEvent("watchCache fresh enough")
+	keys := w.storage.ListKeys()
+	span.AddEvent("ListKeys success")
+	return keys, nil
 }
 
 // NOTICE: Structure follows the shouldDelegateList function in
@@ -446,23 +449,34 @@ func (w *watchCache) waitAndListExactRV(ctx context.Context, key, continueKey st
 	}, "", err
 }
 
-func (w *watchCache) waitAndGetExactSnapshot(ctx context.Context, resourceVersion uint64) (store store.Snapshot, err error) {
+func (w *watchCache) waitAndGetExactSnapshot(ctx context.Context, resourceVersion uint64) (store.Snapshot, error) {
+	span := tracing.SpanFromContext(ctx)
 	consistentReadSupported := delegator.ConsistentReadSupported()
 	w.RLock()
+	span.AddEvent("watchCache locked acquired")
 	defer w.RUnlock()
-	err = w.waitUntilFreshLocked(ctx, consistentReadSupported, resourceVersion)
+	err := w.waitUntilFreshLocked(ctx, consistentReadSupported, resourceVersion)
 	if err != nil {
 		return nil, err
 	}
+	span.AddEvent("watchCache fresh enough")
 
-	return w.storage.GetExactSnapshotLocked(resourceVersion)
+	store, err := w.storage.GetExactSnapshotLocked(resourceVersion)
+	if err != nil {
+		span.AddEvent("GetExactSnapshotLocked failed", attribute.String("error", err.Error()))
+		return nil, err
+	}
+	span.AddEvent("GetExactSnapshotLocked success")
+	return store, nil
 }
 
 func (w *watchCache) waitAndListConsistent(ctx context.Context, key, continueKey string, matchValues []storage.MatchValue) (resp listResp, index string, err error) {
+	span := tracing.SpanFromContext(ctx)
 	resourceVersion, err := w.config.getCurrentRV(ctx)
 	if err != nil {
 		return listResp{}, "", err
 	}
+	span.AddEvent("getCurrentRV success")
 	return w.waitAndListLatestRV(ctx, resourceVersion, key, continueKey, matchValues)
 }
 
@@ -483,23 +497,34 @@ func (w *watchCache) waitAndListLatestRV(ctx context.Context, minResourceVersion
 
 func (w *watchCache) waitAndGetLatestSnapshot(ctx context.Context, minResourceVersion uint64, key, continueKey string, matchValues []storage.MatchValue) (snap store.Snapshot, resourceVersion uint64, index string, err error) {
 	consistentReadSupported := delegator.ConsistentReadSupported()
+	span := tracing.SpanFromContext(ctx)
 	w.RLock()
+	span.AddEvent("watchCache locked acquired")
 	defer w.RUnlock()
 	err = w.waitUntilFreshLocked(ctx, consistentReadSupported, minResourceVersion)
 	if err != nil {
 		return nil, 0, "", err
 	}
+	span.AddEvent("watchCache fresh enough")
 	// This isn't the place where we do "final filtering" - only some "prefiltering" is happening here. So the only
 	// requirement here is to NOT miss anything that should be returned. We can return as many non-matching items as we
 	// want - they will be filtered out later. The fact that we return less things is only further performance improvement.
 	// TODO: if multiple indexes match, return the one with the fewest items, so as to do as much filtering as possible.
 	for _, matchValue := range matchValues {
-		if snap, err := w.storage.GetByIndexSnapshot(matchValue.IndexName, matchValue.Value); err == nil {
+		snap, err := w.storage.GetByIndexSnapshot(matchValue.IndexName, matchValue.Value)
+		if err == nil {
+			span.AddEvent("GetByIndexSnapshot success", attribute.String("index", matchValue.IndexName))
 			return snap, w.resourceVersion, matchValue.IndexName, nil
 		}
+		span.AddEvent("GetByIndexSnapshot fail", attribute.String("index", matchValue.IndexName), attribute.String("error", err.Error()))
 	}
 	snap, err = w.storage.GetLatestSnapshotOrBuildLocked(key, continueKey)
-	return snap, w.resourceVersion, "", err
+	if err != nil {
+		span.AddEvent("GetLatestSnapshotOrBuildLocked failed", attribute.String("error", err.Error()))
+		return nil, 0, "", err
+	}
+	span.AddEvent("GetLatestSnapshotOrBuildLocked success")
+	return snap, w.resourceVersion, "", nil
 }
 
 func (w *watchCache) notFresh(resourceVersion uint64) bool {
@@ -510,14 +535,22 @@ func (w *watchCache) notFresh(resourceVersion uint64) bool {
 
 // WaitUntilFreshAndGet returns a pointers to <storeElement> object.
 func (w *watchCache) WaitUntilFreshAndGet(ctx context.Context, resourceVersion uint64, key string) (interface{}, bool, uint64, error) {
+	span := tracing.SpanFromContext(ctx)
 	consistentReadSupported := delegator.ConsistentReadSupported()
 	w.RLock()
+	span.AddEvent("watchCache locked acquired")
 	defer w.RUnlock()
 	err := w.waitUntilFreshLocked(ctx, consistentReadSupported, resourceVersion)
 	if err != nil {
 		return nil, false, 0, err
 	}
+	span.AddEvent("watchCache fresh enough")
 	value, exists, err := w.storage.GetByKey(key)
+	if err != nil {
+		span.AddEvent("GetByKey failed", attribute.String("error", err.Error()))
+		return nil, false, 0, err
+	}
+	span.AddEvent("GetByKey success")
 	return value, exists, w.resourceVersion, err
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -237,12 +237,21 @@ func (s *store) Get(ctx context.Context, key string, opts storage.GetOptions, ou
 	if err != nil {
 		return err
 	}
+	ctx, span := tracing.Start(ctx, "Get etcd3",
+		attribute.String("audit-id", audit.GetAuditIDTruncated(ctx)),
+		attribute.String("key", key),
+		attribute.String("group", s.groupResource.Group),
+		attribute.String("resource", s.groupResource.Resource),
+	)
+	defer span.End(500 * time.Millisecond)
 	startTime := time.Now()
 	getResp, err := s.client.Kubernetes.Get(ctx, preparedKey, kubernetes.GetOptions{})
 	metrics.RecordEtcdRequest("get", s.groupResource, err, startTime)
 	if err != nil {
+		span.AddEvent("Get call failed", attribute.String("err", err.Error()))
 		return err
 	}
+	span.AddEvent("Get call succeeded")
 	if err = s.validateMinimumResourceVersion(opts.ResourceVersion, uint64(getResp.Revision)); err != nil {
 		return err
 	}
@@ -256,14 +265,18 @@ func (s *store) Get(ctx context.Context, key string, opts storage.GetOptions, ou
 
 	data, _, err := s.transformer.TransformFromStorage(ctx, getResp.KV.Value, authenticatedDataString(preparedKey))
 	if err != nil {
+		span.AddEvent("TransformFromStorage failed", attribute.String("err", err.Error()))
 		return storage.NewInternalError(err)
 	}
+	span.AddEvent("TransformFromStorage succeeded")
 
 	err = s.decoder.Decode(data, out, getResp.KV.ModRevision)
 	if err != nil {
+		span.AddEvent("Decode failed", attribute.Int("len", len(data)), attribute.String("err", err.Error()))
 		recordDecodeError(s.groupResource, preparedKey)
 		return err
 	}
+	span.AddEvent("Decode succeeded", attribute.Int("len", len(data)))
 	return nil
 }
 
@@ -326,11 +339,11 @@ func (s *store) Create(ctx context.Context, key string, obj, out runtime.Object,
 	if out != nil {
 		err = s.decoder.Decode(data, out, txnResp.Revision)
 		if err != nil {
-			span.AddEvent("decode failed", attribute.Int("len", len(data)), attribute.String("err", err.Error()))
+			span.AddEvent("Decode failed", attribute.Int("len", len(data)), attribute.String("err", err.Error()))
 			recordDecodeError(s.groupResource, preparedKey)
 			return err
 		}
-		span.AddEvent("decode succeeded", attribute.Int("len", len(data)))
+		span.AddEvent("Decode succeeded", attribute.Int("len", len(data)))
 	}
 	return nil
 }
@@ -614,11 +627,11 @@ func (s *store) GuaranteedUpdate(
 
 		err = s.decoder.Decode(data, destination, txnResp.Revision)
 		if err != nil {
-			span.AddEvent("decode failed", attribute.Int("len", len(data)), attribute.String("err", err.Error()))
+			span.AddEvent("Decode failed", attribute.Int("len", len(data)), attribute.String("err", err.Error()))
 			recordDecodeError(s.groupResource, preparedKey)
 			return err
 		}
-		span.AddEvent("decode succeeded", attribute.Int("len", len(data)))
+		span.AddEvent("Decode succeeded", attribute.Int("len", len(data)))
 		return nil
 	}
 }

--- a/test/integration/apiserver/tracing/tracing_test.go
+++ b/test/integration/apiserver/tracing/tracing_test.go
@@ -455,7 +455,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 						"Encode succeeded",
 						"TransformToStorage succeeded",
 						"Txn call succeeded",
-						"decode succeeded",
+						"Decode succeeded",
 					},
 				},
 				{
@@ -549,6 +549,114 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 					},
 				},
 				{
+					name: "Get etcd3",
+					attributes: map[string]func(*commonv1.AnyValue) bool{
+						"audit-id": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() != ""
+						},
+						"key": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "/minions/fake"
+						},
+						"resource": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "nodes"
+						},
+					},
+					events: []string{
+						"Get call succeeded",
+						"TransformFromStorage succeeded",
+						"Decode succeeded",
+					},
+				},
+				{
+					name: "etcdserverpb.KV/Range",
+					attributes: map[string]func(*commonv1.AnyValue) bool{
+						"rpc.system.name": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "grpc"
+						},
+					},
+				},
+				{
+					name: "SerializeObject",
+					attributes: map[string]func(*commonv1.AnyValue) bool{
+						"url": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "/api/v1/nodes/fake"
+						},
+						"audit-id": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() != ""
+						},
+						"protocol": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "HTTP/2.0"
+						},
+						"method": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "GET"
+						},
+						"mediaType": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "application/vnd.kubernetes.protobuf"
+						},
+						"encoder": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "{\"encodeGV\":\"v1\",\"encoder\":\"protobuf\",\"name\":\"versioning\"}"
+						},
+					},
+					events: []string{
+						"About to start writing response",
+						"Write call succeeded",
+					},
+				},
+			},
+		},
+		{
+			desc: "get node from cache",
+			apiCall: func(ctx context.Context) error {
+				_, err = clientSet.CoreV1().Nodes().Get(ctx, "fake", metav1.GetOptions{ResourceVersion: "0"})
+				return err
+			},
+			expectedTrace: []*spanExpectation{
+				{
+					name: "GET /api/v1/nodes/{:name}",
+					attributes: map[string]func(*commonv1.AnyValue) bool{
+						"user_agent.original": func(v *commonv1.AnyValue) bool {
+							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
+						},
+						"url.path": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "/api/v1/nodes/fake"
+						},
+						"http.request.method": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "GET"
+						},
+						"audit-id": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() != ""
+						},
+					},
+				},
+				{
+					name: "Get",
+					attributes: map[string]func(*commonv1.AnyValue) bool{
+						"url": func(v *commonv1.AnyValue) bool {
+							return strings.HasSuffix(v.GetStringValue(), "/api/v1/nodes/fake")
+						},
+						"user-agent": func(v *commonv1.AnyValue) bool {
+							return strings.HasPrefix(v.GetStringValue(), "tracing.test")
+						},
+						"audit-id": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() != ""
+						},
+						"client": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "127.0.0.1"
+						},
+						"accept": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "application/vnd.kubernetes.protobuf, */*"
+						},
+						"protocol": func(v *commonv1.AnyValue) bool {
+							return v.GetStringValue() == "HTTP/2.0"
+						},
+					},
+					events: []string{
+						"About to Get from storage",
+						"About to write a response",
+						"Writing http response done",
+					},
+				},
+				{
 					name: "cacher.Get",
 					attributes: map[string]func(*commonv1.AnyValue) bool{
 						"audit-id": func(v *commonv1.AnyValue) bool {
@@ -558,19 +666,13 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 							return v.GetStringValue() == "/minions/fake"
 						},
 						"resource-version": func(v *commonv1.AnyValue) bool {
-							return v.GetStringValue() == ""
+							return v.GetStringValue() == "0"
 						},
 					},
 					events: []string{
-						"About to Get from underlying storage",
-					},
-				},
-				{
-					name: "etcdserverpb.KV/Range",
-					attributes: map[string]func(*commonv1.AnyValue) bool{
-						"rpc.system.name": func(v *commonv1.AnyValue) bool {
-							return v.GetStringValue() == "grpc"
-						},
+						"watchCache locked acquired",
+						"watchCache fresh enough",
+						"GetByKey success",
 					},
 				},
 				{
@@ -764,8 +866,10 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 					},
 					events: []string{
 						"Ready",
+						"getCurrentRV success",
 						"watchCache locked acquired",
 						"watchCache fresh enough",
+						"GetLatestSnapshotOrBuildLocked success",
 						"Listed items from cache",
 						"Filtered items",
 					},
@@ -892,7 +996,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 						"Transaction prepared",
 						"Txn call completed",
 						"Transaction committed",
-						"decode succeeded",
+						"Decode succeeded",
 					},
 				},
 				{
@@ -1035,7 +1139,7 @@ endpoint: %s`, listener.Addr().String())), os.FileMode(0755)); err != nil {
 						"Transaction prepared",
 						"Txn call completed",
 						"Transaction committed",
-						"decode succeeded",
+						"Decode succeeded",
 					},
 				},
 				{


### PR DESCRIPTION
/kind feature

```release-note
NONE
```

From Scalabilityt test failure https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-performance-5000/2074539413072777216
```
Trace[796841828]: "Create" ... (total time: 1156ms):
Trace[796841828]: ["cacher.Get" audit-id:f67f696a-9876-46bd-93f8-f2ac752dc186,key:/serviceaccounts/test-iqadlf-1/default,resource-version: 1156ms (18:27:25.119)]
Trace[796841828]: [1.156881094s] [1.156881094s] END
```

Looks like something is bad happening in cacher.Get, but it's not etcd which latency is ~30ms at that time. We need traces to debug such issues.

/cc @Jefftree @p0lyn0mial 