### PR TITLE
Drop k8s.io/utils/ptr from genericclioptions

### DIFF
--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -32,7 +32,6 @@
   - k8s.io/cli-runtime/pkg/printers
   - k8s.io/cli-runtime/pkg/resource
   - k8s.io/cli-runtime/pkg/kustomize
-  - k8s.io/utils/ptr
 
 - baseImportPath: "./staging/src/k8s.io/apimachinery"
   allowedImports:

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/utils/ptr"
 )
 
 // ResourceBuilderFlags are flags for finding resources
@@ -48,7 +47,7 @@ func NewResourceBuilderFlags() *ResourceBuilderFlags {
 		FileNameFlags: &FileNameFlags{
 			Usage:     "identifying the resource.",
 			Filenames: &filenames,
-			Recursive: ptr.To(true),
+			Recursive: new(true),
 		},
 	}
 }
@@ -61,7 +60,7 @@ func (o *ResourceBuilderFlags) WithFile(recurse bool, kustomize *string, files .
 		Usage:     "identifying the resource.",
 		Filenames: &files,
 		Kustomize: kustomize,
-		Recursive: ptr.To(recurse),
+		Recursive: new(recurse),
 	}
 
 	return o

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
-	"k8s.io/utils/ptr"
 )
 
 const (
@@ -435,8 +434,8 @@ func (f *ConfigFlags) AddFlags(flags *pflag.FlagSet) {
 
 // WithDeprecatedPasswordFlag enables the username and password config flags
 func (f *ConfigFlags) WithDeprecatedPasswordFlag() *ConfigFlags {
-	f.Username = ptr.To("")
-	f.Password = ptr.To("")
+	f.Username = new("")
+	f.Password = new("")
 	return f
 }
 
@@ -473,22 +472,22 @@ func NewConfigFlags(usePersistentConfig bool) *ConfigFlags {
 
 	return &ConfigFlags{
 		Insecure:   &insecure,
-		Timeout:    ptr.To("0"),
-		KubeConfig: ptr.To(""),
+		Timeout:    new("0"),
+		KubeConfig: new(""),
 
-		CacheDir:             ptr.To(getDefaultCacheDir()),
-		ClusterName:          ptr.To(""),
-		AuthInfoName:         ptr.To(""),
-		Context:              ptr.To(""),
-		Namespace:            ptr.To(""),
-		APIServer:            ptr.To(""),
-		TLSServerName:        ptr.To(""),
-		CertFile:             ptr.To(""),
-		KeyFile:              ptr.To(""),
-		CAFile:               ptr.To(""),
-		BearerToken:          ptr.To(""),
-		Impersonate:          ptr.To(""),
-		ImpersonateUID:       ptr.To(""),
+		CacheDir:             new(getDefaultCacheDir()),
+		ClusterName:          new(""),
+		AuthInfoName:         new(""),
+		Context:              new(""),
+		Namespace:            new(""),
+		APIServer:            new(""),
+		TLSServerName:        new(""),
+		CertFile:             new(""),
+		KeyFile:              new(""),
+		CAFile:               new(""),
+		BearerToken:          new(""),
+		Impersonate:          new(""),
+		ImpersonateUID:       new(""),
 		ImpersonateGroup:     &impersonateGroup,
 		ImpersonateUserExtra: &impersonateUserExtra,
 		DisableCompression:   &disableCompression,


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency
/kind cleanup

#### What this PR does / why we need it:

genericclioptions only uses ptr.To, which can be replaced with new() in Go 1.26+. This also trims the allowed imports list for the package.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/cc @dims 