### PR TITLE
cli-runtime: include group in resource-not-found error message

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -807,6 +807,9 @@ func (b *Builder) mappingFor(resourceOrKindArg string) (*meta.RESTMapping, error
 		// if the error is _not_ a *meta.NoKindMatchError, then we had trouble doing discovery,
 		// so we should return the original error since it may help a user diagnose what is actually wrong
 		if meta.IsNoMatchError(err) {
+			if len(groupResource.Group) > 0 {
+				return nil, fmt.Errorf("the server doesn't have a resource type %q in group %q", groupResource.Resource, groupResource.Group)
+			}
 			return nil, fmt.Errorf("the server doesn't have a resource type %q", groupResource.Resource)
 		}
 		return nil, err

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -1361,6 +1361,21 @@ func TestNoSelectorUnknowResourceType(t *testing.T) {
 		}
 	}
 }
+
+func TestNoSelectorUnknownResourceTypeWithGroup(t *testing.T) {
+	b := newDefaultBuilder().
+		NamespaceParam("test").
+		ResourceTypeOrNameArgs(false, "unknown.somegroup")
+
+	err := b.Do().Err()
+	if err != nil {
+		if !strings.Contains(err.Error(), "server doesn't have a resource type \"unknown\" in group \"somegroup\"") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	} else {
+		t.Fatalf("expected error, got nil")
+	}
+}
 func TestSingleResourceType(t *testing.T) {
 	b := newDefaultBuilder().
 		LabelSelectorParam("a=b").


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a resource argument includes a group qualifier (for example, `kubectl get pdb.hpa`), `mappingFor()` discarded the group name when handling a `meta.NoMatchError`. As a result, kubectl returned the following error:

```
the server doesn't have a resource type "pdb"
```

This PR preserves the group name when available so the error message becomes:

```
the server doesn't have a resource type "pdb" in group "hpa"
```

This provides a more accurate and helpful error message for users.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubectl/issues/1865

#### Special notes for your reviewer:

- Updated `mappingFor()` to preserve the group name in `meta.NoMatchError`.
- Added `TestNoSelectorUnknownResourceTypeWithGroup` to verify the new behavior.

#### Does this PR introduce a user-facing change?

```release-note
kubectl now includes the API group in resource-not-found error messages when a group-qualified resource is specified.
```