### PR TITLE
test/e2e: remove unused parameter from WaitForPodResizeActuation

### DIFF
--- a/test/e2e/common/node/dra_node_allocatable_resources.go
+++ b/test/e2e/common/node/dra_node_allocatable_resources.go
@@ -889,7 +889,7 @@ func doNodeAllocatableResizeTests(f *framework.Framework) {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("waiting for resize actuation to complete")
-			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, pod, desiredContainers)
+			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, pod)
 
 			ginkgo.By("verifying updated pod cgroup limits after resize")
 			err = cgroups.VerifyPodCgroups(ctx, f, resizedPod, &tc.expectedPodCgroupAfterResize)

--- a/test/e2e/common/node/framework/podresize/resize.go
+++ b/test/e2e/common/node/framework/podresize/resize.go
@@ -362,7 +362,7 @@ func verifyOomScoreAdj(ctx context.Context, f *framework.Framework, pod *v1.Pod,
 	})).WithTimeout(framework.PollShortTimeout).Should(gomega.Succeed())
 }
 
-func WaitForPodResizeActuation(ctx context.Context, f *framework.Framework, podClient *e2epod.PodClient, pod *v1.Pod, expectedContainers []ResizableContainerInfo) *v1.Pod {
+func WaitForPodResizeActuation(ctx context.Context, f *framework.Framework, podClient *e2epod.PodClient, pod *v1.Pod) *v1.Pod {
 	ginkgo.GinkgoHelper()
 	// Wait for resize to complete.
 

--- a/test/e2e/common/node/pod_level_resources_resize.go
+++ b/test/e2e/common/node/pod_level_resources_resize.go
@@ -560,7 +560,7 @@ func doPodLevelResourcesMemoryLimitDecreaseTest(f *framework.Framework) {
 		podresize.VerifyPodResources(testPod, containers, viableLoweredLimitPLR)
 
 		ginkgo.By("waiting for viable lowered limit to be actuated")
-		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod, containers)
+		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod)
 		podresize.ExpectPodResized(ctx, f, resizedPod, containers)
 
 		// There is some latency after container startup before memory usage is scraped. On CRI-O
@@ -638,7 +638,7 @@ func doPodLevelResourcesMemoryLimitDecreaseTest(f *framework.Framework) {
 		podresize.VerifyPodResources(testPod, containers, originalPLR)
 
 		ginkgo.By("waiting for the original values to be actuated")
-		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod, containers)
+		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod)
 		podresize.ExpectPodResized(ctx, f, resizedPod, containers)
 
 		ginkgo.By("deleting pod")
@@ -733,7 +733,7 @@ func patchAndVerifyPLR(ctx context.Context, f *framework.Framework, podClient *e
 	expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainers)
 
 	podresize.VerifyPodResources(patchedPod, expected, expectedPodResources)
-	resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPod, expected)
+	resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPod)
 	podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 	// Uncomment pod-level status verification after patch in 1.36 release.
 	// convesion of cgroup values -> Pod.Status.Resources -> cgroup values is

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -611,7 +611,7 @@ func doPodResizeMemoryLimitDecreaseTest(f *framework.Framework) {
 		podresize.VerifyPodResources(testPod, viableLoweredLimit, nil)
 
 		ginkgo.By("waiting for viable lowered limit to be actuated")
-		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod, viableLoweredLimit)
+		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod)
 		podresize.ExpectPodResized(ctx, f, resizedPod, viableLoweredLimit)
 
 		// There is some latency after container startup before memory usage is scraped. On CRI-O
@@ -684,7 +684,7 @@ func doPodResizeMemoryLimitDecreaseTest(f *framework.Framework) {
 		podresize.VerifyPodResources(testPod, original, nil)
 
 		ginkgo.By("waiting for the original values to be actuated")
-		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod, original)
+		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod)
 		podresize.ExpectPodResized(ctx, f, resizedPod, original)
 
 		ginkgo.By("deleting pod")
@@ -817,7 +817,7 @@ func doPodResizeReadAndReplaceTests(f *framework.Framework) {
 
 		ginkgo.By("verifying pod resources after patch")
 		expected := podresize.UpdateExpectedContainerRestarts(ctx, updatedPod, desiredContainers)
-		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, updatedPod, expected)
+		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, updatedPod)
 		podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 
 		ginkgo.By("verifying pod fetched from resize subresource")
@@ -947,7 +947,7 @@ func doPodResizeMemoryVolumeTests(f *framework.Framework) {
 
 			ginkgo.By("waiting for resize actuation to complete")
 			expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainers)
-			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, patchedPod, expected)
+			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, patchedPod)
 			podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 
 			desiredQty := resource.MustParse(desiredSizeLimit)
@@ -989,7 +989,7 @@ func doPodResizeMemoryVolumeTests(f *framework.Framework) {
 			framework.ExpectNoError(pErr, "failed to patch pod for rollback")
 
 			expectedRollback := podresize.UpdateExpectedContainerRestarts(ctx, rolledBackPod, originalContainers)
-			finalPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, rolledBackPod, expectedRollback)
+			finalPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, rolledBackPod)
 			podresize.ExpectPodResized(ctx, f, finalPod, expectedRollback)
 
 			stdout, _, err = e2epod.ExecCommandInContainerWithFullOutput(f, finalPod.Name, "c1", "df", "-m", "/cache")
@@ -1226,7 +1226,7 @@ func patchAndVerify(ctx context.Context, f *framework.Framework, podClient *e2ep
 	expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainers)
 
 	podresize.VerifyPodResources(patchedPod, expected, expectedPodResources)
-	resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPod, expected)
+	resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPod)
 
 	podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 	if expectedPodResources != nil {

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -596,7 +596,7 @@ func doPodResizeMemoryLimitDecreaseTest(f *framework.Framework) {
 		podresize.VerifyPodResources(testPod, viableLoweredLimit, nil)
 
 		ginkgo.By("waiting for viable lowered limit to be actuated")
-		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod, viableLoweredLimit)
+		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod)
 		podresize.ExpectPodResized(ctx, f, resizedPod, viableLoweredLimit)
 
 		// There is some latency after container startup before memory usage is scraped. On CRI-O
@@ -669,7 +669,7 @@ func doPodResizeMemoryLimitDecreaseTest(f *framework.Framework) {
 		podresize.VerifyPodResources(testPod, original, nil)
 
 		ginkgo.By("waiting for the original values to be actuated")
-		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod, original)
+		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod)
 		podresize.ExpectPodResized(ctx, f, resizedPod, original)
 
 		ginkgo.By("deleting pod")
@@ -802,7 +802,7 @@ func doPodResizeReadAndReplaceTests(f *framework.Framework) {
 
 		ginkgo.By("verifying pod resources after patch")
 		expected := podresize.UpdateExpectedContainerRestarts(ctx, updatedPod, desiredContainers)
-		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, updatedPod, expected)
+		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, updatedPod)
 		podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 
 		ginkgo.By("verifying pod fetched from resize subresource")
@@ -932,7 +932,7 @@ func doPodResizeMemoryVolumeTests(f *framework.Framework) {
 
 			ginkgo.By("waiting for resize actuation to complete")
 			expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, desiredContainers)
-			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, patchedPod, expected)
+			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, patchedPod)
 			podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 
 			desiredQty := resource.MustParse(desiredSizeLimit)
@@ -974,7 +974,7 @@ func doPodResizeMemoryVolumeTests(f *framework.Framework) {
 			framework.ExpectNoError(pErr, "failed to patch pod for rollback")
 
 			expectedRollback := podresize.UpdateExpectedContainerRestarts(ctx, rolledBackPod, originalContainers)
-			finalPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, rolledBackPod, expectedRollback)
+			finalPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, rolledBackPod)
 			podresize.ExpectPodResized(ctx, f, finalPod, expectedRollback)
 
 			stdout, _, err = e2epod.ExecCommandInContainerWithFullOutput(f, finalPod.Name, "c1", "df", "-m", "/cache")
@@ -1211,7 +1211,7 @@ func patchAndVerify(ctx context.Context, f *framework.Framework, podClient *e2ep
 	expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, expectedContainers)
 
 	podresize.VerifyPodResources(patchedPod, expected, expectedPodResources)
-	resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPod, expected)
+	resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPod)
 
 	podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 	if expectedPodResources != nil {

--- a/test/e2e/dra/dra_node_allocatable_resources.go
+++ b/test/e2e/dra/dra_node_allocatable_resources.go
@@ -888,7 +888,7 @@ func doNodeAllocatableResizeTests(f *framework.Framework) {
 			framework.ExpectNoError(err)
 
 			ginkgo.By("waiting for resize actuation to complete")
-			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, pod, desiredContainers)
+			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, pod)
 
 			ginkgo.By("verifying updated pod cgroup limits after resize")
 			err = cgroups.VerifyPodCgroups(ctx, f, resizedPod, &tc.expectedPodCgroupAfterResize)

--- a/test/e2e/node/pod_resize.go
+++ b/test/e2e/node/pod_resize.go
@@ -105,7 +105,7 @@ func doPodResizeResourceQuotaTests(f *framework.Framework) {
 				podresize.VerifyPodResources(patchedPod, expected, nil)
 
 				ginkgo.By("waiting for resize to be actuated")
-				resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPods[0], expected)
+				resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPods[0])
 				podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 
 				ginkgo.By("verifying pod resources after resize")
@@ -295,7 +295,7 @@ func doPodResizeLimitRangerTests(f *framework.Framework) {
 				podresize.VerifyPodResources(patchedPod, expected, nil)
 
 				ginkgo.By("waiting for resize to be actuated")
-				resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPods[0], expected)
+				resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, newPods[0])
 				podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 
 				ginkgo.By("verifying pod resources after resize")
@@ -672,7 +672,7 @@ func doPodResizeSchedulerTests(f *framework.Framework) {
 				RestartCount: testPod1.Status.ContainerStatuses[0].RestartCount,
 			},
 		}
-		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1, expected)
+		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod1)
 		podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 
 		ginkgo.By(fmt.Sprintf("TEST3: Resize pod '%s' to exceed the node capacity", testPod1.Name))
@@ -811,7 +811,7 @@ func doPodResizeRetryDeferredTests(f *framework.Framework) {
 				Resources: &cgroups.ContainerResources{CPUReq: podBResizedCPU.String(), CPULim: podBResizedCPU.String()},
 			},
 		}
-		resizedPodB := podresize.WaitForPodResizeActuation(ctx, f, podClient, podB, expected)
+		resizedPodB := podresize.WaitForPodResizeActuation(ctx, f, podClient, podB)
 		podresize.ExpectPodResized(ctx, f, resizedPodB, expected)
 
 		ginkgo.By("Cleaning up test pods")
@@ -977,7 +977,7 @@ func doPodResizeRetryDeferredTests(f *framework.Framework) {
 				Resources: &cgroups.ContainerResources{CPUReq: majorityCPUQuantity.String(), CPULim: majorityCPUQuantity.String()},
 			},
 		}
-		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod2, expected)
+		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod2)
 		podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 		waitForPodDeferred(ctx, f, testPod3)
 		waitForPodDeferred(ctx, f, testPod4)
@@ -1000,7 +1000,7 @@ func doPodResizeRetryDeferredTests(f *framework.Framework) {
 				},
 			},
 		}
-		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod3, expected)
+		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod3)
 		podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 		waitForPodDeferred(ctx, f, testPod4)
 		waitForPodDeferred(ctx, f, testPod5)
@@ -1017,7 +1017,7 @@ func doPodResizeRetryDeferredTests(f *framework.Framework) {
 				Resources: &cgroups.ContainerResources{CPUReq: majorityCPUQuantity.String(), CPULim: majorityCPUQuantity.String()},
 			},
 		}
-		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod4, expected)
+		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod4)
 		podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 		waitForPodDeferred(ctx, f, testPod5)
 
@@ -1033,7 +1033,7 @@ func doPodResizeRetryDeferredTests(f *framework.Framework) {
 				Resources: &cgroups.ContainerResources{CPUReq: majorityCPUQuantity.String(), CPULim: majorityCPUQuantity.String()},
 			},
 		}
-		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod5, expected)
+		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod5)
 		podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 
 		ginkgo.By("deleting pod5")
@@ -1166,15 +1166,15 @@ func doPodResizeRetryDeferredTests(f *framework.Framework) {
 		framework.ExpectNoError(delErr1, "failed to delete pod %s", testPod1.Name)
 
 		ginkgo.By(fmt.Sprintf("Verify pod '%s' is resized successfully after pod deletion '%s'", testPod2.Name, testPod1.Name))
-		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod2, expectedTestPod2Resized)
+		resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod2)
 		podresize.ExpectPodResized(ctx, f, resizedPod, expectedTestPod2Resized)
 
 		ginkgo.By(fmt.Sprintf("Verify pod '%s' is resized successfully after pod resize '%s'", testPod3.Name, testPod2.Name))
-		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod3, expectedTestPod3Resized)
+		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod3)
 		podresize.ExpectPodResized(ctx, f, resizedPod, expectedTestPod3Resized)
 
 		ginkgo.By(fmt.Sprintf("Verify pod '%s' is resized successfully after pod resize '%s'", testPod4.Name, testPod3.Name))
-		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod4, expectedTestPod4Resized)
+		resizedPod = podresize.WaitForPodResizeActuation(ctx, f, podClient, testPod4)
 		podresize.ExpectPodResized(ctx, f, resizedPod, expectedTestPod4Resized)
 
 		ginkgo.By("deleting pods")
@@ -1334,7 +1334,7 @@ func doPodResizeDeferredPreemptionTests(f *framework.Framework) {
 				Resources: &cgroups.ContainerResources{CPUReq: preemptorTargetCPU.String(), CPULim: preemptorTargetCPU.String()},
 			},
 		}
-		resizedPreemptor := podresize.WaitForPodResizeActuation(ctx, f, podClient, preemptor, expectedPreemptorResized)
+		resizedPreemptor := podresize.WaitForPodResizeActuation(ctx, f, podClient, preemptor)
 		podresize.ExpectPodResized(ctx, f, resizedPreemptor, expectedPreemptorResized)
 
 		ginkgo.By(fmt.Sprintf("Verify that mid-priority pod '%s' is preserved and successfully actuated after victim eviction", midPriPod.Name))
@@ -1344,7 +1344,7 @@ func doPodResizeDeferredPreemptionTests(f *framework.Framework) {
 				Resources: &cgroups.ContainerResources{CPUReq: midPriTargetCPU.String(), CPULim: midPriTargetCPU.String()},
 			},
 		}
-		resizedMidPri := podresize.WaitForPodResizeActuation(ctx, f, podClient, midPriPod, expectedMidPriResized)
+		resizedMidPri := podresize.WaitForPodResizeActuation(ctx, f, podClient, midPriPod)
 		podresize.ExpectPodResized(ctx, f, resizedMidPri, expectedMidPriResized)
 	})
 }

--- a/test/e2e_node/pod_resize_criproxy_linux_test.go
+++ b/test/e2e_node/pod_resize_criproxy_linux_test.go
@@ -197,7 +197,7 @@ var _ = SIGDescribe("Pod InPlace Resize Memory-Backed Volume with CRI Proxy", fr
 
 			ginkgo.By("Waiting for the entire actuation to complete after CRI unblocks")
 			expected := podresize.UpdateExpectedContainerRestarts(ctx, patchedPod, resizedContainers)
-			gotPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, patchedPod, expected)
+			gotPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, patchedPod)
 			podresize.ExpectPodResized(ctx, f, gotPod, expected)
 
 			ginkgo.By("Verifying both volume resizes are eventually complete")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR removes unused argument from `WaitForPodResizeActuation` signature.

#### Which issue(s) this PR is related to:
--

#### Special notes for your reviewer:
--

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
