### PR TITLE
kubelet/cm: Use ‘_’ for unused parameters and fixes 'opts' parameter passing

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -161,7 +161,7 @@ func NewCgroupManager(logger klog.Logger, cs *CgroupSubsystems, cgroupDriver str
 	return NewCgroupV1Manager(logger, cs, cgroupDriver)
 }
 
-func newCgroupCommon(logger klog.Logger, cs *CgroupSubsystems, cgroupDriver string) cgroupCommon {
+func newCgroupCommon(_ klog.Logger, cs *CgroupSubsystems, cgroupDriver string) cgroupCommon {
 	return cgroupCommon{
 		subsystems: cs,
 		useSystemd: cgroupDriver == "systemd",

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -1056,7 +1056,7 @@ func (cm *containerManagerImpl) GetAllocatableMemory(logger klog.Logger) []*podr
 	return containerMemoryFromBlock(cm.memoryManager.GetAllocatableMemory(logger))
 }
 
-func (cm *containerManagerImpl) GetPodMemory(logger klog.Logger, podUID string) []*podresourcesapi.ContainerMemory {
+func (cm *containerManagerImpl) GetPodMemory(_ klog.Logger, podUID string) []*podresourcesapi.ContainerMemory {
 	if cm.memoryManager == nil {
 		return []*podresourcesapi.ContainerMemory{}
 	}

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -73,7 +73,7 @@ func (cm *containerManagerStub) GetQOSContainersInfo() QOSContainersInfo {
 	return QOSContainersInfo{}
 }
 
-func (cm *containerManagerStub) UpdateQOSCgroups(logger klog.Logger) error {
+func (cm *containerManagerStub) UpdateQOSCgroups(_ klog.Logger) error {
 	return nil
 }
 
@@ -113,7 +113,7 @@ func (m *podContainerManagerStub) GetPodCgroupConfig(_ *v1.Pod, _ v1.ResourceNam
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (m *podContainerManagerStub) SetPodCgroupConfig(logger klog.Logger, pod *v1.Pod, resourceConfig *ResourceConfig) error {
+func (m *podContainerManagerStub) SetPodCgroupConfig(_ klog.Logger, _ *v1.Pod, _ *ResourceConfig) error {
 	return fmt.Errorf("not implemented")
 }
 
@@ -121,7 +121,7 @@ func (cm *containerManagerStub) NewPodContainerManager() PodContainerManager {
 	return &podContainerManagerStub{}
 }
 
-func (cm *containerManagerStub) GetResources(ctx context.Context, pod *v1.Pod, container *v1.Container) (*kubecontainer.RunContainerOptions, error) {
+func (cm *containerManagerStub) GetResources(_ context.Context, _ *v1.Pod, _ *v1.Container) (*kubecontainer.RunContainerOptions, error) {
 	return &kubecontainer.RunContainerOptions{}, nil
 }
 
@@ -141,7 +141,7 @@ func (cm *containerManagerStub) GetDevices(_, _ string) []*podresourcesapi.Conta
 	return nil
 }
 
-func (cm *containerManagerStub) GetAllocatableDevices(logger klog.Logger) []*podresourcesapi.ContainerDevices {
+func (cm *containerManagerStub) GetAllocatableDevices(_ klog.Logger) []*podresourcesapi.ContainerDevices {
 	return nil
 }
 
@@ -157,7 +157,7 @@ func (cm *containerManagerStub) UpdateAllocatedDevices(_ klog.Logger) {
 	return
 }
 
-func (cm *containerManagerStub) GetCPUs(pod *v1.Pod, container *v1.Container) []int64 {
+func (cm *containerManagerStub) GetCPUs(_ *v1.Pod, _ *v1.Container) []int64 {
 	return nil
 }
 
@@ -169,7 +169,7 @@ func (cm *containerManagerStub) GetAllocatableCPUs() []int64 {
 	return nil
 }
 
-func (cm *containerManagerStub) GetMemory(_ klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.ContainerMemory {
+func (cm *containerManagerStub) GetMemory(_ klog.Logger, _ *v1.Pod, _ *v1.Container) []*podresourcesapi.ContainerMemory {
 	return nil
 }
 
@@ -181,7 +181,7 @@ func (cm *containerManagerStub) GetAllocatableMemory(_ klog.Logger) []*podresour
 	return nil
 }
 
-func (cm *containerManagerStub) GetDynamicResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {
+func (cm *containerManagerStub) GetDynamicResources(_ klog.Logger, _ *v1.Pod, _ *v1.Container) []*podresourcesapi.DynamicResource {
 	return nil
 }
 
@@ -189,30 +189,30 @@ func (cm *containerManagerStub) GetNodeAllocatableAbsolute() v1.ResourceList {
 	return nil
 }
 
-func (cm *containerManagerStub) PrepareDynamicResources(ctx context.Context, pod *v1.Pod) error {
+func (cm *containerManagerStub) PrepareDynamicResources(_ context.Context, _ *v1.Pod) error {
 	return nil
 }
 
-func (cm *containerManagerStub) UnprepareDynamicResources(ctx context.Context, pod *v1.Pod) error {
+func (cm *containerManagerStub) UnprepareDynamicResources(_ context.Context, _ *v1.Pod) error {
 	return nil
 }
 
-func (cm *containerManagerStub) PodMightNeedToUnprepareResources(UID types.UID) bool {
+func (cm *containerManagerStub) PodMightNeedToUnprepareResources(_ types.UID) bool {
 	return false
 }
 
-func (cm *containerManagerStub) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus) {
+func (cm *containerManagerStub) UpdateAllocatedResourcesStatus(_ klog.Logger, _ *v1.Pod, _ *v1.PodStatus) {
 }
 
 func (cm *containerManagerStub) Updates() <-chan resourceupdates.Update {
 	return nil
 }
 
-func (cm *containerManagerStub) PodHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod) bool {
+func (cm *containerManagerStub) PodHasExclusiveCPUs(_ klog.Logger, _ *v1.Pod) bool {
 	return false
 }
 
-func (cm *containerManagerStub) ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool {
+func (cm *containerManagerStub) ContainerHasExclusiveCPUs(_ klog.Logger, _ *v1.Pod, _ *v1.Container) bool {
 	return false
 }
 

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -169,8 +169,8 @@ var _ Manager = &manager{}
 
 type sourcesReadyStub struct{}
 
-func (s *sourcesReadyStub) AddSource(source string) {}
-func (s *sourcesReadyStub) AllReady() bool          { return true }
+func (s *sourcesReadyStub) AddSource(_ string) {}
+func (s *sourcesReadyStub) AllReady() bool     { return true }
 
 // NewManager creates new cpu manager based on provided policy
 func NewManager(logger klog.Logger, cpuPolicyName string, cpuPolicyOptions map[string]string, reconcilePeriod time.Duration, machineInfo *cadvisorapi.MachineInfo, specificCPUs cpuset.CPUSet, nodeAllocatableReservation v1.ResourceList, stateFileDirectory string, affinity topologymanager.Store) (Manager, error) {

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -171,31 +171,31 @@ func (p *mockPolicy) Name() string {
 	return "mock"
 }
 
-func (p *mockPolicy) Start(_ klog.Logger, s state.State) error {
+func (p *mockPolicy) Start(_ klog.Logger, _ state.State) error {
 	return p.err
 }
 
-func (p *mockPolicy) Allocate(_ klog.Logger, s state.State, pod *v1.Pod, container *v1.Container, _ lifecycle.Operation) error {
+func (p *mockPolicy) Allocate(_ klog.Logger, _ state.State, _ *v1.Pod, _ *v1.Container, _ lifecycle.Operation) error {
 	return p.err
 }
 
-func (p *mockPolicy) RemoveContainer(_ klog.Logger, s state.State, podUID string, containerName string) error {
+func (p *mockPolicy) RemoveContainer(_ klog.Logger, _ state.State, _ string, _ string) error {
 	return p.err
 }
 
-func (p *mockPolicy) GetTopologyHints(_ klog.Logger, s state.State, pod *v1.Pod, container *v1.Container, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
+func (p *mockPolicy) GetTopologyHints(_ klog.Logger, _ state.State, _ *v1.Pod, _ *v1.Container, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 
-func (p *mockPolicy) GetPodTopologyHints(_ klog.Logger, s state.State, pod *v1.Pod, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
+func (p *mockPolicy) GetPodTopologyHints(_ klog.Logger, _ state.State, _ *v1.Pod, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 
-func (p *mockPolicy) AllocatePod(_ klog.Logger, s state.State, pod *v1.Pod, _ lifecycle.Operation) error {
+func (p *mockPolicy) AllocatePod(_ klog.Logger, _ state.State, _ *v1.Pod, _ lifecycle.Operation) error {
 	return p.err
 }
 
-func (p *mockPolicy) GetAllocatableCPUs(m state.State) cpuset.CPUSet {
+func (p *mockPolicy) GetAllocatableCPUs(_ state.State) cpuset.CPUSet {
 	return cpuset.New()
 }
 
@@ -203,7 +203,7 @@ type mockRuntimeService struct {
 	err error
 }
 
-func (rt mockRuntimeService) UpdateContainerResources(_ context.Context, id string, resources *runtimeapi.ContainerResources) error {
+func (rt mockRuntimeService) UpdateContainerResources(_ context.Context, _ string, _ *runtimeapi.ContainerResources) error {
 	return rt.err
 }
 
@@ -212,7 +212,7 @@ type mockPodStatusProvider struct {
 	found     bool
 }
 
-func (psp mockPodStatusProvider) GetPodStatus(uid types.UID) (v1.PodStatus, bool) {
+func (psp mockPodStatusProvider) GetPodStatus(_ types.UID) (v1.PodStatus, bool) {
 	return psp.podStatus, psp.found
 }
 

--- a/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/fake_cpu_manager.go
@@ -36,7 +36,7 @@ type fakeManager struct {
 	state  state.State
 }
 
-func (m *fakeManager) Start(ctx context.Context, activePods ActivePodsFunc, sourcesReady config.SourcesReady, podStatusProvider status.PodStatusProvider, containerRuntime runtimeService, initialContainers containermap.ContainerMap) error {
+func (m *fakeManager) Start(ctx context.Context, _ ActivePodsFunc, _ config.SourcesReady, _ status.PodStatusProvider, _ runtimeService, _ containermap.ContainerMap) error {
 	logger := klog.FromContext(ctx)
 	logger.Info("Start()")
 	return nil
@@ -63,12 +63,12 @@ func (m *fakeManager) RemoveContainer(logger klog.Logger, containerID string) er
 	return nil
 }
 
-func (m *fakeManager) GetTopologyHints(logger klog.Logger, pod *v1.Pod, container *v1.Container, operation lifecycle.Operation) map[string][]topologymanager.TopologyHint {
+func (m *fakeManager) GetTopologyHints(logger klog.Logger, _ *v1.Pod, _ *v1.Container, operation lifecycle.Operation) map[string][]topologymanager.TopologyHint {
 	logger.Info("Get container topology hints", "operation", operation)
 	return map[string][]topologymanager.TopologyHint{}
 }
 
-func (m *fakeManager) GetPodTopologyHints(logger klog.Logger, pod *v1.Pod, operation lifecycle.Operation) map[string][]topologymanager.TopologyHint {
+func (m *fakeManager) GetPodTopologyHints(logger klog.Logger, _ *v1.Pod, operation lifecycle.Operation) map[string][]topologymanager.TopologyHint {
 	logger.Info("Get pod topology hints", "operation", operation)
 	return map[string][]topologymanager.TopologyHint{}
 }
@@ -107,7 +107,7 @@ func (m *fakeManager) GetAllCPUs() cpuset.CPUSet {
 	return cpuset.New()
 }
 
-func (m *fakeManager) GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container) cmqos.ResourceIsolationLevel {
+func (m *fakeManager) GetResourceIsolationLevel(_ *v1.Pod, _ *v1.Container) cmqos.ResourceIsolationLevel {
 	return cmqos.ResourceIsolationContainer
 }
 

--- a/pkg/kubelet/cm/cpumanager/policy_none.go
+++ b/pkg/kubelet/cm/cpumanager/policy_none.go
@@ -47,28 +47,28 @@ func (p *nonePolicy) Name() string {
 	return string(PolicyNone)
 }
 
-func (p *nonePolicy) Start(logger klog.Logger, s state.State) error {
+func (p *nonePolicy) Start(logger klog.Logger, _ state.State) error {
 	logger.Info("Start")
 	return nil
 }
 
-func (p *nonePolicy) Allocate(_ klog.Logger, s state.State, pod *v1.Pod, container *v1.Container, _ lifecycle.Operation) error {
+func (p *nonePolicy) Allocate(_ klog.Logger, _ state.State, _ *v1.Pod, _ *v1.Container, _ lifecycle.Operation) error {
 	return nil
 }
 
-func (p *nonePolicy) RemoveContainer(_ klog.Logger, s state.State, podUID string, containerName string) error {
+func (p *nonePolicy) RemoveContainer(_ klog.Logger, _ state.State, _ string, _ string) error {
 	return nil
 }
 
-func (p *nonePolicy) GetTopologyHints(_ klog.Logger, s state.State, pod *v1.Pod, container *v1.Container, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
+func (p *nonePolicy) GetTopologyHints(_ klog.Logger, _ state.State, _ *v1.Pod, _ *v1.Container, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 
-func (p *nonePolicy) GetPodTopologyHints(_ klog.Logger, s state.State, pod *v1.Pod, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
+func (p *nonePolicy) GetPodTopologyHints(_ klog.Logger, _ state.State, _ *v1.Pod, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 
-func (p *nonePolicy) AllocatePod(_ klog.Logger, s state.State, pod *v1.Pod, _ lifecycle.Operation) error {
+func (p *nonePolicy) AllocatePod(_ klog.Logger, _ state.State, _ *v1.Pod, _ lifecycle.Operation) error {
 	return nil
 }
 
@@ -77,6 +77,6 @@ func (p *nonePolicy) AllocatePod(_ klog.Logger, s state.State, pod *v1.Pod, _ li
 // Assignability of CPUs as a concept is only applicable in case of static policy i.e. scenarios where workloads
 // CAN get exclusive access to core(s).
 // Hence, we return empty set here: no cpus are assignable according to above definition with this policy.
-func (p *nonePolicy) GetAllocatableCPUs(m state.State) cpuset.CPUSet {
+func (p *nonePolicy) GetAllocatableCPUs(_ state.State) cpuset.CPUSet {
 	return cpuset.New()
 }

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -280,7 +280,7 @@ func (p *staticPolicy) validateState(logger klog.Logger, s state.State) error {
 }
 
 // GetAllocatableCPUs returns the total set of CPUs available for allocation.
-func (p *staticPolicy) GetAllocatableCPUs(s state.State) cpuset.CPUSet {
+func (p *staticPolicy) GetAllocatableCPUs(_ state.State) cpuset.CPUSet {
 	return p.topology.CPUDetails.CPUs().Difference(p.reservedCPUs)
 }
 

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -127,8 +127,8 @@ type sourcesReadyStub struct{}
 // PodReusableDevices is a map by pod name of devices to reuse.
 type PodReusableDevices map[string]map[string]sets.Set[string]
 
-func (s *sourcesReadyStub) AddSource(source string) {}
-func (s *sourcesReadyStub) AllReady() bool          { return true }
+func (s *sourcesReadyStub) AddSource(_ string) {}
+func (s *sourcesReadyStub) AllReady() bool     { return true }
 
 // NewManagerImpl creates a new manager.
 func NewManagerImpl(logger klog.Logger, topology []cadvisorapi.Node, topologyAffinityStore topologymanager.Store) (*ManagerImpl, error) {
@@ -1143,7 +1143,7 @@ func (m *ManagerImpl) GetAllocatableDevices(logger klog.Logger) ResourceDeviceIn
 }
 
 // AllocatePod is called to trigger the allocation of resources to a pod.
-func (m *ManagerImpl) AllocatePod(logger klog.Logger, pod *v1.Pod, _ lifecycle.Operation) error {
+func (m *ManagerImpl) AllocatePod(logger klog.Logger, _ *v1.Pod, _ lifecycle.Operation) error {
 	// Device Manager does not support pod level resource allocation.
 	logger.V(2).Info("Device Manager does not support pod level resource allocation")
 	return nil
@@ -1154,7 +1154,7 @@ func (m *ManagerImpl) GetDevices(podUID, containerName string) ResourceDeviceIns
 	return m.podDevices.getContainerDevices(podUID, containerName)
 }
 
-func (m *ManagerImpl) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus) {
+func (m *ManagerImpl) UpdateAllocatedResourcesStatus(_ klog.Logger, pod *v1.Pod, status *v1.PodStatus) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -846,14 +846,14 @@ func (m *MockEndpoint) getPreferredAllocation(_ context.Context, available, must
 	return nil, nil
 }
 
-func (m *MockEndpoint) allocate(ctx context.Context, devs []string) (*pluginapi.AllocateResponse, error) {
+func (m *MockEndpoint) allocate(_ context.Context, devs []string) (*pluginapi.AllocateResponse, error) {
 	if m.allocateFunc != nil {
 		return m.allocateFunc(devs)
 	}
 	return nil, nil
 }
 
-func (m *MockEndpoint) setStopTime(t time.Time) {}
+func (m *MockEndpoint) setStopTime(_ time.Time) {}
 
 func (m *MockEndpoint) isStopped() bool { return false }
 

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/handler.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/handler.go
@@ -40,7 +40,7 @@ func (s *server) GetPluginHandler(ctx context.Context) cache.PluginHandler {
 	return s
 }
 
-func (s *server) RegisterPlugin(ctx context.Context, pluginName string, endpoint string, versions []string, pluginClientTimeout *time.Duration) error {
+func (s *server) RegisterPlugin(ctx context.Context, pluginName string, endpoint string, _ []string, _ *time.Duration) error {
 	logger := klog.FromContext(ctx)
 	logger.V(2).Info("Registering plugin at endpoint", "plugin", pluginName, "endpoint", endpoint)
 	return s.connectClient(ctx, pluginName, endpoint)

--- a/pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go
+++ b/pkg/kubelet/cm/devicemanager/plugin/v1beta1/stub.go
@@ -69,7 +69,7 @@ type Stub struct {
 // stubGetPreferredAllocFunc is the function called when a getPreferredAllocation request is received from Kubelet
 type stubGetPreferredAllocFunc func(r *pluginapi.PreferredAllocationRequest, devs map[string]*pluginapi.Device) (*pluginapi.PreferredAllocationResponse, error)
 
-func defaultGetPreferredAllocFunc(r *pluginapi.PreferredAllocationRequest, devs map[string]*pluginapi.Device) (*pluginapi.PreferredAllocationResponse, error) {
+func defaultGetPreferredAllocFunc(_ *pluginapi.PreferredAllocationRequest, _ map[string]*pluginapi.Device) (*pluginapi.PreferredAllocationResponse, error) {
 	var response pluginapi.PreferredAllocationResponse
 
 	return &response, nil
@@ -78,7 +78,7 @@ func defaultGetPreferredAllocFunc(r *pluginapi.PreferredAllocationRequest, devs 
 // stubAllocFunc is the function called when an allocation request is received from Kubelet
 type stubAllocFunc func(r *pluginapi.AllocateRequest, devs map[string]*pluginapi.Device) (*pluginapi.AllocateResponse, error)
 
-func defaultAllocFunc(r *pluginapi.AllocateRequest, devs map[string]*pluginapi.Device) (*pluginapi.AllocateResponse, error) {
+func defaultAllocFunc(_ *pluginapi.AllocateRequest, _ map[string]*pluginapi.Device) (*pluginapi.AllocateResponse, error) {
 	var response pluginapi.AllocateResponse
 
 	return &response, nil
@@ -256,7 +256,7 @@ func (m *Stub) Watch(ctx context.Context, kubeletEndpoint, resourceName, pluginS
 }
 
 // GetInfo is the RPC which return pluginInfo
-func (m *Stub) GetInfo(ctx context.Context, req *watcherapi.InfoRequest) (*watcherapi.PluginInfo, error) {
+func (m *Stub) GetInfo(ctx context.Context, _ *watcherapi.InfoRequest) (*watcherapi.PluginInfo, error) {
 	klog.FromContext(ctx).Info("GetInfo")
 	return &watcherapi.PluginInfo{
 		Type:              watcherapi.DevicePlugin,
@@ -326,7 +326,7 @@ func (m *Stub) Register(ctx context.Context, kubeletEndpoint, resourceName strin
 }
 
 // GetDevicePluginOptions returns DevicePluginOptions settings for the device plugin.
-func (m *Stub) GetDevicePluginOptions(ctx context.Context, e *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
+func (m *Stub) GetDevicePluginOptions(_ context.Context, _ *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
 	options := &pluginapi.DevicePluginOptions{
 		PreStartRequired:                m.preStartContainerFlag,
 		GetPreferredAllocationAvailable: m.getPreferredAllocationFlag,
@@ -341,7 +341,7 @@ func (m *Stub) PreStartContainer(ctx context.Context, r *pluginapi.PreStartConta
 }
 
 // ListAndWatch lists devices and update that list according to the Update call
-func (m *Stub) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
+func (m *Stub) ListAndWatch(_ *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
 	// Use klog.TODO() because this method must match the generated device
 	// plugin gRPC signature in api_grpc.pb.go, which does not accept a logger.
 	klog.TODO().Info("ListAndWatch")

--- a/pkg/kubelet/cm/devicemanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints_test.go
@@ -39,7 +39,7 @@ type mockAffinityStore struct {
 	hint topologymanager.TopologyHint
 }
 
-func (m *mockAffinityStore) GetAffinity(_ klog.Logger, podUID string, containerName string) topologymanager.TopologyHint {
+func (m *mockAffinityStore) GetAffinity(_ klog.Logger, _ string, _ string) topologymanager.TopologyHint {
 	return m.hint
 }
 

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin.go
@@ -107,7 +107,7 @@ func (p *DRAPlugin) NodePrepareResources(
 		response, err = drapbv1beta1.V1Beta1ClientWrapper{DRAPluginClient: client}.NodePrepareResources(ctx, req)
 	case drapbv1.DRAPluginService:
 		client := drapbv1.NewDRAPluginClient(p.conn)
-		response, err = client.NodePrepareResources(ctx, req)
+		response, err = client.NodePrepareResources(ctx, req, opts...)
 	default:
 		// Shouldn't happen, validateSupportedServices should only
 		// return services we support here.
@@ -139,7 +139,7 @@ func (p *DRAPlugin) NodeUnprepareResources(
 		response, err = drapbv1beta1.V1Beta1ClientWrapper{DRAPluginClient: client}.NodeUnprepareResources(ctx, req)
 	case drapbv1.DRAPluginService:
 		client := drapbv1.NewDRAPluginClient(p.conn)
-		response, err = client.NodeUnprepareResources(ctx, req)
+		response, err = client.NodeUnprepareResources(ctx, req, opts...)
 	default:
 		// Shouldn't happen, validateSupportedServices should only
 		// return services we support here.

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
@@ -101,14 +101,14 @@ type monitoredPlugin struct {
 
 var _ grpcstats.Handler = &monitoredPlugin{}
 
-func (m *monitoredPlugin) TagRPC(ctx context.Context, info *grpcstats.RPCTagInfo) context.Context {
+func (m *monitoredPlugin) TagRPC(ctx context.Context, _ *grpcstats.RPCTagInfo) context.Context {
 	return ctx
 }
 
 func (m *monitoredPlugin) HandleRPC(context.Context, grpcstats.RPCStats) {
 }
 
-func (m *monitoredPlugin) TagConn(ctx context.Context, info *grpcstats.ConnTagInfo) context.Context {
+func (m *monitoredPlugin) TagConn(ctx context.Context, _ *grpcstats.ConnTagInfo) context.Context {
 	return ctx
 }
 
@@ -565,7 +565,7 @@ func (pm *DRAPluginManager) ValidatePlugin(_ context.Context, driverName string,
 // NodePrepareResources and NodeUnprepareResources and returns its name
 // (e.g. [drapbv1beta1.DRAPluginService]). An error is returned if the plugin
 // is unusable.
-func (pm *DRAPluginManager) validateSupportedServices(driverName string, supportedServices []string) (string, error) {
+func (pm *DRAPluginManager) validateSupportedServices(_ string, supportedServices []string) (string, error) {
 	if len(supportedServices) == 0 {
 		return "", errors.New("empty list of supported gRPC services (aka supported versions)")
 	}

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -102,7 +102,7 @@ func (cm *FakeContainerManager) GetQOSContainersInfo() QOSContainersInfo {
 	return QOSContainersInfo{}
 }
 
-func (cm *FakeContainerManager) UpdateQOSCgroups(logger klog.Logger) error {
+func (cm *FakeContainerManager) UpdateQOSCgroups(_ klog.Logger) error {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "UpdateQOSCgroups")
@@ -166,7 +166,7 @@ func (cm *FakeContainerManager) NewPodContainerManager() PodContainerManager {
 	return cm.PodContainerManager
 }
 
-func (cm *FakeContainerManager) GetResources(ctx context.Context, pod *v1.Pod, container *v1.Container) (*kubecontainer.RunContainerOptions, error) {
+func (cm *FakeContainerManager) GetResources(_ context.Context, _ *v1.Pod, _ *v1.Container) (*kubecontainer.RunContainerOptions, error) {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "GetResources")
@@ -229,7 +229,7 @@ func (cm *FakeContainerManager) UpdateAllocatedDevices(_ klog.Logger) {
 	return
 }
 
-func (cm *FakeContainerManager) GetCPUs(pod *v1.Pod, container *v1.Container) []int64 {
+func (cm *FakeContainerManager) GetCPUs(_ *v1.Pod, _ *v1.Container) []int64 {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "GetCPUs")
@@ -249,7 +249,7 @@ func (cm *FakeContainerManager) GetAllocatableCPUs() []int64 {
 	return nil
 }
 
-func (cm *FakeContainerManager) GetMemory(_ klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.ContainerMemory {
+func (cm *FakeContainerManager) GetMemory(_ klog.Logger, _ *v1.Pod, _ *v1.Container) []*podresourcesapi.ContainerMemory {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "GetMemory")
@@ -269,7 +269,7 @@ func (cm *FakeContainerManager) GetAllocatableMemory(_ klog.Logger) []*podresour
 	return nil
 }
 
-func (cm *FakeContainerManager) GetDynamicResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) []*podresourcesapi.DynamicResource {
+func (cm *FakeContainerManager) GetDynamicResources(_ klog.Logger, _ *v1.Pod, _ *v1.Container) []*podresourcesapi.DynamicResource {
 	return nil
 }
 
@@ -283,7 +283,7 @@ func (cm *FakeContainerManager) GetNodeAllocatableAbsolute() v1.ResourceList {
 	}
 }
 
-func (cm *FakeContainerManager) PrepareDynamicResources(ctx context.Context, pod *v1.Pod) error {
+func (cm *FakeContainerManager) PrepareDynamicResources(_ context.Context, _ *v1.Pod) error {
 	return nil
 }
 
@@ -291,19 +291,19 @@ func (cm *FakeContainerManager) UnprepareDynamicResources(context.Context, *v1.P
 	return nil
 }
 
-func (cm *FakeContainerManager) PodMightNeedToUnprepareResources(UID types.UID) bool {
+func (cm *FakeContainerManager) PodMightNeedToUnprepareResources(_ types.UID) bool {
 	return false
 }
-func (cm *FakeContainerManager) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1.Pod, status *v1.PodStatus) {
+func (cm *FakeContainerManager) UpdateAllocatedResourcesStatus(_ klog.Logger, _ *v1.Pod, _ *v1.PodStatus) {
 }
 func (cm *FakeContainerManager) Updates() <-chan resourceupdates.Update {
 	return nil
 }
 
-func (cm *FakeContainerManager) PodHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod) bool {
+func (cm *FakeContainerManager) PodHasExclusiveCPUs(_ klog.Logger, _ *v1.Pod) bool {
 	return false
 }
 
-func (cm *FakeContainerManager) ContainerHasExclusiveCPUs(logger klog.Logger, pod *v1.Pod, container *v1.Container) bool {
+func (cm *FakeContainerManager) ContainerHasExclusiveCPUs(_ klog.Logger, _ *v1.Pod, _ *v1.Container) bool {
 	return false
 }

--- a/pkg/kubelet/cm/fake_internal_container_lifecycle.go
+++ b/pkg/kubelet/cm/fake_internal_container_lifecycle.go
@@ -28,14 +28,14 @@ func NewFakeInternalContainerLifecycle() *fakeInternalContainerLifecycle {
 
 type fakeInternalContainerLifecycle struct{}
 
-func (f *fakeInternalContainerLifecycle) PreCreateContainer(logger klog.Logger, pod *v1.Pod, container *v1.Container, containerConfig *runtimeapi.ContainerConfig) error {
+func (f *fakeInternalContainerLifecycle) PreCreateContainer(_ klog.Logger, _ *v1.Pod, _ *v1.Container, _ *runtimeapi.ContainerConfig) error {
 	return nil
 }
 
-func (f *fakeInternalContainerLifecycle) PreStartContainer(logger klog.Logger, pod *v1.Pod, container *v1.Container, containerID string) error {
+func (f *fakeInternalContainerLifecycle) PreStartContainer(_ klog.Logger, _ *v1.Pod, _ *v1.Container, _ string) error {
 	return nil
 }
 
-func (f *fakeInternalContainerLifecycle) PostStopContainer(logger klog.Logger, containerID string) error {
+func (f *fakeInternalContainerLifecycle) PostStopContainer(_ klog.Logger, _ string) error {
 	return nil
 }

--- a/pkg/kubelet/cm/fake_pod_container_manager.go
+++ b/pkg/kubelet/cm/fake_pod_container_manager.go
@@ -99,7 +99,7 @@ func (m *FakePodContainerManager) GetAllPodsFromCgroups(_ klog.Logger) (map[type
 	return grp, nil
 }
 
-func (m *FakePodContainerManager) IsPodCgroup(cgroupfs string) (bool, types.UID) {
+func (m *FakePodContainerManager) IsPodCgroup(_ string) (bool, types.UID) {
 	m.Lock()
 	defer m.Unlock()
 	m.CalledFunctions = append(m.CalledFunctions, "IsPodCgroup")
@@ -120,7 +120,7 @@ func (cm *FakePodContainerManager) GetPodCgroupConfig(_ *v1.Pod, _ v1.ResourceNa
 	return nil, nil
 }
 
-func (cm *FakePodContainerManager) SetPodCgroupConfig(_ klog.Logger, pod *v1.Pod, resourceConfig *ResourceConfig) error {
+func (cm *FakePodContainerManager) SetPodCgroupConfig(_ klog.Logger, _ *v1.Pod, _ *ResourceConfig) error {
 	cm.Lock()
 	defer cm.Unlock()
 	cm.CalledFunctions = append(cm.CalledFunctions, "SetPodCgroupConfig")

--- a/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/fake_memory_manager.go
@@ -35,7 +35,7 @@ type fakeManager struct {
 	state state.State
 }
 
-func (m *fakeManager) Start(ctx context.Context, activePods ActivePodsFunc, sourcesReady config.SourcesReady, podStatusProvider status.PodStatusProvider, containerRuntime runtimeService, initialContainers containermap.ContainerMap) error {
+func (m *fakeManager) Start(ctx context.Context, _ ActivePodsFunc, _ config.SourcesReady, _ status.PodStatusProvider, _ runtimeService, _ containermap.ContainerMap) error {
 	logger := klog.FromContext(ctx)
 	logger.Info("Start()")
 	return nil
@@ -105,7 +105,7 @@ func (m *fakeManager) GetPodMemory(podUID string) []state.Block {
 	return []state.Block{}
 }
 
-func (m *fakeManager) GetResourceIsolationLevel(pod *v1.Pod, container *v1.Container) cmqos.ResourceIsolationLevel {
+func (m *fakeManager) GetResourceIsolationLevel(_ *v1.Pod, _ *v1.Container) cmqos.ResourceIsolationLevel {
 	return cmqos.ResourceIsolationContainer
 }
 

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -56,8 +56,8 @@ type runtimeService interface {
 
 type sourcesReadyStub struct{}
 
-func (s *sourcesReadyStub) AddSource(source string) {}
-func (s *sourcesReadyStub) AllReady() bool          { return true }
+func (s *sourcesReadyStub) AddSource(_ string) {}
+func (s *sourcesReadyStub) AllReady() bool     { return true }
 
 // Manager interface provides methods for Kubelet to manage pod memory.
 type Manager interface {

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -116,7 +116,7 @@ func (p *mockPolicy) GetPodTopologyHints(klog.Logger, state.State, *v1.Pod, life
 	return nil
 }
 
-func (p *mockPolicy) AllocatePod(_ klog.Logger, s state.State, pod *v1.Pod, _ lifecycle.Operation) error {
+func (p *mockPolicy) AllocatePod(_ klog.Logger, _ state.State, _ *v1.Pod, _ lifecycle.Operation) error {
 	return p.err
 }
 
@@ -129,7 +129,7 @@ type mockRuntimeService struct {
 	err error
 }
 
-func (rt mockRuntimeService) UpdateContainerResources(_ context.Context, id string, resources *runtimeapi.ContainerResources) error {
+func (rt mockRuntimeService) UpdateContainerResources(_ context.Context, _ string, _ *runtimeapi.ContainerResources) error {
 	return rt.err
 }
 
@@ -138,7 +138,7 @@ type mockPodStatusProvider struct {
 	found     bool
 }
 
-func (psp mockPodStatusProvider) GetPodStatus(uid types.UID) (v1.PodStatus, bool) {
+func (psp mockPodStatusProvider) GetPodStatus(_ types.UID) (v1.PodStatus, bool) {
 	return psp.podStatus, psp.found
 }
 

--- a/pkg/kubelet/cm/memorymanager/policy_best_effort.go
+++ b/pkg/kubelet/cm/memorymanager/policy_best_effort.go
@@ -83,7 +83,7 @@ func (p *bestEffortPolicy) RemoveContainer(logger klog.Logger, s state.State, po
 	p.static.RemoveContainer(logger, s, podUID, containerName)
 }
 
-func (p *bestEffortPolicy) GetPodTopologyHints(_ klog.Logger, s state.State, pod *v1.Pod, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
+func (p *bestEffortPolicy) GetPodTopologyHints(_ klog.Logger, _ state.State, _ *v1.Pod, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
 	// Pod-level resources are not supported on Windows.
 	return nil
 }
@@ -96,7 +96,7 @@ func (p *bestEffortPolicy) GetAllocatableMemory(s state.State) []state.Block {
 	return p.static.GetAllocatableMemory(s)
 }
 
-func (p *bestEffortPolicy) AllocatePod(_ klog.Logger, s state.State, pod *v1.Pod, _ lifecycle.Operation) error {
+func (p *bestEffortPolicy) AllocatePod(_ klog.Logger, _ state.State, _ *v1.Pod, _ lifecycle.Operation) error {
 	// Pod-level resources are not supported on Windows.
 	return nil
 }

--- a/pkg/kubelet/cm/memorymanager/policy_none.go
+++ b/pkg/kubelet/cm/memorymanager/policy_none.go
@@ -35,7 +35,7 @@ type none struct{}
 var _ Policy = &none{}
 
 // NewPolicyNone returns new none policy instance
-func NewPolicyNone(logger klog.Logger) Policy {
+func NewPolicyNone(_ klog.Logger) Policy {
 	return &none{}
 }
 
@@ -43,39 +43,39 @@ func (p *none) Name() string {
 	return string(policyTypeNone)
 }
 
-func (p *none) Start(logger klog.Logger, s state.State) error {
+func (p *none) Start(logger klog.Logger, _ state.State) error {
 	logger.Info("Start")
 	return nil
 }
 
 // Allocate call is idempotent
-func (p *none) Allocate(_ context.Context, s state.State, pod *v1.Pod, container *v1.Container, _ lifecycle.Operation) error {
+func (p *none) Allocate(_ context.Context, _ state.State, _ *v1.Pod, _ *v1.Container, _ lifecycle.Operation) error {
 	return nil
 }
 
 // RemoveContainer call is idempotent
-func (p *none) RemoveContainer(_ klog.Logger, s state.State, podUID string, containerName string) {
+func (p *none) RemoveContainer(_ klog.Logger, _ state.State, _ string, _ string) {
 }
 
 // GetTopologyHints implements the topologymanager.HintProvider Interface
 // and is consulted to achieve NUMA aware resource alignment among this
 // and other resource controllers.
-func (p *none) GetTopologyHints(_ klog.Logger, s state.State, pod *v1.Pod, container *v1.Container, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
+func (p *none) GetTopologyHints(_ klog.Logger, _ state.State, _ *v1.Pod, _ *v1.Container, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 
 // GetPodTopologyHints implements the topologymanager.HintProvider Interface
 // and is consulted to achieve NUMA aware resource alignment among this
 // and other resource controllers.
-func (p *none) GetPodTopologyHints(_ klog.Logger, s state.State, pod *v1.Pod, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
+func (p *none) GetPodTopologyHints(_ klog.Logger, _ state.State, _ *v1.Pod, _ lifecycle.Operation) map[string][]topologymanager.TopologyHint {
 	return nil
 }
 
-func (p *none) AllocatePod(_ klog.Logger, s state.State, pod *v1.Pod, _ lifecycle.Operation) error {
+func (p *none) AllocatePod(_ klog.Logger, _ state.State, _ *v1.Pod, _ lifecycle.Operation) error {
 	return nil
 }
 
 // GetAllocatableMemory returns the amount of allocatable memory for each NUMA node
-func (p *none) GetAllocatableMemory(s state.State) []state.Block {
+func (p *none) GetAllocatableMemory(_ state.State) []state.Block {
 	return []state.Block{}
 }

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -74,7 +74,7 @@ type staticPolicy struct {
 var _ Policy = &staticPolicy{}
 
 // NewPolicyStatic returns new static policy instance
-func NewPolicyStatic(logger klog.Logger, machineInfo *cadvisorapi.MachineInfo, reserved systemReservedMemory, affinity topologymanager.Store) (Policy, error) {
+func NewPolicyStatic(_ klog.Logger, machineInfo *cadvisorapi.MachineInfo, reserved systemReservedMemory, affinity topologymanager.Store) (Policy, error) {
 	var totalSystemReserved uint64
 	for _, node := range reserved {
 		if _, ok := node[v1.ResourceMemory]; !ok {

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -361,7 +361,7 @@ func (m *podContainerManagerNoop) GetAllPodsFromCgroups(_ klog.Logger) (map[type
 	return nil, nil
 }
 
-func (m *podContainerManagerNoop) IsPodCgroup(cgroupfs string) (bool, types.UID) {
+func (m *podContainerManagerNoop) IsPodCgroup(_ string) (bool, types.UID) {
 	return false, types.UID("")
 }
 

--- a/pkg/kubelet/cm/pod_container_manager_stub.go
+++ b/pkg/kubelet/cm/pod_container_manager_stub.go
@@ -51,7 +51,7 @@ func (m *podContainerManagerStub) GetAllPodsFromCgroups(_ klog.Logger) (map[type
 	return nil, nil
 }
 
-func (m *podContainerManagerStub) IsPodCgroup(cgroupfs string) (bool, types.UID) {
+func (m *podContainerManagerStub) IsPodCgroup(_ string) (bool, types.UID) {
 	return false, types.UID("")
 }
 

--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -464,6 +464,6 @@ func (m *qosContainerManagerNoop) Start(_ context.Context, _ func() v1.ResourceL
 	return nil
 }
 
-func (m *qosContainerManagerNoop) UpdateCgroups(logger klog.Logger) error {
+func (m *qosContainerManagerNoop) UpdateCgroups(_ klog.Logger) error {
 	return nil
 }

--- a/pkg/kubelet/cm/qos_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux_test.go
@@ -462,7 +462,7 @@ type fakeCgroupManager struct {
 
 // Update() is the observation point for this test.
 // Capture the updated cgroup config so it can be validated.
-func (f *fakeCgroupManager) Update(logger klog.Logger, config *CgroupConfig) error {
+func (f *fakeCgroupManager) Update(_ klog.Logger, config *CgroupConfig) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -473,7 +473,7 @@ func (f *fakeCgroupManager) Update(logger klog.Logger, config *CgroupConfig) err
 
 // Create() must succeed for Start() to construct QoS cgroups.
 // We do not assert on Create() behavior in this test.
-func (f *fakeCgroupManager) Create(l klog.Logger, config *CgroupConfig) error {
+func (f *fakeCgroupManager) Create(_ klog.Logger, config *CgroupConfig) error {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -482,22 +482,22 @@ func (f *fakeCgroupManager) Create(l klog.Logger, config *CgroupConfig) error {
 	return nil
 }
 
-func (f *fakeCgroupManager) Destroy(l klog.Logger, config *CgroupConfig) error { return nil }
-func (f *fakeCgroupManager) Validate(name CgroupName) error                    { return nil }
-func (f *fakeCgroupManager) Exists(name CgroupName) bool                       { return false }
-func (f *fakeCgroupManager) Name(name CgroupName) string                       { return name.ToCgroupfs() }
+func (f *fakeCgroupManager) Destroy(_ klog.Logger, _ *CgroupConfig) error { return nil }
+func (f *fakeCgroupManager) Validate(_ CgroupName) error                  { return nil }
+func (f *fakeCgroupManager) Exists(_ CgroupName) bool                     { return false }
+func (f *fakeCgroupManager) Name(name CgroupName) string                  { return name.ToCgroupfs() }
 func (f *fakeCgroupManager) CgroupName(name string) CgroupName {
 	return ParseCgroupfsToCgroupName(name)
 }
-func (f *fakeCgroupManager) Pids(logger klog.Logger, name CgroupName) []int { return nil }
-func (f *fakeCgroupManager) ReduceCPULimits(logger klog.Logger, cgroupName CgroupName) error {
+func (f *fakeCgroupManager) Pids(_ klog.Logger, _ CgroupName) []int { return nil }
+func (f *fakeCgroupManager) ReduceCPULimits(_ klog.Logger, _ CgroupName) error {
 	return nil
 }
-func (f *fakeCgroupManager) MemoryUsage(name CgroupName) (int64, error) { return int64(0), nil }
-func (f *fakeCgroupManager) GetCgroupConfig(name CgroupName, resource v1.ResourceName) (*ResourceConfig, error) {
+func (f *fakeCgroupManager) MemoryUsage(_ CgroupName) (int64, error) { return int64(0), nil }
+func (f *fakeCgroupManager) GetCgroupConfig(_ CgroupName, _ v1.ResourceName) (*ResourceConfig, error) {
 	return nil, nil
 }
-func (f *fakeCgroupManager) SetCgroupConfig(logger klog.Logger, name CgroupName, resourceConfig *ResourceConfig) error {
+func (f *fakeCgroupManager) SetCgroupConfig(_ klog.Logger, _ CgroupName, _ *ResourceConfig) error {
 	return nil
 }
 func (f *fakeCgroupManager) Version() int { return 1 }

--- a/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/fake_topology_manager.go
@@ -91,7 +91,7 @@ func (m *fakeManager) RemoveContainer(logger klog.Logger, containerID string) er
 	return nil
 }
 
-func (m *fakeManager) Admit(ctx context.Context, attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
+func (m *fakeManager) Admit(ctx context.Context, _ *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitResult {
 	logger := klog.FromContext(ctx)
 	logger.Info("Topology Admit Handler")
 	return admission.GetPodAdmitResult(nil)

--- a/pkg/kubelet/cm/topologymanager/policy_best_effort.go
+++ b/pkg/kubelet/cm/topologymanager/policy_best_effort.go
@@ -38,7 +38,7 @@ func (p *bestEffortPolicy) Name() string {
 	return PolicyBestEffort
 }
 
-func (p *bestEffortPolicy) canAdmitPodResult(hint *TopologyHint) bool {
+func (p *bestEffortPolicy) canAdmitPodResult(_ *TopologyHint) bool {
 	return true
 }
 

--- a/pkg/kubelet/cm/topologymanager/policy_none.go
+++ b/pkg/kubelet/cm/topologymanager/policy_none.go
@@ -34,10 +34,10 @@ func (p *nonePolicy) Name() string {
 	return PolicyNone
 }
 
-func (p *nonePolicy) canAdmitPodResult(hint *TopologyHint) bool {
+func (p *nonePolicy) canAdmitPodResult(_ *TopologyHint) bool {
 	return true
 }
 
-func (p *nonePolicy) Merge(logger klog.Logger, providersHints []map[string][]TopologyHint) (TopologyHint, bool) {
+func (p *nonePolicy) Merge(_ klog.Logger, _ []map[string][]TopologyHint) (TopologyHint, bool) {
 	return TopologyHint{}, p.canAdmitPodResult(nil)
 }

--- a/pkg/kubelet/cm/topologymanager/policy_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_test.go
@@ -32,7 +32,7 @@ type policyMergeTestCase struct {
 	expected TopologyHint
 }
 
-func commonPolicyMergeTestCases(numaNodes []int) []policyMergeTestCase {
+func commonPolicyMergeTestCases(_ []int) []policyMergeTestCase {
 	return []policyMergeTestCase{
 		{
 			name: "Two providers, 1 hint each, same mask, both preferred 1/2",
@@ -753,7 +753,7 @@ func (p *bestEffortPolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase
 	}
 }
 
-func (p *bestEffortPolicy) mergeTestCasesNoPolicies(numaNodes []int) []policyMergeTestCase {
+func (p *bestEffortPolicy) mergeTestCasesNoPolicies(_ []int) []policyMergeTestCase {
 	return []policyMergeTestCase{
 		{
 			name: "bestNonPreferredAffinityCount (5)",
@@ -840,7 +840,7 @@ func (p *bestEffortPolicy) mergeTestCasesNoPolicies(numaNodes []int) []policyMer
 	}
 }
 
-func (p *bestEffortPolicy) mergeTestCasesClosestNUMA(numaNodes []int) []policyMergeTestCase {
+func (p *bestEffortPolicy) mergeTestCasesClosestNUMA(_ []int) []policyMergeTestCase {
 	return []policyMergeTestCase{
 		{
 			name: "Two providers, 2 hints each, same mask (some with different bits), same preferred",
@@ -1001,7 +1001,7 @@ func (p *bestEffortPolicy) mergeTestCasesClosestNUMA(numaNodes []int) []policyMe
 	}
 }
 
-func (p *singleNumaNodePolicy) mergeTestCases(numaNodes []int) []policyMergeTestCase {
+func (p *singleNumaNodePolicy) mergeTestCases(_ []int) []policyMergeTestCase {
 	return []policyMergeTestCase{
 		{
 			name: "TopologyHint not set",

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -223,19 +223,19 @@ type mockHintProvider struct {
 	//allocateError error
 }
 
-func (m *mockHintProvider) GetTopologyHints(logger klog.Logger, pod *v1.Pod, container *v1.Container, _ lifecycle.Operation) map[string][]TopologyHint {
+func (m *mockHintProvider) GetTopologyHints(_ klog.Logger, _ *v1.Pod, _ *v1.Container, _ lifecycle.Operation) map[string][]TopologyHint {
 	return m.th
 }
 
-func (m *mockHintProvider) GetPodTopologyHints(logger klog.Logger, pod *v1.Pod, _ lifecycle.Operation) map[string][]TopologyHint {
+func (m *mockHintProvider) GetPodTopologyHints(_ klog.Logger, _ *v1.Pod, _ lifecycle.Operation) map[string][]TopologyHint {
 	return m.th
 }
 
-func (m *mockHintProvider) AllocatePod(logger klog.Logger, pod *v1.Pod, _ lifecycle.Operation) error {
+func (m *mockHintProvider) AllocatePod(_ klog.Logger, _ *v1.Pod, _ lifecycle.Operation) error {
 	return nil
 }
 
-func (m *mockHintProvider) Allocate(ctx context.Context, pod *v1.Pod, container *v1.Container, _ lifecycle.Operation) error {
+func (m *mockHintProvider) Allocate(_ context.Context, _ *v1.Pod, _ *v1.Container, _ lifecycle.Operation) error {
 	//return allocateError
 	return nil
 }
@@ -245,7 +245,7 @@ type mockPolicy struct {
 	ph []map[string][]TopologyHint
 }
 
-func (p *mockPolicy) Merge(logger klog.Logger, providersHints []map[string][]TopologyHint) (TopologyHint, bool) {
+func (p *mockPolicy) Merge(_ klog.Logger, providersHints []map[string][]TopologyHint) (TopologyHint, bool) {
 	p.ph = providersHints
 	return TopologyHint{}, true
 }
@@ -611,22 +611,22 @@ type trackingHintProvider struct {
 	hints                   map[string][]TopologyHint
 }
 
-func (m *trackingHintProvider) GetTopologyHints(logger klog.Logger, pod *v1.Pod, container *v1.Container, operation lifecycle.Operation) map[string][]TopologyHint {
+func (m *trackingHintProvider) GetTopologyHints(_ klog.Logger, _ *v1.Pod, _ *v1.Container, _ lifecycle.Operation) map[string][]TopologyHint {
 	m.containerHintsCalled = true
 	return m.hints
 }
 
-func (m *trackingHintProvider) GetPodTopologyHints(logger klog.Logger, pod *v1.Pod, operation lifecycle.Operation) map[string][]TopologyHint {
+func (m *trackingHintProvider) GetPodTopologyHints(_ klog.Logger, _ *v1.Pod, _ lifecycle.Operation) map[string][]TopologyHint {
 	m.podHintsCalled = true
 	return m.hints
 }
 
-func (m *trackingHintProvider) AllocatePod(logger klog.Logger, pod *v1.Pod, operation lifecycle.Operation) error {
+func (m *trackingHintProvider) AllocatePod(_ klog.Logger, _ *v1.Pod, _ lifecycle.Operation) error {
 	m.allocatePodCalled = true
 	return nil
 }
 
-func (m *trackingHintProvider) Allocate(ctx context.Context, pod *v1.Pod, container *v1.Container, operation lifecycle.Operation) error {
+func (m *trackingHintProvider) Allocate(_ context.Context, _ *v1.Pod, _ *v1.Container, _ lifecycle.Operation) error {
 	m.allocateContainerCalled = true
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it: 
This PR fixes a cleanup/sweeping followup issue as per https://github.com/kubernetes/kubernetes/pull/140224#discussion_r3527985667, https://github.com/kubernetes/kubernetes/pull/140224#discussion_r3527985667.
and thus accordingly replaces all unused parameters in functions with _ increasing code readibility


#### Which issue(s) this PR is related to: #140399


#### Does this PR introduce a user-facing change?
NONE


