### PR TITLE
Reduce locking in etcd3 metrics for now just store.Get to show how it would look like

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -330,3 +330,40 @@ func (c *monitorCollector) CollectWithStability(ch chan<- compbasemetrics.Metric
 		ch <- metric
 	}
 }
+
+// OperationLatencyTracker is a pre-materialized tracker for etcd request latency and request/error counters.
+type OperationLatencyTracker struct {
+	latency  compbasemetrics.ObserverMetric
+	requests compbasemetrics.CounterMetric
+	errors   compbasemetrics.CounterMetric
+}
+
+// NewOperationLatencyTracker pre-materializes etcd request metrics for a specific verb and groupResource.
+func NewOperationLatencyTracker(verb string, groupResource schema.GroupResource) *OperationLatencyTracker {
+	return &OperationLatencyTracker{
+		latency:  etcdRequestLatency.WithLabelValues(verb, groupResource.Group, groupResource.Resource),
+		requests: etcdRequestCounts.WithLabelValues(verb, groupResource.Group, groupResource.Resource),
+		errors:   etcdRequestErrorCounts.WithLabelValues(verb, groupResource.Group, groupResource.Resource),
+	}
+}
+
+// Record records latency, request count, and error count if applicable.
+func (t *OperationLatencyTracker) Record(err error, startTime time.Time) {
+	t.latency.Observe(sinceInSeconds(startTime))
+	t.requests.Inc()
+	if err != nil {
+		t.errors.Inc()
+	}
+}
+
+// EtcdMetricsTracker holds pre-materialized metric trackers for etcd3 storage operations.
+type EtcdMetricsTracker struct {
+	Get *OperationLatencyTracker
+}
+
+// NewEtcdMetricsTracker initializes pre-materialized metric trackers for a given GroupResource.
+func NewEtcdMetricsTracker(groupResource schema.GroupResource) *EtcdMetricsTracker {
+	return &EtcdMetricsTracker{
+		Get: NewOperationLatencyTracker("get", groupResource),
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics_test.go
@@ -440,3 +440,25 @@ func (m fakeEtcdMonitor) Monitor(_ context.Context) (StorageMetrics, error) {
 func (m fakeEtcdMonitor) Close() error {
 	return nil
 }
+func BenchmarkEtcdGetMetrics_Dynamic(b *testing.B) {
+	gr := schema.GroupResource{Group: "apps", Resource: "deployments"}
+	startTime := time.Now()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			RecordEtcdRequest("get", gr, nil, startTime)
+		}
+	})
+}
+
+func BenchmarkEtcdGetMetrics_Tracker(b *testing.B) {
+	gr := schema.GroupResource{Group: "apps", Resource: "deployments"}
+	tracker := NewEtcdMetricsTracker(gr)
+	startTime := time.Now()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			tracker.Get.Record(nil, startTime)
+		}
+	})
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -95,6 +95,8 @@ type store struct {
 
 	collectorMux          sync.RWMutex
 	resourceSizeEstimator *resourceSizeEstimator
+
+	metricsTracker *metrics.EtcdMetricsTracker
 }
 
 var _ storage.Interface = (*store)(nil)
@@ -196,6 +198,8 @@ func New(c *kubernetes.Client, compactor Compactor, codec runtime.Codec, newFunc
 		resourcePrefix: resourcePrefix,
 		newListFunc:    newListFunc,
 		compactor:      compactor,
+
+		metricsTracker: metrics.NewEtcdMetricsTracker(groupResource),
 	}
 
 	w.getResourceSizeEstimator = s.getResourceSizeEstimator
@@ -246,7 +250,7 @@ func (s *store) Get(ctx context.Context, key string, opts storage.GetOptions, ou
 	defer span.End(500 * time.Millisecond)
 	startTime := time.Now()
 	getResp, err := s.client.Kubernetes.Get(ctx, preparedKey, kubernetes.GetOptions{})
-	metrics.RecordEtcdRequest("get", s.groupResource, err, startTime)
+	s.metricsTracker.Get.Record(err, startTime)
 	if err != nil {
 		span.AddEvent("Get call failed", attribute.String("err", err.Error()))
 		return err


### PR DESCRIPTION
At the scale of 5k nodes we can do even 10k Get requests per second to etcd, which becomes a problem. However, it's not etcd that becomes slow, but kube-apiserver lock contention and context switching. This metrics and other observability in store.Get is currently main suspect for issues related to scalability test failure in https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-gce-scale-performance-5000/2074539413072777216

Etcd3 package metrics do a lot of unnecessary locking that we can simply avoid just using libraries more efficiently.
```
goos: linux
goarch: amd64
pkg: k8s.io/apiserver/pkg/storage/etcd3/metrics
cpu: AMD Ryzen Threadripper PRO 3945WX 12-Cores
                  │    Baseline    │             Tracker              │
                  │     sec/op     │   sec/op     vs base             │
EtcdGetMetrics       67.31n ± 15%   38.10n ± 8%  -43.39% (p=0.002 n=6)
EtcdGetMetrics-2     59.23n ± 34%   19.28n ± 9%  -67.45% (p=0.002 n=6)
EtcdGetMetrics-4     71.40n ± 21%    9.43n ± 7%  -86.80% (p=0.002 n=6)
EtcdGetMetrics-8     52.10n ±  4%    4.78n ± 6%  -90.83% (p=0.002 n=6)
EtcdGetMetrics-16    44.12n ±  3%    2.74n ± 3%  -93.79% (p=0.002 n=6)
EtcdGetMetrics-24    31.07n ± 14%    2.15n ± 5%  -93.09% (p=0.002 n=6)
geomean              52.24n          7.61n       -85.43%
```

/kind feature

```release-note
NONE
```

/cc @Jefftree @richabanker 
