### PR TITLE
Do not allow changing job's index related annotations on pods

### DIFF
--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -28,6 +28,8 @@ const (
 	// so we will add a batch.kubernetes.io to designate these labels as official Kubernetes labels.
 	// See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#label-selector-and-annotation-conventions
 	labelPrefix = "batch.kubernetes.io/"
+
+	JobCompletionIndexAnnotation = labelPrefix + "job-completion-index"
 	// JobTrackingFinalizer is a finalizer for Job's pods. It prevents them from
 	// being deleted before being accounted in the Job status.
 	//

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -60,6 +60,7 @@ import (
 
 	apiservice "k8s.io/kubernetes/pkg/api/service"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
 	"k8s.io/kubernetes/pkg/apis/core/helper/qos"
@@ -247,6 +248,9 @@ func ValidatePodSpecificAnnotationUpdates(newPod, oldPod *core.Pod, fldPath *fie
 		if k == core.MirrorPodAnnotationKey {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Key(k), "may not remove or update mirror pod annotation"))
 		}
+		if k == batch.JobCompletionIndexAnnotation || k == batch.JobIndexFailureCountAnnotation || k == batch.JobIndexIgnoredFailureCountAnnotation {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Key(k), "may not remove or update job index annotation"))
+		}
 	}
 	// Check for additions
 	for k := range newAnnotations {
@@ -258,6 +262,9 @@ func ValidatePodSpecificAnnotationUpdates(newPod, oldPod *core.Pod, fldPath *fie
 		}
 		if k == core.MirrorPodAnnotationKey {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Key(k), "may not add mirror pod annotation"))
+		}
+		if k == batch.JobCompletionIndexAnnotation || k == batch.JobIndexFailureCountAnnotation || k == batch.JobIndexIgnoredFailureCountAnnotation {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Key(k), "may not add job index annotation after pod creation"))
 		}
 	}
 	allErrs = append(allErrs, ValidatePodSpecificAnnotations(newAnnotations, &newPod.Spec, fldPath, opts)...)

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -46,6 +46,7 @@ import (
 	ndf "k8s.io/component-helpers/nodedeclaredfeatures/features"
 	kubeletapis "k8s.io/kubelet/pkg/apis"
 	podtest "k8s.io/kubernetes/pkg/api/pod/testing"
+	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/features"
@@ -14384,6 +14385,49 @@ func TestValidatePodUpdate(t *testing.T) {
 				podtest.SetNodeName("foo")),
 			err:  "metadata.annotations[kubernetes.io/config.mirror]",
 			test: "changed mirror pod annotation",
+		}, {
+			new: *podtest.MakePod("foo",
+				podtest.SetAnnotations(map[string]string{batch.JobCompletionIndexAnnotation: "0"}),
+				podtest.SetNodeName("foo")),
+			old: *podtest.MakePod("foo",
+				podtest.SetNodeName("foo")),
+			err:  "metadata.annotations[batch.kubernetes.io/job-completion-index]",
+			test: "added job completion index annotation",
+		}, {
+			new: *podtest.MakePod("foo",
+				podtest.SetNodeName("foo")),
+			old: *podtest.MakePod("foo",
+				podtest.SetAnnotations(map[string]string{batch.JobCompletionIndexAnnotation: "0"}),
+				podtest.SetNodeName("foo")),
+			err:  "metadata.annotations[batch.kubernetes.io/job-completion-index]",
+			test: "removed job completion index annotation",
+		}, {
+			new: *podtest.MakePod("foo",
+				podtest.SetAnnotations(map[string]string{batch.JobCompletionIndexAnnotation: "1"}),
+				podtest.SetNodeName("foo")),
+			old: *podtest.MakePod("foo",
+				podtest.SetAnnotations(map[string]string{batch.JobCompletionIndexAnnotation: "0"}),
+				podtest.SetNodeName("foo")),
+			err:  "metadata.annotations[batch.kubernetes.io/job-completion-index]",
+			test: "changed job completion index annotation",
+		}, {
+			new: *podtest.MakePod("foo",
+				podtest.SetAnnotations(map[string]string{batch.JobIndexFailureCountAnnotation: "2"}),
+				podtest.SetNodeName("foo")),
+			old: *podtest.MakePod("foo",
+				podtest.SetAnnotations(map[string]string{batch.JobIndexFailureCountAnnotation: "1"}),
+				podtest.SetNodeName("foo")),
+			err:  "metadata.annotations[batch.kubernetes.io/job-index-failure-count]",
+			test: "changed job index failure count annotation",
+		}, {
+			new: *podtest.MakePod("foo",
+				podtest.SetAnnotations(map[string]string{batch.JobIndexIgnoredFailureCountAnnotation: "2"}),
+				podtest.SetNodeName("foo")),
+			old: *podtest.MakePod("foo",
+				podtest.SetAnnotations(map[string]string{batch.JobIndexIgnoredFailureCountAnnotation: "1"}),
+				podtest.SetNodeName("foo")),
+			err:  "metadata.annotations[batch.kubernetes.io/job-index-ignored-failure-count]",
+			test: "changed job index ignored failure count annotation",
 		}, {
 			new: *podtest.MakePod("foo",
 				podtest.SetNodeName("node1"),


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig apps

#### What this PR does / why we need it:
Currently it's possible that a user modifies index-related annoations on pods running IndexedJobs. This change ensures those annotations are not mutable after pod creation. 

#### Which issue(s) this PR is related to:
Fixes #140839

#### Special notes for your reviewer:
/assign @mimowo 
for job controller impact
/assign @deads2k
for API bits

#### Does this PR introduce a user-facing change?
```release-note
The validation now rejects attempts to add, remove, or modify a Pod's Job completion-index annotations (`batch.kubernetes.io/job-completion-index`, `batch.kubernetes.io/job-index-failure-count`, `batch.kubernetes.io/job-index-ignored-failure-count`) after pod creation, preventing users from tampering with indexed Job tracking data.
```
