### PR TITLE
memorymanager: include init-only resources in pod requests

### DIFF
--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -772,7 +772,17 @@ func getPodRequestedResources(logger klog.Logger, pod *v1.Pod) (map[v1.ResourceN
 	}
 
 	reqRsrcs := make(map[v1.ResourceName]uint64)
+	resourceNames := make(map[v1.ResourceName]struct{})
 	for rsrcName := range reqRsrcsByAppCtrs {
+		resourceNames[rsrcName] = struct{}{}
+	}
+	for rsrcName := range reqRsrcsByRestartableInitCtrs {
+		resourceNames[rsrcName] = struct{}{}
+	}
+	for rsrcName := range reqRsrcsByInitCtrs {
+		resourceNames[rsrcName] = struct{}{}
+	}
+	for rsrcName := range resourceNames {
 		// Total resources requested by long-running containers.
 		reqRsrcsByLongRunningCtrs := reqRsrcsByAppCtrs[rsrcName] + reqRsrcsByRestartableInitCtrs[rsrcName]
 		reqRsrcs[rsrcName] = reqRsrcsByLongRunningCtrs

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -26,6 +26,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
@@ -772,15 +773,15 @@ func getPodRequestedResources(logger klog.Logger, pod *v1.Pod) (map[v1.ResourceN
 	}
 
 	reqRsrcs := make(map[v1.ResourceName]uint64)
-	resourceNames := make(map[v1.ResourceName]struct{})
+	resourceNames := sets.New[v1.ResourceName]()
 	for rsrcName := range reqRsrcsByAppCtrs {
-		resourceNames[rsrcName] = struct{}{}
+		resourceNames.Insert(rsrcName)
 	}
 	for rsrcName := range reqRsrcsByRestartableInitCtrs {
-		resourceNames[rsrcName] = struct{}{}
+		resourceNames.Insert(rsrcName)
 	}
 	for rsrcName := range reqRsrcsByInitCtrs {
-		resourceNames[rsrcName] = struct{}{}
+		resourceNames.Insert(rsrcName)
 	}
 	for rsrcName := range resourceNames {
 		// Total resources requested by long-running containers.

--- a/pkg/kubelet/cm/memorymanager/policy_static_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_test.go
@@ -4366,6 +4366,37 @@ func Test_getPodRequestedResources(t *testing.T) {
 			},
 		},
 		{
+			description: "resource requested only by a regular init container",
+			pod: getPodWithInitContainers(
+				"",
+				[]v1.Container{
+					{
+						Name: "app-container",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				[]v1.Container{
+					{
+						Name: "init-container",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+								hugepages1Gi:      resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			),
+			expected: map[v1.ResourceName]uint64{
+				v1.ResourceMemory: 1 * gb,
+				hugepages1Gi:      2 * gb,
+			},
+		},
+		{
 			description: "maximum resources of init containers < total resources of containers",
 			pod: getPodWithInitContainers(
 				"",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

The static Memory Manager calculates pod-scope resource requests independently for each memory resource type. The final aggregation previously iterated only over resource names requested by app containers, which dropped hugepage sizes requested exclusively by init containers.

This PR aggregates over the union of resource names requested by app, restartable init, and regular init containers before applying the existing per-resource calculation. It also adds a regression test where `hugepages-1Gi` is requested only by a regular init container.

#### Which issue(s) this PR is related to:

Fixes #140814

#### Special notes for your reviewer:

```console
```

#### Does this PR introduce a user-facing change?

```release-note
Fixed static Memory Manager pod-scope accounting for memory resource types requested only by init containers.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
