### PR TITLE
DRA: move ResourceHealth e2e tests to test/e2e for version-skew coverage

### DIFF
--- a/test/e2e/dra/health.go
+++ b/test/e2e/dra/health.go
@@ -1,0 +1,243 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dra
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilversion "k8s.io/apimachinery/pkg/util/version"
+	"k8s.io/client-go/kubernetes"
+	drahealthv1 "k8s.io/kubelet/pkg/apis/dra-health/v1"
+	drahealthv1alpha1 "k8s.io/kubelet/pkg/apis/dra-health/v1alpha1"
+	"k8s.io/kubernetes/pkg/features"
+	testdriverapp "k8s.io/kubernetes/test/e2e/dra/test-driver/app"
+	drautils "k8s.io/kubernetes/test/e2e/dra/utils"
+	"k8s.io/kubernetes/test/e2e/feature"
+	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+const (
+	// minKubeletVersionForHealth is the first kubelet release which publishes
+	// device health in the pod status by default (ResourceHealthStatus became
+	// beta). 1.36 kubelets only have the v1alpha1 DRAResourceHealth client.
+	minKubeletVersionForHealth = "1.36"
+
+	// minKubeletVersionForHealthV1 is the first kubelet release with the v1
+	// DRAResourceHealth client. Strictly speaking the v1 client was merged
+	// after v1.37.0-beta.0, so kubelets built from earlier 1.37 pre-release
+	// artifacts still negotiate v1alpha1; that window closes with v1.37.0.
+	//
+	// TODO(harche): in 1.40, when kubelet 1.36 falls out of the supported
+	// version skew, remove the kubelet's v1alpha1 client support and the
+	// kubeletplugin helper's v1alpha1 serving support. In this file that
+	// means removing the "v1alpha1 health API" context, the v1alpha1
+	// fallback in expectedHealthMethod, and minKubeletVersionForHealth
+	// (gating on minKubeletVersionForHealthV1 instead).
+	minKubeletVersionForHealthV1 = "1.37"
+)
+
+// The gRPC methods on which the kubelet subscribes to device health updates,
+// depending on the negotiated DRAResourceHealth API version.
+const (
+	nodeWatchResourcesV1Alpha1Method = drahealthv1alpha1.DRAResourceHealth_NodeWatchResources_FullMethodName
+	nodeWatchResourcesV1Method       = drahealthv1.DRAResourceHealth_NodeWatchResources_FullMethodName
+)
+
+// Tests for the DRAResourceHealth gRPC API between the kubelet and a DRA
+// driver and its effect on the pod status.
+var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), func() {
+	f := framework.NewDefaultFramework("dra-health")
+
+	// The driver containers have to run with sufficient privileges to
+	// modify /var/lib/kubelet/plugins.
+	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	framework.Context("kubelet", feature.DynamicResourceAllocation, f.WithFeatureGate(features.ResourceHealthStatus), f.WithKubeletMinVersion(minKubeletVersionForHealth), func() {
+		nodes := drautils.NewNodes(f, 1, 1)
+
+		// expectedHealthMethod determines the DRAResourceHealth gRPC method on
+		// which the kubelet is expected to subscribe: the most recent API
+		// version served by the driver which the kubelet supports.
+		expectedHealthMethod := func(ctx context.Context, driver *drautils.Driver, nodeName string) string {
+			if !driver.HealthV1 {
+				return nodeWatchResourcesV1Alpha1Method
+			}
+			if !driver.HealthV1alpha1 {
+				// Only choice. The KubeletMinVersion gate on the test
+				// ensures that the kubelet has the v1 client.
+				return nodeWatchResourcesV1Method
+			}
+			node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+			framework.ExpectNoError(err, "get node")
+			kubeletVersion, err := utilversion.ParseSemantic(node.Status.NodeInfo.KubeletVersion)
+			framework.ExpectNoError(err, "parse kubelet version %q of node %s", node.Status.NodeInfo.KubeletVersion, nodeName)
+			// The generic (major.minor) comparison intentionally treats all
+			// 1.37 builds, including pre-releases, as v1-capable.
+			if kubeletVersion.AtLeast(utilversion.MustParse(minKubeletVersionForHealthV1)) {
+				return nodeWatchResourcesV1Method
+			}
+			return nodeWatchResourcesV1Alpha1Method
+		}
+
+		// testHealthTransitions runs a pod with an allocated device, then
+		// verifies that device health transitions (Healthy -> Unhealthy ->
+		// Healthy) reported by the DRA plugin are reflected in the pod's
+		// status, and that the kubelet consumed them through the expected
+		// DRAResourceHealth gRPC API version.
+		testHealthTransitions := func(ctx context.Context, b *drautils.Builder) {
+			driver := b.Driver
+			claim := b.ExternalClaim()
+			pod := b.PodExternal(claim.Name)
+			b.Create(f.TContext(ctx), claim, pod)
+			b.TestPod(f.TContext(ctx), pod)
+
+			// Exactly one node was selected, so the pod must be running there.
+			nodeName := nodes.NodeNames[0]
+			plugin, ok := driver.Nodes[nodeName]
+			if !ok {
+				framework.Failf("no test driver plugin for node %s", nodeName)
+			}
+
+			allocatedClaim, err := b.ClientV1(f.TContext(ctx)).ResourceClaims(pod.Namespace).Get(ctx, claim.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err, "get allocated claim")
+			gomega.Expect(allocatedClaim.Status.Allocation).ToNot(gomega.BeNil(), "claim allocation")
+			result := allocatedClaim.Status.Allocation.Devices.Results[0]
+
+			ginkgo.By("Verifying the negotiated health API version")
+			expectedMethod := expectedHealthMethod(ctx, driver, nodeName)
+			// CallCount reads an in-process counter, so polling can be tight.
+			gomega.Eventually(ctx, func() int64 {
+				return driver.CallCount(drautils.MethodInstance{NodeName: nodeName, FullMethod: expectedMethod})
+			}).WithTimeout(60*time.Second).WithPolling(100*time.Millisecond).Should(gomega.BeNumerically(">", 0), "expected health stream on %s", expectedMethod)
+
+			// The kubelet must subscribe on exactly one version.
+			otherMethod := nodeWatchResourcesV1Alpha1Method
+			if expectedMethod == nodeWatchResourcesV1Alpha1Method {
+				otherMethod = nodeWatchResourcesV1Method
+			}
+			gomega.Expect(driver.CallCount(drautils.MethodInstance{NodeName: nodeName, FullMethod: otherMethod})).To(gomega.BeZero(), "unexpected health stream on %s", otherMethod)
+
+			// The kubelet publishes the health under the name of the claim as
+			// declared in the container, including the request name if one
+			// was set there.
+			claimRef := pod.Spec.Containers[0].Resources.Claims[0]
+			statusName := v1.ResourceName("claim:" + claimRef.Name)
+			if claimRef.Request != "" {
+				statusName += v1.ResourceName("/" + claimRef.Request)
+			}
+
+			setHealth := func(health string) {
+				plugin.HealthControlChan <- testdriverapp.DeviceHealthUpdate{
+					PoolName:   result.Pool,
+					DeviceName: result.Device,
+					Health:     health,
+				}
+			}
+			getHealth := func(ctx context.Context) (string, error) {
+				return getDeviceHealth(ctx, f.ClientSet, pod.Namespace, pod.Name, statusName, driver.Name)
+			}
+
+			ginkgo.By("Setting device health to Healthy to establish a baseline")
+			setHealth("Healthy")
+			gomega.Eventually(ctx, getHealth).WithTimeout(60*time.Second).WithPolling(2*time.Second).Should(gomega.Equal("Healthy"), "device health should be Healthy after explicit update")
+
+			ginkgo.By("Setting device health to Unhealthy via control channel")
+			setHealth("Unhealthy")
+			gomega.Eventually(ctx, getHealth).WithTimeout(60*time.Second).WithPolling(2*time.Second).Should(gomega.Equal("Unhealthy"), "device health should update to Unhealthy")
+
+			ginkgo.By("Setting device health back to Healthy via control channel")
+			setHealth("Healthy")
+			gomega.Eventually(ctx, getHealth).WithTimeout(60*time.Second).WithPolling(2*time.Second).Should(gomega.Equal("Healthy"), "device health should recover and update to Healthy")
+		}
+
+		ginkgo.Context("with a driver which serves all health API versions", func() {
+			driver := drautils.NewDriver(f, nodes, drautils.DriverResources(1))
+			b := drautils.NewBuilder(f, driver)
+
+			ginkgo.It("must reflect device health changes in the pod status", func(ctx context.Context) {
+				testHealthTransitions(ctx, b)
+			})
+		})
+
+		ginkgo.Context("with a driver which only serves the v1alpha1 health API", func() {
+			// Like a driver which shipped before the v1 API existed.
+			// TODO(harche): remove in 1.40, see minKubeletVersionForHealthV1.
+			driver := drautils.NewDriver(f, nodes, drautils.DriverResources(1))
+			driver.HealthV1 = false
+			b := drautils.NewBuilder(f, driver)
+
+			ginkgo.It("must reflect device health changes in the pod status", func(ctx context.Context) {
+				testHealthTransitions(ctx, b)
+			})
+		})
+
+		ginkgo.Context("with a driver which only serves the v1 health API", func() {
+			// Like a driver which has dropped v1alpha1 support.
+			driver := drautils.NewDriver(f, nodes, drautils.DriverResources(1))
+			driver.HealthV1alpha1 = false
+			b := drautils.NewBuilder(f, driver)
+
+			// Kubelets older than minKubeletVersionForHealthV1 only have the
+			// v1alpha1 client and cannot consume health from such a driver.
+			f.It("must reflect device health changes in the pod status", f.WithKubeletMinVersion(minKubeletVersionForHealthV1), func(ctx context.Context) {
+				testHealthTransitions(ctx, b)
+			})
+		})
+	})
+})
+
+// getDeviceHealth returns the health of the device of the given driver as
+// published in the pod's AllocatedResourcesStatus under the given resource
+// status name, or "NotFound" if there is no entry for it.
+//
+// The kubelet identifies the device by the first CDI device ID which the
+// driver returned for it during NodePrepareResources, with
+// "<driver>/<pool>/<device>" as fallback when there is none (see
+// buildResourceHealth in pkg/kubelet/cm/dra/manager.go). The test driver
+// generates CDI device IDs of the form "<driver>/test=...", so in both cases
+// the ID starts with the driver name, which is sufficient to identify the
+// device because the claims used in these tests allocate exactly one.
+func getDeviceHealth(ctx context.Context, clientSet kubernetes.Interface, namespace, podName string, statusName v1.ResourceName, driverName string) (string, error) {
+	pod, err := clientSet.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get pod %s/%s: %w", namespace, podName, err)
+	}
+
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		for _, resourceStatus := range containerStatus.AllocatedResourcesStatus {
+			if resourceStatus.Name != statusName {
+				continue
+			}
+			for _, resourceHealth := range resourceStatus.Resources {
+				if strings.HasPrefix(string(resourceHealth.ResourceID), driverName+"/") {
+					return string(resourceHealth.Health), nil
+				}
+			}
+		}
+	}
+
+	return "NotFound", nil
+}

--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -316,8 +316,10 @@ func NewDriverInstance(tCtx ktesting.TContext) *Driver {
 		callCounts: map[MethodInstance]int64{},
 		// By default, test with all gRPC APIs.
 		// TODO: should setting this be optional to test the actual helper defaults?
-		NodeV1:      true,
-		NodeV1beta1: true,
+		NodeV1:         true,
+		NodeV1beta1:    true,
+		HealthV1:       true,
+		HealthV1alpha1: true,
 		// By default, assume that the kubelet supports DRA and that
 		// the driver's removal causes ResourceSlice cleanup.
 		WithKubelet:                true,
@@ -390,6 +392,12 @@ type Driver struct {
 
 	NodeV1      bool
 	NodeV1beta1 bool
+
+	// HealthV1 and HealthV1alpha1 select which DRAResourceHealth gRPC API
+	// versions the plugin serves. Disabling one mimics drivers which only
+	// support the other version.
+	HealthV1       bool
+	HealthV1alpha1 bool
 
 	// Register the DRA test driver with the kubelet and expect DRA to work (= feature.DynamicResourceAllocation).
 	WithKubelet bool
@@ -713,7 +721,11 @@ func (d *Driver) SetUp(tCtx ktesting.TContext, kubeletRootDir string, nodes *Nod
 		}
 
 		pluginOpts := []any{
-			app.Options{EnableHealthService: true},
+			app.Options{
+				EnableHealthService:   true,
+				DisableHealthV1:       !d.HealthV1,
+				DisableHealthV1alpha1: !d.HealthV1alpha1,
+			},
 			kubeletplugin.GRPCVerbosity(0),
 			kubeletplugin.GRPCInterceptor(func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 				return d.interceptor(nodename, ctx, req, info, handler)

--- a/test/e2e_node/dra_test.go
+++ b/test/e2e_node/dra_test.go
@@ -64,8 +64,6 @@ import (
 
 	"k8s.io/dynamic-resource-allocation/kubeletplugin"
 	"k8s.io/dynamic-resource-allocation/resourceslice"
-	drahealthv1 "k8s.io/kubelet/pkg/apis/dra-health/v1"
-	drahealthv1alpha1 "k8s.io/kubelet/pkg/apis/dra-health/v1alpha1"
 	testdriver "k8s.io/kubernetes/test/e2e/dra/test-driver/app"
 	testdrivergomega "k8s.io/kubernetes/test/e2e/dra/test-driver/gomega"
 )
@@ -898,64 +896,8 @@ var _ = framework.SIGDescribe("node")(framework.WithLabel("DRA"), feature.Dynami
 
 	f.Context("Resource Health", framework.WithFeatureGate(features.ResourceHealthStatus), f.WithSerial(), func() {
 
-		// testHealthTransitions verifies that device health transitions
-		// (Healthy -> Unhealthy -> Healthy) reported by a DRA plugin are
-		// correctly reflected in the Pod's status, and that the kubelet
-		// consumed them through the expected DRAResourceHealth gRPC API
-		// version.
-		testHealthTransitions := func(ctx context.Context, prefix string, expectedHealthMethod string, opts ...pluginOption) {
-			ginkgo.By("Starting the test driver with channel-based control")
-			kubeletPlugin := newKubeletPlugin(ctx, f.ClientSet, f.Namespace.Name, getNodeName(ctx, f), driverName, opts...)
-
-			pod, claimName, poolNameForTest, deviceNameForTest := setupAndVerifyHealthyPod(
-				ctx, f, kubeletPlugin, driverName,
-				prefix+"-class", prefix+"-claim", prefix+"-pod", "pool-a", "dev-0",
-			)
-
-			ginkgo.By("Verifying the negotiated health API version")
-			gomega.Expect(kubeletPlugin.GetGRPCCalls()).To(gomega.ContainElement(gomega.HaveField("FullMethod", expectedHealthMethod)), "expected health stream on %s", expectedHealthMethod)
-
-			ginkgo.By("Setting device health to Unhealthy via control channel")
-			kubeletPlugin.HealthControlChan <- testdriver.DeviceHealthUpdate{
-				PoolName:   poolNameForTest,
-				DeviceName: deviceNameForTest,
-				Health:     "Unhealthy",
-			}
-
-			ginkgo.By("Verifying device health is now Unhealthy")
-			gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
-				return getDeviceHealthFromAPIServer(f, pod.Namespace, pod.Name, driverName, claimName, poolNameForTest, deviceNameForTest)
-			}).WithTimeout(60*time.Second).WithPolling(2*time.Second).Should(gomega.Equal("Unhealthy"), "Device health should update to Unhealthy")
-
-			ginkgo.By("Setting device health back to Healthy via control channel")
-			kubeletPlugin.HealthControlChan <- testdriver.DeviceHealthUpdate{
-				PoolName:   poolNameForTest,
-				DeviceName: deviceNameForTest,
-				Health:     "Healthy",
-			}
-
-			ginkgo.By("Verifying device health has recovered to Healthy")
-			gomega.Eventually(ctx, func(ctx context.Context) (string, error) {
-				return getDeviceHealthFromAPIServer(f, pod.Namespace, pod.Name, driverName, claimName, poolNameForTest, deviceNameForTest)
-			}).WithTimeout(60*time.Second).WithPolling(2*time.Second).Should(gomega.Equal("Healthy"), "Device health should recover and update to Healthy")
-		}
-
-		ginkgo.It("should reflect device health changes in the Pod's status", func(ctx context.Context) {
-			// The kubelet picks the most recent version when the plugin
-			// serves several, which is the default.
-			testHealthTransitions(ctx, "health-test", nodeWatchResourcesV1Method)
-		})
-
-		ginkgo.It("should reflect device health changes for a plugin which only supports the v1alpha1 health API", func(ctx context.Context) {
-			// Like a driver which shipped before the v1 API existed.
-			// TODO(harche): remove in 1.40 together with the kubelet's
-			// v1alpha1 client support.
-			testHealthTransitions(ctx, "health-v1alpha1", nodeWatchResourcesV1Alpha1Method, withoutHealthV1())
-		})
-
-		ginkgo.It("should reflect device health changes for a plugin which only supports the v1 health API", func(ctx context.Context) {
-			testHealthTransitions(ctx, "health-v1", nodeWatchResourcesV1Method, withoutHealthV1alpha1())
-		})
+		// The device health transition tests, including negotiation of the
+		// DRAResourceHealth API version, are in test/e2e/dra.
 
 		// This test verifies that the Kubelet establishes only a single gRPC connection
 		// with the DRA plugin throughout the plugin lifecycle.
@@ -1366,30 +1308,6 @@ func withHealthService(enabled bool) pluginOption {
 		o.EnableHealthService = enabled
 	}
 }
-
-// withoutHealthV1 restricts the driver to the v1alpha1 DRAResourceHealth
-// gRPC API, like a driver which shipped before the v1 API existed. The
-// kubelet keeps consuming v1alpha1 for three releases of transition.
-func withoutHealthV1() pluginOption {
-	return func(o *testdriver.Options) {
-		o.DisableHealthV1 = true
-	}
-}
-
-// withoutHealthV1alpha1 restricts the driver to the v1 DRAResourceHealth
-// gRPC API, like a driver which has dropped v1alpha1 support.
-func withoutHealthV1alpha1() pluginOption {
-	return func(o *testdriver.Options) {
-		o.DisableHealthV1alpha1 = true
-	}
-}
-
-// The gRPC methods on which the kubelet subscribes to device health updates,
-// depending on the negotiated DRAResourceHealth API version.
-const (
-	nodeWatchResourcesV1Alpha1Method = "/" + drahealthv1alpha1.DRAResourceHealthService + "/NodeWatchResources"
-	nodeWatchResourcesV1Method       = "/" + drahealthv1.DRAResourceHealthService + "/NodeWatchResources"
-)
 
 // Run Kubelet plugin and wait until it's registered
 func newKubeletPlugin(ctx context.Context, clientSet kubernetes.Interface, testNamespace string, nodeName, driverName string, options ...pluginOption) *testdriver.ExamplePlugin {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node
/wg device-management

#### What this PR does / why we need it:

Moves the DRA Resource Health transition tests (device health `Healthy → Unhealthy → Healthy` reflected in pod status, plus negotiation of the DRAResourceHealth gRPC API version) from `test/e2e_node/dra_test.go` to `test/e2e/dra/health.go`, as suggested in https://github.com/kubernetes/kubernetes/pull/139477#discussion_r3569338535.

The test driver deployment in `test/e2e/dra/utils` gains `HealthV1`/`HealthV1alpha1` knobs (both default `true`, matching the `NodeV1`/`NodeV1beta1` precedent) so tests can restrict which DRAResourceHealth versions the plugin serves.

The health tests that depend on `test/e2e_node` specifics (in-process plugin restart, connection-counting listener, disabled feature gate, ShareID) stay in `test/e2e_node`.

#### Which issue(s) this PR is related to:

Fixes #140746

#### Special notes for your reviewer:

Selection in the DRA CI jobs requires lifting the `!FeatureGate:ResourceHealthStatus` exclusion from the job label filters. This is being done canary-first: kubernetes/test-infra#37519 lifts it in the manually-triggered canary jobs only; once those have been run green against this PR, a follow-up test-infra PR applies it to all DRA lanes.

Verified locally on kind:
- kind `v1.36.0` node image (skew scenario) with `--sem-ver-filter=kubelet=1.36.0`: 2/2 specs pass; the kubelet subscribes on v1alpha1, served by the master `kubeletplugin` helper's conversion path, and the v1-only spec is filtered out by its `KubeletMinVersion:1.37` constraint.
- Node image built from this branch (1.37): 3/3 specs pass; the kubelet subscribes on v1 except against the v1alpha1-only driver.

**AI usage:** This PR was authored with AI assistance, which drafted the test move and ran the local kind verification; I directed and reviewed the approach, code, and results.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP-4680]: https://github.com/kubernetes/enhancements/issues/4680
```
