### PR TITLE
fix(kubectl): fix top pod --sum column alignment with --no-headers

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -22,7 +22,7 @@ import (
 	"slices"
 	"sort"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/cli-runtime/pkg/printers"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
@@ -110,14 +110,19 @@ func (printer *TopCmdPrinter) PrintPodMetrics(metrics []metricsapi.PodMetrics, p
 	defer w.Flush()
 
 	columnWidth := len(printer.podColumns)
+	if withNamespace {
+		columnWidth++
+	}
+	if printContainers {
+		columnWidth++
+	}
+
 	if !noHeaders {
 		if withNamespace {
 			printValue(w, NamespaceColumn)
-			columnWidth++
 		}
 		if printContainers {
 			printValue(w, PodColumn)
-			columnWidth++
 		}
 		printColumnNames(w, printer.podColumns)
 	}
@@ -131,7 +136,6 @@ func (printer *TopCmdPrinter) PrintPodMetrics(metrics []metricsapi.PodMetrics, p
 		} else {
 			printer.printSinglePodMetrics(w, &m, withNamespace, printer.measuredResources)
 		}
-
 	}
 
 	if sum {

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
@@ -367,6 +367,158 @@ test-1   400m         5120Mi
          800m         7168Mi          
 `,
 		},
+		{
+			name: "Multiple Pods - Sum with No Header",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			noHeader: true,
+			sum:      true,
+			expectedOutput: `test     200m       1024Mi     
+test-1   200m       2048Mi     
+         ________   ________   
+         400m       3072Mi     
+`,
+		},
+		{
+			name: "Multiple Pods - Sum with Namespace and No Header",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "ns-1",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: "ns-2",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			withNamespace: true,
+			noHeader:      true,
+			sum:           true,
+			expectedOutput: `ns-1   test     200m       1024Mi     
+ns-2   test-1   200m       2048Mi     
+                ________   ________   
+                400m       3072Mi     
+`,
+		},
+		{
+			name: "Multiple Pods - Sum with Containers and No Header",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			printContainers: true,
+			noHeader:        true,
+			sum:             true,
+			expectedOutput: `test   container1   200m       1024Mi     
+                    ________   ________   
+                    200m       1024Mi     
+`,
+		},
+		{
+			name: "Multiple Pods - Sum with Namespace, Containers and No Header",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "ns-1",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			withNamespace:   true,
+			printContainers: true,
+			noHeader:        true,
+			sum:             true,
+			expectedOutput: `ns-1   test   container1   200m       1024Mi     
+                           ________   ________   
+                           200m       1024Mi     
+`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The `columnWidth` calculation in `PrintPodMetrics` was previously placed inside the `if !noHeaders` block. When `--no-headers` was specified, `columnWidth` failed to account for optional columns (such as `--all-namespaces` or `--containers`), causing the summary line (`--sum`) to be misaligned to the left.

This commit moves the `columnWidth` calculation outside the `if !noHeaders` block so that table dimensions are accurately computed regardless of whether headers are printed.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The output of `kubectl top pod --sum -A --no-headers` is formatted incorrectly.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

##### Before 

```bash
z@dev:~$ kubectl top pod --sum -A
NAMESPACE            NAME                                                          CPU(cores)   MEMORY(bytes)   
botnow-one           web-console-79df587b58-l2plf                                  11m          105Mi           
botnow-runtimes      sandbox-rt-53jher                                             1m           9Mi             
botnow-runtimes      sandbox-rt-vlb0pf                                             1m           5Mi             
botnow-system        arcadia-apiserver-84cbddf9b4-p9b7g                            0m           30Mi            
zs-botnow-one        web-console-f6bc8d4b-gzfx6                                    11m          160Mi           
                                                                                   ________     ________        
                                                                                   1376m        8032Mi   


z@dev:~$ kubectl top pod --sum -A --no-headers
botnow-one           web-console-79df587b58-l2plf                                  12m        106Mi   
botnow-runtimes      sandbox-rt-vlb0pf                                             1m         6Mi     
botnow-system        minio-678c95c4f9-qpxhj                                        1m         564Mi   
zs-botnow-one        sandbox-runtime-operator-797d6b7db-nn7vb                      1m         18Mi    
zs-botnow-one        unoserver-6654d995b4-82nmc                                    1m         50Mi    
zs-botnow-one        web-console-f6bc8d4b-gzfx6                                    11m        160Mi   
                     ________                                                      ________   
                     1341m                                                         8087Mi
```

##### After

```bash
z@dev:~/workspace/kubernetes/_output/bin$ ./kubectl top pod --sum -A
NAMESPACE            NAME                                                          CPU(cores)   MEMORY(bytes)   
botnow-one           web-console-79df587b58-l2plf                                  10m          105Mi           
botnow-runtimes      sandbox-rt-vlb0pf                                             1m           5Mi             
zs-botnow-one        sandbox-runtime-operator-797d6b7db-nn7vb                      1m           19Mi            
zs-botnow-one        unoserver-6654d995b4-82nmc                                    1m           50Mi            
zs-botnow-one        web-console-f6bc8d4b-gzfx6                                    12m          160Mi           
                                                                                   ________     ________        
                                                                                   1417m        8229Mi


z@dev:~/workspace/kubernetes/_output/bin$ ./kubectl top pod --sum -A --no-headers
botnow-one           web-console-79df587b58-l2plf                                  9m         105Mi      
botnow-runtimes      sandbox-rt-vlb0pf                                             1m         6Mi        
botnow-system        minio-678c95c4f9-qpxhj                                        1m         564Mi      
zs-botnow-one        unoserver-6654d995b4-82nmc                                    1m         50Mi       
zs-botnow-one        web-console-f6bc8d4b-gzfx6                                    10m        160Mi      
                                                                                   ________   ________   
                                                                                   1414m      7944Mi
```
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix kubectl top pod --sum column alignment when --no-headers flag is specified.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
