### PR TITLE
Document scheduler profile label and clean up scheduler metric help texts

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6406,7 +6406,7 @@
     endpoint: /metrics
 - name: batch_attempts_total
   subsystem: scheduler
-  help: Counts of results when we attempt to use batching.
+  help: Counts of results when we attempt to use batching, by scheduler profile.
   type: Counter
   stabilityLevel: ALPHA
   labels:
@@ -6417,7 +6417,7 @@
     endpoint: /metrics
 - name: batch_cache_flushed_total
   subsystem: scheduler
-  help: Counts of cache flushes by reason.
+  help: Counts of cache flushes by reason and scheduler profile.
   type: Counter
   stabilityLevel: ALPHA
   labels:
@@ -6428,7 +6428,7 @@
     endpoint: /metrics
 - name: batch_rescore_attempts_total
   subsystem: scheduler
-  help: Counts of rescore attempts during opportunistic batching.
+  help: Counts of rescore attempts during opportunistic batching, by scheduler profile.
   type: Counter
   stabilityLevel: ALPHA
   labels:
@@ -6438,7 +6438,7 @@
     endpoint: /metrics
 - name: batch_rescore_duration_seconds
   subsystem: scheduler
-  help: Latency for rescoring a node during opportunistic batching.
+  help: Latency for rescoring a node during opportunistic batching, by scheduler profile.
   type: Histogram
   stabilityLevel: ALPHA
   labels:
@@ -6472,7 +6472,7 @@
 - name: dra_bindingconditions_allocations_total
   subsystem: scheduler
   help: Number of allocations using devices with BindingConditions, counted per driver
-    per scheduling attempt
+    per scheduling attempt, by scheduler profile.
   type: Counter
   stabilityLevel: ALPHA
   labels:
@@ -6485,7 +6485,7 @@
 - name: dra_bindingconditions_wait_duration_seconds
   subsystem: scheduler
   help: Time in seconds spent waiting for BindingConditions to be satisfied during
-    PreBind.
+    PreBind, by scheduler profile.
   type: Histogram
   stabilityLevel: ALPHA
   labels:
@@ -6535,7 +6535,8 @@
     endpoint: /metrics
 - name: generated_placements_total
   subsystem: scheduler
-  help: Number of candidate placements generated when scheduling pod groups.
+  help: Number of candidate placements generated when scheduling pod groups, by scheduler
+    profile.
   type: Counter
   stabilityLevel: ALPHA
   labels:
@@ -6545,7 +6546,7 @@
     endpoint: /metrics
 - name: get_node_hint_duration_seconds
   subsystem: scheduler
-  help: Latency for getting a node hint.
+  help: Latency for getting a node hint, by scheduler profile.
   type: Histogram
   stabilityLevel: ALPHA
   labels:
@@ -6590,8 +6591,8 @@
 - name: placement_evaluation_duration_seconds
   subsystem: scheduler
   help: Latency in seconds of evaluating a single candidate placement when scheduling
-    pod groups, by result. 'feasible' means the pod group fit into the placement,
-    while 'infeasible' means it did not.
+    pod groups, by result and scheduler profile. 'feasible' means the pod group fit
+    into the placement, while 'infeasible' means it did not.
   type: Histogram
   stabilityLevel: ALPHA
   labels:
@@ -6618,9 +6619,9 @@
     endpoint: /metrics
 - name: placement_evaluations_total
   subsystem: scheduler
-  help: Number of candidate placements evaluated when scheduling pod groups, by result.
-    'feasible' means the pod group fit into the placement, while 'infeasible' means
-    it did not.
+  help: Number of candidate placements evaluated when scheduling pod groups, by result
+    and scheduler profile. 'feasible' means the pod group fit into the placement,
+    while 'infeasible' means it did not.
   type: Counter
   stabilityLevel: ALPHA
   labels:
@@ -6641,9 +6642,9 @@
     endpoint: /metrics
 - name: podgroup_schedule_attempts_total
   subsystem: scheduler
-  help: Number of attempts to schedule pod group, by the result. 'unschedulable' means
-    a pod group could not be scheduled, while 'error' means an internal scheduler
-    problem.
+  help: Number of attempts to schedule pod group, by the result and scheduler profile.
+    'unschedulable' means a pod group could not be scheduled, while 'error' means
+    an internal scheduler problem.
   type: Counter
   stabilityLevel: ALPHA
   labels:
@@ -6678,7 +6679,7 @@
     endpoint: /metrics
 - name: podgroup_scheduling_attempt_duration_seconds
   subsystem: scheduler
-  help: Pod group scheduling attempt latency in seconds
+  help: Pod group scheduling attempt latency in seconds, by scheduler profile.
   type: Histogram
   stabilityLevel: ALPHA
   labels:
@@ -6914,7 +6915,8 @@
     endpoint: /metrics
 - name: store_schedule_results_duration_seconds
   subsystem: scheduler
-  help: Latency for storing scheduling results.
+  help: Latency for storing scheduling results for opportunistic batching, by scheduler
+    profile.
   type: Histogram
   stabilityLevel: ALPHA
   labels:
@@ -8103,7 +8105,7 @@
 - name: plugin_evaluation_total
   subsystem: scheduler
   help: Number of attempts to schedule pods by each plugin and the extension point
-    (available only in PreFilter, Filter, PreScore, and Score).
+    (available only in PreFilter, Filter, PreScore, and Score), by scheduler profile.
   type: Counter
   stabilityLevel: BETA
   labels:
@@ -8204,9 +8206,9 @@
     endpoint: /metrics
 - name: unschedulable_pods
   subsystem: scheduler
-  help: The number of unschedulable pods broken down by plugin name. A pod will increment
-    the gauge for all plugins that caused it to not schedule and so this metric have
-    meaning only when broken down by plugin.
+  help: The number of unschedulable pods broken down by plugin name and scheduler
+    profile. A pod will increment the gauge for all plugins that caused it to not
+    schedule and so this metric has meaning only when broken down by plugin.
   type: Gauge
   stabilityLevel: BETA
   labels:
@@ -8917,7 +8919,8 @@
     endpoint: /metrics/resource
 - name: framework_extension_point_duration_seconds
   subsystem: scheduler
-  help: Latency for running all plugins of a specific extension point.
+  help: Latency for running all plugins of a specific extension point, by scheduler
+    profile.
   type: Histogram
   stabilityLevel: STABLE
   labels:
@@ -9007,8 +9010,9 @@
     endpoint: /metrics
 - name: schedule_attempts_total
   subsystem: scheduler
-  help: Number of attempts to schedule pods, by the result. 'unschedulable' means
-    a pod could not be scheduled, while 'error' means an internal scheduler problem.
+  help: Number of attempts to schedule pods, by the result and scheduler profile.
+    'unschedulable' means a pod could not be scheduled, while 'error' means an internal
+    scheduler problem.
   type: Counter
   stabilityLevel: STABLE
   labels:
@@ -9019,7 +9023,8 @@
     endpoint: /metrics
 - name: scheduling_attempt_duration_seconds
   subsystem: scheduler
-  help: Scheduling attempt latency in seconds (scheduling algorithm + binding)
+  help: Scheduling attempt latency in seconds (scheduling algorithm + binding), by
+    scheduler profile.
   type: Histogram
   stabilityLevel: STABLE
   labels:

--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -534,7 +534,7 @@
 - name: plugin_evaluation_total
   subsystem: scheduler
   help: Number of attempts to schedule pods by each plugin and the extension point
-    (available only in PreFilter, Filter, PreScore, and Score).
+    (available only in PreFilter, Filter, PreScore, and Score), by scheduler profile.
   type: Counter
   stabilityLevel: BETA
   labels:
@@ -623,9 +623,9 @@
   - 16.384
 - name: unschedulable_pods
   subsystem: scheduler
-  help: The number of unschedulable pods broken down by plugin name. A pod will increment
-    the gauge for all plugins that caused it to not schedule and so this metric have
-    meaning only when broken down by plugin.
+  help: The number of unschedulable pods broken down by plugin name and scheduler
+    profile. A pod will increment the gauge for all plugins that caused it to not
+    schedule and so this metric has meaning only when broken down by plugin.
   type: Gauge
   stabilityLevel: BETA
   labels:
@@ -1120,7 +1120,8 @@
   stabilityLevel: STABLE
 - name: framework_extension_point_duration_seconds
   subsystem: scheduler
-  help: Latency for running all plugins of a specific extension point.
+  help: Latency for running all plugins of a specific extension point, by scheduler
+    profile.
   type: Histogram
   stabilityLevel: STABLE
   labels:
@@ -1192,8 +1193,9 @@
   - queue
 - name: schedule_attempts_total
   subsystem: scheduler
-  help: Number of attempts to schedule pods, by the result. 'unschedulable' means
-    a pod could not be scheduled, while 'error' means an internal scheduler problem.
+  help: Number of attempts to schedule pods, by the result and scheduler profile.
+    'unschedulable' means a pod could not be scheduled, while 'error' means an internal
+    scheduler problem.
   type: Counter
   stabilityLevel: STABLE
   labels:
@@ -1201,7 +1203,8 @@
   - result
 - name: scheduling_attempt_duration_seconds
   subsystem: scheduler
-  help: Scheduling attempt latency in seconds (scheduling algorithm + binding)
+  help: Scheduling attempt latency in seconds (scheduling algorithm + binding), by
+    scheduler profile.
   type: Histogram
   stabilityLevel: STABLE
   labels:

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -5767,7 +5767,7 @@ func TestPluginEvaluationTotalMetric(t *testing.T) {
 		t.Fatalf("RunFilterPlugins returned unexpected status: %v", st)
 	}
 
-	want := `# HELP scheduler_plugin_evaluation_total Number of attempts to schedule pods by each plugin and the extension point (available only in PreFilter, Filter, PreScore, and Score).
+	want := `# HELP scheduler_plugin_evaluation_total Number of attempts to schedule pods by each plugin and the extension point (available only in PreFilter, Filter, PreScore, and Score), by scheduler profile.
 # TYPE scheduler_plugin_evaluation_total counter
 scheduler_plugin_evaluation_total{extension_point="Filter",plugin="plugin-eval-filter-a",profile="test-profile"} 1
 scheduler_plugin_evaluation_total{extension_point="Filter",plugin="plugin-eval-filter-b",profile="test-profile-2"} 1

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -269,7 +269,7 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "schedule_attempts_total",
-			Help:           "Number of attempts to schedule pods, by the result. 'unschedulable' means a pod could not be scheduled, while 'error' means an internal scheduler problem.",
+			Help:           "Number of attempts to schedule pods, by the result and scheduler profile. 'unschedulable' means a pod could not be scheduled, while 'error' means an internal scheduler problem.",
 			StabilityLevel: metrics.STABLE,
 		}, []string{"result", "profile"})
 
@@ -287,7 +287,7 @@ func InitMetrics() {
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "scheduling_attempt_duration_seconds",
-			Help:           "Scheduling attempt latency in seconds (scheduling algorithm + binding)",
+			Help:           "Scheduling attempt latency in seconds (scheduling algorithm + binding), by scheduler profile.",
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.STABLE,
 		}, []string{"result", "profile"})
@@ -348,21 +348,21 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "batch_attempts_total",
-			Help:           "Counts of results when we attempt to use batching.",
+			Help:           "Counts of results when we attempt to use batching, by scheduler profile.",
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"profile", "result"})
 	BatchCacheFlushed = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "batch_cache_flushed_total",
-			Help:           "Counts of cache flushes by reason.",
+			Help:           "Counts of cache flushes by reason and scheduler profile.",
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"profile", "reason"})
 	BatchRescoreAttempts = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "batch_rescore_attempts_total",
-			Help:           "Counts of rescore attempts during opportunistic batching.",
+			Help:           "Counts of rescore attempts during opportunistic batching, by scheduler profile.",
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"profile"})
 
@@ -407,7 +407,7 @@ func InitMetrics() {
 		&metrics.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "framework_extension_point_duration_seconds",
-			Help:      "Latency for running all plugins of a specific extension point.",
+			Help:      "Latency for running all plugins of a specific extension point, by scheduler profile.",
 			// Start with 0.1ms with the last bucket being [~200ms, Inf)
 			Buckets:        metrics.ExponentialBuckets(0.0001, 2, 12),
 			StabilityLevel: metrics.STABLE,
@@ -476,7 +476,7 @@ func InitMetrics() {
 		&metrics.GaugeOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "unschedulable_pods",
-			Help:           "The number of unschedulable pods broken down by plugin name. A pod will increment the gauge for all plugins that caused it to not schedule and so this metric have meaning only when broken down by plugin.",
+			Help:           "The number of unschedulable pods broken down by plugin name and scheduler profile. A pod will increment the gauge for all plugins that caused it to not schedule and so this metric has meaning only when broken down by plugin.",
 			StabilityLevel: metrics.BETA,
 		}, []string{"plugin", "profile"})
 
@@ -484,7 +484,7 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "plugin_evaluation_total",
-			Help:           "Number of attempts to schedule pods by each plugin and the extension point (available only in PreFilter, Filter, PreScore, and Score).",
+			Help:           "Number of attempts to schedule pods by each plugin and the extension point (available only in PreFilter, Filter, PreScore, and Score), by scheduler profile.",
 			StabilityLevel: metrics.BETA,
 		}, []string{"plugin", "extension_point", "profile"})
 
@@ -541,7 +541,7 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "dra_bindingconditions_allocations_total",
-			Help:           "Number of allocations using devices with BindingConditions, counted per driver per scheduling attempt",
+			Help:           "Number of allocations using devices with BindingConditions, counted per driver per scheduling attempt, by scheduler profile.",
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"profile", "driver", "status"},
@@ -551,7 +551,7 @@ func InitMetrics() {
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "dra_bindingconditions_wait_duration_seconds",
-			Help:           "Time in seconds spent waiting for BindingConditions to be satisfied during PreBind.",
+			Help:           "Time in seconds spent waiting for BindingConditions to be satisfied during PreBind, by scheduler profile.",
 			Buckets:        metrics.ExponentialBuckets(0.1, 2, 14),
 			StabilityLevel: metrics.ALPHA,
 		},
@@ -562,7 +562,7 @@ func InitMetrics() {
 		&metrics.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "get_node_hint_duration_seconds",
-			Help:      "Latency for getting a node hint.",
+			Help:      "Latency for getting a node hint, by scheduler profile.",
 			// Start with 0.01ms with the last bucket being [~20ms, Inf)
 			Buckets:        metrics.ExponentialBuckets(0.00001, 2, 12),
 			StabilityLevel: metrics.ALPHA,
@@ -573,7 +573,7 @@ func InitMetrics() {
 		&metrics.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "store_schedule_results_duration_seconds",
-			Help:      "Latency for storing scheduling results.",
+			Help:      "Latency for storing scheduling results for opportunistic batching, by scheduler profile.",
 			// Start with 0.01ms with the last bucket being [~20ms, Inf)
 			Buckets:        metrics.ExponentialBuckets(0.00001, 2, 12),
 			StabilityLevel: metrics.ALPHA,
@@ -584,7 +584,7 @@ func InitMetrics() {
 		&metrics.HistogramOpts{
 			Subsystem: SchedulerSubsystem,
 			Name:      "batch_rescore_duration_seconds",
-			Help:      "Latency for rescoring a node during opportunistic batching.",
+			Help:      "Latency for rescoring a node during opportunistic batching, by scheduler profile.",
 			// Start with 0.01ms with the last bucket being [~20ms, Inf)
 			Buckets:        metrics.ExponentialBuckets(0.00001, 2, 12),
 			StabilityLevel: metrics.ALPHA,
@@ -596,14 +596,14 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "podgroup_schedule_attempts_total",
-			Help:           "Number of attempts to schedule pod group, by the result. 'unschedulable' means a pod group could not be scheduled, while 'error' means an internal scheduler problem.",
+			Help:           "Number of attempts to schedule pod group, by the result and scheduler profile. 'unschedulable' means a pod group could not be scheduled, while 'error' means an internal scheduler problem.",
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"result", "profile"})
 	podGroupSchedulingLatency = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "podgroup_scheduling_attempt_duration_seconds",
-			Help:           "Pod group scheduling attempt latency in seconds",
+			Help:           "Pod group scheduling attempt latency in seconds, by scheduler profile.",
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"result", "profile"})
@@ -674,21 +674,21 @@ func InitMetrics() {
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "generated_placements_total",
-			Help:           "Number of candidate placements generated when scheduling pod groups.",
+			Help:           "Number of candidate placements generated when scheduling pod groups, by scheduler profile.",
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"profile"})
 	PlacementEvaluations = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "placement_evaluations_total",
-			Help:           "Number of candidate placements evaluated when scheduling pod groups, by result. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.",
+			Help:           "Number of candidate placements evaluated when scheduling pod groups, by result and scheduler profile. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.",
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"result", "profile"})
 	PlacementEvaluationDuration = metrics.NewHistogramVec(
 		&metrics.HistogramOpts{
 			Subsystem:      SchedulerSubsystem,
 			Name:           "placement_evaluation_duration_seconds",
-			Help:           "Latency in seconds of evaluating a single candidate placement when scheduling pod groups, by result. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.",
+			Help:           "Latency in seconds of evaluating a single candidate placement when scheduling pod groups, by result and scheduler profile. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.",
 			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"result", "profile"})

--- a/pkg/scheduler/metrics/profile_metrics_test.go
+++ b/pkg/scheduler/metrics/profile_metrics_test.go
@@ -34,7 +34,7 @@ func TestRecordGeneratedPlacements(t *testing.T) {
 	RecordGeneratedPlacements("test-profile-2", 4)
 
 	want := `
-		# HELP scheduler_generated_placements_total [ALPHA] Number of candidate placements generated when scheduling pod groups.
+		# HELP scheduler_generated_placements_total [ALPHA] Number of candidate placements generated when scheduling pod groups, by scheduler profile.
 		# TYPE scheduler_generated_placements_total counter
 		scheduler_generated_placements_total{profile="test-profile"} 5
 		scheduler_generated_placements_total{profile="test-profile-2"} 4
@@ -57,7 +57,7 @@ func TestObservePlacementEvaluation(t *testing.T) {
 	ObservePlacementEvaluation(InfeasibleResult, "test-profile-2", 0.3)
 
 	wantCounter := `
-		# HELP scheduler_placement_evaluations_total [ALPHA] Number of candidate placements evaluated when scheduling pod groups, by result. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.
+		# HELP scheduler_placement_evaluations_total [ALPHA] Number of candidate placements evaluated when scheduling pod groups, by result and scheduler profile. 'feasible' means the pod group fit into the placement, while 'infeasible' means it did not.
 		# TYPE scheduler_placement_evaluations_total counter
 		scheduler_placement_evaluations_total{profile="test-profile",result="feasible"} 2
 		scheduler_placement_evaluations_total{profile="test-profile",result="infeasible"} 1


### PR DESCRIPTION
#### What type of PR is this?
/kind documentation
/kind cleanup

#### What this PR does / why we need it:
Several kube-scheduler metrics carry a `profile` label, but their help text did not mention it. This PR documents the `profile` (scheduler profile) dimension in the help text of every profile-labeled kube-scheduler metric, so the label is discoverable directly from the metric's `# HELP` line and generated metrics documentation.

Wording follows existing scheduler conventions:
- Metrics whose help already has a "by..." clause now read "by... and scheduler profile".
- Simple single-sentence help texts get ", by scheduler profile" appended, which follows the convention of other sentences.

Also cleans up two pre-existing issues:
- `store_schedule_results_duration_seconds`: the help read "Latency for getting a no" — a truncated, meaningless phrase copied from the neighboring `get_node_hint_duration_seconds` metric. It now reads "Latency for storing scheduling results for opportunistic batching".
- `unschedulable_pods`: fix a grammar error ("this metric have meaning" -> "this metric has meaning").

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/pull/139604#issuecomment-5031895558

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
kube-scheduler metrics that carry a `profile` label now document that label in their help text.
```
