### PR TITLE
client-go: prevent unbounded goroutine growth in EventBroadcaster

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -71,6 +71,11 @@ type eventBroadcasterImpl struct {
 	eventCache    map[eventKey]*eventsv1.Event
 	sleepDuration time.Duration
 	sink          EventSink
+
+	// startMu guards started and cancel.
+	startMu sync.Mutex
+	started bool
+	cancel  func()
 }
 
 // EventSinkImpl wraps EventsV1Interface to implement EventSink.
@@ -112,7 +117,7 @@ func NewBroadcaster(sink EventSink) EventBroadcaster {
 // NewBroadcasterForTest Creates a new event broadcaster for test purposes.
 func newBroadcaster(sink EventSink, sleepDuration time.Duration, eventCache map[eventKey]*eventsv1.Event) EventBroadcaster {
 	return &eventBroadcasterImpl{
-		Broadcaster:   watch.NewBroadcaster(maxQueuedEvents, watch.DropIfChannelFull),
+		Broadcaster:   watch.NewLongQueueBroadcaster(maxQueuedEvents, watch.DropIfChannelFull),
 		eventCache:    eventCache,
 		sleepDuration: sleepDuration,
 		sink:          sink,
@@ -121,6 +126,13 @@ func newBroadcaster(sink EventSink, sleepDuration time.Duration, eventCache map[
 
 func (e *eventBroadcasterImpl) Shutdown() {
 	e.Broadcaster.Shutdown()
+	e.startMu.Lock()
+	cancel := e.cancel
+	e.cancel = nil
+	e.startMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 }
 
 // refreshExistingEventSeries refresh events TTL
@@ -170,39 +182,37 @@ func (e *eventBroadcasterImpl) NewRecorder(scheme *runtime.Scheme, reportingCont
 func (e *eventBroadcasterImpl) recordToSink(ctx context.Context, event *eventsv1.Event, clock clock.Clock) {
 	// Make a copy before modification, because there could be multiple listeners.
 	eventCopy := event.DeepCopy()
-	go func() {
-		evToRecord := func() *eventsv1.Event {
-			e.mu.Lock()
-			defer e.mu.Unlock()
-			eventKey := getKey(eventCopy)
-			isomorphicEvent, isIsomorphic := e.eventCache[eventKey]
-			if isIsomorphic {
-				if isomorphicEvent.Series != nil {
-					isomorphicEvent.Series.Count++
-					isomorphicEvent.Series.LastObservedTime = metav1.MicroTime{Time: clock.Now()}
-					return nil
-				}
-				isomorphicEvent.Series = &eventsv1.EventSeries{
-					Count:            2,
-					LastObservedTime: metav1.MicroTime{Time: clock.Now()},
-				}
-				// Make a copy of the Event to make sure that recording it
-				// doesn't mess with the object stored in cache.
-				return isomorphicEvent.DeepCopy()
+	evToRecord := func() *eventsv1.Event {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		eventKey := getKey(eventCopy)
+		isomorphicEvent, isIsomorphic := e.eventCache[eventKey]
+		if isIsomorphic {
+			if isomorphicEvent.Series != nil {
+				isomorphicEvent.Series.Count++
+				isomorphicEvent.Series.LastObservedTime = metav1.MicroTime{Time: clock.Now()}
+				return nil
 			}
-			e.eventCache[eventKey] = eventCopy
-			// Make a copy of the Event to make sure that recording it doesn't
-			// mess with the object stored in cache.
-			return eventCopy.DeepCopy()
-		}()
-		if evToRecord != nil {
-			// TODO: Add a metric counting the number of recording attempts
-			e.attemptRecording(ctx, evToRecord)
-			// We don't want the new recorded Event to be reflected in the
-			// client's cache because server-side mutations could mess with the
-			// aggregation mechanism used by the client.
+			isomorphicEvent.Series = &eventsv1.EventSeries{
+				Count:            2,
+				LastObservedTime: metav1.MicroTime{Time: clock.Now()},
+			}
+			// Make a copy of the Event to make sure that recording it
+			// doesn't mess with the object stored in cache.
+			return isomorphicEvent.DeepCopy()
 		}
+		e.eventCache[eventKey] = eventCopy
+		// Make a copy of the Event to make sure that recording it doesn't
+		// mess with the object stored in cache.
+		return eventCopy.DeepCopy()
 	}()
+	if evToRecord != nil {
+		// TODO: Add a metric counting the number of recording attempts
+		e.attemptRecording(ctx, evToRecord)
+		// We don't want the new recorded Event to be reflected in the
+		// client's cache because server-side mutations could mess with the
+		// aggregation mechanism used by the client.
+	}
 }
 
 func (e *eventBroadcasterImpl) attemptRecording(ctx context.Context, event *eventsv1.Event) {
@@ -394,9 +404,24 @@ func (e *eventBroadcasterImpl) StartRecordingToSink(stopCh <-chan struct{}) {
 
 // StartRecordingToSinkWithContext starts sending events received from the specified eventBroadcaster to the given sink.
 func (e *eventBroadcasterImpl) StartRecordingToSinkWithContext(ctx context.Context) error {
+	e.startMu.Lock()
+	defer e.startMu.Unlock()
+	if e.started {
+		return fmt.Errorf("event broadcaster already started")
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	e.started = true
+	e.cancel = cancel
+	if err := e.startRecordingEvents(ctx); err != nil {
+		e.started = false
+		e.cancel = nil
+		cancel()
+		return err
+	}
 	go wait.UntilWithContext(ctx, e.refreshExistingEventSeries, refreshTime)
 	go wait.UntilWithContext(ctx, e.finishSeries, finishTime)
-	return e.startRecordingEvents(ctx)
+	return nil
 }
 
 type eventBroadcasterAdapterImpl struct {

--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -41,18 +41,43 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/tools/record/util"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
 
 const (
-	maxTriesPerEvent = 12
-	finishTime       = 6 * time.Minute
-	refreshTime      = 30 * time.Minute
-	maxQueuedEvents  = 1000
+	maxTriesPerEvent        = 12
+	finishTime              = 6 * time.Minute
+	refreshTime             = 30 * time.Minute
+	maxQueuedEvents         = 1000
+	maxPendingEvents        = 4096
+	workers                 = 8
+	droppedEventLogInterval = 10 * time.Second
 )
 
 var defaultSleepDuration = 10 * time.Second
+
+// droppedEventLogger rate-limits drop logs and counts all dropped Events.
+// The zero value is ready for use.
+type droppedEventLogger struct {
+	mu          sync.Mutex
+	lastLogTime time.Time
+	dropped     uint64
+}
+
+func (d *droppedEventLogger) logDropped(logger klog.Logger, now time.Time, msg string, event *eventsv1.Event) {
+	d.mu.Lock()
+	d.dropped++
+	if !d.lastLogTime.IsZero() && now.Sub(d.lastLogTime) < droppedEventLogInterval {
+		d.mu.Unlock()
+		return
+	}
+	dropped := d.dropped
+	d.lastLogTime = now
+	d.mu.Unlock()
+	logger.Error(nil, msg, "event", event, "totalDroppedEvents", dropped)
+}
 
 // TODO: validate impact of copying and investigate hashing
 type eventKey struct {
@@ -69,8 +94,13 @@ type eventBroadcasterImpl struct {
 	*watch.Broadcaster
 	mu            sync.Mutex
 	eventCache    map[eventKey]*eventsv1.Event
+	pending       map[eventKey]uint64
 	sleepDuration time.Duration
 	sink          EventSink
+	eventQueue    workqueue.TypedInterface[eventKey]
+	droppedEvents droppedEventLogger
+	started       bool
+	cancel        func()
 }
 
 // EventSinkImpl wraps EventsV1Interface to implement EventSink.
@@ -114,13 +144,23 @@ func newBroadcaster(sink EventSink, sleepDuration time.Duration, eventCache map[
 	return &eventBroadcasterImpl{
 		Broadcaster:   watch.NewBroadcaster(maxQueuedEvents, watch.DropIfChannelFull),
 		eventCache:    eventCache,
+		pending:       map[eventKey]uint64{},
 		sleepDuration: sleepDuration,
 		sink:          sink,
+		eventQueue:    workqueue.NewTyped[eventKey](),
 	}
 }
 
 func (e *eventBroadcasterImpl) Shutdown() {
 	e.Broadcaster.Shutdown()
+	e.mu.Lock()
+	cancel := e.cancel
+	e.cancel = nil
+	e.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	e.eventQueue.ShutDown()
 }
 
 // refreshExistingEventSeries refresh events TTL
@@ -164,45 +204,93 @@ func (e *eventBroadcasterImpl) finishSeries(ctx context.Context) {
 func (e *eventBroadcasterImpl) NewRecorder(scheme *runtime.Scheme, reportingController string) EventRecorderLogger {
 	hostname, _ := os.Hostname()
 	reportingInstance := reportingController + "-" + hostname
-	return &recorderImplLogger{recorderImpl: &recorderImpl{scheme, reportingController, reportingInstance, e.Broadcaster, clock.RealClock{}}, logger: klog.Background()}
+	return &recorderImplLogger{recorderImpl: &recorderImpl{
+		scheme:              scheme,
+		reportingController: reportingController,
+		reportingInstance:   reportingInstance,
+		Broadcaster:         e.Broadcaster,
+		clock:               clock.RealClock{},
+	}, logger: klog.Background()}
 }
 
 func (e *eventBroadcasterImpl) recordToSink(ctx context.Context, event *eventsv1.Event, clock clock.Clock) {
 	// Make a copy before modification, because there could be multiple listeners.
 	eventCopy := event.DeepCopy()
-	go func() {
-		evToRecord := func() *eventsv1.Event {
-			e.mu.Lock()
-			defer e.mu.Unlock()
-			eventKey := getKey(eventCopy)
-			isomorphicEvent, isIsomorphic := e.eventCache[eventKey]
-			if isIsomorphic {
-				if isomorphicEvent.Series != nil {
-					isomorphicEvent.Series.Count++
-					isomorphicEvent.Series.LastObservedTime = metav1.MicroTime{Time: clock.Now()}
-					return nil
-				}
-				isomorphicEvent.Series = &eventsv1.EventSeries{
-					Count:            2,
-					LastObservedTime: metav1.MicroTime{Time: clock.Now()},
-				}
-				// Make a copy of the Event to make sure that recording it
-				// doesn't mess with the object stored in cache.
-				return isomorphicEvent.DeepCopy()
+	key := getKey(eventCopy)
+	needsRecording, dropped := func() (bool, bool) {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		isomorphicEvent, isIsomorphic := e.eventCache[key]
+		if isIsomorphic {
+			if isomorphicEvent.Series != nil {
+				isomorphicEvent.Series.Count++
+				isomorphicEvent.Series.LastObservedTime = metav1.MicroTime{Time: clock.Now()}
+				return false, false
 			}
-			e.eventCache[eventKey] = eventCopy
-			// Make a copy of the Event to make sure that recording it doesn't
-			// mess with the object stored in cache.
-			return eventCopy.DeepCopy()
-		}()
-		if evToRecord != nil {
-			// TODO: Add a metric counting the number of recording attempts
-			e.attemptRecording(ctx, evToRecord)
-			// We don't want the new recorded Event to be reflected in the
-			// client's cache because server-side mutations could mess with the
-			// aggregation mechanism used by the client.
+			isomorphicEvent.Series = &eventsv1.EventSeries{
+				Count:            2,
+				LastObservedTime: metav1.MicroTime{Time: clock.Now()},
+			}
+			if _, isPending := e.pending[key]; !isPending && len(e.pending) >= maxPendingEvents {
+				return false, false
+			}
+			e.pending[key]++
+			return true, false
 		}
+		if len(e.pending) >= maxPendingEvents {
+			return false, true
+		}
+		e.eventCache[key] = eventCopy
+		e.pending[key]++
+		return true, false
 	}()
+	if dropped {
+		e.droppedEvents.logDropped(klog.FromContext(ctx), clock.Now(), "Unable to record event: too many events awaiting recording, dropped event", eventCopy)
+		return
+	}
+	if needsRecording {
+		e.eventQueue.Add(key)
+	}
+}
+
+// recordingWorker delivers queued events to the sink until the queue is shut
+// down.
+func (e *eventBroadcasterImpl) recordingWorker(ctx context.Context) {
+	defer utilruntime.HandleCrash()
+	for {
+		key, shutdown := e.eventQueue.Get()
+		if shutdown {
+			return
+		}
+		func() {
+			defer e.eventQueue.Done(key)
+			e.processNextItem(ctx, key)
+		}()
+	}
+}
+
+// processNextItem looks up the current cached state for key and, if it is
+// still present, attempts to record it to the sink.
+func (e *eventBroadcasterImpl) processNextItem(ctx context.Context, key eventKey) {
+	e.mu.Lock()
+	event, ok := e.eventCache[key]
+	if !ok {
+		delete(e.pending, key)
+		e.mu.Unlock()
+		return
+	}
+	generation := e.pending[key]
+	eventCopy := event.DeepCopy()
+	e.mu.Unlock()
+
+	// TODO: Add a metric counting the number of recording attempts
+	e.attemptRecording(ctx, eventCopy)
+
+	e.mu.Lock()
+	if e.pending[key] == generation {
+		delete(e.pending, key)
+	}
+	e.mu.Unlock()
 }
 
 func (e *eventBroadcasterImpl) attemptRecording(ctx context.Context, event *eventsv1.Event) {
@@ -376,9 +464,15 @@ func (e *eventBroadcasterImpl) startRecordingEvents(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	for range workers {
+		go e.recordingWorker(ctx)
+	}
+
 	go func() {
 		<-ctx.Done()
 		stopWatcher()
+		e.eventQueue.ShutDown()
 	}()
 	return nil
 }
@@ -394,9 +488,21 @@ func (e *eventBroadcasterImpl) StartRecordingToSink(stopCh <-chan struct{}) {
 
 // StartRecordingToSinkWithContext starts sending events received from the specified eventBroadcaster to the given sink.
 func (e *eventBroadcasterImpl) StartRecordingToSinkWithContext(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.started {
+		return nil
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	if err := e.startRecordingEvents(ctx); err != nil {
+		cancel()
+		return err
+	}
 	go wait.UntilWithContext(ctx, e.refreshExistingEventSeries, refreshTime)
 	go wait.UntilWithContext(ctx, e.finishSeries, finishTime)
-	return e.startRecordingEvents(ctx)
+	e.started = true
+	e.cancel = cancel
+	return nil
 }
 
 type eventBroadcasterAdapterImpl struct {

--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster_test.go
@@ -18,15 +18,208 @@ package events
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/klog/v2/ktesting"
+	"k8s.io/utils/clock"
 )
+
+func TestPendingEventRemainsCountedWhenRequeued(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	createStarted := make(chan struct{})
+	releaseCreate := make(chan struct{})
+	sink := &testEventSeriesSink{
+		OnCreate: func(event *eventsv1.Event) (*eventsv1.Event, error) {
+			close(createStarted)
+			<-releaseCreate
+			return event, nil
+		},
+	}
+	broadcaster := newBroadcaster(sink, 0, map[eventKey]*eventsv1.Event{}).(*eventBroadcasterImpl)
+	t.Cleanup(func() {
+		broadcaster.eventQueue.ShutDown()
+		broadcaster.Shutdown()
+	})
+
+	event := &eventsv1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: metav1.NamespaceDefault},
+		Regarding: corev1.ObjectReference{
+			Namespace: metav1.NamespaceDefault,
+			Name:      "pod",
+		},
+		Reason: "FailedScheduling",
+		Action: "Scheduling",
+	}
+	key := getKey(event)
+	broadcaster.recordToSink(ctx, event, clock.RealClock{})
+
+	queuedKey, shutdown := broadcaster.eventQueue.Get()
+	if shutdown || queuedKey != key {
+		t.Fatalf("expected the first event key from the queue, got key %#v, shutdown %t", queuedKey, shutdown)
+	}
+	firstAttemptDone := make(chan struct{})
+	go func() {
+		defer close(firstAttemptDone)
+		broadcaster.processNextItem(ctx, key)
+	}()
+
+	select {
+	case <-createStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the first recording attempt")
+	}
+
+	// This transitions the cached Event into a series and marks the key dirty
+	// while the first recording attempt is still in progress.
+	broadcaster.recordToSink(ctx, event, clock.RealClock{})
+	close(releaseCreate)
+	select {
+	case <-firstAttemptDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the first recording attempt to finish")
+	}
+
+	broadcaster.mu.Lock()
+	_, remainsPending := broadcaster.pending[key]
+	broadcaster.mu.Unlock()
+	if !remainsPending {
+		t.Fatal("expected a dirty key to remain pending until its next recording attempt")
+	}
+
+	broadcaster.eventQueue.Done(key)
+	if got := broadcaster.eventQueue.Len(); got != 1 {
+		t.Fatalf("expected the dirty key to be requeued, got queue length %d", got)
+	}
+	queuedKey, shutdown = broadcaster.eventQueue.Get()
+	if shutdown || queuedKey != key {
+		t.Fatalf("expected the dirty event key from the queue, got key %#v, shutdown %t", queuedKey, shutdown)
+	}
+	broadcaster.processNextItem(ctx, key)
+	broadcaster.eventQueue.Done(key)
+
+	broadcaster.mu.Lock()
+	_, remainsPending = broadcaster.pending[key]
+	broadcaster.mu.Unlock()
+	if remainsPending {
+		t.Fatal("expected the key to stop counting as pending after its latest generation was recorded")
+	}
+}
+
+func TestRecordToSinkDropsNewEventsWhenTooManyPending(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	makeEvent := func(name string) *eventsv1.Event {
+		return &eventsv1.Event{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault},
+			Regarding: corev1.ObjectReference{
+				Namespace: metav1.NamespaceDefault,
+				Name:      name,
+			},
+			Reason: "FailedScheduling",
+			Action: "Scheduling",
+		}
+	}
+	broadcaster := newBroadcaster(&testEventSeriesSink{}, 0, map[eventKey]*eventsv1.Event{}).(*eventBroadcasterImpl)
+	t.Cleanup(broadcaster.Shutdown)
+	// Simulate a slow sink: maxPendingEvents keys are cached and still
+	// awaiting recording, plus one cached key that was already recorded.
+	for i := range maxPendingEvents {
+		event := makeEvent(fmt.Sprintf("pod-%d", i))
+		broadcaster.eventCache[getKey(event)] = event
+		broadcaster.pending[getKey(event)] = 1
+	}
+	recordedEvent := makeEvent("pod-recorded")
+	broadcaster.eventCache[getKey(recordedEvent)] = recordedEvent
+
+	newEvent := makeEvent("pod-over-capacity")
+	broadcaster.recordToSink(ctx, newEvent, clock.RealClock{})
+
+	broadcaster.mu.Lock()
+	_, cached := broadcaster.eventCache[getKey(newEvent)]
+	pendingLen := len(broadcaster.pending)
+	broadcaster.mu.Unlock()
+	if cached {
+		t.Error("expected an event for a new key to be dropped while too many events await recording")
+	}
+	if pendingLen != maxPendingEvents {
+		t.Errorf("expected pending to stay at %d keys, got %d", maxPendingEvents, pendingLen)
+	}
+	if got := broadcaster.eventQueue.Len(); got != 0 {
+		t.Errorf("expected no queued keys for a dropped event, got %d", got)
+	}
+
+	// A series transition for a cached, non-pending key must still be
+	// aggregated, but its recording is deferred instead of queued.
+	broadcaster.recordToSink(ctx, makeEvent("pod-recorded"), clock.RealClock{})
+	broadcaster.mu.Lock()
+	series := broadcaster.eventCache[getKey(recordedEvent)].Series
+	_, isPending := broadcaster.pending[getKey(recordedEvent)]
+	broadcaster.mu.Unlock()
+	if series == nil || series.Count != 2 {
+		t.Errorf("expected an isomorphic event to start a series with count 2, got %+v", series)
+	}
+	if isPending {
+		t.Error("expected the deferred series transition not to become pending")
+	}
+	if got := broadcaster.eventQueue.Len(); got != 0 {
+		t.Errorf("expected the deferred series transition not to be queued, got queue length %d", got)
+	}
+
+	// A series transition for a key that is already pending stays allowed.
+	broadcaster.recordToSink(ctx, makeEvent("pod-0"), clock.RealClock{})
+	broadcaster.mu.Lock()
+	series = broadcaster.eventCache[getKey(makeEvent("pod-0"))].Series
+	broadcaster.mu.Unlock()
+	if series == nil || series.Count != 2 {
+		t.Errorf("expected an isomorphic event for a pending key to start a series with count 2, got %+v", series)
+	}
+	if got := broadcaster.eventQueue.Len(); got != 1 {
+		t.Errorf("expected the series transition for a pending key to be queued, got queue length %d", got)
+	}
+}
+
+func TestStartRecordingAfterShutdownKeepsFailing(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	broadcaster := newBroadcaster(&testEventSeriesSink{}, 0, map[eventKey]*eventsv1.Event{}).(*eventBroadcasterImpl)
+	broadcaster.Shutdown()
+	if err := broadcaster.StartRecordingToSinkWithContext(ctx); err == nil {
+		t.Fatal("expected an error when starting recording after shutdown")
+	}
+	if err := broadcaster.StartRecordingToSinkWithContext(ctx); err == nil {
+		t.Fatal("expected a repeated start attempt to report the failure, not success")
+	}
+}
+
+func TestShutdownStopsRecordingWorkers(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	broadcaster := newBroadcaster(&testEventSeriesSink{}, 0, map[eventKey]*eventsv1.Event{}).(*eventBroadcasterImpl)
+	if err := broadcaster.StartRecordingToSinkWithContext(ctx); err != nil {
+		t.Fatalf("unexpected error starting recording: %v", err)
+	}
+	// A repeated start must be a no-op: even with an already canceled
+	// context it must not spawn goroutines that shut down the shared queue.
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	if err := broadcaster.StartRecordingToSinkWithContext(canceledCtx); err != nil {
+		t.Fatalf("unexpected error on repeated start: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if broadcaster.eventQueue.ShuttingDown() {
+		t.Fatal("expected a repeated start to be a no-op, but the event queue was shut down")
+	}
+
+	broadcaster.Shutdown()
+	if !broadcaster.eventQueue.ShuttingDown() {
+		t.Fatal("expected Shutdown to shut down the event queue and stop the workers")
+	}
+}
 
 func TestRecordEventToSink(t *testing.T) {
 	nonIsomorphicEvent := eventsv1.Event{

--- a/staging/src/k8s.io/client-go/tools/events/event_recorder.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder.go
@@ -24,7 +24,6 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/record/util"
 	"k8s.io/client-go/tools/reference"
@@ -37,7 +36,8 @@ type recorderImpl struct {
 	reportingController string
 	reportingInstance   string
 	*watch.Broadcaster
-	clock clock.Clock
+	clock         clock.Clock
+	droppedEvents droppedEventLogger
 }
 
 var _ EventRecorder = &recorderImpl{}
@@ -91,10 +91,14 @@ func (recorder *recorderImpl) eventf(logger klog.Logger, regarding runtime.Objec
 		return
 	}
 	event := recorder.makeEvent(refRegarding, refRelated, timestamp, annotations, eventtype, reason, message, recorder.reportingController, recorder.reportingInstance, action)
-	go func() {
-		defer utilruntime.HandleCrash()
-		recorder.Action(watch.Added, event)
-	}()
+	sent, err := recorder.ActionOrDrop(watch.Added, event)
+	if err != nil {
+		logger.Error(err, "Unable to record event (will not retry!)")
+		return
+	}
+	if !sent {
+		recorder.droppedEvents.logDropped(logger, recorder.clock.Now(), "Unable to record event: too many queued events, dropped event", event)
+	}
 }
 
 func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRelated *v1.ObjectReference, timestamp metav1.MicroTime, annotations map[string]string, eventtype, reason, message string, reportingController string, reportingInstance string, action string) *eventsv1.Event {

--- a/staging/src/k8s.io/client-go/tools/events/event_recorder.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder.go
@@ -24,7 +24,6 @@ import (
 	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/record/util"
 	"k8s.io/client-go/tools/reference"
@@ -91,10 +90,19 @@ func (recorder *recorderImpl) eventf(logger klog.Logger, regarding runtime.Objec
 		return
 	}
 	event := recorder.makeEvent(refRegarding, refRelated, timestamp, annotations, eventtype, reason, message, recorder.reportingController, recorder.reportingInstance, action)
-	go func() {
-		defer utilruntime.HandleCrash()
-		recorder.Action(watch.Added, event)
-	}()
+	// NOTE: events should be a non-blocking operation, but we also need to not
+	// put this in a goroutine, otherwise we'll race to write to a closed channel
+	// when we go to shut down this broadcaster.  Just drop events if we get overloaded,
+	// and log an error if that happens (we've configured the broadcaster to drop
+	// outgoing events anyway).
+	sent, err := recorder.ActionOrDrop(watch.Added, event)
+	if err != nil {
+		logger.Error(err, "Unable to record event (will not retry!)")
+		return
+	}
+	if !sent {
+		logger.Error(nil, "Unable to record event: too many queued events, dropped event", "event", event)
+	}
 }
 
 func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRelated *v1.ObjectReference, timestamp metav1.MicroTime, annotations map[string]string, eventtype, reason, message string, reportingController string, reportingInstance string, action string) *eventsv1.Event {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

**Background**

Under high rates of scheduling failures, kube-scheduler can accumulate goroutines continuously and eventually experience significant memory growth or OOM.

For each scheduling failure, `Scheduler.handleSchedulingFailure` calls `fwk.EventRecorder().Eventf(...)` to emit a `FailedScheduling` Event. These Events are then processed by the `EventBroadcaster` write path, which creates a goroutine per Event without a concurrency bound.

The main execution path is:

```
Scheduler.scheduleOne
  └─ Scheduler.handleSchedulingFailure
       └─ fwk.EventRecorder().Eventf(..., "FailedScheduling", ..., msg)
            └─ client-go events.recorderImpl.Eventf
                 └─ EventBroadcaster watcher handler
                      └─ eventBroadcasterImpl.recordToSink
                           ├─ event.DeepCopy()
                           └─ go func()                 // one goroutine per Event
                                ├─ e.mu.Lock()          // shared event cache mutex
                                ├─ update/aggregate eventCache
                                └─ attemptRecording()
                                     └─ recordEvent()
                                          └─ EventSink.Create / Patch
                                               └─ apiserver Event API
```

The scheduler emits a failure Event from [schedule_one.go](https://github.com/kubernetes/kubernetes/blob/843726939e910e30714ae425d083cd91be4b2437/pkg/scheduler/schedule_one.go#L1282-L1283):

https://github.com/kubernetes/kubernetes/blob/843726939e910e30714ae425d083cd91be4b2437/pkg/scheduler/schedule_one.go#L1282-L1283



The unbounded goroutine creation happens in `eventBroadcasterImpl.recordToSink`:
https://github.com/kubernetes/kubernetes/blob/843726939e910e30714ae425d083cd91be4b2437/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go#L170-L197


In addition, EventSeries refresh and cleanup hold the same `e.mu` while issuing Event API requests. Slow Event writes or a large event cache can therefore extend lock hold times and amplify contention.

```
High FailedScheduling event rate
  → one goroutine created per Event
  → goroutines wait on mutex / rate limiter / Event API
  → Events and formatted messages remain retained
  → goroutine count and heap usage grow without bound
```

This PR prevents unbounded goroutine and memory growth in the events v1 broadcaster during event storms or when the API server is slow.


**kube-scheduler monitoring**

cpu usage:
<img width="2984" height="746" alt="image" src="https://github.com/user-attachments/assets/a3b54c53-1da1-4139-a31b-c80f4b1766dc" />

memory usage:
<img width="2986" height="752" alt="image" src="https://github.com/user-attachments/assets/54bbcf7d-7a4a-4963-8fb4-7ec9d893677a" />


goroutines:
<img width="1882" height="600" alt="image" src="https://github.com/user-attachments/assets/3f26a4a6-3bf5-4e3d-8b46-d6e52548204a" />


heap profiling:
<img width="3822" height="1246" alt="image" src="https://github.com/user-attachments/assets/04403ca6-f3d4-40db-98fe-831c4b38282c" />

cpu profiling:
<img width="3832" height="1730" alt="image" src="https://github.com/user-attachments/assets/e25a9d2c-d20c-4ea3-8647-2576731fe40a" />


goroutines profiling:

Error stack trace encountered while fetching kube-scheduler goroutines: goroutines profiling failed to fetch.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes https://github.com/kubernetes/kubernetes/issues/140393

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
