### PR TITLE
Kubelet ippr overhead

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2268,19 +2268,17 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 	}
 
 	// Memory requests are not read from cgroups because cgroups do not track or enforce memory requests.
-	// Preserve existing status memory requests or fall back to aggregating requests from pod spec.
-	if _, found := resources.Requests[v1.ResourceMemory]; found {
-		if !preserveOldStatusValue(v1.ResourceMemory, oldPodStatus.Resources.Requests, resources.Requests) {
-			addOverheadToFallbackValue(v1.ResourceMemory, resources.Requests, false)
-		}
+	// Always aggregate/derive memory requests from pod spec and overhead.
+	opts := resourcehelper.PodResourcesOptions{
+		SkipPodLevelResources:                          !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources),
+		UseStatusResources:                             utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling),
+		InPlacePodLevelResourcesVerticalScalingEnabled: utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling),
+	}
+	aggregatedResources := resourcehelper.PodRequests(allocatedPod, opts)
+	if val, ok := aggregatedResources[v1.ResourceMemory]; ok {
+		resources.Requests[v1.ResourceMemory] = val
 	} else {
-		opts := resourcehelper.PodResourcesOptions{
-			SkipPodLevelResources: !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources),
-		}
-		aggregatedResources := resourcehelper.PodRequests(allocatedPod, opts)
-		if val, ok := aggregatedResources[v1.ResourceMemory]; ok {
-			resources.Requests[v1.ResourceMemory] = val
-		}
+		delete(resources.Requests, v1.ResourceMemory)
 	}
 
 	if cpuLimit != nil {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2214,10 +2214,22 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 	cpuRequest := cm.CPURequestsFromConfig(cpuConfig)
 	cpuLimit := cm.CPULimitsFromConfig(cpuConfig)
 
-	preserveOldResourcesValue := func(rName v1.ResourceName, oldStatusResource, resource v1.ResourceList) {
+	// preserveOldResourcesValue preserves old pod status resources if already present.
+	// When falling back to spec resources (e.g. cgroup config read fails), pod overhead is added.
+	preserveOldResourcesValue := func(rName v1.ResourceName, oldStatusResource, resource v1.ResourceList, isLimit bool) {
 		if allocatedPod.Status.Phase == v1.PodRunning && oldPodStatus.Phase == v1.PodRunning && oldPodStatus.Resources != nil {
 			if r, exists := oldStatusResource[rName]; exists {
 				resource[rName] = r.DeepCopy()
+				return
+			}
+		}
+		if val, found := resource[rName]; found && allocatedPod.Spec.Overhead != nil {
+			if overhead, ok := allocatedPod.Spec.Overhead[rName]; ok {
+				// Add overhead for requests, but for limits only add if a non-zero limit is set.
+				if !isLimit || !val.IsZero() {
+					val.Add(overhead)
+					resource[rName] = val
+				}
 			}
 		}
 	}
@@ -2248,10 +2260,14 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 			resources.Requests[v1.ResourceCPU] = cpuRequest.DeepCopy()
 		}
 	} else {
-		preserveOldResourcesValue(v1.ResourceCPU, oldPodStatus.Resources.Requests, resources.Requests)
+		preserveOldResourcesValue(v1.ResourceCPU, oldPodStatus.Resources.Requests, resources.Requests, false)
 	}
 
-	if _, found := resources.Requests[v1.ResourceMemory]; !found {
+	// Memory requests are not read from cgroups because cgroups do not track or enforce memory requests.
+	// Preserve existing status memory requests or fall back to aggregating requests from pod spec.
+	if _, found := resources.Requests[v1.ResourceMemory]; found {
+		preserveOldResourcesValue(v1.ResourceMemory, oldPodStatus.Resources.Requests, resources.Requests, false)
+	} else {
 		opts := resourcehelper.PodResourcesOptions{
 			SkipPodLevelResources: !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources),
 		}
@@ -2269,14 +2285,13 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 			resources.Limits[v1.ResourceCPU] = cpuLimit.DeepCopy()
 		}
 	} else {
-		preserveOldResourcesValue(v1.ResourceCPU, oldPodStatus.Resources.Limits, resources.Limits)
-
+		preserveOldResourcesValue(v1.ResourceCPU, oldPodStatus.Resources.Limits, resources.Limits, true)
 	}
 
 	if memoryLimit != nil {
 		resources.Limits[v1.ResourceMemory] = memoryLimit.DeepCopy()
 	} else {
-		preserveOldResourcesValue(v1.ResourceMemory, oldPodStatus.Resources.Limits, resources.Limits)
+		preserveOldResourcesValue(v1.ResourceMemory, oldPodStatus.Resources.Limits, resources.Limits, true)
 	}
 
 	return resources

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2214,15 +2214,19 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 	cpuRequest := cm.CPURequestsFromConfig(cpuConfig)
 	cpuLimit := cm.CPULimitsFromConfig(cpuConfig)
 
-	// preserveOldResourcesValue preserves old pod status resources if already present.
-	// When falling back to spec resources (e.g. cgroup config read fails), pod overhead is added.
-	preserveOldResourcesValue := func(rName v1.ResourceName, oldStatusResource, resource v1.ResourceList, isLimit bool) {
+	// preserveOldStatusValue preserves old pod status resources if already present.
+	preserveOldStatusValue := func(rName v1.ResourceName, oldStatusResource, resource v1.ResourceList) bool {
 		if allocatedPod.Status.Phase == v1.PodRunning && oldPodStatus.Phase == v1.PodRunning && oldPodStatus.Resources != nil {
 			if r, exists := oldStatusResource[rName]; exists {
 				resource[rName] = r.DeepCopy()
-				return
+				return true
 			}
 		}
+		return false
+	}
+
+	// addOverheadToFallbackValue adds pod overhead when falling back to spec resources.
+	addOverheadToFallbackValue := func(rName v1.ResourceName, resource v1.ResourceList, isLimit bool) {
 		if val, found := resource[rName]; found && allocatedPod.Spec.Overhead != nil {
 			if overhead, ok := allocatedPod.Spec.Overhead[rName]; ok {
 				// Add overhead for requests, but for limits only add if a non-zero limit is set.
@@ -2259,14 +2263,16 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 		if cpuRequest.MilliValue() > cm.MinShares || resources.Requests.Cpu().MilliValue() > cm.MinShares {
 			resources.Requests[v1.ResourceCPU] = cpuRequest.DeepCopy()
 		}
-	} else {
-		preserveOldResourcesValue(v1.ResourceCPU, oldPodStatus.Resources.Requests, resources.Requests, false)
+	} else if !preserveOldStatusValue(v1.ResourceCPU, oldPodStatus.Resources.Requests, resources.Requests) {
+		addOverheadToFallbackValue(v1.ResourceCPU, resources.Requests, false)
 	}
 
 	// Memory requests are not read from cgroups because cgroups do not track or enforce memory requests.
 	// Preserve existing status memory requests or fall back to aggregating requests from pod spec.
 	if _, found := resources.Requests[v1.ResourceMemory]; found {
-		preserveOldResourcesValue(v1.ResourceMemory, oldPodStatus.Resources.Requests, resources.Requests, false)
+		if !preserveOldStatusValue(v1.ResourceMemory, oldPodStatus.Resources.Requests, resources.Requests) {
+			addOverheadToFallbackValue(v1.ResourceMemory, resources.Requests, false)
+		}
 	} else {
 		opts := resourcehelper.PodResourcesOptions{
 			SkipPodLevelResources: !utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResources),
@@ -2284,14 +2290,14 @@ func (kl *Kubelet) convertToAPIPodLevelResourcesStatus(logger klog.Logger, alloc
 		if cpuLimit.MilliValue() > cm.MinMilliCPULimit || resources.Limits.Cpu().MilliValue() > cm.MinMilliCPULimit {
 			resources.Limits[v1.ResourceCPU] = cpuLimit.DeepCopy()
 		}
-	} else {
-		preserveOldResourcesValue(v1.ResourceCPU, oldPodStatus.Resources.Limits, resources.Limits, true)
+	} else if !preserveOldStatusValue(v1.ResourceCPU, oldPodStatus.Resources.Limits, resources.Limits) {
+		addOverheadToFallbackValue(v1.ResourceCPU, resources.Limits, true)
 	}
 
 	if memoryLimit != nil {
 		resources.Limits[v1.ResourceMemory] = memoryLimit.DeepCopy()
-	} else {
-		preserveOldResourcesValue(v1.ResourceMemory, oldPodStatus.Resources.Limits, resources.Limits, true)
+	} else if !preserveOldStatusValue(v1.ResourceMemory, oldPodStatus.Resources.Limits, resources.Limits) {
+		addOverheadToFallbackValue(v1.ResourceMemory, resources.Limits, true)
 	}
 
 	return resources

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -51,8 +52,10 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/cri-streaming/pkg/streaming/portforward"
 	"k8s.io/cri-streaming/pkg/streaming/remotecommand"
+	"k8s.io/klog/v2"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/features"
+	cmtesting "k8s.io/kubernetes/pkg/kubelet/cm/testing"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
@@ -4403,6 +4406,115 @@ func TestConvertToAPIContainerStatusesWithImageVolumeDigest(t *testing.T) {
 			for i, status := range containerStatuses {
 				assert.Equal(t, test.expected[i], status, "[test %s]", test.name)
 			}
+		})
+	}
+}
+
+func TestConvertToAPIPodLevelResourcesStatus(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
+
+	testKubelet := newTestKubelet(t, false)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	mockPCM := cmtesting.NewMockPodContainerManager(t)
+	mockCM := cmtesting.NewMockContainerManager(t)
+	mockCM.EXPECT().NewPodContainerManager().Return(mockPCM).Maybe()
+	kl.containerManager = mockCM
+
+	mockPCM.EXPECT().GetPodCgroupConfig(mock.Anything, v1.ResourceMemory).Return(nil, errors.New("cgroup not found")).Maybe()
+	mockPCM.EXPECT().GetPodCgroupConfig(mock.Anything, v1.ResourceCPU).Return(nil, errors.New("cgroup not found")).Maybe()
+
+	cases := []struct {
+		name        string
+		pod         *v1.Pod
+		oldStatus   v1.PodStatus
+		expectedRes *v1.ResourceRequirements
+	}{
+		{
+			name: "running pod with overhead adds overhead to fallback requests and limits",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{Phase: v1.PodRunning},
+				Spec: v1.PodSpec{
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("500m"),
+						v1.ResourceMemory: resource.MustParse("200Mi"),
+					},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("1"),
+							v1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("2"),
+							v1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+			oldStatus: v1.PodStatus{Phase: v1.PodRunning},
+			expectedRes: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(1500, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(1283457024, resource.BinarySI),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(2500, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(2357198848, resource.BinarySI),
+				},
+			},
+		},
+		{
+			name: "running pod preserves old status resources without double-adding overhead",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{Phase: v1.PodRunning},
+				Spec: v1.PodSpec{
+					Overhead: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("500m"),
+						v1.ResourceMemory: resource.MustParse("200Mi"),
+					},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("1"),
+							v1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("2"),
+							v1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+			oldStatus: v1.PodStatus{
+				Phase: v1.PodRunning,
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("1.5"),
+						v1.ResourceMemory: resource.MustParse("1.2Gi"),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2.5"),
+						v1.ResourceMemory: resource.MustParse("2.2Gi"),
+					},
+				},
+			},
+			expectedRes: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1.5"),
+					v1.ResourceMemory: resource.MustParse("1.2Gi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2.5"),
+					v1.ResourceMemory: resource.MustParse("2.2Gi"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := kl.convertToAPIPodLevelResourcesStatus(klog.Background(), tc.pod, tc.oldStatus)
+			assert.Equal(t, tc.expectedRes, got)
 		})
 	}
 }

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -4501,12 +4501,65 @@ func TestConvertToAPIPodLevelResourcesStatus(t *testing.T) {
 			expectedRes: &v1.ResourceRequirements{
 				Requests: v1.ResourceList{
 					v1.ResourceCPU:    resource.MustParse("1.5"),
-					v1.ResourceMemory: resource.MustParse("1.2Gi"),
+					v1.ResourceMemory: *resource.NewQuantity(1283457024, resource.BinarySI),
 				},
 				Limits: v1.ResourceList{
 					v1.ResourceCPU:    resource.MustParse("2.5"),
 					v1.ResourceMemory: resource.MustParse("2.2Gi"),
 				},
+			},
+		},
+		{
+			name: "running pod memory request resize updates status to new spec value rather than preserving old status",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{Phase: v1.PodRunning},
+				Spec: v1.PodSpec{
+					Overhead: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("200Mi"),
+					},
+					Resources: &v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+					},
+				},
+			},
+			oldStatus: v1.PodStatus{
+				Phase: v1.PodRunning,
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("1.2Gi"),
+					},
+				},
+			},
+			expectedRes: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceMemory: *resource.NewQuantity(2357198848, resource.BinarySI),
+				},
+				Limits: v1.ResourceList{},
+			},
+		},
+		{
+			name: "running pod without memory request clears memory request from status",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{Phase: v1.PodRunning},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "c1"},
+					},
+				},
+			},
+			oldStatus: v1.PodStatus{
+				Phase: v1.PodRunning,
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse("1.2Gi"),
+					},
+				},
+			},
+			expectedRes: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{},
+				Limits:   v1.ResourceList{},
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


#### What this PR does / why we need it:

- This PR adds the missing overhead in PodStatus resources when the values fall back to requested resources
- preserves the memory in PodStatus resources.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/135082
& Adding back memory in reported pod status that was removed in https://github.com/kubernetes/kubernetes/pull/140646 and fixing the calculation.
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

This change was initially part of https://github.com/kubernetes/kubernetes/pull/140481. 
