### PR TITLE
kubelet/dra: expire device health at its deadline

### DIFF
--- a/pkg/kubelet/cm/dra/healthinfo.go
+++ b/pkg/kubelet/cm/dra/healthinfo.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/kubelet/cm/dra/state"
+	"k8s.io/utils/clock"
 )
 
 const (
@@ -49,6 +50,7 @@ type healthInfoCache struct {
 	sync.RWMutex
 	HealthInfo *state.DevicesHealthMap
 	stateFile  string
+	clock      clock.Clock
 }
 
 // newHealthInfoCache creates a new cache, loading from a checkpoint if present.
@@ -57,6 +59,7 @@ func newHealthInfoCache(logger klog.Logger, stateFile string) (*healthInfoCache,
 	cache := &healthInfoCache{
 		HealthInfo: &state.DevicesHealthMap{},
 		stateFile:  stateFile,
+		clock:      clock.RealClock{},
 	}
 	if err := cache.loadFromCheckpoint(); err != nil {
 		logger.Error(err, "Failed to load health checkpoint, proceeding with empty cache")
@@ -143,7 +146,7 @@ func (cache *healthInfoCache) getHealthInfo(driverName, poolName, deviceName str
 	}
 
 	_ = cache.withRLock(func() error {
-		now := time.Now()
+		now := cache.clock.Now()
 		if driver, ok := (*cache.HealthInfo)[driverName]; ok {
 			key := poolName + "/" + deviceName
 			if device, ok := driver.Devices[key]; ok {
@@ -175,7 +178,7 @@ func (cache *healthInfoCache) updateHealthInfo(logger klog.Logger, driverName st
 	logger = logger.WithName("dra-healthinfo")
 	changedDevices := []state.DeviceHealth{}
 	err := cache.withLock(func() error {
-		now := time.Now()
+		now := cache.clock.Now()
 		currentDriver, exists := (*cache.HealthInfo)[driverName]
 		if !exists {
 			currentDriver = state.DriverHealthState{Devices: make(map[string]state.DeviceHealth)}
@@ -257,6 +260,55 @@ func (cache *healthInfoCache) updateHealthInfo(logger klog.Logger, driverName st
 		return nil, err
 	}
 	return changedDevices, nil
+}
+
+// expireHealthInfo removes devices whose health report has expired and returns
+// the state changes together with the next expiration deadline.
+func (cache *healthInfoCache) expireHealthInfo(logger klog.Logger) (map[string][]state.DeviceHealth, time.Time) {
+	logger = logger.WithName("dra-healthinfo")
+	expiredDevices := make(map[string][]state.DeviceHealth)
+	var nextExpiration time.Time
+
+	_ = cache.withLock(func() error {
+		now := cache.clock.Now()
+		stateChanged := false
+		for driverName, driver := range *cache.HealthInfo {
+			for key, device := range driver.Devices {
+				timeout := device.HealthCheckTimeout
+				if timeout == 0 {
+					timeout = DefaultHealthTimeout
+				}
+				deadline := device.LastUpdated.Add(timeout)
+				if deadline.After(now) {
+					if nextExpiration.IsZero() || deadline.Before(nextExpiration) {
+						nextExpiration = deadline
+					}
+					continue
+				}
+
+				if device.Health != state.DeviceHealthStatusUnknown {
+					device.Health = state.DeviceHealthStatusUnknown
+					device.Message = ""
+					expiredDevices[driverName] = append(expiredDevices[driverName], device)
+				}
+				delete(driver.Devices, key)
+				stateChanged = true
+			}
+			if len(driver.Devices) == 0 {
+				delete(*cache.HealthInfo, driverName)
+				stateChanged = true
+			}
+		}
+
+		if stateChanged {
+			if err := cache.saveToCheckpointInternal(logger); err != nil {
+				logger.Error(err, "Failed to save health checkpoint after device health expiration; kubelet restart may lose device health information")
+			}
+		}
+		return nil
+	})
+
+	return expiredDevices, nextExpiration
 }
 
 // clearDriver clears all health data for a specific driver.

--- a/pkg/kubelet/cm/dra/healthinfo_test.go
+++ b/pkg/kubelet/cm/dra/healthinfo_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/kubernetes/pkg/kubelet/cm/dra/state"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	clocktesting "k8s.io/utils/clock/testing"
 )
 
 const (
@@ -353,11 +354,46 @@ func TestGetHealthInfoRobust(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cache := &healthInfoCache{HealthInfo: tt.initialState}
+			cache := &healthInfoCache{HealthInfo: tt.initialState, clock: clocktesting.NewFakeClock(time.Now())}
 			health := cache.getHealthInfo(tt.driverName, tt.poolName, tt.deviceName).Health
 			assert.Equal(t, tt.expectedHealth, health)
 		})
 	}
+}
+
+func TestExpireHealthInfo(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	now := time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC)
+	fakeClock := clocktesting.NewFakeClock(now)
+	cache, err := newHealthInfoCache(logger, "")
+	require.NoError(t, err)
+	cache.clock = fakeClock
+
+	_, err = cache.updateHealthInfo(logger, testDriver, []state.DeviceHealth{
+		{PoolName: testPool, DeviceName: "first", Health: state.DeviceHealthStatusHealthy, Message: "fresh", HealthCheckTimeout: time.Second},
+		{PoolName: testPool, DeviceName: "second", Health: state.DeviceHealthStatusUnhealthy, Message: "still fresh", HealthCheckTimeout: 2 * time.Second},
+	})
+	require.NoError(t, err)
+
+	expired, nextExpiration := cache.expireHealthInfo(logger)
+	assert.Empty(t, expired)
+	assert.Equal(t, now.Add(time.Second), nextExpiration)
+
+	fakeClock.Step(time.Second)
+	expired, nextExpiration = cache.expireHealthInfo(logger)
+	require.Len(t, expired[testDriver], 1)
+	assert.Equal(t, "first", expired[testDriver][0].DeviceName)
+	assert.Equal(t, state.DeviceHealthStatusUnknown, expired[testDriver][0].Health)
+	assert.Empty(t, expired[testDriver][0].Message)
+	assert.Equal(t, now.Add(2*time.Second), nextExpiration)
+	assert.NotContains(t, (*cache.HealthInfo)[testDriver].Devices, testPool+"/first")
+
+	fakeClock.Step(time.Second)
+	expired, nextExpiration = cache.expireHealthInfo(logger)
+	require.Len(t, expired[testDriver], 1)
+	assert.Equal(t, "second", expired[testDriver][0].DeviceName)
+	assert.True(t, nextExpiration.IsZero())
+	assert.NotContains(t, *cache.HealthInfo, testDriver)
 }
 
 // TestUpdateHealthInfo tests adding, updating, and reconciling device health.

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/component-base/metrics"
 	"k8s.io/dynamic-resource-allocation/resourceclaim"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 
 	drahealthv1 "k8s.io/kubelet/pkg/apis/dra-health/v1"
 	drapb "k8s.io/kubelet/pkg/apis/dra/v1"
@@ -110,6 +111,10 @@ type Manager struct {
 
 	// update channel for resource updates
 	update chan resourceupdates.Update
+
+	// healthInfoUpdated prevents the expiration loop from sleeping past a
+	// deadline that was changed by a new report.
+	healthInfoUpdated chan struct{}
 }
 
 // NewManager creates a new DRA manager.
@@ -137,13 +142,14 @@ func NewManager(logger klog.Logger, kubeClient clientset.Interface, stateFileDir
 	reconcilePeriod := defaultReconcilePeriod
 
 	manager := &Manager{
-		cache:           claimInfoCache,
-		kubeClient:      kubeClient,
-		reconcilePeriod: reconcilePeriod,
-		activePods:      nil,
-		sourcesReady:    nil,
-		healthInfoCache: healthInfoCache,
-		update:          make(chan resourceupdates.Update, 100),
+		cache:             claimInfoCache,
+		kubeClient:        kubeClient,
+		reconcilePeriod:   reconcilePeriod,
+		activePods:        nil,
+		sourcesReady:      nil,
+		healthInfoCache:   healthInfoCache,
+		update:            make(chan resourceupdates.Update, 100),
+		healthInfoUpdated: make(chan struct{}, 1),
 	}
 
 	return manager, nil
@@ -174,6 +180,7 @@ func (m *Manager) Start(ctx context.Context, activePods ActivePodsFunc, getNode 
 	m.activePods = activePods
 	m.sourcesReady = sourcesReady
 	go wait.UntilWithContext(ctx, func(ctx context.Context) { m.reconcileLoop(ctx) }, m.reconcilePeriod)
+	go m.runHealthInfoExpirationLoop(ctx)
 	return nil
 }
 
@@ -1063,6 +1070,90 @@ func buildDeviceHealth(logger klog.Logger, device *drahealthv1.DeviceHealth) sta
 	}
 }
 
+func (m *Manager) signalHealthInfoUpdated() {
+	select {
+	case m.healthInfoUpdated <- struct{}{}:
+	default:
+	}
+}
+
+func (m *Manager) runHealthInfoExpirationLoop(ctx context.Context) {
+	logger := klog.FromContext(ctx).WithName("dra-manager")
+	for {
+		expiredDevices, nextExpiration := m.healthInfoCache.expireHealthInfo(logger)
+		for driverName, devices := range expiredDevices {
+			m.notifyPodsForDevices(logger, driverName, devices)
+		}
+
+		var timer clock.Timer
+		var timerCh <-chan time.Time
+		if !nextExpiration.IsZero() {
+			delay := max(nextExpiration.Sub(m.healthInfoCache.clock.Now()), 0)
+			timer = m.healthInfoCache.clock.NewTimer(delay)
+			timerCh = timer.C()
+		}
+
+		select {
+		case <-ctx.Done():
+			if timer != nil {
+				timer.Stop()
+			}
+			return
+		case <-m.healthInfoUpdated:
+		case <-timerCh:
+		}
+		if timer != nil {
+			timer.Stop()
+		}
+	}
+}
+
+func (m *Manager) notifyPodsForDevices(logger klog.Logger, driverName string, changedDevices []state.DeviceHealth) {
+	if len(changedDevices) == 0 {
+		return
+	}
+
+	logger.V(4).Info("Health info changed, checking affected pods", "driverName", driverName, "changedDevicesCount", len(changedDevices))
+
+	// Snapshot which pods use which of this plugin's devices. The claim info
+	// cache lock is then held once per update and only while building the index,
+	// independent of how many devices changed.
+	type deviceKey struct {
+		poolName   string
+		deviceName string
+	}
+	podsByDevice := make(map[deviceKey][]string)
+	m.cache.RLock()
+	for _, cInfo := range m.cache.claimInfo {
+		if driverState, ok := cInfo.DriverState[driverName]; ok {
+			for _, allocatedDevice := range driverState.Devices {
+				key := deviceKey{poolName: allocatedDevice.PoolName, deviceName: allocatedDevice.DeviceName}
+				podsByDevice[key] = append(podsByDevice[key], cInfo.PodUIDs.UnsortedList()...)
+			}
+		}
+	}
+	m.cache.RUnlock()
+
+	podsToUpdate := sets.New[string]()
+	for _, device := range changedDevices {
+		key := deviceKey{poolName: device.PoolName, deviceName: device.DeviceName}
+		podsToUpdate.Insert(podsByDevice[key]...)
+	}
+
+	if podsToUpdate.Len() == 0 {
+		logger.V(4).Info("Health info changed, but no active pods found using the affected devices", "driverName", driverName)
+		return
+	}
+
+	podUIDs := podsToUpdate.UnsortedList()
+	logger.Info("Sending health update notification for pods", "driverName", driverName, "pods", podUIDs)
+	select {
+	case m.update <- resourceupdates.Update{PodUIDs: podUIDs}:
+	default:
+		logger.Error(nil, "DRA health update channel is full, discarding pod update notification", "driverName", driverName, "pods", podUIDs)
+	}
+}
+
 // HandleWatchResourcesStream processes health updates from the DRA plugin.
 func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream drahealthv1.DRAResourceHealth_NodeWatchResourcesClient, pluginName string) error {
 	logger := klog.FromContext(ctx).WithName("dra-manager")
@@ -1074,6 +1165,7 @@ func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream draheal
 		if err := m.healthInfoCache.clearDriver(logger, pluginName); err != nil {
 			logger.Error(err, "Failed to clear health info cache for driver")
 		}
+		m.signalHealthInfoUpdated()
 	}()
 
 	for {
@@ -1110,47 +1202,8 @@ func (m *Manager) HandleWatchResourcesStream(ctx context.Context, stream draheal
 		if updateErr != nil {
 			logger.Error(updateErr, "Failed to update health info cache")
 		}
-		if len(changedDevices) > 0 {
-			logger.V(4).Info("Health info changed, checking affected pods", "changedDevicesCount", len(changedDevices))
-
-			// Snapshot which pods use which of this plugin's devices. The
-			// claim info cache lock is then held once per report and only
-			// while building the index, independent of how many devices
-			// changed, so that a plugin sending large reports at a high
-			// rate cannot block DRA operations on the lock.
-			type deviceKey struct {
-				poolName   string
-				deviceName string
-			}
-			podsByDevice := make(map[deviceKey][]string)
-			m.cache.RLock()
-			for _, cInfo := range m.cache.claimInfo {
-				if driverState, ok := cInfo.DriverState[pluginName]; ok {
-					for _, allocatedDevice := range driverState.Devices {
-						key := deviceKey{poolName: allocatedDevice.PoolName, deviceName: allocatedDevice.DeviceName}
-						podsByDevice[key] = append(podsByDevice[key], cInfo.PodUIDs.UnsortedList()...)
-					}
-				}
-			}
-			m.cache.RUnlock()
-
-			podsToUpdate := sets.New[string]()
-			for _, dev := range changedDevices {
-				podsToUpdate.Insert(podsByDevice[deviceKey{poolName: dev.PoolName, deviceName: dev.DeviceName}]...)
-			}
-
-			if podsToUpdate.Len() > 0 {
-				podUIDs := podsToUpdate.UnsortedList()
-				logger.Info("Sending health update notification for pods", "pods", podUIDs)
-				select {
-				case m.update <- resourceupdates.Update{PodUIDs: podUIDs}:
-				default:
-					logger.Error(nil, "DRA health update channel is full, discarding pod update notification", "pods", podUIDs)
-				}
-			} else {
-				logger.V(4).Info("Health info changed, but no active pods found using the affected devices")
-			}
-		}
+		m.signalHealthInfoUpdated()
+		m.notifyPodsForDevices(logger, pluginName, changedDevices)
 
 	}
 }

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubeletmetrics "k8s.io/kubernetes/pkg/kubelet/metrics"
+	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
 	drahealthv1 "k8s.io/kubelet/pkg/apis/dra-health/v1"
@@ -2080,7 +2081,68 @@ func TestHandleWatchResourcesStream(t *testing.T) {
 		assert.True(t, finalErr == nil || errors.Is(finalErr, io.EOF), "Expected nil or io.EOF, got %v", finalErr)
 	})
 
-	// Test Case 2: Health change for a non-allocated device
+	// A connected stream which stops sending must still expire device health.
+	t.Run("HealthTimeoutForAllocatedDevice", func(t *testing.T) {
+		stCtx, stCancel := context.WithCancel(overallTestCtx)
+		defer stCancel()
+
+		initialClaim := genTestClaimInfo(claimUID, []string{string(podUID)}, true, nil)
+		manager, runStreamTest := setupNewManagerAndRunStreamTest(t, stCtx, initialClaim)
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		manager.healthInfoCache.clock = fakeClock
+		go manager.runHealthInfoExpirationLoop(stCtx)
+
+		responses := make(chan struct {
+			Resp *drahealthv1.NodeWatchResourcesResponse
+			Err  error
+		}, 1)
+		updateChan, done, streamErrChan := runStreamTest(stCtx, responses)
+		responses <- struct {
+			Resp *drahealthv1.NodeWatchResourcesResponse
+			Err  error
+		}{
+			Resp: &drahealthv1.NodeWatchResourcesResponse{Devices: []*drahealthv1.DeviceHealth{{
+				Device: &drahealthv1.DeviceIdentifier{
+					PoolName:   poolName,
+					DeviceName: deviceName,
+				},
+				Health:                    drahealthv1.HealthStatus_HEALTHY,
+				LastUpdatedTime:           fakeClock.Now().Unix(),
+				HealthCheckTimeoutSeconds: 1,
+				Message:                   "fresh health",
+			}}},
+		}
+
+		select {
+		case update := <-updateChan:
+			assert.ElementsMatch(t, []string{string(podUID)}, update.PodUIDs)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for the initial device health update")
+		}
+		require.Eventually(t, fakeClock.HasWaiters, time.Second, time.Millisecond, "expiration loop did not start a deadline timer")
+
+		fakeClock.Step(time.Second)
+		select {
+		case update := <-updateChan:
+			assert.ElementsMatch(t, []string{string(podUID)}, update.PodUIDs)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for the device health expiration update")
+		}
+
+		health := manager.healthInfoCache.getHealthInfo(driverName, poolName, deviceName)
+		assert.Equal(t, state.DeviceHealthStatusUnknown, health.Health)
+		assert.Empty(t, health.Message)
+
+		close(responses)
+		select {
+		case <-done:
+			require.NoError(t, <-streamErrChan)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for the health stream to stop")
+		}
+	})
+
+	// Test Case 3: Health change for a non-allocated device
 	t.Run("NonAllocatedDeviceChange", func(t *testing.T) {
 		stCtx, stCancel := context.WithCancel(overallTestCtx)
 		defer stCancel()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node
/wg device-management

#### What this PR does / why we need it:

DRA device health currently becomes stale only when another plugin response is processed or when Pod status is rebuilt for an unrelated reason. The health deadline itself does not enqueue affected Pods.

This PR adds one manager-level deadline loop. It recalculates the nearest device deadline after each report, transitions expired entries to Unknown, clears stale health messages, persists the cache change, and reuses the existing device-to-Pod notification path. A fake-clock regression test keeps the health stream connected without sending another response and verifies the deadline-driven Pod update.

#### Which issue(s) this PR is related to:

Fixes #140819

KEP: https://github.com/kubernetes/enhancements/issues/4680

#### Special notes for your reviewer:

#140842 changes stream ownership in the same area. This PR is based on master and keeps expiration manager-scoped; I will resolve the small overlap when either PR moves first.


#### Does this PR introduce a user-facing change?

```release-note
Kubelet now updates Pod status when a DRA device health report expires, without waiting for another plugin response or periodic Pod sync.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4680
```