### PR TITLE
fix: deflake kubelet init container action tests

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1888,14 +1888,14 @@ func verifyActions(t *testing.T, expected, actual *podActions, desc string) {
 		// No need to distinguish empty and nil maps for the test.
 		expected.ContainersToUpdate = map[v1.ResourceName][]containerToUpdateInfo{}
 	}
+	if expected.ContainersToUpdate != nil && len(expected.ContainersToUpdate) == 0 && actual.ContainersToUpdate == nil {
+		// No need to distinguish empty and nil maps for the test.
+		actual.ContainersToUpdate = map[v1.ResourceName][]containerToUpdateInfo{}
+	}
 	assert.Equal(t, expected, actual, desc)
 }
 
 func TestComputePodActionsWithInitContainers(t *testing.T) {
-	tCtx := ktesting.Init(t)
-	_, _, m, err := createTestRuntimeManager(tCtx)
-	require.NoError(t, err)
-
 	cpu400m := resource.MustParse("400m")
 	memory400Mi := resource.MustParse("400Mi")
 	cpu800m := resource.MustParse("800m")
@@ -1915,7 +1915,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 		mutateStatusFn       func(*kubecontainer.PodStatus)
 		actions              podActions
 		disableIPPRInitCtrFG bool
-		skipWindows          bool
+		skipNonLinux         bool
 	}{
 		"initialization completed; start all containers": {
 			actions: podActions{
@@ -2166,7 +2166,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 					},
 				},
 			},
-			skipWindows: true, // Windows does not support resize.
+			skipNonLinux: true,
 		},
 		"resize of a running non-sidecar init container with FG disabled": {
 			mutatePodFn: func(pod *v1.Pod) {
@@ -2187,20 +2187,27 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				ContainersToKill:      getKillMapWithInitContainers(basePod, baseStatus, []int{}),
 				ContainersToUpdate:    map[v1.ResourceName][]containerToUpdateInfo{},
 			},
-			skipWindows:          true, // Windows does not support resize.
+			skipNonLinux:         true,
 			disableIPPRInitCtrFG: true,
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			if test.skipWindows && goruntime.GOOS == "windows" {
-				t.Skip("Skipping test since Windows does not support resize")
+			if test.skipNonLinux && goruntime.GOOS != "linux" {
+				t.Skip("Skipping test since in-place resize is only supported on Linux")
 			}
 			tCtx := ktesting.Init(t)
 
 			if test.disableIPPRInitCtrFG {
 				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.36"))
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingInitContainers, false)
+			} else {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.37"))
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeDeclaredFeatures, true)
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingInitContainers, true)
 			}
+
+			_, _, m, err := createTestRuntimeManager(tCtx)
+			require.NoError(t, err)
 
 			pod, status := makeBasePodAndStatusWithInitContainers()
 
@@ -2850,8 +2857,6 @@ func TestComputePodActionsWithContainerRestartRules(t *testing.T) {
 		containerRestartPolicyOnFailure = v1.ContainerRestartPolicyOnFailure
 		containerRestartPolicyNever     = v1.ContainerRestartPolicyNever
 	)
-	_, _, m, err := createTestRuntimeManager(tCtx)
-	require.NoError(t, err)
 
 	// Creating a pair reference pod and status for the test cases to refer
 	// the specific fields.
@@ -2965,6 +2970,9 @@ func TestComputePodActionsWithContainerRestartRules(t *testing.T) {
 			},
 		},
 	} {
+		_, _, m, err := createTestRuntimeManager(tCtx)
+		require.NoError(t, err)
+
 		pod, status := makeBasePodAndStatus()
 		if test.mutatePodFn != nil {
 			test.mutatePodFn(pod)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR deflakes kubelet init container pod action unit tests by isolating mutable runtime manager state per subtest and explicitly setting the feature gates required by the in-place
  resize scenarios.

  `TestComputePodActionsWithInitContainers` uses a map-based test table, so subtest execution order is randomized. The test previously reused a single `kubeGenericRuntimeManager`
  across all subtests. Some cases mutate feature gate state and initialize actuated pod resource state for the same pod UID, which can make later cases observe stale or incomplete
  actuated resource records.

  This caused intermittent failures such as missing actuated resource records for `init1` in resize-related init container cases.

  The PR makes each subtest create its own runtime manager and sets the relevant feature gates inside the subtest, so each case starts from isolated state.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/140815#event-28305125558
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
N/A
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
