### PR TITLE
kubelet: fix flaky kuberuntime manager unit test

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1892,10 +1892,6 @@ func verifyActions(t *testing.T, expected, actual *podActions, desc string) {
 }
 
 func TestComputePodActionsWithInitContainers(t *testing.T) {
-	tCtx := ktesting.Init(t)
-	_, _, m, err := createTestRuntimeManager(tCtx)
-	require.NoError(t, err)
-
 	cpu400m := resource.MustParse("400m")
 	memory400Mi := resource.MustParse("400Mi")
 	cpu800m := resource.MustParse("800m")
@@ -2196,6 +2192,8 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				t.Skip("Skipping test since Windows does not support resize")
 			}
 			tCtx := ktesting.Init(t)
+			_, _, m, err := createTestRuntimeManager(tCtx)
+			require.NoError(t, err)
 
 			if test.disableIPPRInitCtrFG {
 				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.36"))


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

Fixes a unit test flake in `TestComputePodActionsWithInitContainers` (which also caused
`TestComputePodActionsWithInitAndEphemeralContainers` to fail since it re-runs the init container
test suite).

The test start flaking after https://github.com/kubernetes/kubernetes/pull/140846, where commit f8f9d0571e9db4a3937b3f5fa4da0a567fa24f83 being the commit that introduced the flake.

The test suite shared a single `kubeGenericRuntimeManager` instance across all subtests in the
table test. Inside each subtest, `InitializeActuatedPod` checks if pod resource state is already
cached in `actuatedState`. Because every subtest uses the exact same pod UID, only the first subtest
to run actually populated the cache—subsequent subtests hit the early return guard and skipped
initialization, inheriting leftover state from whichever test ran before them. 

Since Go map iteration order is randomized, this caused intermittent failures whenever a subtest
ran after one that modified container resources.

Moving `createTestRuntimeManager` inside `t.Run` ensures every subtest gets its own isolated
manager and clean state.

#### Which issue(s) this PR is related to:

https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/140244/pull-kubernetes-unit/2079889038847774720

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```