### PR TITLE
[KUBELET]: Filter scoped link-local DNS servers

### DIFF
--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -382,6 +383,19 @@ func appendDNSConfig(existingDNSConfig *runtimeapi.DNSConfig, dnsConfig *v1.PodD
 	return existingDNSConfig
 }
 
+func filterScopedLinkLocalNameservers(logger klog.Logger, nameservers []string) []string {
+	filteredNameservers := nameservers[:0]
+	for _, nameserver := range nameservers {
+		addr, err := netip.ParseAddr(nameserver)
+		if err == nil && addr.Is6() && addr.IsLinkLocalUnicast() && addr.Zone() != "" {
+			logger.V(4).Info("Removed inherited scoped IPv6 link-local nameserver from pod DNS config", "nameserver", nameserver)
+			continue
+		}
+		filteredNameservers = append(filteredNameservers, nameserver)
+	}
+	return filteredNameservers
+}
+
 // GetPodDNS returns DNS settings for the pod.
 func (c *Configurer) GetPodDNS(ctx context.Context, pod *v1.Pod) (*runtimeapi.DNSConfig, error) {
 	logger := klog.FromContext(ctx)
@@ -440,6 +454,14 @@ func (c *Configurer) GetPodDNS(ctx context.Context, pod *v1.Pod) (*runtimeapi.DN
 				dnsConfig.Servers = append(dnsConfig.Servers, "127.0.0.1")
 			}
 			dnsConfig.Searches = []string{"."}
+		}
+
+		if !kubecontainer.IsHostNetworkPod(pod) {
+			originalServerCount := len(dnsConfig.Servers)
+			dnsConfig.Servers = filterScopedLinkLocalNameservers(logger, dnsConfig.Servers)
+			if originalServerCount > 0 && len(dnsConfig.Servers) == 0 {
+				logger.Info("No inherited nameservers remain after filtering scoped IPv6 link-local addresses", "pod", klog.KObj(pod))
+			}
 		}
 	}
 

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -387,6 +387,9 @@ func filterScopedLinkLocalNameservers(logger klog.Logger, nameservers []string) 
 	filteredNameservers := nameservers[:0]
 	for _, nameserver := range nameservers {
 		addr, err := netip.ParseAddr(nameserver)
+		// Remove only inherited scoped IPv6 link-local nameservers that can be
+		// positively identified; preserve unparsable values rather than dropping
+		// unexpected valid resolver syntax.
 		if err == nil && addr.Is6() && addr.IsLinkLocalUnicast() && addr.Zone() != "" {
 			logger.V(4).Info("Removed inherited scoped IPv6 link-local nameserver from pod DNS config", "nameserver", nameserver)
 			continue
@@ -403,6 +406,7 @@ func (c *Configurer) GetPodDNS(ctx context.Context, pod *v1.Pod) (*runtimeapi.DN
 	if err != nil {
 		return nil, err
 	}
+	allInheritedNameserversFiltered := false
 
 	dnsType, err := getPodDNSType(pod)
 	if err != nil {
@@ -459,14 +463,15 @@ func (c *Configurer) GetPodDNS(ctx context.Context, pod *v1.Pod) (*runtimeapi.DN
 		if !kubecontainer.IsHostNetworkPod(pod) {
 			originalServerCount := len(dnsConfig.Servers)
 			dnsConfig.Servers = filterScopedLinkLocalNameservers(logger, dnsConfig.Servers)
-			if originalServerCount > 0 && len(dnsConfig.Servers) == 0 {
-				logger.Info("No inherited nameservers remain after filtering scoped IPv6 link-local addresses", "pod", klog.KObj(pod))
-			}
+			allInheritedNameserversFiltered = originalServerCount > 0 && len(dnsConfig.Servers) == 0
 		}
 	}
 
 	if pod.Spec.DNSConfig != nil {
 		dnsConfig = appendDNSConfig(dnsConfig, pod.Spec.DNSConfig)
+	}
+	if allInheritedNameserversFiltered && len(dnsConfig.Servers) == 0 {
+		logger.Error(nil, "All inherited nameservers were scoped IPv6 link-local addresses and were removed; no nameservers remain for pod DNS", "pod", klog.KObj(pod), "resolverConfig", c.ResolverConfig)
 	}
 	return c.formDNSConfigFitsLimits(logger, dnsConfig, pod), nil
 }

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	netutils "k8s.io/utils/net"
@@ -109,6 +110,58 @@ func TestParseResolvConf(t *testing.T) {
 		} else {
 			require.Error(t, err, "tc.searches %v", tc.searches)
 		}
+	}
+}
+
+func TestFilterScopedLinkLocalNameservers(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	testCases := []struct {
+		desc                string
+		nameservers         []string
+		expectedNameservers []string
+	}{
+		{
+			desc:                "IPv4 nameserver is preserved",
+			nameservers:         []string{"1.1.1.1"},
+			expectedNameservers: []string{"1.1.1.1"},
+		},
+		{
+			desc:                "global IPv6 nameserver is preserved",
+			nameservers:         []string{"2001:4860:4860::8888"},
+			expectedNameservers: []string{"2001:4860:4860::8888"},
+		},
+		{
+			desc:                "scoped link-local IPv6 with numeric zone is removed",
+			nameservers:         []string{"fe80::1%3"},
+			expectedNameservers: []string{},
+		},
+		{
+			desc:                "scoped link-local IPv6 with named zone is removed",
+			nameservers:         []string{"fe80::1%eth0"},
+			expectedNameservers: []string{},
+		},
+		{
+			desc:                "unscoped link-local IPv6 is outside the filter scope",
+			nameservers:         []string{"fe80::1"},
+			expectedNameservers: []string{"fe80::1"},
+		},
+		{
+			desc:                "mixed nameservers remove only scoped link-local IPv6",
+			nameservers:         []string{"1.1.1.1", "fe80::1%3", "2001:4860:4860::8888"},
+			expectedNameservers: []string{"1.1.1.1", "2001:4860:4860::8888"},
+		},
+		{
+			desc:                "malformed input is preserved",
+			nameservers:         []string{"not-an-ip"},
+			expectedNameservers: []string{"not-an-ip"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			nameservers := append([]string{}, tc.nameservers...)
+			assert.Equal(t, tc.expectedNameservers, filterScopedLinkLocalNameservers(logger, nameservers))
+		})
 	}
 }
 
@@ -544,6 +597,135 @@ func TestGetPodDNS(t *testing.T) {
 		t.Errorf("expected prepend of cluster domain, got %+v", options[2].DNSSearch)
 	} else if options[2].DNSSearch[0] != ".svc."+configurer.ClusterDomain {
 		t.Errorf("expected domain %s, got %s", ".svc."+configurer.ClusterDomain, options[0].DNSSearch)
+	}
+}
+
+func TestGetPodDNSFiltersScopedLinkLocalNameservers(t *testing.T) {
+	ctx := ktesting.Init(t)
+	recorder := record.NewFakeRecorder(20)
+	nodeRef := &v1.ObjectReference{
+		Kind:      "Node",
+		Name:      string("testNode"),
+		UID:       types.UID("testNode"),
+		Namespace: "",
+	}
+	testPodNamespace := "testNS"
+	testClusterNameserver := "10.0.0.10"
+	testClusterDNSDomain := "kubernetes.io"
+	testSvcDomain := fmt.Sprintf("svc.%s", testClusterDNSDomain)
+	testNsSvcDomain := fmt.Sprintf("%s.svc.%s", testPodNamespace, testClusterDNSDomain)
+	defaultHostNameservers := []string{"1.1.1.1", "fe80::1%3", "2001:4860:4860::8888"}
+	configurer := NewConfigurer(recorder, nodeRef, nil, []net.IP{netutils.ParseIPSloppy(testClusterNameserver)}, testClusterDNSDomain, defaultResolvConf)
+
+	testCases := []struct {
+		desc              string
+		hostnetwork       bool
+		dnsPolicy         v1.DNSPolicy
+		hostNameservers   []string
+		dnsConfig         *v1.PodDNSConfig
+		expectedDNSConfig *runtimeapi.DNSConfig
+	}{
+		{
+			desc:            "DNSDefault without host network filters inherited scoped link-local IPv6 in podDNSHost path",
+			dnsPolicy:       v1.DNSDefault,
+			hostNameservers: defaultHostNameservers,
+			expectedDNSConfig: &runtimeapi.DNSConfig{
+				Servers:  []string{"1.1.1.1", "2001:4860:4860::8888"},
+				Searches: []string{testHostDomain},
+			},
+		},
+		{
+			desc:            "DNSDefault with host network preserves inherited scoped link-local IPv6",
+			hostnetwork:     true,
+			dnsPolicy:       v1.DNSDefault,
+			hostNameservers: defaultHostNameservers,
+			expectedDNSConfig: &runtimeapi.DNSConfig{
+				Servers:  defaultHostNameservers,
+				Searches: []string{testHostDomain},
+			},
+		},
+		{
+			desc:            "DNSClusterFirst is not filtered",
+			dnsPolicy:       v1.DNSClusterFirst,
+			hostNameservers: defaultHostNameservers,
+			expectedDNSConfig: &runtimeapi.DNSConfig{
+				Servers:  []string{testClusterNameserver},
+				Searches: []string{testNsSvcDomain, testSvcDomain, testClusterDNSDomain, testHostDomain},
+				Options:  defaultDNSOptions,
+			},
+		},
+		{
+			desc:            "DNSClusterFirstWithHostNet is not filtered",
+			hostnetwork:     true,
+			dnsPolicy:       v1.DNSClusterFirstWithHostNet,
+			hostNameservers: defaultHostNameservers,
+			expectedDNSConfig: &runtimeapi.DNSConfig{
+				Servers:  []string{testClusterNameserver},
+				Searches: []string{testNsSvcDomain, testSvcDomain, testClusterDNSDomain, testHostDomain},
+				Options:  defaultDNSOptions,
+			},
+		},
+		{
+			desc:            "DNSNone is not filtered",
+			dnsPolicy:       v1.DNSNone,
+			hostNameservers: defaultHostNameservers,
+			expectedDNSConfig: &runtimeapi.DNSConfig{
+				Servers:  nil,
+				Searches: nil,
+				Options:  nil,
+			},
+		},
+		{
+			desc:            "DNSDefault without host network filters all inherited scoped link-local IPv6 nameservers",
+			dnsPolicy:       v1.DNSDefault,
+			hostNameservers: []string{"fe80::1%3", "fe80::2%eth0"},
+			expectedDNSConfig: &runtimeapi.DNSConfig{
+				Servers:  []string{},
+				Searches: []string{testHostDomain},
+			},
+		},
+		{
+			desc:            "explicit scoped link-local IPv6 nameserver is not filtered",
+			dnsPolicy:       v1.DNSDefault,
+			hostNameservers: []string{"fe80::1%3"},
+			dnsConfig: &v1.PodDNSConfig{
+				Nameservers: []string{"fe80::2%eth0"},
+			},
+			expectedDNSConfig: &runtimeapi.DNSConfig{
+				Servers:  []string{"fe80::2%eth0"},
+				Searches: []string{testHostDomain},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			configurer.getHostDNSConfig = func(klog.Logger, string) (*runtimeapi.DNSConfig, error) {
+				return &runtimeapi.DNSConfig{
+					Servers:  append([]string{}, tc.hostNameservers...),
+					Searches: []string{testHostDomain},
+				}, nil
+			}
+			testPod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test_pod",
+					Namespace: testPodNamespace,
+				},
+				Spec: v1.PodSpec{
+					DNSConfig:   tc.dnsConfig,
+					DNSPolicy:   tc.dnsPolicy,
+					HostNetwork: tc.hostnetwork,
+				},
+			}
+
+			resDNSConfig, err := configurer.GetPodDNS(ctx, testPod)
+			if err != nil {
+				t.Errorf("%s: GetPodDNS(%v), unexpected error: %v", tc.desc, testPod, err)
+			}
+			if !dnsConfigsAreEqual(resDNSConfig, tc.expectedDNSConfig) {
+				t.Errorf("%s: GetPodDNS(%v)=%v, want %v", tc.desc, testPod, resDNSConfig, tc.expectedDNSConfig)
+			}
+		})
 	}
 }
 

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/kubernetes/test/utils/ktesting/initoption"
 	netutils "k8s.io/utils/net"
 
 	"github.com/stretchr/testify/assert"
@@ -601,7 +602,6 @@ func TestGetPodDNS(t *testing.T) {
 }
 
 func TestGetPodDNSFiltersScopedLinkLocalNameservers(t *testing.T) {
-	ctx := ktesting.Init(t)
 	recorder := record.NewFakeRecorder(20)
 	nodeRef := &v1.ObjectReference{
 		Kind:      "Node",
@@ -624,6 +624,8 @@ func TestGetPodDNSFiltersScopedLinkLocalNameservers(t *testing.T) {
 		hostNameservers   []string
 		dnsConfig         *v1.PodDNSConfig
 		expectedDNSConfig *runtimeapi.DNSConfig
+		expectedLog       string
+		unexpectedLog     string
 	}{
 		{
 			desc:            "DNSDefault without host network filters inherited scoped link-local IPv6 in podDNSHost path",
@@ -683,9 +685,10 @@ func TestGetPodDNSFiltersScopedLinkLocalNameservers(t *testing.T) {
 				Servers:  []string{},
 				Searches: []string{testHostDomain},
 			},
+			expectedLog: "All inherited nameservers were scoped IPv6 link-local addresses and were removed; no nameservers remain for pod DNS",
 		},
 		{
-			desc:            "explicit scoped link-local IPv6 nameserver is not filtered",
+			desc:            "explicit scoped link-local IPv6 nameserver replaces empty inherited nameservers",
 			dnsPolicy:       v1.DNSDefault,
 			hostNameservers: []string{"fe80::1%3"},
 			dnsConfig: &v1.PodDNSConfig{
@@ -695,11 +698,13 @@ func TestGetPodDNSFiltersScopedLinkLocalNameservers(t *testing.T) {
 				Servers:  []string{"fe80::2%eth0"},
 				Searches: []string{testHostDomain},
 			},
+			unexpectedLog: "All inherited nameservers were scoped IPv6 link-local addresses and were removed; no nameservers remain for pod DNS",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			ctx := ktesting.Init(t, initoption.BufferLogs(true))
 			configurer.getHostDNSConfig = func(klog.Logger, string) (*runtimeapi.DNSConfig, error) {
 				return &runtimeapi.DNSConfig{
 					Servers:  append([]string{}, tc.hostNameservers...),
@@ -724,6 +729,18 @@ func TestGetPodDNSFiltersScopedLinkLocalNameservers(t *testing.T) {
 			}
 			if !dnsConfigsAreEqual(resDNSConfig, tc.expectedDNSConfig) {
 				t.Errorf("%s: GetPodDNS(%v)=%v, want %v", tc.desc, testPod, resDNSConfig, tc.expectedDNSConfig)
+			}
+
+			underlier, ok := ctx.Logger().GetSink().(ktesting.Underlier)
+			if !ok {
+				t.Fatalf("expected ktesting LogSink, got %T", ctx.Logger().GetSink())
+			}
+			logs := underlier.GetBuffer().String()
+			if tc.expectedLog != "" && !strings.Contains(logs, tc.expectedLog) {
+				t.Errorf("%s: expected logs to contain %q, got %q", tc.desc, tc.expectedLog, logs)
+			}
+			if tc.unexpectedLog != "" && strings.Contains(logs, tc.unexpectedLog) {
+				t.Errorf("%s: expected logs not to contain %q, got %q", tc.desc, tc.unexpectedLog, logs)
 			}
 		})
 	}


### PR DESCRIPTION
## What type of PR is this?

/kind bug
/sig node
/area kubelet

## What this PR does / why we need it

Fixes an issue where kubelet propagates unusable scoped IPv6 link-local nameservers into pods using `dnsPolicy: Default`.

Today, when kubelet reads the node's resolver configuration, nameserver entries are copied into the pod's `/etc/resolv.conf` verbatim. If the node contains a scoped IPv6 link-local nameserver such as:

```text
nameserver fe80::29c:2ff:fea9:fdd0%3
```

that exact value is written into every `dnsPolicy: Default` pod.

The scope (`%3` in this example) refers to an interface index that only exists in the node's network namespace. Regular pods run in their own network namespace, so the scoped address cannot be used from inside the pod, resulting in DNS failures such as:

- `network unreachable`
- `invalid argument`

This also affects workloads (such as CoreDNS when configured with `dnsPolicy: Default`) that inherit the node resolver configuration and forward DNS queries using `/etc/resolv.conf`.

### This change

This PR filters inherited scoped IPv6 link-local nameservers **only** for pods that satisfy:

- `dnsPolicy: Default`
- `hostNetwork: false`

The filtering removes nameservers that:

- are IPv6
- are link-local unicast (`fe80::/10`)
- contain a scope zone (for example `%3` or `%eth0`)

Examples:

| Nameserver | Result |
|------------|--------|
| `1.1.1.1` | ✅ preserved |
| `2001:4860:4860::8888` | ✅ preserved |
| `fe80::1` | ✅ preserved |
| `fe80::1%3` | ❌ removed |
| `fe80::1%eth0` | ❌ removed |

Host-network pods are **not** modified because they share the node network namespace and can legitimately use scoped link-local addresses.

The filtering is performed in the kubelet pod DNS generation flow rather than in `parseResolvConf()`, keeping the resolver parser responsible only for parsing while making the filtering decision where pod networking context is available.

## Which issue(s) this PR fixes

Fixes #140844

## Special notes for your reviewer

### Unit tests

Added unit tests covering:

- IPv4 nameservers are preserved.
- Global IPv6 nameservers are preserved.
- Scoped IPv6 link-local nameservers with numeric zones are removed.
- Scoped IPv6 link-local nameservers with interface-name zones are removed.
- Unscoped IPv6 link-local nameservers are preserved.
- Mixed nameserver lists only remove the scoped link-local entries.
- Malformed nameserver values remain unchanged.
- `dnsPolicy: Default` with `hostNetwork: false` filters inherited scoped IPv6 link-local nameservers.
- `dnsPolicy: Default` with `hostNetwork: true` preserves them.
- Other DNS policies retain their existing behaviour.

### Manual validation

Built kubelet from this branch and configured it to use a resolver file containing:

```text
nameserver 1.1.1.1
nameserver fe80::29c:2ff:fea9:fdd0%3
nameserver 2001:4860:4860::8888
options timeout:1 attempts:1
```

#### Scenario 1

Pod configuration:

```yaml
dnsPolicy: Default
hostNetwork: false
```

Result:

```text
nameserver 1.1.1.1
nameserver 2001:4860:4860::8888
options attempts:1 timeout:1
```

The scoped IPv6 link-local nameserver was correctly removed.

#### Scenario 2

Pod configuration:

```yaml
dnsPolicy: Default
hostNetwork: true
```

Result:

```text
nameserver 1.1.1.1
nameserver fe80::29c:2ff:fea9:fdd0%3
nameserver 2001:4860:4860::8888
options timeout:1 attempts:1
```

The scoped IPv6 link-local nameserver was correctly preserved because the pod shares the host network namespace.

These tests verify that:

- only normal `dnsPolicy: Default` pods are filtered,
- host-network pods retain the existing behaviour,
- IPv4 and global IPv6 nameservers remain unchanged.

## Does this PR introduce a user-facing change?

```release-note
Fixed kubelet so that pods using `dnsPolicy: Default` no longer inherit scoped IPv6 link-local nameservers (for example `fe80::1%3`) from the node resolver configuration unless the pod uses the host network namespace.
```