### PR TITLE
DRA: re-validate device capacity when allowMultipleAllocations changes

### DIFF
--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -848,9 +848,16 @@ func validateDevice(device resource.Device, oldDevice *resource.Device, fldPath 
 	}
 
 	allErrs = append(allErrs, validateMap(device.Attributes, -1, attributeAndCapacityMaxKeyLength, validateQualifiedName, validateDeviceAttribute, fldPath.Child("attributes"))...)
-	// If the entire capacity is the same as before then validation can be skipped.
-	// We could also do the DeepEqual on the entire spec, but here it is a bit cheaper.
-	if oldDevice == nil || !apiequality.Semantic.DeepEqual(oldDevice.Capacity, device.Capacity) {
+	// Capacity validation depends on the effective allowMultipleAllocations value (it selects the
+	// multi- vs single-allocatable validator), so it must re-run when that value changes even if
+	// the capacity map itself is unchanged. Otherwise, when both are unchanged, validation can be
+	// skipped (cheaper than a full spec DeepEqual).
+	oldAllowMultipleAllocations := oldDevice != nil &&
+		oldDevice.AllowMultipleAllocations != nil &&
+		*oldDevice.AllowMultipleAllocations
+	if oldDevice == nil ||
+		allowMultipleAllocations != oldAllowMultipleAllocations ||
+		!apiequality.Semantic.DeepEqual(oldDevice.Capacity, device.Capacity) {
 		if allowMultipleAllocations {
 			allErrs = append(allErrs, validateMap(device.Capacity, -1, attributeAndCapacityMaxKeyLength, validateQualifiedName, validateMultiAllocatableDeviceCapacity, fldPath.Child("capacity"))...)
 		} else {
@@ -1076,7 +1083,7 @@ func validateDeviceAttributeVersionValue(value *string, fldPath *field.Path) fie
 }
 
 // validateMultiAllocatableDeviceCapacity must check requestPolicy in consumable capacity.
-// It only gets called for new or modified capacity.
+// It gets called for new or modified capacity, or when allowMultipleAllocations changes.
 func validateMultiAllocatableDeviceCapacity(capacity resource.DeviceCapacity, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if capacity.RequestPolicy != nil {
@@ -1098,7 +1105,7 @@ func validateSingleAllocatableDeviceCapacity(capacity resource.DeviceCapacity, f
 
 // validateRequestPolicy validates at most one of ValidRequestValues can be defined.
 // If any ValidRequestValues are defined, Default must also be defined and valid.
-// Only gets called for new or modified policy.
+// Gets called for new or modified policy, or when allowMultipleAllocations changes.
 func validateRequestPolicy(maxCapacity apiresource.Quantity, policy *resource.CapacityRequestPolicy, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if len(policy.ValidValues) > 0 && policy.ValidRange != nil {
@@ -1168,7 +1175,7 @@ func validateRequestPolicyValidValues(defaultValue apiresource.Quantity, maxCapa
 }
 
 // validateRequestPolicyRange validates a CapacityRequestPolicyRange.
-// Only gets called for a new or modified range.
+// Gets called for a new or modified range, or when allowMultipleAllocations changes.
 func validateRequestPolicyRange(defaultValue apiresource.Quantity, maxCapacity apiresource.Quantity, valueRange resource.CapacityRequestPolicyRange, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if valueRange.Min == nil {

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -728,7 +728,7 @@ func validateResourceSliceSpec(spec, oldSpec *resource.ResourceSliceSpec, fldPat
 	allErrs = append(allErrs, validateSet(spec.Devices, maxDevices,
 		func(device resource.Device, fldPath *field.Path) field.ErrorList {
 			oldDevice := lookupDevice(oldSpec, device.Name)
-			return validateDevice(device, oldDevice, fldPath, spec.PerDeviceNodeSelection)
+			return validateDevice(device, deviceRevalidationFor(oldDevice, device), fldPath, spec.PerDeviceNodeSelection)
 		},
 		func(device resource.Device) string {
 			return device.Name
@@ -830,9 +830,66 @@ func validateResourcePool(pool resource.ResourcePool, fldPath *field.Path) field
 	return allErrs
 }
 
-func validateDevice(device resource.Device, oldDevice *resource.Device, fldPath *field.Path, perDeviceNodeSelection *bool) field.ErrorList {
+// capacityRevalidation selects how much of a device's capacity map an update must
+// re-validate. Its zero value re-validates everything, so a newly created device
+// (which has no stored device to correlate with) is always fully validated.
+type capacityRevalidation int
+
+const (
+	// capacityValidateAll re-validates capacity keys and values. Used for a new
+	// device or a changed capacity map.
+	capacityValidateAll capacityRevalidation = iota
+	// capacityValidateValues re-validates capacity values only, leaving unchanged
+	// keys ratcheted. Used when the capacity map is unchanged but the effective
+	// allowMultipleAllocations value changed: that flips the value validator
+	// (single- vs multi-allocatable) without affecting key syntax, so re-checking
+	// unchanged keys would risk rejecting stored data that a later, stricter key
+	// check has not grandfathered (see #141644).
+	capacityValidateValues
+	// capacitySkip skips capacity validation. Used when neither the capacity map nor
+	// the effective allocation mode changed.
+	capacitySkip
+)
+
+// deviceRevalidation records what an update must re-validate for one device.
+// validateResourceSliceSpec owns this decision by correlating the stored and
+// updated device; validateDevice consumes it. The zero value re-validates
+// everything.
+type deviceRevalidation struct {
+	capacity     capacityRevalidation
+	taintsStored bool
+}
+
+// effectiveAllowMultipleAllocations reports a device's effective
+// AllowMultipleAllocations, treating a nil pointer (and a nil device) as false.
+func effectiveAllowMultipleAllocations(device *resource.Device) bool {
+	return device != nil && device.AllowMultipleAllocations != nil && *device.AllowMultipleAllocations
+}
+
+// deviceRevalidationFor decides what an update must re-validate for a device by
+// correlating it with the stored device. A new device (oldDevice == nil) gets the
+// zero value, which re-validates everything. New per-device ratcheting rules
+// should be added here rather than inside validateDevice.
+func deviceRevalidationFor(oldDevice *resource.Device, device resource.Device) deviceRevalidation {
+	if oldDevice == nil {
+		return deviceRevalidation{}
+	}
+	revalidation := deviceRevalidation{
+		taintsStored: apiequality.Semantic.DeepEqual(oldDevice.Taints, device.Taints),
+	}
+	switch {
+	case !apiequality.Semantic.DeepEqual(oldDevice.Capacity, device.Capacity):
+		revalidation.capacity = capacityValidateAll
+	case effectiveAllowMultipleAllocations(oldDevice) != effectiveAllowMultipleAllocations(&device):
+		revalidation.capacity = capacityValidateValues
+	default:
+		revalidation.capacity = capacitySkip
+	}
+	return revalidation
+}
+
+func validateDevice(device resource.Device, revalidation deviceRevalidation, fldPath *field.Path, perDeviceNodeSelection *bool) field.ErrorList {
 	var allErrs field.ErrorList
-	allowMultipleAllocations := device.AllowMultipleAllocations != nil && *device.AllowMultipleAllocations
 	allErrs = append(allErrs, validateDeviceName(device.Name, fldPath.Child("name"))...)
 
 	// Warn about exceeding the maximum length only once. If any individual
@@ -848,18 +905,25 @@ func validateDevice(device resource.Device, oldDevice *resource.Device, fldPath 
 	}
 
 	allErrs = append(allErrs, validateMap(device.Attributes, -1, attributeAndCapacityMaxKeyLength, validateQualifiedName, validateDeviceAttribute, fldPath.Child("attributes"))...)
-	// If the entire capacity is the same as before then validation can be skipped.
-	// We could also do the DeepEqual on the entire spec, but here it is a bit cheaper.
-	if oldDevice == nil || !apiequality.Semantic.DeepEqual(oldDevice.Capacity, device.Capacity) {
-		if allowMultipleAllocations {
-			allErrs = append(allErrs, validateMap(device.Capacity, -1, attributeAndCapacityMaxKeyLength, validateQualifiedName, validateMultiAllocatableDeviceCapacity, fldPath.Child("capacity"))...)
-		} else {
-			allErrs = append(allErrs, validateMap(device.Capacity, -1, attributeAndCapacityMaxKeyLength, validateQualifiedName, validateSingleAllocatableDeviceCapacity, fldPath.Child("capacity"))...)
+	// The value validator for capacity depends on the effective allowMultipleAllocations
+	// value: it selects the single- vs multi-allocatable check. The key validator does not.
+	// validateResourceSliceSpec decides, per device, whether to validate the whole capacity
+	// map, only its values (map unchanged but the mode flipped), or nothing (both unchanged).
+	if revalidation.capacity != capacitySkip {
+		validateCapacityKey := validateQualifiedName
+		if revalidation.capacity == capacityValidateValues {
+			// The capacity map is unchanged, so its keys keep whatever validation they
+			// already passed; only the values need re-checking under the new mode.
+			validateCapacityKey = func(resource.QualifiedName, *field.Path) field.ErrorList { return nil }
 		}
+		validateCapacityValue := validateSingleAllocatableDeviceCapacity
+		if effectiveAllowMultipleAllocations(&device) {
+			validateCapacityValue = validateMultiAllocatableDeviceCapacity
+		}
+		allErrs = append(allErrs, validateMap(device.Capacity, -1, attributeAndCapacityMaxKeyLength, validateCapacityKey, validateCapacityValue, fldPath.Child("capacity"))...)
 	}
-	// If the entire set is the same as before then validation can be skipped.
-	// We could also do the DeepEqual on the entire spec, but here it is a bit cheaper.
-	if oldDevice == nil || !apiequality.Semantic.DeepEqual(oldDevice.Taints, device.Taints) {
+	// Unchanged taints keep the validation they already passed.
+	if !revalidation.taintsStored {
 		allErrs = append(allErrs, validateSlice(device.Taints, resource.DeviceTaintsMaxLength,
 			func(taint resource.DeviceTaint, fldPath *field.Path) field.ErrorList {
 				return validateDeviceTaint(taint, nil, fldPath)
@@ -1076,7 +1140,7 @@ func validateDeviceAttributeVersionValue(value *string, fldPath *field.Path) fie
 }
 
 // validateMultiAllocatableDeviceCapacity must check requestPolicy in consumable capacity.
-// It only gets called for new or modified capacity.
+// It gets called for new or modified capacity, or when allowMultipleAllocations changes.
 func validateMultiAllocatableDeviceCapacity(capacity resource.DeviceCapacity, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if capacity.RequestPolicy != nil {
@@ -1098,7 +1162,7 @@ func validateSingleAllocatableDeviceCapacity(capacity resource.DeviceCapacity, f
 
 // validateRequestPolicy validates at most one of ValidRequestValues can be defined.
 // If any ValidRequestValues are defined, Default must also be defined and valid.
-// Only gets called for new or modified policy.
+// Gets called for new or modified policy, or when allowMultipleAllocations changes.
 func validateRequestPolicy(maxCapacity apiresource.Quantity, policy *resource.CapacityRequestPolicy, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if len(policy.ValidValues) > 0 && policy.ValidRange != nil {
@@ -1168,7 +1232,7 @@ func validateRequestPolicyValidValues(defaultValue apiresource.Quantity, maxCapa
 }
 
 // validateRequestPolicyRange validates a CapacityRequestPolicyRange.
-// Only gets called for a new or modified range.
+// Gets called for a new or modified range, or when allowMultipleAllocations changes.
 func validateRequestPolicyRange(defaultValue apiresource.Quantity, maxCapacity apiresource.Quantity, valueRange resource.CapacityRequestPolicyRange, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if valueRange.Min == nil {

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -1733,6 +1733,28 @@ func TestValidateResourceSliceUpdate(t *testing.T) {
 			oldResourceSlice: validResourceSlice,
 			update:           func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice { return slice },
 		},
+		"disable-allow-multiple-keeps-request-policy": {
+			consumableCapacityFeatureGate: true,
+			oldResourceSlice:              testResourceSliceWithConsumableCapacity(name, name, name, 1),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].AllowMultipleAllocations = ptr.To(false)
+				return slice
+			},
+			wantFailures: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "devices").Index(0).Child("capacity").Key("a").Child("requestPolicy"), "allowMultipleAllocations must be true"),
+			},
+		},
+		"unset-allow-multiple-keeps-request-policy": {
+			consumableCapacityFeatureGate: true,
+			oldResourceSlice:              testResourceSliceWithConsumableCapacity(name, name, name, 1),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].AllowMultipleAllocations = nil
+				return slice
+			},
+			wantFailures: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "devices").Index(0).Child("capacity").Key("a").Child("requestPolicy"), "allowMultipleAllocations must be true"),
+			},
+		},
 		"invalid-name-update": {
 			oldResourceSlice: validResourceSlice,
 			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -1722,6 +1722,40 @@ func TestValidateResourceSliceUpdate(t *testing.T) {
 		},
 	}
 
+	// Not creatable today: single-allocatable forbids a requestPolicy, so this models legacy or skewed stored data.
+	singleAllocWithStoredInvalidPolicy := testResourceSliceWithConsumableCapacity(name, name, name, 1)
+	singleAllocWithStoredInvalidPolicy.Spec.Devices[0].AllowMultipleAllocations = ptr.To(false)
+	updateConsumableCapacity(singleAllocWithStoredInvalidPolicy, 0, func(cap *resourceapi.DeviceCapacity) {
+		cap.RequestPolicy = &resourceapi.CapacityRequestPolicy{
+			ValidValues: []resource.Quantity{resource.MustParse("10")},
+			ValidRange:  &resourceapi.CapacityRequestPolicyRange{Min: ptr.To(resource.MustParse("1"))},
+		}
+	})
+
+	// Not creatable today: the capacity key "a-b" fails the current validateQualifiedName (a
+	// hyphen is not a valid C identifier), so this models legacy or skewed stored data. The
+	// value carries no requestPolicy, so it stays valid in both allocation modes and only the
+	// key would be re-checked. This is the ratcheting that #141644's stricter key syntax needs.
+	sliceWithStoredInvalidCapacityKey := testResourceSliceWithConsumableCapacity(name, name, name, 1)
+	sliceWithStoredInvalidCapacityKey.Spec.Devices[0].AllowMultipleAllocations = ptr.To(false)
+	updateConsumableCapacity(sliceWithStoredInvalidCapacityKey, 0, func(cap *resourceapi.DeviceCapacity) {
+		cap.RequestPolicy = nil
+	})
+	sliceWithStoredInvalidCapacityKey.Spec.Devices[0].Capacity = map[resourceapi.QualifiedName]resourceapi.DeviceCapacity{
+		"a-b": sliceWithStoredInvalidCapacityKey.Spec.Devices[0].Capacity["a"],
+	}
+
+	// Same modeling as singleAllocWithStoredInvalidPolicy but with the mode left unset, to
+	// cover the unset<->false direction (both are the same effective mode).
+	unsetAllocWithStoredInvalidPolicy := testResourceSliceWithConsumableCapacity(name, name, name, 1)
+	unsetAllocWithStoredInvalidPolicy.Spec.Devices[0].AllowMultipleAllocations = nil
+	updateConsumableCapacity(unsetAllocWithStoredInvalidPolicy, 0, func(cap *resourceapi.DeviceCapacity) {
+		cap.RequestPolicy = &resourceapi.CapacityRequestPolicy{
+			ValidValues: []resource.Quantity{resource.MustParse("10")},
+			ValidRange:  &resourceapi.CapacityRequestPolicyRange{Min: ptr.To(resource.MustParse("1"))},
+		}
+	})
+
 	scenarios := map[string]struct {
 		consumableCapacityFeatureGate      bool
 		fractionalCapacityRangeFeatureGate bool
@@ -1732,6 +1766,96 @@ func TestValidateResourceSliceUpdate(t *testing.T) {
 		"valid-no-op-update": {
 			oldResourceSlice: validResourceSlice,
 			update:           func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice { return slice },
+		},
+		"disable-allow-multiple-keeps-request-policy": {
+			consumableCapacityFeatureGate: true,
+			oldResourceSlice:              testResourceSliceWithConsumableCapacity(name, name, name, 1),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].AllowMultipleAllocations = ptr.To(false)
+				return slice
+			},
+			wantFailures: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "devices").Index(0).Child("capacity").Key("a").Child("requestPolicy"), "allowMultipleAllocations must be true"),
+			},
+		},
+		"unset-allow-multiple-keeps-request-policy": {
+			consumableCapacityFeatureGate: true,
+			oldResourceSlice:              testResourceSliceWithConsumableCapacity(name, name, name, 1),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].AllowMultipleAllocations = nil
+				return slice
+			},
+			wantFailures: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "devices").Index(0).Child("capacity").Key("a").Child("requestPolicy"), "allowMultipleAllocations must be true"),
+			},
+		},
+		"enable-allow-multiple-revalidates-stored-invalid-request-policy": {
+			consumableCapacityFeatureGate: true,
+			oldResourceSlice:              singleAllocWithStoredInvalidPolicy,
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].AllowMultipleAllocations = ptr.To(true)
+				return slice
+			},
+			wantFailures: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "devices").Index(0).Child("capacity").Key("a").Child("requestPolicy"), `exactly one policy can be specified, cannot specify "validValues" and "validRange" at the same time`),
+			},
+		},
+		"attribute-update-does-not-revalidate-unchanged-capacity": {
+			consumableCapacityFeatureGate: true,
+			oldResourceSlice:              singleAllocWithStoredInvalidPolicy,
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				if slice.Spec.Devices[0].Attributes == nil {
+					slice.Spec.Devices[0].Attributes = map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{}
+				}
+				slice.Spec.Devices[0].Attributes["foo"] = resourceapi.DeviceAttribute{StringValue: ptr.To("bar")}
+				return slice
+			},
+			// No failures: changing an unrelated field must not re-validate the unchanged,
+			// stored-invalid capacity. Guards against whole-device revalidation.
+		},
+		"disable-to-unset-does-not-revalidate-capacity": {
+			consumableCapacityFeatureGate: true,
+			oldResourceSlice:              singleAllocWithStoredInvalidPolicy,
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].AllowMultipleAllocations = nil
+				return slice
+			},
+			// No failures: false and unset are the same effective mode, so the unchanged
+			// capacity stays ratcheted. Guards against comparing the raw pointers.
+		},
+		"unset-to-disable-does-not-revalidate-capacity": {
+			consumableCapacityFeatureGate: true,
+			oldResourceSlice:              unsetAllocWithStoredInvalidPolicy,
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].AllowMultipleAllocations = ptr.To(false)
+				return slice
+			},
+			// No failures: the reverse direction of the same effective-mode no-op.
+		},
+		"disable-allow-multiple-and-remove-request-policy": {
+			consumableCapacityFeatureGate: true,
+			oldResourceSlice:              testResourceSliceWithConsumableCapacity(name, name, name, 1),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].AllowMultipleAllocations = ptr.To(false)
+				updateConsumableCapacity(slice, 0, func(cap *resourceapi.DeviceCapacity) {
+					cap.RequestPolicy = nil
+				})
+				return slice
+			},
+			// No failures: disabling allowMultipleAllocations while removing the now-invalid
+			// requestPolicy is a valid repair, not an immutable-field or blanket rejection.
+		},
+		"allocation-mode-change-does-not-revalidate-stored-capacity-key": {
+			consumableCapacityFeatureGate: true,
+			oldResourceSlice:              sliceWithStoredInvalidCapacityKey,
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].AllowMultipleAllocations = ptr.To(true)
+				return slice
+			},
+			// No failures: the capacity map is unchanged, so its keys stay ratcheted even
+			// though the mode change re-runs the value validator. The stored key is invalid
+			// under the current validateQualifiedName, so a full re-validation would wrongly
+			// reject it; this is the ratcheting #141644's stricter key syntax relies on.
 		},
 		"invalid-name-update": {
 			oldResourceSlice: validResourceSlice,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node
/wg device-management

#### What this PR does / why we need it:

`ValidateResourceSliceUpdate` skips device capacity validation when the capacity map is unchanged (a `DeepEqual` optimization). But which capacity validator applies depends on the device's effective `allowMultipleAllocations`: `validateMultiAllocatableDeviceCapacity` validates a capacity `requestPolicy`, while `validateSingleAllocatableDeviceCapacity` forbids it.

So an update that changes `allowMultipleAllocations` from `true` to `false` (or unsets it) while leaving the capacity byte-identical skips this validation, and the object is accepted in a state that create validation rejects with `requestPolicy: Forbidden: allowMultipleAllocations must be true`. `ValidateResourceSliceUpdate` keeps only `spec.pool.name`, `spec.driver`, and `spec.nodeName` immutable, so the transition itself is allowed, and nothing else catches the stale `requestPolicy`: the generated declarative validation records `field Device.AllowMultipleAllocations has no validation`, and the NodeRestriction admission plugin only checks the ResourceSlice `nodeName`.

This PR re-runs capacity validation when the effective `allowMultipleAllocations` changes, not only when the capacity map changes. The comparison uses the effective boolean, so `nil` and `false` stay equivalent and switching between those representations does not trigger revalidation.

#### Which issue(s) this PR is related to:

Fixes #140799

#### Special notes for your reviewer:

* Three new `TestValidateResourceSliceUpdate` cases (`disable-allow-multiple-keeps-request-policy`, `unset-allow-multiple-keeps-request-policy`, and `enable-allow-multiple-revalidates-stored-invalid-request-policy`) fail before this change, because `ValidateResourceSliceUpdate` returns no error for the flip. They pass after it. The full `pkg/apis/resource/validation` suite stays green, so re-running validation on an `allowMultipleAllocations` change does not over-validate unchanged objects (the no-op update cases still pass).
* The check compares the effective `allowMultipleAllocations` with the old one and re-runs capacity validation whenever it changes, in either direction, because that value selects which capacity validator applies. `nil` and `false` are the same effective value, so switching between them does not re-run validation. The `true`->`false` flip is the reported, normally-reachable regression; the `false`->`true` case can only surface an error from an already-invalid stored object that current validation would not accept, so it is written as a guard for legacy or skewed data.
* This is the validation-layer sibling of #140797 (allocator exclusivity). Both are reachable through the same `allowMultipleAllocations` true->false ResourceSlice update, but they are separate: #140797 stops the allocator from handing the device out exclusively on top of a live share, while this stops the API from accepting the invalid device shape in the first place.

#### Does this PR introduce a user-facing change?

```release-note
Fixed DRA ResourceSlice update validation so that an update which disables or unsets `allowMultipleAllocations` while keeping a capacity `requestPolicy` is now rejected, consistent with create validation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
None
```

#### AI usage disclosure:

YES. AI-assisted tools were used during implementation, test planning, and review; I reviewed and validated the final change.
