### PR TITLE
Fix flaky TestComputePodActionsWithInitContainers in kuberuntime_manager_test

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1892,10 +1892,6 @@ func verifyActions(t *testing.T, expected, actual *podActions, desc string) {
 }
 
 func TestComputePodActionsWithInitContainers(t *testing.T) {
-	tCtx := ktesting.Init(t)
-	_, _, m, err := createTestRuntimeManager(tCtx)
-	require.NoError(t, err)
-
 	cpu400m := resource.MustParse("400m")
 	memory400Mi := resource.MustParse("400Mi")
 	cpu800m := resource.MustParse("800m")
@@ -2201,6 +2197,9 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.36"))
 				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingInitContainers, false)
 			}
+
+			_, _, m, err := createTestRuntimeManager(tCtx)
+			require.NoError(t, err)
 
 			pod, status := makeBasePodAndStatusWithInitContainers()
 
@@ -2850,8 +2849,6 @@ func TestComputePodActionsWithContainerRestartRules(t *testing.T) {
 		containerRestartPolicyOnFailure = v1.ContainerRestartPolicyOnFailure
 		containerRestartPolicyNever     = v1.ContainerRestartPolicyNever
 	)
-	_, _, m, err := createTestRuntimeManager(tCtx)
-	require.NoError(t, err)
 
 	// Creating a pair reference pod and status for the test cases to refer
 	// the specific fields.
@@ -2965,6 +2962,8 @@ func TestComputePodActionsWithContainerRestartRules(t *testing.T) {
 			},
 		},
 	} {
+		_, _, m, err := createTestRuntimeManager(tCtx)
+		require.NoError(t, err)
 		pod, status := makeBasePodAndStatus()
 		if test.mutatePodFn != nil {
 			test.mutatePodFn(pod)


### PR DESCRIPTION
Isolate the kubeGenericRuntimeManager instance per subtest in TestComputePodActionsWithInitContainers and TestComputePodActionsWithContainerRestartRules so that actuatedState checkpoints are not leaked across subtests.

#### What type of PR is this?

/kind flake
/kind failing-test

#### What this PR does / why we need it:

Because in `TestComputePodActionsWithInitContainers`, the runtime manager is instantiated at the top level and shared by each sub-testcases. However each sub-testcase rely on some internal state in the runtime manager for podResize `m.InitializeActuatedPod(tCtx.Logger(), pod)`, and caused the flake. This PR moves the runtime manager instantiation in each sub-testcase to ensure isolated runtime manager.

Same issue for TestComputePodActionsWithContainerRestartRules because it invokes TestComputePodActionsWithInitContainers.

Tested 50 times in parallel and no more flake are seen with the fix.

#### Which issue(s) this PR is related to:

Fixes #140815

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
