### PR TITLE
bump network policies to latest stable

### DIFF
--- a/cluster/addons/kube-network-policies/kube-network-policies.yaml
+++ b/cluster/addons/kube-network-policies/kube-network-policies.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: kube-network-policies
       containers:
       - name: kube-network-policies
-        image: registry.k8s.io/networking/kube-network-policies:v0.9.2
+        image: registry.k8s.io/networking/kube-network-policies:v1.1.0
         command:
         - /bin/netpol
         - --v=4


### PR DESCRIPTION
While reviewing the testgrids and dashboards I realized we are not using the latest stable https://perf-dash.k8s.io/#/?jobname=networkpolicies&metriccategoryname=E2E&metricname=LoadResources&PodName=kube-network-policies%2Fkube-network-policies&Resource=CPU

Also lower
/kind cleanup

```release-note
NONE
```

/assign 