### PR TITLE
kubelet: detach probe workers from the pod sync context

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -187,6 +187,18 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 	defer m.workerLock.Unlock()
 
 	logger := klog.FromContext(ctx)
+	// Detach the workers' context from the caller's: the pod worker cancels the
+	// sync context when the pod begins terminating, but probe workers must keep
+	// probing until the container stops so a failing readiness probe can mark
+	// the pod NotReady during graceful termination. Workers are stopped
+	// explicitly via their stop channel (RemovePod/CleanupPods).
+	//
+	// TODO(#140977): This also means nothing cancels an in-flight probe. worker.stop()
+	// only signals stopCh, which is checked between probes, so an exec probe that is
+	// already running keeps executing in a container that is being killed until its
+	// own TimeoutSeconds elapses. The fix is a per-worker cancellable context
+	// cancelled by stop(), not the pod sync context, which cancels too early.
+	ctx = context.WithoutCancel(ctx)
 	key := probeKey{podUID: pod.UID}
 	for _, c := range append(pod.Spec.Containers, getRestartableInitContainers(pod)...) {
 		key.containerName = c.Name

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package prober
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
@@ -769,5 +771,60 @@ func cleanup(t ktesting.TB, m *manager) {
 	}
 	if err := wait.Poll(interval, wait.ForeverTestTimeout, condition); err != nil {
 		t.Fatalf("Error during cleanup: %v", err)
+	}
+}
+
+// ctxAwareRunner implements kubecontainer.CommandRunner and fails once the
+// probe context is canceled, like a real CRI runtime client.
+type ctxAwareRunner struct{}
+
+func (r ctxAwareRunner) RunInContainer(ctx context.Context, id kubecontainer.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return []byte("ok"), nil
+}
+
+// TestProbeWorkersSurviveSyncContextCancellation verifies that probe workers
+// keep probing after the context passed to AddPod is canceled. The pod worker
+// cancels its sync context when a pod begins terminating, and readiness probes
+// must keep executing through termination so a failing probe can mark the pod
+// NotReady. Regression test for https://github.com/kubernetes/kubernetes/issues/140881.
+func TestProbeWorkersSurviveSyncContextCancellation(t *testing.T) {
+	ktesting.Init(t).SyncTest("", testProbeWorkersSurviveSyncContextCancellation)
+}
+
+func testProbeWorkersSurviveSyncContextCancellation(tCtx ktesting.TContext) {
+	t := tCtx.TB()
+	logger := tCtx.Logger()
+	testPod := getTestPod()
+	setTestProbe(testPod, readiness, v1.Probe{})
+	m := newTestManager()
+	defer cleanup(t, m)
+
+	// Probe through the real exec prober backed by a runner that honors
+	// context cancellation, mirroring how CRI ExecSync fails once its
+	// context is canceled.
+	m.prober = newProber(ctxAwareRunner{}, &record.FakeRecorder{})
+
+	m.statusManager.SetPodStatus(logger, testPod, getTestRunningStatus())
+
+	ctx, cancel := context.WithCancel(tCtx)
+	m.AddPod(ctx, testPod)
+	// Simulate the pod worker canceling the sync context at the start of
+	// pod termination.
+	cancel()
+
+	// The readiness worker seeds the result cache with Failure for a new
+	// container, then must record Success from an actual probe execution.
+	for {
+		select {
+		case update := <-m.readinessManager.Updates():
+			if update.Result == results.Success {
+				return
+			}
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Fatal("Probe worker recorded no probe result after the sync context was canceled; probes are likely being canceled by pod termination")
+		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression
/sig node

#### What this PR does / why we need it:

Since #130487 (v1.35.0), probe workers inherit the pod worker's sync context via `probeManager.AddPod(ctx, pod)`. The pod worker cancels that context as soon as a pod begins terminating ("Cancelling current pod sync"), so every subsequent exec probe fails with `rpc error: code = Canceled desc = context canceled`, `doProbe` discards the errored result, and the pod's Ready condition stays frozen for the entire graceful termination. Before #130487 the workers ran on `context.Background()` and readiness probes kept working during shutdown.

This PR detaches the workers' context with `context.WithoutCancel`, preserving the logger and trace values. Worker lifecycle is unchanged: workers are stopped explicitly via their stop channel (`RemovePod`/`CleanupPods`).

Verified on kind with a v1.35.0 kubelet carrying this change: a pod with an exec readiness probe (period 1s, failureThreshold 1) whose probe starts failing on SIGTERM flips Ready to False 1s after `kubectl delete`, where stock v1.35.0 stays Ready=True for the full 60s grace period. Full test matrix and `--v=4` logs in #140881.

The regression test probes through the real exec prober backed by a `CommandRunner` that honors context cancellation (mirroring CRI `ExecSync`), and fails without the fix.

#### Which issue(s) this PR is related to:

Fixes #140881

Related: #124648, #116965, #139167

#### Special notes for your reviewer:

Only exec probes are affected by the regression; the HTTP, TCP, and gRPC probers do not take the probe context. The `ready = !workerExists` latching issue discussed in #116965 is real but separate; fixing it is only observable once this lands.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a v1.35 regression where exec readiness probes stopped executing (failing with "context canceled") once a pod began graceful termination, leaving the pod's Ready condition frozen during shutdown.
```
