### PR TITLE
chore(volume): clarify attach-detach reconciler sync behavior

### DIFF
--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package reconciler implements interfaces that attempt to reconcile the
-// desired state of the with the actual state of the world by triggering
+// desired state of the world with the actual state of the world by triggering
 // actions.
 package reconciler
 
@@ -108,15 +108,16 @@ type reconciler struct {
 }
 
 func (rc *reconciler) Run(ctx context.Context) {
-	wait.UntilWithContext(ctx, rc.reconciliationLoopFunc(ctx), rc.loopPeriod)
+	wait.UntilWithContext(ctx, rc.reconciliationLoopFunc(), rc.loopPeriod)
 }
 
-// reconciliationLoopFunc this can be disabled via cli option disableReconciliation.
-// It periodically checks whether the attached volumes from actual state
-// are still attached to the node and update the status if they are not.
-func (rc *reconciler) reconciliationLoopFunc(ctx context.Context) func(context.Context) {
+// reconciliationLoopFunc periodically checks whether volumes in the actual
+// state are still attached to their nodes and updates the actual state if they
+// are not. This check can be disabled with the
+// --disable-attach-detach-reconcile-sync flag.
+// See https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#disable-attach-detach-reconcile-sync
+func (rc *reconciler) reconciliationLoopFunc() func(context.Context) {
 	return func(ctx context.Context) {
-
 		rc.reconcile(ctx)
 		logger := klog.FromContext(ctx)
 		if rc.disableReconciliationSync {

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
@@ -677,7 +677,7 @@ func Test_Run_UpdateNodeStatusFailBeforeOneVolumeDetachNodeWithReadWriteOnce(t *
 	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
 	rc := NewReconciler(
 		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, false, dsw, asw, ad, nsu, nodeLister, fakeRecorder)
-	reconciliationLoopFunc := rc.(*reconciler).reconciliationLoopFunc(ctx)
+	reconciliationLoopFunc := rc.(*reconciler).reconciliationLoopFunc()
 	podName1 := "pod-uid1"
 	volumeName := v1.UniqueVolumeName("volume-name")
 	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -70933,7 +70933,7 @@ func schema_k8sio_kube_controller_manager_config_v1alpha1_AttachDetachController
 				Properties: map[string]spec.Schema{
 					"DisableAttachDetachReconcilerSync": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Reconciler runs a periodic loop to reconcile the desired state of the with the actual state of the world by triggering attach detach operations. This flag enables or disables reconcile.  Is false by default, and thus enabled.",
+							Description: "DisableAttachDetachReconcilerSync disables the periodic sync that verifies volumes in the actual state of the world are still attached. Defaults to false.",
 							Default:     false,
 							Type:        []string{"boolean"},
 							Format:      "",

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -179,9 +179,8 @@ type KubeControllerManagerConfiguration struct {
 
 // AttachDetachControllerConfiguration contains elements describing AttachDetachController.
 type AttachDetachControllerConfiguration struct {
-	// Reconciler runs a periodic loop to reconcile the desired state of the with
-	// the actual state of the world by triggering attach detach operations.
-	// This flag enables or disables reconcile.  Is false by default, and thus enabled.
+	// DisableAttachDetachReconcilerSync disables the periodic sync that verifies
+	// volumes in the actual state of the world are still attached. Defaults to false.
 	DisableAttachDetachReconcilerSync bool
 	// ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 60 sec by default.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind documentation
/sig storage

#### What this PR does / why we need it:

- Fixes a typo in the package comment.
- Improves the documentation for `reconciliationLoopFunc`.
- Removes an unused outer `ctx` parameter.
- Updates the corresponding test call.
- Clarifies how the kube-controller-manager `--disable-attach-detach-reconcile-sync` option affects the reconciliation loop.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
