### PR TITLE
kubelet: Remove obsolete EventedPLEG status handling

### DIFF
--- a/pkg/kubelet/container/cache.go
+++ b/pkg/kubelet/container/cache.go
@@ -21,8 +21,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/kubernetes/pkg/features"
 )
 
 // Cache stores the PodStatus for the pods. It represents *all* the visible
@@ -36,10 +34,8 @@ import (
 // Delete() to explicitly free the cache entries.
 type Cache interface {
 	ROCache
-	// Set updates the cache by setting the PodStatus for the pod only
-	// if the data is newer than the cache based on the provided
-	// time stamp. Returns if the cache was updated.
-	Set(types.UID, *PodStatus, error, time.Time) (updated bool)
+	// Set updates the cache by setting the PodStatus for the pod.
+	Set(types.UID, *PodStatus, error, time.Time)
 	// SetObservedTime modifies the observed timestamp of a pod in the cache.
 	// This indicates that the pod's state was recently confirmed to be accurate
 	// by the runtime, even if its status wasn't modified.
@@ -111,22 +107,13 @@ func (c *cache) GetNewerThan(id types.UID, minTime time.Time) (*PodStatus, error
 	return d.status, d.err
 }
 
-// Set sets the PodStatus for the pod only if the data is newer than the cache
-func (c *cache) Set(id types.UID, status *PodStatus, err error, timestamp time.Time) (updated bool) {
+// Set sets the PodStatus for the pod.
+func (c *cache) Set(id types.UID, status *PodStatus, err error, timestamp time.Time) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
-		// Set the value in the cache only if it's not present already
-		// or the timestamp in the cache is older than the current update timestamp
-		if cachedVal, ok := c.pods[id]; ok && cachedVal.modified.After(timestamp) {
-			return false
-		}
-	}
-
 	c.pods[id] = &data{status: status, err: err, modified: timestamp, observedTime: timestamp}
 	c.notify(id, timestamp)
-	return true
 }
 
 // SetObservedTime modifies the observed timestamp of a pod in the cache and

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -131,8 +131,6 @@ type Runtime interface {
 	// CheckpointContainer tells the runtime to checkpoint a container
 	// and store the resulting archive to the checkpoint directory.
 	CheckpointContainer(ctx context.Context, options *runtimeapi.CheckpointContainerRequest) error
-	// Generate pod status from the CRI event
-	GeneratePodStatus(event *runtimeapi.ContainerEventResponse) *PodStatus
 	// ListMetricDescriptors gets the descriptors for the metrics that will be returned in ListPodSandboxMetrics.
 	// This list should be static at startup: either the client and server restart together when
 	// adding or removing metrics descriptors, or they should not change.
@@ -354,8 +352,6 @@ type PodStatus struct {
 	// Status of the pod sandbox.
 	// Only for kuberuntime now, other runtime may keep it nil.
 	SandboxStatuses []*runtimeapi.PodSandboxStatus
-	// Timestamp at which container and pod statuses were recorded
-	TimeStamp time.Time
 }
 
 // ContainerResources represents the Resources allocated to the running container.

--- a/pkg/kubelet/container/testing/fake_cache.go
+++ b/pkg/kubelet/container/testing/fake_cache.go
@@ -44,8 +44,7 @@ func (c *fakeCache) GetNewerThan(id types.UID, minTime time.Time) (*container.Po
 	return c.Get(id)
 }
 
-func (c *fakeCache) Set(id types.UID, status *container.PodStatus, err error, timestamp time.Time) (updated bool) {
-	return true
+func (c *fakeCache) Set(id types.UID, status *container.PodStatus, err error, timestamp time.Time) {
 }
 
 func (c *fakeCache) Delete(id types.UID) {

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -316,15 +316,6 @@ func (f *FakeRuntime) KillContainerInPod(container v1.Container, pod *v1.Pod) er
 	return f.Err
 }
 
-func (f *FakeRuntime) GeneratePodStatus(event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
-	f.Lock()
-	defer f.Unlock()
-
-	f.CalledFunctions = append(f.CalledFunctions, "GeneratePodStatus")
-	status := f.PodStatus
-	return &status
-}
-
 func (f *FakeRuntime) GetPodStatus(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
 	f.Lock()
 	defer f.Unlock()

--- a/pkg/kubelet/container/testing/mocks.go
+++ b/pkg/kubelet/container/testing/mocks.go
@@ -301,59 +301,6 @@ func (_c *MockRuntime_GarbageCollect_Call) RunAndReturn(run func(ctx context.Con
 	return _c
 }
 
-// GeneratePodStatus provides a mock function for the type MockRuntime
-func (_mock *MockRuntime) GeneratePodStatus(event *v1.ContainerEventResponse) *container.PodStatus {
-	ret := _mock.Called(event)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GeneratePodStatus")
-	}
-
-	var r0 *container.PodStatus
-	if returnFunc, ok := ret.Get(0).(func(*v1.ContainerEventResponse) *container.PodStatus); ok {
-		r0 = returnFunc(event)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*container.PodStatus)
-		}
-	}
-	return r0
-}
-
-// MockRuntime_GeneratePodStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GeneratePodStatus'
-type MockRuntime_GeneratePodStatus_Call struct {
-	*mock.Call
-}
-
-// GeneratePodStatus is a helper method to define mock.On call
-//   - event *v1.ContainerEventResponse
-func (_e *MockRuntime_Expecter) GeneratePodStatus(event interface{}) *MockRuntime_GeneratePodStatus_Call {
-	return &MockRuntime_GeneratePodStatus_Call{Call: _e.mock.On("GeneratePodStatus", event)}
-}
-
-func (_c *MockRuntime_GeneratePodStatus_Call) Run(run func(event *v1.ContainerEventResponse)) *MockRuntime_GeneratePodStatus_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *v1.ContainerEventResponse
-		if args[0] != nil {
-			arg0 = args[0].(*v1.ContainerEventResponse)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockRuntime_GeneratePodStatus_Call) Return(podStatus *container.PodStatus) *MockRuntime_GeneratePodStatus_Call {
-	_c.Call.Return(podStatus)
-	return _c
-}
-
-func (_c *MockRuntime_GeneratePodStatus_Call) RunAndReturn(run func(event *v1.ContainerEventResponse) *container.PodStatus) *MockRuntime_GeneratePodStatus_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetContainerLogs provides a mock function for the type MockRuntime
 func (_mock *MockRuntime) GetContainerLogs(ctx context.Context, pod *v10.Pod, containerID container.ContainerID, logOptions *v10.PodLogOptions, stdout io.Writer, stderr io.Writer) error {
 	ret := _mock.Called(ctx, pod, containerID, logOptions, stdout, stderr)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -2133,28 +2133,6 @@ func (m *kubeGenericRuntimeManager) killPodWithSyncResult(ctx context.Context, p
 	return
 }
 
-func (m *kubeGenericRuntimeManager) GeneratePodStatus(event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
-	ctx := context.TODO() // This context will be passed as parameter in the future
-	podUID := kubetypes.UID(event.PodSandboxStatus.Metadata.Uid)
-	podIPs := m.determinePodSandboxIPs(ctx, event.PodSandboxStatus.Metadata.Namespace, event.PodSandboxStatus.Metadata.Name, event.PodSandboxStatus)
-
-	kubeContainerStatuses := []*kubecontainer.Status{}
-	for _, status := range event.ContainersStatuses {
-		kubeContainerStatuses = append(kubeContainerStatuses, m.convertToKubeContainerStatus(ctx, podUID, status))
-	}
-
-	sort.Sort(containerStatusByCreated(kubeContainerStatuses))
-
-	return &kubecontainer.PodStatus{
-		ID:                kubetypes.UID(event.PodSandboxStatus.Metadata.Uid),
-		Name:              event.PodSandboxStatus.Metadata.Name,
-		Namespace:         event.PodSandboxStatus.Metadata.Namespace,
-		IPs:               podIPs,
-		SandboxStatuses:   []*runtimeapi.PodSandboxStatus{event.PodSandboxStatus},
-		ContainerStatuses: kubeContainerStatuses,
-	}
-}
-
 // GetPodStatus retrieves the status of the pod, including the
 // information of all containers in the pod that are visible in Runtime.
 func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
@@ -2182,14 +2160,6 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, pod *kubec
 	}
 
 	sandboxStatuses := []*runtimeapi.PodSandboxStatus{}
-	containerStatuses := []*kubecontainer.Status{}
-	activeContainerStatuses := []*kubecontainer.Status{}
-
-	// Since we rely on the sandbox & container IDs in the kubecontainer.Pod, we must be
-	// conservative and use it's timestamp as the status timestamp. Otherwise, we risk reporting a
-	// newer PodStatus timestamp that is missing Sandboxes or Containers that should have been
-	// present at that time.
-	timestamp := pod.Timestamp
 
 	podIPs := []string{}
 	var activePodSandboxID string
@@ -2216,44 +2186,15 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, pod *kubec
 			podIPs = m.determinePodSandboxIPs(ctx, pod.Namespace, pod.Name, resp.Status)
 			activePodSandboxID = podSandboxID
 		}
-
-		if idx == 0 && utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
-			if resp.Timestamp == 0 {
-				// If the Evented PLEG is enabled in the kubelet, but not in the runtime
-				// then the pod status we get will not have the timestamp set.
-				// e.g. CI job 'pull-kubernetes-e2e-gce-alpha-features' will runs with
-				// features gate enabled, which includes Evented PLEG, but uses the
-				// runtime without Evented PLEG support.
-				logger.V(4).Info("Runtime does not set pod status timestamp")
-				containerStatuses, activeContainerStatuses, err = m.getPodContainerStatuses(ctx, pod, activePodSandboxID)
-				if err != nil {
-					if m.logReduction.ShouldMessageBePrinted(err.Error(), podFullName) {
-						logger.Error(err, "getPodContainerStatuses for pod failed")
-					}
-					return nil, err
-				}
-			} else {
-				// Get the statuses of all containers visible to the pod and
-				// timestamp from sandboxStatus.
-				timestamp = time.Unix(0, resp.Timestamp)
-				for _, cs := range resp.ContainersStatuses {
-					cStatus := m.convertToKubeContainerStatus(ctx, pod.ID, cs)
-					containerStatuses = append(containerStatuses, cStatus)
-				}
-			}
-		}
 	}
 
-	if !utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
-		// Get statuses of all containers visible in the pod.
-		var err error
-		containerStatuses, activeContainerStatuses, err = m.getPodContainerStatuses(ctx, pod, activePodSandboxID)
-		if err != nil {
-			if m.logReduction.ShouldMessageBePrinted(err.Error(), podFullName) {
-				logger.Error(err, "getPodContainerStatuses for pod failed")
-			}
-			return nil, err
+	// Get statuses of all containers visible in the pod.
+	containerStatuses, activeContainerStatuses, err := m.getPodContainerStatuses(ctx, pod, activePodSandboxID)
+	if err != nil {
+		if m.logReduction.ShouldMessageBePrinted(err.Error(), podFullName) {
+			logger.Error(err, "getPodContainerStatuses for pod failed")
 		}
+		return nil, err
 	}
 
 	m.logReduction.ClearID(podFullName)
@@ -2265,7 +2206,6 @@ func (m *kubeGenericRuntimeManager) GetPodStatus(ctx context.Context, pod *kubec
 		SandboxStatuses:         sandboxStatuses,
 		ContainerStatuses:       containerStatuses,
 		ActiveContainerStatuses: activeContainerStatuses,
-		TimeStamp:               timestamp,
 	}, nil
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -118,6 +118,19 @@ func createTestRuntimeManager(ctx context.Context, opts ...testRuntimeManagerOpt
 	return fakeRuntimeService, fakeImageService, manager, err
 }
 
+type timestampedPodSandboxRuntimeService struct {
+	*apitest.FakeRuntimeService
+}
+
+func (r *timestampedPodSandboxRuntimeService) PodSandboxStatus(ctx context.Context, podSandboxID string, verbose bool) (*runtimeapi.PodSandboxStatusResponse, error) {
+	response, err := r.FakeRuntimeService.PodSandboxStatus(ctx, podSandboxID, verbose)
+	if response != nil {
+		// A non-zero timestamp selected the old EventedPLEG-specific status path.
+		response.Timestamp = time.Now().UnixNano()
+	}
+	return response, err
+}
+
 // sandboxTemplate is a sandbox template to create fake sandbox.
 type sandboxTemplate struct {
 	pod         *v1.Pod
@@ -333,6 +346,8 @@ func TestContainerRuntimeType(t *testing.T) {
 }
 
 func TestGetPodStatus(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EventedPLEG, true)
+
 	tCtx := ktesting.Init(t)
 	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
 	assert.NoError(t, err)
@@ -365,12 +380,17 @@ func TestGetPodStatus(t *testing.T) {
 
 	runtimePod, err := m.GetPod(tCtx, pod.UID)
 	require.NoError(t, err)
+	// EventedPLEG is only a relist hint, so aggregate status fields returned by
+	// PodSandboxStatus must not change GenericPLEG's status collection path.
+	m.runtimeService = &timestampedPodSandboxRuntimeService{FakeRuntimeService: fakeRuntime}
 	podStatus, err := m.GetPodStatus(tCtx, runtimePod)
 	require.NoError(t, err)
 	assert.Equal(t, pod.UID, podStatus.ID)
 	assert.Equal(t, pod.Name, podStatus.Name)
 	assert.Equal(t, pod.Namespace, podStatus.Namespace)
 	assert.Equal(t, apitest.FakePodSandboxIPs, podStatus.IPs)
+	assert.Len(t, podStatus.ContainerStatuses, len(containers))
+	assert.Len(t, podStatus.ActiveContainerStatuses, len(containers))
 }
 
 func TestStopContainerWithNotFoundError(t *testing.T) {

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -583,7 +583,7 @@ func TestReinspect(t *testing.T) {
 
 			var expectedStatus *kubecontainer.PodStatus
 			if tc.updateCacheError == nil {
-				expectedStatus = &kubecontainer.PodStatus{ID: podID, TimeStamp: time.Now()}
+				expectedStatus = &kubecontainer.PodStatus{ID: podID}
 			}
 			if tc.expectUpdateCache {
 				if tc.podDeleted {
@@ -625,40 +625,6 @@ func TestReinspect(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestUpdateCacheUsesPodTimestampWhenEventedPLEGIsEnabled(t *testing.T) {
-	featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.EventedPLEG, true)
-
-	ctx := t.Context()
-	podID := types.UID("test-pod")
-	cachedTimestamp := time.Unix(0, 20)
-	statusTimestamp := time.Unix(0, 10)
-	podTimestamp := time.Unix(0, 30)
-
-	runtimeMock := containertest.NewMockRuntime(t)
-	cache := kubecontainer.NewCache()
-	pleg := NewGenericPLEG(
-		runtimeMock,
-		make(chan *PodLifecycleEvent, largeChannelCap),
-		&RelistDuration{RelistPeriod: time.Hour, RelistThreshold: 3 * time.Minute},
-		cache,
-		testingclock.NewFakeClock(time.Time{}),
-	).(*GenericPLEG)
-
-	cache.Set(podID, &kubecontainer.PodStatus{ID: podID}, nil, cachedTimestamp)
-
-	pod := &kubecontainer.Pod{ID: podID, Name: "name", Namespace: "ns", Timestamp: podTimestamp}
-	expectedStatus := &kubecontainer.PodStatus{ID: podID, TimeStamp: statusTimestamp}
-	runtimeMock.EXPECT().GetPodStatus(ctx, pod).Return(expectedStatus, nil)
-
-	status, err := pleg.updateCache(ctx, pod, podID)
-	require.NoError(t, err)
-	assert.Equal(t, expectedStatus, status)
-
-	cachedStatus, cachedErr := cache.Get(podID)
-	require.NoError(t, cachedErr)
-	assert.Equal(t, expectedStatus, cachedStatus)
 }
 
 // Test detecting sandbox state changes.
@@ -912,14 +878,14 @@ func TestWorkerLoop(t *testing.T) {
 		}).Once()
 		call = runtimeMock.EXPECT().GetPodStatus(mock.Anything, pod1).RunAndReturn(func(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
 			assert.Equal(t, pod1, pod)
-			return &kubecontainer.PodStatus{ID: pod1.ID, TimeStamp: time.Now()}, nil
+			return &kubecontainer.PodStatus{ID: pod1.ID, Name: "first"}, nil
 		}).NotBefore(call).Once()
 
 		pleg.workerLoopIteration(tCtx)
 
 		p1Status := requireUnblocked(t, p1res) // pod1 is now unblocked
 		assert.Equal(t, pod1.ID, p1Status.ID)
-		assert.Equal(t, time.Now(), p1Status.TimeStamp)
+		assert.Equal(t, "first", p1Status.Name)
 		requireBlocked(t, p2res) // pod2 is still blocked
 
 		p1NewRes := getNewerThanAsync(t, cache, pod1.ID, startTime.Add(2*time.Second))
@@ -936,7 +902,7 @@ func TestWorkerLoop(t *testing.T) {
 		}).NotBefore(call).Once()
 		call = runtimeMock.EXPECT().GetPodStatus(mock.Anything, pod2).RunAndReturn(func(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
 			assert.Equal(t, pod2, pod)
-			return &kubecontainer.PodStatus{ID: pod2.ID, TimeStamp: time.Now()}, nil
+			return &kubecontainer.PodStatus{ID: pod2.ID, Name: "pod2"}, nil
 		}).NotBefore(call).Once()
 
 		pleg.workerLoopIteration(tCtx)
@@ -945,7 +911,7 @@ func TestWorkerLoop(t *testing.T) {
 		p2Status := requireUnblocked(t, p2res)
 		assert.Equal(t, pod2.ID, p2Status.ID)
 		p1NewStatus := requireUnblocked(t, p1NewRes)
-		assert.Equal(t, p1Status, p1NewStatus) // Status timestamp should be unchanged
+		assert.Equal(t, p1Status, p1NewStatus) // Status should be unchanged.
 
 		// The pod2 relist request should NOT trigger a relist, since it was made before the global
 		// relist occurred. Drain it from the channel to verify (the mock will trigger an error if GetPod is called for it).
@@ -967,14 +933,14 @@ func TestWorkerLoop(t *testing.T) {
 		}).NotBefore(call).Once()
 		runtimeMock.EXPECT().GetPodStatus(mock.Anything, pod1).RunAndReturn(func(_ context.Context, pod *kubecontainer.Pod) (*kubecontainer.PodStatus, error) {
 			assert.Equal(t, pod1, pod)
-			return &kubecontainer.PodStatus{ID: pod1.ID, TimeStamp: time.Now()}, nil
+			return &kubecontainer.PodStatus{ID: pod1.ID, Name: "reinspected"}, nil
 		}).NotBefore(call).Once()
 
 		pleg.workerLoopIteration(tCtx)
 
 		p1ReinspectStatus := requireUnblocked(t, p1ReinpsectRes)
 		assert.Equal(t, pod1.ID, p1ReinspectStatus.ID)
-		assert.Equal(t, time.Now(), p1ReinspectStatus.TimeStamp) // Status timestamp should be updated.
+		assert.Equal(t, "reinspected", p1ReinspectStatus.Name)
 
 		// The pod1 relist request should NOT trigger a relist, since it was made before the global
 		// relist occurred. Drain it from the channel to verify (the mock will trigger an error if GetPod is called for it).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

After #139262, EventedPLEG only requests on-demand GenericPLEG relists. GenericPLEG remains responsible for collecting runtime status, updating the pod cache, and generating lifecycle events.

This removes code left over from the previous EventedPLEG status handling:

- Timestamp-based cache write filtering
- The EventedPLEG-specific `GetPodStatus` path
- The unused `GeneratePodStatus` method and `PodStatus.TimeStamp` field

Related tests and feature gate comments are updated accordingly.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
