### PR TITLE
[FG: InPlacePodVerticalScalingExclusiveCPUs] cpumanager: populate and consume baseline data

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -507,14 +507,29 @@ func (m *manager) reconcileState(ctx context.Context) (success []reconciledConta
 			// Idempotently add it to the containerMap incase it is missing.
 			// This can happen after a kubelet restart, for example.
 			m.containerMap.Add(string(pod.UID), container.Name, containerID)
-			m.Unlock()
 
 			cset := m.state.GetCPUSetOrDefault(string(pod.UID), container.Name)
+			baselineCPUs, hasBaselineCPUs := m.state.GetBaselineCPUSet(string(pod.UID), container.Name)
+			m.Unlock()
+
 			if cset.IsEmpty() {
 				// NOTE: This should not happen outside of tests.
 				logger.V(2).Info("ReconcileState: skipping container; empty cpuset assigned")
 				failure = append(failure, reconciledContainer{pod.Name, container.Name, containerID})
 				continue
+			}
+
+			if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.InPlacePodVerticalScalingExclusiveCPUs) {
+				// this is less clear than it should be because of the constraints of the GetCPUSetOrDefault API which should
+				// be revisited separately. A container can only have baseline CPUs set if it got an exclusive CPU assignment
+				// the first time it was admitted. Baseline CPUs reflects the CPUs promised at that time, which no following
+				// scaleup/down can ever mutate. In that case, we are also guaranteed that the `GetCPUSetOrDefault` will return
+				// _an_ exclusive CPUSet and never the default set. A clear improvement would be get rid of GetCPUSetOrDefault
+				// and make a new API which returns TWO cpusets: the exclusively allocated and the shared set.
+				if hasBaselineCPUs && !baselineCPUs.Equals(cset) {
+					logger.V(4).Info("Current container CPU assignments differ from CPU assignments recorded at admission time",
+						"currentCPUSet", cset, "baselineCPUSet", baselineCPUs)
+				}
 			}
 
 			lcset := m.lastUpdateState.GetCPUSetOrDefault(string(pod.UID), container.Name)

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -41,6 +41,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/kubernetes/test/utils/ktesting/initoption"
 
 	"k8s.io/kubernetes/pkg/kubelet/cm/containermap"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
@@ -1419,6 +1420,173 @@ func TestReconcileState(t *testing.T) {
 				t.Errorf("Expected reconciliation failure for container: %s", testCase.expectFailedContainerName)
 			}
 		}
+	}
+}
+
+func TestReconcileStateBaselineLog(t *testing.T) {
+	testCases := []struct {
+		description   string
+		fgEnabled     bool
+		stAssignments state.ContainerCPUAssignments
+		stBaselines   state.ContainerCPUBaselines
+		expectLog     bool
+	}{
+		{
+			description: "feature gate disabled, current container CPU assignments differ from CPU assignments recorded at admission time, no log expected",
+			fgEnabled:   false,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(3, 4)},
+				},
+			},
+			expectLog: false,
+		},
+		{
+			description: "feature gate enabled, current container CPU assignments matches CPU assignments recorded at admission time, no log expected",
+			fgEnabled:   true,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(1, 2)},
+				},
+			},
+			expectLog: false,
+		},
+		{
+			description: "feature gate enabled, current container CPU assignments differs from CPU assignments recorded at admission time, log expected",
+			fgEnabled:   true,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(3, 4)},
+				},
+			},
+			expectLog: true,
+		},
+		{
+			description: "feature gate enabled, no CPU assignments recorded at admission time, no log expected",
+			fgEnabled:   true,
+			stAssignments: state.ContainerCPUAssignments{
+				"fakePodUID": map[string]cpuset.CPUSet{
+					"fakeContainerName": cpuset.New(1, 2),
+				},
+			},
+			stBaselines: state.ContainerCPUBaselines{},
+			expectLog:   false,
+		},
+		{
+			description:   "feature gate enabled, no current container CPU assignments, CPU assignments recorded at admission time doesn't match default shared CPU set, log expected",
+			fgEnabled:     true,
+			stAssignments: state.ContainerCPUAssignments{}, // so we will get the default CPUSet for the container
+			stBaselines: state.ContainerCPUBaselines{
+				"fakePodUID": map[string]state.ContainerCPUBaseline{
+					"fakeContainerName": {Baseline: cpuset.New(3, 4)},
+				},
+			},
+			expectLog: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingExclusiveCPUs, tc.fgEnabled)
+			ktesting.SetDefaultVerbosity(4)
+			tCtx := ktesting.Init(t, initoption.BufferLogs(true))
+			logger := tCtx.Logger()
+
+			testPolicy, _ := NewStaticPolicy(
+				logger,
+				&topology.CPUTopology{
+					NumCPUs:    8,
+					NumSockets: 2,
+					NumCores:   4,
+					CPUDetails: map[int]topology.CPUInfo{
+						0: {CoreID: 0, SocketID: 0},
+						1: {CoreID: 1, SocketID: 0},
+						2: {CoreID: 2, SocketID: 0},
+						3: {CoreID: 3, SocketID: 0},
+						4: {CoreID: 0, SocketID: 1},
+						5: {CoreID: 1, SocketID: 1},
+						6: {CoreID: 2, SocketID: 1},
+						7: {CoreID: 3, SocketID: 1},
+					},
+				},
+				0,
+				cpuset.New(),
+				topologymanager.NewFakeManager(logger),
+				nil)
+
+			mgr := &manager{
+				policy: testPolicy,
+				state: &mockState{
+					assignments:   tc.stAssignments,
+					defaultCPUSet: cpuset.New(5, 6, 7),
+					baselines:     tc.stBaselines,
+				},
+				lastUpdateState: state.NewMemoryState(logger),
+				containerRuntime: mockRuntimeService{
+					err: nil,
+				},
+				containerMap: containermap.NewContainerMap(),
+				activePods: func() []*v1.Pod {
+					return []*v1.Pod{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "fakePodName",
+								UID:  "fakePodUID",
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{Name: "fakeContainerName"},
+								},
+							},
+						},
+					}
+				},
+				podStatusProvider: mockPodStatusProvider{
+					podStatus: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:        "fakeContainerName",
+								ContainerID: "docker://fakeContainerID",
+								State: v1.ContainerState{
+									Running: &v1.ContainerStateRunning{},
+								},
+							},
+						},
+					},
+					found: true,
+				},
+			}
+			mgr.sourcesReady = &sourcesReadyStub{}
+			mgr.reconcileState(tCtx)
+
+			underlier, ok := logger.GetSink().(ktesting.Underlier)
+			if !ok {
+				t.Fatalf("expected ktesting LogSink, got %T", logger.GetSink())
+			}
+			logs := underlier.GetBuffer().String()
+			expectedLog := "Current container CPU assignments differ from CPU assignments recorded at admission time"
+			if tc.expectLog && !strings.Contains(logs, expectedLog) {
+				t.Errorf("expected log %q not found in logs:\n%s", expectedLog, logs)
+			}
+			if !tc.expectLog && strings.Contains(logs, expectedLog) {
+				t.Errorf("unexpected log %q found in logs:\n%s", expectedLog, logs)
+			}
+		})
 	}
 }
 

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -711,6 +711,7 @@ func runStaticPolicyTestCase(t *testing.T, testCase staticPolicyTest) {
 	st := &mockState{
 		assignments:   testCase.stAssignments,
 		defaultCPUSet: testCase.stDefaultCPUSet,
+		baselines:     state.ContainerCPUBaselines{},
 	}
 
 	container := &testCase.pod.Spec.Containers[0]
@@ -750,6 +751,46 @@ func runStaticPolicyTestCase(t *testing.T, testCase staticPolicyTest) {
 func runStaticPolicyTestCaseWithFeatureGate(t *testing.T, testCase staticPolicyTest) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.CPUManagerPolicyAlphaOptions, true)
 	runStaticPolicyTestCase(t, testCase)
+}
+
+func TestStaticPolicyAllocateRecordsBaseline(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScalingExclusiveCPUs, true)
+
+	logger, _ := ktesting.NewTestContext(t)
+	tm := topologymanager.NewFakeManager(logger)
+	topo := topoDualSocketHT // any topology suffice, pick a simple one
+	opts := map[string]string{}
+	policy, err := NewStaticPolicy(logger, topo, 1, cpuset.New(), tm, opts)
+	if err != nil {
+		t.Fatalf("NewStaticPolicy() failed: %v", err)
+	}
+
+	st := &mockState{
+		assignments:   state.ContainerCPUAssignments{},
+		defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), // matches the topo we use
+		baselines:     state.ContainerCPUBaselines{},
+	}
+
+	pod := makePod("testPod", "testContainer", "2000m", "2000m") // any allocation triggering exclusive CPU assignment is fine
+	container := &pod.Spec.Containers[0]                         // shortcut
+
+	if err := policy.Allocate(logger, st, pod, container, lifecycle.AddOperation); err != nil {
+		t.Fatalf("Allocate() failed: %v", err)
+	}
+
+	cset, ok := st.GetCPUSet(string(pod.UID), container.Name)
+	if !ok {
+		t.Fatal("expected container to be present in assignments")
+	}
+
+	baseline, ok := st.GetBaselineCPUSet(string(pod.UID), container.Name)
+	if !ok {
+		t.Fatal("expected container to be present in baselines")
+	}
+
+	if !baseline.Equals(cset) {
+		t.Errorf("expected baseline %s to equal allocated cpuset %s", baseline, cset)
+	}
 }
 
 func TestStaticPolicyReuseCPUs(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:
Followup to https://github.com/kubernetes/kubernetes/pull/140314 - we added the baseline to the state manager, so we can consume to implement a consistency check. Both the writing of the baseline and the consumption is controlled by the feature gae.

#### Which issue(s) this PR is related to:
KEP: https://github.com/kubernetes/enhancements/issues/5554

#### Special notes for your reviewer:
Some AI assistance was used to figure out the reconcileState unit test.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
N/A