### PR TITLE
scheduler: extract NewFrameworks constructor and add FrameworkForPod helper

### DIFF
--- a/pkg/scheduler/framework_init.go
+++ b/pkg/scheduler/framework_init.go
@@ -1,0 +1,213 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	resourceslicetracker "k8s.io/dynamic-resource-allocation/resourceslice/tracker"
+	"k8s.io/klog/v2"
+	configv1 "k8s.io/kube-scheduler/config/v1"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
+	apidispatcher "k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
+	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
+	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
+	frameworkplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodevolumelimits"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	"k8s.io/kubernetes/pkg/scheduler/profile"
+	"k8s.io/kubernetes/pkg/scheduler/util/assumecache"
+)
+
+// FrameworkComponents holds the shared scheduler dependencies that span across
+// all framework profiles, the scheduling queue, and event handlers.
+//
+// It decouples the initialization of cluster-state caches and DRA/extender
+// managers from the per-profile framework wiring, allowing synthetic callers
+// and simulation harnesses to construct profiles without redundant shared state.
+type FrameworkComponents struct {
+	// cache stores cluster state shared across framework profiles, scheduling queue,
+	// and event handlers.
+	cache internalcache.Cache
+
+	extenders []fwk.Extender
+
+	// APIDispatcher is non-nil when the SchedulerAsyncAPICalls feature gate is enabled.
+	apiDispatcher   *apidispatcher.APIDispatcher
+	metricsRecorder *metrics.MetricAsyncRecorder
+
+	// DRA components required for registering event handlers. Nil unless
+	// DynamicResourceAllocation feature gate is enabled.
+	resourceClaimCache   *assumecache.AssumeCache
+	resourceSliceTracker *resourceslicetracker.Tracker
+	draManager           fwk.SharedDRAManager
+
+	client          clientset.Interface
+	informerFactory informers.SharedInformerFactory
+	options         schedulerOptions
+}
+
+var defaultComponentsOptions = schedulerOptions{
+	parallelism:         defaultSchedulerOptions.parallelism,
+	applyDefaultProfile: defaultSchedulerOptions.applyDefaultProfile,
+}
+
+// NewFrameworkComponents initializes the shared dependencies required across
+// scheduler framework profiles.
+//
+// Callers must invoke NewFrameworkComponents before starting the shared
+// informer factory so that any required informers are registered prior to Start().
+func NewFrameworkComponents(ctx context.Context, client clientset.Interface, informerFactory informers.SharedInformerFactory, opts ...Option) (*FrameworkComponents, error) {
+	options := defaultComponentsOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return newFrameworkComponents(ctx, client, informerFactory, options)
+}
+
+func newFrameworkComponents(ctx context.Context,
+	client clientset.Interface,
+	informerFactory informers.SharedInformerFactory,
+	options schedulerOptions,
+) (*FrameworkComponents, error) {
+	logger := klog.FromContext(ctx)
+	stopEverything := ctx.Done()
+
+	if options.applyDefaultProfile {
+		var versionedCfg configv1.KubeSchedulerConfiguration
+		scheme.Scheme.Default(&versionedCfg)
+		cfg := schedulerapi.KubeSchedulerConfiguration{}
+		if err := scheme.Scheme.Convert(&versionedCfg, &cfg, nil); err != nil {
+			return nil, err
+		}
+		options.profiles = cfg.Profiles
+	}
+
+	extenders, err := buildExtenders(logger, options.extenders, options.profiles)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't build extenders: %w", err)
+	}
+
+	metricsRecorder := metrics.NewMetricsAsyncRecorder(1000, time.Second, stopEverything)
+
+	var resourceClaimCache *assumecache.AssumeCache
+	var resourceSliceTracker *resourceslicetracker.Tracker
+	var draManager fwk.SharedDRAManager
+	if feature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
+		resourceClaimInformer := informerFactory.Resource().V1().ResourceClaims().Informer()
+		resourceClaimCache = assumecache.NewAssumeCache(logger, resourceClaimInformer, "ResourceClaim", "", nil)
+		resourceSliceTrackerOpts := resourceslicetracker.Options{
+			EnableDeviceTaintRules:   feature.DefaultFeatureGate.Enabled(features.DRADeviceTaintRules),
+			EnableConsumableCapacity: feature.DefaultFeatureGate.Enabled(features.DRAConsumableCapacity),
+			SliceInformer:            informerFactory.Resource().V1().ResourceSlices(),
+			KubeClient:               client,
+		}
+		// If device taint rules are disabled, the additional informers are not needed and
+		// the tracker turns into a simple wrapper around the slice informer.
+		if resourceSliceTrackerOpts.EnableDeviceTaintRules {
+			resourceSliceTrackerOpts.TaintInformer = informerFactory.Resource().V1().DeviceTaintRules()
+		}
+		resourceSliceTracker, err = resourceslicetracker.StartTracker(ctx, resourceSliceTrackerOpts)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't start resource slice tracker: %w", err)
+		}
+		draManager = dynamicresources.NewDRAManager(ctx, resourceClaimCache, resourceSliceTracker, informerFactory)
+	}
+
+	var apiDispatcher *apidispatcher.APIDispatcher
+	if feature.DefaultFeatureGate.Enabled(features.SchedulerAsyncAPICalls) {
+		apiDispatcher = apidispatcher.New(client, int(options.parallelism), apicalls.Relevances)
+	}
+
+	schedulerCache := internalcache.New(ctx, apiDispatcher, feature.DefaultFeatureGate.Enabled(features.GenericWorkload), feature.DefaultFeatureGate.Enabled(features.CompositePodGroup))
+
+	return &FrameworkComponents{
+		cache: schedulerCache,
+
+		extenders:            extenders,
+		apiDispatcher:        apiDispatcher,
+		metricsRecorder:      metricsRecorder,
+		resourceClaimCache:   resourceClaimCache,
+		resourceSliceTracker: resourceSliceTracker,
+		draManager:           draManager,
+		client:               client,
+		informerFactory:      informerFactory,
+		options:              options,
+	}, nil
+}
+
+// GetCache returns the shared scheduler cache instance.
+func (c *FrameworkComponents) GetCache() internalcache.Cache {
+	return c.cache
+}
+
+// NewFrameworkMap builds the map of scheduling framework profiles from the
+// resolved configurations and shared components.
+//
+// It must run before the informer factory is started because it instantiates
+// informers (such as CSINodes) that Start() would otherwise never run.
+//
+// snapshot is injected into every framework profile as its SharedLister;
+// Scheduler passes the scheduler's internal cache snapshot, while library
+// consumers may inject custom snapshots for testing or simulation.
+func NewFrameworkMap(ctx context.Context, c *FrameworkComponents, recorderFactory profile.RecorderFactory, snapshot *internalcache.Snapshot) (profile.Map, error) {
+	registry := frameworkplugins.NewInTreeRegistry()
+	if err := registry.Merge(c.options.frameworkOutOfTreeRegistry); err != nil {
+		return nil, err
+	}
+	csiManager := nodevolumelimits.NewCSIManager(
+		c.informerFactory.Storage().V1().CSINodes().Lister())
+
+	profiles, err := profile.NewMap(ctx, c.options.profiles, registry, recorderFactory,
+		frameworkruntime.WithComponentConfigVersion(c.options.componentConfigVersion),
+		frameworkruntime.WithClientSet(c.client),
+		frameworkruntime.WithKubeConfig(c.options.kubeConfig),
+		frameworkruntime.WithInformerFactory(c.informerFactory),
+		frameworkruntime.WithSharedDRAManager(c.draManager),
+		frameworkruntime.WithSnapshotSharedLister(snapshot),
+		frameworkruntime.WithMutableSnapshotLister(snapshot),
+		frameworkruntime.WithCaptureProfile(frameworkruntime.CaptureProfile(c.options.frameworkCapturer)),
+		frameworkruntime.WithParallelism(int(c.options.parallelism)),
+		frameworkruntime.WithExtenders(c.extenders),
+		frameworkruntime.WithMetricsRecorder(c.metricsRecorder),
+		frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+		frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
+		frameworkruntime.WithAPIDispatcher(c.apiDispatcher),
+		frameworkruntime.WithSharedCSIManager(csiManager),
+		frameworkruntime.WithPodGroupManager(c.cache),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("initializing profiles: %w", err)
+	}
+	if len(profiles) == 0 {
+		return nil, errors.New("at least one profile is required")
+	}
+
+	return profiles, nil
+}

--- a/pkg/scheduler/profile/profile.go
+++ b/pkg/scheduler/profile/profile.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -80,6 +81,22 @@ func (m Map) Close() error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// FrameworkForPod returns the framework registered for the pod's scheduler
+// name. An empty scheduler name falls back to the default scheduler — this
+// cannot happen for pods observed via the API (the field is defaulted there),
+// but can for synthetic pods used in scheduling simulations.
+func (m Map) FrameworkForPod(pod *v1.Pod) (framework.Framework, error) {
+	name := pod.Spec.SchedulerName
+	if name == "" {
+		name = v1.DefaultSchedulerName
+	}
+	f, ok := m[name]
+	if !ok {
+		return nil, fmt.Errorf("profile not found for scheduler name %q", name)
+	}
+	return f, nil
 }
 
 // NewRecorderFactory returns a RecorderFactory for the broadcaster.

--- a/pkg/scheduler/profile/profile_test.go
+++ b/pkg/scheduler/profile/profile_test.go
@@ -274,6 +274,83 @@ func TestNewMap(t *testing.T) {
 	}
 }
 
+func TestFrameworkForPod(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	cfgs := []config.KubeSchedulerProfile{
+		{
+			SchedulerName: v1.DefaultSchedulerName,
+			Plugins: &config.Plugins{
+				QueueSort: config.PluginSet{Enabled: []config.Plugin{{Name: "QueueSort"}}},
+				Bind:      config.PluginSet{Enabled: []config.Plugin{{Name: "Bind1"}}},
+			},
+		},
+		{
+			SchedulerName: "custom-scheduler",
+			Plugins: &config.Plugins{
+				QueueSort: config.PluginSet{Enabled: []config.Plugin{{Name: "QueueSort"}}},
+				Bind:      config.PluginSet{Enabled: []config.Plugin{{Name: "Bind2"}}},
+			},
+		},
+	}
+
+	m, err := NewMap(ctx, cfgs, fakeRegistry, nilRecorderFactory)
+	if err != nil {
+		t.Fatalf("failed to create profile map: %v", err)
+	}
+	defer func() {
+		err := m.Close()
+		if err != nil {
+			t.Errorf("error closing map: %v", err)
+		}
+	}()
+
+	tests := []struct {
+		name          string
+		schedulerName string
+		wantErr       string
+	}{
+		{
+			name:          "explicit scheduler name matching profile",
+			schedulerName: "custom-scheduler",
+		},
+		{
+			name:          "empty scheduler name defaults to default-scheduler",
+			schedulerName: "",
+		},
+		{
+			name:          "unknown scheduler name returns error",
+			schedulerName: "non-existent",
+			wantErr:       `profile not found for scheduler name "non-existent"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &v1.Pod{
+				Spec: v1.PodSpec{
+					SchedulerName: tt.schedulerName,
+				},
+			}
+			fwk, err := m.FrameworkForPod(pod)
+			if tt.wantErr != "" {
+				if err.Error() != tt.wantErr {
+					t.Errorf("FrameworkForPod() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if fwk == nil {
+				t.Errorf("expected non-nil framework for scheduler name %q", tt.schedulerName)
+			}
+		})
+	}
+}
+
 type fakePlugin struct {
 	name string
 }

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -538,11 +538,7 @@ func (sched *Scheduler) handleBindingCycleError(
 }
 
 func (sched *Scheduler) frameworkForPod(pod *v1.Pod) (framework.Framework, error) {
-	fwk, ok := sched.Profiles[pod.Spec.SchedulerName]
-	if !ok {
-		return nil, fmt.Errorf("profile not found for scheduler name %q", pod.Spec.SchedulerName)
-	}
-	return fwk, nil
+	return sched.Profiles.FrameworkForPod(pod)
 }
 
 // skipPodSchedule returns true if we could skip scheduling the pod for specified cases.

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -35,29 +35,21 @@ import (
 	schedulinglisters "k8s.io/client-go/listers/scheduling/v1alpha3"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	resourceslicetracker "k8s.io/dynamic-resource-allocation/resourceslice/tracker"
 	"k8s.io/klog/v2"
-	configv1 "k8s.io/kube-scheduler/config/v1"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/features"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
-	"k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	apicache "k8s.io/kubernetes/pkg/scheduler/backend/api_cache"
 	apidispatcher "k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	cachedebugger "k8s.io/kubernetes/pkg/scheduler/backend/cache/debugger"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-	apicalls "k8s.io/kubernetes/pkg/scheduler/framework/api_calls"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
-	frameworkplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodevolumelimits"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/profile"
-	"k8s.io/kubernetes/pkg/scheduler/util/assumecache"
 	"k8s.io/utils/clock"
 )
 
@@ -146,7 +138,6 @@ type schedulerOptions struct {
 	frameworkCapturer          FrameworkCapturer
 	parallelism                int32
 	applyDefaultProfile        bool
-	nodeInfoSnapshot           *internalcache.Snapshot
 }
 
 // Option configures a Scheduler
@@ -261,13 +252,6 @@ func WithBuildFrameworkCapturer(fc FrameworkCapturer) Option {
 	}
 }
 
-// WithNodeInfoSnapshot sets the nodeInfoSnapshot for Scheduler.
-func WithNodeInfoSnapshot(snapshot *internalcache.Snapshot) Option {
-	return func(o *schedulerOptions) {
-		o.nodeInfoSnapshot = snapshot
-	}
-}
-
 var defaultSchedulerOptions = schedulerOptions{
 	clock:                             clock.RealClock{},
 	percentageOfNodesToScore:          schedulerapi.DefaultPercentageOfNodesToScore,
@@ -298,98 +282,20 @@ func New(ctx context.Context,
 		opt(&options)
 	}
 
-	if options.applyDefaultProfile {
-		var versionedCfg configv1.KubeSchedulerConfiguration
-		scheme.Scheme.Default(&versionedCfg)
-		cfg := schedulerapi.KubeSchedulerConfiguration{}
-		if err := scheme.Scheme.Convert(&versionedCfg, &cfg, nil); err != nil {
-			return nil, err
-		}
-		options.profiles = cfg.Profiles
-	}
-
-	registry := frameworkplugins.NewInTreeRegistry()
-	if err := registry.Merge(options.frameworkOutOfTreeRegistry); err != nil {
-		return nil, err
-	}
-
 	metrics.Register()
-
-	extenders, err := buildExtenders(logger, options.extenders, options.profiles)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't build extenders: %w", err)
-	}
 
 	podLister := informerFactory.Core().V1().Pods().Lister()
 	nodeLister := informerFactory.Core().V1().Nodes().Lister()
 
-	snapshot := options.nodeInfoSnapshot
-	if snapshot == nil {
-		snapshot = internalcache.NewEmptySnapshot()
-	}
-	metricsRecorder := metrics.NewMetricsAsyncRecorder(1000, time.Second, stopEverything)
-	// waitingPods holds all the pods that are in the scheduler and waiting in the permit stage
-	waitingPods := frameworkruntime.NewWaitingPodsMap()
+	snapshot := internalcache.NewEmptySnapshot()
 
-	// podsInPreBind holds all the pods that are in the scheduler in the preBind phase
-	podsInPreBind := frameworkruntime.NewPodsInPreBindMap()
-
-	var resourceClaimCache *assumecache.AssumeCache
-	var resourceSliceTracker *resourceslicetracker.Tracker
-	var draManager fwk.SharedDRAManager
-	if feature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
-		resourceClaimInformer := informerFactory.Resource().V1().ResourceClaims().Informer()
-		resourceClaimCache = assumecache.NewAssumeCache(logger, resourceClaimInformer, "ResourceClaim", "", nil)
-		resourceSliceTrackerOpts := resourceslicetracker.Options{
-			EnableDeviceTaintRules:   feature.DefaultFeatureGate.Enabled(features.DRADeviceTaintRules),
-			EnableConsumableCapacity: feature.DefaultFeatureGate.Enabled(features.DRAConsumableCapacity),
-			SliceInformer:            informerFactory.Resource().V1().ResourceSlices(),
-			KubeClient:               client,
-		}
-		// If device taint rules are disabled, the additional informers are not needed and
-		// the tracker turns into a simple wrapper around the slice informer.
-		if resourceSliceTrackerOpts.EnableDeviceTaintRules {
-			resourceSliceTrackerOpts.TaintInformer = informerFactory.Resource().V1().DeviceTaintRules()
-		}
-		resourceSliceTracker, err = resourceslicetracker.StartTracker(ctx, resourceSliceTrackerOpts)
-		if err != nil {
-			return nil, fmt.Errorf("couldn't start resource slice tracker: %w", err)
-		}
-		draManager = dynamicresources.NewDRAManager(ctx, resourceClaimCache, resourceSliceTracker, informerFactory)
-	}
-	sharedCSIManager := nodevolumelimits.NewCSIManager(informerFactory.Storage().V1().CSINodes().Lister())
-
-	var apiDispatcher *apidispatcher.APIDispatcher
-	if feature.DefaultFeatureGate.Enabled(features.SchedulerAsyncAPICalls) {
-		apiDispatcher = apidispatcher.New(client, int(options.parallelism), apicalls.Relevances)
-	}
-
-	schedulerCache := internalcache.New(ctx, apiDispatcher, feature.DefaultFeatureGate.Enabled(features.GenericWorkload), feature.DefaultFeatureGate.Enabled(features.CompositePodGroup))
-
-	profiles, err := profile.NewMap(ctx, options.profiles, registry, recorderFactory,
-		frameworkruntime.WithComponentConfigVersion(options.componentConfigVersion),
-		frameworkruntime.WithClientSet(client),
-		frameworkruntime.WithKubeConfig(options.kubeConfig),
-		frameworkruntime.WithInformerFactory(informerFactory),
-		frameworkruntime.WithSharedDRAManager(draManager),
-		frameworkruntime.WithSnapshotSharedLister(snapshot),
-		frameworkruntime.WithMutableSnapshotLister(snapshot),
-		frameworkruntime.WithCaptureProfile(frameworkruntime.CaptureProfile(options.frameworkCapturer)),
-		frameworkruntime.WithParallelism(int(options.parallelism)),
-		frameworkruntime.WithExtenders(extenders),
-		frameworkruntime.WithMetricsRecorder(metricsRecorder),
-		frameworkruntime.WithWaitingPods(waitingPods),
-		frameworkruntime.WithPodsInPreBind(podsInPreBind),
-		frameworkruntime.WithAPIDispatcher(apiDispatcher),
-		frameworkruntime.WithSharedCSIManager(sharedCSIManager),
-		frameworkruntime.WithPodGroupManager(schedulerCache),
-	)
+	comps, err := newFrameworkComponents(ctx, client, informerFactory, options)
 	if err != nil {
-		return nil, fmt.Errorf("initializing profiles: %v", err)
+		return nil, err
 	}
-
-	if len(profiles) == 0 {
-		return nil, errors.New("at least one profile is required")
+	profiles, err := NewFrameworkMap(ctx, comps, recorderFactory, snapshot)
+	if err != nil {
+		return nil, err
 	}
 
 	preEnqueuePluginMap := make(map[string]map[string]fwk.PreEnqueuePlugin)
@@ -419,7 +325,7 @@ func New(ctx context.Context,
 	}
 
 	podQueue := internalqueue.NewSchedulingQueue(
-		profiles[options.profiles[0].SchedulerName].QueueSortFunc(),
+		profiles[comps.options.profiles[0].SchedulerName].QueueSortFunc(),
 		informerFactory,
 		internalqueue.WithClock(options.clock),
 		internalqueue.WithPodInitialBackoffDuration(time.Duration(options.podInitialBackoffSeconds)*time.Second),
@@ -429,13 +335,15 @@ func New(ctx context.Context,
 		internalqueue.WithPreEnqueuePluginMap(preEnqueuePluginMap),
 		internalqueue.WithQueueingHintMapPerProfile(queueingHintsPerProfile),
 		internalqueue.WithPluginMetricsSamplePercent(pluginMetricsSamplePercent),
-		internalqueue.WithMetricsRecorder(metricsRecorder),
-		internalqueue.WithAPIDispatcher(apiDispatcher),
+		internalqueue.WithMetricsRecorder(comps.metricsRecorder),
+		internalqueue.WithAPIDispatcher(comps.apiDispatcher),
 		internalqueue.WithPodSigners(podSigners),
 	)
 
+	schedulerCache := comps.GetCache()
+
 	var apiCache fwk.APICacher
-	if apiDispatcher != nil {
+	if comps.apiDispatcher != nil {
 		apiCache = apicache.New(podQueue, schedulerCache)
 	}
 
@@ -459,12 +367,12 @@ func New(ctx context.Context,
 		client:                                 client,
 		nodeInfoSnapshot:                       snapshot,
 		percentageOfNodesToScore:               options.percentageOfNodesToScore,
-		Extenders:                              extenders,
+		Extenders:                              comps.extenders,
 		StopEverything:                         stopEverything,
 		SchedulingQueue:                        podQueue,
 		Profiles:                               profiles,
 		logger:                                 logger,
-		APIDispatcher:                          apiDispatcher,
+		APIDispatcher:                          comps.apiDispatcher,
 		compositePodGroupLister:                compositePodGroupLister,
 		nominatedNodeNameForExpectationEnabled: feature.DefaultFeatureGate.Enabled(features.NominatedNodeNameForExpectation),
 		genericWorkloadEnabled:                 feature.DefaultFeatureGate.Enabled(features.GenericWorkload),
@@ -473,7 +381,7 @@ func New(ctx context.Context,
 	sched.NextEntity = podQueue.Pop
 	sched.applyDefaultHandlers()
 
-	if err = addAllEventHandlers(sched, informerFactory, dynInformerFactory, resourceClaimCache, resourceSliceTracker, draManager, unionedGVKs(queueingHintsPerProfile)); err != nil {
+	if err = addAllEventHandlers(sched, informerFactory, dynInformerFactory, comps.resourceClaimCache, comps.resourceSliceTracker, comps.draManager, unionedGVKs(queueingHintsPerProfile)); err != nil {
 		return nil, fmt.Errorf("adding event handlers: %w", err)
 	}
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -85,7 +85,6 @@ func TestSchedulerCreation(t *testing.T) {
 	validRegistry := map[string]frameworkruntime.PluginFactory{
 		"Foo": defaultbinder.New,
 	}
-	customSnapshot := internalcache.NewEmptySnapshot()
 	cases := []struct {
 		name                 string
 		opts                 []Option
@@ -195,14 +194,6 @@ func TestSchedulerCreation(t *testing.T) {
 			wantProfiles:  []string{"default-scheduler"},
 			wantExtenders: []string{"http://extender.kube-system/"},
 		},
-		{
-			name: "With custom nodeInfoSnapshot",
-			opts: []Option{
-				WithNodeInfoSnapshot(customSnapshot),
-			},
-			wantProfiles:         []string{"default-scheduler"},
-			wantNodeInfoSnapshot: customSnapshot,
-		},
 	}
 
 	for _, tc := range cases {
@@ -266,11 +257,6 @@ func TestSchedulerCreation(t *testing.T) {
 						t.Errorf("unexpected extenders (-want, +got):\n%s", diff)
 					}
 				}
-			}
-
-			// nodeInfoSnapshot
-			if tc.wantNodeInfoSnapshot != nil && s.nodeInfoSnapshot != tc.wantNodeInfoSnapshot {
-				t.Errorf("unexpected nodeInfoSnapshot: got %p, want %p", s.nodeInfoSnapshot, tc.wantNodeInfoSnapshot)
 			}
 		})
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -85,7 +85,6 @@ func TestSchedulerCreation(t *testing.T) {
 	validRegistry := map[string]frameworkruntime.PluginFactory{
 		"Foo": defaultbinder.New,
 	}
-	customSnapshot := internalcache.NewEmptySnapshot()
 	cases := []struct {
 		name                            string
 		isSchedulerAsyncAPICallsEnabled bool
@@ -198,14 +197,6 @@ func TestSchedulerCreation(t *testing.T) {
 			wantExtenders: []string{"http://extender.kube-system/"},
 		},
 		{
-			name: "With custom nodeInfoSnapshot",
-			opts: []Option{
-				WithNodeInfoSnapshot(customSnapshot),
-			},
-			wantProfiles:         []string{"default-scheduler"},
-			wantNodeInfoSnapshot: customSnapshot,
-		},
-		{
 			name:                            "With SchedulerAsyncAPICalls enabled",
 			isSchedulerAsyncAPICallsEnabled: true,
 			opts: []Option{
@@ -290,11 +281,6 @@ func TestSchedulerCreation(t *testing.T) {
 						t.Errorf("unexpected extenders (-want, +got):\n%s", diff)
 					}
 				}
-			}
-
-			// nodeInfoSnapshot
-			if tc.wantNodeInfoSnapshot != nil && s.nodeInfoSnapshot != tc.wantNodeInfoSnapshot {
-				t.Errorf("unexpected nodeInfoSnapshot: got %p, want %p", s.nodeInfoSnapshot, tc.wantNodeInfoSnapshot)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR refactors the scheduler initialization logic by extracting framework and shared component construction from `scheduler.New` into an exported constructor `NewFrameworks` in `pkg/scheduler/frameworks.go`.

Key changes:
1. **Exported `NewFrameworks` constructor**: Allows out-of-tree consumers (such as scheduler library integrations) to construct scheduling frameworks and shared dependencies (`Profiles`, `Cache`, `APIDispatcher`, `MetricsRecorder`, DRA components) identically to `kube-scheduler` without duplicating internal wiring.
2. **Centralized `FrameworkForPod` helper**: Adds `(m Map) FrameworkForPod(pod *v1.Pod)` in `pkg/scheduler/profile/profile.go` to encapsulate profile lookups by `pod.Spec.SchedulerName`, falling back to `v1.DefaultSchedulerName` when unspecified.

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/issues/140281

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE