### PR TITLE
Add request metric for the aggregated OpenAPI v2 endpoint

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -26,6 +26,7 @@ import (
 
 	restful "github.com/emicklei/go-restful/v3"
 
+	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/klog/v2"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -100,8 +101,16 @@ func buildAndRegisterSpecAggregatorForLocalServices(downloader *Downloader, aggr
 	}
 
 	s.openAPIVersionedService = handler.NewOpenAPIServiceLazy(s.buildMergeSpecLocked())
-	s.openAPIVersionedService.RegisterOpenAPIVersionedService("/openapi/v2", pathHandler)
+	s.openAPIVersionedService.RegisterOpenAPIVersionedService("/openapi/v2", instrumentedPathHandler{delegate: pathHandler})
 	return s
+}
+
+type instrumentedPathHandler struct {
+	delegate common.PathHandler
+}
+
+func (i instrumentedPathHandler) Handle(path string, h http.Handler) {
+	i.delegate.Handle(path, metrics.InstrumentHandlerFunc("GET", "", "", "", "openapi/v2", "", "", false, "", h.ServeHTTP))
 }
 
 // BuildAndRegisterAggregator registered OpenAPI aggregator handler. This function is not thread safe as it only being called on startup.

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -101,16 +101,30 @@ func buildAndRegisterSpecAggregatorForLocalServices(downloader *Downloader, aggr
 	}
 
 	s.openAPIVersionedService = handler.NewOpenAPIServiceLazy(s.buildMergeSpecLocked())
-	s.openAPIVersionedService.RegisterOpenAPIVersionedService("/openapi/v2", instrumentedPathHandler{delegate: pathHandler})
+	// RegisterOpenAPIVersionedService builds the handler internally, so capture it
+	// instead of registering it directly and install the instrumented handler here.
+	var openAPIHandler http.Handler
+	s.openAPIVersionedService.RegisterOpenAPIVersionedService("/openapi/v2", pathHandlerFunc(func(_ string, h http.Handler) {
+		openAPIHandler = h
+	}))
+	pathHandler.Handle("/openapi/v2", metrics.InstrumentHandlerFunc("GET",
+		/* group = */ "",
+		/* version = */ "",
+		/* resource = */ "",
+		/* subresource = */ "openapi/v2",
+		/* scope = */ "",
+		/* component = */ "",
+		/* deprecated */ false,
+		/* removedRelease */ "",
+		openAPIHandler.ServeHTTP))
 	return s
 }
 
-type instrumentedPathHandler struct {
-	delegate common.PathHandler
-}
+// pathHandlerFunc adapts a function to the common.PathHandler interface.
+type pathHandlerFunc func(path string, handler http.Handler)
 
-func (i instrumentedPathHandler) Handle(path string, h http.Handler) {
-	i.delegate.Handle(path, metrics.InstrumentHandlerFunc("GET", "", "", "", "openapi/v2", "", "", false, "", h.ServeHTTP))
+func (f pathHandlerFunc) Handle(path string, handler http.Handler) {
+	f(path, handler)
 }
 
 // BuildAndRegisterAggregator registered OpenAPI aggregator handler. This function is not thread safe as it only being called on startup.

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -26,6 +26,7 @@ import (
 
 	restful "github.com/emicklei/go-restful/v3"
 
+	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/server"
 	"k8s.io/klog/v2"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -100,8 +101,26 @@ func buildAndRegisterSpecAggregatorForLocalServices(downloader *Downloader, aggr
 	}
 
 	s.openAPIVersionedService = handler.NewOpenAPIServiceLazy(s.buildMergeSpecLocked())
-	s.openAPIVersionedService.RegisterOpenAPIVersionedService("/openapi/v2", pathHandler)
+	s.openAPIVersionedService.RegisterOpenAPIVersionedService("/openapi/v2", instrumentedPathHandler{delegate: pathHandler})
 	return s
+}
+
+type instrumentedPathHandler struct {
+	delegate common.PathHandler
+}
+
+// Handle is called once to register the handler, not per request.
+func (i instrumentedPathHandler) Handle(path string, h http.Handler) {
+	i.delegate.Handle(path, metrics.InstrumentHandlerFunc("GET",
+		/* group = */ "",
+		/* version = */ "",
+		/* resource = */ "",
+		/* subresource = */ "openapi/v2",
+		/* scope = */ "",
+		/* component = */ "",
+		/* deprecated = */ false,
+		/* removedRelease = */ "",
+		h.ServeHTTP))
 }
 
 // BuildAndRegisterAggregator registered OpenAPI aggregator handler. This function is not thread safe as it only being called on startup.

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator_test.go
@@ -21,11 +21,15 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"bytes"
 
+	"k8s.io/apiserver/pkg/endpoints/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 	v1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -571,6 +575,45 @@ func TestFailingAPIServiceDoesNotBlockAdd(t *testing.T) {
 	}
 	expectPath(t, swagger, "/apis/foo/v1/")
 	expectNoPath(t, swagger, "/apis/failed/v1/")
+}
+
+func TestOpenAPIRequestMetrics(t *testing.T) {
+	metrics.Register()
+	metrics.Reset()
+
+	mux := http.NewServeMux()
+	delegationHandlers := []http.Handler{
+		&openAPIHandler{
+			openapi: &spec.Swagger{
+				SwaggerProps: spec.SwaggerProps{
+					Paths: &spec.Paths{
+						Paths: map[string]spec.PathItem{
+							"/apis/foo/v1/": {},
+						},
+					},
+				},
+			},
+		},
+	}
+	buildAndRegisterSpecAggregator(delegationHandlers, mux)
+
+	req, err := http.NewRequest(http.MethodGet, "/openapi/v2", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(`
+# HELP apiserver_request_total [STABLE] Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, and HTTP response code.
+# TYPE apiserver_request_total counter
+apiserver_request_total{code="200",component="",dry_run="",group="",resource="",scope="",subresource="openapi/v2",verb="GET",version=""} 1
+`), "apiserver_request_total"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 type openAPIHandler struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Counts /openapi/v2 requests in apiserver_request_total, matching OpenAPI v3.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
apiserver_request_total now counts requests to the aggregated /openapi/v2 endpoint under subresource="openapi/v2".
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```