### PR TITLE
DRA: do not over-commit counters of a device dropped from its slice

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -3991,6 +3991,120 @@ func TestAllocator(t *testing.T,
 				deviceAllocationResult(req1, driverA, pool1, device3, false),
 			)},
 		},
+		// device1 is allocated, but the driver has republished the pool
+		// without it. How much it consumed is recorded nowhere: the slice no
+		// longer declares the device, and the allocated state carries only
+		// its ID - there is no allocation-time record of counter
+		// consumption. The premise of this scenario is that device1 consumed
+		// the entire 8Gi counter when it was allocated, so granting device2
+		// (which needs all 8Gi) over-commits the physical counter. The
+		// allocator must not hand out counters it cannot account for; the
+		// allocated DeviceID names this pool, so the unaccounted device is
+		// detectable even without a consumption record.
+		"partitionable-devices-allocated-device-removed-from-slice": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						},
+					),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: nil,
+		},
+		// Same as above, but device1's allocation is recorded as a shared
+		// (allow-multiple) allocation rather than a dedicated one. It is still
+		// allocated, the pool no longer publishes it, and its counter
+		// consumption is unaccountable, so device2 must not be granted the 8Gi
+		// counter device1 may still hold.
+		"partitionable-devices-allocated-shared-device-removed-from-slice": {
+			features: Features{
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						},
+					),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: nil,
+		},
+		// Same as above, but device1's allocation is recorded only as aggregated
+		// consumed capacity (a manually constructed or future producer state that
+		// IsDeviceAllocated still counts as allocated), with no dedicated or shared
+		// entry. The pool no longer publishes device1, so the pool must fail closed
+		// here too, not just when the allocation is recorded dedicated or shared.
+		"partitionable-devices-allocated-capacity-device-removed-from-slice": {
+			features: Features{
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedCapacityDevices: ConsumedCapacityCollection{
+				MakeDeviceID(driverA, pool1, device1): ConsumedCapacity{
+					capacity0: new(one),
+				},
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						},
+					),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: nil,
+		},
 		"partitionable-devices-multiple-capacity-pools": {
 			features: Features{
 				PrioritizedList:      true,

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -87,6 +87,7 @@ const (
 	req2SubReq1 = "req-2/subReq-1"
 	claim0      = "claim-0"
 	claim1      = "claim-1"
+	claim2      = "claim-2"
 	slice1      = "slice-1"
 	slice2      = "slice-2"
 	slice3      = "slice-3"
@@ -245,6 +246,13 @@ func request(name, class string, count int64, selectors ...resourceapi.DeviceSel
 			Selectors:       selectors,
 		},
 	}
+}
+
+// adminRequest is request with AdminAccess set.
+func adminRequest(name, class string, count int64, selectors ...resourceapi.DeviceSelector) resourceapi.DeviceRequest {
+	r := request(name, class, count, selectors...)
+	r.Exactly.AdminAccess = new(true)
+	return r
 }
 
 func deviceRequest(name, class string, count int64) wrapDeviceRequest {
@@ -712,6 +720,13 @@ func deviceAllocationResult(request, driver, pool, device string, adminAccess bo
 	if adminAccess {
 		r.AdminAccess = &adminAccess
 	}
+	return r
+}
+
+// sharedDeviceAllocationResult is deviceAllocationResult for a share, which carries a ShareID.
+func sharedDeviceAllocationResult(request, driver, pool, device string, adminAccess bool) resourceapi.DeviceRequestAllocationResult {
+	r := deviceAllocationResult(request, driver, pool, device, adminAccess)
+	r.ShareID = &fixedShareID
 	return r
 }
 
@@ -3879,6 +3894,81 @@ func TestAllocator(t *testing.T,
 					deviceRequestAllocationResult(req3, driverA, pool1, device1).withConsumedCapacity(&fixedShareID, nil)),
 			},
 		},
+		"partitionable-devices-admin-backtracking-preserves-ordinary-share": {
+			features: Features{
+				AdminAccess:          true,
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(
+				// claim0 pins device1 as the first share and reserves its single
+				// shared counter.
+				claimWithRequests(claim0, nil,
+					request(req0, classA, 1, resourceapi.DeviceSelector{
+						CEL: &resourceapi.CELDeviceSelector{
+							Expression: fmt.Sprintf(`device.attributes["%s"].kind == "shared"`, driverA),
+						}}),
+				),
+				// claim1's req1 is administrative and first tries device1 as a share, which
+				// reserves nothing. The match-attribute constraint with req2 forces it to
+				// backtrack onto device2. That rollback must not drop device1's shared marker,
+				// which claim0 owns, or req3 would recharge the single counter and fail.
+				claimWithRequests(claim1,
+					[]resourceapi.DeviceConstraint{
+						{MatchAttribute: &stringAttribute, Requests: []string{req1, req2}},
+					},
+					adminRequest(req1, classA, 1, resourceapi.DeviceSelector{
+						CEL: &resourceapi.CELDeviceSelector{
+							Expression: fmt.Sprintf(`device.attributes["%s"].kind == "shared" || device.attributes["%s"].kind == "fallback"`, driverA, driverA),
+						}}),
+					adminRequest(req2, classA, 1, resourceapi.DeviceSelector{
+						CEL: &resourceapi.CELDeviceSelector{
+							Expression: fmt.Sprintf(`device.attributes["%s"].kind == "gate"`, driverA),
+						}}),
+					request(req3, classA, 1, resourceapi.DeviceSelector{
+						CEL: &resourceapi.CELDeviceSelector{
+							Expression: fmt.Sprintf(`device.attributes["%s"].kind == "shared"`, driverA),
+						}}),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					// device1: allow-multiple, no capacity, consumes the single counter.
+					// kind steers the selectors; stringAttribute steers the constraint.
+					device(device1, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"kind":            {StringValue: new("shared")},
+						"stringAttribute": {StringValue: new("red")},
+					}).withAllowMultipleAllocations().withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1, map[string]resource.Quantity{"c": resource.MustParse("1")}),
+					),
+					// device2: the fallback for req1, matching req2's stringAttribute.
+					device(device2, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"kind":            {StringValue: new("fallback")},
+						"stringAttribute": {StringValue: new("blue")},
+					}),
+					// device3: the only device req2 can take.
+					device(device3, nil, map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+						"kind":            {StringValue: new("gate")},
+						"stringAttribute": {StringValue: new("blue")},
+					}),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1, map[string]resource.Quantity{"c": resource.MustParse("1")}),
+				),
+			),
+			node: node(node1, region1),
+			// The administrative req1 leaves no reservation of its own, so backtracking it
+			// off device1 must leave claim0's share, and its counter, untouched.
+			expectResults: []any{
+				allocationResult(localNodeSelector(node1),
+					deviceRequestAllocationResult(req0, driverA, pool1, device1).withConsumedCapacity(&fixedShareID, nil)),
+				allocationResult(localNodeSelector(node1),
+					deviceAllocationResult(req1, driverA, pool1, device2, true),
+					deviceAllocationResult(req2, driverA, pool1, device3, true),
+					deviceRequestAllocationResult(req3, driverA, pool1, device1).withConsumedCapacity(&fixedShareID, nil)),
+			},
+		},
 		"partitionable-devices-prioritized-list": {
 			features: Features{
 				PrioritizedList:      true,
@@ -3989,6 +4079,819 @@ func TestAllocator(t *testing.T,
 				localNodeSelector(node1),
 				deviceAllocationResult(req0, driverA, pool1, device1, false),
 				deviceAllocationResult(req1, driverA, pool1, device3, false),
+			)},
+		},
+		// device1 is allocated but the republished pool no longer declares it, and nothing
+		// records what it consumed. Granting device2 the whole 8Gi counter would hand out
+		// counters device1 may still hold, so the pool has to refuse instead.
+		"partitionable-devices-allocated-device-removed-from-slice": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						},
+					),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: nil,
+		},
+		// device2 is still allocated and still published. Administrative access to it must
+		// not be refused because device1 disappeared from the pool.
+		"partitionable-devices-admin-access-with-missing-peer": {
+			features: Features{
+				AdminAccess:          true,
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, adminRequest(req0, classA, 1)),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+				MakeDeviceID(driverA, pool1, device2),
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device2, true),
+			)},
+		},
+		// The counter set holds exactly what the allocated device2 already consumes.
+		// Administrative access to it reserves nothing, so it fits where an ordinary claim
+		// would not, and the scheduler never counts an admin result as allocated.
+		"partitionable-devices-admin-access-does-not-charge-counters": {
+			features: Features{
+				AdminAccess:          true,
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, adminRequest(req0, classA, 1)),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device2),
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device2, true),
+			)},
+		},
+		// An admin claim leaves no marker that the first ordinary share of the same device
+		// can read as a counter reservation. device1 already holds the whole counter set, so
+		// the ordinary claim has nothing left and the pair cannot both be satisfied.
+		"partitionable-devices-admin-access-does-not-seed-shared-counter-reservation": {
+			features: Features{
+				AdminAccess:          true,
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, adminRequest(req0, classA, 1)),
+				claimWithRequest(claim1, req0, classA),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withAllowMultipleAllocations().withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+					device(device1, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						},
+					),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: nil,
+		},
+		// Counters cover device2 exactly once. The admin claim reserves nothing, the first
+		// ordinary share reserves, and the second inherits that reservation, so all three
+		// fit where there is room for a single reservation.
+		"partitionable-devices-admin-then-two-shares-reserves-once": {
+			features: Features{
+				AdminAccess:          true,
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, adminRequest(req0, classA, 1)),
+				claimWithRequest(claim1, req1, classA),
+				claimWithRequest(claim2, req2, classA),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withAllowMultipleAllocations().withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+					device(device1, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{
+				allocationResult(localNodeSelector(node1), sharedDeviceAllocationResult(req0, driverA, pool1, device2, true)),
+				allocationResult(localNodeSelector(node1), sharedDeviceAllocationResult(req1, driverA, pool1, device2, false)),
+				allocationResult(localNodeSelector(node1), sharedDeviceAllocationResult(req2, driverA, pool1, device2, false)),
+			},
+		},
+		// Counters are sufficient, so only the incompatible group can reject the ordinary
+		// share. Administrative access must not have exempted it from that check.
+		"compatibility-groups-admin-then-share-incompatible": {
+			features: Features{
+				AdminAccess:          true,
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+				CompatibilityGroups:  true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, adminRequest(req0, classA, 1)),
+				claimWithRequest(claim1, req1, classA),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withAllowMultipleAllocations().withDeviceCounterConsumption(
+						deviceCounterConsumptionWithGroups(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							}, "vgpu",
+						),
+					),
+					device(device1, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumptionWithGroups(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							}, "mig",
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: nil,
+		},
+		// The same incompatible pair with only the administrative claim: it is still allowed,
+		// so the case above cannot pass by rejecting admin access itself.
+		"compatibility-groups-admin-access-with-incompatible-peer": {
+			features: Features{
+				AdminAccess:          true,
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+				CompatibilityGroups:  true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, adminRequest(req0, classA, 1)),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withAllowMultipleAllocations().withDeviceCounterConsumption(
+						deviceCounterConsumptionWithGroups(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							}, "vgpu",
+						),
+					),
+					device(device1, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumptionWithGroups(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							}, "mig",
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{
+				allocationResult(localNodeSelector(node1), sharedDeviceAllocationResult(req0, driverA, pool1, device2, true)),
+			},
+		},
+		// Compatible groups: the administrative claim and the ordinary share both succeed, so
+		// the check above is not rejecting every mix of the two.
+		"compatibility-groups-admin-then-share-compatible": {
+			features: Features{
+				AdminAccess:          true,
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+				CompatibilityGroups:  true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, adminRequest(req0, classA, 1)),
+				claimWithRequest(claim1, req1, classA),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withAllowMultipleAllocations().withDeviceCounterConsumption(
+						deviceCounterConsumptionWithGroups(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							}, "mig",
+						),
+					),
+					device(device1, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumptionWithGroups(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							}, "mig",
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{
+				allocationResult(localNodeSelector(node1), sharedDeviceAllocationResult(req0, driverA, pool1, device2, true)),
+				allocationResult(localNodeSelector(node1), sharedDeviceAllocationResult(req1, driverA, pool1, device2, false)),
+			},
+		},
+		// An administrative claim between two ordinary shares must leave the first share's
+		// reservation intact for the second to inherit.
+		"partitionable-devices-share-admin-share-preserves-reservation": {
+			features: Features{
+				AdminAccess:          true,
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequest(claim0, req0, classA),
+				claimWithRequests(claim1, nil, adminRequest(req1, classA, 1)),
+				claimWithRequest(claim2, req2, classA),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withAllowMultipleAllocations().withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+					device(device1, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{
+				allocationResult(localNodeSelector(node1), sharedDeviceAllocationResult(req0, driverA, pool1, device2, false)),
+				allocationResult(localNodeSelector(node1), sharedDeviceAllocationResult(req1, driverA, pool1, device2, true)),
+				allocationResult(localNodeSelector(node1), sharedDeviceAllocationResult(req2, driverA, pool1, device2, false)),
+			},
+		},
+		// Administrative access skips the accountability check, but the ordinary share that
+		// follows must still meet it: the pool no longer publishes the allocated device1.
+		"partitionable-devices-admin-then-share-with-missing-peer": {
+			features: Features{
+				AdminAccess:          true,
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, adminRequest(req0, classA, 1)),
+				claimWithRequest(claim1, req1, classA),
+			),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(classWithAllowMultipleAllocations(classA, driverA, true)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withAllowMultipleAllocations().withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: nil,
+		},
+		// A missing device also blocks new counter reservations when its allocation is
+		// recorded as a shared (allow-multiple) one rather than a dedicated one.
+		"partitionable-devices-allocated-shared-device-removed-from-slice": {
+			features: Features{
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						},
+					),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: nil,
+		},
+		// Same as above, but device1's allocation is recorded only as aggregated
+		// consumed capacity (a manually constructed or future producer state that
+		// IsDeviceAllocated still counts as allocated), with no dedicated or shared
+		// entry. The pool no longer publishes device1, so the pool must fail closed
+		// here too, not just when the allocation is recorded dedicated or shared.
+		"partitionable-devices-allocated-capacity-device-removed-from-slice": {
+			features: Features{
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedCapacityDevices: ConsumedCapacityCollection{
+				MakeDeviceID(driverA, pool1, device1): ConsumedCapacity{
+					capacity0: new(one),
+				},
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						},
+					),
+				),
+			),
+			node:          node(node1, region1),
+			expectResults: nil,
+		},
+		// One allocation can be recorded as a share and as consumed capacity at once.
+		// Both name device1, so the pool holds one allocated device, not two, and
+		// device2 still fits in what device1 leaves behind.
+		"partitionable-devices-allocated-device-shared-and-capacity-counted-once": {
+			features: Features{
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
+			),
+			allocatedCapacityDevices: ConsumedCapacityCollection{
+				MakeDeviceID(driverA, pool1, device1): ConsumedCapacity{
+					capacity0: new(one),
+				},
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+			)},
+		},
+		// device1 is allocated and still published, but only in a slice targeting another
+		// node. The pool must scan those slices too, so device1 counts as present (no fail
+		// closed) and its 8Gi is deducted, leaving device2 room to allocate.
+		"partitionable-devices-allocated-device-present-in-not-targeting-slice": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 3), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithDevices(slice2, node2, resourcePool(pool1, 3), driverA,
+					device(device1, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice3, node1, resourcePool(pool1, 3), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+			)},
+		},
+		// driver-b/pool-1 has an allocated device it no longer publishes, so that pool
+		// fails closed. The index is keyed by the full driver+pool ID, so driver-a/pool-1
+		// is untouched and its candidate device2 still allocates.
+		"partitionable-devices-missing-device-isolated-by-pool-id": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverB, pool1, device1),
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+			)},
+		},
+		// device1 is still published, only by an obsolete generation (1); the resolved
+		// generation (2) drops it. Unlike the -removed-from-slice cases, this pins that
+		// presence is judged from the resolved generation, not every published slice.
+		"partitionable-devices-allocated-device-only-in-obsolete-generation": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+						device(device2, fromCounters, nil).withDeviceCounterConsumption(
+							deviceCounterConsumption(counterSet1,
+								map[string]resource.Quantity{
+									"memory": resource.MustParse("8Gi"),
+								},
+							),
+						),
+					)
+					s.Spec.Pool.Generation = 2
+					return s
+				}(),
+				func() wrapResourceSliceWithCounterSets {
+					s := sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+						counterSet(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("16Gi"),
+							},
+						),
+					)
+					s.Spec.Pool.Generation = 2
+					return s
+				}(),
+				func() wrapResourceSliceWithDevices {
+					s := sliceWithDevices(slice3, node1, resourcePool(pool1, 1), driverA,
+						device(device1, fromCounters, nil).withDeviceCounterConsumption(
+							deviceCounterConsumption(counterSet1,
+								map[string]resource.Quantity{
+									"memory": resource.MustParse("8Gi"),
+								},
+							),
+						),
+					)
+					s.Spec.Pool.Generation = 1
+					return s
+				}(),
+			),
+			node:          node(node1, region1),
+			expectResults: nil,
+		},
+		// Failing a pool closed must drop only that pool. pool1 cannot account for its
+		// allocated device1, but pool2 is intact and satisfies the claim.
+		"partitionable-devices-unaccountable-pool-does-not-block-a-valid-pool": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+				sliceWithDevices(slice3, node1, resourcePool(pool2, 2), driverA,
+					device(device3, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet2,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice4, node1, resourcePool(pool2, 2), driverA,
+					counterSet(counterSet2,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool2, device3, false),
+			)},
+		},
+		// Only counter-consuming candidates stop. device2 draws on the counter set the dropped
+		// device1 makes unaccountable, device3 draws on nothing.
+		"partitionable-devices-unaccountable-pool-still-allows-a-counterless-device": {
+			features: Features{
+				PartitionableDevices: true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+					device(device3, nil, nil),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("16Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device3, false),
+			)},
+		},
+		// device2 already carries a share, so its counters were charged when that share was
+		// granted and an extra share must not charge them again. The guard sits behind that
+		// skip, so an unaccountable pool does not block the extra share.
+		"partitionable-devices-unaccountable-pool-still-allows-another-share": {
+			features: Features{
+				PartitionableDevices: true,
+				ConsumableCapacity:   true,
+			},
+			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
+			allocatedDevices: []DeviceID{
+				MakeDeviceID(driverA, pool1, device1),
+			},
+			allocatedSharedDeviceIDs: sets.New(
+				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device2), &fixedShareID),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device2, fromCounters, nil).withAllowMultipleAllocations().withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("8Gi"),
+							},
+						),
+					),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("8Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceRequestAllocationResult(req0, driverA, pool1, device2).withConsumedCapacity(&fixedShareID, nil),
 			)},
 		},
 		"partitionable-devices-multiple-capacity-pools": {
@@ -6705,11 +7608,9 @@ func TestAllocator(t *testing.T,
 			allocatedSharedDeviceIDs: sets.New(
 				internal.MakeSharedDeviceID(MakeDeviceID(driverA, pool1, device1), &fixedShareID),
 			),
-			claimsToAllocate: func() []wrapResourceClaim {
-				c := claimWithRequest(claim0, req0, classA)
-				c.Spec.Devices.Requests[0].Exactly.AdminAccess = new(true)
-				return []wrapResourceClaim{c}
-			}(),
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil, adminRequest(req0, classA, 1)),
+			),
 			classes: objects(class(classA, driverA)),
 			slices: unwrapResourceSlices(
 				sliceWithDevices(slice1, node1, resourcePool(pool1, 1), driverA,
@@ -9333,4 +10234,213 @@ func (l informerLister[T]) Get(name string) (*T, error) {
 		}
 	}
 	return nil, apierrors.NewNotFound(schema.GroupResource{}, "not found")
+}
+
+// TestCounterPoolAccountabilityAcrossNodesWithUnderreportedSliceCount verifies that a node which
+// cannot account for a pool allocates nothing from it, even once another node has cached the
+// pool's counter baseline, and that refusing it leaves the pool usable for a node that can.
+func TestCounterPoolAccountabilityAcrossNodesWithUnderreportedSliceCount(t *testing.T,
+	newAllocator func(
+		ctx context.Context,
+		features Features,
+		allocateState AllocatedState,
+		classLister DeviceClassLister,
+		slices []*resourceapi.ResourceSlice,
+		celCache *cel.Cache,
+	) (Allocator, error)) {
+	memory := func(q string) map[string]resource.Quantity {
+		return map[string]resource.Quantity{"memory": resource.MustParse(q)}
+	}
+	consuming := func(name, q string) wrapDevice {
+		return device(name, fromCounters, nil).withDeviceCounterConsumption(deviceCounterConsumption(counterSet1, memory(q)))
+	}
+
+	// The pool holds three slices at one generation but every slice reports two, so each node
+	// takes its own two as the whole pool and never looks for the third. node-1 ends up
+	// publishing the allocated device1 and node-2 does not. A driver that reports the count
+	// correctly does not produce this, since the node seeing too few slices pulls in the rest,
+	// but the allocator must not let one node's view answer for another's regardless.
+	resourceSlices := unwrapResourceSlices(
+		sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA, consuming(device1, "8Gi"), consuming(device2, "8Gi")),
+		sliceWithDevices(slice2, node2, resourcePool(pool1, 2), driverA, consuming(device3, "8Gi")),
+		sliceWithCounterSets(slice3, nodeSelectionAll, resourcePool(pool1, 2), driverA, counterSet(counterSet1, memory("16Gi"))),
+	)
+
+	allocatedState := AllocatedState{AllocatedDevices: sets.New(MakeDeviceID(driverA, pool1, device1))}
+	var classLister informerLister[resourceapi.DeviceClass]
+	for _, c := range objects(class(classA, driverA)) {
+		classLister.objs = append(classLister.objs, c.DeepCopy())
+	}
+	claims := unwrap(objects(claimWithRequest(claim0, req0, classA))...)
+
+	newFor := func(t *testing.T) (context.Context, Allocator) {
+		t.Helper()
+		_, ctx := ktesting.NewTestContext(t)
+		allocator, err := newAllocator(ctx, Features{PartitionableDevices: true}, allocatedState, classLister, resourceSlices, cel.NewCache(1, cel.Features{}))
+		if err != nil {
+			t.Fatalf("create allocator: %v", err)
+		}
+		return ctx, allocator
+	}
+	allocate := func(t *testing.T, ctx context.Context, allocator Allocator, n *v1.Node) []resourceapi.AllocationResult {
+		t.Helper()
+		results, err := allocator.Allocate(ctx, n, claims)
+		if err != nil {
+			t.Fatalf("allocate for %s: %v", n.Name, err)
+		}
+		return results
+	}
+
+	// node-1 accounts for device1 and can hand device2 the remaining half of the counter set.
+	// node-2 cannot account for device1, so it must allocate nothing. A nil want means empty.
+	type nodeCase struct {
+		node *v1.Node
+		want types.GomegaMatcher
+	}
+	accountable := nodeCase{node(node1, region1), allocationResult(localNodeSelector(node1),
+		deviceAllocationResult(req0, driverA, pool1, device2, false))}
+	unaccountable := nodeCase{node(node2, region1), nil}
+
+	expect := func(g gomega.Gomega, nc nodeCase, results []resourceapi.AllocationResult, context string) {
+		if nc.want == nil {
+			g.Expect(results).To(gomega.BeEmpty(), "%s allocated from a pool it cannot account for, %s", nc.node.Name, context)
+			return
+		}
+		g.Expect(results).To(gomega.ConsistOf(nc.want), "%s allocated something else, %s", nc.node.Name, context)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		first, then nodeCase
+	}{
+		{"unaccountable node first", unaccountable, accountable},
+		{"accountable node first", accountable, unaccountable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			ctx, shared := newFor(t)
+			expect(g, tc.first, allocate(t, ctx, shared, tc.first.node), "filtered first")
+			gotThen := allocate(t, ctx, shared, tc.then.node)
+			expect(g, tc.then, gotThen, "filtered after "+tc.first.node.Name)
+
+			// The same node on its own must reach the same result.
+			ctxFresh, fresh := newFor(t)
+			g.Expect(gotThen).To(gomega.Equal(allocate(t, ctxFresh, fresh, tc.then.node)),
+				"%s depended on %s being filtered first", tc.then.node.Name, tc.first.node.Name)
+		})
+	}
+
+	// Concurrent Allocate calls must reach the same per-node verdicts as the sequential
+	// runs while sharing the lazily built allocated-device index.
+	t.Run("concurrent nodes", func(t *testing.T) {
+		g := gomega.NewWithT(t)
+		ctx, shared := newFor(t)
+		type outcome struct {
+			nc      nodeCase
+			results []resourceapi.AllocationResult
+			err     error
+		}
+		start := make(chan struct{})
+		done := make(chan outcome, 2)
+		for _, nc := range []nodeCase{accountable, unaccountable} {
+			go func() {
+				<-start
+				// Allocate directly: t.Fatalf must not run outside the test goroutine.
+				results, err := shared.Allocate(ctx, nc.node, claims)
+				done <- outcome{nc: nc, results: results, err: err}
+			}()
+		}
+		close(start)
+		for range 2 {
+			got := <-done
+			if got.err != nil {
+				t.Errorf("allocate for %s: %v", got.nc.node.Name, got.err)
+				continue
+			}
+			expect(g, got.nc, got.results, "filtered concurrently")
+		}
+	})
+}
+
+// TestCompatibilityBaselineNotSeededByUnaccountablePool checks that a pool a node cannot account
+// for does not seed the compatibility baseline for a node that can. The baseline is cached per
+// pool and skips allocated devices the snapshot no longer publishes, so seeding it from an
+// incomplete view would let an incompatible device through on a complete one.
+func TestCompatibilityBaselineNotSeededByUnaccountablePool(t *testing.T,
+	newAllocator func(
+		ctx context.Context,
+		features Features,
+		allocateState AllocatedState,
+		classLister DeviceClassLister,
+		slices []*resourceapi.ResourceSlice,
+		celCache *cel.Cache,
+	) (Allocator, error)) {
+	// device1 is allocated and declares "mig"; the candidate device2 declares "vgpu", so the two
+	// cannot share counterSet1. node-1 publishes both, node-2 has dropped device1.
+	resourceSlices := unwrapResourceSlices(
+		sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+			device(device1, nil, nil).withDeviceCounterConsumption(
+				deviceCounterConsumptionWithGroups(counterSet1, map[string]resource.Quantity{capacity0: two}, "mig"),
+			),
+			device(device2, nil, nil).withDeviceCounterConsumption(
+				deviceCounterConsumptionWithGroups(counterSet1, map[string]resource.Quantity{capacity0: two}, "vgpu"),
+			),
+		),
+		sliceWithDevices(slice2, node2, resourcePool(pool1, 2), driverA,
+			device(device3, nil, nil).withDeviceCounterConsumption(
+				deviceCounterConsumptionWithGroups(counterSet1, map[string]resource.Quantity{capacity0: two}, "vgpu"),
+			),
+		),
+		sliceWithCounterSets(slice3, nodeSelectionAll, resourcePool(pool1, 2), driverA,
+			counterSet(counterSet1, map[string]resource.Quantity{capacity0: four}),
+		),
+	)
+	allocatedState := AllocatedState{AllocatedDevices: sets.New(MakeDeviceID(driverA, pool1, device1))}
+	var classLister informerLister[resourceapi.DeviceClass]
+	for _, c := range objects(class(classA, driverA)) {
+		classLister.objs = append(classLister.objs, c.DeepCopy())
+	}
+	claims := unwrap(objects(claimWithRequest(claim0, req0, classA))...)
+
+	newFor := func(t *testing.T) (context.Context, Allocator) {
+		t.Helper()
+		_, ctx := ktesting.NewTestContext(t)
+		allocator, err := newAllocator(ctx, Features{PartitionableDevices: true, CompatibilityGroups: true},
+			allocatedState, classLister, resourceSlices, cel.NewCache(1, cel.Features{}))
+		if err != nil {
+			t.Fatalf("create allocator: %v", err)
+		}
+		return ctx, allocator
+	}
+	allocate := func(t *testing.T, ctx context.Context, allocator Allocator, n *v1.Node) []resourceapi.AllocationResult {
+		t.Helper()
+		results, err := allocator.Allocate(ctx, n, claims)
+		if err != nil {
+			t.Fatalf("allocate for %s: %v", n.Name, err)
+		}
+		return results
+	}
+
+	for _, tc := range []struct {
+		name        string
+		first, then *v1.Node
+	}{
+		{"unaccountable node first", node(node2, region1), node(node1, region1)},
+		{"accountable node first", node(node1, region1), node(node2, region1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			ctx, alloc := newFor(t)
+			wantFirst := allocate(t, ctx, alloc, tc.first)
+			ctx, alloc = newFor(t)
+			wantThen := allocate(t, ctx, alloc, tc.then)
+			g.Expect(wantFirst).To(gomega.BeEmpty(), "%s must not co-allocate vgpu with the allocated mig device", tc.first.Name)
+			g.Expect(wantThen).To(gomega.BeEmpty(), "%s must not co-allocate vgpu with the allocated mig device", tc.then.Name)
+
+			ctx, shared := newFor(t)
+			g.Expect(allocate(t, ctx, shared, tc.first)).To(gomega.Equal(wantFirst))
+			g.Expect(allocate(t, ctx, shared, tc.then)).To(gomega.Equal(wantThen), "%s changed after %s was filtered", tc.then.Name, tc.first.Name)
+		})
+	}
+
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -115,6 +115,14 @@ type Allocator struct {
 	// and pool name), and the inner map keys are counter set names.
 	compatibilityGroupsBaseline map[PoolID]map[string]compatibilityGroupIntersection
 	mutex                       sync.RWMutex
+	// allocatedDeviceIDsByPool groups every allocated device ID (from all the
+	// sources IsDeviceAllocated considers) by the pool that published it, letting
+	// checkAvailableCounters detect an allocated device a pool no longer publishes
+	// without rescanning the whole allocated state for every pool. Built lazily the
+	// first time checkAvailableCounters needs it, guarded by allocatedDeviceIDsByPoolOnce,
+	// then read-only, so a pod whose candidates never consult counters pays nothing.
+	allocatedDeviceIDsByPool     map[PoolID]sets.Set[DeviceID]
+	allocatedDeviceIDsByPoolOnce sync.Once
 	// numAllocateOneInvocations counts the number of times the allocateOne
 	// function is called for the allocator. This is a measurement of the
 	// amount of work the allocator had to do to allocate devices
@@ -158,6 +166,34 @@ func NewAllocator(ctx context.Context,
 		compatibilityGroupsBaseline: make(map[PoolID]map[string]compatibilityGroupIntersection),
 	}
 	return a, nil
+}
+
+// allocatedDeviceIDsByPool groups every allocated device ID by the pool that
+// published it, using the same sources as IsDeviceAllocated (dedicated devices,
+// shared allocations, and aggregated consumed capacity), so an allocated device
+// missing from a republished pool is detectable regardless of how the allocation
+// was recorded.
+func allocatedDeviceIDsByPool(state AllocatedState) map[PoolID]sets.Set[DeviceID] {
+	byPool := make(map[PoolID]sets.Set[DeviceID])
+	add := func(id DeviceID) {
+		poolID := PoolID{Driver: id.Driver, Pool: id.Pool}
+		ids := byPool[poolID]
+		if ids == nil {
+			ids = sets.New[DeviceID]()
+			byPool[poolID] = ids
+		}
+		ids.Insert(id)
+	}
+	for id := range state.AllocatedDevices {
+		add(id)
+	}
+	for sharedID := range state.AllocatedSharedDeviceIDs {
+		add(sharedID.GetDeviceID())
+	}
+	for id := range state.AggregatedCapacity {
+		add(id)
+	}
+	return byPool
 }
 
 func (a *Allocator) Channel() internal.AllocatorChannel {
@@ -1879,7 +1915,9 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 
 		// Update the data structure to reflect counters already consumed by allocated devices. This
 		// only includes devices where the allocation process has completed, so this will never
-		// change during the allocation process.
+		// change during the allocation process. While iterating, also record every DeviceID the
+		// pool currently publishes so allocated devices that are no longer present are detectable.
+		poolDeviceIDs := sets.New[DeviceID]()
 		for _, resourceSlices := range [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode} {
 			for _, slice := range resourceSlices {
 				for _, device := range slice.Spec.Devices {
@@ -1888,6 +1926,7 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 						Pool:   slice.Spec.Pool.Name,
 						Device: device.Name,
 					}
+					poolDeviceIDs.Insert(deviceID)
 					// Devices that aren't allocated doesn't consume any counters, so we don't
 					// need to consider them.
 					if !internal.IsDeviceAllocated(deviceID, &alloc.allocatedState) {
@@ -1914,11 +1953,38 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 			}
 		}
 
+		// Build the allocated-device-by-pool index the first time a pool's counters are
+		// computed rather than eagerly in NewAllocator, so a pod whose candidates never reach
+		// a counter check pays nothing. sync.Once keeps it safe across concurrent Allocate calls.
+		alloc.allocatedDeviceIDsByPoolOnce.Do(func() {
+			alloc.allocatedDeviceIDsByPool = allocatedDeviceIDsByPool(alloc.allocatedState)
+		})
+
+		// An allocated device this pool no longer publishes in any slice cannot have its counter
+		// consumption reconstructed (the slice is the only source), so the pool's counter
+		// availability is unknowable. Mark it unusable (nil) rather than over-commit counters
+		// still in use; the allocated DeviceID names this pool, so the device is detectable even
+		// without a consumption record.
+		for allocatedID := range alloc.allocatedDeviceIDsByPool[poolID] {
+			if !poolDeviceIDs.Has(allocatedID) {
+				alloc.logger.V(5).Info("Marking counter pool unavailable: an allocated device is no longer published in any slice",
+					"pool", poolID, "device", allocatedID)
+				availableCountersForPool = nil
+				break
+			}
+		}
+
 		// Set the available counters on the allocator so we don't have to
 		// compute this again.
 		alloc.mutex.Lock()
 		alloc.availableCounters[poolID] = availableCountersForPool
 		alloc.mutex.Unlock()
+	}
+
+	// A pool with an allocated device it no longer publishes has unknowable counter
+	// availability; do not allocate from it.
+	if availableCountersForPool == nil {
+		return false, nil
 	}
 
 	// Update the consumedCounters data structure with the counters consumed

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -97,13 +97,9 @@ type Allocator struct {
 	slicesShared   []*resourceapi.ResourceSlice
 	allSlices      []*resourceapi.ResourceSlice
 	celCache       *cel.Cache
-	// availableCounters contains the available counters for each
-	// resource pool. It acts as a cache that is updated the first time
-	// the available counters are needed for each pool. The information
-	// about each pool is never updated once set the first time.
-	// This is computed bsed on information on the Allocator, so it will
-	// be correct even for multiple usages of the Allocator.
-	// The keys in the map are resource pool IDs (driver name and pool name).
+	// availableCounters caches the counter baseline of each resource pool, keyed by driver
+	// and pool name. Sharing it across Allocate calls is only correct while they resolve
+	// equivalent counter sets, totals and allocated-device consumption for that pool.
 	// The allocator might be accessed by different goroutines, so
 	// access to this map must be synchronized.
 	availableCounters map[PoolID]counterSets
@@ -115,6 +111,8 @@ type Allocator struct {
 	// and pool name), and the inner map keys are counter set names.
 	compatibilityGroupsBaseline map[PoolID]map[string]compatibilityGroupIntersection
 	mutex                       sync.RWMutex
+	// allocatedDeviceIndex reports the allocated devices and how many of them each pool holds.
+	allocatedDeviceIndex func() (sets.Set[DeviceID], map[PoolID]int)
 	// numAllocateOneInvocations counts the number of times the allocateOne
 	// function is called for the allocator. This is a measurement of the
 	// amount of work the allocator had to do to allocate devices
@@ -157,7 +155,32 @@ func NewAllocator(ctx context.Context,
 
 		compatibilityGroupsBaseline: make(map[PoolID]map[string]compatibilityGroupIntersection),
 	}
+	a.allocatedDeviceIndex = sync.OnceValues(a.buildAllocatedDeviceIndex)
 	return a, nil
+}
+
+// buildAllocatedDeviceIndex walks the three sources IsDeviceAllocated recognizes. A device
+// named by more than one of them counts once.
+func (a *Allocator) buildAllocatedDeviceIndex() (sets.Set[DeviceID], map[PoolID]int) {
+	ids := sets.New[DeviceID]()
+	perPool := make(map[PoolID]int)
+	add := func(id DeviceID) {
+		if ids.Has(id) {
+			return
+		}
+		ids.Insert(id)
+		perPool[PoolID{Driver: id.Driver, Pool: id.Pool}]++
+	}
+	for id := range a.allocatedState.AllocatedDevices {
+		add(id)
+	}
+	for sharedID := range a.allocatedState.AllocatedSharedDeviceIDs {
+		add(sharedID.GetDeviceID())
+	}
+	for id := range a.allocatedState.AggregatedCapacity {
+		add(id)
+	}
+	return ids, perPool
 }
 
 func (a *Allocator) Channel() internal.AllocatorChannel {
@@ -691,6 +714,8 @@ type allocator struct {
 	// that are in the process of being allocated.
 	// The keys in the map are resource pool IDs (driver name and pool name).
 	consumedCounters map[PoolID]counterSets
+	// counterPoolAccountable is per node, since nodes can resolve different devices for a pool.
+	counterPoolAccountable map[PoolID]bool
 	// consumedCompatibilityGroups tracks the rolling compatibility-group
 	// intersection per counter set for each pool across the devices being
 	// allocated in the current attempt. It is seeded from the already-allocated
@@ -1617,9 +1642,10 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		return false, nil, nil
 	}
 
-	// Skip the counter check for an allow-multiple device in use: its counters are already
-	// accounted for, so a further share must not charge them again.
-	skipCounterCheck := allowMultipleAllocations && alloc.deviceCapacityInUse(device.id)
+	// An admin-access result is not part of the allocated state the scheduler feeds back,
+	// and a further share of an in-use device is already accounted for: neither reserves.
+	skipCounterCheck := request.adminAccess() ||
+		(allowMultipleAllocations && alloc.deviceCapacityInUse(device.id))
 
 	var parentRequestName string
 	if requestData.parentRequest != nil {
@@ -1644,7 +1670,16 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 	// a rejection returns before any counters have been reserved. While the
 	// feature is disabled there is nothing to check: GatherPools already ignored
 	// all slices with compatibility groups.
-	if alloc.features.CompatibilityGroups && !skipCounterCheck && len(device.ConsumesCounters) > 0 {
+	checkCounters := !skipCounterCheck && len(device.ConsumesCounters) > 0
+
+	// Both baselines are cached per pool and seeded by whichever snapshot reaches them first,
+	// so a pool this node cannot account for has to be rejected before either is built.
+	if checkCounters && !alloc.counterPoolIsAccountable(device.pool) {
+		alloc.logger.V(7).Info("Counter pool cannot be accounted for", "device", device.id)
+		return false, nil, nil
+	}
+
+	if alloc.features.CompatibilityGroups && checkCounters {
 		ok, restore := alloc.checkAndConsumeCompatibilityGroups(device)
 		if !ok {
 			alloc.logger.V(7).Info("Incompatible compatibility groups", "device", device.id)
@@ -1658,7 +1693,7 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 	// reserved this device's counters. It is not the same as
 	// len(device.ConsumesCounters) > 0, because skipCounterCheck can bypass the
 	// reservation.
-	if !skipCounterCheck && len(device.ConsumesCounters) > 0 {
+	if checkCounters {
 		// If a device consumes counters from a counter set, verify that
 		// there is sufficient counters available.
 		ok, err := alloc.checkAvailableCounters(device)
@@ -1739,14 +1774,18 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 			shareID = GenerateNewShareID()
 			alloc.logger.V(7).Info("Device capacity allocated", "device", device.id,
 				"consumed capacity", klog.Format(consumedCapacity))
-			// A prior share of this device may already hold the capacity entry.
-			// That entry doubles as the "already shared" marker that lets a later
-			// share skip the counter check, so record whether it predated this
-			// share; rollback must not delete it while another share still needs it.
-			_, state.capacityEntryExisted = alloc.allocatingCapacity[device.id]
-			alloc.allocatingCapacity.Insert(NewDeviceConsumedCapacity(device.id, consumedCapacity))
-			state.capacityInserted = true
-			state.consumedCapacity = consumedCapacity
+			// The entry doubles as the "already shared" marker that lets a later share
+			// skip the counter check, so administrative access must not leave one: it
+			// reserved nothing for that share to inherit.
+			if !request.adminAccess() {
+				// A prior share of this device may already hold the entry. Record whether
+				// it predated this share; rollback must not delete it while another share
+				// still needs it.
+				_, state.capacityEntryExisted = alloc.allocatingCapacity[device.id]
+				alloc.allocatingCapacity.Insert(NewDeviceConsumedCapacity(device.id, consumedCapacity))
+				state.capacityInserted = true
+				state.consumedCapacity = consumedCapacity
+			}
 		}
 	}
 
@@ -1853,6 +1892,68 @@ func taintTolerated(taint resourceapi.DeviceTaint, request requestAccessor) bool
 	return false
 }
 
+// rememberAccountable memoizes the answer for this node's view of the pool.
+func (alloc *allocator) rememberAccountable(poolID PoolID, accountable bool) {
+	if alloc.counterPoolAccountable == nil {
+		alloc.counterPoolAccountable = make(map[PoolID]bool)
+	}
+	alloc.counterPoolAccountable[poolID] = accountable
+}
+
+// counterPoolIsAccountable reports whether the pool, as resolved for this node, still publishes
+// every device allocated from it; a dropped device leaves its counter use unreconstructable.
+// The answer is per node, unlike availableCounters, so it must be settled before that cache.
+func (alloc *allocator) counterPoolIsAccountable(pool *Pool) bool {
+	poolID := pool.PoolID
+	if accountable, found := alloc.counterPoolAccountable[poolID]; found {
+		return accountable
+	}
+
+	// Nothing allocated from the pool means nothing to account for, which is the common case.
+	allocated, perPool := alloc.allocatedDeviceIndex()
+	want := perPool[poolID]
+	if want == 0 {
+		alloc.rememberAccountable(poolID, true)
+		return true
+	}
+
+	// Track only the allocated devices, since a pool usually publishes far more, and stop
+	// once all of them have turned up. A view that dropped most of the pool publishes
+	// fewer than it has allocated, so size for whichever is smaller.
+	deviceSlices := [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode}
+	numPublished := 0
+	for _, resourceSlices := range deviceSlices {
+		for _, slice := range resourceSlices {
+			numPublished += len(slice.Spec.Devices)
+		}
+	}
+	seen := make(sets.Set[DeviceID], min(want, numPublished))
+scan:
+	for _, resourceSlices := range deviceSlices {
+		for _, slice := range resourceSlices {
+			for _, device := range slice.Spec.Devices {
+				id := DeviceID{Driver: slice.Spec.Driver, Pool: slice.Spec.Pool.Name, Device: device.Name}
+				if !allocated.Has(id) {
+					continue
+				}
+				seen.Insert(id)
+				if seen.Len() == want {
+					break scan
+				}
+			}
+		}
+	}
+
+	accountable := seen.Len() == want
+	if !accountable {
+		alloc.logger.V(5).Info("Marking counter pool unavailable: it no longer publishes every device allocated from it",
+			"node", klog.KObj(alloc.node), "pool", poolID,
+			"numAllocatedDevices", want, "numMissingDevices", want-seen.Len())
+	}
+	alloc.rememberAccountable(poolID, accountable)
+	return accountable
+}
+
 // checkAvailableCounters checks if there are enough counters available to allocate
 // the specified device.
 //
@@ -1862,6 +1963,10 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 	pool := device.pool
 	poolID := pool.PoolID
 
+	if !alloc.counterPoolIsAccountable(pool) {
+		return false, nil
+	}
+
 	// Check first if the available counters for this pool have already been
 	// calculated.
 	alloc.mutex.RLock()
@@ -1870,8 +1975,8 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 	// If not, we need to do it now. But we store the result so it doesn't need
 	// to be calculated again.
 	// Since this is computed without holding the lock on the mutex, other goroutines
-	// might also do this work. But the input will be the same to all of them, so
-	// the result will also always be the same.
+	// might also do this work. The results agree only when the resolved pools have the
+	// same counter sets and totals and the same consumption for their allocated devices.
 	if !found {
 		availableCountersForPool = make(counterSets, len(pool.CounterSets))
 		for _, counterSet := range pool.CounterSets {
@@ -1885,7 +1990,9 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 
 		// Update the data structure to reflect counters already consumed by allocated devices. This
 		// only includes devices where the allocation process has completed, so this will never
-		// change during the allocation process.
+		// change during the allocation process. Whether the pool can still account for all of
+		// them was settled before this point.
+		allocated, _ := alloc.allocatedDeviceIndex()
 		for _, resourceSlices := range [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode} {
 			for _, slice := range resourceSlices {
 				for _, device := range slice.Spec.Devices {
@@ -1894,9 +2001,8 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 						Pool:   slice.Spec.Pool.Name,
 						Device: device.Name,
 					}
-					// Devices that aren't allocated doesn't consume any counters, so we don't
-					// need to consider them.
-					if !internal.IsDeviceAllocated(deviceID, &alloc.allocatedState) {
+					// Devices that aren't allocated consume no counters.
+					if !allocated.Has(deviceID) {
 						continue
 					}
 					for _, deviceCounterConsumption := range device.ConsumesCounters {
@@ -2019,15 +2125,15 @@ func (alloc *allocator) deallocateCountersForDevice(device deviceWithID) {
 	}
 }
 
-// compatibilityGroupsBaselineForPool returns, per counter set in the pool, the
-// compatibility-group intersection contributed by the devices that are already
-// allocated (i.e. recorded in allocatedState). Both counter set membership and
-// the declared group values are read live from the source ResourceSlice,
-// exactly like checkAvailableCounters does for counters: an allocated device's
-// consumption is assumed stable in the slice. A device that is allocated but no
-// longer present in the slice contributes nothing, just as its counters do not.
+// compatibilityGroupsBaselineForPool returns, per counter set, the compatibility-group
+// intersection contributed by the devices already allocated from the pool. Membership and
+// the declared group values are read from the current ResourceSlices; allocation-time
+// values are retained nowhere.
 //
-// The result is computed once per pool and cached, mirroring availableCounters.
+// A device missing from those slices contributes nothing, which leaves the intersection
+// too permissive, so callers must reject a resolved pool that no longer publishes every
+// allocated device before reading or populating this cache. The cache is keyed by pool
+// alone, so reuse also assumes equivalent compatibility metadata across the views.
 func (alloc *allocator) compatibilityGroupsBaselineForPool(pool *Pool) map[string]compatibilityGroupIntersection {
 	poolID := pool.PoolID
 
@@ -2039,6 +2145,7 @@ func (alloc *allocator) compatibilityGroupsBaselineForPool(pool *Pool) map[strin
 	}
 
 	baseline = make(map[string]compatibilityGroupIntersection)
+	allocated, _ := alloc.allocatedDeviceIndex()
 	for _, resourceSlices := range [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode} {
 		for _, slice := range resourceSlices {
 			for _, device := range slice.Spec.Devices {
@@ -2047,7 +2154,8 @@ func (alloc *allocator) compatibilityGroupsBaselineForPool(pool *Pool) map[strin
 					Pool:   slice.Spec.Pool.Name,
 					Device: device.Name,
 				}
-				if !internal.IsDeviceAllocated(deviceID, &alloc.allocatedState) {
+				// Only allocated devices contributed to the baseline.
+				if !allocated.Has(deviceID) {
 					continue
 				}
 				for _, deviceCounterConsumption := range device.ConsumesCounters {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_test.go
@@ -46,3 +46,33 @@ func TestAllocator(t *testing.T) {
 		newAllocator,
 	)
 }
+
+func TestCounterPoolAccountabilityAcrossNodesWithUnderreportedSliceCount(t *testing.T) {
+	allocatortesting.TestCounterPoolAccountabilityAcrossNodesWithUnderreportedSliceCount(t,
+		func(
+			ctx context.Context,
+			features Features,
+			allocatedState internal.AllocatedState,
+			classLister DeviceClassLister,
+			slices []*resourceapi.ResourceSlice,
+			celCache *cel.Cache,
+		) (internal.Allocator, error) {
+			return NewAllocator(ctx, features, allocatedState, classLister, slices, celCache)
+		},
+	)
+}
+
+func TestCompatibilityBaselineNotSeededByUnaccountablePool(t *testing.T) {
+	allocatortesting.TestCompatibilityBaselineNotSeededByUnaccountablePool(t,
+		func(
+			ctx context.Context,
+			features Features,
+			allocatedState internal.AllocatedState,
+			classLister DeviceClassLister,
+			slices []*resourceapi.ResourceSlice,
+			celCache *cel.Cache,
+		) (internal.Allocator, error) {
+			return NewAllocator(ctx, features, allocatedState, classLister, slices, celCache)
+		},
+	)
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -103,6 +103,14 @@ type Allocator struct {
 	// access to this map must be synchronized.
 	availableCounters map[PoolID]counterSets
 	mutex             sync.RWMutex
+	// allocatedDeviceIDsByPool groups every allocated device ID (from all the
+	// sources IsDeviceAllocated considers) by the pool that published it, letting
+	// checkAvailableCounters detect an allocated device a pool no longer publishes
+	// without rescanning the whole allocated state for every pool. Built lazily the
+	// first time checkAvailableCounters needs it, guarded by allocatedDeviceIDsByPoolOnce,
+	// then read-only, so a pod whose candidates never consult counters pays nothing.
+	allocatedDeviceIDsByPool     map[PoolID]sets.Set[DeviceID]
+	allocatedDeviceIDsByPoolOnce sync.Once
 	// numAllocateOneInvocations counts the number of times the allocateOne
 	// function is called for the allocator. This is a measurement of the
 	// amount of work the allocator had to do to allocate devices
@@ -133,7 +141,7 @@ func NewAllocator(ctx context.Context,
 			slicesOnNode[nodeName] = append(slicesOnNode[nodeName], slice)
 		}
 	}
-	return &Allocator{
+	a := &Allocator{
 		features:          features,
 		allocatedState:    allocatedState,
 		classLister:       classLister,
@@ -142,7 +150,36 @@ func NewAllocator(ctx context.Context,
 		allSlices:         slices,
 		celCache:          celCache,
 		availableCounters: make(map[PoolID]counterSets),
-	}, nil
+	}
+	return a, nil
+}
+
+// allocatedDeviceIDsByPool groups every allocated device ID by the pool that
+// published it, using the same sources as IsDeviceAllocated (dedicated devices,
+// shared allocations, and aggregated consumed capacity), so an allocated device
+// missing from a republished pool is detectable regardless of how the allocation
+// was recorded.
+func allocatedDeviceIDsByPool(state AllocatedState) map[PoolID]sets.Set[DeviceID] {
+	byPool := make(map[PoolID]sets.Set[DeviceID])
+	add := func(id DeviceID) {
+		poolID := PoolID{Driver: id.Driver, Pool: id.Pool}
+		ids := byPool[poolID]
+		if ids == nil {
+			ids = sets.New[DeviceID]()
+			byPool[poolID] = ids
+		}
+		ids.Insert(id)
+	}
+	for id := range state.AllocatedDevices {
+		add(id)
+	}
+	for sharedID := range state.AllocatedSharedDeviceIDs {
+		add(sharedID.GetDeviceID())
+	}
+	for id := range state.AggregatedCapacity {
+		add(id)
+	}
+	return byPool
 }
 
 func (a *Allocator) Channel() internal.AllocatorChannel {
@@ -1602,7 +1639,9 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 
 		// Update the data structure to reflect counters already consumed by allocated devices. This
 		// only includes devices where the allocation process has completed, so this will never
-		// change during the allocation process.
+		// change during the allocation process. While iterating, also record every DeviceID the
+		// pool currently publishes so allocated devices that are no longer present are detectable.
+		poolDeviceIDs := sets.New[DeviceID]()
 		for _, resourceSlices := range [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode} {
 			for _, slice := range resourceSlices {
 				for _, device := range slice.Spec.Devices {
@@ -1611,6 +1650,7 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 						Pool:   slice.Spec.Pool.Name,
 						Device: device.Name,
 					}
+					poolDeviceIDs.Insert(deviceID)
 					// Devices that aren't allocated doesn't consume any counters, so we don't
 					// need to consider them.
 					if !internal.IsDeviceAllocated(deviceID, &alloc.allocatedState) {
@@ -1637,11 +1677,38 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 			}
 		}
 
+		// Build the allocated-device-by-pool index the first time a pool's counters are
+		// computed rather than eagerly in NewAllocator, so a pod whose candidates never reach
+		// a counter check pays nothing. sync.Once keeps it safe across concurrent Allocate calls.
+		alloc.allocatedDeviceIDsByPoolOnce.Do(func() {
+			alloc.allocatedDeviceIDsByPool = allocatedDeviceIDsByPool(alloc.allocatedState)
+		})
+
+		// An allocated device this pool no longer publishes in any slice cannot have its counter
+		// consumption reconstructed (the slice is the only source), so the pool's counter
+		// availability is unknowable. Mark it unusable (nil) rather than over-commit counters
+		// still in use; the allocated DeviceID names this pool, so the device is detectable even
+		// without a consumption record.
+		for allocatedID := range alloc.allocatedDeviceIDsByPool[poolID] {
+			if !poolDeviceIDs.Has(allocatedID) {
+				alloc.logger.V(5).Info("Marking counter pool unavailable: an allocated device is no longer published in any slice",
+					"pool", poolID, "device", allocatedID)
+				availableCountersForPool = nil
+				break
+			}
+		}
+
 		// Set the available counters on the allocator so we don't have to
 		// compute this again.
 		alloc.mutex.Lock()
 		alloc.availableCounters[poolID] = availableCountersForPool
 		alloc.mutex.Unlock()
+	}
+
+	// A pool with an allocated device it no longer publishes has unknowable counter
+	// availability; do not allocate from it.
+	if availableCountersForPool == nil {
+		return false, nil
 	}
 
 	// Update the consumedCounters data structure with the counters consumed

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -92,17 +92,15 @@ type Allocator struct {
 	slicesShared   []*resourceapi.ResourceSlice
 	allSlices      []*resourceapi.ResourceSlice
 	celCache       *cel.Cache
-	// availableCounters contains the available counters for each
-	// resource pool. It acts as a cache that is updated the first time
-	// the available counters are needed for each pool. The information
-	// about each pool is never updated once set the first time.
-	// This is computed bsed on information on the Allocator, so it will
-	// be correct even for multiple usages of the Allocator.
-	// The keys in the map are resource pool IDs (driver name and pool name).
+	// availableCounters caches the counter baseline of each resource pool, keyed by driver
+	// and pool name. Sharing it across Allocate calls is only correct while they resolve
+	// equivalent counter sets, totals and allocated-device consumption for that pool.
 	// The allocator might be accessed by different goroutines, so
 	// access to this map must be synchronized.
 	availableCounters map[PoolID]counterSets
 	mutex             sync.RWMutex
+	// allocatedDeviceIndex reports the allocated devices and how many of them each pool holds.
+	allocatedDeviceIndex func() (sets.Set[DeviceID], map[PoolID]int)
 	// numAllocateOneInvocations counts the number of times the allocateOne
 	// function is called for the allocator. This is a measurement of the
 	// amount of work the allocator had to do to allocate devices
@@ -133,7 +131,7 @@ func NewAllocator(ctx context.Context,
 			slicesOnNode[nodeName] = append(slicesOnNode[nodeName], slice)
 		}
 	}
-	return &Allocator{
+	a := &Allocator{
 		features:          features,
 		allocatedState:    allocatedState,
 		classLister:       classLister,
@@ -142,7 +140,33 @@ func NewAllocator(ctx context.Context,
 		allSlices:         slices,
 		celCache:          celCache,
 		availableCounters: make(map[PoolID]counterSets),
-	}, nil
+	}
+	a.allocatedDeviceIndex = sync.OnceValues(a.buildAllocatedDeviceIndex)
+	return a, nil
+}
+
+// buildAllocatedDeviceIndex walks the three sources IsDeviceAllocated recognizes. A device
+// named by more than one of them counts once.
+func (a *Allocator) buildAllocatedDeviceIndex() (sets.Set[DeviceID], map[PoolID]int) {
+	ids := sets.New[DeviceID]()
+	perPool := make(map[PoolID]int)
+	add := func(id DeviceID) {
+		if ids.Has(id) {
+			return
+		}
+		ids.Insert(id)
+		perPool[PoolID{Driver: id.Driver, Pool: id.Pool}]++
+	}
+	for id := range a.allocatedState.AllocatedDevices {
+		add(id)
+	}
+	for sharedID := range a.allocatedState.AllocatedSharedDeviceIDs {
+		add(sharedID.GetDeviceID())
+	}
+	for id := range a.allocatedState.AggregatedCapacity {
+		add(id)
+	}
+	return ids, perPool
 }
 
 func (a *Allocator) Channel() internal.AllocatorChannel {
@@ -650,7 +674,9 @@ type allocator struct {
 	// that are in the process of being allocated.
 	// The keys in the map are resource pool IDs (driver name and pool name).
 	consumedCounters map[PoolID]counterSets
-	requestData      map[requestIndices]requestData // one entry per request with no subrequests and one entry per subrequest
+	// counterPoolAccountable is per node, since nodes can resolve different devices for a pool.
+	counterPoolAccountable map[PoolID]bool
+	requestData            map[requestIndices]requestData // one entry per request with no subrequests and one entry per subrequest
 	// allocatingDevices tracks which devices will be newly allocated for a
 	// particular attempt to find a solution. The map is indexed by device
 	// and its values represent for which of a pod's claims the device will
@@ -1365,9 +1391,10 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 		return false, nil, nil
 	}
 
-	// Skip the counter check for an allow-multiple device in use: its counters are already
-	// accounted for, so a further share must not charge them again.
-	skipCounterCheck := allowMultipleAllocations && alloc.deviceCapacityInUse(device.id)
+	// An admin-access result is not part of the allocated state the scheduler feeds back,
+	// and a further share of an in-use device is already accounted for: neither reserves.
+	skipCounterCheck := request.adminAccess() ||
+		(allowMultipleAllocations && alloc.deviceCapacityInUse(device.id))
 
 	// The API validation logic has checked the ConsumesCounters referred should exist inside SharedCounters.
 	// countersReserved records whether checkAvailableCounters actually reserved
@@ -1469,14 +1496,18 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 			shareID = GenerateNewShareID()
 			alloc.logger.V(7).Info("Device capacity allocated", "device", device.id,
 				"consumed capacity", klog.Format(consumedCapacity))
-			// A prior share of this device may already hold the capacity entry.
-			// That entry doubles as the "already shared" marker that lets a later
-			// share skip the counter check, so record whether it predated this
-			// share; rollback must not delete it while another share still needs it.
-			_, state.capacityEntryExisted = alloc.allocatingCapacity[device.id]
-			alloc.allocatingCapacity.Insert(NewDeviceConsumedCapacity(device.id, consumedCapacity))
-			state.capacityInserted = true
-			state.consumedCapacity = consumedCapacity
+			// The entry doubles as the "already shared" marker that lets a later share
+			// skip the counter check, so administrative access must not leave one: it
+			// reserved nothing for that share to inherit.
+			if !request.adminAccess() {
+				// A prior share of this device may already hold the entry. Record whether
+				// it predated this share; rollback must not delete it while another share
+				// still needs it.
+				_, state.capacityEntryExisted = alloc.allocatingCapacity[device.id]
+				alloc.allocatingCapacity.Insert(NewDeviceConsumedCapacity(device.id, consumedCapacity))
+				state.capacityInserted = true
+				state.consumedCapacity = consumedCapacity
+			}
 		}
 	}
 
@@ -1576,6 +1607,68 @@ func taintTolerated(taint resourceapi.DeviceTaint, request requestAccessor) bool
 	return false
 }
 
+// rememberAccountable memoizes the answer for this node's view of the pool.
+func (alloc *allocator) rememberAccountable(poolID PoolID, accountable bool) {
+	if alloc.counterPoolAccountable == nil {
+		alloc.counterPoolAccountable = make(map[PoolID]bool)
+	}
+	alloc.counterPoolAccountable[poolID] = accountable
+}
+
+// counterPoolIsAccountable reports whether the pool, as resolved for this node, still publishes
+// every device allocated from it; a dropped device leaves its counter use unreconstructable.
+// The answer is per node, unlike availableCounters, so it must be settled before that cache.
+func (alloc *allocator) counterPoolIsAccountable(pool *Pool) bool {
+	poolID := pool.PoolID
+	if accountable, found := alloc.counterPoolAccountable[poolID]; found {
+		return accountable
+	}
+
+	// Nothing allocated from the pool means nothing to account for, which is the common case.
+	allocated, perPool := alloc.allocatedDeviceIndex()
+	want := perPool[poolID]
+	if want == 0 {
+		alloc.rememberAccountable(poolID, true)
+		return true
+	}
+
+	// Track only the allocated devices, since a pool usually publishes far more, and stop
+	// once all of them have turned up. A view that dropped most of the pool publishes
+	// fewer than it has allocated, so size for whichever is smaller.
+	deviceSlices := [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode}
+	numPublished := 0
+	for _, resourceSlices := range deviceSlices {
+		for _, slice := range resourceSlices {
+			numPublished += len(slice.Spec.Devices)
+		}
+	}
+	seen := make(sets.Set[DeviceID], min(want, numPublished))
+scan:
+	for _, resourceSlices := range deviceSlices {
+		for _, slice := range resourceSlices {
+			for _, device := range slice.Spec.Devices {
+				id := DeviceID{Driver: slice.Spec.Driver, Pool: slice.Spec.Pool.Name, Device: device.Name}
+				if !allocated.Has(id) {
+					continue
+				}
+				seen.Insert(id)
+				if seen.Len() == want {
+					break scan
+				}
+			}
+		}
+	}
+
+	accountable := seen.Len() == want
+	if !accountable {
+		alloc.logger.V(5).Info("Marking counter pool unavailable: it no longer publishes every device allocated from it",
+			"node", klog.KObj(alloc.node), "pool", poolID,
+			"numAllocatedDevices", want, "numMissingDevices", want-seen.Len())
+	}
+	alloc.rememberAccountable(poolID, accountable)
+	return accountable
+}
+
 // checkAvailableCounters checks if there are enough counters available to allocate
 // the specified device.
 //
@@ -1585,6 +1678,10 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 	pool := device.pool
 	poolID := pool.PoolID
 
+	if !alloc.counterPoolIsAccountable(pool) {
+		return false, nil
+	}
+
 	// Check first if the available counters for this pool have already been
 	// calculated.
 	alloc.mutex.RLock()
@@ -1593,8 +1690,8 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 	// If not, we need to do it now. But we store the result so it doesn't need
 	// to be calculated again.
 	// Since this is computed without holding the lock on the mutex, other goroutines
-	// might also do this work. But the input will be the same to all of them, so
-	// the result will also always be the same.
+	// might also do this work. The results agree only when the resolved pools have the
+	// same counter sets and totals and the same consumption for their allocated devices.
 	if !found {
 		availableCountersForPool = make(counterSets, len(pool.CounterSets))
 		for _, counterSet := range pool.CounterSets {
@@ -1608,7 +1705,9 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 
 		// Update the data structure to reflect counters already consumed by allocated devices. This
 		// only includes devices where the allocation process has completed, so this will never
-		// change during the allocation process.
+		// change during the allocation process. Whether the pool can still account for all of
+		// them was settled before this point.
+		allocated, _ := alloc.allocatedDeviceIndex()
 		for _, resourceSlices := range [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode} {
 			for _, slice := range resourceSlices {
 				for _, device := range slice.Spec.Devices {
@@ -1617,9 +1716,8 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 						Pool:   slice.Spec.Pool.Name,
 						Device: device.Name,
 					}
-					// Devices that aren't allocated doesn't consume any counters, so we don't
-					// need to consider them.
-					if !internal.IsDeviceAllocated(deviceID, &alloc.allocatedState) {
+					// Devices that aren't allocated consume no counters.
+					if !allocated.Has(deviceID) {
 						continue
 					}
 					for _, deviceCounterConsumption := range device.ConsumesCounters {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_test.go
@@ -46,3 +46,18 @@ func TestAllocator(t *testing.T) {
 		newAllocator,
 	)
 }
+
+func TestCounterPoolAccountabilityAcrossNodesWithUnderreportedSliceCount(t *testing.T) {
+	allocatortesting.TestCounterPoolAccountabilityAcrossNodesWithUnderreportedSliceCount(t,
+		func(
+			ctx context.Context,
+			features Features,
+			allocatedState internal.AllocatedState,
+			classLister DeviceClassLister,
+			slices []*resourceapi.ResourceSlice,
+			celCache *cel.Cache,
+		) (internal.Allocator, error) {
+			return NewAllocator(ctx, features, allocatedState, classLister, slices, celCache)
+		},
+	)
+}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
@@ -74,6 +74,14 @@ type Allocator struct {
 	// access to this map must be synchronized.
 	availableCounters map[PoolID]counterSets
 	mutex             sync.RWMutex
+	// allocatedDeviceIDsByPool groups every allocated device ID by the pool that
+	// published it, letting checkAvailableCounters detect an allocated device a pool
+	// no longer publishes without rescanning the whole allocated set for every pool.
+	// Built lazily the first time checkAvailableCounters needs it, guarded by
+	// allocatedDeviceIDsByPoolOnce, then read-only, so a pod whose candidates never
+	// consult counters pays nothing.
+	allocatedDeviceIDsByPool     map[PoolID]sets.Set[DeviceID]
+	allocatedDeviceIDsByPoolOnce sync.Once
 	// numAllocateOneInvocations counts the number of times the allocateOne
 	// function is called for the allocator. This is a measurement of the
 	// amount of work the allocator had to do to allocate devices
@@ -94,14 +102,32 @@ func NewAllocator(ctx context.Context,
 	slices []*resourceapi.ResourceSlice,
 	celCache *cel.Cache,
 ) (*Allocator, error) {
-	return &Allocator{
+	a := &Allocator{
 		features:          features,
 		allocatedDevices:  allocatedDevices,
 		classLister:       classLister,
 		slices:            slices,
 		celCache:          celCache,
 		availableCounters: make(map[PoolID]counterSets),
-	}, nil
+	}
+	return a, nil
+}
+
+// allocatedDeviceIDsByPool groups every allocated device ID by the pool that
+// published it, so checkAvailableCounters can detect an allocated device a pool
+// no longer publishes without rescanning the whole allocated set for every pool.
+func allocatedDeviceIDsByPool(allocatedDevices sets.Set[DeviceID]) map[PoolID]sets.Set[DeviceID] {
+	byPool := make(map[PoolID]sets.Set[DeviceID])
+	for id := range allocatedDevices {
+		poolID := PoolID{Driver: id.Driver, Pool: id.Pool}
+		ids := byPool[poolID]
+		if ids == nil {
+			ids = sets.New[DeviceID]()
+			byPool[poolID] = ids
+		}
+		ids.Insert(id)
+	}
+	return byPool
 }
 
 func (a *Allocator) Channel() internal.AllocatorChannel {
@@ -1341,7 +1367,9 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 
 		// Update the data structure to reflect counters already consumed by allocated devices. This
 		// only includes devices where the allocation process has completed, so this will never
-		// change during the allocation process.
+		// change during the allocation process. While iterating, also record every DeviceID the
+		// pool currently publishes so allocated devices that are no longer present are detectable.
+		poolDeviceIDs := sets.New[DeviceID]()
 		for _, resourceSlices := range [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode} {
 			for _, slice := range resourceSlices {
 				for _, device := range slice.Spec.Devices {
@@ -1350,6 +1378,7 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 						Pool:   slice.Spec.Pool.Name,
 						Device: device.Name,
 					}
+					poolDeviceIDs.Insert(deviceID)
 					// Devices that aren't allocated doesn't consume any counters, so we don't
 					// need to consider them.
 					if !alloc.allocatedDevices.Has(deviceID) {
@@ -1376,11 +1405,38 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 			}
 		}
 
+		// Build the allocated-device-by-pool index the first time a pool's counters are
+		// computed rather than eagerly in NewAllocator, so a pod whose candidates never reach
+		// a counter check pays nothing. sync.Once keeps it safe across concurrent Allocate calls.
+		alloc.allocatedDeviceIDsByPoolOnce.Do(func() {
+			alloc.allocatedDeviceIDsByPool = allocatedDeviceIDsByPool(alloc.allocatedDevices)
+		})
+
+		// An allocated device this pool no longer publishes in any slice cannot have its counter
+		// consumption reconstructed (the slice is the only source), so the pool's counter
+		// availability is unknowable. Mark it unusable (nil) rather than over-commit counters
+		// still in use; the allocated DeviceID names this pool, so the device is detectable even
+		// without a consumption record.
+		for allocatedID := range alloc.allocatedDeviceIDsByPool[poolID] {
+			if !poolDeviceIDs.Has(allocatedID) {
+				alloc.logger.V(5).Info("Marking counter pool unavailable: an allocated device is no longer published in any slice",
+					"pool", poolID, "device", allocatedID)
+				availableCountersForPool = nil
+				break
+			}
+		}
+
 		// Set the available counters on the allocator so we don't have to
 		// compute this again.
 		alloc.mutex.Lock()
 		alloc.availableCounters[poolID] = availableCountersForPool
 		alloc.mutex.Unlock()
+	}
+
+	// A pool with an allocated device it no longer publishes has unknowable counter
+	// availability; do not allocate from it.
+	if availableCountersForPool == nil {
+		return false, nil
 	}
 
 	// Update the consumedCounters data structure with the counters consumed

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
@@ -63,17 +63,15 @@ type Allocator struct {
 	classLister      DeviceClassLister
 	slices           []*resourceapi.ResourceSlice
 	celCache         *cel.Cache
-	// availableCounters contains the available counters for each
-	// resource pool. It acts as a cache that is updated the first time
-	// the available counters are needed for each pool. The information
-	// about each pool is never updated once set the first time.
-	// This is computed bsed on information on the Allocator, so it will
-	// be correct even for multiple usages of the Allocator.
-	// The keys in the map are resource pool IDs (driver name and pool name).
+	// availableCounters caches the counter baseline of each resource pool, keyed by driver
+	// and pool name. Sharing it across Allocate calls is only correct while they resolve
+	// equivalent counter sets, totals and allocated-device consumption for that pool.
 	// The allocator might be accessed by different goroutines, so
 	// access to this map must be synchronized.
 	availableCounters map[PoolID]counterSets
 	mutex             sync.RWMutex
+	// allocatedDeviceIndex counts the allocations each pool holds; allocatedDevices answers membership.
+	allocatedDeviceIndex func() map[PoolID]int
 	// numAllocateOneInvocations counts the number of times the allocateOne
 	// function is called for the allocator. This is a measurement of the
 	// amount of work the allocator had to do to allocate devices
@@ -94,14 +92,26 @@ func NewAllocator(ctx context.Context,
 	slices []*resourceapi.ResourceSlice,
 	celCache *cel.Cache,
 ) (*Allocator, error) {
-	return &Allocator{
+	a := &Allocator{
 		features:          features,
 		allocatedDevices:  allocatedDevices,
 		classLister:       classLister,
 		slices:            slices,
 		celCache:          celCache,
 		availableCounters: make(map[PoolID]counterSets),
-	}, nil
+	}
+	a.allocatedDeviceIndex = sync.OnceValue(a.buildAllocatedDeviceIndex)
+	return a, nil
+}
+
+// buildAllocatedDeviceIndex counts the dedicated allocations of each pool. Their ids are
+// already unique.
+func (a *Allocator) buildAllocatedDeviceIndex() map[PoolID]int {
+	perPool := make(map[PoolID]int)
+	for id := range a.allocatedDevices {
+		perPool[PoolID{Driver: id.Driver, Pool: id.Pool}]++
+	}
+	return perPool
 }
 
 func (a *Allocator) Channel() internal.AllocatorChannel {
@@ -549,7 +559,9 @@ type allocator struct {
 	// that are in the process of being allocated.
 	// The keys in the map are resource pool IDs (driver name and pool name).
 	consumedCounters map[PoolID]counterSets
-	requestData      map[requestIndices]requestData // one entry per request with no subrequests and one entry per subrequest
+	// counterPoolAccountable is per node, since nodes can resolve different devices for a pool.
+	counterPoolAccountable map[PoolID]bool
+	requestData            map[requestIndices]requestData // one entry per request with no subrequests and one entry per subrequest
 	// allocatingDevices tracks which devices will be newly allocated for a
 	// particular attempt to find a solution. The map is indexed by device
 	// and its values represent for which of a pod's claims the device will
@@ -1163,8 +1175,9 @@ func (alloc *allocator) allocateDevice(r deviceIndices, device deviceWithID, mus
 	// The API validation logic has checked the ConsumesCounters referred should exist inside SharedCounters.
 	// countersReserved records whether checkAvailableCounters actually reserved
 	// this device's counters, so the rollback below only releases what was taken.
+	// An admin-access result is not part of the allocated state the scheduler feeds back.
 	countersReserved := false
-	if len(device.ConsumesCounters) > 0 {
+	if !request.adminAccess() && len(device.ConsumesCounters) > 0 {
 		// If a device consumes counters from a counter set, verify that
 		// there is sufficient counters available.
 		ok, err := alloc.checkAvailableCounters(device)
@@ -1309,6 +1322,68 @@ func taintTolerated(taint resourceapi.DeviceTaint, request requestAccessor) bool
 	return false
 }
 
+// rememberAccountable memoizes the answer for this node's view of the pool.
+func (alloc *allocator) rememberAccountable(poolID PoolID, accountable bool) {
+	if alloc.counterPoolAccountable == nil {
+		alloc.counterPoolAccountable = make(map[PoolID]bool)
+	}
+	alloc.counterPoolAccountable[poolID] = accountable
+}
+
+// counterPoolIsAccountable reports whether the pool, as resolved for this node, still publishes
+// every device allocated from it; a dropped device leaves its counter use unreconstructable.
+// The answer is per node, unlike availableCounters, so it must be settled before that cache.
+func (alloc *allocator) counterPoolIsAccountable(pool *Pool) bool {
+	poolID := pool.PoolID
+	if accountable, found := alloc.counterPoolAccountable[poolID]; found {
+		return accountable
+	}
+
+	// Nothing allocated from the pool means nothing to account for, which is the common case.
+	want := alloc.allocatedDeviceIndex()[poolID]
+	if want == 0 {
+		alloc.rememberAccountable(poolID, true)
+		return true
+	}
+
+	// Track only the allocated devices, since a pool usually publishes far more, and stop
+	// once all of them have turned up. A view that dropped most of the pool publishes
+	// fewer than it has allocated, so size for whichever is smaller.
+	allocated := alloc.allocatedDevices
+	deviceSlices := [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode}
+	numPublished := 0
+	for _, resourceSlices := range deviceSlices {
+		for _, slice := range resourceSlices {
+			numPublished += len(slice.Spec.Devices)
+		}
+	}
+	seen := make(sets.Set[DeviceID], min(want, numPublished))
+scan:
+	for _, resourceSlices := range deviceSlices {
+		for _, slice := range resourceSlices {
+			for _, device := range slice.Spec.Devices {
+				id := DeviceID{Driver: slice.Spec.Driver, Pool: slice.Spec.Pool.Name, Device: device.Name}
+				if !allocated.Has(id) {
+					continue
+				}
+				seen.Insert(id)
+				if seen.Len() == want {
+					break scan
+				}
+			}
+		}
+	}
+
+	accountable := seen.Len() == want
+	if !accountable {
+		alloc.logger.V(5).Info("Marking counter pool unavailable: it no longer publishes every device allocated from it",
+			"node", klog.KObj(alloc.node), "pool", poolID,
+			"numAllocatedDevices", want, "numMissingDevices", want-seen.Len())
+	}
+	alloc.rememberAccountable(poolID, accountable)
+	return accountable
+}
+
 // checkAvailableCounters checks if there are enough counters available to allocate
 // the specified device.
 //
@@ -1318,6 +1393,10 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 	pool := device.pool
 	poolID := pool.PoolID
 
+	if !alloc.counterPoolIsAccountable(pool) {
+		return false, nil
+	}
+
 	// Check first if the available counters for this pool have already been
 	// calculated.
 	alloc.mutex.RLock()
@@ -1326,8 +1405,8 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 	// If not, we need to do it now. But we store the result so it doesn't need
 	// to be calculated again.
 	// Since this is computed without holding the lock on the mutex, other goroutines
-	// might also do this work. But the input will be the same to all of them, so
-	// the result will also always be the same.
+	// might also do this work. The results agree only when the resolved pools have the
+	// same counter sets and totals and the same consumption for their allocated devices.
 	if !found {
 		availableCountersForPool = make(counterSets, len(pool.CounterSets))
 		for _, counterSet := range pool.CounterSets {
@@ -1341,7 +1420,8 @@ func (alloc *allocator) checkAvailableCounters(device deviceWithID) (bool, error
 
 		// Update the data structure to reflect counters already consumed by allocated devices. This
 		// only includes devices where the allocation process has completed, so this will never
-		// change during the allocation process.
+		// change during the allocation process. Whether the pool can still account for all of
+		// them was settled before this point.
 		for _, resourceSlices := range [][]*draapi.ResourceSlice{pool.DeviceSlicesTargetingNode, pool.DeviceSlicesNotTargetingNode} {
 			for _, slice := range resourceSlices {
 				for _, device := range slice.Spec.Devices {

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_test.go
@@ -41,3 +41,18 @@ func TestAllocator(t *testing.T) {
 		},
 	)
 }
+
+func TestCounterPoolAccountabilityAcrossNodesWithUnderreportedSliceCount(t *testing.T) {
+	allocatortesting.TestCounterPoolAccountabilityAcrossNodesWithUnderreportedSliceCount(t,
+		func(
+			ctx context.Context,
+			features Features,
+			allocatedState internal.AllocatedState,
+			classLister DeviceClassLister,
+			slices []*resourceapi.ResourceSlice,
+			celCache *cel.Cache,
+		) (internal.Allocator, error) {
+			return NewAllocator(ctx, features, allocatedState.AllocatedDevices, classLister, slices, celCache)
+		},
+	)
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`checkAvailableCounters` starts from the counter-set totals and subtracts the consumption of every allocated device it finds in the current ResourceSlices. When a driver republishes a pool without a device that is still allocated, that device is no longer in the slices, its consumption is not subtracted, and the pool looks like it has more counters free than it does, so the next allocation can over-commit them. The slices are the only record of what a device consumed, so the loss is unrecoverable from the allocated state.

The allocator now checks, per node and before it reads the shared counter cache, that every device allocated from the pool is still published by the pool view resolved for that node. A missing one stops new counter-consuming allocations from the pool on that node. Other nodes, other pools, and counterless devices are unaffected. The check runs before the cache because `availableCounters` is keyed by pool alone and shared across a cycle's `Allocate` calls. The allocated devices are indexed once per allocator, from the three sources `IsDeviceAllocated` reads.

Claims with `adminAccess` no longer reserve a device's shared counters. The scheduler already leaves admin-access results out of the allocated state, so reserving them charged the counters twice and could reject a monitoring claim.

The tests cover a dropped device recorded as dedicated, shared, or aggregated capacity, which all over-commit on master, a device published only by an obsolete generation or only in a slice for another node, an unaccountable pool next to a valid one, and the admin-access cases. One allocator is also run across two nodes in both orders, and that fails if the check moves behind the cache.

#### Which issue(s) this PR is related to:

Part of #140802

#### Special notes for your reviewer:

This only handles a device that disappeared from its slice. A device whose `ConsumesCounters` changed while allocated stays in #140802. In the 4 September benchstat run below, the usual paths were within noise at 10 to 10000 devices, and a pool with 200 shares per node went from 541ms to 6ms because the index replaces the scan in `IsDeviceAllocated`. The one slow row was the dropped-device case, where the allocator now exhausts the pool instead of over-committing. It predates the last rebase and I'll rerun it on request.

#### Does this PR introduce a user-facing change?

```release-note
kube-scheduler: the structured DRA allocator no longer over-commits a pool's shared counters after a driver republishes the pool without a device that is still allocated. Claims with adminAccess no longer reserve shared counters.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

The change and the tests were drafted with an AI assistant. I reviewed and edited them and ran the tests, benchmarks and linters myself.

/sig scheduling
/wg device-management
