### PR TITLE
featuregates: log resolved feature gates along with explicit overrides

### DIFF
--- a/staging/src/k8s.io/component-base/featuregate/feature_gate.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate.go
@@ -507,7 +507,7 @@ func (f *featureGate) SetFromMapWithLogger(logger klog.Logger, m map[string]bool
 	if len(errs) == 0 {
 		// Persist changes
 		f.enabled.Store(enabled)
-		logger.V(1).Info("Updated", "featureGates", enabled)
+		logger.V(1).Info("Updated", "featureGates", enabled, "resolved", f.resolvedMap())
 	}
 	return utilerrors.NewAggregate(errs)
 }
@@ -832,6 +832,23 @@ func (f *featureGate) GetAll() map[Feature]FeatureSpec {
 		retval[k] = *spec
 	}
 	return retval
+}
+
+func (f *featureGate) resolvedMap() map[Feature]bool {
+	known := f.known.Load().(map[Feature]VersionedSpecs)
+	enabled := f.enabled.Load().(map[Feature]bool)
+	emulationVersion := f.EmulationVersion()
+	minCompatibilityVersion := f.MinCompatibilityVersion()
+
+	resolved := map[Feature]bool{}
+	for k, v := range known {
+		featureSpec := featureSpecAtEmulationAndMinCompatVersion(v, emulationVersion, minCompatibilityVersion)
+		if featureSpec.PreRelease == PreAlpha {
+			continue
+		}
+		resolved[k] = featureEnabled(k, enabled, known, emulationVersion, minCompatibilityVersion)
+	}
+	return resolved
 }
 
 // GetAllVersioned returns a copy of the map of known feature names to versioned feature specs.

--- a/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
+++ b/staging/src/k8s.io/component-base/featuregate/feature_gate_test.go
@@ -2578,3 +2578,40 @@ func TestValidateDependencies(t *testing.T) {
 		})
 	}
 }
+
+func TestFeatureGateResolvedMap(t *testing.T) {
+	const testAlphaGate Feature = "TestAlpha"
+	const testBetaGate Feature = "TestBeta"
+
+	f := NewFeatureGate()
+	err := f.Add(map[Feature]FeatureSpec{
+		testAlphaGate: {Default: false, PreRelease: Alpha},
+		testBetaGate:  {Default: true, PreRelease: Beta},
+	})
+	if err != nil {
+		t.Fatalf("failed to add features: %v", err)
+	}
+
+	// Check initially defaults are resolved
+	resolved := f.resolvedMap()
+	if resolved[testAlphaGate] != false {
+		t.Errorf("expected TestAlpha to be false, got true")
+	}
+	if resolved[testBetaGate] != true {
+		t.Errorf("expected TestBeta to be true, got false")
+	}
+
+	// Override alpha to true and beta to false
+	err = f.Set("TestAlpha=true,TestBeta=false")
+	if err != nil {
+		t.Fatalf("failed to set feature gates: %v", err)
+	}
+
+	resolved = f.resolvedMap()
+	if resolved[testAlphaGate] != true {
+		t.Errorf("expected TestAlpha to be true, got false")
+	}
+	if resolved[testBetaGate] != false {
+		t.Errorf("expected TestBeta to be false, got true")
+	}
+}


### PR DESCRIPTION
See while debugging a new feature depending on a feature gate in [kube-proxy , logs show](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-kind-network-nftables/2080163255812100096/artifacts/kind-worker/pods/kube-system_kube-proxy-fnw2t_473d2a62-d343-4b81-8e2b-4ba947f3f4c3/kube-proxy/0.log):

```
26-07-23T05:38:35.580133141Z stderr F I0723 05:38:35.580072       1 flags.go:64] FLAG: --feature-gates=""
2026-07-23T05:38:35.580133989Z stderr F I0723 05:38:35.580074       1 flags.go:64] FLAG: --healthz-bind-address="0.0.0.0:10256"
....
2026-07-23T05:38:35.58029752Z stderr F I0723 05:38:35.580260       1 feature_gate.go:477] "Updated" featureGates={}
2026-07-23T05:38:35.616848901Z stderr F I0723 05:38:35.616778       1 iptables.go:299] "Running" command="iptables-save" arguments=[
```

When feature gates are updated (typically at component startup), the logged 'featureGates' map contains only explicitly configured feature gates (which is empty when running with defaults). This can be confusing for troubleshooting.

This patch adds a private helper method 'resolvedMap()' to 'featureGate' that returns the effective state of all available feature gates at the current emulation version. The feature gate update log now outputs both the explicitly configured overrides ('featureGates') and the final effective state of all feature gates ('resolved').

/kind cleanup
/kind documentation

```release-note
NONE
```

/assign @richabanker @siyuanfoundation @liggitt 