### PR TITLE
scheduler_perf: re-enable checkEmptyInFlightEvents

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -35,6 +35,7 @@ import (
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/component-base/featuregate"
@@ -42,6 +43,7 @@ import (
 	"k8s.io/component-base/logs"
 	logsapi "k8s.io/component-base/logs/api/v1"
 	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
@@ -874,7 +876,7 @@ func RunBenchmarkPerfScheduling(b *testing.B, configFile string, topicName strin
 					}
 
 					// In any case, we should make sure InFlightEvents is empty after running the scenario.
-					if err = checkEmptyInFlightEvents(); err != nil {
+					if err = waitForEmptyInFlightEvents(tCtx); err != nil {
 						tCtx.Errorf("%s: %s", w.Name, err)
 					}
 
@@ -963,7 +965,7 @@ func RunIntegrationPerfScheduling(t *testing.T, configFile string, options ...Sc
 					}
 
 					// In any case, we should make sure InFlightEvents is empty after running the scenario.
-					if err = checkEmptyInFlightEvents(); err != nil {
+					if err = waitForEmptyInFlightEvents(tCtx); err != nil {
 						tCtx.Errorf("%s: %s", w.Name, err)
 					}
 				})
@@ -1074,23 +1076,40 @@ func applyThreshold(items []DataItem, threshold float64, metricSelector threshol
 }
 
 func checkEmptyInFlightEvents() error {
-	// checkEmptyInFlightEvents seems to race with completion of the scenario,
-	// which started to go wrong a lot after speeding up metrics gathering
-	// during the scenario.
-	//
-	// TODO: re-enable it when it's reliable again.
+	labels := append(schedframework.AllClusterEventLabels(), metrics.PodPoppedInFlightEvent)
+	for _, label := range labels {
+		value, err := testutil.GetGaugeMetricValue(metrics.InFlightEvents.WithLabelValues(label))
+		if err != nil {
+			return fmt.Errorf("failed to get InFlightEvents metric for label %s", label)
+		}
+		if value > 0 {
+			return fmt.Errorf("InFlightEvents for label %s should be empty, but has %v items", label, value)
+		}
+	}
 	return nil
-	// labels := append(schedframework.AllClusterEventLabels(), metrics.PodPoppedInFlightEvent)
-	// for _, label := range labels {
-	// 	value, err := testutil.GetGaugeMetricValue(metrics.InFlightEvents.WithLabelValues(label))
-	// 	if err != nil {
-	// 		return fmt.Errorf("failed to get InFlightEvents metric for label %s", label)
-	// 	}
-	//	if value > 0 {
-	//		return fmt.Errorf("InFlightEvents for label %s should be empty, but has %v items", label, value)
-	//	}
-	//}
-	// return nil
+}
+
+const (
+	inFlightEventsCheckInterval = 100 * time.Millisecond
+	inFlightEventsCheckTimeout  = time.Minute
+)
+
+// waitForEmptyInFlightEvents waits for scheduling and binding cycles that are
+// still completing when a workload reports its Pods as scheduled.
+func waitForEmptyInFlightEvents(ctx context.Context) error {
+	return waitForEmptyInFlightEventsWithCheck(ctx, inFlightEventsCheckInterval, inFlightEventsCheckTimeout, checkEmptyInFlightEvents)
+}
+
+func waitForEmptyInFlightEventsWithCheck(ctx context.Context, interval, timeout time.Duration, check func() error) error {
+	var lastErr error
+	err := wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(context.Context) (bool, error) {
+		lastErr = check()
+		return lastErr == nil, nil
+	})
+	if err != nil {
+		return fmt.Errorf("InFlightEvents did not become empty: %w", errors.Join(err, lastErr))
+	}
+	return nil
 }
 
 func runWorkload(tCtx ktesting.TContext, tc *testCase, w *Workload, topicName string, scheduler *scheduler.Scheduler, informerFactory informers.SharedInformerFactory, opts *schedulerPerfOptions) ([]DataItem, error) {

--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -17,11 +17,48 @@ limitations under the License.
 package benchmark
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/component-base/featuregate"
 )
+
+func TestWaitForEmptyInFlightEvents(t *testing.T) {
+	checks := 0
+	err := waitForEmptyInFlightEventsWithCheck(t.Context(), time.Millisecond, time.Second, func() error {
+		checks++
+		if checks < 3 {
+			return errors.New("InFlightEvents for label AssignedPodAdd should be empty, but has 1 items")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("waitForEmptyInFlightEventsWithCheck() returned error: %v", err)
+	}
+	if checks != 3 {
+		t.Errorf("check was called %d times, want 3", checks)
+	}
+}
+
+func TestWaitForEmptyInFlightEventsTimeout(t *testing.T) {
+	const checkError = "InFlightEvents for label AssignedPodAdd should be empty, but has 1 items"
+	err := waitForEmptyInFlightEventsWithCheck(t.Context(), time.Millisecond, 5*time.Millisecond, func() error {
+		return errors.New(checkError)
+	})
+	if err == nil {
+		t.Fatal("waitForEmptyInFlightEventsWithCheck() returned nil, want timeout error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("waitForEmptyInFlightEventsWithCheck() error = %v, want deadline exceeded", err)
+	}
+	if !strings.Contains(err.Error(), checkError) {
+		t.Errorf("waitForEmptyInFlightEventsWithCheck() error = %q, want last check error", err)
+	}
+}
 
 func TestFeatureGatesMerge(t *testing.T) {
 	const (


### PR DESCRIPTION
#### What this PR does

Re-enables `checkEmptyInFlightEvents` in scheduler perf tests.

After #140695 reduced scheduler-perf execution time, scheduler perf scenarios could complete before the scheduling queue finished cleaning up in-flight events, causing `checkEmptyInFlightEvents()` to race with cleanup.

This change replaces the immediate assertion with a bounded wait that polls `checkEmptyInFlightEvents()` until `InFlightEvents` is empty.

The wait:
- preserves the original leak detection,
- respects context cancellation and has a timeout,
- reports the final non-empty metric state on timeout,
- is applied to both scheduler perf paths.

Unit tests cover successful draining and timeout behavior.

#### Which issue(s) this PR fixes

Fixes #140751

#### Does this PR introduce a user-facing change?

```release-note
NONE
```