### PR TITLE
Fix typos in scheduler, kubelet, and apiserver code comments

### DIFF
--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -277,7 +277,7 @@ func Test_Discover(t *testing.T) {
 			// TODO(fromanirh): replace with a real-world topology
 			// once we find a suitable one.
 			// Note: this is a fake topology. Thus, there is not a "correct"
-			// representation. This one was created following the these concepts:
+			// representation. This one was created following these concepts:
 			// 1. be internally consistent (most important rule)
 			// 2. be as close as possible as existing HW topologies
 			// 3. if possible, minimize chances wrt existing HW topologies.

--- a/pkg/kubelet/cm/dra/claiminfo.go
+++ b/pkg/kubelet/cm/dra/claiminfo.go
@@ -299,7 +299,7 @@ func (cache *claimInfoCache) syncToCheckpoint() error {
 	return cache.checkpointer.Store(checkpoint)
 }
 
-// claimsInUse computes the the current counter vector for DRAResourceClaimsInUse.
+// claimsInUse computes the current counter vector for DRAResourceClaimsInUse.
 // It returns a map of driver name to number of claims which have been prepared using
 // the driver. The [kubeletmetrics.DRAResourceClaimsInUseAnyDriver] key stands for
 // all prepared claims.

--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -111,7 +111,7 @@ func (m *kubeGenericRuntimeManager) ListImages(ctx context.Context) ([]kubeconta
 
 	for _, img := range allImages {
 		// Container runtimes may choose not to implement changes needed for KEP 4216. If
-		// the changes are not implemented by a container runtime, the exisiting behavior
+		// the changes are not implemented by a container runtime, the existing behavior
 		// of not populating the runtimeHandler CRI field in ImageSpec struct is preserved.
 		// Therefore, when RuntimeClassInImageCriAPI feature gate is set, check to see if this
 		// field is empty and log a warning message.

--- a/pkg/scheduler/backend/cache/snapshot.go
+++ b/pkg/scheduler/backend/cache/snapshot.go
@@ -39,7 +39,7 @@ type placementNodes struct {
 	// placement is the placement object used to assume this placement.
 	placement *fwk.Placement
 	// nodeInfoSet contains the set of nodes in the placement.
-	// This is useful for quickly checking if a node belongs the the placement.
+	// This is useful for quickly checking if a node belongs to the placement.
 	nodeInfoSet sets.Set[string]
 }
 

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1826,7 +1826,7 @@ func (p *PriorityQueue) MoveAllToActiveOrBackoffQueue(logger klog.Logger, event 
 // NOTE: this function assumes lock has been acquired in caller
 func (p *PriorityQueue) requeueEntityWithQueueingStrategy(logger klog.Logger, entity framework.QueuedEntityInfo, strategy queueingStrategy, event string) string {
 	if strategy == queueSkip {
-		// Current Gate status is required for already exisiting entities. For new entities, this parameter is ignored/unused by addPod/addPodGroup.
+		// Current Gate status is required for already existing entities. For new entities, this parameter is ignored/unused by addPod/addPodGroup.
 		p.unschedulableEntities.addOrUpdate(entity, entity.Gated(), event, &strategy)
 		return unschedulableQ
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/read_write_deadline_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/read_write_deadline_test.go
@@ -191,7 +191,7 @@ func TestRequestTimeoutBehavior(t *testing.T) {
 		//   d) the handler flushes the ResponseWriter object before request times out: No
 		// observation:
 		//  the timeout filter detects that the context of the request has exceeded its
-		//  deadline, and the the following takes place:
+		//  deadline, and the following takes place:
 		//   - it marks the ResponseWriter object as timeout=true, so any further attempt
 		//   to write to it will yield an 'http: Handler timeout' error
 		//   - it can't send '504 GatewayTimeout' to the client since the ResponseWriter


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup

### What this PR does / why we need it:
Fixes typographical errors in non-generated code comments across pkg/scheduler, pkg/kubelet, and staging/src/k8s.io/apiserver.

### Which issue(s) this PR fixes:
N/A

### Special notes for your reviewer:
None.

### Does this PR introduce a user-facing change?
```release-note
NONE
```
