### PR TITLE
Fix flaky WorkloadAwarePreemption E2E test

### DIFF
--- a/test/e2e/scheduling/workload_aware_preemption.go
+++ b/test/e2e/scheduling/workload_aware_preemption.go
@@ -228,6 +228,19 @@ var _ = SIGDescribe("WorkloadAwarePreemption", framework.WithFeatureGate(feature
 		addExtendedResource(ctx, nodeName)
 		defer removeExtendedResource(ctx, nodeName)
 
+		ginkgo.By("Waiting for the extended resource to be allocatable on the node")
+		gomega.Eventually(ctx, func(ctx context.Context) error {
+			node, err := cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			alloc := node.Status.Allocatable[v1.ResourceName(extendedResourceName)]
+			if alloc.Cmp(resource.MustParse("2")) < 0 {
+				return fmt.Errorf("resource not ready yet")
+			}
+			return nil
+		}).WithTimeout(1 * time.Minute).Should(gomega.Succeed())
+
 		ginkgo.By(fmt.Sprintf("Creating low-priority pod group PG-victim with disruptionMode %v", args.victimDisruptionMode))
 		pgVictimName := "pg-victim-" + ns
 		pgVictim := makePodGroup(pgVictimName, lowPriorityName, gangPolicy, args.victimDisruptionMode)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes a race condition (flakiness) in the `WorkloadAwarePreemption` scheduling E2E test suite. 

Prior to this fix, the test would patch the Node's `Capacity` with a custom extended resource (`example.com/combined-resource`) and immediately proceed to create victim pods that requested it. Because Kubernetes is eventually consistent, the victim pods would often reach the Scheduler before the Kubelet had time to reconcile the new capacity and update the Node's `.Status.Allocatable`. This caused the pods to fail scheduling due to insufficient resources, resulting in a test timeout.

We fix this by introducing a `gomega.Eventually` wait-loop that explicitly polls the Node's `.Status.Allocatable` map. It guarantees that the kubelet has finished making the extended resource allocatable before the test proceeds to create the pod groups, eliminating the race condition.

Tested via:
```
sudo rm -rf /var/run/kubernetes/ /tmp/kube*.log
export KUBE_ENABLE_CLUSTER_DNS=false
export FEATURE_GATES="GenericWorkload=true"
export RUNTIME_CONFIG="scheduling.k8s.io/v1beta1=true"
export ALLOW_PRIVILEGED=1
./hack/local-up-cluster.sh

# different terminal 
for i in {1..10}; do   echo "========== RUN $i ==========";   go test ./test/e2e -v -timeout=30m -args     --ginkgo.focus="WorkloadAwarePreemption"     --kubeconfig=$KUBECONFIG     --provider=local || break; done
```


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
