### PR TITLE
client-go/reflector: give up on watch-list after incomplete streams

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -65,6 +65,10 @@ var (
 	defaultBackoffReset  = 2 * time.Minute
 	defaultBackoffFactor = 2.0
 	defaultBackoffJitter = 1.0
+	// defaultWatchListRetryDuration bounds how long watchList retries
+	// requests that never deliver the "initial-events-end" bookmark before
+	// giving up and falling back to a regular list.
+	defaultWatchListRetryDuration = defaultMinWatchTimeout
 )
 
 // ReflectorStore is the subset of cache.Store that the reflector uses
@@ -837,11 +841,17 @@ func (r *Reflector) watchList(ctx context.Context) (watch.Interface, error) {
 
 	initTrace := trace.New("Reflector WatchList", trace.Field{Key: "name", Value: r.name})
 	defer initTrace.LogIfLong(10 * time.Second)
+	watchListStart := r.clock.Now()
 	for {
 		select {
 		case <-stopCh:
 			return nil, nil
 		default:
+		}
+
+		if elapsed := r.clock.Since(watchListStart); elapsed > defaultWatchListRetryDuration {
+			// A misbehaving API server could otherwise keep this informer from ever syncing.
+			return nil, fmt.Errorf("watch-list for %s did not receive the initial-events-end bookmark within %s, giving up", r.typeDescription, defaultWatchListRetryDuration)
 		}
 
 		resourceVersion = ""

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -1141,6 +1141,73 @@ func TestReflectorWatchListPageSize(t *testing.T) {
 	}
 }
 
+// TestReflectorWatchListGivesUpAfterIncompleteStream reproduces
+// https://github.com/kubernetes/kubernetes/issues/140890: if the watch-list
+// stream keeps ending without ever delivering the "initial-events-end"
+// bookmark, the reflector must eventually give up on watch-list and fall
+// back to a regular list, instead of retrying forever.
+func TestReflectorWatchListGivesUpAfterIncompleteStream(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+
+	var watchListAttempts int
+	lw := &ListWatch{
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			if options.SendInitialEvents == nil || !*options.SendInitialEvents {
+				return watch.NewFake(), nil
+			}
+
+			watchListAttempts++
+			fakeClock.Step(time.Minute)
+
+			w := watch.NewFakeWithChanSize(1, false)
+			w.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "stale", ResourceVersion: "1"}})
+			w.Stop()
+			return w, nil
+		},
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return &v1.PodList{
+				ListMeta: metav1.ListMeta{ResourceVersion: "5"},
+				Items:    []v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", ResourceVersion: "5"}}},
+			}, nil
+		},
+	}
+
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, true)
+	s := NewStore(MetaNamespaceKeyFunc)
+	r := NewReflectorWithOptions(lw, &v1.Pod{}, s, ReflectorOptions{Clock: fakeClock})
+
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+
+	doneCh := make(chan error, 1)
+	go func() {
+		doneCh <- r.ListAndWatchWithContext(ctx)
+	}()
+
+	if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond, wait.ForeverTestTimeout, true, func(context.Context) (bool, error) {
+		return r.LastSyncResourceVersion() == "5", nil
+	}); err != nil {
+		cancel()
+		t.Fatalf("reflector never fell back to list and synced: %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-doneCh:
+		require.NoError(t, err)
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("timed out waiting for ListAndWatchWithContext to return")
+	}
+
+	if watchListAttempts < 2 {
+		t.Errorf("expected watch-list to be retried at least once before giving up, got %d attempt(s)", watchListAttempts)
+	}
+	results := s.List()
+	if len(results) != 1 {
+		t.Errorf("expected 1 result from the fallback list, got %d", len(results))
+	}
+}
+
 func TestReflectorNotPaginatingNotConsistentReads(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If an aggregated API server accepts a WatchList request, sends some initial
events, and then closes the stream without ever sending the
`initial-events-end` bookmark, `Reflector.watchList()` retries the
watch-list request forever inside its own loop. There is no deadline or
retry limit on this path, so a single misbehaving `APIService` can prevent
the informer from ever completing its initial sync.

In the reported incident this happened to one of the per-resource
`QuotaMonitor` informers in kube-controller-manager. Because
`QuotaMonitor.IsSynced()` requires all of its informers to report
`HasSynced()`, the ResourceQuota controller's workers never started,
`ResourceQuota.status.used` went stale, and new pods were rejected.

This PR bounds how long `watchList()` will keep re-establishing watch-list
requests that end without the bookmark. Once the bound is exceeded, it
returns an error, which the existing code in `ListAndWatchWithContext`
already treats as "watch-list didn't work, fall back to a regular list" -
so no changes were needed to the fallback path itself.

**Which issue(s) this PR fixes**:

Fixes #140890

**Special notes for your reviewer**:

This PR was written in part with the assistance of generative AI.

The retry bound reuses `defaultMinWatchTimeout` (5m) as a reasonable
default; happy to make it configurable via `ReflectorOptions` if
maintainers would prefer that instead of a fixed constant.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```

