### PR TITLE
apf: do not remove a queue while a lingering request still holds its seats

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go
@@ -969,10 +969,11 @@ func (qs *queueSet) removeQueueIfEmptyLocked(r *request) {
 	}
 
 	// If there are more queues than desired and this one has no
-	// requests then remove it
+	// requests and no seats in use (e.g. lingering requests) then remove it
 	if len(qs.queues) > qs.qCfg.DesiredNumQueues &&
 		r.queue.requestsWaiting.Length() == 0 &&
-		r.queue.requestsExecuting.Len() == 0 {
+		r.queue.requestsExecuting.Len() == 0 &&
+		r.queue.seatsInUse == 0 {
 		qs.queues = removeQueueAndUpdateIndexes(qs.queues, r.queue.index)
 
 		// decrement here to maintain the invariant that (qs.robinIndex+1) % numQueues

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -1548,6 +1548,53 @@ func newFIFO(requests ...*request) fifo {
 	return l
 }
 
+func TestLingeringRequestDoesNotCauseDoubleQueueRemoval(t *testing.T) {
+	metrics.Register()
+	now := time.Now()
+	clk, counter := testeventclock.NewFake(now, 0, nil)
+	qsf := newTestableQueueSetFactory(clk, countingPromiseFactoryFactory(counter))
+
+	// HandSize 1 => a hash maps to a single deterministic queue index.
+	qCfg := fq.QueuingConfig{Name: "lingering", DesiredNumQueues: 3, QueueLengthLimit: 10, HandSize: 1}
+	qsc, err := qsf.BeginConstruction(qCfg, newGaugePair(clk), newExecSeatsGauge(clk), fq.NewNamedIntegrator(clk, "lingering"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	qs := qsComplete(qsc, 100) // ample concurrency: dispatch immediately
+	qsi := qs.(*queueSet)
+	ctx := context.Background()
+
+	// Two requests into the same queue (highest index, 2): r lingers, s does not.
+	weLinger := &fcrequest.WorkEstimate{InitialSeats: 1, FinalSeats: 1, AdditionalLatency: time.Second}
+	weNormal := &fcrequest.WorkEstimate{InitialSeats: 1, FinalSeats: 0}
+	const hash = uint64(2)
+	r, _ := qs.StartRequest(ctx, weLinger, hash, "", "fs", "r", nil, nil)
+	s, _ := qs.StartRequest(ctx, weNormal, hash, "", "fs", "s", nil, nil)
+	if r == nil || s == nil {
+		t.Fatal("requests not dispatched")
+	}
+
+	// Reduce the desired number of queues; the three queues remain (attrition).
+	newQCfg := fq.QueuingConfig{Name: "lingering", DesiredNumQueues: 1, QueueLengthLimit: 10, HandSize: 1}
+	dealer, derr := checkConfig(newQCfg)
+	if derr != nil {
+		t.Fatal(derr)
+	}
+	qsi.setConfiguration(ctx, newQCfg, dealer, fq.DispatchingConfig{ConcurrencyLimit: 100, ConcurrencyDenominator: 100})
+
+	// r finishes first and lingers (seats retained); s then finishes.
+	r.Finish(func() {})
+	s.Finish(func() {})
+
+	// Fire r's lingering timer. On unfixed code this panics (apiserver crash) in
+	// the eventclock goroutine; with the fix it removes the queue exactly once.
+	clk.SetTime(now.Add(2 * time.Second))
+
+	if got, want := len(qsi.queues), 2; got != want {
+		t.Fatalf("expected %d queues after lingering completion, got %d", want, got)
+	}
+}
+
 func newGaugePair(clk clock.PassiveClock) metrics.RatioedGaugePair {
 	return metrics.RatioedGaugeVecPhasedElementPair(metrics.PriorityLevelConcurrencyGaugeVec, 1, 1, []string{"test"})
 }


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

`removeQueueIfEmptyLocked` drops an excess queue when it has no waiting and no executing requests, but it does not check `seatsInUse`. A request that has finished its main service but is still lingering (holding seats during its `AdditionalLatency`) has already been removed from `requestsExecuting`, while its seat release and its own `removeQueueIfEmptyLocked` are deferred to a later `EventAfterDuration` callback.

So, after a `DesiredNumQueues` reduction (excess queues draining by attrition), if a queue holds a lingering request plus another request, the other request finishing removes the queue while the lingering request's seats are still counted. `removeQueueAndUpdateIndexes` leaves the removed queue's `index` field stale, so when the lingering request's deferred `removeQueueIfEmptyLocked` runs, it removes a queue a second time with a stale index — panicking with `slice bounds out of range` (the panic runs in the eventclock goroutine, with no recover, crashing the apiserver), or silently removing a different live queue and corrupting fairness/seat accounting.

This adds `&& r.queue.seatsInUse == 0` to the guard so the queue is not removed while a lingering request still holds seats; it is then removed exactly once, by the lingering request's own deferred call after its seats are released.

## Which issue(s) this PR fixes

Fixes #140884

## Special notes for your reviewer

Added a regression test in `queueset_test.go` using the fake event clock: two requests share a queue (one lingering), `DesiredNumQueues` is reduced, both finish, and the lingering timer fires. It panics (`slice bounds out of range`) on current code and passes with the fix; the rest of the queueset suite is unaffected.

## Does this PR introduce a user-facing change?

```release-note
Fixed a bug where the API Priority and Fairness queueset could panic (crashing the apiserver) or corrupt its queue accounting when a priority level's number of queues was reduced while a request was lingering (holding seats during its additional latency).
```
