### PR TITLE
kubelet/dra: track authoritative device health stream

### DIFF
--- a/pkg/kubelet/cm/dra/healthinfo.go
+++ b/pkg/kubelet/cm/dra/healthinfo.go
@@ -264,11 +264,19 @@ func (cache *healthInfoCache) updateHealthInfo(logger klog.Logger, driverName st
 func (cache *healthInfoCache) clearDriver(logger klog.Logger, driverName string) ([]state.DeviceHealth, error) {
 	changedDevices := []state.DeviceHealth{}
 	err := cache.withLock(func() error {
+		now := time.Now()
 		driver, exists := (*cache.HealthInfo)[driverName]
 		if !exists {
 			return nil
 		}
 		for _, device := range driver.Devices {
+			timeout := device.HealthCheckTimeout
+			if timeout == 0 {
+				timeout = DefaultHealthTimeout
+			}
+			if now.Sub(device.LastUpdated) > timeout {
+				continue
+			}
 			if device.Health != state.DeviceHealthStatusUnknown || device.Message != "" {
 				device.Health = state.DeviceHealthStatusUnknown
 				device.Message = ""

--- a/pkg/kubelet/cm/dra/healthinfo.go
+++ b/pkg/kubelet/cm/dra/healthinfo.go
@@ -259,10 +259,24 @@ func (cache *healthInfoCache) updateHealthInfo(logger klog.Logger, driverName st
 	return changedDevices, nil
 }
 
-// clearDriver clears all health data for a specific driver.
-func (cache *healthInfoCache) clearDriver(logger klog.Logger, driverName string) error {
-	return cache.withLock(func() error {
+// clearDriver clears all health data for a specific driver and returns devices
+// whose externally visible health information changed.
+func (cache *healthInfoCache) clearDriver(logger klog.Logger, driverName string) ([]state.DeviceHealth, error) {
+	changedDevices := []state.DeviceHealth{}
+	err := cache.withLock(func() error {
+		driver, exists := (*cache.HealthInfo)[driverName]
+		if !exists {
+			return nil
+		}
+		for _, device := range driver.Devices {
+			if device.Health != state.DeviceHealthStatusUnknown || device.Message != "" {
+				device.Health = state.DeviceHealthStatusUnknown
+				device.Message = ""
+				changedDevices = append(changedDevices, device)
+			}
+		}
 		delete(*cache.HealthInfo, driverName)
 		return cache.saveToCheckpointInternal(logger)
 	})
+	return changedDevices, err
 }

--- a/pkg/kubelet/cm/dra/healthinfo_test.go
+++ b/pkg/kubelet/cm/dra/healthinfo_test.go
@@ -535,13 +535,32 @@ func TestClearDriver(t *testing.T) {
 	cache, err := newHealthInfoCache(logger, "")
 	require.NoError(t, err)
 
-	_, err = cache.updateHealthInfo(logger, testDriver, []state.DeviceHealth{testDeviceHealth})
+	now := time.Now()
+	devices := []state.DeviceHealth{
+		{PoolName: testPool, DeviceName: "fresh-healthy", Health: state.DeviceHealthStatusHealthy, LastUpdated: now, HealthCheckTimeout: time.Minute},
+		{PoolName: testPool, DeviceName: "expired-healthy", Health: state.DeviceHealthStatusHealthy, LastUpdated: now.Add(-2 * time.Minute), HealthCheckTimeout: time.Minute},
+		{PoolName: testPool, DeviceName: "unknown-with-message", Health: state.DeviceHealthStatusUnknown, Message: "initializing", LastUpdated: now, HealthCheckTimeout: time.Minute},
+		{PoolName: testPool, DeviceName: "unknown-without-message", Health: state.DeviceHealthStatusUnknown, LastUpdated: now, HealthCheckTimeout: time.Minute},
+	}
+	_, err = cache.updateHealthInfo(logger, testDriver, devices)
 	require.NoError(t, err)
-	assert.Equal(t, state.DeviceHealthStatusHealthy, cache.getHealthInfo(testDriver, testPool, testDevice).Health)
+	require.NoError(t, cache.withLock(func() error {
+		expired := (*cache.HealthInfo)[testDriver].Devices[testPool+"/expired-healthy"]
+		expired.LastUpdated = now.Add(-2 * time.Minute)
+		(*cache.HealthInfo)[testDriver].Devices[testPool+"/expired-healthy"] = expired
+		return nil
+	}))
 
 	changedDevices, err := cache.clearDriver(logger, testDriver)
 	require.NoError(t, err)
-	require.Len(t, changedDevices, 1)
-	assert.Equal(t, state.DeviceHealthStatusUnknown, changedDevices[0].Health)
-	assert.Equal(t, state.DeviceHealthStatusUnknown, cache.getHealthInfo(testDriver, testPool, testDevice).Health)
+	changedDeviceNames := make([]string, 0, len(changedDevices))
+	for _, device := range changedDevices {
+		changedDeviceNames = append(changedDeviceNames, device.DeviceName)
+		assert.Equal(t, state.DeviceHealthStatusUnknown, device.Health)
+		assert.Empty(t, device.Message)
+	}
+	assert.ElementsMatch(t, []string{"fresh-healthy", "unknown-with-message"}, changedDeviceNames)
+	for _, device := range devices {
+		assert.Equal(t, state.DeviceHealthStatusUnknown, cache.getHealthInfo(testDriver, testPool, device.DeviceName).Health)
+	}
 }

--- a/pkg/kubelet/cm/dra/healthinfo_test.go
+++ b/pkg/kubelet/cm/dra/healthinfo_test.go
@@ -539,7 +539,9 @@ func TestClearDriver(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, state.DeviceHealthStatusHealthy, cache.getHealthInfo(testDriver, testPool, testDevice).Health)
 
-	err = cache.clearDriver(logger, testDriver)
+	changedDevices, err := cache.clearDriver(logger, testDriver)
 	require.NoError(t, err)
+	require.Len(t, changedDevices, 1)
+	assert.Equal(t, state.DeviceHealthStatusUnknown, changedDevices[0].Health)
 	assert.Equal(t, state.DeviceHealthStatusUnknown, cache.getHealthInfo(testDriver, testPool, testDevice).Health)
 }

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -1075,18 +1075,12 @@ func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream draheal
 	logger = klog.LoggerWithValues(logger, "pluginName", pluginName, "generation", generation)
 
 	m.healthStreamMutex.Lock()
-	if err := ctx.Err(); err != nil {
+	activeGeneration, active := m.activeHealthStreams[pluginName]
+	if !active || activeGeneration != generation {
 		m.healthStreamMutex.Unlock()
-		return err
+		return fmt.Errorf("health stream generation %d for DRA driver %s is not active", generation, pluginName)
 	}
-	if activeGeneration, ok := m.activeHealthStreams[pluginName]; ok && activeGeneration > generation {
-		m.healthStreamMutex.Unlock()
-		return fmt.Errorf("health stream generation %d for DRA driver %s is older than active generation %d", generation, pluginName, activeGeneration)
-	}
-	m.activeHealthStreams[pluginName] = generation
 	m.healthStreamMutex.Unlock()
-
-	defer m.stopHealthStream(logger, pluginName, generation)
 
 	for {
 		resp, err := stream.Recv()
@@ -1136,7 +1130,23 @@ func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream draheal
 	}
 }
 
-func (m *Manager) stopHealthStream(logger klog.Logger, pluginName string, generation uint64) {
+// ActivateHealthStream transfers ownership before the old stream gets
+// canceled, so its remaining updates can no longer modify the cache.
+func (m *Manager) ActivateHealthStream(_ context.Context, pluginName string, generation uint64) {
+	m.healthStreamMutex.Lock()
+	defer m.healthStreamMutex.Unlock()
+	if activeGeneration, ok := m.activeHealthStreams[pluginName]; ok && activeGeneration >= generation {
+		return
+	}
+	m.activeHealthStreams[pluginName] = generation
+}
+
+// DeactivateHealthStream clears health only when the authoritative endpoint
+// is permanently lost. A retryable stream exit does not call this method.
+func (m *Manager) DeactivateHealthStream(ctx context.Context, pluginName string, generation uint64) {
+	logger := klog.FromContext(ctx).WithName("dra-manager")
+	logger = klog.LoggerWithValues(logger, "pluginName", pluginName, "generation", generation)
+
 	m.healthStreamMutex.Lock()
 	defer m.healthStreamMutex.Unlock()
 
@@ -1145,7 +1155,7 @@ func (m *Manager) stopHealthStream(logger klog.Logger, pluginName string, genera
 	}
 	delete(m.activeHealthStreams, pluginName)
 
-	logger.V(4).Info("Clearing health cache for driver upon stream exit")
+	logger.V(4).Info("Clearing health cache for driver after health reporting stopped")
 	changedDevices, err := m.healthInfoCache.clearDriver(logger, pluginName)
 	if err != nil {
 		logger.Error(err, "Failed to clear health info cache for driver")

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -110,6 +111,10 @@ type Manager struct {
 
 	// update channel for resource updates
 	update chan resourceupdates.Update
+
+	// healthStreamMutex serializes stream ownership changes with cache updates.
+	healthStreamMutex   sync.Mutex
+	activeHealthStreams map[string]uint64
 }
 
 // NewManager creates a new DRA manager.
@@ -137,13 +142,14 @@ func NewManager(logger klog.Logger, kubeClient clientset.Interface, stateFileDir
 	reconcilePeriod := defaultReconcilePeriod
 
 	manager := &Manager{
-		cache:           claimInfoCache,
-		kubeClient:      kubeClient,
-		reconcilePeriod: reconcilePeriod,
-		activePods:      nil,
-		sourcesReady:    nil,
-		healthInfoCache: healthInfoCache,
-		update:          make(chan resourceupdates.Update, 100),
+		cache:               claimInfoCache,
+		kubeClient:          kubeClient,
+		reconcilePeriod:     reconcilePeriod,
+		activePods:          nil,
+		sourcesReady:        nil,
+		healthInfoCache:     healthInfoCache,
+		update:              make(chan resourceupdates.Update, 100),
+		activeHealthStreams: make(map[string]uint64),
 	}
 
 	return manager, nil
@@ -1064,17 +1070,23 @@ func buildDeviceHealth(logger klog.Logger, device *drahealthv1.DeviceHealth) sta
 }
 
 // HandleWatchResourcesStream processes health updates from the DRA plugin.
-func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream drahealthv1.DRAResourceHealth_NodeWatchResourcesClient, pluginName string) error {
+func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream drahealthv1.DRAResourceHealth_NodeWatchResourcesClient, pluginName string, generation uint64) error {
 	logger := klog.FromContext(ctx).WithName("dra-manager")
-	logger = klog.LoggerWithValues(logger, "pluginName", pluginName)
+	logger = klog.LoggerWithValues(logger, "pluginName", pluginName, "generation", generation)
 
-	defer func() {
-		logger.V(4).Info("Clearing health cache for driver upon stream exit")
-		// Use a separate context for clearDriver if needed, though background should be fine.
-		if err := m.healthInfoCache.clearDriver(logger, pluginName); err != nil {
-			logger.Error(err, "Failed to clear health info cache for driver")
-		}
-	}()
+	m.healthStreamMutex.Lock()
+	if err := ctx.Err(); err != nil {
+		m.healthStreamMutex.Unlock()
+		return err
+	}
+	if activeGeneration, ok := m.activeHealthStreams[pluginName]; ok && activeGeneration > generation {
+		m.healthStreamMutex.Unlock()
+		return fmt.Errorf("health stream generation %d for DRA driver %s is older than active generation %d", generation, pluginName, activeGeneration)
+	}
+	m.activeHealthStreams[pluginName] = generation
+	m.healthStreamMutex.Unlock()
+
+	defer m.stopHealthStream(logger, pluginName, generation)
 
 	for {
 		resp, err := stream.Recv()
@@ -1099,6 +1111,9 @@ func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream draheal
 			logger.Error(err, "Error receiving from WatchResources stream")
 			return err
 		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 
 		// Convert drahealthv1.DeviceHealth to state.DeviceHealth
 		devices := make([]state.DeviceHealth, len(resp.GetDevices()))
@@ -1106,52 +1121,77 @@ func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream draheal
 			devices[i] = buildDeviceHealth(logger, d)
 		}
 
+		m.healthStreamMutex.Lock()
+		if m.activeHealthStreams[pluginName] != generation {
+			m.healthStreamMutex.Unlock()
+			return fmt.Errorf("health stream generation %d for DRA driver %s was superseded", generation, pluginName)
+		}
+
 		changedDevices, updateErr := m.healthInfoCache.updateHealthInfo(logger, pluginName, devices)
 		if updateErr != nil {
 			logger.Error(updateErr, "Failed to update health info cache")
 		}
-		if len(changedDevices) > 0 {
-			logger.V(4).Info("Health info changed, checking affected pods", "changedDevicesCount", len(changedDevices))
+		m.notifyPodsForHealthChanges(logger, pluginName, changedDevices)
+		m.healthStreamMutex.Unlock()
+	}
+}
 
-			// Snapshot which pods use which of this plugin's devices. The
-			// claim info cache lock is then held once per report and only
-			// while building the index, independent of how many devices
-			// changed, so that a plugin sending large reports at a high
-			// rate cannot block DRA operations on the lock.
-			type deviceKey struct {
-				poolName   string
-				deviceName string
-			}
-			podsByDevice := make(map[deviceKey][]string)
-			m.cache.RLock()
-			for _, cInfo := range m.cache.claimInfo {
-				if driverState, ok := cInfo.DriverState[pluginName]; ok {
-					for _, allocatedDevice := range driverState.Devices {
-						key := deviceKey{poolName: allocatedDevice.PoolName, deviceName: allocatedDevice.DeviceName}
-						podsByDevice[key] = append(podsByDevice[key], cInfo.PodUIDs.UnsortedList()...)
-					}
-				}
-			}
-			m.cache.RUnlock()
+func (m *Manager) stopHealthStream(logger klog.Logger, pluginName string, generation uint64) {
+	m.healthStreamMutex.Lock()
+	defer m.healthStreamMutex.Unlock()
 
-			podsToUpdate := sets.New[string]()
-			for _, dev := range changedDevices {
-				podsToUpdate.Insert(podsByDevice[deviceKey{poolName: dev.PoolName, deviceName: dev.DeviceName}]...)
-			}
+	if m.activeHealthStreams[pluginName] != generation {
+		return
+	}
+	delete(m.activeHealthStreams, pluginName)
 
-			if podsToUpdate.Len() > 0 {
-				podUIDs := podsToUpdate.UnsortedList()
-				logger.Info("Sending health update notification for pods", "pods", podUIDs)
-				select {
-				case m.update <- resourceupdates.Update{PodUIDs: podUIDs}:
-				default:
-					logger.Error(nil, "DRA health update channel is full, discarding pod update notification", "pods", podUIDs)
-				}
-			} else {
-				logger.V(4).Info("Health info changed, but no active pods found using the affected devices")
+	logger.V(4).Info("Clearing health cache for driver upon stream exit")
+	changedDevices, err := m.healthInfoCache.clearDriver(logger, pluginName)
+	if err != nil {
+		logger.Error(err, "Failed to clear health info cache for driver")
+	}
+	m.notifyPodsForHealthChanges(logger, pluginName, changedDevices)
+}
+
+func (m *Manager) notifyPodsForHealthChanges(logger klog.Logger, pluginName string, changedDevices []state.DeviceHealth) {
+	if len(changedDevices) == 0 {
+		return
+	}
+
+	logger.V(4).Info("Health info changed, checking affected pods", "changedDevicesCount", len(changedDevices))
+
+	type deviceKey struct {
+		poolName   string
+		deviceName string
+	}
+	podsByDevice := make(map[deviceKey][]string)
+	m.cache.RLock()
+	for _, claimInfo := range m.cache.claimInfo {
+		if driverState, ok := claimInfo.DriverState[pluginName]; ok {
+			for _, allocatedDevice := range driverState.Devices {
+				key := deviceKey{poolName: allocatedDevice.PoolName, deviceName: allocatedDevice.DeviceName}
+				podsByDevice[key] = append(podsByDevice[key], claimInfo.PodUIDs.UnsortedList()...)
 			}
 		}
+	}
+	m.cache.RUnlock()
 
+	podsToUpdate := sets.New[string]()
+	for _, device := range changedDevices {
+		podsToUpdate.Insert(podsByDevice[deviceKey{poolName: device.PoolName, deviceName: device.DeviceName}]...)
+	}
+
+	if podsToUpdate.Len() == 0 {
+		logger.V(4).Info("Health info changed, but no active pods found using the affected devices")
+		return
+	}
+
+	podUIDs := podsToUpdate.UnsortedList()
+	logger.Info("Sending health update notification for pods", "pods", podUIDs)
+	select {
+	case m.update <- resourceupdates.Update{PodUIDs: podUIDs}:
+	default:
+		logger.Error(nil, "DRA health update channel is full, discarding pod update notification", "pods", podUIDs)
 	}
 }
 

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -2007,7 +2007,7 @@ func TestHandleWatchResourcesStreamOwnership(t *testing.T) {
 		t.Fatal("superseded health stream did not stop")
 	}
 	require.Equal(t, state.DeviceHealthStatusUnhealthy, manager.healthInfoCache.getHealthInfo(driverName, poolName, deviceName).Health)
-	require.Zero(t, len(manager.update), "superseded health stream triggered an unexpected pod update")
+	require.Empty(t, manager.update, "superseded health stream triggered an unexpected pod update")
 
 	close(newResponses)
 	expectPodUpdate()

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -1991,9 +1991,14 @@ func TestHandleWatchResourcesStreamOwnership(t *testing.T) {
 		}
 	}
 
+	manager.ActivateHealthStream(tCtx, driverName, 1)
 	oldResponses, oldDone := startStream(1)
 	oldResponses <- response(drahealthv1.HealthStatus_HEALTHY)
 	expectPodUpdate()
+
+	manager.ActivateHealthStream(tCtx, driverName, 2)
+	require.Equal(t, state.DeviceHealthStatusHealthy, manager.healthInfoCache.getHealthInfo(driverName, poolName, deviceName).Health)
+	require.Empty(t, manager.update, "handover triggered an unexpected pod update")
 
 	newResponses, newDone := startStream(2)
 	newResponses <- response(drahealthv1.HealthStatus_UNHEALTHY)
@@ -2009,16 +2014,38 @@ func TestHandleWatchResourcesStreamOwnership(t *testing.T) {
 	require.Equal(t, state.DeviceHealthStatusUnhealthy, manager.healthInfoCache.getHealthInfo(driverName, poolName, deviceName).Health)
 	require.Empty(t, manager.update, "superseded health stream triggered an unexpected pod update")
 
-	close(newResponses)
-	expectPodUpdate()
+	newResponses <- struct {
+		Resp *drahealthv1.NodeWatchResourcesResponse
+		Err  error
+	}{Err: errors.New("transient stream error")}
 	select {
 	case err := <-newDone:
-		require.NoError(t, err)
+		require.ErrorContains(t, err, "transient stream error")
 	case <-time.After(time.Second):
 		t.Fatal("active health stream did not stop")
 	}
+	require.Equal(t, state.DeviceHealthStatusUnhealthy, manager.healthInfoCache.getHealthInfo(driverName, poolName, deviceName).Health)
+	require.Empty(t, manager.update, "retryable stream exit triggered an unexpected pod update")
+
+	manager.ActivateHealthStream(tCtx, driverName, 1)
+	staleResponses, staleDone := startStream(1)
+	select {
+	case err := <-staleDone:
+		require.ErrorContains(t, err, "is not active")
+	case <-time.After(time.Second):
+		t.Fatal("older health stream entered its receive loop")
+	}
+
+	manager.DeactivateHealthStream(tCtx, driverName, 1)
+	require.Equal(t, state.DeviceHealthStatusUnhealthy, manager.healthInfoCache.getHealthInfo(driverName, poolName, deviceName).Health)
+	require.Empty(t, manager.update, "stale deactivation triggered an unexpected pod update")
+
+	manager.DeactivateHealthStream(tCtx, driverName, 2)
+	expectPodUpdate()
 	require.Equal(t, state.DeviceHealthStatusUnknown, manager.healthInfoCache.getHealthInfo(driverName, poolName, deviceName).Health)
 	close(oldResponses)
+	close(newResponses)
+	close(staleResponses)
 }
 
 // TestHandleWatchResourcesStream verifies the manager's ability to process health updates
@@ -2062,6 +2089,7 @@ func TestHandleWatchResourcesStream(t *testing.T) {
 				Err  error
 			},
 		) (<-chan resourceupdates.Update, chan struct{}, chan error) {
+			managerInstance.ActivateHealthStream(streamCtx, driverName, 1)
 			mockStream := &mockWatchResourcesClient{
 				RecvChan: responses,
 				Ctx:      streamCtx,

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -1944,6 +1944,83 @@ func TestParallelPrepareUnprepareResources(t *testing.T) {
 	wgSync.Wait()  // Wait for all goroutines to finish
 }
 
+func TestHandleWatchResourcesStreamOwnership(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	manager, err := NewManager(tCtx.Logger(), nil, t.TempDir())
+	require.NoError(t, err)
+	defer manager.Stop()
+	manager.cache.add(genTestClaimInfo(claimUID, []string{string(podUID)}, true, nil))
+
+	startStream := func(generation uint64) (chan struct {
+		Resp *drahealthv1.NodeWatchResourcesResponse
+		Err  error
+	}, <-chan error) {
+		responses := make(chan struct {
+			Resp *drahealthv1.NodeWatchResourcesResponse
+			Err  error
+		}, 1)
+		stream := &mockWatchResourcesClient{RecvChan: responses, Ctx: tCtx}
+		done := make(chan error, 1)
+		go func() {
+			done <- manager.HandleWatchResourcesStream(tCtx, stream, driverName, generation)
+		}()
+		return responses, done
+	}
+	response := func(health drahealthv1.HealthStatus) struct {
+		Resp *drahealthv1.NodeWatchResourcesResponse
+		Err  error
+	} {
+		return struct {
+			Resp *drahealthv1.NodeWatchResourcesResponse
+			Err  error
+		}{Resp: &drahealthv1.NodeWatchResourcesResponse{Devices: []*drahealthv1.DeviceHealth{{
+			Device: &drahealthv1.DeviceIdentifier{
+				PoolName:   poolName,
+				DeviceName: deviceName,
+			},
+			Health:          health,
+			LastUpdatedTime: time.Now().Unix(),
+		}}}}
+	}
+	expectPodUpdate := func() {
+		select {
+		case update := <-manager.update:
+			require.ElementsMatch(t, []string{string(podUID)}, update.PodUIDs)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for pod health update")
+		}
+	}
+
+	oldResponses, oldDone := startStream(1)
+	oldResponses <- response(drahealthv1.HealthStatus_HEALTHY)
+	expectPodUpdate()
+
+	newResponses, newDone := startStream(2)
+	newResponses <- response(drahealthv1.HealthStatus_UNHEALTHY)
+	expectPodUpdate()
+
+	oldResponses <- response(drahealthv1.HealthStatus_HEALTHY)
+	select {
+	case err := <-oldDone:
+		require.ErrorContains(t, err, "was superseded")
+	case <-time.After(time.Second):
+		t.Fatal("superseded health stream did not stop")
+	}
+	require.Equal(t, state.DeviceHealthStatusUnhealthy, manager.healthInfoCache.getHealthInfo(driverName, poolName, deviceName).Health)
+	require.Zero(t, len(manager.update), "superseded health stream triggered an unexpected pod update")
+
+	close(newResponses)
+	expectPodUpdate()
+	select {
+	case err := <-newDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("active health stream did not stop")
+	}
+	require.Equal(t, state.DeviceHealthStatusUnknown, manager.healthInfoCache.getHealthInfo(driverName, poolName, deviceName).Health)
+	close(oldResponses)
+}
+
 // TestHandleWatchResourcesStream verifies the manager's ability to process health updates
 // received from a DRA plugin's WatchResources stream. It checks if the internal health cache
 // is updated correctly, if affected pods are identified, and if update notifications are sent
@@ -1997,7 +2074,7 @@ func TestHandleWatchResourcesStream(t *testing.T) {
 				logger := klog.FromContext(streamCtx).WithName(st.Name())
 				hdlCtx := klog.NewContext(streamCtx, logger)
 
-				err := managerInstance.HandleWatchResourcesStream(hdlCtx, mockStream, driverName)
+				err := managerInstance.HandleWatchResourcesStream(hdlCtx, mockStream, driverName, 1)
 				if err != nil {
 					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, io.EOF) {
 						logger.V(4).Info("HandleWatchResourcesStream (test goroutine) exited as expected", "error", err)

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin.go
@@ -19,7 +19,6 @@ package plugin
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -75,11 +74,7 @@ type DRAPlugin struct {
 	chosenHealthService string
 	clientCallTimeout   time.Duration
 
-	mutex         sync.Mutex
 	backgroundCtx context.Context
-
-	healthStreamCtx    context.Context
-	healthStreamCancel context.CancelFunc
 }
 
 func (p *DRAPlugin) DriverName() string {
@@ -156,21 +151,6 @@ func newMetricsInterceptor(driverName string) grpc.UnaryClientInterceptor {
 		metrics.DRAGRPCOperationsDuration.WithLabelValues(driverName, method, status.Code(err).String()).Observe(time.Since(start).Seconds())
 		return err
 	}
-}
-
-// SetHealthStream stores the context and cancel function for the active health stream.
-func (p *DRAPlugin) SetHealthStream(ctx context.Context, cancel context.CancelFunc) {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-	p.healthStreamCtx = ctx
-	p.healthStreamCancel = cancel
-}
-
-// HealthStreamCancel returns the cancel function for the current health stream, if any.
-func (p *DRAPlugin) HealthStreamCancel() context.CancelFunc {
-	p.mutex.Lock()
-	defer p.mutex.Unlock()
-	return p.healthStreamCancel
 }
 
 // NodeWatchResources establishes a stream to receive health updates from the DRA

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
@@ -73,6 +73,10 @@ type DRAPluginManager struct {
 	// driver name -> DRAPlugin in the order in which they got added
 	store map[string][]*monitoredPlugin
 
+	// nextHealthStreamGeneration distinguishes successive authoritative streams
+	// for a driver. It is protected by mutex.
+	nextHealthStreamGeneration uint64
+
 	// pendingWipes tracks at which time ResourceSlices for a
 	// DRA driver should be removed. The removal then happens in
 	// the background in a callback function that is invoked
@@ -97,6 +101,10 @@ type monitoredPlugin struct {
 
 	// connected is protected by store.mutex.
 	connected bool
+
+	// healthStreamCancel and healthStreamGeneration are protected by pm.mutex.
+	healthStreamCancel     context.CancelFunc
+	healthStreamGeneration uint64
 }
 
 var _ grpcstats.Handler = &monitoredPlugin{}
@@ -286,6 +294,16 @@ func (pm *DRAPluginManager) GetPlugin(driverName string) (*DRAPlugin, error) {
 func (pm *DRAPluginManager) get(driverName string) *DRAPlugin {
 	pm.mutex.RLock()
 	defer pm.mutex.RUnlock()
+	plugin := pm.getPreferredPlugin(driverName)
+	if plugin == nil {
+		return nil
+	}
+	return plugin.DRAPlugin
+}
+
+// getPreferredPlugin returns the endpoint which should handle calls for a
+// driver. The mutex must be locked for reading or writing.
+func (pm *DRAPluginManager) getPreferredPlugin(driverName string) *monitoredPlugin {
 
 	logger := klog.FromContext(pm.backgroundCtx)
 
@@ -304,12 +322,12 @@ func (pm *DRAPluginManager) get(driverName string) *DRAPlugin {
 	for i := len(plugins) - 1; i >= 0; i-- {
 		if plugin := plugins[i]; plugin.connected {
 			logger.V(5).Info("Preferring connected plugin", "driverName", driverName, "endpoint", plugin.endpoint)
-			return plugin.DRAPlugin
+			return plugin
 		}
 	}
 	plugin := plugins[len(plugins)-1]
 	logger.V(5).Info("No plugin connected, using latest one", "driverName", driverName, "endpoint", plugin.endpoint)
-	return plugin.DRAPlugin
+	return plugin
 }
 
 // RegisterPlugin implements [cache.PluginHandler].
@@ -403,37 +421,6 @@ func (pm *DRAPluginManager) add(driverName string, endpoint string, chosenServic
 		return fmt.Errorf("create gRPC connection to DRA driver %s plugin at endpoint %s: %w", driverName, endpoint, err)
 	}
 	p.conn = conn
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.ResourceHealthStatus) && pm.streamHandler != nil && p.chosenHealthService != "" {
-		pm.wg.Add(1)
-		go func() {
-			defer pm.wg.Done()
-			streamCtx, streamCancel := context.WithCancel(p.backgroundCtx)
-			p.SetHealthStream(streamCtx, streamCancel)
-
-			wait.UntilWithContext(streamCtx, func(ctx context.Context) {
-				logger.V(4).Info("Attempting to start WatchResources health stream")
-				stream, err := p.NodeWatchResources(ctx)
-				if err != nil {
-					logger.V(3).Info("Failed to establish WatchResources stream, will retry", "err", err)
-					return
-				}
-
-				logger.V(2).Info("Successfully started WatchResources health stream")
-
-				err = pm.streamHandler.HandleWatchResourcesStream(ctx, stream, driverName)
-				logger.V(2).Info("WatchResources health stream has ended", "error", err)
-				if status.Code(err) == codes.Unimplemented {
-					// The driver advertises the health service but does not
-					// support health reporting. Stop watching instead of
-					// retrying; a driver which gains support re-registers.
-					logger.V(2).Info("Driver does not support WatchResources health stream, stopping")
-					streamCancel()
-				}
-			}, 5*time.Second)
-		}()
-	}
-
 	// Ensure that gRPC tries to connect even if we don't call any gRPC method.
 	// This is necessary to detect early whether a plugin is really available.
 	// This is currently an experimental gRPC method. Should it be removed we
@@ -488,11 +475,13 @@ func (pm *DRAPluginManager) remove(driverName, endpoint string) {
 		pm.store[driverName] = slices.Delete(plugins, i, i+1)
 	}
 
-	// Cancel the plugin's health stream if it was active.
-	healthCancel := p.HealthStreamCancel()
-	if healthCancel != nil {
+	// Cancel the plugin's health stream if it was active. sync will start a
+	// stream for the new preferred endpoint, if there is one.
+	if p.healthStreamCancel != nil {
 		logger.V(4).Info("Canceling health stream during deregistration")
-		healthCancel()
+		p.healthStreamCancel()
+		p.healthStreamCancel = nil
+		p.healthStreamGeneration = 0
 	}
 
 	logger.V(3).Info("Unregistered DRA plugin", "driverName", driverName, "endpoint", endpoint, "numPlugins", len(pm.store[driverName]))
@@ -502,6 +491,8 @@ func (pm *DRAPluginManager) remove(driverName, endpoint string) {
 // sync must be called each time the information about a plugin changes.
 // The mutex must be locked for writing.
 func (pm *DRAPluginManager) sync(driverName string) {
+	pm.syncHealthStream(driverName)
+
 	if pm.kubeClient == nil {
 		// Cannot wipe.
 		return
@@ -535,6 +526,66 @@ func (pm *DRAPluginManager) sync(driverName string) {
 	logger = klog.LoggerWithValues(logger, "driverName", driverName)
 	ctx = klog.NewContext(ctx, logger)
 	pm.pendingWipes.AddWork(ctx, timedworkers.NewWorkArgs(driverName, ""), now, fireAt)
+}
+
+// syncHealthStream ensures that only the preferred endpoint for a driver has
+// a health stream. The mutex must be locked for writing.
+func (pm *DRAPluginManager) syncHealthStream(driverName string) {
+	if pm.backgroundCtx.Err() != nil || !utilfeature.DefaultFeatureGate.Enabled(features.ResourceHealthStatus) || pm.streamHandler == nil {
+		return
+	}
+
+	logger := klog.FromContext(pm.backgroundCtx)
+	preferredPlugin := pm.getPreferredPlugin(driverName)
+	for _, plugin := range pm.store[driverName] {
+		if plugin == preferredPlugin || plugin.healthStreamCancel == nil {
+			continue
+		}
+		logger.V(4).Info("Canceling health stream for non-preferred endpoint", "driverName", driverName, "endpoint", plugin.endpoint)
+		plugin.healthStreamCancel()
+		plugin.healthStreamCancel = nil
+		plugin.healthStreamGeneration = 0
+	}
+
+	if preferredPlugin == nil || preferredPlugin.chosenHealthService == "" || preferredPlugin.healthStreamCancel != nil {
+		return
+	}
+
+	pm.nextHealthStreamGeneration++
+	generation := pm.nextHealthStreamGeneration
+	streamCtx, streamCancel := context.WithCancel(preferredPlugin.backgroundCtx)
+	preferredPlugin.healthStreamCancel = streamCancel
+	preferredPlugin.healthStreamGeneration = generation
+
+	pm.wg.Add(1)
+	go pm.runHealthStream(streamCtx, streamCancel, preferredPlugin.DRAPlugin, generation)
+}
+
+func (pm *DRAPluginManager) runHealthStream(ctx context.Context, cancel context.CancelFunc, plugin *DRAPlugin, generation uint64) {
+	defer pm.wg.Done()
+
+	logger := klog.LoggerWithValues(klog.FromContext(ctx), "driverName", plugin.driverName, "endpoint", plugin.endpoint, "generation", generation)
+	ctx = klog.NewContext(ctx, logger)
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
+		logger.V(4).Info("Attempting to start WatchResources health stream")
+		stream, err := plugin.NodeWatchResources(ctx)
+		if err != nil {
+			logger.V(3).Info("Failed to establish WatchResources health stream, will retry", "err", err)
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+
+		logger.V(2).Info("Successfully started WatchResources health stream")
+		err = pm.streamHandler.HandleWatchResourcesStream(ctx, stream, plugin.driverName, generation)
+		logger.V(2).Info("WatchResources health stream has ended", "error", err)
+		if status.Code(err) == codes.Unimplemented {
+			// A driver which gains support re-registers and gets a new stream.
+			logger.V(2).Info("Driver does not support WatchResources health stream, stopping")
+			cancel()
+		}
+	}, 5*time.Second)
 }
 
 // usable returns true if at least one endpoint is ready to handle gRPC calls for the DRA driver.

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_manager.go
@@ -73,6 +73,11 @@ type DRAPluginManager struct {
 	// driver name -> DRAPlugin in the order in which they got added
 	store map[string][]*monitoredPlugin
 
+	// healthStreams tracks the endpoint which owns health reporting for each
+	// driver. A zero generation means that the preferred endpoint does not
+	// provide health reports. It is protected by mutex.
+	healthStreams map[string]*healthStreamState
+
 	// nextHealthStreamGeneration distinguishes successive authoritative streams
 	// for a driver. It is protected by mutex.
 	nextHealthStreamGeneration uint64
@@ -101,10 +106,12 @@ type monitoredPlugin struct {
 
 	// connected is protected by store.mutex.
 	connected bool
+}
 
-	// healthStreamCancel and healthStreamGeneration are protected by pm.mutex.
-	healthStreamCancel     context.CancelFunc
-	healthStreamGeneration uint64
+type healthStreamState struct {
+	plugin     *monitoredPlugin
+	generation uint64
+	cancel     context.CancelFunc
 }
 
 var _ grpcstats.Handler = &monitoredPlugin{}
@@ -165,6 +172,7 @@ func NewDRAPluginManager(ctx context.Context, kubeClient kubernetes.Interface, g
 		getNode:       getNode,
 		wipingDelay:   wipingDelay,
 		streamHandler: streamHandler,
+		healthStreams: make(map[string]*healthStreamState),
 	}
 	pm.pendingWipes = timedworkers.CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *timedworkers.WorkArgs) error {
 		pm.wipeResourceSlices(ctx, args.Object.Name)
@@ -475,15 +483,6 @@ func (pm *DRAPluginManager) remove(driverName, endpoint string) {
 		pm.store[driverName] = slices.Delete(plugins, i, i+1)
 	}
 
-	// Cancel the plugin's health stream if it was active. sync will start a
-	// stream for the new preferred endpoint, if there is one.
-	if p.healthStreamCancel != nil {
-		logger.V(4).Info("Canceling health stream during deregistration")
-		p.healthStreamCancel()
-		p.healthStreamCancel = nil
-		p.healthStreamGeneration = 0
-	}
-
 	logger.V(3).Info("Unregistered DRA plugin", "driverName", driverName, "endpoint", endpoint, "numPlugins", len(pm.store[driverName]))
 	pm.sync(driverName)
 }
@@ -537,31 +536,51 @@ func (pm *DRAPluginManager) syncHealthStream(driverName string) {
 
 	logger := klog.FromContext(pm.backgroundCtx)
 	preferredPlugin := pm.getPreferredPlugin(driverName)
-	for _, plugin := range pm.store[driverName] {
-		if plugin == preferredPlugin || plugin.healthStreamCancel == nil {
-			continue
-		}
-		logger.V(4).Info("Canceling health stream for non-preferred endpoint", "driverName", driverName, "endpoint", plugin.endpoint)
-		plugin.healthStreamCancel()
-		plugin.healthStreamCancel = nil
-		plugin.healthStreamGeneration = 0
+	current := pm.healthStreams[driverName]
+	if current != nil && current.plugin == preferredPlugin {
+		return
 	}
 
-	if preferredPlugin == nil || preferredPlugin.chosenHealthService == "" || preferredPlugin.healthStreamCancel != nil {
+	if preferredPlugin == nil || preferredPlugin.chosenHealthService == "" {
+		if preferredPlugin == nil {
+			delete(pm.healthStreams, driverName)
+		} else {
+			// Health reporting follows the same authoritative endpoint as other
+			// DRA calls. Do not fall back to an older health-capable endpoint.
+			pm.healthStreams[driverName] = &healthStreamState{plugin: preferredPlugin}
+		}
+		if current != nil && current.generation != 0 {
+			pm.streamHandler.DeactivateHealthStream(pm.backgroundCtx, driverName, current.generation)
+		}
+		if current != nil && current.cancel != nil {
+			logger.V(4).Info("Canceling health stream with no replacement", "driverName", driverName, "endpoint", current.plugin.endpoint)
+			current.cancel()
+		}
 		return
 	}
 
 	pm.nextHealthStreamGeneration++
 	generation := pm.nextHealthStreamGeneration
 	streamCtx, streamCancel := context.WithCancel(preferredPlugin.backgroundCtx)
-	preferredPlugin.healthStreamCancel = streamCancel
-	preferredPlugin.healthStreamGeneration = generation
+
+	// Transfer ownership before canceling the old stream. This prevents its
+	// teardown from clearing health data during a seamless handover.
+	pm.streamHandler.ActivateHealthStream(pm.backgroundCtx, driverName, generation)
+	pm.healthStreams[driverName] = &healthStreamState{
+		plugin:     preferredPlugin,
+		generation: generation,
+		cancel:     streamCancel,
+	}
+	if current != nil && current.cancel != nil {
+		logger.V(4).Info("Canceling health stream for non-preferred endpoint", "driverName", driverName, "endpoint", current.plugin.endpoint)
+		current.cancel()
+	}
 
 	pm.wg.Add(1)
-	go pm.runHealthStream(streamCtx, streamCancel, preferredPlugin.DRAPlugin, generation)
+	go pm.runHealthStream(streamCtx, preferredPlugin, generation)
 }
 
-func (pm *DRAPluginManager) runHealthStream(ctx context.Context, cancel context.CancelFunc, plugin *DRAPlugin, generation uint64) {
+func (pm *DRAPluginManager) runHealthStream(ctx context.Context, plugin *monitoredPlugin, generation uint64) {
 	defer pm.wg.Done()
 
 	logger := klog.LoggerWithValues(klog.FromContext(ctx), "driverName", plugin.driverName, "endpoint", plugin.endpoint, "generation", generation)
@@ -580,12 +599,35 @@ func (pm *DRAPluginManager) runHealthStream(ctx context.Context, cancel context.
 		logger.V(2).Info("Successfully started WatchResources health stream")
 		err = pm.streamHandler.HandleWatchResourcesStream(ctx, stream, plugin.driverName, generation)
 		logger.V(2).Info("WatchResources health stream has ended", "error", err)
-		if status.Code(err) == codes.Unimplemented {
+		if pm.healthStreamTerminated(ctx, plugin, generation, err) {
 			// A driver which gains support re-registers and gets a new stream.
 			logger.V(2).Info("Driver does not support WatchResources health stream, stopping")
-			cancel()
 		}
 	}, 5*time.Second)
+}
+
+// healthStreamTerminated permanently stops a stream only when the health RPC
+// is unsupported. Retryable failures retain the last reported health until the
+// retry succeeds or the health timeout expires.
+func (pm *DRAPluginManager) healthStreamTerminated(ctx context.Context, plugin *monitoredPlugin, generation uint64, streamErr error) bool {
+	if status.Code(streamErr) != codes.Unimplemented {
+		return false
+	}
+
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
+	current := pm.healthStreams[plugin.driverName]
+	if current == nil || current.plugin != plugin || current.generation != generation {
+		return false
+	}
+	pm.streamHandler.DeactivateHealthStream(ctx, plugin.driverName, generation)
+	current.generation = 0
+	if current.cancel != nil {
+		current.cancel()
+		current.cancel = nil
+	}
+	return true
 }
 
 // usable returns true if at least one endpoint is ready to handle gRPC calls for the DRA driver.

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_manager_test.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_manager_test.go
@@ -17,11 +17,14 @@ limitations under the License.
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	drahealthv1 "k8s.io/kubelet/pkg/apis/dra-health/v1"
 	drahealthv1alpha1 "k8s.io/kubelet/pkg/apis/dra-health/v1alpha1"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -99,36 +102,102 @@ func TestAddSameName(t *testing.T) {
 func TestHealthStreamUsesLatestPlugin(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	driverName := fmt.Sprintf("dummy-driver-%d", rand.IntN(10000))
-	manager := NewDRAPluginManager(tCtx, nil, nil, &mockStreamHandler{}, 0)
+	streamHandler := &mockStreamHandler{}
+	manager := NewDRAPluginManager(tCtx, nil, nil, streamHandler, 0)
 	defer manager.Stop()
 
-	activeStreams := func() map[string]uint64 {
+	activeStream := func() (string, uint64) {
 		manager.mutex.RLock()
 		defer manager.mutex.RUnlock()
-		streams := make(map[string]uint64)
-		for _, plugin := range manager.store[driverName] {
-			if plugin.healthStreamCancel != nil {
-				streams[plugin.endpoint] = plugin.healthStreamGeneration
-			}
+		stream := manager.healthStreams[driverName]
+		if stream == nil {
+			return "", 0
 		}
-		return streams
+		return stream.plugin.endpoint, stream.generation
 	}
 
 	tCtx.ExpectNoError(manager.add(driverName, "old.sock", "", drahealthv1.DRAResourceHealthService, defaultClientCallTimeout), "add old plugin")
-	oldStreams := activeStreams()
-	require.Len(t, oldStreams, 1)
-	oldGeneration := oldStreams["old.sock"]
+	endpoint, oldGeneration := activeStream()
+	require.Equal(t, "old.sock", endpoint)
 	require.NotZero(t, oldGeneration)
 
 	tCtx.ExpectNoError(manager.add(driverName, "new.sock", "", drahealthv1.DRAResourceHealthService, defaultClientCallTimeout), "add new plugin")
-	newStreams := activeStreams()
-	require.Equal(t, map[string]uint64{"new.sock": oldGeneration + 1}, newStreams)
+	endpoint, newGeneration := activeStream()
+	require.Equal(t, "new.sock", endpoint)
+	require.Equal(t, oldGeneration+1, newGeneration)
+	require.Equal(t, []healthStreamLifecycleEvent{
+		{action: "activate", driverName: driverName, generation: oldGeneration},
+		{action: "activate", driverName: driverName, generation: newGeneration},
+	}, streamHandler.lifecycleEvents(), "handover must activate the replacement without deactivating health")
 
 	manager.remove(driverName, "old.sock")
-	require.Equal(t, newStreams, activeStreams(), "removing the old endpoint must not replace the active stream")
+	endpoint, generation := activeStream()
+	require.Equal(t, "new.sock", endpoint)
+	require.Equal(t, newGeneration, generation, "removing the old endpoint must not replace the active stream")
 
 	manager.remove(driverName, "new.sock")
-	require.Empty(t, activeStreams())
+	endpoint, generation = activeStream()
+	require.Empty(t, endpoint)
+	require.Zero(t, generation)
+	require.Equal(t, []healthStreamLifecycleEvent{
+		{action: "activate", driverName: driverName, generation: oldGeneration},
+		{action: "activate", driverName: driverName, generation: newGeneration},
+		{action: "deactivate", driverName: driverName, generation: newGeneration},
+	}, streamHandler.lifecycleEvents())
+}
+
+func TestHealthStreamDoesNotFallBackFromPreferredPlugin(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	driverName := fmt.Sprintf("dummy-driver-%d", rand.IntN(10000))
+	streamHandler := &mockStreamHandler{}
+	manager := NewDRAPluginManager(tCtx, nil, nil, streamHandler, 0)
+	defer manager.Stop()
+
+	tCtx.ExpectNoError(manager.add(driverName, "old.sock", "", drahealthv1.DRAResourceHealthService, defaultClientCallTimeout), "add old plugin")
+	tCtx.ExpectNoError(manager.add(driverName, "new.sock", "", "", defaultClientCallTimeout), "add new plugin without health service")
+
+	manager.mutex.RLock()
+	stream := manager.healthStreams[driverName]
+	manager.mutex.RUnlock()
+	require.NotNil(t, stream)
+	require.Equal(t, "new.sock", stream.plugin.endpoint)
+	require.Zero(t, stream.generation)
+	require.Equal(t, []healthStreamLifecycleEvent{
+		{action: "activate", driverName: driverName, generation: 1},
+		{action: "deactivate", driverName: driverName, generation: 1},
+	}, streamHandler.lifecycleEvents())
+}
+
+func TestHealthStreamUnimplemented(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	driverName := fmt.Sprintf("dummy-driver-%d", rand.IntN(10000))
+	streamHandler := &mockStreamHandler{}
+	manager := NewDRAPluginManager(tCtx, nil, nil, streamHandler, 0)
+	defer manager.Stop()
+
+	tCtx.ExpectNoError(manager.add(driverName, "plugin.sock", "", drahealthv1.DRAResourceHealthService, defaultClientCallTimeout), "add plugin")
+	manager.mutex.RLock()
+	stream := manager.healthStreams[driverName]
+	manager.mutex.RUnlock()
+	require.NotNil(t, stream)
+	require.NotZero(t, stream.generation)
+	generation := stream.generation
+
+	require.False(t, manager.healthStreamTerminated(tCtx, stream.plugin, generation, errors.New("temporary stream failure")))
+	require.Equal(t, []healthStreamLifecycleEvent{
+		{action: "activate", driverName: driverName, generation: generation},
+	}, streamHandler.lifecycleEvents())
+
+	require.True(t, manager.healthStreamTerminated(tCtx, stream.plugin, generation, status.Error(codes.Unimplemented, "not supported")))
+	require.Equal(t, []healthStreamLifecycleEvent{
+		{action: "activate", driverName: driverName, generation: generation},
+		{action: "deactivate", driverName: driverName, generation: generation},
+	}, streamHandler.lifecycleEvents())
+
+	manager.mutex.RLock()
+	defer manager.mutex.RUnlock()
+	require.Zero(t, manager.healthStreams[driverName].generation)
+	require.Nil(t, manager.healthStreams[driverName].cancel)
 }
 
 func TestDelete(t *testing.T) {

--- a/pkg/kubelet/cm/dra/plugin/dra_plugin_manager_test.go
+++ b/pkg/kubelet/cm/dra/plugin/dra_plugin_manager_test.go
@@ -96,6 +96,41 @@ func TestAddSameName(t *testing.T) {
 	}
 }
 
+func TestHealthStreamUsesLatestPlugin(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	driverName := fmt.Sprintf("dummy-driver-%d", rand.IntN(10000))
+	manager := NewDRAPluginManager(tCtx, nil, nil, &mockStreamHandler{}, 0)
+	defer manager.Stop()
+
+	activeStreams := func() map[string]uint64 {
+		manager.mutex.RLock()
+		defer manager.mutex.RUnlock()
+		streams := make(map[string]uint64)
+		for _, plugin := range manager.store[driverName] {
+			if plugin.healthStreamCancel != nil {
+				streams[plugin.endpoint] = plugin.healthStreamGeneration
+			}
+		}
+		return streams
+	}
+
+	tCtx.ExpectNoError(manager.add(driverName, "old.sock", "", drahealthv1.DRAResourceHealthService, defaultClientCallTimeout), "add old plugin")
+	oldStreams := activeStreams()
+	require.Len(t, oldStreams, 1)
+	oldGeneration := oldStreams["old.sock"]
+	require.NotZero(t, oldGeneration)
+
+	tCtx.ExpectNoError(manager.add(driverName, "new.sock", "", drahealthv1.DRAResourceHealthService, defaultClientCallTimeout), "add new plugin")
+	newStreams := activeStreams()
+	require.Equal(t, map[string]uint64{"new.sock": oldGeneration + 1}, newStreams)
+
+	manager.remove(driverName, "old.sock")
+	require.Equal(t, newStreams, activeStreams(), "removing the old endpoint must not replace the active stream")
+
+	manager.remove(driverName, "new.sock")
+	require.Empty(t, activeStreams())
+}
+
 func TestDelete(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	driverName := fmt.Sprintf("dummy-driver-%d", rand.IntN(10000))

--- a/pkg/kubelet/cm/dra/plugin/testing_helpers_test.go
+++ b/pkg/kubelet/cm/dra/plugin/testing_helpers_test.go
@@ -28,7 +28,7 @@ type mockStreamHandler struct{}
 
 var _ StreamHandler = &mockStreamHandler{}
 
-func (m *mockStreamHandler) HandleWatchResourcesStream(ctx context.Context, stream drahealthv1.DRAResourceHealth_NodeWatchResourcesClient, resourceName string) error {
+func (m *mockStreamHandler) HandleWatchResourcesStream(ctx context.Context, stream drahealthv1.DRAResourceHealth_NodeWatchResourcesClient, driverName string, generation uint64) error {
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/kubelet/cm/dra/plugin/testing_helpers_test.go
+++ b/pkg/kubelet/cm/dra/plugin/testing_helpers_test.go
@@ -18,17 +18,47 @@ package plugin
 
 import (
 	"context"
+	"sync"
 
 	drahealthv1 "k8s.io/kubelet/pkg/apis/dra-health/v1"
 )
 
+type healthStreamLifecycleEvent struct {
+	action     string
+	driverName string
+	generation uint64
+}
+
 // mockStreamHandler is a mock implementation of the StreamHandler interface,
 // shared across all tests in this package.
-type mockStreamHandler struct{}
+type mockStreamHandler struct {
+	mutex  sync.Mutex
+	events []healthStreamLifecycleEvent
+}
 
 var _ StreamHandler = &mockStreamHandler{}
+
+func (m *mockStreamHandler) ActivateHealthStream(_ context.Context, driverName string, generation uint64) {
+	m.record("activate", driverName, generation)
+}
+
+func (m *mockStreamHandler) DeactivateHealthStream(_ context.Context, driverName string, generation uint64) {
+	m.record("deactivate", driverName, generation)
+}
 
 func (m *mockStreamHandler) HandleWatchResourcesStream(ctx context.Context, stream drahealthv1.DRAResourceHealth_NodeWatchResourcesClient, driverName string, generation uint64) error {
 	<-ctx.Done()
 	return nil
+}
+
+func (m *mockStreamHandler) record(action, driverName string, generation uint64) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.events = append(m.events, healthStreamLifecycleEvent{action: action, driverName: driverName, generation: generation})
+}
+
+func (m *mockStreamHandler) lifecycleEvents() []healthStreamLifecycleEvent {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	return append([]healthStreamLifecycleEvent(nil), m.events...)
 }

--- a/pkg/kubelet/cm/dra/plugin/types.go
+++ b/pkg/kubelet/cm/dra/plugin/types.go
@@ -27,5 +27,5 @@ import (
 // package from the manager package, breaking the import cycle.
 type StreamHandler interface {
 	// HandleWatchResourcesStream processes health updates from a specific DRA plugin stream.
-	HandleWatchResourcesStream(ctx context.Context, stream drahealthv1.DRAResourceHealth_NodeWatchResourcesClient, resourceName string) error
+	HandleWatchResourcesStream(ctx context.Context, stream drahealthv1.DRAResourceHealth_NodeWatchResourcesClient, driverName string, generation uint64) error
 }

--- a/pkg/kubelet/cm/dra/plugin/types.go
+++ b/pkg/kubelet/cm/dra/plugin/types.go
@@ -26,6 +26,10 @@ import (
 // This interface is implemented by the DRA Manager to decouple the plugin
 // package from the manager package, breaking the import cycle.
 type StreamHandler interface {
+	// ActivateHealthStream transfers ownership of a driver's health data to a stream.
+	ActivateHealthStream(ctx context.Context, driverName string, generation uint64)
+	// DeactivateHealthStream releases ownership and clears the driver's health data.
+	DeactivateHealthStream(ctx context.Context, driverName string, generation uint64)
 	// HandleWatchResourcesStream processes health updates from a specific DRA plugin stream.
 	HandleWatchResourcesStream(ctx context.Context, stream drahealthv1.DRAResourceHealth_NodeWatchResourcesClient, driverName string, generation uint64) error
 }


### PR DESCRIPTION
#### What type of PR is this?

kind bug
/sig node
/wg device-management

#### What this PR does / why we need it:

The DRA plugin manager previously started a `NodeWatchResources` stream for every registered endpoint of a driver. Those streams shared the same per-driver health cache, allowing an older endpoint to overwrite health reported by the preferred endpoint or clear it when the old stream exited.


#### Which issue(s) this PR is related to:
Fixes #140818

KEP: https://github.com/kubernetes/enhancements/issues/4680

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed kubelet DRA device health monitoring during seamless plugin upgrades so stale plugin endpoints cannot overwrite or clear active health state, and affected Pod status is refreshed when the authoritative health stream ends.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
