### PR TITLE
Downgrade log level for expected websocket close in wsstream

### DIFF
--- a/staging/src/k8s.io/streaming/go.mod
+++ b/staging/src/k8s.io/streaming/go.mod
@@ -8,10 +8,9 @@ godebug default=go1.26
 
 require (
 	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
+	github.com/go-logr/logr v1.4.3
 	github.com/moby/spdystream v0.5.1
 	golang.org/x/net v0.57.0
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd
 )
-
-require github.com/go-logr/logr v1.4.3 // indirect

--- a/staging/src/k8s.io/streaming/go.sum
+++ b/staging/src/k8s.io/streaming/go.sum
@@ -1,16 +1,11 @@
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
 github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
-golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
-golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
-golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
 k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/utils v0.0.0-20260626114624-be93311217bd h1:Ea7fgQ5we8Y9T0OX5o0dAHzQOBRI07D/dEYRaB9ZZEs=

--- a/staging/src/k8s.io/streaming/go.sum
+++ b/staging/src/k8s.io/streaming/go.sum
@@ -1,11 +1,16 @@
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
 github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
 golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
+golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 k8s.io/klog/v2 v2.140.0 h1:Tf+J3AH7xnUzZyVVXhTgGhEKnFqye14aadWv7bzXdzc=
 k8s.io/klog/v2 v2.140.0/go.mod h1:o+/RWfJ6PwpnFn7OyAG3QnO47BFsymfEfrz6XyYSSp0=
 k8s.io/utils v0.0.0-20260626114624-be93311217bd h1:Ea7fgQ5we8Y9T0OX5o0dAHzQOBRI07D/dEYRaB9ZZEs=

--- a/staging/src/k8s.io/streaming/pkg/httpstream/wsstream/conn.go
+++ b/staging/src/k8s.io/streaming/pkg/httpstream/wsstream/conn.go
@@ -349,8 +349,10 @@ func (conn *Conn) handle(ws *websocket.Conn) {
 		conn.resetTimeout()
 		var data []byte
 		if err := websocket.Message.Receive(ws, &data); err != nil {
-			if err != io.EOF {
+			if err != io.EOF && !strings.Contains(err.Error(), "use of closed network connection") {
 				logger.Error(err, "Error on socket receive")
+			} else if err != io.EOF {
+				logger.V(4).Info("Websocket connection closed", "err", err)
 			}
 			break
 		}

--- a/staging/src/k8s.io/streaming/pkg/httpstream/wsstream/conn.go
+++ b/staging/src/k8s.io/streaming/pkg/httpstream/wsstream/conn.go
@@ -349,10 +349,12 @@ func (conn *Conn) handle(ws *websocket.Conn) {
 		conn.resetTimeout()
 		var data []byte
 		if err := websocket.Message.Receive(ws, &data); err != nil {
-			if err != io.EOF && !strings.Contains(err.Error(), "use of closed network connection") {
-				logger.Error(err, "Error on socket receive")
-			} else if err != io.EOF {
-				logger.V(4).Info("Websocket connection closed", "err", err)
+			if err != io.EOF {
+				if strings.Contains(err.Error(), "use of closed network connection") {
+					logger.V(4).Info("Websocket connection closed", "err", err)
+				} else {
+					logger.Error(err, "Error on socket receive")
+				}
 			}
 			break
 		}

--- a/staging/src/k8s.io/streaming/pkg/httpstream/wsstream/conn_test.go
+++ b/staging/src/k8s.io/streaming/pkg/httpstream/wsstream/conn_test.go
@@ -172,7 +172,7 @@ func TestConnCloseWhileReceivingDoesNotLogError(t *testing.T) {
 
 	s, addr := newServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		req = req.WithContext(klog.NewContext(req.Context(), logger))
-		conn.Open(w, req)
+		_, _, _ = conn.Open(w, req)
 	}))
 	defer s.Close()
 
@@ -180,7 +180,7 @@ func TestConnCloseWhileReceivingDoesNotLogError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	<-conn.ready
 

--- a/staging/src/k8s.io/streaming/pkg/httpstream/wsstream/conn_test.go
+++ b/staging/src/k8s.io/streaming/pkg/httpstream/wsstream/conn_test.go
@@ -24,8 +24,12 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr"
 	"golang.org/x/net/websocket"
+
+	"k8s.io/klog/v2"
 )
 
 func newServer(handler http.Handler) (*httptest.Server, string) {
@@ -114,6 +118,92 @@ func TestRawConn(t *testing.T) {
 
 	client.Close()
 	wg.Wait()
+}
+
+// recordingLogSink is a minimal logr.LogSink that records whether Error or
+// Info was called, and signals "logged" the first time either happens, so
+// tests can assert on log severity.
+type recordingLogSink struct {
+	logged     chan struct{}
+	loggedOnce sync.Once
+
+	mu        sync.Mutex
+	errorCall bool
+	infoCall  bool
+}
+
+func newRecordingLogSink() *recordingLogSink {
+	return &recordingLogSink{logged: make(chan struct{})}
+}
+
+func (s *recordingLogSink) Init(logr.RuntimeInfo)                        {}
+func (s *recordingLogSink) Enabled(level int) bool                       { return true }
+func (s *recordingLogSink) WithValues(keysAndValues ...any) logr.LogSink { return s }
+func (s *recordingLogSink) WithName(name string) logr.LogSink            { return s }
+func (s *recordingLogSink) Info(level int, msg string, keysAndValues ...any) {
+	s.mu.Lock()
+	s.infoCall = true
+	s.mu.Unlock()
+	s.loggedOnce.Do(func() { close(s.logged) })
+}
+func (s *recordingLogSink) Error(err error, msg string, keysAndValues ...any) {
+	s.mu.Lock()
+	s.errorCall = true
+	s.mu.Unlock()
+	s.loggedOnce.Do(func() { close(s.logged) })
+}
+
+func (s *recordingLogSink) calls() (errorCall, infoCall bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.errorCall, s.infoCall
+}
+
+// TestConnCloseWhileReceivingDoesNotLogError verifies that closing the
+// connection while "handle" is blocked in a receive (mirroring what
+// httpstream translation layers do once a session finishes) is logged at
+// V(4), not as an error, since it is the expected way an in-progress
+// websocket connection ends.
+func TestConnCloseWhileReceivingDoesNotLogError(t *testing.T) {
+	channels := []ChannelType{ReadWriteChannel}
+	conn := NewConn(NewDefaultChannelProtocols(channels))
+	sink := newRecordingLogSink()
+	logger := logr.New(sink)
+
+	s, addr := newServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		req = req.WithContext(klog.NewContext(req.Context(), logger))
+		conn.Open(w, req)
+	}))
+	defer s.Close()
+
+	client, err := websocket.Dial("ws://"+addr, "", "http://localhost/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	<-conn.ready
+
+	// Close the connection out from under "handle" while its receive loop is
+	// still blocked waiting for the next frame, the same way a caller of
+	// Open() closes the connection once it is done streaming.
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-sink.logged:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the closed connection to be logged")
+	}
+
+	errorCall, infoCall := sink.calls()
+	if errorCall {
+		t.Errorf("expected no error-level log for a connection closed while receiving")
+	}
+	if !infoCall {
+		t.Errorf("expected a V(4) info log for a connection closed while receiving")
+	}
 }
 
 func TestBase64Conn(t *testing.T) {


### PR DESCRIPTION
Fixes #140102

When a client finishes an exec/attach/port-forward session over the websocket protocol and the connection is closed, the read loop in wsstream/conn.go can still be blocked waiting on the next frame. Once the connection is closed out from under it, that pending read fails with "use of closed network connection", and today that gets logged at error level. Since KEP-4006 made websockets the default streaming protocol for exec/attach/port-forward starting in 1.30, this fires on every normal session close and floods apiserver logs with what looks like an error but isn't one.

This only touches the log level for that specific, expected close case. Anything else still logs at error like before, and the read loop behavior is unchanged, only the severity of this one message changes, following the same string match already used for the equivalent case in util/proxy/upgradeaware.go.

Tested with go test on the wsstream package, including a new test that closes the connection while a receive is in flight and checks the resulting log call is not at error level.

```release-note
kube-apiserver no longer logs an error for the expected "use of closed network connection" condition when a websocket-based exec/attach/port-forward session ends normally.
```