### PR TITLE
kubelet: skip zero-valued device requests

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -880,6 +880,9 @@ func (m *ManagerImpl) allocateContainerResources(ctx context.Context, pod *v1.Po
 		if !m.isDevicePluginResource(resource) {
 			continue
 		}
+		if needed == 0 {
+			continue
+		}
 		// Updates allocatedDevices to garbage collect any stranded resources
 		// before doing the device plugin allocation.
 		if !allocatedDevicesUpdated {

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -881,6 +881,7 @@ func (m *ManagerImpl) allocateContainerResources(ctx context.Context, pod *v1.Po
 			continue
 		}
 		if needed == 0 {
+			logger.V(3).Info("Skipping allocation for zero device request", "resourceName", resource, "pod", klog.KObj(pod), "containerName", container.Name)
 			continue
 		}
 		// Updates allocatedDevices to garbage collect any stranded resources

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -1055,9 +1055,13 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 		devs:             checkpoint.DevicesPerNUMA{0: []string{"dev3", "dev4"}},
 		topology:         false,
 	}
-	testResources := make([]TestResource, 2)
-	testResources = append(testResources, res1)
-	testResources = append(testResources, res2)
+	res3 := TestResource{
+		resourceName:     "domain3.com/resource3",
+		resourceQuantity: *resource.NewQuantity(int64(0), resource.DecimalSI),
+		devs:             checkpoint.DevicesPerNUMA{0: nil},
+		topology:         false,
+	}
+	testResources := []TestResource{res1, res2, res3}
 	as := require.New(t)
 	podsStub := activePodsStub{
 		activePods: []*v1.Pod{},
@@ -1079,6 +1083,8 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 			v1.ResourceName(res1.resourceName): res2.resourceQuantity}),
 		makePod(v1.ResourceList{
 			v1.ResourceName(res2.resourceName): res2.resourceQuantity}),
+		makePod(v1.ResourceList{
+			v1.ResourceName(res3.resourceName): res3.resourceQuantity}),
 	}
 	testCases := []struct {
 		description               string
@@ -1086,6 +1092,7 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 		expectedContainerOptsLen  []int
 		expectedAllocatedResName1 int
 		expectedAllocatedResName2 int
+		expectedAllocatedResName3 int
 		expErr                    error
 	}{
 		{
@@ -1112,6 +1119,15 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 			expectedAllocatedResName2: 2,
 			expErr:                    nil,
 		},
+		{
+			description:               "Successful allocation of zero Res3 resources with zero healthy devices",
+			testPod:                   testPods[3],
+			expectedContainerOptsLen:  nil,
+			expectedAllocatedResName1: 2,
+			expectedAllocatedResName2: 2,
+			expectedAllocatedResName3: 0,
+			expErr:                    nil,
+		},
 	}
 	activePods := []*v1.Pod{}
 	for _, testCase := range testCases {
@@ -1136,31 +1152,8 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 		}
 		as.Equal(testCase.expectedAllocatedResName1, testManager.allocatedDevices[res1.resourceName].Len())
 		as.Equal(testCase.expectedAllocatedResName2, testManager.allocatedDevices[res2.resourceName].Len())
+		as.Equal(testCase.expectedAllocatedResName3, testManager.allocatedDevices[res3.resourceName].Len())
 	}
-
-	zeroResourceName := "domain3.com/resource3"
-	testManager.healthyDevices[zeroResourceName] = sets.New[string]()
-	testManager.unhealthyDevices[zeroResourceName] = sets.New("dev5")
-	testManager.allDevices[zeroResourceName] = makeDevice(checkpoint.DevicesPerNUMA{0: []string{"dev5"}}, false)
-	allocateCalled := false
-	testManager.endpoints[zeroResourceName] = endpointInfo{
-		e: &MockEndpoint{
-			allocateFunc: func([]string) (*pluginapi.AllocateResponse, error) {
-				allocateCalled = true
-				return nil, nil
-			},
-		},
-	}
-	zeroPod := makePod(v1.ResourceList{
-		v1.ResourceName(zeroResourceName): *resource.NewQuantity(0, resource.DecimalSI),
-	})
-	activePods = append(activePods, zeroPod)
-	podsStub.updateActivePods(activePods)
-
-	as.NoError(testManager.Allocate(tCtx, zeroPod, &zeroPod.Spec.Containers[0], lifecycle.AddOperation))
-	as.False(allocateCalled)
-	as.Empty(testManager.allocatedDevices[zeroResourceName])
-
 }
 
 func TestPodContainerDeviceToAllocate(t *testing.T) {

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -1138,6 +1138,29 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 		as.Equal(testCase.expectedAllocatedResName2, testManager.allocatedDevices[res2.resourceName].Len())
 	}
 
+	zeroResourceName := "domain3.com/resource3"
+	testManager.healthyDevices[zeroResourceName] = sets.New[string]()
+	testManager.unhealthyDevices[zeroResourceName] = sets.New("dev5")
+	testManager.allDevices[zeroResourceName] = makeDevice(checkpoint.DevicesPerNUMA{0: []string{"dev5"}}, false)
+	allocateCalled := false
+	testManager.endpoints[zeroResourceName] = endpointInfo{
+		e: &MockEndpoint{
+			allocateFunc: func([]string) (*pluginapi.AllocateResponse, error) {
+				allocateCalled = true
+				return nil, nil
+			},
+		},
+	}
+	zeroPod := makePod(v1.ResourceList{
+		v1.ResourceName(zeroResourceName): *resource.NewQuantity(0, resource.DecimalSI),
+	})
+	activePods = append(activePods, zeroPod)
+	podsStub.updateActivePods(activePods)
+
+	as.NoError(testManager.Allocate(tCtx, zeroPod, &zeroPod.Spec.Containers[0], lifecycle.AddOperation))
+	as.False(allocateCalled)
+	as.Empty(testManager.allocatedDevices[zeroResourceName])
+
 }
 
 func TestPodContainerDeviceToAllocate(t *testing.T) {

--- a/test/e2e_node/device_plugin_failures_test.go
+++ b/test/e2e_node/device_plugin_failures_test.go
@@ -212,6 +212,39 @@ var _ = SIGDescribe("Device Plugin Failures:", framework.WithNodeConformance(), 
 		gomega.Eventually(getNodeResourceValues, devicePluginGracefulTimeout+1*time.Minute, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: 0, Capacity: 1}))
 	})
 
+	ginkgo.It("will run a pod requesting zero devices when all devices are unhealthy", func(ctx context.Context) {
+		// randomizing so tests can run in parallel
+		resourceName := fmt.Sprintf("test.device/%s", f.UniqueName)
+		devices := []*kubeletdevicepluginv1beta1.Device{{ID: "testdevice", Health: kubeletdevicepluginv1beta1.Unhealthy}}
+		plugin := testdeviceplugin.NewDevicePlugin(nil)
+
+		ginkgo.By("Wait enough for unix socket to be open")
+		time.Sleep(time.Second)
+
+		err := plugin.RegisterDevicePlugin(ctx, f.UniqueName, resourceName, devices)
+		defer plugin.Stop() // should stop even if registration failed
+		gomega.Expect(err).To(gomega.Succeed())
+
+		ginkgo.By("initial state: capacity is one and allocatable is zero")
+		gomega.Eventually(getNodeResourceValues, nodeStatusUpdateTimeout, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: 0, Capacity: 1}))
+
+		client := e2epod.NewPodClient(f)
+		pod := client.Create(ctx, createPod(resourceName, 0))
+
+		gomega.Expect(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)).To(gomega.Succeed())
+
+		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		gomega.Expect(err).To(gomega.Succeed())
+
+		gomega.Eventually(func() error {
+			_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
+			return err
+		}, f.Timeouts.PodDelete, f.Timeouts.Poll).Should(gomega.MatchError(gomega.ContainSubstring("not found")))
+
+		ginkgo.By("when pod is deleted, resource values do not change")
+		gomega.Eventually(getNodeResourceValues, devicePluginGracefulTimeout+1*time.Minute, f.Timeouts.Poll).WithContext(ctx).WithArguments(resourceName).Should(gomega.Equal(ResourceValue{Allocatable: 0, Capacity: 1}))
+	})
+
 	ginkgo.It("will lower allocatable to a number of unhealthy devices and then back if they became healthy again", func(ctx context.Context) {
 		// randomizing so tests can run in parallel
 		resourceName := fmt.Sprintf("test.device/%s", f.UniqueName)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Device manager currently sends zero-valued device-plugin limits through allocation, which fails when the registered resource has no healthy devices.

Skip allocation for zero-valued limits before updating allocation state or calling `devicesToAllocate`. Positive device requests continue through the existing health and restart-recovery checks.

#### Which issue(s) this PR is related to:

Fixes #128854

#### Special notes for your reviewer:

Tests:
- `go test ./pkg/kubelet/cm/devicemanager -run '^TestPodContainerDeviceAllocation$' -count=1`
- `go test ./pkg/kubelet/cm/devicemanager -count=1`
- `go test ./test/e2e_node -run '^$' -count=1` (compile only)

The scoped golangci-lint script was not run locally because the Windows WSL environment lacks Go and jq. Repository verification and cross-platform checks are delegated to CI.

#### Does this PR introduce a user-facing change?

```release-note
Kubelet no longer rejects pods that request zero of a device-plugin resource when the plugin reports no healthy devices.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```