### PR TITLE
Fix qhint for updates of basic pod groups

### DIFF
--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -128,10 +128,9 @@ func (pl *GangScheduling) isSchedulableAfterPodGroupUpdated(logger klog.Logger, 
 	oldPolicy := oldPodGroup.Spec.SchedulingPolicy
 	newPolicy := newPodGroup.Spec.SchedulingPolicy
 
-	// Non-gang policies should not be updated.
+	// Updates to non-gang policies will not make the waiting pods schedulable.
 	if newPolicy.Gang == nil || oldPolicy.Gang == nil {
-		logger.V(5).Info("pod group was updated but it's not a gang policy, this is unexpected, enqueuing pod", "pod", klog.KObj(pod), "podGroup", klog.KObj(newPodGroup))
-		return fwk.Queue, nil
+		return fwk.QueueSkip, nil
 	}
 
 	// If the gang scheduling policy minCount did not decrease, it will not make the waiting pods schedulable.

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -463,7 +463,7 @@ func Test_isSchedulableAfterPodGroupUpdated(t *testing.T) {
 			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
 			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().WorkloadRef("t", "w").Obj(),
 			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().Obj(),
-			expectedHint:               fwk.Queue,
+			expectedHint:               fwk.QueueSkip,
 			isCompositePodGroupEnabled: true,
 		},
 		{
@@ -471,7 +471,7 @@ func Test_isSchedulableAfterPodGroupUpdated(t *testing.T) {
 			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
 			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().WorkloadRef("t", "w").Obj(),
 			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().Obj(),
-			expectedHint:               fwk.Queue,
+			expectedHint:               fwk.QueueSkip,
 			isCompositePodGroupEnabled: false,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Basic pod groups are not expected to be updated in a way to make the waiting pods schedulable, therefore they should always result in QueueSkip hint.

It's valid for an update event to come for a basic pod group, e.g. when a status is updated. Note that the status may be updated whenever the pod group fails scheduling, so it's particularly important that we don't return Queue hint in this case to avoid perpetually activating the pod group.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
