### PR TITLE
Fix TestTimeTravelHealthcheck by making the healthcheck clock overridable

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -55,7 +55,11 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/component-base/metrics/legacyregistry"
 	tracing "k8s.io/component-base/tracing"
+	"k8s.io/utils/clock"
 )
+
+// healthcheckClock is overridable in tests to advance the rate limiter deterministically.
+var healthcheckClock clock.Clock = clock.RealClock{}
 
 const (
 	// The short keepalive timeout and interval have been chosen to aggressively
@@ -211,12 +215,12 @@ func newETCD3Check(c storagebackend.Config, timeout time.Duration, stopCh <-chan
 		if clientErr != nil {
 			return clientErr
 		}
-		if limiter.Allow() == false {
+		if !limiter.AllowN(healthcheckClock.Now(), 1) {
 			return lastError.Load()
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
-		now := time.Now()
+		now := healthcheckClock.Now()
 		err := prober.Probe(ctx)
 		lastError.Store(err, now)
 		return err

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
@@ -30,6 +30,7 @@ import (
 	"go.etcd.io/etcd/client/v3/kubernetes"
 	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
+	testingclock "k8s.io/utils/clock/testing"
 )
 
 type mockKV struct {
@@ -366,6 +367,13 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 		newETCD3Client = newETCD3ClientFn
 	}()
 
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	originalClock := healthcheckClock
+	healthcheckClock = fakeClock
+	defer func() {
+		healthcheckClock = originalClock
+	}()
+
 	cfg := storagebackend.Config{
 		Type:               storagebackend.StorageTypeETCD3,
 		Transport:          storagebackend.TransportConfig{},
@@ -374,6 +382,8 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	cfg.Transport.ServerList = client.Endpoints()
 
 	ready := make(chan struct{})
+	firstProbe := make(chan struct{})
+	release := make(chan struct{})
 	signal := make(chan struct{})
 
 	var counter uint64
@@ -381,23 +391,11 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 		defer close(ready)
 		dummyKV := mockKV{
 			get: func(ctx context.Context) (*clientv3.GetResponse, error) {
-				atomic.AddUint64(&counter, 1)
-				val := atomic.LoadUint64(&counter)
-				// the first request wait for a custom timeout to trigger an error.
-				// We don't use the context timeout because we want to check that
-				// the cached answer is not overridden, and since the rate limit is
-				// based on cfg.HealthcheckTimeout / 2, the timeout will race with
-				// the race limiter to server the new request from the cache or allow
-				// it to go through
-				if val == 1 {
-					select {
-					case <-ctx.Done():
-						return nil, ctx.Err()
-					case <-time.After((2 * cfg.HealthcheckTimeout) / 3):
-						return nil, fmt.Errorf("etcd down")
-					}
+				if atomic.AddUint64(&counter, 1) == 1 {
+					close(firstProbe)
+					<-release
+					return nil, fmt.Errorf("etcd down")
 				}
-				// subsequent requests will always work
 				return nil, nil
 			},
 		}
@@ -413,7 +411,6 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	}
 	// Wait for healthcheck to establish connection
 	<-ready
-	// run a first request that fails after 2 seconds
 	go func() {
 		err := healthcheck()
 		if !strings.Contains(err.Error(), "etcd down") {
@@ -422,14 +419,16 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 		close(signal)
 	}()
 
-	// wait until the rate limit allows new connections
-	time.Sleep(cfg.HealthcheckTimeout / 2)
+	<-firstProbe
 
 	select {
 	case <-signal:
 		t.Errorf("first request should not return yet")
 	default:
 	}
+
+	// advance time so the rate limiter allows a new request
+	fakeClock.Step(cfg.HealthcheckTimeout / 2)
 
 	// a new run on request should succeed and increment the counter
 	err = healthcheck()
@@ -442,6 +441,7 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	}
 
 	// cached request should be success and not be overridden by the late error
+	close(release)
 	<-signal
 	err = healthcheck()
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/sig api-machinery

#### What this PR does / why we need it:

Makes `TestTimeTravelHealthcheck` deterministic by driving the healthcheck rate limiter from an overridable clock the test steps, instead of racing a `time.Sleep` against it.

#### Which issue(s) this PR fixes:

Fixes #140526

#### Testing

Build the test binary and stress it in parallel:

```
go test -c -o factory.test k8s.io/apiserver/pkg/storage/storagebackend/factory
stress -p 24 ./factory.test -test.run '^TestTimeTravelHealthcheck$'
```

On master this fails within a few hundred runs:

```
unexpected error: etcd client connection not yet established
healthcheck() called etcd 1 times, expected only two calls
```

With this change it does not flake. 1000 sequential runs pass:

```
go test -run '^TestTimeTravelHealthcheck$' -count=1000 k8s.io/apiserver/pkg/storage/storagebackend/factory
ok  k8s.io/apiserver/pkg/storage/storagebackend/factory  596.380s
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
