### PR TITLE
Clarify storage topology selector semantics

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12524,7 +12524,7 @@
           "type": "string"
         },
         "values": {
-          "description": "An array of string values. One value must match the label to be selected. Each entry in Values is ORed.",
+          "description": "An array of string values. A label with this key matches the selector if at least one value in this array equals the label value. Each entry in Values is ORed.",
           "items": {
             "type": "string"
           },
@@ -20922,7 +20922,7 @@
           "type": "boolean"
         },
         "allowedTopologies": {
-          "description": "allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.",
+          "description": "allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. A provisioner may create a volume accessible from one or more of these topologies, depending on its capabilities and the StorageClass parameters. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.core.v1.TopologySelectorTerm"
           },

--- a/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__storage.k8s.io__v1_openapi.json
@@ -1096,7 +1096,7 @@
             "type": "string"
           },
           "values": {
-            "description": "An array of string values. One value must match the label to be selected. Each entry in Values is ORed.",
+            "description": "An array of string values. A label with this key matches the selector if at least one value in this array equals the label value. Each entry in Values is ORed.",
             "items": {
               "type": "string"
             },
@@ -1556,7 +1556,7 @@
             "type": "boolean"
           },
           "allowedTopologies": {
-            "description": "allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.",
+            "description": "allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. A provisioner may create a volume accessible from one or more of these topologies, depending on its capabilities and the StorageClass parameters. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.core.v1.TopologySelectorTerm"
             },

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3422,7 +3422,8 @@ type TopologySelectorTerm struct {
 type TopologySelectorLabelRequirement struct {
 	// The label key that the selector applies to.
 	Key string
-	// An array of string values. One value must match the label to be selected.
+	// An array of string values. A label with this key matches the selector
+	// if at least one value in this array equals the label value.
 	// Each entry in Values is ORed.
 	Values []string
 }

--- a/pkg/apis/storage/types.go
+++ b/pkg/apis/storage/types.go
@@ -71,7 +71,9 @@ type StorageClass struct {
 	// +optional
 	VolumeBindingMode *VolumeBindingMode
 
-	// Restrict the node topologies where volumes can be dynamically provisioned.
+	// AllowedTopologies restricts the node topologies where volumes can be dynamically provisioned.
+	// A provisioner may create a volume accessible from one or more of these topologies,
+	// depending on its capabilities and the StorageClass parameters.
 	// Each volume plugin defines its own supported topology specifications.
 	// An empty TopologySelectorTerm list means there is no topology restriction.
 	// This field is only honored by servers that enable the VolumeScheduling feature.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -32314,7 +32314,7 @@ func schema_k8sio_api_core_v1_TopologySelectorLabelRequirement(ref common.Refere
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "An array of string values. One value must match the label to be selected. Each entry in Values is ORed.",
+							Description: "An array of string values. A label with this key matches the selector if at least one value in this array equals the label value. Each entry in Values is ORed.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -56508,7 +56508,7 @@ func schema_k8sio_api_storage_v1_StorageClass(ref common.ReferenceCallback) comm
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.",
+							Description: "allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. A provisioner may create a volume accessible from one or more of these topologies, depending on its capabilities and the StorageClass parameters. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -6703,7 +6703,8 @@ message TopologySelectorLabelRequirement {
   // The label key that the selector applies to.
   optional string key = 1;
 
-  // An array of string values. One value must match the label to be selected.
+  // An array of string values. A label with this key matches the selector
+  // if at least one value in this array equals the label value.
   // Each entry in Values is ORed.
   // +listType=atomic
   repeated string values = 2;

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3848,7 +3848,8 @@ type TopologySelectorTerm struct {
 type TopologySelectorLabelRequirement struct {
 	// The label key that the selector applies to.
 	Key string `json:"key" protobuf:"bytes,1,opt,name=key"`
-	// An array of string values. One value must match the label to be selected.
+	// An array of string values. A label with this key matches the selector
+	// if at least one value in this array equals the label value.
 	// Each entry in Values is ORed.
 	// +listType=atomic
 	Values []string `json:"values" protobuf:"bytes,2,rep,name=values"`

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -2718,7 +2718,7 @@ func (Toleration) SwaggerDoc() map[string]string {
 var map_TopologySelectorLabelRequirement = map[string]string{
 	"":       "A topology selector requirement is a selector that matches given label. This is an alpha feature and may change in the future.",
 	"key":    "The label key that the selector applies to.",
-	"values": "An array of string values. One value must match the label to be selected. Each entry in Values is ORed.",
+	"values": "An array of string values. A label with this key matches the selector if at least one value in this array equals the label value. Each entry in Values is ORed.",
 }
 
 func (TopologySelectorLabelRequirement) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/storage/v1/generated.proto
+++ b/staging/src/k8s.io/api/storage/v1/generated.proto
@@ -495,6 +495,8 @@ message StorageClass {
   optional string volumeBindingMode = 7;
 
   // allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.
+  // A provisioner may create a volume accessible from one or more of these topologies,
+  // depending on its capabilities and the StorageClass parameters.
   // Each volume plugin defines its own supported topology specifications.
   // An empty TopologySelectorTerm list means there is no topology restriction.
   // This field is only honored by servers that enable the VolumeScheduling feature.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -80,6 +80,8 @@ type StorageClass struct {
 	VolumeBindingMode *VolumeBindingMode `json:"volumeBindingMode,omitempty" protobuf:"bytes,7,opt,name=volumeBindingMode"`
 
 	// allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.
+	// A provisioner may create a volume accessible from one or more of these topologies,
+	// depending on its capabilities and the StorageClass parameters.
 	// Each volume plugin defines its own supported topology specifications.
 	// An empty TopologySelectorTerm list means there is no topology restriction.
 	// This field is only honored by servers that enable the VolumeScheduling feature.

--- a/staging/src/k8s.io/api/storage/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/storage/v1/types_swagger_doc_generated.go
@@ -139,7 +139,7 @@ var map_StorageClass = map[string]string{
 	"mountOptions":         "mountOptions controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class. e.g. [\"ro\", \"soft\"]. Not validated - mount of the PVs will simply fail if one is invalid.",
 	"allowVolumeExpansion": "allowVolumeExpansion shows whether the storage class allow volume expand.",
 	"volumeBindingMode":    "volumeBindingMode indicates how PersistentVolumeClaims should be provisioned and bound.  When unset, VolumeBindingImmediate is used. This field is only honored by servers that enable the VolumeScheduling feature.",
-	"allowedTopologies":    "allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.",
+	"allowedTopologies":    "allowedTopologies restrict the node topologies where volumes can be dynamically provisioned. A provisioner may create a volume accessible from one or more of these topologies, depending on its capabilities and the StorageClass parameters. Each volume plugin defines its own supported topology specifications. An empty TopologySelectorTerm list means there is no topology restriction. This field is only honored by servers that enable the VolumeScheduling feature.",
 }
 
 func (StorageClass) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyselectorlabelrequirement.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/topologyselectorlabelrequirement.go
@@ -26,7 +26,8 @@ package v1
 type TopologySelectorLabelRequirementApplyConfiguration struct {
 	// The label key that the selector applies to.
 	Key *string `json:"key,omitempty"`
-	// An array of string values. One value must match the label to be selected.
+	// An array of string values. A label with this key matches the selector
+	// if at least one value in this array equals the label value.
 	// Each entry in Values is ORed.
 	Values []string `json:"values,omitempty"`
 }

--- a/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/storage/v1/storageclass.go
@@ -61,6 +61,8 @@ type StorageClassApplyConfiguration struct {
 	// This field is only honored by servers that enable the VolumeScheduling feature.
 	VolumeBindingMode *storagev1.VolumeBindingMode `json:"volumeBindingMode,omitempty"`
 	// allowedTopologies restrict the node topologies where volumes can be dynamically provisioned.
+	// A provisioner may create a volume accessible from one or more of these topologies,
+	// depending on its capabilities and the StorageClass parameters.
 	// Each volume plugin defines its own supported topology specifications.
 	// An empty TopologySelectorTerm list means there is no topology restriction.
 	// This field is only honored by servers that enable the VolumeScheduling feature.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/sig storage

#### What this PR does / why we need it:

Clarifies the generated API documentation for Kubernetes storage topology selectors.

The updated descriptions explain that:

- a `TopologySelectorLabelRequirement` matches when at least one entry in its `values` array equals the label value;
- `StorageClass.allowedTopologies` constrains the topologies where dynamic provisioning may occur;
- a provisioner may create a volume accessible from one or more allowed topologies, depending on the provisioner's capabilities and the StorageClass parameters.

This PR also updates the related generated protobuf comments, OpenAPI specifications, Swagger documentation maps, and client-go apply-configuration comments.

#### Which issue(s) this PR is related to:

Related to https://github.com/kubernetes/website/issues/30237

This PR addresses the upstream generated API documentation portion of that issue. A separate `kubernetes/website` PR will clarify the StorageClass concepts documentation.

#### Special notes for your reviewer:

The following validation completed successfully:

- `hack/verify-codegen.sh`
- `hack/verify-openapi-spec.sh`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [Issue]: https://github.com/kubernetes/website/issues/30237
```

