### PR TITLE
dra: guard health cache against nil map from checkpoint

### DIFF
--- a/pkg/kubelet/cm/dra/healthinfo.go
+++ b/pkg/kubelet/cm/dra/healthinfo.go
@@ -64,15 +64,30 @@ func newHealthInfoCache(logger klog.Logger, stateFile string) (*healthInfoCache,
 	return cache, nil
 }
 
-// loadFromCheckpoint loads the cache from the state file.
-func (cache *healthInfoCache) loadFromCheckpoint() error {
+// loadFromCheckpoint loads the cache from the state file. On return,
+// cache.HealthInfo always points to a non-nil map, and every driver entry
+// has a non-nil Devices map — even if the file was missing, unreadable, or
+// decoded a nil map at either level (e.g., `null` or
+// `{"driverA":{"Devices":null}}`), which json.Unmarshal would otherwise
+// silently turn into a nil map, causing a panic on the first update.
+func (cache *healthInfoCache) loadFromCheckpoint() (err error) {
+	defer func() {
+		if cache.HealthInfo == nil || *cache.HealthInfo == nil {
+			cache.HealthInfo = &state.DevicesHealthMap{}
+		}
+		for name, driver := range *cache.HealthInfo {
+			if driver.Devices == nil {
+				driver.Devices = make(map[string]state.DeviceHealth)
+				(*cache.HealthInfo)[name] = driver
+			}
+		}
+	}()
 	if cache.stateFile == "" {
 		return nil
 	}
 	data, err := os.ReadFile(cache.stateFile)
 	if err != nil {
 		if os.IsNotExist(err) {
-			cache.HealthInfo = &state.DevicesHealthMap{}
 			return nil
 		}
 		return err

--- a/pkg/kubelet/cm/dra/healthinfo_test.go
+++ b/pkg/kubelet/cm/dra/healthinfo_test.go
@@ -85,6 +85,45 @@ func TestNewHealthInfoCache(t *testing.T) {
 	}
 }
 
+// TestNewHealthInfoCacheCorruptCheckpoint verifies that a checkpoint which
+// decodes to a nil map — at the top level or inside a driver entry — does not
+// leave the cache with a nil map. Without this guarantee, the first
+// updateHealthInfo call would panic in the health goroutine with
+// "assignment to entry in nil map".
+func TestNewHealthInfoCacheCorruptCheckpoint(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	tests := []struct {
+		description string
+		contents    string
+	}{
+		{description: "json null", contents: "null"},
+		{description: "nil driver devices", contents: fmt.Sprintf(`{"%s":{"Devices":null}}`, testDriver)},
+		{description: "torn write", contents: `{"driver": {"Devices`},
+		{description: "empty file", contents: ""},
+		{description: "garbage", contents: "not json"},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			stateFile := path.Join(t.TempDir(), "health_checkpoint")
+			require.NoError(t, os.WriteFile(stateFile, []byte(test.contents), 0o600))
+
+			cache, err := newHealthInfoCache(logger, stateFile)
+			require.NoError(t, err)
+			require.NotNil(t, cache)
+			require.NotNil(t, cache.HealthInfo)
+			require.NotNil(t, *cache.HealthInfo, "top-level map must not be nil after loading a corrupt checkpoint")
+			for name, driver := range *cache.HealthInfo {
+				require.NotNil(t, driver.Devices, "Devices map for driver %q must not be nil after loading a corrupt checkpoint", name)
+			}
+
+			// A follow-up update must not panic on a nil map.
+			_, err = cache.updateHealthInfo(logger, testDriver, []state.DeviceHealth{testDeviceHealth})
+			require.NoError(t, err)
+			assert.Equal(t, state.DeviceHealthStatusHealthy, cache.getHealthInfo(testDriver, testPool, testDevice).Health)
+		})
+	}
+}
+
 // Helper function to compare DeviceHealth slices ignoring LastUpdated time
 func assertDeviceHealthElementsMatchIgnoreTime(t *testing.T, expected, actual []state.DeviceHealth) {
 	require.Len(t, actual, len(expected), "Number of changed devices mismatch")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes a possible panic in the `DRA device-health` code when the health checkpoint file on disk decodes to a nil map - at the top level (null) or inside a driver entry ({"driverA":{"Devices":null}}).

`healthInfoCache.loadFromCheckpoint` calls `json.Unmarshal(data, cache.HealthInfo).` In both shapes above, `Unmarshal` silently leaves a map field nil and returns no error, so the load appears to succeed. The next `updateHealthInfo` then panics with assignment to entry in nil map, either on:

(*cache.HealthInfo)[driverName] = currentDriver   // top-level nil
or one level down:
currentDriver.Devices[key] = reportedDevice       // inner nil

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer

Small refactor of pkg/kubelet/cm/dra/healthinfo.go: the nil-map reset lives in a defer inside `loadFromCheckpoint`, so the invariant is documented and enforced where the `JSON` decode happens rather than in each caller.

Small refactor of `pkg/kubelet/cm/dra/healthinfo.go`: the nil-map sanitation lives in a defer inside `loadFromCheckpoint`, so the invariant is documented and enforced where the JSON decode happens rather than in each caller. The `defer` runs on the empty-stateFile and IsNotExist paths too, which is why the redundant reset inside the `IsNotExist` branch was removed.

#### Does this PR introduce a user-facing change?

```release-note
kubelet: fixed a panic in the DRA device-health goroutine when the on-disk health checkpoint file decoded to a nil map — either the top-level map (`null`) or a driver's inner `Devices` map (e.g. `{"driverA":{"Devices":null}}`). Both cases are now handled on load, and the next health update proceeds normally instead of panicking.

```

/sig node
/wg device-management
/cc @ffromani @harche @shivamerla 