### PR TITLE
e2e: fix pod level resources partial request defaulting test

### DIFF
--- a/test/e2e/common/node/pod_level_resources.go
+++ b/test/e2e/common/node/pod_level_resources.go
@@ -506,21 +506,18 @@ func podLevelResourcesFixDefaultingTests(f *framework.Framework) {
 		framework.ExpectNoError(delErr, "failed to delete pod %s", delErr)
 	})
 
-	// When only a CPU request is set at pod level (no memory request), and containers
-	// define both CPU and memory limits, defaulting should set ONLY the CPU limit.
-	// Memory limit must NOT be defaulted — no pod-level memory request exists, so
-	// defaulting a memory limit would create an asymmetric limits-without-requests state.
-	// Furthermore, a subsequent update (e.g. adding an annotation) must not cause
-	// decode-time defaulting to inject a memory request (since pod-level limits now
-	// exist after the initial create), which would produce request-without-limit asymmetry.
-	ginkgo.It("partial pod-level request: only CPU limit defaulted, memory limit not set, stable across updates", func(ctx context.Context) {
+	// When only a CPU request is set at pod level (no memory request or limits), defaulting
+	// populates missing pod-level requests from aggregated container requests and missing
+	// pod-level limits from container limits to maintain complete pod-level accounting.
+	// Furthermore, subsequent updates preserve these defaulted values.
+	ginkgo.It("partial pod-level request: all missing pod requests and limits defaulted from containers, stable across updates", func(ctx context.Context) {
 		containers := []containerInfo{
 			{Name: "c1", Resources: &cgroups.ContainerResources{CPUReq: "50m", CPULim: "50m", MemReq: "50Mi", MemLim: "50Mi"}},
 		}
-		// Only CPU request set at pod level — no memory request.
+		// Only CPU request set at pod level — no memory request or limits.
 		podResources := &cgroups.ContainerResources{CPUReq: "50m"}
-		// Expected: CPU limit defaulted from container, memory limit must remain unset.
-		expectedResources := &cgroups.ContainerResources{CPUReq: "50m", CPULim: "50m"}
+		// Expected: memory request defaulted from container, CPU and memory limits defaulted from container limits.
+		expectedResources := &cgroups.ContainerResources{CPUReq: "50m", CPULim: "50m", MemReq: "50Mi", MemLim: "50Mi"}
 
 		podMetadata := makeObjectMetadata("testpod-partial-req", f.Namespace.Name)
 		testPod := makePod(&podMetadata, podResources, containers)
@@ -529,7 +526,7 @@ func podLevelResourcesFixDefaultingTests(f *framework.Framework) {
 		podClient := e2epod.NewPodClient(f)
 		pod := podClient.CreateSync(ctx, testPod)
 
-		ginkgo.By("verifying pod resources after create: CPU limit defaulted, memory limit absent")
+		ginkgo.By("verifying pod resources after create: missing memory request and limits defaulted from container")
 		verifyPodResources(*pod, podResources, expectedResources)
 
 		ginkgo.By("patching an annotation to trigger a decode+update cycle")
@@ -538,7 +535,7 @@ func podLevelResourcesFixDefaultingTests(f *framework.Framework) {
 			ctx, pod.Name, types.MergePatchType, patch, metav1.PatchOptions{})
 		framework.ExpectNoError(err, "failed to patch pod annotation")
 
-		ginkgo.By("verifying pod resources after annotation update: still no memory request or limit")
+		ginkgo.By("verifying pod resources after annotation update: defaulted memory request and limits remain unchanged")
 		verifyPodResources(*updatedPod, podResources, expectedResources)
 
 		ginkgo.By("deleting pod")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes the failing defaulting related tests for PLR
https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/139277/pull-kubernetes-node-kubelet-serial-containerd/2079893945810161664

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

The behavior was changed over time since the PR was first created https://github.com/kubernetes/kubernetes/pull/136676 and the test case wasn't updated. 

The correct behavior which is implemented in the API server code is if any resource is set at pod-level, the defaulting logic kicks in to apply defaults for other resources as well which are not explicitly set at pod-level. 


https://github.com/kubernetes/kubernetes/blob/2524f10e40ef2c20ca8c228e78f510084a24afb6/pkg/api/pod/util.go#L2162


```release-note
NONE
```