### PR TITLE
Revert "Speed up pkg/kubelet/podcertificate tests with synctest"

### DIFF
--- a/pkg/kubelet/podcertificate/podcertificatemanager_test.go
+++ b/pkg/kubelet/podcertificate/podcertificatemanager_test.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/test/utils/hermeticpodcertificatesigner"
 	"k8s.io/kubernetes/test/utils/ktesting"
-	"k8s.io/utils/clock"
 	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 )
@@ -308,14 +307,10 @@ func TestPCRDeletedWhileWaiting(t *testing.T) {
 }
 
 func TestFullFlow(t *testing.T) {
-	ktesting.Init(t).SyncTest("", testFullFlow)
-}
+	ctx, cancel := context.WithCancel(ktesting.Init(t))
+	defer cancel()
 
-func testFullFlow(tCtx ktesting.TContext) {
-	defer tCtx.Cancel("test completed")
-	t := tCtx.TB()
-	ctx := tCtx.Context
-
+	clock := testclock.NewFakeClock(mustRFC3339(t, "2010-01-01T00:00:00Z"))
 	kc := fake.NewSimpleClientset()
 
 	// Assign PCR name and creationTimeStamp
@@ -326,7 +321,7 @@ func testFullFlow(tCtx ktesting.TContext) {
 			if obj.Name == "" {
 				obj.Name = fmt.Sprintf("%s-pcr-%d", obj.Spec.PodName, rand.Int63n(1_000_000))
 			}
-			obj.CreationTimestamp = metav1.NewTime(time.Now())
+			obj.CreationTimestamp = metav1.NewTime(clock.Now())
 
 			return false, obj, nil // allow normal processing
 		})
@@ -371,7 +366,7 @@ func testFullFlow(tCtx ktesting.TContext) {
 	if err != nil {
 		t.Fatalf("Unexpected error generating CA hierarchy: %v", err)
 	}
-	pcrSigner := hermeticpodcertificatesigner.New(clock.RealClock{}, signerName, caKeys, caCerts, kc)
+	pcrSigner := hermeticpodcertificatesigner.New(clock, signerName, caKeys, caCerts, kc)
 	go pcrSigner.Run(ctx)
 	//
 	// Configure and boot up enough Kubelet subsystems to run an IssuingManager.
@@ -397,7 +392,7 @@ func testFullFlow(tCtx ktesting.TContext) {
 		informerFactory.Certificates().V1().PodCertificateRequests(),
 		informerFactory.Core().V1().Nodes(),
 		types.NodeName(node1.ObjectMeta.Name),
-		clock.RealClock{},
+		clock,
 	)
 	// Start informers
 	informerFactory.Start(ctx.Done())
@@ -601,7 +596,7 @@ func testFullFlow(tCtx ktesting.TContext) {
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, _, err := node1PodCertificateManager.GetPodCertificateCredentialBundle(ctx, workloadPod.ObjectMeta.Namespace, workloadPod.ObjectMeta.Name, string(workloadPod.ObjectMeta.UID), "certificate", 0)
 		if err != nil {
-			tCtx.Logf("Credential bundle not ready yet: %v", err)
+			t.Logf("Credential bundle not ready yet: %v", err)
 			return false, nil
 		}
 		return true, nil
@@ -619,10 +614,8 @@ func testFullFlow(tCtx ktesting.TContext) {
 		t.Fatalf("PodCertificate manager returned bad cert chain; diff (-got +want)\n%s", diff)
 	}
 
-	oldPCRName := gotPCR.ObjectMeta.Name
-
 	// Fast-forward time until it is past beginRefreshAt (including the possible 5-minute jitter).
-	time.Sleep(23*time.Hour + 37*time.Minute)
+	clock.Step(23*time.Hour + 37*time.Minute)
 
 	// Within a few seconds, we should see a new PodCertificateRequest created for
 	// this pod.
@@ -632,18 +625,15 @@ func testFullFlow(tCtx ktesting.TContext) {
 			return false, fmt.Errorf("while listing PodCertificateRequests: %w", err)
 		}
 
-		for _, pcr := range pcrs.Items {
-			// Old PCR is still there, make sure we get the new one.
-			if pcr.ObjectMeta.Name != oldPCRName {
-				gotPCR = &pcr
-				return true, nil
-			}
+		if len(pcrs.Items) == 0 {
+			return false, nil
 		}
 
-		return false, nil
+		gotPCR = &pcrs.Items[0]
+		return true, nil
 	})
 	if err != nil {
-		t.Fatalf("Error while waiting for new PCR to be created: %v", err)
+		t.Fatalf("Error while waiting for PCR to be created: %v", err)
 	}
 
 	// We will assume that the created PCR matches our expectations.
@@ -655,17 +645,11 @@ func testFullFlow(tCtx ktesting.TContext) {
 			return false, fmt.Errorf("while listing PodCertificateRequests: %w", err)
 		}
 
-		var updatedPCR *certsv1.PodCertificateRequest
-		for _, pcr := range pcrs.Items {
-			if pcr.ObjectMeta.Name == gotPCR.ObjectMeta.Name {
-				updatedPCR = &pcr
-				break
-			}
-		}
-		if updatedPCR == nil {
+		if len(pcrs.Items) == 0 {
 			return false, nil
 		}
-		gotPCR = updatedPCR
+
+		gotPCR = &pcrs.Items[0]
 
 		for _, cond := range gotPCR.Status.Conditions {
 			switch cond.Type {
@@ -686,7 +670,7 @@ func testFullFlow(tCtx ktesting.TContext) {
 	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, certChain, err := node1PodCertificateManager.GetPodCertificateCredentialBundle(ctx, workloadPod.ObjectMeta.Namespace, workloadPod.ObjectMeta.Name, string(workloadPod.ObjectMeta.UID), "certificate", 0)
 		if err != nil {
-			tCtx.Logf("Refreshed credential bundle not ready yet: %v", err)
+			t.Logf("Refreshed credential bundle not ready yet: %v", err)
 			return false, nil
 		}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/kind flake

#### What this PR does / why we need it:

This reverts commit d17b4548245288515101be6719c0a807cfafe6d2 from https://github.com/kubernetes/kubernetes/pull/138455.

The synctest bubble occasionally fails with:

    --- FAIL: TestFullFlow (0.01s)
    panic: deadlock: main bubble goroutine has exited but blocked goroutines remain [recovered, repanicked]

The code running inside the bubble seems to leak a goroutine. That must be fixed before the commit can be re-applied.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/140545
https://github.com/kubernetes/kubernetes/issues/140822

#### Special notes for your reviewer:

There was a conflict with 57c6b19abb8b0b2861960b18524a31f7afe0015a, resolved manually:

```
<<<<<<< HEAD
		var updatedPCR *certsv1.PodCertificateRequest
		for _, pcr := range pcrs.Items {
			if pcr.ObjectMeta.Name == gotPCR.ObjectMeta.Name {
				updatedPCR = &pcr
				break
			}
		}
		if updatedPCR == nil {
||||||| parent of f76e5733cd8 (Revert "Speed up pkg/kubelet/podcertificate tests with synctest")
		var updatedPCR *certsv1beta1.PodCertificateRequest
		for _, pcr := range pcrs.Items {
			if pcr.ObjectMeta.Name == gotPCR.ObjectMeta.Name {
				updatedPCR = &pcr
				break
			}
		}
		if updatedPCR == nil {
=======
		if len(pcrs.Items) == 0 {
>>>>>>> f76e5733cd8 (Revert "Speed up pkg/kubelet/podcertificate tests with synctest")
```

The more complex for loop is from the to-be-reverted commit. I don't know how that relates to synctest, but for the sake of doing a full revert I am going back to the original `if len(pcrs.Items) == 0 {`

/cc @tallclair @pacoxu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
