### PR TITLE
feat: add error outcome to route_sync_total metric

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -6270,8 +6270,9 @@
 - name: route_sync_total
   subsystem: route_controller
   help: A metric counting the number of route reconciles with the cloud provider,
-    labeled by the trigger (periodic or node_change) and the outcome (changed if at
-    least one route was created or deleted, otherwise noop).
+    labeled by the trigger (periodic or node_change) and the outcome (error if the
+    reconcile failed, changed if at least one route was created or deleted, otherwise
+    noop).
   type: Counter
   stabilityLevel: ALPHA
   labels:

--- a/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/metrics.go
@@ -26,6 +26,11 @@ import (
 const (
 	// subsystem is the name of this subsystem used for prometheus metrics.
 	subsystem = "route_controller"
+
+	// outcome label values for route_sync_total.
+	outcomeChanged = "changed"
+	outcomeNoop    = "noop"
+	outcomeError   = "error"
 )
 
 var registration sync.Once
@@ -33,7 +38,7 @@ var registration sync.Once
 var routeSyncCount = metrics.NewCounterVec(&metrics.CounterOpts{
 	Name:           "route_sync_total",
 	Subsystem:      subsystem,
-	Help:           "A metric counting the number of route reconciles with the cloud provider, labeled by the trigger (periodic or node_change) and the outcome (changed if at least one route was created or deleted, otherwise noop).",
+	Help:           "A metric counting the number of route reconciles with the cloud provider, labeled by the trigger (periodic or node_change) and the outcome (error if the reconcile failed, changed if at least one route was created or deleted, otherwise noop).",
 	StabilityLevel: metrics.ALPHA,
 }, []string{"outcome", "trigger"})
 
@@ -44,11 +49,15 @@ func registerMetrics() {
 }
 
 // recordRouteSync increments route_sync_total for a completed reconcile,
-// deriving the outcome label from whether any route was created or deleted.
-func recordRouteSync(routesChanged bool, trigger string) {
-	outcome := "noop"
-	if routesChanged {
-		outcome = "changed"
+// deriving the outcome label from the reconcile error and whether any route
+// was created or deleted.
+func recordRouteSync(routesChanged bool, err error, trigger string) {
+	outcome := outcomeNoop
+	switch {
+	case err != nil:
+		outcome = outcomeError
+	case routesChanged:
+		outcome = outcomeChanged
 	}
 	routeSyncCount.WithLabelValues(outcome, trigger).Inc()
 }

--- a/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/route/route_controller.go
@@ -208,13 +208,13 @@ func (rc *RouteController) Run(ctx context.Context, syncPeriod time.Duration, co
 	} else {
 		go wait.NonSlidingUntil(func() {
 			routesChanged, err := rc.reconcileNodeRoutes(ctx)
+			// Without the workqueue, reconciles are only driven by the
+			// syncPeriod timer, so the trigger is always periodic.
+			recordRouteSync(routesChanged, err, "periodic")
 			if err != nil {
 				klog.Errorf("Couldn't reconcile node routes: %v", err)
 				return
 			}
-			// Without the workqueue, reconciles are only driven by the
-			// syncPeriod timer, so the trigger is always periodic.
-			recordRouteSync(routesChanged, "periodic")
 		}, syncPeriod, ctx.Done())
 	}
 
@@ -250,14 +250,13 @@ func (rc *RouteController) processNextWorkItem(ctx context.Context) bool {
 
 		// Run the route reconciliation
 		routesChanged, err := rc.reconcileNodeRoutes(ctx)
+		recordRouteSync(routesChanged, err, key)
 		if err != nil {
 			// Put the item back on the workqueue to handle any transient errors.
 			rc.workqueue.AddRateLimited(key)
 			klog.Infof("Couldn't reconcile node routes: %v, requeuing", err)
 			return fmt.Errorf("couldn't reconcile node routes: %w, requeuing", err)
 		}
-
-		recordRouteSync(routesChanged, key)
 
 		return nil
 	}(obj)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds an `error` outcome to the `route_sync_total` metric in the cloud-provider route controller. Previously the metric only distinguished between `changed` (at least one route was created or deleted) and `noop` outcomes, and the metric was only recorded on successful reconciles. Failed reconciles were not counted at all.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The `route_sync_total` metric now records an `error` outcome when a route reconcile fails, in addition to the existing `changed` and `noop` outcomes.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/5237
```
