### PR TITLE
Skip Unused condition evaluation for unbound PVCs

### DIFF
--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -260,7 +260,9 @@ func (c *Controller) processPVC(ctx context.Context, pvcNamespace, pvcName strin
 		return err
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.PersistentVolumeClaimUnusedSinceTime) && pvc.DeletionTimestamp == nil {
+	if utilfeature.DefaultFeatureGate.Enabled(features.PersistentVolumeClaimUnusedSinceTime) &&
+		pvc.DeletionTimestamp == nil && pvc.Status.Phase == v1.ClaimBound {
+		// Avoid conflict with PV controller binding process.
 		isUsed, err := c.isBeingUsedWith(ctx, pvc, lazyLivePodList, c.podUsesPVCForUnusedSince)
 		if err != nil {
 			return err

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller_test.go
@@ -152,6 +152,11 @@ func withProtectionFinalizer(pvc *v1.PersistentVolumeClaim) *v1.PersistentVolume
 	return pvc
 }
 
+func bound(pvc *v1.PersistentVolumeClaim) *v1.PersistentVolumeClaim {
+	pvc.Status.Phase = v1.ClaimBound
+	return pvc
+}
+
 func withUnusedCondition(status v1.ConditionStatus, ts metav1.Time, pvc *v1.PersistentVolumeClaim) *v1.PersistentVolumeClaim {
 	pvc.Status.Conditions = append(pvc.Status.Conditions, v1.PersistentVolumeClaimCondition{
 		Type:               v1.PersistentVolumeClaimUnused,
@@ -425,42 +430,50 @@ func TestPVCProtectionController(t *testing.T) {
 		// PVC UnusedSince condition — when feature gate is enabled
 		//
 		{
-			name:                     "feature enabled: unused PVC with no pods -> Unused=True condition set",
+			name:                     "feature enabled: unused bound PVC with no pods -> Unused=True condition set",
 			enablePVCUnusedSinceTime: true,
-			updatedPVCs:              []*v1.PersistentVolumeClaim{withProtectionFinalizer(pvc())},
+			updatedPVCs:              []*v1.PersistentVolumeClaim{bound(withProtectionFinalizer(pvc()))},
 			expectedActions: []clienttesting.Action{
 				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 			},
 		},
 		{
-			name:                     "feature enabled: PVC already has Unused=True and is still unused -> no update",
+			name:                     "feature enabled: pending PVC -> no Unused condition",
 			enablePVCUnusedSinceTime: true,
-			updatedPVCs:              []*v1.PersistentVolumeClaim{withUnusedCondition(v1.ConditionTrue, metav1.Unix(100, 0), withProtectionFinalizer(pvc()))},
+			updatedPVCs:              []*v1.PersistentVolumeClaim{withProtectionFinalizer(pvc())},
+			// PVC is not Bound, so the Unused condition is not evaluated.
+			// No pod list, no status update.
+			expectedActions: []clienttesting.Action{},
+		},
+		{
+			name:                     "feature enabled: bound PVC already has Unused=True and is still unused -> no update",
+			enablePVCUnusedSinceTime: true,
+			updatedPVCs:              []*v1.PersistentVolumeClaim{bound(withUnusedCondition(v1.ConditionTrue, metav1.Unix(100, 0), withProtectionFinalizer(pvc())))},
 			// PVC already has condition (index != -1), so pvcAddedUpdated does not enqueue it.
 			// No pod event to trigger re-evaluation. No actions expected.
 			expectedActions: []clienttesting.Action{},
 		},
 		{
-			name:                     "feature enabled: running pod references PVC with Unused=True -> condition set to False",
+			name:                     "feature enabled: running pod references bound PVC with Unused=True -> condition set to False",
 			enablePVCUnusedSinceTime: true,
 			initialObjects: []runtime.Object{
-				withUnusedCondition(v1.ConditionTrue, metav1.Unix(100, 0), withProtectionFinalizer(pvc())),
+				bound(withUnusedCondition(v1.ConditionTrue, metav1.Unix(100, 0), withProtectionFinalizer(pvc()))),
 			},
 			updatedPod: withStatus(v1.PodRunning, withPVC(defaultPVCName, pod())),
 			expectedActions: []clienttesting.Action{
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 			},
 		},
 		{
-			name:                     "feature enabled: PVC in use by running pod without condition -> Unused=False set proactively",
+			name:                     "feature enabled: bound PVC in use by running pod without condition -> Unused=False set proactively",
 			enablePVCUnusedSinceTime: true,
 			initialObjects: []runtime.Object{
 				withStatus(v1.PodRunning, withPVC(defaultPVCName, pod())),
 			},
-			updatedPVCs: []*v1.PersistentVolumeClaim{withProtectionFinalizer(pvc())},
+			updatedPVCs: []*v1.PersistentVolumeClaim{bound(withProtectionFinalizer(pvc()))},
 			expectedActions: []clienttesting.Action{
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 			},
 		},
 		{
@@ -478,44 +491,44 @@ func TestPVCProtectionController(t *testing.T) {
 			expectedActions: []clienttesting.Action{},
 		},
 		{
-			name:                     "feature enabled: unscheduled pending pod references PVC -> Unused=False set proactively",
+			name:                     "feature enabled: unscheduled pending pod references bound PVC -> Unused=False set proactively",
 			enablePVCUnusedSinceTime: true,
 			initialObjects: []runtime.Object{
 				unscheduled(withPVC(defaultPVCName, pod())),
 			},
-			updatedPVCs: []*v1.PersistentVolumeClaim{withProtectionFinalizer(pvc())},
+			updatedPVCs: []*v1.PersistentVolumeClaim{bound(withProtectionFinalizer(pvc()))},
 			expectedActions: []clienttesting.Action{
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 			},
 		},
 		{
-			name:                     "feature enabled: terminated (Succeeded) pod does not count as using PVC -> Unused=True set",
+			name:                     "feature enabled: terminated (Succeeded) pod does not count as using bound PVC -> Unused=True set",
 			enablePVCUnusedSinceTime: true,
 			initialObjects: []runtime.Object{
 				withStatus(v1.PodSucceeded, withPVC(defaultPVCName, pod())),
 			},
-			updatedPVCs: []*v1.PersistentVolumeClaim{withProtectionFinalizer(pvc())},
+			updatedPVCs: []*v1.PersistentVolumeClaim{bound(withProtectionFinalizer(pvc()))},
 			expectedActions: []clienttesting.Action{
 				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 			},
 		},
 		{
-			name:                     "feature enabled: terminated (Failed) pod does not count as using PVC -> Unused=True set",
+			name:                     "feature enabled: terminated (Failed) pod does not count as using bound PVC -> Unused=True set",
 			enablePVCUnusedSinceTime: true,
 			initialObjects: []runtime.Object{
 				withStatus(v1.PodFailed, withPVC(defaultPVCName, pod())),
 			},
-			updatedPVCs: []*v1.PersistentVolumeClaim{withProtectionFinalizer(pvc())},
+			updatedPVCs: []*v1.PersistentVolumeClaim{bound(withProtectionFinalizer(pvc()))},
 			expectedActions: []clienttesting.Action{
 				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 			},
 		},
 		{
 			name:                     "feature enabled: status update fails -> controller retries",
 			enablePVCUnusedSinceTime: true,
-			updatedPVCs:              []*v1.PersistentVolumeClaim{withProtectionFinalizer(pvc())},
+			updatedPVCs:              []*v1.PersistentVolumeClaim{bound(withProtectionFinalizer(pvc()))},
 			reactors: []reaction{
 				{
 					verb:      "update",
@@ -525,11 +538,11 @@ func TestPVCProtectionController(t *testing.T) {
 			},
 			expectedActions: []clienttesting.Action{
 				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 			},
 		},
 		{
@@ -539,22 +552,22 @@ func TestPVCProtectionController(t *testing.T) {
 				withPVC(defaultPVCName, pod()),
 			},
 			informersAreLate: true,
-			updatedPVCs:      []*v1.PersistentVolumeClaim{withProtectionFinalizer(pvc())},
+			updatedPVCs:      []*v1.PersistentVolumeClaim{bound(withProtectionFinalizer(pvc()))},
 			expectedActions: []clienttesting.Action{
 				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 			},
 		},
 		{
-			name:                     "feature enabled: one of two pods deleted, remaining pod keeps PVC in use -> Unused=False set proactively",
+			name:                     "feature enabled: one of two pods deleted, remaining pod keeps bound PVC in use -> Unused=False set proactively",
 			enablePVCUnusedSinceTime: true,
 			initialObjects: []runtime.Object{
 				withPVC(defaultPVCName, pod()),
-				withProtectionFinalizer(pvc()),
+				bound(withProtectionFinalizer(pvc())),
 			},
 			deletedPod: withPVC(defaultPVCName, withUID("uid2", podWithConfig("pod2", defaultNS))),
 			expectedActions: []clienttesting.Action{
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 			},
 		},
 		{
@@ -569,29 +582,29 @@ func TestPVCProtectionController(t *testing.T) {
 			},
 		},
 		{
-			name:                     "feature enabled: pod deleted, PVC becomes unused -> Unused=True condition set",
+			name:                     "feature enabled: pod deleted, bound PVC becomes unused -> Unused=True condition set",
 			enablePVCUnusedSinceTime: true,
 			initialObjects: []runtime.Object{
-				withProtectionFinalizer(pvc()),
+				bound(withProtectionFinalizer(pvc())),
 			},
 			deletedPod: withPVC(defaultPVCName, pod()),
 			expectedActions: []clienttesting.Action{
 				clienttesting.NewListAction(podGVR, podGVK, defaultNS, metav1.ListOptions{}),
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), withProtectionFinalizer(pvc()))),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionTrue, metav1.Unix(123, 0), bound(withProtectionFinalizer(pvc())))),
 			},
 		},
 		{
-			name:                     "feature enabled: used PVC without finalizer -> Unused=False set then finalizer added",
+			name:                     "feature enabled: used bound PVC without finalizer -> Unused=False set then finalizer added",
 			enablePVCUnusedSinceTime: true,
 			initialObjects: []runtime.Object{
 				withPVC(defaultPVCName, pod()),
 			},
-			updatedPVCs: []*v1.PersistentVolumeClaim{pvc()},
+			updatedPVCs: []*v1.PersistentVolumeClaim{bound(pvc())},
 			expectedActions: []clienttesting.Action{
 				// First: condition set proactively (UpdateStatus on PVC without finalizer)
-				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), pvc())),
+				clienttesting.NewUpdateSubresourceAction(pvcGVR, "status", defaultNS, withUnusedCondition(v1.ConditionFalse, metav1.Unix(123, 0), bound(pvc()))),
 				// Then: finalizer added (Update on original PVC without condition)
-				clienttesting.NewUpdateAction(pvcGVR, defaultNS, withProtectionFinalizer(pvc())),
+				clienttesting.NewUpdateAction(pvcGVR, defaultNS, bound(withProtectionFinalizer(pvc()))),
 			},
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig storage

#### What this PR does / why we need it:

The PVC protection controller evaluates the `Unused` condition (gated by the `PersistentVolumeClaimUnusedSinceTime` feature) and writes it to the PVC status. During initial binding, this write races with the PV binder's `bindClaimToVolume`, which also updates the same PVC. The two writers collide and produce 409 Conflict errors, causing wasted retries on both controllers during the busy binding phase.

This PR skips the `Unused` condition evaluation until the PVC is `Bound`. Once the claim is bound, the PV binder is finished writing it, so the protection controller can safely own the condition without contending with the binder. An unbound PVC is not in use by any pod anyway, so deferring the evaluation has no functional downside.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

/cc @arvindparekh @gnufied

This fixes a binding-time conflict in the `Unused` condition introduced by KEP-5541. It was discovered during development of #140721. We measured up to 15% of the PVCs receiving a 409 Conflict error during a benchmark.

`PersistentVolumeClaimUnusedSinceTime` is Alpha in 1.36 (off by default) and Beta in 1.37 (on by default), so this only affects clusters with the feature enabled.

Since this is a slight behavior change to the `Unused` condition, it would be ideal to land it before the 1.37 release, so the "evaluate only once bound" semantics ship as part of the initial Beta (on-by-default) rollout rather than changing behavior in a later release.

Unit tests in `pvc_protection_controller_test.go` are updated: a new `bound()` helper marks the PVC as `ClaimBound` in the existing feature-enabled cases, plus a new case asserts that a pending (unbound) PVC produces no pod list and no status update.

#### Does this PR introduce a user-facing change?

```release-note
Fixed 409 Conflict errors between the PVC protection controller and the PV binder during initial PVC binding. The `Unused` condition is now evaluated only after the PVC is bound.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP-5541] (Report Last Used Time On a PVC): https://github.com/kubernetes/enhancements/blob/45f8bae48eb69f8aab2f6d5a9ef55d4a2675f3d7/keps/sig-storage/5541-pvc-last-used-time-status-field/README.md
```