### PR TITLE
Fix CompositePodGroup event handler argument order and unit tests

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -546,7 +546,7 @@ func (sched *Scheduler) addCompositePodGroup(obj any) {
 	logger.V(3).Info("Add event for composite pod group", "compositePodGroup", klog.KObj(cpg))
 	sched.Cache.AddCompositePodGroup(logger, cpg)
 	sched.SchedulingQueue.AddCompositePodGroup(logger, cpg)
-	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, cpg, nil, nil)
+	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, nil, cpg, nil)
 }
 
 func (sched *Scheduler) updateCompositePodGroup(oldObj, newObj any) {
@@ -571,7 +571,7 @@ func (sched *Scheduler) updateCompositePodGroup(oldObj, newObj any) {
 	logger.V(4).Info("Update event for composite pod group", "compositePodGroup", klog.KObj(newCPG))
 	sched.Cache.UpdateCompositePodGroup(logger, oldCPG, newCPG)
 	sched.SchedulingQueue.UpdateCompositePodGroup(logger, newCPG)
-	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, newCPG, oldCPG, nil)
+	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, oldCPG, newCPG, nil)
 }
 
 func (sched *Scheduler) deleteCompositePodGroup(obj any) {

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -1500,10 +1500,11 @@ func TestAddCompositePodGroup(t *testing.T) {
 	cpg := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
 
 	tests := []struct {
-		name          string
-		cpg           any
-		cpgEnabled    bool
-		expectInCache bool
+		name                string
+		cpg                 any
+		cpgEnabled          bool
+		expectInCache       bool
+		triggerQueueingHint bool
 	}{
 		{
 			name:          "add valid composite pod group with feature enabled",
@@ -1523,6 +1524,13 @@ func TestAddCompositePodGroup(t *testing.T) {
 			cpgEnabled:    true,
 			expectInCache: false,
 		},
+		{
+			name:                "add valid composite pod group triggers queueing hint with correct arguments",
+			cpg:                 cpg,
+			cpgEnabled:          true,
+			expectInCache:       true,
+			triggerQueueingHint: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1537,10 +1545,54 @@ func TestAddCompositePodGroup(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
+			var actualOldObj, actualNewObj any
+			var queueingHintCalled bool
+			activeHint := func(logger klog.Logger, pod *v1.Pod, oldObj, newObj any) (fwk.QueueingHint, error) {
+				queueingHintCalled = true
+				actualOldObj = oldObj
+				actualNewObj = newObj
+				return fwk.QueueSkip, nil
+			}
+
+			queueingHintMap := internalqueue.QueueingHintMapPerProfile{
+				testSchedulerName: {
+					fwk.ClusterEvent{Resource: fwk.CompositePodGroup, ActionType: fwk.Add}: {
+						{PluginName: "fake-plugin", QueueingHintFn: activeHint},
+					},
+				},
+			}
+
+			pod := st.MakePod().Name("p").Namespace("ns1").UID("pns").SchedulerName(testSchedulerName).Obj()
+			client := fake.NewClientset(pod)
+			apiDispatcher := apidispatcher.New(client, 16, apicalls.Relevances)
+			apiDispatcher.Run(logger)
+			defer apiDispatcher.Close()
+
+			queue := internalqueue.NewTestQueue(ctx, nil,
+				internalqueue.WithQueueingHintMapPerProfile(queueingHintMap),
+				internalqueue.WithAPIDispatcher(apiDispatcher),
+			)
+
 			sched := &Scheduler{
 				Cache:           internalcache.New(ctx, nil, true, tt.cpgEnabled),
-				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+				SchedulingQueue: queue,
 				logger:          logger,
+			}
+
+			if tt.triggerQueueingHint {
+				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
+				queue.AddCompositePodGroup(logger, cpgObj)
+				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
+				queue.AddPodGroup(logger, pg)
+
+				queue.Add(ctx, pod)
+				poppedEntity, _ := queue.Pop(logger)
+				poppedPod := poppedEntity.(*framework.QueuedPodInfo)
+				poppedPod.QueueingParams.Timestamp = time.Now().Add(-10 * time.Minute)
+				poppedPod.QueueingParams.UnschedulablePlugins = sets.New("fake-plugin")
+				if err := queue.AddUnschedulablePodIfNotPresent(logger, poppedPod, queue.SchedulingCycle()); err != nil {
+					t.Fatalf("Failed to add unschedulable pod: %v", err)
+				}
 			}
 
 			sched.addCompositePodGroup(tt.cpg)
@@ -1556,6 +1608,18 @@ func TestAddCompositePodGroup(t *testing.T) {
 			} else if err == nil {
 				t.Errorf("Expected composite pod group NOT to be in cache, but got: %v", gotCPG)
 			}
+
+			if tt.triggerQueueingHint {
+				if !queueingHintCalled {
+					t.Errorf("expected QueueingHint to be called")
+				}
+				if actualOldObj != nil {
+					t.Errorf("expected oldObj to be nil, got %v", actualOldObj)
+				}
+				if actualNewObj != tt.cpg {
+					t.Errorf("expected newObj to be %v, got %v", tt.cpg, actualNewObj)
+				}
+			}
 		})
 	}
 }
@@ -1567,12 +1631,13 @@ func TestUpdateCompositePodGroup(t *testing.T) {
 	newCPG.ResourceVersion = "2"
 
 	tests := []struct {
-		name          string
-		oldCPG        any
-		newCPG        any
-		expectCPG     *schedulingv1alpha3.CompositePodGroup
-		cpgEnabled    bool
-		expectInCache bool
+		name                string
+		oldCPG              any
+		newCPG              any
+		expectCPG           *schedulingv1alpha3.CompositePodGroup
+		cpgEnabled          bool
+		expectInCache       bool
+		triggerQueueingHint bool
 	}{
 		{
 			name:          "update valid composite pod group with feature enabled",
@@ -1614,6 +1679,15 @@ func TestUpdateCompositePodGroup(t *testing.T) {
 			cpgEnabled:    true,
 			expectInCache: true,
 		},
+		{
+			name:                "update valid composite pod group triggers queueing hint with correct arguments",
+			oldCPG:              oldCPG,
+			newCPG:              newCPG,
+			expectCPG:           newCPG,
+			cpgEnabled:          true,
+			expectInCache:       true,
+			triggerQueueingHint: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1628,14 +1702,58 @@ func TestUpdateCompositePodGroup(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
+			var actualOldObj, actualNewObj any
+			var queueingHintCalled bool
+			activeHint := func(logger klog.Logger, pod *v1.Pod, oldObj, newObj any) (fwk.QueueingHint, error) {
+				queueingHintCalled = true
+				actualOldObj = oldObj
+				actualNewObj = newObj
+				return fwk.QueueSkip, nil
+			}
+
+			queueingHintMap := internalqueue.QueueingHintMapPerProfile{
+				testSchedulerName: {
+					fwk.ClusterEvent{Resource: fwk.CompositePodGroup, ActionType: fwk.Update}: {
+						{PluginName: "fake-plugin", QueueingHintFn: activeHint},
+					},
+				},
+			}
+
+			pod := st.MakePod().Name("p").Namespace("ns1").UID("pns").SchedulerName(testSchedulerName).Obj()
+			client := fake.NewClientset(pod)
+			apiDispatcher := apidispatcher.New(client, 16, apicalls.Relevances)
+			apiDispatcher.Run(logger)
+			defer apiDispatcher.Close()
+
+			queue := internalqueue.NewTestQueue(ctx, nil,
+				internalqueue.WithQueueingHintMapPerProfile(queueingHintMap),
+				internalqueue.WithAPIDispatcher(apiDispatcher),
+			)
+
 			sched := &Scheduler{
 				Cache:           internalcache.New(ctx, nil, true, tt.cpgEnabled),
-				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+				SchedulingQueue: queue,
 				logger:          logger,
 			}
 
 			if tt.cpgEnabled {
 				sched.Cache.AddCompositePodGroup(logger, oldCPG)
+			}
+
+			if tt.triggerQueueingHint {
+				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
+				queue.AddCompositePodGroup(logger, cpgObj)
+				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
+				queue.AddPodGroup(logger, pg)
+
+				queue.Add(ctx, pod)
+				poppedEntity, _ := queue.Pop(logger)
+				poppedPod := poppedEntity.(*framework.QueuedPodInfo)
+				poppedPod.QueueingParams.Timestamp = time.Now().Add(-10 * time.Minute)
+				poppedPod.QueueingParams.UnschedulablePlugins = sets.New("fake-plugin")
+				if err := queue.AddUnschedulablePodIfNotPresent(logger, poppedPod, queue.SchedulingCycle()); err != nil {
+					t.Fatalf("Failed to add unschedulable pod: %v", err)
+				}
 			}
 
 			sched.updateCompositePodGroup(tt.oldCPG, tt.newCPG)
@@ -1651,6 +1769,18 @@ func TestUpdateCompositePodGroup(t *testing.T) {
 			} else if err == nil {
 				t.Errorf("Expected composite pod group NOT to be in cache, but got: %v", gotCPG)
 			}
+
+			if tt.triggerQueueingHint {
+				if !queueingHintCalled {
+					t.Errorf("expected QueueingHint to be called")
+				}
+				if actualOldObj != tt.oldCPG {
+					t.Errorf("expected oldObj to be %v, got %v", tt.oldCPG, actualOldObj)
+				}
+				if actualNewObj != tt.newCPG {
+					t.Errorf("expected newObj to be %v, got %v", tt.newCPG, actualNewObj)
+				}
+			}
 		})
 	}
 }
@@ -1659,25 +1789,28 @@ func TestDeleteCompositePodGroup(t *testing.T) {
 	cpg := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
 
 	tests := []struct {
-		name              string
-		initCPG           *schedulingv1alpha3.CompositePodGroup
-		cpgToDelete       any
-		cpgEnabled        bool
-		expectStillExists bool
+		name                string
+		initCPG             *schedulingv1alpha3.CompositePodGroup
+		cpgToDelete         any
+		cpgEnabled          bool
+		expectStillExists   bool
+		triggerQueueingHint bool
 	}{
 		{
-			name:              "delete composite pod group",
-			initCPG:           cpg,
-			cpgToDelete:       cpg,
-			cpgEnabled:        true,
-			expectStillExists: false,
+			name:                "delete composite pod group",
+			initCPG:             cpg,
+			cpgToDelete:         cpg,
+			cpgEnabled:          true,
+			expectStillExists:   false,
+			triggerQueueingHint: true,
 		},
 		{
-			name:              "delete DeletedFinalStateUnknown tombstone with composite pod group",
-			initCPG:           cpg,
-			cpgToDelete:       cache.DeletedFinalStateUnknown{Obj: cpg},
-			cpgEnabled:        true,
-			expectStillExists: false,
+			name:                "delete DeletedFinalStateUnknown tombstone with composite pod group",
+			initCPG:             cpg,
+			cpgToDelete:         cache.DeletedFinalStateUnknown{Obj: cpg},
+			cpgEnabled:          true,
+			expectStillExists:   false,
+			triggerQueueingHint: true,
 		},
 		{
 			name:              "delete composite pod group with feature disabled",
@@ -1707,10 +1840,54 @@ func TestDeleteCompositePodGroup(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
+			var actualOldObj, actualNewObj any
+			var queueingHintCalled bool
+			activeHint := func(logger klog.Logger, pod *v1.Pod, oldObj, newObj any) (fwk.QueueingHint, error) {
+				queueingHintCalled = true
+				actualOldObj = oldObj
+				actualNewObj = newObj
+				return fwk.QueueSkip, nil
+			}
+
+			queueingHintMap := internalqueue.QueueingHintMapPerProfile{
+				testSchedulerName: {
+					fwk.ClusterEvent{Resource: fwk.CompositePodGroup, ActionType: fwk.Delete}: {
+						{PluginName: "fake-plugin", QueueingHintFn: activeHint},
+					},
+				},
+			}
+
+			pod := st.MakePod().Name("p").Namespace("ns1").UID("pns").SchedulerName(testSchedulerName).Obj()
+			client := fake.NewClientset(pod)
+			apiDispatcher := apidispatcher.New(client, 16, apicalls.Relevances)
+			apiDispatcher.Run(logger)
+			defer apiDispatcher.Close()
+
+			queue := internalqueue.NewTestQueue(ctx, nil,
+				internalqueue.WithQueueingHintMapPerProfile(queueingHintMap),
+				internalqueue.WithAPIDispatcher(apiDispatcher),
+			)
+
 			sched := &Scheduler{
 				Cache:           internalcache.New(ctx, nil, true, tt.cpgEnabled),
-				SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
+				SchedulingQueue: queue,
 				logger:          logger,
+			}
+
+			if tt.triggerQueueingHint {
+				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
+				queue.AddCompositePodGroup(logger, cpgObj)
+				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
+				queue.AddPodGroup(logger, pg)
+
+				queue.Add(ctx, pod)
+				poppedEntity, _ := queue.Pop(logger)
+				poppedPod := poppedEntity.(*framework.QueuedPodInfo)
+				poppedPod.QueueingParams.Timestamp = time.Now().Add(-10 * time.Minute)
+				poppedPod.QueueingParams.UnschedulablePlugins = sets.New("fake-plugin")
+				if err := queue.AddUnschedulablePodIfNotPresent(logger, poppedPod, queue.SchedulingCycle()); err != nil {
+					t.Fatalf("Failed to add unschedulable pod: %v", err)
+				}
 			}
 
 			if tt.initCPG != nil && tt.cpgEnabled {
@@ -1718,6 +1895,22 @@ func TestDeleteCompositePodGroup(t *testing.T) {
 			}
 
 			sched.deleteCompositePodGroup(tt.cpgToDelete)
+
+			if tt.triggerQueueingHint {
+				if !queueingHintCalled {
+					t.Errorf("expected QueueingHint to be called")
+				}
+				expectedOldObj := tt.cpgToDelete
+				if tombstone, ok := tt.cpgToDelete.(cache.DeletedFinalStateUnknown); ok {
+					expectedOldObj = tombstone.Obj
+				}
+				if actualOldObj != expectedOldObj {
+					t.Errorf("expected oldObj to be %v, got %v", expectedOldObj, actualOldObj)
+				}
+				if actualNewObj != nil {
+					t.Errorf("expected newObj to be nil, got %v", actualNewObj)
+				}
+			}
 
 			gotCPG, err := sched.Cache.CompositePodGroups().Get(cpg.Namespace, cpg.Name)
 			if tt.expectStillExists {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes a scheduler panic caused by incorrect argument ordering in `CompositePodGroup` event handlers.
Previously, the `addCompositePodGroup` and `updateCompositePodGroup` handlers were passing arguments in the wrong order or providing `nil` incorrectly to `MoveAllToActiveOrBackoffQueue` (e.g., passing `(newObj, oldObj)` or `(cpg, nil)` instead of `(nil, cpg)` for Add events). This resulted in downstream `QueueingHint` functions receiving `nil` objects where they expected valid API objects, causing a `nil pointer dereference` panic when plugins (like `GangScheduling`) attempted to evaluate the hint.
This PR:
1. Corrects the argument ordering to adhere to the standard `(oldObj, newObj)` convention.
2. Refactors `TestAddCompositePodGroup` and `TestUpdateCompositePodGroup` to utilize the real plugin `QueueingHint` logic. The test hook now correctly stages the test Pod and its hierarchical groups in the queue so the hints evaluate successfully, ensuring the correct order of arguments passed to QueueingHint functions.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:
The unit tests in `eventhandlers_test.go` were refactored to actively inject the pods into the `unschedulableQ` alongside the parent `PodGroup` and `CompositePodGroup`. This ensures that the `MoveAllToActiveOrBackoffQueue` logic successfully routes the test pods to the actual `QueueingHint` execution branch. Without this robust setup, the pods would be swallowed by the `incompletePodGroupPods` queue, and the test would silently pass without evaluating the hint arguments.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
