### PR TITLE
DRA: drop AllocationTimestamp when DRADeviceBindingConditions is disa…

### DIFF
--- a/pkg/registry/resource/resourceclaim/strategy.go
+++ b/pkg/registry/resource/resourceclaim/strategy.go
@@ -412,6 +412,9 @@ func draDeviceBindingConditionsInUse(claim *resource.ResourceClaim) bool {
 		return false
 	}
 	if allocation := claim.Status.Allocation; allocation != nil {
+		if allocation.AllocationTimestamp != nil {
+			return true
+		}
 		for _, result := range allocation.Devices.Results {
 			if result.BindingConditions != nil || result.BindingFailureConditions != nil {
 				return true
@@ -454,6 +457,7 @@ func dropDeviceBindingConditionsFields(newClaim, oldClaim *resource.ResourceClai
 	}
 
 	if allocation := newClaim.Status.Allocation; allocation != nil {
+		newClaim.Status.Allocation.AllocationTimestamp = nil
 		for i := range allocation.Devices.Results {
 			newClaim.Status.Allocation.Devices.Results[i].BindingConditions = nil
 			newClaim.Status.Allocation.Devices.Results[i].BindingFailureConditions = nil

--- a/pkg/registry/resource/resourceclaim/strategy_test.go
+++ b/pkg/registry/resource/resourceclaim/strategy_test.go
@@ -369,6 +369,41 @@ var objWithSkipNodeOperationsStatus = &resource.ResourceClaim{
 	},
 }
 
+var objWithAllocationTimestamp = &resource.ResourceClaim{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "valid-claim",
+		Namespace: "kube-system",
+	},
+	Spec: resource.ResourceClaimSpec{
+		Devices: resource.DeviceClaim{
+			Requests: []resource.DeviceRequest{
+				{
+					Name: "req-0",
+					Exactly: &resource.ExactDeviceRequest{
+						DeviceClassName: "class",
+						AllocationMode:  resource.DeviceAllocationModeAll,
+					},
+				},
+			},
+		},
+	},
+	Status: resource.ResourceClaimStatus{
+		Allocation: &resource.AllocationResult{
+			Devices: resource.DeviceAllocationResult{
+				Results: []resource.DeviceRequestAllocationResult{
+					{
+						Request: "req-0",
+						Driver:  "dra.example.com",
+						Pool:    "pool-0",
+						Device:  "device-0",
+					},
+				},
+			},
+			AllocationTimestamp: &metav1.Time{},
+		},
+	},
+}
+
 var objWithCapacityRequests = &resource.ResourceClaim{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "valid-claim",
@@ -1518,6 +1553,39 @@ func TestStatusStrategyUpdate(t *testing.T) {
 				}
 			},
 			featureOverrides: featuregatetesting.FeatureOverrides{features.DRAOptionalNodeOperations: false},
+		},
+		"keep-fields-allocation-timestamp": {
+			oldObj:    obj,
+			newObj:    objWithAllocationTimestamp,
+			expectObj: objWithAllocationTimestamp,
+			verify: func(t *testing.T, as []testclient.Action) {
+				if len(as) != 0 {
+					t.Errorf("expected no action to be taken")
+				}
+			},
+			featureOverrides: featuregatetesting.FeatureOverrides{features.DRAResourceClaimDeviceStatus: true, features.DRADeviceBindingConditions: true},
+		},
+		"drop-fields-allocation-timestamp": {
+			oldObj:    obj,
+			newObj:    objWithAllocationTimestamp,
+			expectObj: objWithStatus,
+			verify: func(t *testing.T, as []testclient.Action) {
+				if len(as) != 0 {
+					t.Errorf("expected no action to be taken")
+				}
+			},
+			featureOverrides: featuregatetesting.FeatureOverrides{features.DRAResourceClaimDeviceStatus: true, features.DRADeviceBindingConditions: false},
+		},
+		"keep-exist-fields-allocation-timestamp-disable-feature-gate": {
+			oldObj:    objWithAllocationTimestamp,
+			newObj:    objWithAllocationTimestamp,
+			expectObj: objWithAllocationTimestamp,
+			verify: func(t *testing.T, as []testclient.Action) {
+				if len(as) != 0 {
+					t.Errorf("expected no action to be taken")
+				}
+			},
+			featureOverrides: featuregatetesting.FeatureOverrides{features.DRAResourceClaimDeviceStatus: true, features.DRADeviceBindingConditions: false},
 		},
 		"keep-fields-consumable-capacity-with-device-status": {
 			oldObj: func() *resource.ResourceClaim {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`dropDeviceBindingConditionsFields` in the ResourceClaim status strategy clears the feature-gated BindingConditions and BindingFailureConditions fields from each allocation result when the DRADeviceBindingConditions gate is disabled and the fields were not already in use. `AllocationResult.AllocationTimestamp` was added to the API in the same KEP (KEP-5007, #130160) and carries the same `DRADeviceBindingConditions,DRAResourceClaimDeviceStatus` feature-gate annotation, but it lives one level up on `AllocationResult` and was not included when the drop was introduced in #134964. As a result an apiserver with `DRADeviceBindingConditions` disabled can still persist allocationTimestamp, and `draDeviceBindingConditionsInUse` does not recognize it.

This PR drops `AllocationTimestamp` alongside the binding-condition fields and teaches `draDeviceBindingConditionsInUse` to treat an already-set timestamp as in use. The latter is required because `status.allocation` is immutable once set: without it, disabling the gate would strip the timestamp on an unrelated status update to an existing claim and the update would be rejected.

Gating the drop on `DRADeviceBindingConditions` alone (as the existing code does for the binding conditions) is sufficient because the companion `DRAResourceClaimDeviceStatus` gate is GA and locked to its default, so it cannot be disabled. The scheduler stamps the timestamp only when the gate is enabled, so in a single-version cluster this is defense-in-depth; the field can only appear with the gate disabled under version skew which is the same risk profile as the binding-condition fields it is dropped with.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A. 
Related precedent: #134964 (introduced `dropDeviceBindingConditionsFields`).

#### Special notes for your reviewer:

AllocationTimestamp is dropped inside `dropDeviceBindingConditionsFields` rather than in a new helper because it shares the `DRADeviceBindingConditions` gate with the binding-condition fields already handled there. The added tests mirror the existing *-binding-conditions cases in TestStatusStrategyUpdate (keep when enabled, drop when disabled, keep when disabled but already set).

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
KEP-5007: https://kep.k8s.io/5007

```

/sig scheduling
/wg device-management
