### PR TITLE
DRA: block a dedicated allocation over a device's live persisted share

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -6215,6 +6215,49 @@ func TestAllocator(t *testing.T,
 				deviceRequestAllocationResult(req0, driverA, pool1, device1).withConsumedCapacity(&fixedShareID, nil),
 			)},
 		},
+		"dedicated-request-blocked-by-persisted-share": {
+			// device1 carries a persisted shared allocation (share ID), but the slice
+			// now advertises it as an ordinary, non-allow-multiple device: an
+			// AllowMultipleAllocations true->false flip while the share is still live.
+			// The dedicated-allocation gate must recognize the share (via deviceCapacityInUse,
+			// not deviceInUse) and refuse to hand device1 out exclusively on top of the share.
+			features: Features{ConsumableCapacity: true},
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+			),
+			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 1))),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 1), driverA,
+					device(device1, nil, nil),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: []any{},
+		},
+		"dedicated-request-falls-back-past-persisted-share": {
+			// Like dedicated-request-blocked-by-persisted-share, device1 carries a
+			// live persisted share and is now non-allow-multiple, so the dedicated
+			// gate must skip it. device2 is free, so the request still succeeds on
+			// device2: the guard drops the one candidate without aborting the search.
+			features: Features{ConsumableCapacity: true},
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+			),
+			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 1))),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 1), driverA,
+					device(device1, nil, nil),
+					device(device2, nil, nil),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+			)},
+		},
 		"consumable-capacity-with-partitionable-device-multiple-capacity-pools": {
 			// This test case combines integration of PrioritizedList, PartitionableDevices, and ConsumableCapacity features.
 			features: Features{

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -6662,6 +6662,66 @@ func TestAllocator(t *testing.T,
 				deviceRequestAllocationResult(req0, driverA, pool1, device1).withConsumedCapacity(&fixedShareID, nil),
 			)},
 		},
+		"consumable-capacity-dedicated-request-blocked-by-persisted-share": {
+			// device1 still carries a live share after allowMultipleAllocations flipped to false,
+			// so a dedicated request must not be handed the device on top of it.
+			features: Features{ConsumableCapacity: true},
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+			),
+			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 1))),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 1), driverA,
+					device(device1, nil, nil),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: []any{},
+		},
+		"consumable-capacity-dedicated-request-falls-back-past-persisted-share": {
+			// The guard drops device1 without aborting the search, so the request still lands on device2.
+			features: Features{ConsumableCapacity: true},
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+			),
+			claimsToAllocate: objects(claimWithRequests(claim0, nil, request(req0, classA, 1))),
+			classes:          objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 1), driverA,
+					device(device1, nil, nil),
+					device(device2, nil, nil),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+			)},
+		},
+		"consumable-capacity-with-admin-access-request-allowed-over-persisted-share": {
+			// Admin access skips the availability checks, so the live share does not withhold device1.
+			features: Features{ConsumableCapacity: true, AdminAccess: true},
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+			),
+			claimsToAllocate: func() []wrapResourceClaim {
+				c := claimWithRequest(claim0, req0, classA)
+				c.Spec.Devices.Requests[0].Exactly.AdminAccess = new(true)
+				return []wrapResourceClaim{c}
+			}(),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 1), driverA,
+					device(device1, nil, nil),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device1, true),
+			)},
+		},
 		"consumable-capacity-with-partitionable-device-multiple-capacity-pools": {
 			// This test case combines integration of PrioritizedList, PartitionableDevices, and ConsumableCapacity features.
 			features: Features{

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -1479,6 +1479,13 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		alloc.logger.V(7).Info("Device in use", "device", device.id)
 		return false, nil, nil
 	}
+	// A device that is not allow-multiple must not be handed out dedicated while a
+	// persisted share of it is still live (e.g. after an allowMultipleAllocations
+	// true->false slice update). deviceInUse only tracks exclusive allocations.
+	if !request.adminAccess() && !allowMultipleAllocations && alloc.deviceCapacityInUse(device.id) {
+		alloc.logger.V(7).Info("Device has an active shared allocation, cannot be allocated exclusively", "device", device.id)
+		return false, nil, nil
+	}
 
 	// Devices that consume counters can not be allocated if the PartitionableDevices feature
 	// is not enabled.

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -1592,6 +1592,12 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		alloc.logger.V(7).Info("Device in use", "device", device.id)
 		return false, nil, nil
 	}
+	// A non-allow-multiple device can still carry a live share after an
+	// allowMultipleAllocations true->false update, which deviceInUse above does not see.
+	if !request.adminAccess() && !allowMultipleAllocations && alloc.deviceCapacityInUse(device.id) {
+		alloc.logger.V(7).Info("Device has an active shared allocation, cannot be allocated exclusively", "device", device.id)
+		return false, nil, nil
+	}
 
 	if len(device.slice.Spec.SkipNodeOperations) > 0 {
 		if !alloc.features.OptionalNodeOperations {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -1342,6 +1342,13 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		alloc.logger.V(7).Info("Device in use", "device", device.id)
 		return false, nil, nil
 	}
+	// A device that is not allow-multiple must not be handed out dedicated while a
+	// persisted share of it is still live (e.g. after an allowMultipleAllocations
+	// true->false slice update). deviceInUse only tracks exclusive allocations.
+	if !request.adminAccess() && !allowMultipleAllocations && alloc.deviceCapacityInUse(device.id) {
+		alloc.logger.V(7).Info("Device has an active shared allocation, cannot be allocated exclusively", "device", device.id)
+		return false, nil, nil
+	}
 
 	// Devices that consume counters can not be allocated if the PartitionableDevices feature
 	// is not enabled.

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -1351,6 +1351,12 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		alloc.logger.V(7).Info("Device in use", "device", device.id)
 		return false, nil, nil
 	}
+	// A non-allow-multiple device can still carry a live share after an
+	// allowMultipleAllocations true->false update, which deviceInUse above does not see.
+	if !request.adminAccess() && !allowMultipleAllocations && alloc.deviceCapacityInUse(device.id) {
+		alloc.logger.V(7).Info("Device has an active shared allocation, cannot be allocated exclusively", "device", device.id)
+		return false, nil, nil
+	}
 
 	// Devices that consume counters can not be allocated if the PartitionableDevices feature
 	// is not enabled.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node
/wg device-management

#### What this PR does / why we need it:

The structured DRA allocator can hand out a device for exclusive use while that device still has a live persisted shared allocation.

`allocateDevice` rejects unavailable devices for normal (non-admin) requests through `deviceInUse`, which checks `AllocatedDevices` and the in-flight `allocatingDeviceForAnyClaim`. It does not check `AllocatedSharedDeviceIDs`, so a persisted share recorded only by a `ShareID` is not covered by that check.

This becomes reachable when a ResourceSlice flips a device's `allowMultipleAllocations` from true to false while a share is still live. The allocator now treats the device as non-allow-multiple, `deviceInUse` does not see the persisted share, and the device can still be handed to another claim exclusively.

It is the same kind of accounting gap #140437 fixed for counters, where `deviceCapacityInUse` already recognizes persisted shares in `AllocatedSharedDeviceIDs`. `IsDeviceAllocated` recognizes them too.

The fix extends the existing non-admin guard in `allocateDevice`: for a device that does not allow multiple allocations, the allocation is refused when `deviceCapacityInUse` reports an active share. A device that still allows multiple allocations is left alone, so a legitimate further share keeps working.

#### Which issue(s) this PR is related to:

Fixes #140797

#### Special notes for your reviewer:

* Making `deviceInUse` itself recognize every shared allocation (for example by calling `IsDeviceAllocated`) would be wrong. It would reject a legitimate further share of an allow-multiple device, and it breaks the `partitionable-consumable-capacity-shared-device-counter-not-recharged` case from #140437.
* Two regression cases fail before this change and pass after, in both the incubating and experimental allocators. `dedicated-request-blocked-by-persisted-share` allocates `device-1` with `ShareID: nil` despite its live share before the fix, and refuses it after. `dedicated-request-falls-back-past-persisted-share` refuses `device-1` but still allocates a free `device-2` from the same pool, so the guard drops one candidate without ending the search.
* `admin-access-request-allowed-over-persisted-share` is a third case and a different kind. It passes with or without this change, since admin access was already exempt from the availability checks, so it proves nothing about the fix. It is there so the exemption cannot be dropped silently: of the 271 cases in the shared table, nine exercise admin access and five set `AllocatedSharedDeviceIDs`, and none combined the two. Removing the `!request.adminAccess()` term from the new guard fails that case and nothing else.
* The shared-device regression cases from #140437 still pass.
* The full `structured/...` suite passes, including `-race`.
* The stable allocator has no consumable capacity, so it is untouched.
* `deviceInUse` also runs as a cheap pre-filter earlier in the device loop, with the same blind spot. That is harmless here: a device with a live share is no longer skipped early, but the `allocateDevice` gate still refuses it. I kept the pre-filter as is to keep the change small, and can align it if you prefer.
* `deviceCapacityInUse` scans `AllocatedSharedDeviceIDs` inline for the share, the same as `IsDeviceAllocated` and #140437. This guard runs it on the common non-allow-multiple path, so the scan is hotter here than in #140437, where it sat behind `allowMultipleAllocations`: a claim with many candidates on a cluster with many persisted shares now walks that set once per candidate. I kept the inline scan rather than add a parallel `Set[DeviceID]`, since #140437 chose against a second copy of the shared-device IDs. If the hot path is worth optimizing, changing how those IDs are stored so both call sites benefit looks like the better route than a derived set, and I am happy to follow up on that separately.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a DRA scheduling bug where a device with a live shared allocation could also be allocated exclusively after a ResourceSlice changed it to disallow multiple allocations.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
None
```


