### PR TITLE
Remove excessive metrics reporting in wap reprieval

### DIFF
--- a/pkg/scheduler/framework/cycle_state.go
+++ b/pkg/scheduler/framework/cycle_state.go
@@ -30,6 +30,8 @@ type CycleState struct {
 	storage sync.Map
 	// if recordPluginMetrics is true, metrics.PluginExecutionDuration will be recorded for this cycle.
 	recordPluginMetrics bool
+	// if recordFrameworkExtensionPointMetrics is true, framework extension metrics will be recorded for this cycle.
+	recordFrameworkExtensionPointMetrics bool
 	// skipFilterPlugins are plugins that will be skipped in the Filter extension point.
 	skipFilterPlugins sets.Set[string]
 	// skipScorePlugins are plugins that will be skipped in the Score extension point.
@@ -71,6 +73,22 @@ func (c *CycleState) SetRecordPluginMetrics(flag bool) {
 		return
 	}
 	c.recordPluginMetrics = flag
+}
+
+// ShouldRecordFrameworkExtensionPointMetrics returns whether metrics.FrameworkExtensionPointDuration metrics should be recorded.
+func (c *CycleState) ShouldRecordFrameworkExtensionPointMetrics() bool {
+	if c == nil {
+		return false
+	}
+	return c.recordFrameworkExtensionPointMetrics
+}
+
+// SetRecordFrameworkExtensionPointMetrics sets recordFrameworkExtensionPointMetrics to the given value.
+func (c *CycleState) SetRecordFrameworkExtensionPointMetrics(flag bool) {
+	if c == nil {
+		return
+	}
+	c.recordFrameworkExtensionPointMetrics = flag
 }
 
 func (c *CycleState) SetSkipFilterPlugins(plugins sets.Set[string]) {
@@ -154,6 +172,7 @@ func (c *CycleState) Clone() fwk.CycleState {
 	})
 	// The below are not mutated, so we don't have to safe copy.
 	copy.recordPluginMetrics = c.recordPluginMetrics
+	copy.recordFrameworkExtensionPointMetrics = c.recordFrameworkExtensionPointMetrics
 	copy.skipFilterPlugins = c.skipFilterPlugins
 	copy.skipScorePlugins = c.skipScorePlugins
 	copy.skipPreBindPlugins = c.skipPreBindPlugins

--- a/pkg/scheduler/framework/cycle_state_test.go
+++ b/pkg/scheduler/framework/cycle_state_test.go
@@ -69,6 +69,9 @@ func isCycleStateEqual(a, b *CycleState) (bool, string) {
 	if a.recordPluginMetrics != b.recordPluginMetrics {
 		return false, fmt.Sprintf("CycleState A and B have a different recordPluginMetrics. A: %v, B: %v", a.recordPluginMetrics, b.recordPluginMetrics)
 	}
+	if a.recordFrameworkExtensionPointMetrics != b.recordFrameworkExtensionPointMetrics {
+		return false, fmt.Sprintf("CycleState A and B have a different recordFrameworkExtensionPointMetrics. A: %v, B: %v", a.recordFrameworkExtensionPointMetrics, b.recordFrameworkExtensionPointMetrics)
+	}
 	if diff := cmp.Diff(a.skipFilterPlugins, b.skipFilterPlugins); diff != "" {
 		return false, fmt.Sprintf("CycleState A and B have different SkipFilterPlugin sets. -wanted,+got:\n%s", diff)
 	}
@@ -281,6 +284,50 @@ func TestPlacementCycleState(t *testing.T) {
 		cloned := state.Clone().(*CycleState)
 		if cloned.GetPlacementCycleState() != nil {
 			t.Errorf("cloned state should have nil PlacementCycleState when original has nil")
+		}
+	})
+}
+
+func TestRecordFrameworkExtensionPointMetrics(t *testing.T) {
+	t.Run("nil cycle state", func(t *testing.T) {
+		var state *CycleState
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			t.Errorf("expected false for nil CycleState")
+		}
+		// Should not panic
+		state.SetRecordFrameworkExtensionPointMetrics(true)
+	})
+
+	t.Run("default false", func(t *testing.T) {
+		state := NewCycleState()
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			t.Errorf("expected default false for ShouldRecordFrameworkExtensionPointMetrics")
+		}
+	})
+
+	t.Run("set and get true", func(t *testing.T) {
+		state := NewCycleState()
+		state.SetRecordFrameworkExtensionPointMetrics(true)
+		if !state.ShouldRecordFrameworkExtensionPointMetrics() {
+			t.Errorf("expected true after setting to true")
+		}
+	})
+
+	t.Run("set false", func(t *testing.T) {
+		state := NewCycleState()
+		state.SetRecordFrameworkExtensionPointMetrics(true)
+		state.SetRecordFrameworkExtensionPointMetrics(false)
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			t.Errorf("expected false after setting to false")
+		}
+	})
+
+	t.Run("clone preserves flag", func(t *testing.T) {
+		state := NewCycleState()
+		state.SetRecordFrameworkExtensionPointMetrics(true)
+		cloned := state.Clone().(*CycleState)
+		if !cloned.ShouldRecordFrameworkExtensionPointMetrics() {
+			t.Errorf("expected cloned CycleState to retain recordFrameworkExtensionPointMetrics true")
 		}
 	})
 }

--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -245,6 +245,8 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	// Prepare podInfos for each of the assigned preemptor pods
 	for _, assignment := range podGroupAssignments.ProposedAssignments {
 		if assignment.GetNodeName() != "" {
+			assignment.GetCycleState().SetRecordPluginMetrics(false)
+			assignment.GetCycleState().SetRecordFrameworkExtensionPointMetrics(false)
 			validAssignment = append(validAssignment, assignment)
 		}
 	}

--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -251,6 +251,8 @@ func (ev *PodGroupEvaluator) selectVictimsOnDomain(
 	// Prepare podInfos for each of the assigned preemptor pods
 	for _, assignment := range podGroupAssignments.ProposedAssignments {
 		if assignment.GetNodeName() != "" {
+			assignment.GetCycleState().SetRecordPluginMetrics(false)
+			assignment.GetCycleState().SetRecordFrameworkExtensionPointMetrics(false)
 			validAssignment = append(validAssignment, assignment)
 		}
 	}

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -936,7 +936,9 @@ func (f *frameworkImpl) RunPreFilterPlugins(ctx context.Context, state fwk.Cycle
 	skipPlugins := sets.New[string]()
 	defer func() {
 		state.SetSkipFilterPlugins(skipPlugins)
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	nodes, err := f.SnapshotSharedLister().NodeInfos().List()
 	if err != nil {
@@ -1152,7 +1154,9 @@ func (f *frameworkImpl) runFilterPlugin(ctx context.Context, pl fwk.FilterPlugin
 func (f *frameworkImpl) RunPostFilterPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, filteredNodeStatusMap fwk.NodeToStatusReader) (_ *fwk.PostFilterResult, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PostFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PostFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 
 	if state.ShouldSkipAllPostFilterPlugins() {
@@ -1216,7 +1220,9 @@ func (f *frameworkImpl) RunPodGroupPostFilterPlugins(ctx context.Context, state 
 
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PodGroupPostFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PodGroupPostFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 
 	logger := klog.FromContext(ctx)
@@ -1295,8 +1301,11 @@ func (f *frameworkImpl) RunFilterPluginsWithNominatedPods(ctx context.Context, s
 	// nominated pods are running because they are not running right now and in fact,
 	// they may end up getting scheduled to a different node.
 	logger := klog.FromContext(ctx)
-	logger = klog.LoggerWithName(logger, "FilterWithNominatedPods")
-	ctx = klog.NewContext(ctx, logger)
+	verboseLogs := logger.V(4).Enabled()
+	if verboseLogs {
+		logger = klog.LoggerWithName(logger, "FilterWithNominatedPods")
+		ctx = klog.NewContext(ctx, logger)
+	}
 	for i := 0; i < 2; i++ {
 		stateToUse := state
 		nodeInfoToUse := info
@@ -1361,7 +1370,9 @@ func (f *frameworkImpl) RunPreScorePlugins(
 	skipPlugins := sets.New[string]()
 	defer func() {
 		state.SetSkipScorePlugins(skipPlugins)
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreScore, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreScore, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	logger := klog.FromContext(ctx)
 	verboseLogs := logger.V(4).Enabled()
@@ -1405,7 +1416,9 @@ func (f *frameworkImpl) runPreScorePlugin(ctx context.Context, pl fwk.PreScorePl
 func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) (ns []fwk.NodePluginScores, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Score, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Score, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	allNodePluginScores := make([]fwk.NodePluginScores, len(nodes))
 	plugins := f.nonSkippedScorePlugins(state)
@@ -1625,7 +1638,9 @@ func (f *frameworkImpl) runScoreExtension(ctx context.Context, pl fwk.ScorePlugi
 func (f *frameworkImpl) RunPlacementScorePlugins(ctx context.Context, state fwk.PodGroupCycleState, podGroupInfo fwk.PodGroupInfo, podGroupAssignments []*fwk.PodGroupAssignments, placementStates []fwk.PlacementCycleState) (ps []fwk.PlacementPluginScores, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementScore, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementScore, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 
 	if len(podGroupAssignments) != len(placementStates) {
@@ -1766,7 +1781,9 @@ func (f *frameworkImpl) StoreScheduleResults(ctx context.Context, signature fwk.
 func (f *frameworkImpl) RunPreBindPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreBind, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreBind, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	logger := klog.FromContext(ctx)
 	verboseLogs := logger.V(4).Enabled()
@@ -1875,7 +1892,9 @@ func (f *frameworkImpl) runPreBindPlugin(ctx context.Context, pl fwk.PreBindPlug
 func (f *frameworkImpl) RunPreBindPreFlights(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreBindPreFlight, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreBindPreFlight, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	logger := klog.FromContext(ctx)
 	verboseLogs := logger.V(4).Enabled()
@@ -1930,7 +1949,9 @@ func (f *frameworkImpl) runPreBindPreFlight(ctx context.Context, pl fwk.PreBindP
 func (f *frameworkImpl) RunBindPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Bind, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Bind, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	if len(f.bindPlugins) == 0 {
 		return fwk.NewStatus(fwk.Skip, "")
@@ -1979,7 +2000,9 @@ func (f *frameworkImpl) runBindPlugin(ctx context.Context, bp fwk.BindPlugin, st
 func (f *frameworkImpl) RunPostBindPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PostBind, fwk.Success.String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PostBind, fwk.Success.String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	logger := klog.FromContext(ctx)
 	verboseLogs := logger.V(4).Enabled()
@@ -2014,7 +2037,9 @@ func (f *frameworkImpl) runPostBindPlugin(ctx context.Context, pl fwk.PostBindPl
 func (f *frameworkImpl) RunReservePluginsReserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Reserve, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Reserve, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	logger := klog.FromContext(ctx)
 	verboseLogs := logger.V(4).Enabled()
@@ -2058,7 +2083,9 @@ func (f *frameworkImpl) runReservePluginReserve(ctx context.Context, pl fwk.Rese
 func (f *frameworkImpl) RunReservePluginsUnreserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Unreserve, fwk.Success.String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Unreserve, fwk.Success.String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	// Execute the Unreserve operation of each reserve plugin in the
 	// *reverse* order in which the Reserve operation was executed.
@@ -2097,7 +2124,9 @@ func (f *frameworkImpl) runReservePluginUnreserve(ctx context.Context, pl fwk.Re
 func (f *frameworkImpl) RunPermitPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (pluginsWaitTime map[string]time.Duration, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Permit, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Permit, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	var waitStatus *fwk.Status
 	pluginsWaitTime = make(map[string]time.Duration)
@@ -2160,7 +2189,9 @@ func (f *frameworkImpl) runPermitPlugin(ctx context.Context, pl fwk.PermitPlugin
 func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, args framework.PlacementProgress) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementFeasible, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if placementCycleState.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementFeasible, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 
 	for _, pl := range f.placementFeasiblePlugins {
@@ -2208,7 +2239,9 @@ func (f *frameworkImpl) AddWaitingPod(pod *v1.Pod, pluginsWaitTime map[string]ti
 func (f *frameworkImpl) RunPlacementGeneratePlugins(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, nodes []fwk.NodeInfo) (placements []*fwk.Placement, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementGenerate, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementGenerate, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 
 	placement := &fwk.Placement{

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -945,7 +945,9 @@ func (f *frameworkImpl) RunPreFilterPlugins(ctx context.Context, state fwk.Cycle
 	skipPlugins := sets.New[string]()
 	defer func() {
 		state.SetSkipFilterPlugins(skipPlugins)
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	nodes, err := f.SnapshotSharedLister().NodeInfos().List()
 	if err != nil {
@@ -1161,7 +1163,9 @@ func (f *frameworkImpl) runFilterPlugin(ctx context.Context, pl fwk.FilterPlugin
 func (f *frameworkImpl) RunPostFilterPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, filteredNodeStatusMap fwk.NodeToStatusReader) (_ *fwk.PostFilterResult, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PostFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PostFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 
 	if state.ShouldSkipAllPostFilterPlugins() {
@@ -1225,7 +1229,9 @@ func (f *frameworkImpl) RunPodGroupPostFilterPlugins(ctx context.Context, state 
 
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PodGroupPostFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PodGroupPostFilter, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 
 	logger := klog.FromContext(ctx)
@@ -1304,8 +1310,11 @@ func (f *frameworkImpl) RunFilterPluginsWithNominatedPods(ctx context.Context, s
 	// nominated pods are running because they are not running right now and in fact,
 	// they may end up getting scheduled to a different node.
 	logger := klog.FromContext(ctx)
-	logger = klog.LoggerWithName(logger, "FilterWithNominatedPods")
-	ctx = klog.NewContext(ctx, logger)
+	verboseLogs := logger.V(4).Enabled()
+	if verboseLogs {
+		logger = klog.LoggerWithName(logger, "FilterWithNominatedPods")
+		ctx = klog.NewContext(ctx, logger)
+	}
 	for i := 0; i < 2; i++ {
 		stateToUse := state
 		nodeInfoToUse := info
@@ -1370,7 +1379,9 @@ func (f *frameworkImpl) RunPreScorePlugins(
 	skipPlugins := sets.New[string]()
 	defer func() {
 		state.SetSkipScorePlugins(skipPlugins)
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreScore, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreScore, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	logger := klog.FromContext(ctx)
 	verboseLogs := logger.V(4).Enabled()
@@ -1414,7 +1425,9 @@ func (f *frameworkImpl) runPreScorePlugin(ctx context.Context, pl fwk.PreScorePl
 func (f *frameworkImpl) RunScorePlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodes []fwk.NodeInfo) (ns []fwk.NodePluginScores, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Score, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Score, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	allNodePluginScores := make([]fwk.NodePluginScores, len(nodes))
 	plugins := f.nonSkippedScorePlugins(state)
@@ -1634,7 +1647,9 @@ func (f *frameworkImpl) runScoreExtension(ctx context.Context, pl fwk.ScorePlugi
 func (f *frameworkImpl) RunPlacementScorePlugins(ctx context.Context, state fwk.PodGroupCycleState, podGroupInfo fwk.PodGroupInfo, podGroupAssignments []*fwk.PodGroupAssignments, placementStates []fwk.PlacementCycleState) (ps []fwk.PlacementPluginScores, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementScore, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementScore, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 
 	if len(podGroupAssignments) != len(placementStates) {
@@ -1775,7 +1790,9 @@ func (f *frameworkImpl) StoreScheduleResults(ctx context.Context, signature fwk.
 func (f *frameworkImpl) RunPreBindPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreBind, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreBind, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	logger := klog.FromContext(ctx)
 	verboseLogs := logger.V(4).Enabled()
@@ -1884,7 +1901,9 @@ func (f *frameworkImpl) runPreBindPlugin(ctx context.Context, pl fwk.PreBindPlug
 func (f *frameworkImpl) RunPreBindPreFlights(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreBindPreFlight, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PreBindPreFlight, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	logger := klog.FromContext(ctx)
 	verboseLogs := logger.V(4).Enabled()
@@ -1939,7 +1958,9 @@ func (f *frameworkImpl) runPreBindPreFlight(ctx context.Context, pl fwk.PreBindP
 func (f *frameworkImpl) RunBindPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Bind, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Bind, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	if len(f.bindPlugins) == 0 {
 		return fwk.NewStatus(fwk.Skip, "")
@@ -1988,7 +2009,9 @@ func (f *frameworkImpl) runBindPlugin(ctx context.Context, bp fwk.BindPlugin, st
 func (f *frameworkImpl) RunPostBindPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PostBind, fwk.Success.String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PostBind, fwk.Success.String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	logger := klog.FromContext(ctx)
 	verboseLogs := logger.V(4).Enabled()
@@ -2023,7 +2046,9 @@ func (f *frameworkImpl) runPostBindPlugin(ctx context.Context, pl fwk.PostBindPl
 func (f *frameworkImpl) RunReservePluginsReserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Reserve, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Reserve, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	logger := klog.FromContext(ctx)
 	verboseLogs := logger.V(4).Enabled()
@@ -2067,7 +2092,9 @@ func (f *frameworkImpl) runReservePluginReserve(ctx context.Context, pl fwk.Rese
 func (f *frameworkImpl) RunReservePluginsUnreserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Unreserve, fwk.Success.String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Unreserve, fwk.Success.String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	// Execute the Unreserve operation of each reserve plugin in the
 	// *reverse* order in which the Reserve operation was executed.
@@ -2106,7 +2133,9 @@ func (f *frameworkImpl) runReservePluginUnreserve(ctx context.Context, pl fwk.Re
 func (f *frameworkImpl) RunPermitPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (pluginsWaitTime map[string]time.Duration, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Permit, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Permit, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 	var waitStatus *fwk.Status
 	pluginsWaitTime = make(map[string]time.Duration)
@@ -2169,7 +2198,9 @@ func (f *frameworkImpl) runPermitPlugin(ctx context.Context, pl fwk.PermitPlugin
 func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, args framework.PlacementProgress) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementFeasible, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if placementCycleState.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementFeasible, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 
 	for _, pl := range f.placementFeasiblePlugins {
@@ -2217,7 +2248,9 @@ func (f *frameworkImpl) AddWaitingPod(pod *v1.Pod, pluginsWaitTime map[string]ti
 func (f *frameworkImpl) RunPlacementGeneratePlugins(ctx context.Context, state fwk.PodGroupCycleState, podGroup fwk.PodGroupInfo, nodes []fwk.NodeInfo) (placements []*fwk.Placement, status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementGenerate, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementGenerate, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
+		}
 	}()
 
 	placement := &fwk.Placement{

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -4526,6 +4526,7 @@ func withMetricsRecorder(recorder *metrics.MetricAsyncRecorder) Option {
 
 func TestRecordingMetrics(t *testing.T) {
 	state.SetRecordPluginMetrics(true)
+	state.SetRecordFrameworkExtensionPointMetrics(true)
 	tests := []struct {
 		name               string
 		action             func(ctx context.Context, f framework.Framework)
@@ -4791,6 +4792,73 @@ func TestRecordingMetrics(t *testing.T) {
 
 			collectAndCompareFrameworkMetrics(t, tt.wantExtensionPoint, tt.wantStatus)
 			collectAndComparePluginMetrics(t, tt.wantExtensionPoint, testPlugin, tt.wantStatus)
+		})
+	}
+}
+
+func TestRecordFrameworkExtensionPointMetricsGating(t *testing.T) {
+	tests := []struct {
+		name       string
+		recordFlag bool
+		wantCount  uint64
+	}{
+		{
+			name:       "disabled flag does not record metrics",
+			recordFlag: false,
+			wantCount:  0,
+		},
+		{
+			name:       "enabled flag records metrics",
+			recordFlag: true,
+			wantCount:  1,
+		},
+	}
+
+	_, ctx := ktesting.NewTestContext(t)
+	plugin := &TestPlugin{name: testPlugin}
+	r := make(Registry)
+	err := r.Register(testPlugin, func(_ context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
+		return plugin, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to register plugin: %v", err)
+	}
+	plugins := &config.Plugins{
+		PreFilter: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+	}
+	profile := config.KubeSchedulerProfile{
+		SchedulerName: testProfileName,
+		Plugins:       plugins,
+	}
+	f, err := newFrameworkWithQueueSortAndBind(ctx, r, profile,
+		WithWaitingPods(NewWaitingPodsMap()),
+		WithSnapshotSharedLister(cache.NewEmptySnapshot()),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	pod := &v1.Pod{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics.FrameworkExtensionPointDuration.Reset()
+			cycleState := framework.NewCycleState()
+			cycleState.SetRecordFrameworkExtensionPointMetrics(tt.recordFlag)
+
+			f.RunPreFilterPlugins(ctx, cycleState, pod)
+
+			m := metrics.FrameworkExtensionPointDuration.WithLabelValues("PreFilter", fwk.Success.String(), testProfileName)
+			count, err := testutil.GetHistogramMetricCount(m)
+			if err != nil {
+				t.Fatalf("Failed to get metric count: %v", err)
+			}
+			if count != tt.wantCount {
+				t.Errorf("Expected %d samples when flag is %v, got: %v", tt.wantCount, tt.recordFlag, count)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -4511,6 +4511,7 @@ func withMetricsRecorder(recorder *metrics.MetricAsyncRecorder) Option {
 
 func TestRecordingMetrics(t *testing.T) {
 	state.SetRecordPluginMetrics(true)
+	state.SetRecordFrameworkExtensionPointMetrics(true)
 	tests := []struct {
 		name               string
 		action             func(ctx context.Context, f framework.Framework)
@@ -4776,6 +4777,73 @@ func TestRecordingMetrics(t *testing.T) {
 
 			collectAndCompareFrameworkMetrics(t, tt.wantExtensionPoint, tt.wantStatus)
 			collectAndComparePluginMetrics(t, tt.wantExtensionPoint, testPlugin, tt.wantStatus)
+		})
+	}
+}
+
+func TestRecordFrameworkExtensionPointMetricsGating(t *testing.T) {
+	tests := []struct {
+		name       string
+		recordFlag bool
+		wantCount  uint64
+	}{
+		{
+			name:       "disabled flag does not record metrics",
+			recordFlag: false,
+			wantCount:  0,
+		},
+		{
+			name:       "enabled flag records metrics",
+			recordFlag: true,
+			wantCount:  1,
+		},
+	}
+
+	_, ctx := ktesting.NewTestContext(t)
+	plugin := &TestPlugin{name: testPlugin}
+	r := make(Registry)
+	err := r.Register(testPlugin, func(_ context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
+		return plugin, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to register plugin: %v", err)
+	}
+	plugins := &config.Plugins{
+		PreFilter: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+	}
+	profile := config.KubeSchedulerProfile{
+		SchedulerName: testProfileName,
+		Plugins:       plugins,
+	}
+	f, err := newFrameworkWithQueueSortAndBind(ctx, r, profile,
+		WithWaitingPods(NewWaitingPodsMap()),
+		WithSnapshotSharedLister(cache.NewEmptySnapshot()),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	pod := &v1.Pod{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics.FrameworkExtensionPointDuration.Reset()
+			cycleState := framework.NewCycleState()
+			cycleState.SetRecordFrameworkExtensionPointMetrics(tt.recordFlag)
+
+			f.RunPreFilterPlugins(ctx, cycleState, pod)
+
+			m := metrics.FrameworkExtensionPointDuration.WithLabelValues("PreFilter", fwk.Success.String(), testProfileName)
+			count, err := testutil.GetHistogramMetricCount(m)
+			if err != nil {
+				t.Fatalf("Failed to get metric count: %v", err)
+			}
+			if count != tt.wantCount {
+				t.Errorf("Expected %d samples when flag is %v, got: %v", tt.wantCount, tt.recordFlag, count)
+			}
 		})
 	}
 }

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -123,6 +123,7 @@ func (sched *Scheduler) scheduleOnePod(ctx context.Context, podInfo *framework.Q
 	// for every plugin execution in each scheduling cycle. Instead it samples a portion of scheduling cycles - percentage
 	// determined by pluginMetricsSamplePercent. The line below helps to randomly pick appropriate scheduling cycles.
 	state.SetRecordPluginMetrics(rand.Intn(100) < pluginMetricsSamplePercent)
+	state.SetRecordFrameworkExtensionPointMetrics(true)
 
 	// Initialize an empty podsToActivate struct, which will be filled up by plugins or stay empty.
 	podsToActivate := framework.NewPodsToActivate()
@@ -840,7 +841,9 @@ func (sched *Scheduler) findNodesThatPassFilters(
 		// We record Filter extension point latency here instead of in framework.go because framework.RunFilterPlugins
 		// function is called for each node, whereas we want to have an overall latency for all nodes per scheduling cycle.
 		// Note that this latency also includes latency for `addNominatedPods`, which calls framework.RunPreFilterAddPod.
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Filter, statusCode.String(), schedFramework.ProfileName()).Observe(metrics.SinceInSeconds(beginCheckNode))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Filter, statusCode.String(), schedFramework.ProfileName()).Observe(metrics.SinceInSeconds(beginCheckNode))
+		}
 	}()
 
 	// Stops searching for more nodes once the configured number of feasible nodes

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -125,6 +125,7 @@ func (sched *Scheduler) scheduleOnePod(ctx context.Context, podInfo *framework.Q
 	// for every plugin execution in each scheduling cycle. Instead it samples a portion of scheduling cycles - percentage
 	// determined by pluginMetricsSamplePercent. The line below helps to randomly pick appropriate scheduling cycles.
 	state.SetRecordPluginMetrics(rand.Intn(100) < pluginMetricsSamplePercent)
+	state.SetRecordFrameworkExtensionPointMetrics(true)
 
 	// Initialize an empty podsToActivate struct, which will be filled up by plugins or stay empty.
 	podsToActivate := framework.NewPodsToActivate()
@@ -849,7 +850,9 @@ func (sched *Scheduler) findNodesThatPassFilters(
 		// We record Filter extension point latency here instead of in framework.go because framework.RunFilterPlugins
 		// function is called for each node, whereas we want to have an overall latency for all nodes per scheduling cycle.
 		// Note that this latency also includes latency for `addNominatedPods`, which calls framework.RunPreFilterAddPod.
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Filter, statusCode.String(), schedFramework.ProfileName()).Observe(metrics.SinceInSeconds(beginCheckNode))
+		if state.ShouldRecordFrameworkExtensionPointMetrics() {
+			metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Filter, statusCode.String(), schedFramework.ProfileName()).Observe(metrics.SinceInSeconds(beginCheckNode))
+		}
 	}()
 
 	// Stops searching for more nodes once the configured number of feasible nodes

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -402,6 +402,7 @@ func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleSt
 	// for every plugin execution in each scheduling cycle. Instead it samples a portion of scheduling cycles - percentage
 	// determined by pluginMetricsSamplePercent. The line below helps to randomly pick appropriate scheduling cycles.
 	state.SetRecordPluginMetrics(rand.Intn(100) < pluginMetricsSamplePercent)
+	state.SetRecordFrameworkExtensionPointMetrics(true)
 
 	// Initialize an empty podsToActivate struct, which will be filled up by plugins or stay empty.
 	podsToActivate := framework.NewPodsToActivate()
@@ -977,6 +978,7 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 
 	// For now, always record plugin metrics until we understand its impact on performance.
 	podGroupCycleState.SetRecordPluginMetrics(true)
+	podGroupCycleState.SetRecordFrameworkExtensionPointMetrics(true)
 	placements, status := schedFwk.RunPlacementGeneratePlugins(ctx, podGroupCycleState, podGroupInfo, allNodes)
 	if !status.IsSuccess() {
 		return &podGroupAlgorithmResult{
@@ -1082,6 +1084,7 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 
 	// For now, always record plugin metrics until we understand its impact on performance.
 	podGroupCycleState.SetRecordPluginMetrics(true)
+	podGroupCycleState.SetRecordFrameworkExtensionPointMetrics(true)
 	placements, status := schedFwk.RunPlacementGeneratePlugins(ctx, podGroupCycleState, podGroupInfo, allNodes)
 	if !status.IsSuccess() {
 		return &podGroupAlgorithmResult{

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -352,6 +352,7 @@ func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleSt
 	// for every plugin execution in each scheduling cycle. Instead it samples a portion of scheduling cycles - percentage
 	// determined by pluginMetricsSamplePercent. The line below helps to randomly pick appropriate scheduling cycles.
 	state.SetRecordPluginMetrics(rand.Intn(100) < pluginMetricsSamplePercent)
+	state.SetRecordFrameworkExtensionPointMetrics(true)
 
 	// Initialize an empty podsToActivate struct, which will be filled up by plugins or stay empty.
 	podsToActivate := framework.NewPodsToActivate()
@@ -888,6 +889,7 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 
 	// For now, always record plugin metrics until we understand its impact on performance.
 	podGroupCycleState.SetRecordPluginMetrics(true)
+	podGroupCycleState.SetRecordFrameworkExtensionPointMetrics(true)
 	placements, status := schedFwk.RunPlacementGeneratePlugins(ctx, podGroupCycleState, podGroupInfo, allNodes)
 	if !status.IsSuccess() {
 		return &podGroupAlgorithmResult{
@@ -994,6 +996,7 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 
 	// For now, always record plugin metrics until we understand its impact on performance.
 	podGroupCycleState.SetRecordPluginMetrics(true)
+	podGroupCycleState.SetRecordFrameworkExtensionPointMetrics(true)
 	placements, status := schedFwk.RunPlacementGeneratePlugins(ctx, podGroupCycleState, podGroupInfo, allNodes)
 	if !status.IsSuccess() {
 		return &podGroupAlgorithmResult{
@@ -1025,6 +1028,8 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 			}, nil
 		}
 		placementCycleState := framework.NewCycleState()
+		placementCycleState.SetRecordFrameworkExtensionPointMetrics(true)
+		placementCycleState.SetRecordPluginMetrics(true)
 		placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
 		subtreeResult := map[fwk.EntityKey]*podGroupAlgorithmResult{}
 		result, placementRevertFns := sched.compositePodGroupSchedulingDefaultAlgorithm(ctx, schedFwk, placementCycleState, root, podGroupInfo, subtreeResult)

--- a/staging/src/k8s.io/kube-scheduler/framework/cycle_state.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/cycle_state.go
@@ -47,6 +47,16 @@ type CycleState interface {
 	// should be recorded.
 	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
 	ShouldRecordPluginMetrics() bool
+	// SetRecordPluginMetrics sets recordPluginMetrics to the given value.
+	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
+	SetRecordPluginMetrics(flag bool)
+	// ShouldRecordFrameworkExtensionPointMetrics returns whether framework extension metrics
+	// should be recorded.
+	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
+	ShouldRecordFrameworkExtensionPointMetrics() bool
+	// SetRecordFrameworkExtensionPointMetrics sets recordFrameworkExtensionPointMetrics to the given value.
+	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
+	SetRecordFrameworkExtensionPointMetrics(flag bool)
 	// GetSkipFilterPlugins returns plugins that will be skipped in the Filter extension point.
 	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
 	GetSkipFilterPlugins() sets.Set[string]
@@ -118,6 +128,10 @@ type PlacementCycleState interface {
 	// should be recorded.
 	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
 	ShouldRecordPluginMetrics() bool
+	// ShouldRecordFrameworkExtensionPointMetrics returns whether framework extension metrics
+	// should be recorded.
+	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
+	ShouldRecordFrameworkExtensionPointMetrics() bool
 	// Read retrieves data with the given "key" from PlacementCycleState. If the key is not
 	// present, ErrNotFound is returned.
 	//
@@ -145,6 +159,10 @@ type PodGroupCycleState interface {
 	// should be recorded.
 	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
 	ShouldRecordPluginMetrics() bool
+	// ShouldRecordFrameworkExtensionPointMetrics returns whether framework extension metrics
+	// should be recorded.
+	// This function is mostly for the scheduling framework runtime, plugins usually don't have to use it.
+	ShouldRecordFrameworkExtensionPointMetrics() bool
 	// Read retrieves data with the given "key" from PodGroupCycleState. If the key is not
 	// present, ErrNotFound is returned.
 	//

--- a/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
@@ -162,6 +162,15 @@
       podsPerGroup: 10
       lowPriorityCpuRequest: 600m
       highPriorityCpuRequest: 3500m
+  - name: 1000Nodes_10PreemptorGangs_100Pods_Evicting_50LowPriorityGangs
+    labels: [performance]
+    params:
+      initNodes: 1000
+      lowPriorityGroups: 50
+      highPriorityGroups: 10
+      podsPerGroup: 100
+      lowPriorityCpuRequest: 600m
+      highPriorityCpuRequest: 3500m
 
 # GangPreemptionAffinity benchmarks the performance of gang preemption (WorkloadAwarePreemption)
 # in the presence of pod affinity constraints.

--- a/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
+++ b/test/integration/scheduler_perf/workload_preemption/performance-config.yaml
@@ -208,6 +208,15 @@
     featureGates:
       TopologyAwareWorkloadScheduling: true
       CompositePodGroup: true
+  - name: 1000Nodes_10PreemptorGangs_100Pods_Evicting_50LowPriorityGangs
+    labels: [performance]
+    params:
+      initNodes: 1000
+      lowPriorityGroups: 50
+      highPriorityGroups: 10
+      podsPerGroup: 100
+      lowPriorityCpuRequest: 600m
+      highPriorityCpuRequest: 3500m
 
 # GangPreemptionAffinity benchmarks the performance of gang preemption (WorkloadAwarePreemption)
 # in the presence of pod affinity constraints.


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR removes the metrics reporting during the "reprieve" phase of the WAP. For the benchmark scenario that is added in this PR (1000Nodes_10PreemptorGangs_100Pods_Evicting_50LowPriorityGangs), the SchedulingDuration drops from 32s to 22s on my machine. 

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/enhancements/issues/5710

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Metrics for plugins and extension points run during podgroup preemption reprieval phase will not be exported.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

