### PR TITLE
Validate finalizers on ObjectMeta updates

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go
@@ -363,6 +363,7 @@ func ValidateObjectMetaAccessorUpdate(newMeta, oldMeta metav1.Object, fldPath *f
 	allErrs = append(allErrs, v1validation.ValidateLabels(newMeta.GetLabels(), fldPath.Child("labels"))...)
 	allErrs = append(allErrs, ValidateAnnotations(newMeta.GetAnnotations(), fldPath.Child("annotations"))...)
 	allErrs = append(allErrs, ValidateOwnerReferences(newMeta.GetOwnerReferences(), fldPath.Child("ownerReferences"))...)
+	allErrs = append(allErrs, ValidateFinalizers(newMeta.GetFinalizers(), fldPath.Child("finalizers"))...)
 	allErrs = append(allErrs, v1validation.ValidateManagedFields(newMeta.GetManagedFields(), fldPath.Child("managedFields"), v1validation.CoveredByDeclarative)...)
 
 	return allErrs

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
@@ -404,10 +404,14 @@ func TestValidateFinalizersUpdate(t *testing.T) {
 	}
 	for name, tc := range testcases {
 		errs := ValidateObjectMetaUpdate(&tc.New, &tc.Old, field.NewPath("field"))
-		if len(errs) == 0 {
-			if len(tc.ExpectedErr) != 0 {
-				t.Errorf("case: %q, expected error to contain %q", name, tc.ExpectedErr)
+		if len(tc.ExpectedErr) == 0 {
+			if len(errs) != 0 {
+				t.Errorf("case: %q, expected no errors, got %q", name, errs.ToAggregate().Error())
 			}
+			continue
+		}
+		if len(errs) == 0 {
+			t.Errorf("case: %q, expected error to contain %q", name, tc.ExpectedErr)
 		} else if e, a := tc.ExpectedErr, errs.ToAggregate().Error(); !strings.Contains(a, e) {
 			t.Errorf("case: %q, expected error to contain %q, got error %q", name, e, a)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta_test.go
@@ -391,6 +391,16 @@ func TestValidateFinalizersUpdate(t *testing.T) {
 			New:         metav1.ObjectMeta{Name: "test", ResourceVersion: "1", Finalizers: []string{"x/a", "y/b"}},
 			ExpectedErr: "",
 		},
+		"invalid finalizer name": {
+			Old:         metav1.ObjectMeta{Name: "test", ResourceVersion: "1"},
+			New:         metav1.ObjectMeta{Name: "test", ResourceVersion: "1", Finalizers: []string{"not valid"}},
+			ExpectedErr: `Invalid value: "not valid"`,
+		},
+		"conflicting finalizers": {
+			Old:         metav1.ObjectMeta{Name: "test", ResourceVersion: "1"},
+			New:         metav1.ObjectMeta{Name: "test", ResourceVersion: "1", Finalizers: []string{metav1.FinalizerOrphanDependents, metav1.FinalizerDeleteDependents}},
+			ExpectedErr: "cannot be both set",
+		},
 	}
 	for name, tc := range testcases {
 		errs := ValidateObjectMetaUpdate(&tc.New, &tc.Old, field.NewPath("field"))


### PR DESCRIPTION
/kind bug
/sig api-machinery
/area api-validation

#### What this PR does / why we need it:

`ValidateObjectMetaAccessorWithOptsCommon` validates finalizer names and rejects conflicting orphan/foreground deletion finalizers during create validation. `ValidateObjectMetaAccessorUpdate` revalidates the other mutable ObjectMeta fields, but skipped finalizers.

This adds the missing finalizer validation on update and covers malformed and conflicting finalizers in the existing update test. It is the prerequisite for safely removing redundant create-time ObjectMeta validation from update paths.

#### Which issue(s) this PR is related to:

Part of #134444

#### Special notes for your reviewer:

Built-in kube-apiserver update paths currently invoke both `ValidateObjectMetaAccessor` and `ValidateObjectMetaAccessorUpdate` through generic registry validation. This patch therefore preserves existing built-in API server behavior while making update validation self-contained for the follow-up call-site cleanup.

This PR intentionally contains only the shared validation fix. The affected API call-site cleanup can follow separately without mixing broad mechanical changes into this behavior change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```