### PR TITLE
Drop k8s.io/utils/ptr from code-generator

### DIFF
--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -63,7 +63,6 @@
   - k8s.io/kube-openapi
   - k8s.io/klog
   - k8s.io/utils/dump
-  - k8s.io/utils/ptr
 
 - baseImportPath: "./staging/src/k8s.io/component-base"
   allowedImports:

--- a/staging/src/k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/marker_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/marker_test.go
@@ -25,7 +25,6 @@ import (
 	externalexternal "k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/external/external"
 	"k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/external2"
 	"k8s.io/code-generator/cmd/defaulter-gen/output_tests/marker/external3"
-	"k8s.io/utils/ptr"
 )
 
 var (
@@ -46,7 +45,7 @@ func Test_Marker(t *testing.T) {
 				StringDefault:      "bar",
 				StringEmptyDefault: "",
 				StringEmpty:        "",
-				StringPointer:      ptr.To("default"),
+				StringPointer:      new("default"),
 				Int64:              &defaultInt64,
 				Int32:              &defaultInt32,
 				IntDefault:         1,
@@ -56,8 +55,8 @@ func Test_Marker(t *testing.T) {
 				FloatEmptyDefault:  0.0,
 				FloatEmpty:         0.0,
 				List: []Item{
-					ptr.To("foo"),
-					ptr.To("bar"),
+					new("foo"),
+					new("bar"),
 				},
 				Sub: &SubStruct{
 					S: "foo",
@@ -91,7 +90,7 @@ func Test_Marker(t *testing.T) {
 					"foo",
 				},
 				Map: map[string]Item{
-					"foo": ptr.To("bar"),
+					"foo": new("bar"),
 				},
 				StructMap: map[string]SubStruct{
 					"foo": {
@@ -105,7 +104,7 @@ func Test_Marker(t *testing.T) {
 						I: 1,
 					},
 				},
-				AliasPtr: ptr.To("banana"),
+				AliasPtr: new("banana"),
 			},
 		},
 		{
@@ -118,7 +117,7 @@ func Test_Marker(t *testing.T) {
 				StringDefault:      "changed",
 				StringEmptyDefault: "",
 				StringEmpty:        "",
-				StringPointer:      ptr.To("default"),
+				StringPointer:      new("default"),
 				Int64:              &defaultInt64,
 				Int32:              &defaultInt32,
 				IntDefault:         5,
@@ -128,8 +127,8 @@ func Test_Marker(t *testing.T) {
 				FloatEmptyDefault:  0.0,
 				FloatEmpty:         0.0,
 				List: []Item{
-					ptr.To("foo"),
-					ptr.To("bar"),
+					new("foo"),
+					new("bar"),
 				},
 				Sub: &SubStruct{
 					S: "foo",
@@ -163,7 +162,7 @@ func Test_Marker(t *testing.T) {
 					I: 1,
 				},
 				Map: map[string]Item{
-					"foo": ptr.To("bar"),
+					"foo": new("bar"),
 				},
 				StructMap: map[string]SubStruct{
 					"foo": {
@@ -177,7 +176,7 @@ func Test_Marker(t *testing.T) {
 						I: 1,
 					},
 				},
-				AliasPtr: ptr.To("banana"),
+				AliasPtr: new("banana"),
 			},
 		},
 		{
@@ -185,14 +184,14 @@ func Test_Marker(t *testing.T) {
 			in: Defaulted{
 				List: []Item{
 					nil,
-					ptr.To("bar"),
+					new("bar"),
 				},
 			},
 			out: Defaulted{
 				StringDefault:      "bar",
 				StringEmptyDefault: "",
 				StringEmpty:        "",
-				StringPointer:      ptr.To("default"),
+				StringPointer:      new("default"),
 				Int64:              &defaultInt64,
 				Int32:              &defaultInt32,
 				IntDefault:         1,
@@ -202,8 +201,8 @@ func Test_Marker(t *testing.T) {
 				FloatEmptyDefault:  0.0,
 				FloatEmpty:         0.0,
 				List: []Item{
-					ptr.To("apple"),
-					ptr.To("bar"),
+					new("apple"),
+					new("bar"),
 				},
 				Sub: &SubStruct{
 					S: "foo",
@@ -237,7 +236,7 @@ func Test_Marker(t *testing.T) {
 					I: 1,
 				},
 				Map: map[string]Item{
-					"foo": ptr.To("bar"),
+					"foo": new("bar"),
 				},
 				StructMap: map[string]SubStruct{
 					"foo": {
@@ -251,7 +250,7 @@ func Test_Marker(t *testing.T) {
 						I: 1,
 					},
 				},
-				AliasPtr: ptr.To("banana"),
+				AliasPtr: new("banana"),
 			},
 		},
 		{
@@ -259,14 +258,14 @@ func Test_Marker(t *testing.T) {
 			in: Defaulted{
 				Map: map[string]Item{
 					"foo": nil,
-					"bar": ptr.To("banana"),
+					"bar": new("banana"),
 				},
 			},
 			out: Defaulted{
 				StringDefault:      "bar",
 				StringEmptyDefault: "",
 				StringEmpty:        "",
-				StringPointer:      ptr.To("default"),
+				StringPointer:      new("default"),
 				Int64:              &defaultInt64,
 				Int32:              &defaultInt32,
 				IntDefault:         1,
@@ -276,8 +275,8 @@ func Test_Marker(t *testing.T) {
 				FloatEmptyDefault:  0.0,
 				FloatEmpty:         0.0,
 				List: []Item{
-					ptr.To("foo"),
-					ptr.To("bar"),
+					new("foo"),
+					new("bar"),
 				},
 				Sub: &SubStruct{
 					S: "foo",
@@ -311,8 +310,8 @@ func Test_Marker(t *testing.T) {
 					I: 1,
 				},
 				Map: map[string]Item{
-					"foo": ptr.To("apple"),
-					"bar": ptr.To("banana"),
+					"foo": new("apple"),
+					"bar": new("banana"),
 				},
 				StructMap: map[string]SubStruct{
 					"foo": {
@@ -326,7 +325,7 @@ func Test_Marker(t *testing.T) {
 						I: 1,
 					},
 				},
-				AliasPtr: ptr.To("banana"),
+				AliasPtr: new("banana"),
 			},
 		},
 	}
@@ -384,7 +383,7 @@ func Test_DefaultingReference(t *testing.T) {
 				AliasOverride:                   Item(&SomeDefault),
 				AliasConvertDefaultPointer:      &dv,
 				AliasPointerDefault:             &dv,
-				PointerAliasDefault:             Item(ptr.To("apple")),
+				PointerAliasDefault:             Item(new("apple")),
 				AliasNonPointer:                 SomeValue,
 				AliasPointer:                    &SomeValue,
 				SymbolReference:                 SomeDefault,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/default_behavior/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/default_behavior/doc_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test_StructPrimitive(t *testing.T) {
 	mkTest := func() *StructPrimitive {
 		return &StructPrimitive{
 			IntField:    1,
-			IntPtrField: ptr.To(1), // Different pointers each call, but same value.
+			IntPtrField: new(1), // Different pointers each call, but same value.
 		}
 	}
 
@@ -87,13 +86,13 @@ func Test_StructStruct(t *testing.T) {
 				IntField: 1,
 			},
 			NonDirectComparableStructField: NonDirectComparableStruct{
-				IntPtrField: ptr.To(1),
+				IntPtrField: new(1),
 			},
 			DirectComparableStructPtr: &DirectComparableStruct{
 				IntField: 1,
 			},
 			NonDirectComparableStructPtr: &NonDirectComparableStruct{
-				IntPtrField: ptr.To(1),
+				IntPtrField: new(1),
 			},
 		}
 	}
@@ -124,7 +123,7 @@ func Test_StructEmbedded(t *testing.T) {
 				IntField: 1,
 			},
 			NonDirectComparableStruct: NonDirectComparableStruct{
-				IntPtrField: ptr.To(1),
+				IntPtrField: new(1),
 			},
 			NestedDirectComparableStructField: NestedDirectComparableStruct{
 				DirectComparableStructField: DirectComparableStruct{
@@ -133,7 +132,7 @@ func Test_StructEmbedded(t *testing.T) {
 			},
 			NestedNonDirectComparableStructField: NestedNonDirectComparableStruct{
 				NonDirectComparableStructField: NonDirectComparableStruct{
-					IntPtrField: ptr.To(1),
+					IntPtrField: new(1),
 				},
 			},
 		}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/list/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/list/doc_test.go
@@ -18,8 +18,6 @@ package list
 
 import (
 	"testing"
-
-	"k8s.io/utils/ptr"
 )
 
 func Test_StructSlice(t *testing.T) {
@@ -29,13 +27,13 @@ func Test_StructSlice(t *testing.T) {
 		AtomicSliceStringField:        []StringType{""},
 		AtomicSliceTypeField:          IntSliceType{1},
 		AtomicSliceComparableField:    []ComparableStruct{{IntField: 1}},
-		AtomicSliceNonComparableField: []NonComparableStruct{{IntPtrField: ptr.To(1)}},
+		AtomicSliceNonComparableField: []NonComparableStruct{{IntPtrField: new(1)}},
 		SetSliceComparableField:       []ComparableStruct{{IntField: 1}},
-		SetSliceNonComparableField:    []NonComparableStruct{{IntPtrField: ptr.To(1)}},
+		SetSliceNonComparableField:    []NonComparableStruct{{IntPtrField: new(1)}},
 		MapSliceComparableField:       []ComparableStructWithKey{{Key: "x", IntField: 1}},
-		MapSliceNonComparableField:    []NonComparableStructWithKey{{Key: "x", IntPtrField: ptr.To(1)}},
-		MapSlicePtrKeyField:           []PtrKeyStruct{{Key: ptr.To("x"), Data: "y"}},
-		MapSliceMixedKeyField:         []MixedKeyStruct{{Key1: ptr.To("x"), Key2: "y", Data: "z"}},
+		MapSliceNonComparableField:    []NonComparableStructWithKey{{Key: "x", IntPtrField: new(1)}},
+		MapSlicePtrKeyField:           []PtrKeyStruct{{Key: new("x"), Data: "y"}},
+		MapSliceMixedKeyField:         []MixedKeyStruct{{Key1: new("x"), Key2: "y", Data: "z"}},
 	}
 	st.Value(invalidStructSlice).ExpectValidateFalseByPath(map[string][]string{
 		"atomicSliceStringField[0]":        {"field AtomicSliceStringField[*]"},
@@ -58,24 +56,24 @@ func Test_StructSlice(t *testing.T) {
 		AtomicSliceStringField:        []StringType{""},
 		AtomicSliceTypeField:          IntSliceType{1},
 		AtomicSliceComparableField:    []ComparableStruct{{IntField: 1}},
-		AtomicSliceNonComparableField: []NonComparableStruct{{IntPtrField: ptr.To(1)}},
+		AtomicSliceNonComparableField: []NonComparableStruct{{IntPtrField: new(1)}},
 		SetSliceComparableField:       []ComparableStruct{{IntField: 1}},
-		SetSliceNonComparableField:    []NonComparableStruct{{IntPtrField: ptr.To(1)}},
+		SetSliceNonComparableField:    []NonComparableStruct{{IntPtrField: new(1)}},
 		MapSliceComparableField:       []ComparableStructWithKey{{Key: "x", IntField: 1}},
-		MapSliceNonComparableField:    []NonComparableStructWithKey{{Key: "x", IntPtrField: ptr.To(1)}},
-		MapSlicePtrKeyField:           []PtrKeyStruct{{Key: ptr.To("x"), Data: "y"}},
-		MapSliceMixedKeyField:         []MixedKeyStruct{{Key1: ptr.To("x"), Key2: "y", Data: "z"}},
+		MapSliceNonComparableField:    []NonComparableStructWithKey{{Key: "x", IntPtrField: new(1)}},
+		MapSlicePtrKeyField:           []PtrKeyStruct{{Key: new("x"), Data: "y"}},
+		MapSliceMixedKeyField:         []MixedKeyStruct{{Key1: new("x"), Key2: "y", Data: "z"}},
 	}).OldValue(&StructSlice{
 		AtomicSliceStringField:        []StringType{"", "x"},
 		AtomicSliceTypeField:          IntSliceType{1, 2},
 		AtomicSliceComparableField:    []ComparableStruct{{IntField: 2}, {IntField: 1}},
-		AtomicSliceNonComparableField: []NonComparableStruct{{IntPtrField: ptr.To(2)}, {IntPtrField: ptr.To(1)}},
+		AtomicSliceNonComparableField: []NonComparableStruct{{IntPtrField: new(2)}, {IntPtrField: new(1)}},
 		SetSliceComparableField:       []ComparableStruct{{IntField: 2}, {IntField: 1}},
-		SetSliceNonComparableField:    []NonComparableStruct{{IntPtrField: ptr.To(2)}, {IntPtrField: ptr.To(1)}},
+		SetSliceNonComparableField:    []NonComparableStruct{{IntPtrField: new(2)}, {IntPtrField: new(1)}},
 		MapSliceComparableField:       []ComparableStructWithKey{{Key: "y", IntField: 2}, {Key: "x", IntField: 1}},
-		MapSliceNonComparableField:    []NonComparableStructWithKey{{Key: "y", IntPtrField: ptr.To(2)}, {Key: "x", IntPtrField: ptr.To(1)}},
-		MapSlicePtrKeyField:           []PtrKeyStruct{{Key: ptr.To("a"), Data: "b"}, {Key: ptr.To("x"), Data: "y"}},
-		MapSliceMixedKeyField:         []MixedKeyStruct{{Key1: ptr.To("a"), Key2: "b", Data: "c"}, {Key1: ptr.To("x"), Key2: "y", Data: "z"}},
+		MapSliceNonComparableField:    []NonComparableStructWithKey{{Key: "y", IntPtrField: new(2)}, {Key: "x", IntPtrField: new(1)}},
+		MapSlicePtrKeyField:           []PtrKeyStruct{{Key: new("a"), Data: "b"}, {Key: new("x"), Data: "y"}},
+		MapSliceMixedKeyField:         []MixedKeyStruct{{Key1: new("a"), Key2: "b", Data: "c"}, {Key1: new("x"), Key2: "y", Data: "z"}},
 	}).ExpectValidateFalseByPath(map[string][]string{"atomicSliceStringField[0]": {"field AtomicSliceStringField[*]"},
 		"atomicSliceTypeField[0]":          {"field AtomicSliceTypeField[*]"},
 		"atomicSliceComparableField[0]":    {"field AtomicSliceComparableField[*]"},
@@ -85,18 +83,18 @@ func Test_StructSlice(t *testing.T) {
 	// Same data, different order.
 	st.Value(&StructSlice{
 		SetSliceComparableField:    []ComparableStruct{{IntField: 2}, {IntField: 1}},
-		SetSliceNonComparableField: []NonComparableStruct{{IntPtrField: ptr.To(2)}, {IntPtrField: ptr.To(1)}},
+		SetSliceNonComparableField: []NonComparableStruct{{IntPtrField: new(2)}, {IntPtrField: new(1)}},
 		MapSliceComparableField:    []ComparableStructWithKey{{Key: "y", IntField: 2}, {Key: "x", IntField: 1}},
-		MapSliceNonComparableField: []NonComparableStructWithKey{{Key: "y", IntPtrField: ptr.To(2)}, {Key: "x", IntPtrField: ptr.To(1)}},
-		MapSlicePtrKeyField:        []PtrKeyStruct{{Key: ptr.To("b"), Data: "2"}, {Key: ptr.To("a"), Data: "1"}},
-		MapSliceMixedKeyField:      []MixedKeyStruct{{Key1: ptr.To("b"), Key2: "2", Data: "B"}, {Key1: ptr.To("a"), Key2: "1", Data: "A"}},
+		MapSliceNonComparableField: []NonComparableStructWithKey{{Key: "y", IntPtrField: new(2)}, {Key: "x", IntPtrField: new(1)}},
+		MapSlicePtrKeyField:        []PtrKeyStruct{{Key: new("b"), Data: "2"}, {Key: new("a"), Data: "1"}},
+		MapSliceMixedKeyField:      []MixedKeyStruct{{Key1: new("b"), Key2: "2", Data: "B"}, {Key1: new("a"), Key2: "1", Data: "A"}},
 	}).OldValue(&StructSlice{
 		SetSliceComparableField:    []ComparableStruct{{IntField: 1}, {IntField: 2}},
-		SetSliceNonComparableField: []NonComparableStruct{{IntPtrField: ptr.To(1)}, {IntPtrField: ptr.To(2)}},
+		SetSliceNonComparableField: []NonComparableStruct{{IntPtrField: new(1)}, {IntPtrField: new(2)}},
 		MapSliceComparableField:    []ComparableStructWithKey{{Key: "x", IntField: 1}, {Key: "y", IntField: 2}},
-		MapSliceNonComparableField: []NonComparableStructWithKey{{Key: "x", IntPtrField: ptr.To(1)}, {Key: "y", IntPtrField: ptr.To(2)}},
-		MapSlicePtrKeyField:        []PtrKeyStruct{{Key: ptr.To("a"), Data: "1"}, {Key: ptr.To("b"), Data: "2"}},
-		MapSliceMixedKeyField:      []MixedKeyStruct{{Key1: ptr.To("a"), Key2: "1", Data: "A"}, {Key1: ptr.To("b"), Key2: "2", Data: "B"}},
+		MapSliceNonComparableField: []NonComparableStructWithKey{{Key: "x", IntPtrField: new(1)}, {Key: "y", IntPtrField: new(2)}},
+		MapSlicePtrKeyField:        []PtrKeyStruct{{Key: new("a"), Data: "1"}, {Key: new("b"), Data: "2"}},
+		MapSliceMixedKeyField:      []MixedKeyStruct{{Key1: new("a"), Key2: "1", Data: "A"}, {Key1: new("b"), Key2: "2", Data: "B"}},
 	}).ExpectValid()
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/maps/eachval/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/maps/eachval/doc_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test_StructWithMaps(t *testing.T) {
@@ -36,7 +35,7 @@ func Test_StructWithMaps(t *testing.T) {
 				"x": {IntField: 1},
 			},
 			MapNonComparableStructField: map[string]NonComparableStruct{
-				"x": {IntPtrField: ptr.To(1)},
+				"x": {IntPtrField: new(1)},
 			},
 		}
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/subfield/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/ratcheting/subfield/doc_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestStruct(t *testing.T) {
@@ -32,7 +31,7 @@ func TestStruct(t *testing.T) {
 	st.Value(&Struct{
 		SubStructField: SubStruct{
 			IntField:    1,
-			IntPtrField: ptr.To(1),
+			IntPtrField: new(1),
 		},
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Invalid(field.NewPath("subStructField").Child("intField"), 1, "field IntField"),
@@ -41,10 +40,10 @@ func TestStruct(t *testing.T) {
 
 	st.Value(&StructWithSubfield{
 		IntField:    1,
-		IntPtrField: ptr.To(1),
+		IntPtrField: new(1),
 	}).OldValue(&StructWithSubfield{
 		IntField:    1,
-		IntPtrField: ptr.To(1),
+		IntPtrField: new(1),
 	}).ExpectValid()
 }
 
@@ -52,7 +51,7 @@ func TestStructWithSubfield(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 	st.Value(&StructWithSubfield{
 		IntField:    1,
-		IntPtrField: ptr.To(1),
+		IntPtrField: new(1),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Invalid(field.NewPath("intField"), 1, "field IntField"),
 		field.Invalid(field.NewPath("intPtrField"), 1, "field IntPtrField"),
@@ -61,10 +60,10 @@ func TestStructWithSubfield(t *testing.T) {
 	st.Value(&StructWithSubfield{
 		TypeMeta:    1,
 		IntField:    1,
-		IntPtrField: ptr.To(1),
+		IntPtrField: new(1),
 	}).OldValue(&StructWithSubfield{
 		TypeMeta:    1,
 		IntField:    1,
-		IntPtrField: ptr.To(1),
+		IntPtrField: new(1),
 	}).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/dependentrequired/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/dependentrequired/doc_test.go
@@ -20,18 +20,17 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestStruct(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	// One-directional: dependent alone is fine.
-	st.Value(&Struct{Dependent: ptr.To("d")}).ExpectValid()
+	st.Value(&Struct{Dependent: new("d")}).ExpectValid()
 
-	st.Value(&Struct{Trigger: ptr.To("t"), Dependent: ptr.To("d")}).ExpectValid()
+	st.Value(&Struct{Trigger: new("t"), Dependent: new("d")}).ExpectValid()
 
-	st.Value(&Struct{Trigger: ptr.To("t")}).ExpectMatches(
+	st.Value(&Struct{Trigger: new("t")}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin(),
 		field.ErrorList{
 			field.Required(field.NewPath("dependent"), "").WithOrigin("dependentRequired"),
@@ -39,18 +38,18 @@ func TestStruct(t *testing.T) {
 	)
 
 	// Ratchet: unrelated field changed, trigger and dependent set-ness unchanged → skip.
-	st.Value(&Struct{Trigger: ptr.To("t"), OtherField: ptr.To("new")}).
-		OldValue(&Struct{Trigger: ptr.To("t"), OtherField: ptr.To("old")}).
+	st.Value(&Struct{Trigger: new("t"), OtherField: new("new")}).
+		OldValue(&Struct{Trigger: new("t"), OtherField: new("old")}).
 		ExpectValid()
 
 	// Ratchet: trigger value changed but set-ness unchanged → skip (same rationale as union).
-	st.Value(&Struct{Trigger: ptr.To("t")}).
-		OldValue(&Struct{Trigger: ptr.To("old")}).
+	st.Value(&Struct{Trigger: new("t")}).
+		OldValue(&Struct{Trigger: new("old")}).
 		ExpectValid()
 
 	// Newly cleared dependent → fire.
-	st.Value(&Struct{Trigger: ptr.To("t")}).
-		OldValue(&Struct{Trigger: ptr.To("t"), Dependent: ptr.To("d")}).
+	st.Value(&Struct{Trigger: new("t")}).
+		OldValue(&Struct{Trigger: new("t"), Dependent: new("d")}).
 		ExpectMatches(
 			field.ErrorMatcher{}.ByType().ByField().ByOrigin(),
 			field.ErrorList{
@@ -63,7 +62,7 @@ func TestMultiDependent(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	// Repeated tags → independent implications, each at its own dependent path.
-	st.Value(&MultiDependent{Trigger: ptr.To("t")}).ExpectMatches(
+	st.Value(&MultiDependent{Trigger: new("t")}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin(),
 		field.ErrorList{
 			field.Required(field.NewPath("dependentA"), "").WithOrigin("dependentRequired"),
@@ -77,7 +76,7 @@ func TestMultiTrigger(t *testing.T) {
 
 	// Distinct triggers → independent implications at the same path.
 	// ByOrigin absorbs both actuals.
-	st.Value(&MultiTrigger{TriggerA: ptr.To("a"), TriggerB: ptr.To("b")}).ExpectMatches(
+	st.Value(&MultiTrigger{TriggerA: new("a"), TriggerB: new("b")}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin(),
 		field.ErrorList{
 			field.Required(field.NewPath("dependent"), "").WithOrigin("dependentRequired"),
@@ -90,7 +89,7 @@ func TestAllKinds(t *testing.T) {
 
 	// Each kind's extractor fires.
 	st.Value(&AllKinds{
-		PtrTrigger:   ptr.To("t"),
+		PtrTrigger:   new("t"),
 		SliceTrigger: []string{"x"},
 		MapTrigger:   map[string]string{"k": "v"},
 		IntTrigger:   1,

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/enum/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -35,28 +34,28 @@ func Test(t *testing.T) {
 	})
 
 	st.Value(&Struct{
-		Enum0Field:      "",                // no valid value exists
-		Enum0PtrField:   ptr.To(Enum0("")), // no valid value exists
+		Enum0Field:      "",             // no valid value exists
+		Enum0PtrField:   new(Enum0("")), // no valid value exists
 		Enum1Field:      E1V1,
-		Enum1PtrField:   ptr.To(E1V1),
+		Enum1PtrField:   new(E1V1),
 		Enum2Field:      E2V1,
-		Enum2PtrField:   ptr.To(E2V1),
+		Enum2PtrField:   new(E2V1),
 		NotEnumField:    "x",
-		NotEnumPtrField: ptr.To(NotEnum("x")),
+		NotEnumPtrField: new(NotEnum("x")),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("enum0Field"), Enum0(""), []Enum0{}),
 		field.NotSupported(field.NewPath("enum0PtrField"), Enum0(""), []Enum0{}),
 	})
 
 	st.Value(&Struct{
-		Enum0Field:      "x",                // no valid value exists
-		Enum0PtrField:   ptr.To(Enum0("x")), // no valid value exists
+		Enum0Field:      "x",             // no valid value exists
+		Enum0PtrField:   new(Enum0("x")), // no valid value exists
 		Enum1Field:      "x",
-		Enum1PtrField:   ptr.To(Enum1("x")),
+		Enum1PtrField:   new(Enum1("x")),
 		Enum2Field:      "x",
-		Enum2PtrField:   ptr.To(Enum2("x")),
+		Enum2PtrField:   new(Enum2("x")),
 		NotEnumField:    "x",
-		NotEnumPtrField: ptr.To(NotEnum("x")),
+		NotEnumPtrField: new(NotEnum("x")),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.NotSupported(field.NewPath("enum0Field"), Enum0("x"), []Enum0{}),
 		field.NotSupported(field.NewPath("enum0PtrField"), Enum0("x"), []Enum0{}),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/forbidden/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -53,13 +52,13 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		StringField:           "abc",
-		StringPtrField:        ptr.To("xyz"),
+		StringPtrField:        new("xyz"),
 		StringTypedefField:    StringType("abc"),
-		StringTypedefPtrField: ptr.To(StringType("xyz")),
+		StringTypedefPtrField: new(StringType("xyz")),
 		IntField:              123,
-		IntPtrField:           ptr.To(456),
+		IntPtrField:           new(456),
 		IntTypedefField:       IntType(123),
-		IntTypedefPtrField:    ptr.To(IntType(456)),
+		IntTypedefPtrField:    new(IntType(456)),
 		BoolField:             true,
 		FloatField:            1.23,
 		ByteField:             'a',

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-extended-resource-name/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-extended-resource-name/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestK8sExtendedResourceName(t *testing.T) {
@@ -28,19 +27,19 @@ func TestK8sExtendedResourceName(t *testing.T) {
 
 	st.Value(&MyType{
 		NameField:        "example.com/my-resource",
-		NamePtrField:     ptr.To("my-domain.org/foo"),
+		NamePtrField:     new("my-domain.org/foo"),
 		NameTypedefField: "example.com/another-resource",
 	}).ExpectValid()
 
 	st.Value(&MyType{
 		NameField:        "example.com/my_resource",
-		NamePtrField:     ptr.To("example.com/My-Resource"),
+		NamePtrField:     new("example.com/My-Resource"),
 		NameTypedefField: "example.com/my.resource",
 	}).ExpectValid()
 
 	invalidStruct := &MyType{
 		NameField:        "kubernetes.io/my-resource",
-		NamePtrField:     ptr.To("requests.example.com/my-resource"),
+		NamePtrField:     new("requests.example.com/my-resource"),
 		NameTypedefField: "my-resource",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
@@ -54,7 +53,7 @@ func TestK8sExtendedResourceName(t *testing.T) {
 	const commonDetail = "a valid extended resource name must consist of a domain name prefix and a path segment separated by a slash, where the path segment consists of alphanumeric characters, '-', and must start and end with an alphanumeric character, and the domain name prefix is a valid DNS subdomain name, with the exception that 'requests' is a valid domain name prefix"
 	invalidStruct = &MyType{
 		NameField:        "example.com/my-resource-",
-		NamePtrField:     ptr.To("example.com/-my-resource"),
+		NamePtrField:     new("example.com/-my-resource"),
 		NameTypedefField: "example.com/",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-label-key/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-label-key/doc_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -49,7 +48,7 @@ func Test(t *testing.T) {
 	for _, s := range validCases {
 		st.Value(&Struct{
 			LabelKeyField:        s,
-			LabelKeyPtrField:     ptr.To(s),
+			LabelKeyPtrField:     new(s),
 			LabelKeyTypedefField: LabelKeyStringType(s),
 		}).ExpectValid()
 	}
@@ -70,7 +69,7 @@ func Test(t *testing.T) {
 	for _, s := range invalidCases {
 		st.Value(&Struct{
 			LabelKeyField:        s,
-			LabelKeyPtrField:     ptr.To(s),
+			LabelKeyPtrField:     new(s),
 			LabelKeyTypedefField: LabelKeyStringType(s),
 		}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
 			field.Invalid(field.NewPath("labelKeyField"), nil, "").WithOrigin("format=k8s-label-key"),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-label-value/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-label-value/doc_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -45,7 +44,7 @@ func Test(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			st.Value(&Struct{
 				LabelValueField:        tc.value,
-				LabelValuePtrField:     ptr.To(tc.value),
+				LabelValuePtrField:     new(tc.value),
 				LabelValueTypedefField: LabelValueStringType(tc.value),
 			}).ExpectValid()
 		})
@@ -70,7 +69,7 @@ func Test(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			invalidStruct := &Struct{
 				LabelValueField:        tc.value,
-				LabelValuePtrField:     ptr.To(tc.value),
+				LabelValuePtrField:     new(tc.value),
 				LabelValueTypedefField: LabelValueStringType(tc.value),
 			}
 			st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-long-name-caseless/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-long-name-caseless/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestCaseless(t *testing.T) {
@@ -28,25 +27,25 @@ func TestCaseless(t *testing.T) {
 
 	st.Value(&Struct{
 		LongNameField:        "foo.bar",
-		LongNamePtrField:     ptr.To("foo.bar"),
+		LongNamePtrField:     new("foo.bar"),
 		LongNameTypedefField: "foo.bar",
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		LongNameField:        "1.2.3.4",
-		LongNamePtrField:     ptr.To("1.2.3.4"),
+		LongNamePtrField:     new("1.2.3.4"),
 		LongNameTypedefField: "1.2.3.4",
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		LongNameField:        "Foo.Bar",
-		LongNamePtrField:     ptr.To("Foo.Bar"),
+		LongNamePtrField:     new("Foo.Bar"),
 		LongNameTypedefField: "Foo.Bar",
 	}).ExpectValid()
 
 	invalidStruct := &Struct{
 		LongNameField:        "",
-		LongNamePtrField:     ptr.To(""),
+		LongNamePtrField:     new(""),
 		LongNameTypedefField: "",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
@@ -59,7 +58,7 @@ func TestCaseless(t *testing.T) {
 
 	invalidStruct = &Struct{
 		LongNameField:        "Not a LongName",
-		LongNamePtrField:     ptr.To("Not a LongName"),
+		LongNamePtrField:     new("Not a LongName"),
 		LongNameTypedefField: "Not a LongName",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-long-name/k8s-long-name/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-long-name/k8s-long-name/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -28,19 +27,19 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		LongNameField:        "foo.bar",
-		LongNamePtrField:     ptr.To("foo.bar"),
+		LongNamePtrField:     new("foo.bar"),
 		LongNameTypedefField: "foo.bar",
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		LongNameField:        "1.2.3.4",
-		LongNamePtrField:     ptr.To("1.2.3.4"),
+		LongNamePtrField:     new("1.2.3.4"),
 		LongNameTypedefField: "1.2.3.4",
 	}).ExpectValid()
 
 	invalidStruct := &Struct{
 		LongNameField:        "",
-		LongNamePtrField:     ptr.To(""),
+		LongNamePtrField:     new(""),
 		LongNameTypedefField: "",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
@@ -53,7 +52,7 @@ func Test(t *testing.T) {
 
 	invalidStruct = &Struct{
 		LongNameField:        "Not a LongName",
-		LongNamePtrField:     ptr.To("Not a LongName"),
+		LongNamePtrField:     new("Not a LongName"),
 		LongNameTypedefField: "Not a LongName",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-resource-fully-qualified-name/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-resource-fully-qualified-name/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestFullyQualifiedName(t *testing.T) {
@@ -28,13 +27,13 @@ func TestFullyQualifiedName(t *testing.T) {
 
 	st.Value(&Struct{
 		FullyQualifiedNameField:        "my-prefix/my_name",
-		FullyQualifiedNamePtrField:     ptr.To("my-prefix/my_name"),
+		FullyQualifiedNamePtrField:     new("my-prefix/my_name"),
 		FullyQualifiedNameTypedefField: "my-prefix/my_name",
 	}).ExpectValid()
 
 	invalidStruct := &Struct{
 		FullyQualifiedNameField:        "my_name",
-		FullyQualifiedNamePtrField:     ptr.To(""),
+		FullyQualifiedNamePtrField:     new(""),
 		FullyQualifiedNameTypedefField: "my-prefix/",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByOrigin().ByField(), field.ErrorList{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-resource-pool-name/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-resource-pool-name/doc_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -29,19 +28,19 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		ResourcePoolNameField:        "foo.bar",
-		ResourcePoolNamePtrField:     ptr.To("foo.bar"),
+		ResourcePoolNamePtrField:     new("foo.bar"),
 		ResourcePoolNameTypedefField: "foo.bar",
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		ResourcePoolNameField:        "1.2.3.4",
-		ResourcePoolNamePtrField:     ptr.To("1.2.3.4"),
+		ResourcePoolNamePtrField:     new("1.2.3.4"),
 		ResourcePoolNameTypedefField: "1.2.3.4",
 	}).ExpectValid()
 
 	invalidStruct := &Struct{
 		ResourcePoolNameField:        "",
-		ResourcePoolNamePtrField:     ptr.To(""),
+		ResourcePoolNamePtrField:     new(""),
 		ResourcePoolNameTypedefField: "",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
@@ -54,7 +53,7 @@ func Test(t *testing.T) {
 
 	invalidStruct = &Struct{
 		ResourcePoolNameField:        "Not a ResourcePoolName",
-		ResourcePoolNamePtrField:     ptr.To("Not a ResourcePoolName"),
+		ResourcePoolNamePtrField:     new("Not a ResourcePoolName"),
 		ResourcePoolNameTypedefField: "Not a ResourcePoolName",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
@@ -67,7 +66,7 @@ func Test(t *testing.T) {
 
 	invalidStruct = &Struct{
 		ResourcePoolNameField:        "a..b",
-		ResourcePoolNamePtrField:     ptr.To("a..b"),
+		ResourcePoolNamePtrField:     new("a..b"),
 		ResourcePoolNameTypedefField: "a..b",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-short-name/k8s-short-name/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-short-name/k8s-short-name/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -28,19 +27,19 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		ShortNameField:        "foo-bar",
-		ShortNamePtrField:     ptr.To("foo-bar"),
+		ShortNamePtrField:     new("foo-bar"),
 		ShortNameTypedefField: "foo-bar",
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		ShortNameField:        "1234",
-		ShortNamePtrField:     ptr.To("1234"),
+		ShortNamePtrField:     new("1234"),
 		ShortNameTypedefField: "1234",
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		ShortNameField:        "",
-		ShortNamePtrField:     ptr.To(""),
+		ShortNamePtrField:     new(""),
 		ShortNameTypedefField: "",
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("shortNameField"), nil, "").WithOrigin("format=k8s-short-name"),
@@ -50,7 +49,7 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		ShortNameField:        "Not a DNS label",
-		ShortNamePtrField:     ptr.To("Not a DNS label"),
+		ShortNamePtrField:     new("Not a DNS label"),
 		ShortNameTypedefField: "Not a DNS label",
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("shortNameField"), nil, "").WithOrigin("format=k8s-short-name"),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-uuid/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/format/k8s-uuid/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestK8sUUID(t *testing.T) {
@@ -28,13 +27,13 @@ func TestK8sUUID(t *testing.T) {
 
 	st.Value(&MyType{
 		UUIDField:        "123e4567-e89b-12d3-a456-426614174000",
-		UUIDPtrField:     ptr.To("123e4567-e89b-12d3-a456-426614174000"),
+		UUIDPtrField:     new("123e4567-e89b-12d3-a456-426614174000"),
 		UUIDTypedefField: "123e4567-e89b-12d3-a456-426614174000",
 	}).ExpectValid()
 
 	invalidStruct := &MyType{
 		UUIDField:        "123E4567-E89B-12D3-A456-426614174000",
-		UUIDPtrField:     ptr.To("123E4567-E89B-12D3-A456-426614174000"),
+		UUIDPtrField:     new("123E4567-E89B-12D3-A456-426614174000"),
 		UUIDTypedefField: "123E4567-E89B-12D3-A456-426614174000",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
@@ -47,7 +46,7 @@ func TestK8sUUID(t *testing.T) {
 
 	invalidStruct = &MyType{
 		UUIDField:        "not-a-uuid",
-		UUIDPtrField:     ptr.To("not-a-uuid"),
+		UUIDPtrField:     new("not-a-uuid"),
 		UUIDTypedefField: "not-a-uuid",
 	}
 	st.Value(invalidStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/immutable/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -28,36 +27,36 @@ func Test(t *testing.T) {
 
 	structA := Struct{
 		StringField:                 "aaa",
-		StringPtrField:              ptr.To("aaa"),
-		StructField:                 ComparableStruct{"bbb", ptr.To("BBB")},
-		StructPtrField:              ptr.To(ComparableStruct{"bbb", ptr.To("BBB")}),
+		StringPtrField:              new("aaa"),
+		StructField:                 ComparableStruct{"bbb", new("BBB")},
+		StructPtrField:              new(ComparableStruct{"bbb", new("BBB")}),
 		NonComparableStructField:    NonComparableStruct{[]string{"ccc"}},
-		NonComparableStructPtrField: ptr.To(NonComparableStruct{[]string{"ccc"}}),
+		NonComparableStructPtrField: new(NonComparableStruct{[]string{"ccc"}}),
 		SliceField:                  []string{"ddd"},
 		MapField:                    map[string]string{"eee": "eee"},
 		ImmutableField:              "fff",
-		ImmutablePtrField:           ptr.To(ImmutableType("fff")),
+		ImmutablePtrField:           new(ImmutableType("fff")),
 	}
 
 	structA2 := structA // dup of A but with different pointer values
-	structA2.StringPtrField = ptr.To(*structA2.StringPtrField)
-	structA2.StructField.StringPtrField = ptr.To("BBB")
-	structA2.StructPtrField = ptr.To(*structA2.StructPtrField)
-	structA2.StructPtrField.StringPtrField = ptr.To("BBB")
-	structA2.NonComparableStructPtrField = ptr.To(*structA2.NonComparableStructPtrField)
-	structA2.ImmutablePtrField = ptr.To(*structA2.ImmutablePtrField)
+	structA2.StringPtrField = new(*structA2.StringPtrField)
+	structA2.StructField.StringPtrField = new("BBB")
+	structA2.StructPtrField = new(*structA2.StructPtrField)
+	structA2.StructPtrField.StringPtrField = new("BBB")
+	structA2.NonComparableStructPtrField = new(*structA2.NonComparableStructPtrField)
+	structA2.ImmutablePtrField = new(*structA2.ImmutablePtrField)
 
 	structB := Struct{
 		StringField:                 "uuu",
-		StringPtrField:              ptr.To("uuu"),
-		StructField:                 ComparableStruct{"vvv", ptr.To("VVV")},
-		StructPtrField:              ptr.To(ComparableStruct{"vvv", ptr.To("VVV")}),
+		StringPtrField:              new("uuu"),
+		StructField:                 ComparableStruct{"vvv", new("VVV")},
+		StructPtrField:              new(ComparableStruct{"vvv", new("VVV")}),
 		NonComparableStructField:    NonComparableStruct{[]string{"www"}},
-		NonComparableStructPtrField: ptr.To(NonComparableStruct{[]string{"www"}}),
+		NonComparableStructPtrField: new(NonComparableStruct{[]string{"www"}}),
 		SliceField:                  []string{"xxx"},
 		MapField:                    map[string]string{"yyy": "yyy"},
 		ImmutableField:              "zzz",
-		ImmutablePtrField:           ptr.To(ImmutableType("zzz")),
+		ImmutablePtrField:           new(ImmutableType("zzz")),
 	}
 
 	st.Value(&structA).OldValue(&structA).ExpectValid()

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/multiple_keys/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/multiple_keys/doc_test.go
@@ -18,8 +18,6 @@ package multiplekeys
 
 import (
 	"testing"
-
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -76,10 +74,10 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		PtrItems: []PtrItem{
-			{StringKey: ptr.To("target-ptr"), IntKey: 42, BoolKey: true, Data: "match"},
-			{StringKey: ptr.To("target-ptr"), IntKey: 42, BoolKey: false, Data: "no match, bool differs"},
-			{StringKey: ptr.To("target-ptr"), IntKey: 99, BoolKey: true, Data: "no match, int differs"},
-			{StringKey: ptr.To("other"), IntKey: 42, BoolKey: true, Data: "no match, string differs"},
+			{StringKey: new("target-ptr"), IntKey: 42, BoolKey: true, Data: "match"},
+			{StringKey: new("target-ptr"), IntKey: 42, BoolKey: false, Data: "no match, bool differs"},
+			{StringKey: new("target-ptr"), IntKey: 99, BoolKey: true, Data: "no match, int differs"},
+			{StringKey: new("other"), IntKey: 42, BoolKey: true, Data: "no match, string differs"},
 			{StringKey: nil, IntKey: 42, BoolKey: true, Data: "no match, nil string"},
 		},
 	}).ExpectValidateFalseByPath(map[string][]string{
@@ -90,8 +88,8 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		MixedPtrItems: []MixedPtrItem{
-			{StringPtrKey: ptr.To("target-ptr"), StringKey: "target", Data: "match"},
-			{StringPtrKey: ptr.To("target-ptr"), StringKey: "other", Data: "no match"},
+			{StringPtrKey: new("target-ptr"), StringKey: "target", Data: "match"},
+			{StringPtrKey: new("target-ptr"), StringKey: "other", Data: "no match"},
 			{StringPtrKey: nil, StringKey: "target", Data: "no match"},
 		},
 	}).ExpectValidateFalseByPath(map[string][]string{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/item/single_key/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -148,8 +147,8 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		PtrKeyItems: []PtrKeyItem{
-			{Key: ptr.To("a"), Data: "d1"},
-			{Key: ptr.To("target-ptr"), Data: "d2"},
+			{Key: new("a"), Data: "d1"},
+			{Key: new("target-ptr"), Data: "d2"},
 			{Key: nil, Data: "d3"},
 		},
 	}).ExpectValidateFalseByPath(map[string][]string{
@@ -160,8 +159,8 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		PtrKeyItems: []PtrKeyItem{
-			{Key: ptr.To("a"), Data: "d1"},
-			{Key: ptr.To("b"), Data: "d2"},
+			{Key: new("a"), Data: "d1"},
+			{Key: new("b"), Data: "d2"},
 			{Key: nil, Data: "d3"},
 		},
 	}).ExpectValid()

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/modes/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/modes/doc_test.go
@@ -20,14 +20,13 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestAlpha(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	// Valid: mode A with FieldA set
-	st.Value(&AlphaStruct{D1: "A", FieldA: ptr.To("val")}).ExpectValid()
+	st.Value(&AlphaStruct{D1: "A", FieldA: new("val")}).ExpectValid()
 
 	// Invalid: mode A with FieldA missing (required), should be stability level alpha
 	st.Value(&AlphaStruct{D1: "A"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
@@ -35,12 +34,12 @@ func TestAlpha(t *testing.T) {
 	})
 
 	// Invalid: mode A with FieldB set (forbidden), should be stability level alpha
-	st.Value(&AlphaStruct{D1: "A", FieldA: ptr.To("val"), FieldB: ptr.To("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
+	st.Value(&AlphaStruct{D1: "A", FieldA: new("val"), FieldB: new("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
 		field.Forbidden(field.NewPath("fieldB"), "").MarkAlpha(),
 	})
 
 	// Valid: mode B with FieldB set
-	st.Value(&AlphaStruct{D1: "B", FieldB: ptr.To("val")}).ExpectValid()
+	st.Value(&AlphaStruct{D1: "B", FieldB: new("val")}).ExpectValid()
 
 	// Invalid: mode B with FieldB missing (required), should be stability level alpha
 	st.Value(&AlphaStruct{D1: "B"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
@@ -52,7 +51,7 @@ func TestBeta(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	// Valid: mode A with FieldA set
-	st.Value(&BetaStruct{D1: "A", FieldA: ptr.To("val")}).ExpectValid()
+	st.Value(&BetaStruct{D1: "A", FieldA: new("val")}).ExpectValid()
 
 	// Invalid: mode A with FieldA missing (required), should be stability level beta
 	st.Value(&BetaStruct{D1: "A"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
@@ -60,12 +59,12 @@ func TestBeta(t *testing.T) {
 	})
 
 	// Invalid: mode A with FieldB set (forbidden), should be stability level beta
-	st.Value(&BetaStruct{D1: "A", FieldA: ptr.To("val"), FieldB: ptr.To("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
+	st.Value(&BetaStruct{D1: "A", FieldA: new("val"), FieldB: new("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
 		field.Forbidden(field.NewPath("fieldB"), "").MarkBeta(),
 	})
 
 	// Valid: mode B with FieldB set
-	st.Value(&BetaStruct{D1: "B", FieldB: ptr.To("val")}).ExpectValid()
+	st.Value(&BetaStruct{D1: "B", FieldB: new("val")}).ExpectValid()
 
 	// Invalid: mode B with FieldB missing (required), should be stability level beta
 	st.Value(&BetaStruct{D1: "B"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
@@ -77,8 +76,8 @@ func TestMixedLevels(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	// Valid cases
-	st.Value(&MixedLevels{Mode: "A", A: ptr.To("val")}).ExpectValid()
-	st.Value(&MixedLevels{Mode: "B", B: ptr.To("val")}).ExpectValid()
+	st.Value(&MixedLevels{Mode: "A", A: new("val")}).ExpectValid()
+	st.Value(&MixedLevels{Mode: "B", B: new("val")}).ExpectValid()
 
 	// Mode=A, missing A -> alpha error (field A is alpha-gated)
 	st.Value(&MixedLevels{Mode: "A"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
@@ -91,12 +90,12 @@ func TestMixedLevels(t *testing.T) {
 	})
 
 	// Mode=A with B set (forbidden) -> beta error (field B's +k8s:modeDiscriminator is beta)
-	st.Value(&MixedLevels{Mode: "A", A: ptr.To("val"), B: ptr.To("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
+	st.Value(&MixedLevels{Mode: "A", A: new("val"), B: new("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
 		field.Forbidden(field.NewPath("b"), "").MarkBeta(),
 	})
 
 	// Mode=B with A set (forbidden) -> alpha error (field A's +k8s:modeDiscriminator is alpha)
-	st.Value(&MixedLevels{Mode: "B", A: ptr.To("val"), B: ptr.To("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
+	st.Value(&MixedLevels{Mode: "B", A: new("val"), B: new("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
 		field.Forbidden(field.NewPath("a"), "").MarkAlpha(),
 	})
 }
@@ -105,8 +104,8 @@ func TestCrossLevels(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	// Valid cases
-	st.Value(&CrossLevels{Kind: "A", A: ptr.To("val")}).ExpectValid()
-	st.Value(&CrossLevels{Kind: "B", B: ptr.To("val")}).ExpectValid()
+	st.Value(&CrossLevels{Kind: "A", A: new("val")}).ExpectValid()
+	st.Value(&CrossLevels{Kind: "B", B: new("val")}).ExpectValid()
 
 	// Kind=A, missing A -> alpha error (field A is alpha-gated, discriminator is beta)
 	st.Value(&CrossLevels{Kind: "A"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
@@ -119,7 +118,7 @@ func TestCrossLevels(t *testing.T) {
 	})
 
 	// Kind=A with B set (forbidden) -> alpha error (field B's member tag is alpha)
-	st.Value(&CrossLevels{Kind: "A", A: ptr.To("val"), B: ptr.To("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
+	st.Value(&CrossLevels{Kind: "A", A: new("val"), B: new("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
 		field.Forbidden(field.NewPath("b"), "").MarkAlpha(),
 	})
 }
@@ -128,8 +127,8 @@ func TestSameFieldMixed(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	// Valid cases
-	st.Value(&SameFieldMixed{Mode: "A", Value: ptr.To("val")}).ExpectValid()
-	st.Value(&SameFieldMixed{Mode: "B", Value: ptr.To("val")}).ExpectValid()
+	st.Value(&SameFieldMixed{Mode: "A", Value: new("val")}).ExpectValid()
+	st.Value(&SameFieldMixed{Mode: "B", Value: new("val")}).ExpectValid()
 
 	// Mode=A, missing Value -> alpha error (member("A") is alpha-gated)
 	st.Value(&SameFieldMixed{Mode: "A"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
@@ -148,7 +147,7 @@ func TestSameValueMixedPayloads(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	// Valid: Mode=A with Value set and long enough
-	st.Value(&SameValueMixedPayloads{Mode: "A", Value: ptr.To("abc")}).ExpectValid()
+	st.Value(&SameValueMixedPayloads{Mode: "A", Value: new("abc")}).ExpectValid()
 
 	// Mode=A, missing Value -> alpha error (required is alpha-gated)
 	st.Value(&SameValueMixedPayloads{Mode: "A"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
@@ -156,7 +155,7 @@ func TestSameValueMixedPayloads(t *testing.T) {
 	})
 
 	// Mode=A, Value too short -> beta error (minLength is beta-gated)
-	st.Value(&SameValueMixedPayloads{Mode: "A", Value: ptr.To("ab")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
+	st.Value(&SameValueMixedPayloads{Mode: "A", Value: new("ab")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
 		field.TooShort(field.NewPath("value"), "", 3).MarkBeta(),
 	})
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/optionalrequired/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/optionalrequired/doc_test.go
@@ -20,24 +20,23 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestAlpha(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	st.Value(&Struct{
-		RequiredField:     ptr.To("val"),
-		RequiredFieldBeta: ptr.To("val"),
+		RequiredField:     new("val"),
+		RequiredFieldBeta: new("val"),
 	}).ExpectValid()
 
 	// Test failures marked as alpha
 	st.Value(&Struct{
 		RequiredField:     nil,
-		RequiredFieldBeta: ptr.To("val"),
+		RequiredFieldBeta: new("val"),
 	}).OldValue(&Struct{
-		RequiredField:     ptr.To("old"),
-		RequiredFieldBeta: ptr.To("old"),
+		RequiredField:     new("old"),
+		RequiredFieldBeta: new("old"),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByValidationStabilityLevel(), field.ErrorList{
 		field.Required(field.NewPath("requiredField"), "").MarkAlpha(),
 	})
@@ -47,17 +46,17 @@ func TestBeta(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	st.Value(&Struct{
-		RequiredField:     ptr.To("val"),
-		RequiredFieldBeta: ptr.To("val"),
+		RequiredField:     new("val"),
+		RequiredFieldBeta: new("val"),
 	}).ExpectValid()
 
 	// Test failures marked as beta
 	st.Value(&Struct{
-		RequiredField:     ptr.To("val"),
+		RequiredField:     new("val"),
 		RequiredFieldBeta: nil,
 	}).OldValue(&Struct{
-		RequiredField:     ptr.To("old"),
-		RequiredFieldBeta: ptr.To("old"),
+		RequiredField:     new("old"),
+		RequiredFieldBeta: new("old"),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin().ByValidationStabilityLevel(), field.ErrorList{
 		field.Required(field.NewPath("requiredFieldBeta"), "").MarkBeta(),
 	})

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/simple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/levels/simple/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestAlpha(t *testing.T) {
@@ -114,8 +113,8 @@ func TestSpecialValidationStruct(t *testing.T) {
 	st.Value(&SpecialValidationStruct{
 		NEQField:           5,
 		NEQFieldBeta:       5,
-		ForbiddenField:     ptr.To("val"),
-		ForbiddenFieldBeta: ptr.To("val"),
+		ForbiddenField:     new("val"),
+		ForbiddenFieldBeta: new("val"),
 		UpdateField:        "new",
 		UpdateFieldBeta:    "new",
 	}).OldValue(&SpecialValidationStruct{
@@ -131,8 +130,8 @@ func TestSpecialValidationStruct(t *testing.T) {
 	})
 
 	st.Value(&StructWithValidateFalse{
-		ValidateFalse:     ptr.To("val"),
-		ValidateFalseBeta: ptr.To("val"),
+		ValidateFalse:     new("val"),
+		ValidateFalseBeta: new("val"),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByValidationStabilityLevel(), field.ErrorList{
 		field.Invalid(field.NewPath("validateFalse"), "val", "always fails").MarkAlpha(),
 		field.Invalid(field.NewPath("validateFalseBeta"), "val", "always fails").MarkBeta(),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/multiple_keys/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	field "k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestUniqueness(t *testing.T) {
@@ -169,9 +168,9 @@ func TestItemWithPtrKey(t *testing.T) {
 
 	st.Value(&Struct{
 		ListPtrKeyField: []PtrKeyStruct{
-			{Key1Field: ptr.To("target-ptr"), Key2Field: 42, DataField: "match"},
-			{Key1Field: ptr.To("target-ptr"), Key2Field: 99, DataField: "no match, int differs"},
-			{Key1Field: ptr.To("other"), Key2Field: 42, DataField: "no match, string differs"},
+			{Key1Field: new("target-ptr"), Key2Field: 42, DataField: "match"},
+			{Key1Field: new("target-ptr"), Key2Field: 99, DataField: "no match, int differs"},
+			{Key1Field: new("other"), Key2Field: 42, DataField: "no match, string differs"},
 			{Key1Field: nil, Key2Field: 42, DataField: "no match, nil string"},
 		},
 	}).ExpectValidateFalseByPath(map[string][]string{
@@ -182,15 +181,15 @@ func TestItemWithPtrKey(t *testing.T) {
 
 	st.Value(&Struct{
 		ListPtrKeyField: []PtrKeyStruct{
-			{Key1Field: ptr.To("other"), Key2Field: 42, DataField: "d1"},
+			{Key1Field: new("other"), Key2Field: 42, DataField: "d1"},
 			{Key1Field: nil, Key2Field: 99, DataField: "d2"},
 		},
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		ListMixedPtrKeyField: []MixedPtrKeyStruct{
-			{StringPtrKey: ptr.To("target-ptr"), StringKey: "target", DataField: "match"},
-			{StringPtrKey: ptr.To("target-ptr"), StringKey: "other", DataField: "no match"},
+			{StringPtrKey: new("target-ptr"), StringKey: "target", DataField: "match"},
+			{StringPtrKey: new("target-ptr"), StringKey: "other", DataField: "no match"},
 			{StringPtrKey: nil, StringKey: "target", DataField: "no match"},
 		},
 	}).ExpectValidateFalseByPath(map[string][]string{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listmap/single_key/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	field "k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestUniqueness(t *testing.T) {
@@ -137,8 +136,8 @@ func TestRatcheting(t *testing.T) {
 			{"key2", "two"},
 		},
 		ListNonComparableField: []NonComparableStruct{
-			{"key1", ptr.To("one")},
-			{"key2", ptr.To("two")},
+			{"key1", new("one")},
+			{"key2", new("two")},
 		},
 	}
 
@@ -149,8 +148,8 @@ func TestRatcheting(t *testing.T) {
 			{"key1", "one"},
 		},
 		ListNonComparableField: []NonComparableStruct{
-			{"key2", ptr.To("two")},
-			{"key1", ptr.To("one")},
+			{"key2", new("two")},
+			{"key1", new("one")},
 		},
 	}
 	st.Value(&struct1).ExpectValidateFalseByPath(map[string][]string{
@@ -168,9 +167,9 @@ func TestUniquenessPtrKey(t *testing.T) {
 
 	st.Value(&Struct{
 		ListPtrKeyField: []PtrKeyStruct{
-			{ptr.To("key1"), "one"},
-			{ptr.To("key2"), "two"},
-			{ptr.To("key2"), "three"}, // duplicate key
+			{new("key1"), "one"},
+			{new("key2"), "two"},
+			{new("key2"), "three"}, // duplicate key
 			{nil, "four"},
 			{nil, "five"}, // duplicate nil key
 		},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/listset/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -38,8 +37,8 @@ func Test(t *testing.T) {
 		},
 	}).ExpectValid()
 
-	ptrS1 := ptr.To("same value")
-	ptrS2 := ptr.To("same value")
+	ptrS1 := new("same value")
+	ptrS2 := new("same value")
 	st.Value(&Struct{
 		SliceStringField:     []string{"aaa", "bbb", "ccc", "ccc", "bbb", "aaa"},
 		SliceIntField:        []int{1, 2, 3, 3, 2, 1},
@@ -88,7 +87,7 @@ func TestSetCorrelation(t *testing.T) {
 	structOld = ImmutableStruct{SliceSetPrimitiveField: []int{2, 1}}
 	st.Value(&structNew).OldValue(&structOld).ExpectValid()
 
-	structNew = ImmutableStruct{SliceSetFalselyComparableField: []FalselyComparableStruct{{StringPtrField: ptr.To("same value")}}}
-	structOld = ImmutableStruct{SliceSetFalselyComparableField: []FalselyComparableStruct{{StringPtrField: ptr.To("same value")}}}
+	structNew = ImmutableStruct{SliceSetFalselyComparableField: []FalselyComparableStruct{{StringPtrField: new("same value")}}}
+	structOld = ImmutableStruct{SliceSetFalselyComparableField: []FalselyComparableStruct{{StringPtrField: new("same value")}}}
 	st.Value(&structNew).OldValue(&structOld).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxbytes/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxbytes/doc_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -33,44 +32,44 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		Max10Field:                      strings.Repeat("x", 1),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 1)),
+		Max10PtrField:                   new(strings.Repeat("x", 1)),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 1)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 1))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 1))),
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		Max10Field:                      strings.Repeat("x", 9),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 9)),
+		Max10PtrField:                   new(strings.Repeat("x", 9)),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 9)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 9))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 9))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 9)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 9))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 9))),
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		Max10Field:                      strings.Repeat("x", 10),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 10)),
+		Max10PtrField:                   new(strings.Repeat("x", 10)),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 10)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 10))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 10))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 10)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 10))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 10))),
 	}).ExpectValid()
 
 	testVal := &Struct{
 		Max0Field:                       strings.Repeat("x", 1),
-		Max0PtrField:                    ptr.To(strings.Repeat("x", 1)),
+		Max0PtrField:                    new(strings.Repeat("x", 1)),
 		Max10Field:                      strings.Repeat("x", 11),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 11)),
+		Max10PtrField:                   new(strings.Repeat("x", 11)),
 		Max0UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max0UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max0UnvalidatedTypedefPtrField:  new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 11)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 11))),
 		Max0ValidatedTypedefField:       Max0Type(strings.Repeat("x", 1)),
-		Max0ValidatedTypedefPtrField:    ptr.To(Max0Type(strings.Repeat("x", 1))),
+		Max0ValidatedTypedefPtrField:    new(Max0Type(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 11)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 11))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 11))),
 	}
 	st.Value(testVal).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.TooLong(field.NewPath("max0Field"), "", 0),
@@ -90,29 +89,29 @@ func Test(t *testing.T) {
 	// Test validation ratcheting
 	st.Value(&Struct{
 		Max0Field:                       strings.Repeat("x", 1),
-		Max0PtrField:                    ptr.To(strings.Repeat("x", 1)),
+		Max0PtrField:                    new(strings.Repeat("x", 1)),
 		Max10Field:                      strings.Repeat("x", 11),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 11)),
+		Max10PtrField:                   new(strings.Repeat("x", 11)),
 		Max0UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max0UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max0UnvalidatedTypedefPtrField:  new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 11)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 11))),
 		Max0ValidatedTypedefField:       Max0Type(strings.Repeat("x", 1)),
-		Max0ValidatedTypedefPtrField:    ptr.To(Max0Type(strings.Repeat("x", 1))),
+		Max0ValidatedTypedefPtrField:    new(Max0Type(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 11)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 11))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 11))),
 	}).OldValue(&Struct{
 		Max0Field:                       strings.Repeat("x", 1),
-		Max0PtrField:                    ptr.To(strings.Repeat("x", 1)),
+		Max0PtrField:                    new(strings.Repeat("x", 1)),
 		Max10Field:                      strings.Repeat("x", 11),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 11)),
+		Max10PtrField:                   new(strings.Repeat("x", 11)),
 		Max0UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max0UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max0UnvalidatedTypedefPtrField:  new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 11)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 11))),
 		Max0ValidatedTypedefField:       Max0Type(strings.Repeat("x", 1)),
-		Max0ValidatedTypedefPtrField:    ptr.To(Max0Type(strings.Repeat("x", 1))),
+		Max0ValidatedTypedefPtrField:    new(Max0Type(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 11)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 11))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 11))),
 	}).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxbytes/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxbytes/doc_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -34,46 +33,46 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		Max10Field:                      strings.Repeat("x", 1),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 1)),
+		Max10PtrField:                   new(strings.Repeat("x", 1)),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 1)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 1))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 1))),
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		Max10Field:                      strings.Repeat("x", 9),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 9)),
+		Max10PtrField:                   new(strings.Repeat("x", 9)),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 9)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 9))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 9))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 9)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 9))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 9))),
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		Max10Field:                      strings.Repeat("x", 10),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 10)),
+		Max10PtrField:                   new(strings.Repeat("x", 10)),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 10)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 10))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 10))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 10)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 10))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 10))),
 		Max10BytesField:                 bytes.Repeat([]byte("x"), 10),
 		Max10ValidatedTypedefBytesField: Max10BytesType(bytes.Repeat([]byte("x"), 10)),
 	}).ExpectValid()
 
 	testVal := &Struct{
 		Max0Field:                       strings.Repeat("x", 1),
-		Max0PtrField:                    ptr.To(strings.Repeat("x", 1)),
+		Max0PtrField:                    new(strings.Repeat("x", 1)),
 		Max10Field:                      strings.Repeat("x", 11),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 11)),
+		Max10PtrField:                   new(strings.Repeat("x", 11)),
 		Max0UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max0UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max0UnvalidatedTypedefPtrField:  new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 11)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 11))),
 		Max0ValidatedTypedefField:       Max0Type(strings.Repeat("x", 1)),
-		Max0ValidatedTypedefPtrField:    ptr.To(Max0Type(strings.Repeat("x", 1))),
+		Max0ValidatedTypedefPtrField:    new(Max0Type(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 11)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 11))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 11))),
 		Max10BytesField:                 bytes.Repeat([]byte("x"), 11),
 		Max10ValidatedTypedefBytesField: Max10BytesType(bytes.Repeat([]byte("x"), 11)),
 	}
@@ -97,32 +96,32 @@ func Test(t *testing.T) {
 	// Test validation ratcheting
 	st.Value(&Struct{
 		Max0Field:                       strings.Repeat("x", 1),
-		Max0PtrField:                    ptr.To(strings.Repeat("x", 1)),
+		Max0PtrField:                    new(strings.Repeat("x", 1)),
 		Max10Field:                      strings.Repeat("x", 11),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 11)),
+		Max10PtrField:                   new(strings.Repeat("x", 11)),
 		Max0UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max0UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max0UnvalidatedTypedefPtrField:  new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 11)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 11))),
 		Max0ValidatedTypedefField:       Max0Type(strings.Repeat("x", 1)),
-		Max0ValidatedTypedefPtrField:    ptr.To(Max0Type(strings.Repeat("x", 1))),
+		Max0ValidatedTypedefPtrField:    new(Max0Type(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 11)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 11))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 11))),
 		Max10BytesField:                 bytes.Repeat([]byte("x"), 11),
 		Max10ValidatedTypedefBytesField: Max10BytesType(bytes.Repeat([]byte("x"), 11)),
 	}).OldValue(&Struct{
 		Max0Field:                       strings.Repeat("x", 1),
-		Max0PtrField:                    ptr.To(strings.Repeat("x", 1)),
+		Max0PtrField:                    new(strings.Repeat("x", 1)),
 		Max10Field:                      strings.Repeat("x", 11),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 11)),
+		Max10PtrField:                   new(strings.Repeat("x", 11)),
 		Max0UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max0UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max0UnvalidatedTypedefPtrField:  new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 11)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 11))),
 		Max0ValidatedTypedefField:       Max0Type(strings.Repeat("x", 1)),
-		Max0ValidatedTypedefPtrField:    ptr.To(Max0Type(strings.Repeat("x", 1))),
+		Max0ValidatedTypedefPtrField:    new(Max0Type(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 11)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 11))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 11))),
 		Max10BytesField:                 bytes.Repeat([]byte("x"), 11),
 		Max10ValidatedTypedefBytesField: Max10BytesType(bytes.Repeat([]byte("x"), 11)),
 	}).ExpectValid()

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maximum/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maximum/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -29,7 +28,7 @@ func Test(t *testing.T) {
 	st.Value(&Struct{
 		// invalid values (greater than maximum=1)
 		IntField:        2,
-		IntPtrField:     ptr.To(2),
+		IntPtrField:     new(2),
 		Int16Field:      2,
 		Int32Field:      2,
 		Int64Field:      2,
@@ -37,9 +36,9 @@ func Test(t *testing.T) {
 		Uint16Field:     2,
 		Uint32Field:     2,
 		Uint64Field:     2,
-		UintPtrField:    ptr.To(uint(2)),
+		UintPtrField:    new(uint(2)),
 		TypedefField:    IntType(2),
-		TypedefPtrField: ptr.To(IntType(2)),
+		TypedefPtrField: new(IntType(2)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring(), field.ErrorList{
 		field.Invalid(field.NewPath("intField"), nil, ""),
 		field.Invalid(field.NewPath("intPtrField"), nil, ""),
@@ -57,7 +56,7 @@ func Test(t *testing.T) {
 	// Test validation ratcheting
 	st.Value(&Struct{
 		IntField:        2,
-		IntPtrField:     ptr.To(2),
+		IntPtrField:     new(2),
 		Int16Field:      2,
 		Int32Field:      2,
 		Int64Field:      2,
@@ -65,12 +64,12 @@ func Test(t *testing.T) {
 		Uint16Field:     2,
 		Uint32Field:     2,
 		Uint64Field:     2,
-		UintPtrField:    ptr.To(uint(2)),
+		UintPtrField:    new(uint(2)),
 		TypedefField:    IntType(2),
-		TypedefPtrField: ptr.To(IntType(2)),
+		TypedefPtrField: new(IntType(2)),
 	}).OldValue(&Struct{
 		IntField:        2,
-		IntPtrField:     ptr.To(2),
+		IntPtrField:     new(2),
 		Int16Field:      2,
 		Int32Field:      2,
 		Int64Field:      2,
@@ -78,14 +77,14 @@ func Test(t *testing.T) {
 		Uint16Field:     2,
 		Uint32Field:     2,
 		Uint64Field:     2,
-		UintPtrField:    ptr.To(uint(2)),
+		UintPtrField:    new(uint(2)),
 		TypedefField:    IntType(2),
-		TypedefPtrField: ptr.To(IntType(2)),
+		TypedefPtrField: new(IntType(2)),
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		IntField:        1,
-		IntPtrField:     ptr.To(1),
+		IntPtrField:     new(1),
 		Int16Field:      1,
 		Int32Field:      1,
 		Int64Field:      1,
@@ -93,8 +92,8 @@ func Test(t *testing.T) {
 		Uint16Field:     1,
 		Uint32Field:     1,
 		Uint64Field:     1,
-		UintPtrField:    ptr.To(uint(1)),
+		UintPtrField:    new(uint(1)),
 		TypedefField:    IntType(1),
-		TypedefPtrField: ptr.To(IntType(1)),
+		TypedefPtrField: new(IntType(1)),
 	}).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/maxlength/doc_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -33,44 +32,44 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		Max10Field:                      strings.Repeat("x", 1),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 1)),
+		Max10PtrField:                   new(strings.Repeat("x", 1)),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 1)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 1))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 1))),
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		Max10Field:                      strings.Repeat("x", 9),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 9)),
+		Max10PtrField:                   new(strings.Repeat("x", 9)),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 9)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 9))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 9))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 9)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 9))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 9))),
 	}).ExpectValid()
 
 	st.Value(&Struct{
 		Max10Field:                      strings.Repeat("x", 10),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 10)),
+		Max10PtrField:                   new(strings.Repeat("x", 10)),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 10)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 10))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 10))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 10)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 10))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 10))),
 	}).ExpectValid()
 
 	testVal := &Struct{
 		Max0Field:                       strings.Repeat("x", 1),
-		Max0PtrField:                    ptr.To(strings.Repeat("x", 1)),
+		Max0PtrField:                    new(strings.Repeat("x", 1)),
 		Max10Field:                      strings.Repeat("x", 11),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 11)),
+		Max10PtrField:                   new(strings.Repeat("x", 11)),
 		Max0UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max0UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max0UnvalidatedTypedefPtrField:  new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 11)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 11))),
 		Max0ValidatedTypedefField:       Max0Type(strings.Repeat("x", 1)),
-		Max0ValidatedTypedefPtrField:    ptr.To(Max0Type(strings.Repeat("x", 1))),
+		Max0ValidatedTypedefPtrField:    new(Max0Type(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 11)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 11))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 11))),
 	}
 	st.Value(testVal).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.TooLongCharacters(field.NewPath("max0Field"), "", 0),
@@ -90,29 +89,29 @@ func Test(t *testing.T) {
 	// Test validation ratcheting
 	st.Value(&Struct{
 		Max0Field:                       strings.Repeat("x", 1),
-		Max0PtrField:                    ptr.To(strings.Repeat("x", 1)),
+		Max0PtrField:                    new(strings.Repeat("x", 1)),
 		Max10Field:                      strings.Repeat("x", 11),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 11)),
+		Max10PtrField:                   new(strings.Repeat("x", 11)),
 		Max0UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max0UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max0UnvalidatedTypedefPtrField:  new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 11)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 11))),
 		Max0ValidatedTypedefField:       Max0Type(strings.Repeat("x", 1)),
-		Max0ValidatedTypedefPtrField:    ptr.To(Max0Type(strings.Repeat("x", 1))),
+		Max0ValidatedTypedefPtrField:    new(Max0Type(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 11)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 11))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 11))),
 	}).OldValue(&Struct{
 		Max0Field:                       strings.Repeat("x", 1),
-		Max0PtrField:                    ptr.To(strings.Repeat("x", 1)),
+		Max0PtrField:                    new(strings.Repeat("x", 1)),
 		Max10Field:                      strings.Repeat("x", 11),
-		Max10PtrField:                   ptr.To(strings.Repeat("x", 11)),
+		Max10PtrField:                   new(strings.Repeat("x", 11)),
 		Max0UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 1)),
-		Max0UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Max0UnvalidatedTypedefPtrField:  new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Max10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 11)),
-		Max10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Max10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 11))),
 		Max0ValidatedTypedefField:       Max0Type(strings.Repeat("x", 1)),
-		Max0ValidatedTypedefPtrField:    ptr.To(Max0Type(strings.Repeat("x", 1))),
+		Max0ValidatedTypedefPtrField:    new(Max0Type(strings.Repeat("x", 1))),
 		Max10ValidatedTypedefField:      Max10Type(strings.Repeat("x", 11)),
-		Max10ValidatedTypedefPtrField:   ptr.To(Max10Type(strings.Repeat("x", 11))),
+		Max10ValidatedTypedefPtrField:   new(Max10Type(strings.Repeat("x", 11))),
 	}).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minimum/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestBasicStruct(t *testing.T) {
@@ -29,9 +28,9 @@ func TestBasicStruct(t *testing.T) {
 	// Test that zero values are rejected because they are below the minimum of 1.
 	st.Value(&BasicStruct{
 		// all zero values
-		IntPtrField:     ptr.To(0),
-		UintPtrField:    ptr.To(uint(0)),
-		TypedefPtrField: ptr.To(IntType(0)),
+		IntPtrField:     new(0),
+		UintPtrField:    new(uint(0)),
+		TypedefPtrField: new(IntType(0)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("intField"), nil, "").WithOrigin("minimum"),
 		field.Invalid(field.NewPath("intPtrField"), nil, "").WithOrigin("minimum"),
@@ -49,32 +48,32 @@ func TestBasicStruct(t *testing.T) {
 
 	// Test validation ratcheting: unchanged invalid data is allowed.
 	st.Value(&BasicStruct{
-		IntPtrField:     ptr.To(0),
-		UintPtrField:    ptr.To(uint(0)),
-		TypedefPtrField: ptr.To(IntType(0)),
+		IntPtrField:     new(0),
+		UintPtrField:    new(uint(0)),
+		TypedefPtrField: new(IntType(0)),
 	}).OldValue(&BasicStruct{
-		IntPtrField:     ptr.To(0),
-		UintPtrField:    ptr.To(uint(0)),
-		TypedefPtrField: ptr.To(IntType(0)),
+		IntPtrField:     new(0),
+		UintPtrField:    new(uint(0)),
+		TypedefPtrField: new(IntType(0)),
 	}).ExpectValid()
 
 	// Changed invalid data is still rejected.
 	st.Value(&BasicStruct{
 		IntField:        -1,
-		IntPtrField:     ptr.To(-1),
+		IntPtrField:     new(-1),
 		Int16Field:      -1,
 		Int32Field:      -1,
 		Int64Field:      -1,
 		TypedefField:    IntType(-1),
-		TypedefPtrField: ptr.To(IntType(-1)),
+		TypedefPtrField: new(IntType(-1)),
 	}).OldValue(&BasicStruct{
 		IntField:        0,
-		IntPtrField:     ptr.To(0),
+		IntPtrField:     new(0),
 		Int16Field:      0,
 		Int32Field:      0,
 		Int64Field:      0,
 		TypedefField:    IntType(0),
-		TypedefPtrField: ptr.To(IntType(0)),
+		TypedefPtrField: new(IntType(0)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("intField"), nil, "").WithOrigin("minimum"),
 		field.Invalid(field.NewPath("intPtrField"), nil, "").WithOrigin("minimum"),
@@ -88,7 +87,7 @@ func TestBasicStruct(t *testing.T) {
 	// Test that values meeting the minimum of 1 are valid.
 	st.Value(&BasicStruct{
 		IntField:        1,
-		IntPtrField:     ptr.To(1),
+		IntPtrField:     new(1),
 		Int16Field:      1,
 		Int32Field:      1,
 		Int64Field:      1,
@@ -96,9 +95,9 @@ func TestBasicStruct(t *testing.T) {
 		Uint16Field:     1,
 		Uint32Field:     1,
 		Uint64Field:     1,
-		UintPtrField:    ptr.To(uint(1)),
+		UintPtrField:    new(uint(1)),
 		TypedefField:    IntType(1),
-		TypedefPtrField: ptr.To(IntType(1)),
+		TypedefPtrField: new(IntType(1)),
 	}).ExpectValid()
 }
 
@@ -108,8 +107,8 @@ func TestOptionalStruct(t *testing.T) {
 	// Test that explicitly provided zero values for optional pointers are still validated against minimum.
 	st.Value(&OptionalStruct{
 		// zero values
-		OptionalIntPtrField:     ptr.To(0),
-		OptionalTypedefPtrField: ptr.To(IntType(0)),
+		OptionalIntPtrField:     new(0),
+		OptionalTypedefPtrField: new(IntType(0)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("optionalIntPtrField"), nil, "").WithOrigin("minimum"),
 		field.Invalid(field.NewPath("optionalTypedefPtrField"), nil, "").WithOrigin("minimum"),
@@ -124,27 +123,27 @@ func TestOptionalStruct(t *testing.T) {
 	// Test validation ratcheting: unchanged invalid data is allowed.
 	st.Value(&OptionalStruct{
 		OptionalIntField:        -1,
-		OptionalIntPtrField:     ptr.To(-1),
+		OptionalIntPtrField:     new(-1),
 		OptionalTypedefField:    IntType(-1),
-		OptionalTypedefPtrField: ptr.To(IntType(-1)),
+		OptionalTypedefPtrField: new(IntType(-1)),
 	}).OldValue(&OptionalStruct{
 		OptionalIntField:        -1,
-		OptionalIntPtrField:     ptr.To(-1),
+		OptionalIntPtrField:     new(-1),
 		OptionalTypedefField:    IntType(-1),
-		OptionalTypedefPtrField: ptr.To(IntType(-1)),
+		OptionalTypedefPtrField: new(IntType(-1)),
 	}).ExpectValid()
 
 	// Changed invalid data is still rejected.
 	st.Value(&OptionalStruct{
 		OptionalIntField:        -2,
-		OptionalIntPtrField:     ptr.To(-2),
+		OptionalIntPtrField:     new(-2),
 		OptionalTypedefField:    IntType(-2),
-		OptionalTypedefPtrField: ptr.To(IntType(-2)),
+		OptionalTypedefPtrField: new(IntType(-2)),
 	}).OldValue(&OptionalStruct{
 		OptionalIntField:        -1,
-		OptionalIntPtrField:     ptr.To(-1),
+		OptionalIntPtrField:     new(-1),
 		OptionalTypedefField:    IntType(-1),
-		OptionalTypedefPtrField: ptr.To(IntType(-1)),
+		OptionalTypedefPtrField: new(IntType(-1)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("optionalIntField"), nil, "").WithOrigin("minimum"),
 		field.Invalid(field.NewPath("optionalIntPtrField"), nil, "").WithOrigin("minimum"),
@@ -155,17 +154,17 @@ func TestOptionalStruct(t *testing.T) {
 	// Test that values meeting the minimum of 1 are valid.
 	st.Value(&OptionalStruct{
 		OptionalIntField:        1,
-		OptionalIntPtrField:     ptr.To(1),
+		OptionalIntPtrField:     new(1),
 		OptionalTypedefField:    IntType(1),
-		OptionalTypedefPtrField: ptr.To(IntType(1)),
+		OptionalTypedefPtrField: new(IntType(1)),
 	}).ExpectValid()
 
 	// Test that invalid values below the minimum are rejected.
 	st.Value(&OptionalStruct{
 		OptionalIntField:        -1,
-		OptionalIntPtrField:     ptr.To(-1),
+		OptionalIntPtrField:     new(-1),
 		OptionalTypedefField:    IntType(-1),
-		OptionalTypedefPtrField: ptr.To(IntType(-1)),
+		OptionalTypedefPtrField: new(IntType(-1)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("optionalIntField"), nil, "").WithOrigin("minimum"),
 		field.Invalid(field.NewPath("optionalIntPtrField"), nil, "").WithOrigin("minimum"),
@@ -182,9 +181,9 @@ func TestRequiredStruct(t *testing.T) {
 	st.Value(&RequiredStruct{
 		// zero values
 		RequiredIntField:        0,
-		RequiredIntPtrField:     ptr.To(0),
+		RequiredIntPtrField:     new(0),
 		RequiredTypedefField:    IntType(0),
-		RequiredTypedefPtrField: ptr.To(IntType(0)),
+		RequiredTypedefPtrField: new(IntType(0)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Required(field.NewPath("requiredIntField"), ""),
 		field.Invalid(field.NewPath("requiredIntPtrField"), nil, "").WithOrigin("minimum"),
@@ -205,27 +204,27 @@ func TestRequiredStruct(t *testing.T) {
 	// Test validation ratcheting: unchanged invalid data is allowed.
 	st.Value(&RequiredStruct{
 		RequiredIntField:        0,
-		RequiredIntPtrField:     ptr.To(0),
+		RequiredIntPtrField:     new(0),
 		RequiredTypedefField:    IntType(0),
-		RequiredTypedefPtrField: ptr.To(IntType(0)),
+		RequiredTypedefPtrField: new(IntType(0)),
 	}).OldValue(&RequiredStruct{
 		RequiredIntField:        0,
-		RequiredIntPtrField:     ptr.To(0),
+		RequiredIntPtrField:     new(0),
 		RequiredTypedefField:    IntType(0),
-		RequiredTypedefPtrField: ptr.To(IntType(0)),
+		RequiredTypedefPtrField: new(IntType(0)),
 	}).ExpectValid()
 
 	// Changed invalid data is still rejected.
 	st.Value(&RequiredStruct{
 		RequiredIntField:        -1,
-		RequiredIntPtrField:     ptr.To(-1),
+		RequiredIntPtrField:     new(-1),
 		RequiredTypedefField:    IntType(-1),
-		RequiredTypedefPtrField: ptr.To(IntType(-1)),
+		RequiredTypedefPtrField: new(IntType(-1)),
 	}).OldValue(&RequiredStruct{
 		RequiredIntField:        0,
-		RequiredIntPtrField:     ptr.To(0),
+		RequiredIntPtrField:     new(0),
 		RequiredTypedefField:    IntType(0),
-		RequiredTypedefPtrField: ptr.To(IntType(0)),
+		RequiredTypedefPtrField: new(IntType(0)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("requiredIntField"), nil, "").WithOrigin("minimum"),
 		field.Invalid(field.NewPath("requiredIntPtrField"), nil, "").WithOrigin("minimum"),
@@ -236,17 +235,17 @@ func TestRequiredStruct(t *testing.T) {
 	// Test that values meeting the minimum of 1 are valid.
 	st.Value(&RequiredStruct{
 		RequiredIntField:        1,
-		RequiredIntPtrField:     ptr.To(1),
+		RequiredIntPtrField:     new(1),
 		RequiredTypedefField:    IntType(1),
-		RequiredTypedefPtrField: ptr.To(IntType(1)),
+		RequiredTypedefPtrField: new(IntType(1)),
 	}).ExpectValid()
 
 	// Test that invalid values below the minimum are rejected.
 	st.Value(&RequiredStruct{
 		RequiredIntField:        -1,
-		RequiredIntPtrField:     ptr.To(-1),
+		RequiredIntPtrField:     new(-1),
 		RequiredTypedefField:    IntType(-1),
-		RequiredTypedefPtrField: ptr.To(IntType(-1)),
+		RequiredTypedefPtrField: new(IntType(-1)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("requiredIntField"), nil, "").WithOrigin("minimum"),
 		field.Invalid(field.NewPath("requiredIntPtrField"), nil, "").WithOrigin("minimum"),
@@ -262,10 +261,10 @@ func TestNegativeMinimumStruct(t *testing.T) {
 	// while zero values for non-pointers trigger required validation.
 	st.Value(&NegativeMinimumStruct{
 		// zero values (valid for -10)
-		NegativeMinimumPtrField:         ptr.To(0),
-		OptionalNegativeMinimumPtrField: ptr.To(0),
+		NegativeMinimumPtrField:         new(0),
+		OptionalNegativeMinimumPtrField: new(0),
 		RequiredNegativeMinimumField:    0,
-		RequiredNegativeMinimumPtrField: ptr.To(0),
+		RequiredNegativeMinimumPtrField: new(0),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Required(field.NewPath("requiredNegativeMinimumField"), ""),
 	})
@@ -273,45 +272,45 @@ func TestNegativeMinimumStruct(t *testing.T) {
 	// Test that valid values at the negative minimum boundary (-10) are accepted.
 	st.Value(&NegativeMinimumStruct{
 		NegativeMinimumField:            -10,
-		NegativeMinimumPtrField:         ptr.To(-10),
+		NegativeMinimumPtrField:         new(-10),
 		OptionalNegativeMinimumField:    -10,
-		OptionalNegativeMinimumPtrField: ptr.To(-10),
+		OptionalNegativeMinimumPtrField: new(-10),
 		RequiredNegativeMinimumField:    -10,
-		RequiredNegativeMinimumPtrField: ptr.To(-10),
+		RequiredNegativeMinimumPtrField: new(-10),
 	}).ExpectValid()
 
 	// Test validation ratcheting: unchanged invalid data is allowed.
 	st.Value(&NegativeMinimumStruct{
 		NegativeMinimumField:            -11,
-		NegativeMinimumPtrField:         ptr.To(-11),
+		NegativeMinimumPtrField:         new(-11),
 		OptionalNegativeMinimumField:    -11,
-		OptionalNegativeMinimumPtrField: ptr.To(-11),
+		OptionalNegativeMinimumPtrField: new(-11),
 		RequiredNegativeMinimumField:    -11,
-		RequiredNegativeMinimumPtrField: ptr.To(-11),
+		RequiredNegativeMinimumPtrField: new(-11),
 	}).OldValue(&NegativeMinimumStruct{
 		NegativeMinimumField:            -11,
-		NegativeMinimumPtrField:         ptr.To(-11),
+		NegativeMinimumPtrField:         new(-11),
 		OptionalNegativeMinimumField:    -11,
-		OptionalNegativeMinimumPtrField: ptr.To(-11),
+		OptionalNegativeMinimumPtrField: new(-11),
 		RequiredNegativeMinimumField:    -11,
-		RequiredNegativeMinimumPtrField: ptr.To(-11),
+		RequiredNegativeMinimumPtrField: new(-11),
 	}).ExpectValid()
 
 	// Changed invalid data is still rejected.
 	st.Value(&NegativeMinimumStruct{
 		NegativeMinimumField:            -12,
-		NegativeMinimumPtrField:         ptr.To(-12),
+		NegativeMinimumPtrField:         new(-12),
 		OptionalNegativeMinimumField:    -12,
-		OptionalNegativeMinimumPtrField: ptr.To(-12),
+		OptionalNegativeMinimumPtrField: new(-12),
 		RequiredNegativeMinimumField:    -12,
-		RequiredNegativeMinimumPtrField: ptr.To(-12),
+		RequiredNegativeMinimumPtrField: new(-12),
 	}).OldValue(&NegativeMinimumStruct{
 		NegativeMinimumField:            -11,
-		NegativeMinimumPtrField:         ptr.To(-11),
+		NegativeMinimumPtrField:         new(-11),
 		OptionalNegativeMinimumField:    -11,
-		OptionalNegativeMinimumPtrField: ptr.To(-11),
+		OptionalNegativeMinimumPtrField: new(-11),
 		RequiredNegativeMinimumField:    -11,
-		RequiredNegativeMinimumPtrField: ptr.To(-11),
+		RequiredNegativeMinimumPtrField: new(-11),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("negativeMinimumField"), nil, "").WithOrigin("minimum"),
 		field.Invalid(field.NewPath("negativeMinimumPtrField"), nil, "").WithOrigin("minimum"),
@@ -324,11 +323,11 @@ func TestNegativeMinimumStruct(t *testing.T) {
 	// Test that invalid values below the negative minimum (-10) are rejected.
 	st.Value(&NegativeMinimumStruct{
 		NegativeMinimumField:            -11,
-		NegativeMinimumPtrField:         ptr.To(-11),
+		NegativeMinimumPtrField:         new(-11),
 		OptionalNegativeMinimumField:    -11,
-		OptionalNegativeMinimumPtrField: ptr.To(-11),
+		OptionalNegativeMinimumPtrField: new(-11),
 		RequiredNegativeMinimumField:    -11,
-		RequiredNegativeMinimumPtrField: ptr.To(-11),
+		RequiredNegativeMinimumPtrField: new(-11),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("negativeMinimumField"), nil, "").WithOrigin("minimum"),
 		field.Invalid(field.NewPath("negativeMinimumPtrField"), nil, "").WithOrigin("minimum"),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minlength/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/minlength/doc_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -33,19 +32,19 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		Min2Field:                          strings.Repeat("x", 1),
-		Min2PtrField:                       ptr.To(strings.Repeat("x", 1)),
+		Min2PtrField:                       new(strings.Repeat("x", 1)),
 		Min2UnvalidatedTypedefField:        UnvalidatedStringType(strings.Repeat("x", 1)),
-		Min2UnvalidatedTypedefPtrField:     ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Min2UnvalidatedTypedefPtrField:     new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Min2ValidatedTypedefField:          Min2Type(strings.Repeat("x", 1)),
-		Min2ValidatedTypedefPtrField:       ptr.To(Min2Type(strings.Repeat("x", 1))),
+		Min2ValidatedTypedefPtrField:       new(Min2Type(strings.Repeat("x", 1))),
 		Min10Field:                         strings.Repeat("x", 1),
-		Min10PtrField:                      ptr.To(strings.Repeat("x", 1)),
+		Min10PtrField:                      new(strings.Repeat("x", 1)),
 		Min10UnvalidatedTypedefField:       UnvalidatedStringType(strings.Repeat("x", 1)),
-		Min10UnvalidatedTypedefPtrField:    ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Min10UnvalidatedTypedefPtrField:    new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Min10ValidatedTypedefField:         Min10Type(strings.Repeat("x", 1)),
-		Min10ValidatedTypedefPtrField:      ptr.To(Min10Type(strings.Repeat("x", 1))),
+		Min10ValidatedTypedefPtrField:      new(Min10Type(strings.Repeat("x", 1))),
 		Min2UnvalidatedStringAliasField:    strings.Repeat("x", 1),
-		Min2UnvalidatedStringAliasPtrField: ptr.To(strings.Repeat("x", 1)),
+		Min2UnvalidatedStringAliasPtrField: new(strings.Repeat("x", 1)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.TooShort(field.NewPath("min10Field"), "", 10),
 		field.TooShort(field.NewPath("min10PtrField"), "", 10),
@@ -65,19 +64,19 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		Min2Field:                          strings.Repeat("x", 1),
-		Min2PtrField:                       ptr.To(strings.Repeat("x", 1)),
+		Min2PtrField:                       new(strings.Repeat("x", 1)),
 		Min2UnvalidatedTypedefField:        UnvalidatedStringType(strings.Repeat("x", 1)),
-		Min2UnvalidatedTypedefPtrField:     ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Min2UnvalidatedTypedefPtrField:     new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Min2ValidatedTypedefField:          Min2Type(strings.Repeat("x", 1)),
-		Min2ValidatedTypedefPtrField:       ptr.To(Min2Type(strings.Repeat("x", 1))),
+		Min2ValidatedTypedefPtrField:       new(Min2Type(strings.Repeat("x", 1))),
 		Min10Field:                         strings.Repeat("x", 9),
-		Min10PtrField:                      ptr.To(strings.Repeat("x", 9)),
+		Min10PtrField:                      new(strings.Repeat("x", 9)),
 		Min10UnvalidatedTypedefField:       UnvalidatedStringType(strings.Repeat("x", 9)),
-		Min10UnvalidatedTypedefPtrField:    ptr.To(UnvalidatedStringType(strings.Repeat("x", 9))),
+		Min10UnvalidatedTypedefPtrField:    new(UnvalidatedStringType(strings.Repeat("x", 9))),
 		Min10ValidatedTypedefField:         Min10Type(strings.Repeat("x", 9)),
-		Min10ValidatedTypedefPtrField:      ptr.To(Min10Type(strings.Repeat("x", 9))),
+		Min10ValidatedTypedefPtrField:      new(Min10Type(strings.Repeat("x", 9))),
 		Min2UnvalidatedStringAliasField:    strings.Repeat("x", 1),
-		Min2UnvalidatedStringAliasPtrField: ptr.To(strings.Repeat("x", 1)),
+		Min2UnvalidatedStringAliasPtrField: new(strings.Repeat("x", 1)),
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.TooShort(field.NewPath("min10Field"), "", 10),
 		field.TooShort(field.NewPath("min10PtrField"), "", 10),
@@ -97,64 +96,64 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		Min2Field:                          strings.Repeat("x", 2),
-		Min2PtrField:                       ptr.To(strings.Repeat("x", 2)),
+		Min2PtrField:                       new(strings.Repeat("x", 2)),
 		Min2UnvalidatedTypedefField:        UnvalidatedStringType(strings.Repeat("x", 2)),
-		Min2UnvalidatedTypedefPtrField:     ptr.To(UnvalidatedStringType(strings.Repeat("x", 2))),
+		Min2UnvalidatedTypedefPtrField:     new(UnvalidatedStringType(strings.Repeat("x", 2))),
 		Min2ValidatedTypedefField:          Min2Type(strings.Repeat("x", 2)),
 		Min10Field:                         strings.Repeat("x", 10),
-		Min10PtrField:                      ptr.To(strings.Repeat("x", 10)),
+		Min10PtrField:                      new(strings.Repeat("x", 10)),
 		Min10UnvalidatedTypedefField:       UnvalidatedStringType(strings.Repeat("x", 10)),
-		Min10UnvalidatedTypedefPtrField:    ptr.To(UnvalidatedStringType(strings.Repeat("x", 10))),
+		Min10UnvalidatedTypedefPtrField:    new(UnvalidatedStringType(strings.Repeat("x", 10))),
 		Min10ValidatedTypedefField:         Min10Type(strings.Repeat("x", 10)),
-		Min10ValidatedTypedefPtrField:      ptr.To(Min10Type(strings.Repeat("x", 10))),
+		Min10ValidatedTypedefPtrField:      new(Min10Type(strings.Repeat("x", 10))),
 		Min2UnvalidatedStringAliasField:    strings.Repeat("x", 2),
-		Min2UnvalidatedStringAliasPtrField: ptr.To(strings.Repeat("x", 2)),
+		Min2UnvalidatedStringAliasPtrField: new(strings.Repeat("x", 2)),
 	}).ExpectValid()
 
 	testVal := &Struct{
 		Min2Field:                          strings.Repeat("x", 3),
-		Min2PtrField:                       ptr.To(strings.Repeat("x", 3)),
+		Min2PtrField:                       new(strings.Repeat("x", 3)),
 		Min10Field:                         strings.Repeat("x", 11),
-		Min10PtrField:                      ptr.To(strings.Repeat("x", 11)),
+		Min10PtrField:                      new(strings.Repeat("x", 11)),
 		Min2UnvalidatedTypedefField:        UnvalidatedStringType(strings.Repeat("x", 3)),
-		Min2UnvalidatedTypedefPtrField:     ptr.To(UnvalidatedStringType(strings.Repeat("x", 3))),
+		Min2UnvalidatedTypedefPtrField:     new(UnvalidatedStringType(strings.Repeat("x", 3))),
 		Min10UnvalidatedTypedefField:       UnvalidatedStringType(strings.Repeat("x", 11)),
-		Min10UnvalidatedTypedefPtrField:    ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Min10UnvalidatedTypedefPtrField:    new(UnvalidatedStringType(strings.Repeat("x", 11))),
 		Min2ValidatedTypedefField:          Min2Type(strings.Repeat("x", 3)),
-		Min2ValidatedTypedefPtrField:       ptr.To(Min2Type(strings.Repeat("x", 3))),
+		Min2ValidatedTypedefPtrField:       new(Min2Type(strings.Repeat("x", 3))),
 		Min10ValidatedTypedefField:         Min10Type(strings.Repeat("x", 11)),
-		Min10ValidatedTypedefPtrField:      ptr.To(Min10Type(strings.Repeat("x", 11))),
+		Min10ValidatedTypedefPtrField:      new(Min10Type(strings.Repeat("x", 11))),
 		Min2UnvalidatedStringAliasField:    strings.Repeat("x", 3),
-		Min2UnvalidatedStringAliasPtrField: ptr.To(strings.Repeat("x", 3)),
+		Min2UnvalidatedStringAliasPtrField: new(strings.Repeat("x", 3)),
 	}
 	st.Value(testVal).ExpectValid()
 
 	// Test validation ratcheting
 	st.Value(&Struct{
 		Min2Field:                       strings.Repeat("x", 2),
-		Min2PtrField:                    ptr.To(strings.Repeat("x", 2)),
+		Min2PtrField:                    new(strings.Repeat("x", 2)),
 		Min10Field:                      strings.Repeat("x", 11),
-		Min10PtrField:                   ptr.To(strings.Repeat("x", 11)),
+		Min10PtrField:                   new(strings.Repeat("x", 11)),
 		Min2UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 2)),
-		Min2UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 2))),
+		Min2UnvalidatedTypedefPtrField:  new(UnvalidatedStringType(strings.Repeat("x", 2))),
 		Min10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 11)),
-		Min10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 11))),
+		Min10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 11))),
 		Min2ValidatedTypedefField:       Min2Type(strings.Repeat("x", 2)),
-		Min2ValidatedTypedefPtrField:    ptr.To(Min2Type(strings.Repeat("x", 2))),
+		Min2ValidatedTypedefPtrField:    new(Min2Type(strings.Repeat("x", 2))),
 		Min10ValidatedTypedefField:      Min10Type(strings.Repeat("x", 11)),
-		Min10ValidatedTypedefPtrField:   ptr.To(Min10Type(strings.Repeat("x", 11))),
+		Min10ValidatedTypedefPtrField:   new(Min10Type(strings.Repeat("x", 11))),
 	}).OldValue(&Struct{
 		Min2Field:                       strings.Repeat("x", 1),
-		Min2PtrField:                    ptr.To(strings.Repeat("x", 1)),
+		Min2PtrField:                    new(strings.Repeat("x", 1)),
 		Min10Field:                      strings.Repeat("x", 9),
-		Min10PtrField:                   ptr.To(strings.Repeat("x", 1)),
+		Min10PtrField:                   new(strings.Repeat("x", 1)),
 		Min2UnvalidatedTypedefField:     UnvalidatedStringType(strings.Repeat("x", 1)),
-		Min2UnvalidatedTypedefPtrField:  ptr.To(UnvalidatedStringType(strings.Repeat("x", 1))),
+		Min2UnvalidatedTypedefPtrField:  new(UnvalidatedStringType(strings.Repeat("x", 1))),
 		Min10UnvalidatedTypedefField:    UnvalidatedStringType(strings.Repeat("x", 9)),
-		Min10UnvalidatedTypedefPtrField: ptr.To(UnvalidatedStringType(strings.Repeat("x", 9))),
+		Min10UnvalidatedTypedefPtrField: new(UnvalidatedStringType(strings.Repeat("x", 9))),
 		Min2ValidatedTypedefField:       Min2Type(strings.Repeat("x", 1)),
-		Min2ValidatedTypedefPtrField:    ptr.To(Min2Type(strings.Repeat("x", 1))),
+		Min2ValidatedTypedefPtrField:    new(Min2Type(strings.Repeat("x", 1))),
 		Min10ValidatedTypedefField:      Min10Type(strings.Repeat("x", 9)),
-		Min10ValidatedTypedefPtrField:   ptr.To(Min10Type(strings.Repeat("x", 9))),
+		Min10ValidatedTypedefPtrField:   new(Min10Type(strings.Repeat("x", 9))),
 	}).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/mode/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/mode/doc_test.go
@@ -20,27 +20,26 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestStrictUnion(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	// Mode A: FieldA required, FieldB implicitly forbidden
-	st.Value(&StrictUnion{D1: "A", FieldA: ptr.To("val")}).ExpectValid()
+	st.Value(&StrictUnion{D1: "A", FieldA: new("val")}).ExpectValid()
 	st.Value(&StrictUnion{D1: "A"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Required(field.NewPath("fieldA"), ""),
 	})
-	st.Value(&StrictUnion{D1: "A", FieldA: ptr.To("val"), FieldB: ptr.To("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	st.Value(&StrictUnion{D1: "A", FieldA: new("val"), FieldB: new("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Forbidden(field.NewPath("fieldB"), ""),
 	})
 
 	// Mode B: FieldA implicitly forbidden, FieldB required
-	st.Value(&StrictUnion{D1: "B", FieldB: ptr.To("val")}).ExpectValid()
+	st.Value(&StrictUnion{D1: "B", FieldB: new("val")}).ExpectValid()
 	st.Value(&StrictUnion{D1: "B"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Required(field.NewPath("fieldB"), ""),
 	})
-	st.Value(&StrictUnion{D1: "B", FieldA: ptr.To("val"), FieldB: ptr.To("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	st.Value(&StrictUnion{D1: "B", FieldA: new("val"), FieldB: new("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Forbidden(field.NewPath("fieldA"), ""),
 	})
 }
@@ -50,12 +49,12 @@ func TestSharedField(t *testing.T) {
 
 	// Valid (optional) in A and B
 	st.Value(&SharedField{D1: "A"}).ExpectValid()
-	st.Value(&SharedField{D1: "A", FieldA: ptr.To("val")}).ExpectValid()
+	st.Value(&SharedField{D1: "A", FieldA: new("val")}).ExpectValid()
 	st.Value(&SharedField{D1: "B"}).ExpectValid()
-	st.Value(&SharedField{D1: "B", FieldA: ptr.To("val")}).ExpectValid()
+	st.Value(&SharedField{D1: "B", FieldA: new("val")}).ExpectValid()
 
 	// Forbidden in C
-	st.Value(&SharedField{D1: "C", FieldA: ptr.To("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	st.Value(&SharedField{D1: "C", FieldA: new("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Forbidden(field.NewPath("fieldA"), ""),
 	})
 }
@@ -64,16 +63,16 @@ func TestChainedValidation(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	// Mode A: Required AND maxLength 5
-	st.Value(&ChainedValidation{D1: "A", FieldA: ptr.To("abc")}).ExpectValid()
+	st.Value(&ChainedValidation{D1: "A", FieldA: new("abc")}).ExpectValid()
 	st.Value(&ChainedValidation{D1: "A"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Required(field.NewPath("fieldA"), ""),
 	})
-	st.Value(&ChainedValidation{D1: "A", FieldA: ptr.To("too-long")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	st.Value(&ChainedValidation{D1: "A", FieldA: new("too-long")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.TooLong(field.NewPath("fieldA"), "too-long", 5),
 	})
 
 	// Mode B: Unlisted, so implicitly forbidden
-	st.Value(&ChainedValidation{D1: "B", FieldA: ptr.To("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	st.Value(&ChainedValidation{D1: "B", FieldA: new("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Forbidden(field.NewPath("fieldA"), ""),
 	})
 }
@@ -83,10 +82,10 @@ func TestImplicitForbidden(t *testing.T) {
 
 	// Mode A: Optional
 	st.Value(&ImplicitForbidden{D1: "A"}).ExpectValid()
-	st.Value(&ImplicitForbidden{D1: "A", FieldA: ptr.To("val")}).ExpectValid()
+	st.Value(&ImplicitForbidden{D1: "A", FieldA: new("val")}).ExpectValid()
 
 	// Mode B: Not listed, so implicitly Forbidden
-	st.Value(&ImplicitForbidden{D1: "B", FieldA: ptr.To("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	st.Value(&ImplicitForbidden{D1: "B", FieldA: new("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Forbidden(field.NewPath("fieldA"), ""),
 	})
 }
@@ -95,11 +94,11 @@ func TestNonStringDiscriminator(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	// Bool mode
-	st.Value(&NonStringDiscriminator{D1: true, FieldA: ptr.To("val")}).ExpectValid()
+	st.Value(&NonStringDiscriminator{D1: true, FieldA: new("val")}).ExpectValid()
 	st.Value(&NonStringDiscriminator{D1: true}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Required(field.NewPath("fieldA"), ""),
 	})
-	st.Value(&NonStringDiscriminator{D1: false, FieldA: ptr.To("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
+	st.Value(&NonStringDiscriminator{D1: false, FieldA: new("val")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
 		field.Forbidden(field.NewPath("fieldA"), ""),
 	})
 }
@@ -110,8 +109,8 @@ func TestMultipleDiscriminators(t *testing.T) {
 	st.Value(&MultipleDiscriminators{
 		D1:     "A",
 		D2:     "B",
-		FieldA: ptr.To("valA"),
-		FieldB: ptr.To("valB"),
+		FieldA: new("valA"),
+		FieldB: new("valB"),
 	}).ExpectValid()
 
 	st.Value(&MultipleDiscriminators{
@@ -157,7 +156,7 @@ func TestRatcheting(t *testing.T) {
 	mkTest := func() *ChainedValidation {
 		return &ChainedValidation{
 			D1:     "A",
-			FieldA: ptr.To("too-long-string"),
+			FieldA: new("too-long-string"),
 		}
 	}
 
@@ -175,7 +174,7 @@ func TestRatcheting(t *testing.T) {
 	mkDifferent := func() *ChainedValidation {
 		return &ChainedValidation{
 			D1:     "A",
-			FieldA: ptr.To("also-too-long"),
+			FieldA: new("also-too-long"),
 		}
 	}
 	st.Value(mkTest()).OldValue(mkDifferent()).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{
@@ -186,7 +185,7 @@ func TestRatcheting(t *testing.T) {
 	mkDifferentDisc := func() *ChainedValidation {
 		return &ChainedValidation{
 			D1:     "B", // Discriminator changed from B -> A
-			FieldA: ptr.To("too-long-string"),
+			FieldA: new("too-long-string"),
 		}
 	}
 	st.Value(mkTest()).OldValue(mkDifferentDisc()).ExpectMatches(field.ErrorMatcher{}.ByType().ByField(), field.ErrorList{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqbool/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqbool/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -28,7 +27,7 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		NeqTrueField:          false,
-		NeqFalsePtrField:      ptr.To(true),
+		NeqFalsePtrField:      new(true),
 		ValidatedTypedefField: false,
 	}).ExpectValid()
 
@@ -40,7 +39,7 @@ func Test(t *testing.T) {
 
 	invalid := &Struct{
 		NeqTrueField:          true,
-		NeqFalsePtrField:      ptr.To(false),
+		NeqFalsePtrField:      new(false),
 		ValidatedTypedefField: true,
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqint/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqint/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -28,7 +27,7 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		IntField:              1,
-		IntPtrField:           ptr.To(0),
+		IntPtrField:           new(0),
 		IntTypedefField:       41,
 		ValidatedTypedefField: 99,
 	}).ExpectValid()
@@ -42,7 +41,7 @@ func Test(t *testing.T) {
 
 	invalid := &Struct{
 		IntField:              0,
-		IntPtrField:           ptr.To(-1),
+		IntPtrField:           new(-1),
 		IntTypedefField:       42,
 		ValidatedTypedefField: 100,
 	}

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqstring/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/neq/neqstring/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -28,11 +27,11 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		StringField:              "allowed-string",
-		StringPtrField:           ptr.To("allowed-pointer"),
+		StringPtrField:           new("allowed-pointer"),
 		StringTypedefField:       "allowed-typedef",
-		StringTypedefPtrField:    ptr.To(StringType("allowed-typedef-pointer")),
+		StringTypedefPtrField:    new(StringType("allowed-typedef-pointer")),
 		ValidatedTypedefField:    "allowed-on-type",
-		ValidatedTypedefPtrField: ptr.To(ValidatedStringType("allowed-on-type-ptr")),
+		ValidatedTypedefPtrField: new(ValidatedStringType("allowed-on-type-ptr")),
 	}).ExpectValid()
 
 	st.Value(&Struct{
@@ -46,11 +45,11 @@ func Test(t *testing.T) {
 
 	invalid := &Struct{
 		StringField:              "disallowed-string",
-		StringPtrField:           ptr.To("disallowed-pointer"),
+		StringPtrField:           new("disallowed-pointer"),
 		StringTypedefField:       "disallowed-typedef",
-		StringTypedefPtrField:    ptr.To(StringType("disallowed-typedef-pointer")),
+		StringTypedefPtrField:    new(StringType("disallowed-typedef-pointer")),
 		ValidatedTypedefField:    "disallowed-on-type",
-		ValidatedTypedefPtrField: ptr.To(ValidatedStringType("disallowed-on-type")),
+		ValidatedTypedefPtrField: new(ValidatedStringType("disallowed-on-type")),
 	}
 
 	st.Value(invalid).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc_test.go
@@ -18,8 +18,6 @@ package optional
 
 import (
 	"testing"
-
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -31,13 +29,13 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		StringField:           "abc",
-		StringPtrField:        ptr.To("xyz"),
+		StringPtrField:        new("xyz"),
 		StringTypedefField:    StringType("abc"),
-		StringTypedefPtrField: ptr.To(StringType("xyz")),
+		StringTypedefPtrField: new(StringType("xyz")),
 		IntField:              123,
-		IntPtrField:           ptr.To(456),
+		IntPtrField:           new(456),
 		IntTypedefField:       IntType(123),
-		IntTypedefPtrField:    ptr.To(IntType(456)),
+		IntTypedefPtrField:    new(IntType(456)),
 		OtherStructPtrField:   &OtherStruct{},
 		SliceField:            []string{"a", "b"},
 		SliceTypedefField:     SliceType([]string{"a", "b"}),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -34,13 +33,13 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		StringField:           "abc",
-		StringPtrField:        ptr.To("xyz"),
+		StringPtrField:        new("xyz"),
 		StringTypedefField:    StringType("abc"),
-		StringTypedefPtrField: ptr.To(StringType("xyz")),
+		StringTypedefPtrField: new(StringType("xyz")),
 		IntField:              123,
-		IntPtrField:           ptr.To(456),
+		IntPtrField:           new(456),
 		IntTypedefField:       IntType(123),
-		IntTypedefPtrField:    ptr.To(IntType(456)),
+		IntTypedefPtrField:    new(IntType(456)),
 		OtherStructField:      OtherStruct{},
 		OtherStructPtrField:   &OtherStruct{},
 		SliceField:            []string{"a", "b"},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/nonzero_defaults/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/nonzero_defaults/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -42,11 +41,11 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		StringField:    "abc",
-		StringPtrField: ptr.To(""),
+		StringPtrField: new(""),
 		IntField:       123,
-		IntPtrField:    ptr.To(0),
+		IntPtrField:    new(0),
 		BoolField:      true,
-		BoolPtrField:   ptr.To(false),
+		BoolPtrField:   new(false),
 		StructPtrField: &Submarker{Name: "x"},
 		SliceField:     []string{"foo"},
 		MapField:       map[string]string{"k": "v"},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zero_defaults/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/optional/zero_defaults/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -39,10 +38,10 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		StringField:    "abc",
-		StringPtrField: ptr.To(""),
+		StringPtrField: new(""),
 		IntField:       123,
-		IntPtrField:    ptr.To(0),
+		IntPtrField:    new(0),
 		BoolField:      true,
-		BoolPtrField:   ptr.To(false),
+		BoolPtrField:   new(false),
 	}).ExpectValid()
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/discriminators/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/options/discriminators/doc_test.go
@@ -17,9 +17,9 @@ limitations under the License.
 package discriminators
 
 import (
-	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func Test(t *testing.T) {
@@ -32,11 +32,11 @@ func Test(t *testing.T) {
 	st.Value(&Struct{
 		DiscriminatorField: Discriminator{
 			Discriminator: "A",
-			FieldB:        ptr.To("invalid"), // invalid because discriminator is A
+			FieldB:        new("invalid"), // invalid because discriminator is A
 		},
 		DiscriminatorFieldDisabled: DiscriminatorDisabled{
 			Discriminator: "A",
-			FieldB:        ptr.To("invalid"), // invalid because discriminator is A
+			FieldB:        new("invalid"), // invalid because discriminator is A
 		},
 	}).Opts(map[string]bool{"FeatureZ": false}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin(),
@@ -46,11 +46,11 @@ func Test(t *testing.T) {
 	st.Value(&Struct{
 		DiscriminatorField: Discriminator{
 			Discriminator: "A",
-			FieldB:        ptr.To("invalid"), // invalid because discriminator is A
+			FieldB:        new("invalid"), // invalid because discriminator is A
 		},
 		DiscriminatorFieldDisabled: DiscriminatorDisabled{
 			Discriminator: "A",
-			FieldB:        ptr.To("invalid"), // invalid because discriminator is A
+			FieldB:        new("invalid"), // invalid because discriminator is A
 		},
 	}).Opts(map[string]bool{"FeatureZ": true}).ExpectMatches(
 		field.ErrorMatcher{}.ByType().ByField().ByOrigin(),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -89,13 +88,13 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		StringField:           "abc",
-		StringPtrField:        ptr.To("xyz"),
+		StringPtrField:        new("xyz"),
 		StringTypedefField:    StringType("abc"),
-		StringTypedefPtrField: ptr.To(StringType("xyz")),
+		StringTypedefPtrField: new(StringType("xyz")),
 		IntField:              123,
-		IntPtrField:           ptr.To(456),
+		IntPtrField:           new(456),
 		IntTypedefField:       IntType(123),
-		IntTypedefPtrField:    ptr.To(IntType(456)),
+		IntTypedefPtrField:    new(IntType(456)),
 		BoolField:             true,
 		FloatField:            1.23,
 		ByteField:             'a',

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/required/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -92,13 +91,13 @@ func Test(t *testing.T) {
 
 	st.Value(&Struct{
 		StringField:           "abc",
-		StringPtrField:        ptr.To("xyz"),
+		StringPtrField:        new("xyz"),
 		StringTypedefField:    StringType("abc"),
-		StringTypedefPtrField: ptr.To(StringType("xyz")),
+		StringTypedefPtrField: new(StringType("xyz")),
 		IntField:              123,
-		IntPtrField:           ptr.To(456),
+		IntPtrField:           new(456),
 		IntTypedefField:       IntType(123),
-		IntTypedefPtrField:    ptr.To(IntType(456)),
+		IntTypedefPtrField:    new(IntType(456)),
 		BoolField:             true,
 		FloatField:            1.23,
 		ByteField:             'a',

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/shallow/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/shallow/doc_test.go
@@ -18,8 +18,6 @@ package shallow
 
 import (
 	"testing"
-
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -28,14 +26,14 @@ func Test(t *testing.T) {
 	st.Value(&Struct{
 		StructField: OtherStruct{
 			StringField:  "",
-			PointerField: ptr.To(""),
+			PointerField: new(""),
 			StructField:  SmallStruct{},
 			SliceField:   []string{},
 			MapField:     map[string]string{},
 		},
 		StructPtrField: &OtherStruct{
 			StringField:  "",
-			PointerField: ptr.To(""),
+			PointerField: new(""),
 			StructField:  SmallStruct{},
 			SliceField:   []string{},
 			MapField:     map[string]string{},

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/unions/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/subfield/unions/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestStructValidation(t *testing.T) {
@@ -30,7 +29,7 @@ func TestStructValidation(t *testing.T) {
 	st.Value(&Struct{
 		Subfield: SubStruct{
 			D:  "M1",
-			M1: ptr.To(1),
+			M1: new(1),
 		},
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{})
 
@@ -38,7 +37,7 @@ func TestStructValidation(t *testing.T) {
 	st.Value(&Struct{
 		Subfield: SubStruct{
 			D:  "M2",
-			M2: ptr.To(1),
+			M2: new(1),
 		},
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{})
 
@@ -46,7 +45,7 @@ func TestStructValidation(t *testing.T) {
 	st.Value(&Struct{
 		Subfield: SubStruct{
 			D:  "M1",
-			M2: ptr.To(1),
+			M2: new(1),
 		},
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("subfield", "m1"), "", "must be specified when `d` is \"M1\"").WithOrigin("union"),
@@ -57,8 +56,8 @@ func TestStructValidation(t *testing.T) {
 	st.Value(&Struct{
 		Subfield: SubStruct{
 			D:  "M1",
-			M1: ptr.To(1),
-			M2: ptr.To(1),
+			M1: new(1),
+			M2: new(1),
 		},
 	}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("subfield", "m2"), "", "may only be specified when `d` is \"M2\"").WithOrigin("union"),

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/simple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/union/union/undiscriminated/simple/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -33,7 +32,7 @@ func Test(t *testing.T) {
 	st.Value(&Struct{M1: &M1{}}).ExpectValid()
 	st.Value(&Struct{M2: &M2{}}).ExpectValid()
 	st.Value(&Struct{M3: "a string"}).ExpectValid()
-	st.Value(&Struct{M4: ptr.To("a string")}).ExpectValid()
+	st.Value(&Struct{M4: new("a string")}).ExpectValid()
 	st.Value(&Struct{M5: []string{"a string"}}).ExpectValid()
 	st.Value(&Struct{M6: map[string]string{"k": "v"}}).ExpectValid()
 
@@ -51,7 +50,7 @@ func Test(t *testing.T) {
 	st.Value(&Struct{M1: &M1{}, M3: "a string"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(nil, nil, "must specify exactly one of"),
 	}.WithOrigin("union"))
-	st.Value(&Struct{M1: &M1{}, M4: ptr.To("a string")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+	st.Value(&Struct{M1: &M1{}, M4: new("a string")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(nil, nil, "must specify exactly one of"),
 	}.WithOrigin("union"))
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/primitives/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/update/primitives/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func TestUpdateTags(t *testing.T) {
@@ -32,10 +31,10 @@ func TestUpdateTags(t *testing.T) {
 	old := baseStruct
 	old.StringNoSet = "" // unset
 
-	new := baseStruct
-	new.StringNoSet = "value"
+	newWithValue := baseStruct
+	newWithValue.StringNoSet = "value"
 
-	st.Value(&new).OldValue(&old).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+	st.Value(&newWithValue).OldValue(&old).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(field.NewPath("stringNoSet"), nil, "field cannot be set once created").WithOrigin("update"),
 	})
 
@@ -261,7 +260,7 @@ func TestUpdateTags(t *testing.T) {
 
 	// Pointer NoSet
 	withSet := baseStruct
-	withSet.PointerNoSet = ptr.To("value")
+	withSet.PointerNoSet = new("value")
 
 	// Cannot set after creation (nil to non-nil)
 	st.Value(&withSet).OldValue(&baseStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
@@ -270,7 +269,7 @@ func TestUpdateTags(t *testing.T) {
 
 	// Pointer NoUnset
 	withPointer := baseStruct
-	withPointer.PointerNoUnset = ptr.To("value")
+	withPointer.PointerNoUnset = new("value")
 
 	// Can set initially
 	st.Value(&withPointer).OldValue(&baseStruct).ExpectValid()
@@ -282,10 +281,10 @@ func TestUpdateTags(t *testing.T) {
 
 	// Pointer NoModify
 	withPointer = baseStruct
-	withPointer.PointerNoModify = ptr.To("value")
+	withPointer.PointerNoModify = new("value")
 
 	modifiedPointer := baseStruct
-	modifiedPointer.PointerNoModify = ptr.To("different")
+	modifiedPointer.PointerNoModify = new("different")
 
 	// Can set initially
 	st.Value(&withPointer).OldValue(&baseStruct).ExpectValid()
@@ -300,10 +299,10 @@ func TestUpdateTags(t *testing.T) {
 
 	// Pointer Fully Restricted
 	withPointer = baseStruct
-	withPointer.PointerFullyRestricted = ptr.To("value")
+	withPointer.PointerFullyRestricted = new("value")
 
 	modifiedPointer = baseStruct
-	modifiedPointer.PointerFullyRestricted = ptr.To("different")
+	modifiedPointer.PointerFullyRestricted = new("different")
 
 	// Cannot set (NoSet)
 	st.Value(&withPointer).OldValue(&baseStruct).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
@@ -322,10 +321,10 @@ func TestUpdateTags(t *testing.T) {
 
 	// Int Pointer NoModify
 	withPointer = baseStruct
-	withPointer.IntPointerNoModify = ptr.To(42)
+	withPointer.IntPointerNoModify = new(42)
 
 	modifiedPointer = baseStruct
-	modifiedPointer.IntPointerNoModify = ptr.To(100)
+	modifiedPointer.IntPointerNoModify = new(100)
 
 	// Can set initially
 	st.Value(&withPointer).OldValue(&baseStruct).ExpectValid()

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/simple/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/tags/zerooroneof/zerooroneof/simple/doc_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
@@ -32,7 +31,7 @@ func Test(t *testing.T) {
 	st.Value(&Struct{M1: &M1{}}).ExpectValid()
 	st.Value(&Struct{M2: &M2{}}).ExpectValid()
 	st.Value(&Struct{M3: "a string"}).ExpectValid()
-	st.Value(&Struct{M4: ptr.To("a string")}).ExpectValid()
+	st.Value(&Struct{M4: new("a string")}).ExpectValid()
 
 	st.Value(&Struct{M1: &M1{}, M2: &M2{}}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(nil, nil, "must specify at most one of").WithOrigin("zeroOrOneOf"),
@@ -40,7 +39,7 @@ func Test(t *testing.T) {
 	st.Value(&Struct{M1: &M1{}, M3: "a string"}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(nil, nil, "must specify at most one of").WithOrigin("zeroOrOneOf"),
 	})
-	st.Value(&Struct{M1: &M1{}, M4: ptr.To("a string")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
+	st.Value(&Struct{M1: &M1{}, M4: new("a string")}).ExpectMatches(field.ErrorMatcher{}.ByType().ByField().ByDetailSubstring().ByOrigin(), field.ErrorList{
 		field.Invalid(nil, nil, "must specify at most one of").WithOrigin("zeroOrOneOf"),
 	})
 

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/output_tests/update_validations/primitive_pointers/doc_test.go
@@ -20,32 +20,31 @@ import (
 	"testing"
 
 	field "k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 )
 
 func Test(t *testing.T) {
 	st := localSchemeBuilder.Test(t)
 
 	structA1 := Struct{
-		SP: ptr.To("zero"),
-		IP: ptr.To(0),
-		BP: ptr.To(false),
-		FP: ptr.To(0.0),
+		SP: new("zero"),
+		IP: new(0),
+		BP: new(false),
+		FP: new(0.0),
 	}
 
 	// Same data, different pointers
 	structA2 := Struct{
-		SP: ptr.To("zero"),
-		IP: ptr.To(0),
-		BP: ptr.To(false),
-		FP: ptr.To(0.0),
+		SP: new("zero"),
+		IP: new(0),
+		BP: new(false),
+		FP: new(0.0),
 	}
 	// Different data.
 	structB := Struct{
-		SP: ptr.To("one"),
-		IP: ptr.To(1),
-		BP: ptr.To(true),
-		FP: ptr.To(1.1),
+		SP: new("one"),
+		IP: new(1),
+		BP: new(true),
+		FP: new(1.1),
 	}
 
 	st.Value(&structA1).OldValue(&structA1).ExpectValid()


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency
/kind cleanup

#### What this PR does / why we need it:

code-generator only uses ptr.To, which can be replaced with new() in Go 1.26+. This also trims the allowed imports list for the package.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

/cc @dims