### PR TITLE
Add back `admissioninitializer.WantsAuthorizer` for v1.37

### DIFF
--- a/plugin/pkg/admission/gc/gc_admission_test.go
+++ b/plugin/pkg/admission/gc/gc_admission_test.go
@@ -100,6 +100,16 @@ func (fakeAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (a
 	return authorizer.DecisionAllow, "", nil
 }
 
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (f fakeAuthorizer) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(f.Authorize(ctx, a))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (fakeAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}
+
 // newGCPermissionsEnforcement returns the admission controller configured for testing.
 func newGCPermissionsEnforcement() (*gcPermissionsEnforcement, error) {
 	// the pods/status endpoint is ignored by this plugin since old kubelets

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
@@ -31,7 +31,7 @@ type pluginInitializer struct {
 	externalClient    kubernetes.Interface
 	dynamicClient     dynamic.Interface
 	externalInformers informers.SharedInformerFactory
-	authorizer        authorizer.UnconditionalAuthorizer
+	authorizer        authorizer.Authorizer
 	featureGates      featuregate.FeatureGate
 	effectiveVersion  compatibility.EffectiveVersion
 	stopCh            <-chan struct{}
@@ -45,7 +45,7 @@ func New(
 	extClientset kubernetes.Interface,
 	dynamicClient dynamic.Interface,
 	extInformers informers.SharedInformerFactory,
-	authz authorizer.UnconditionalAuthorizer,
+	authz authorizer.Authorizer,
 	featureGates featuregate.FeatureGate,
 	effectiveVersion compatibility.EffectiveVersion,
 	stopCh <-chan struct{},
@@ -93,6 +93,9 @@ func (i pluginInitializer) Initialize(plugin admission.Interface) {
 
 	if wants, ok := plugin.(WantsUnconditionalAuthorizer); ok {
 		wants.SetUnconditionalAuthorizer(i.authorizer)
+	}
+	if wants, ok := plugin.(WantsAuthorizer); ok {
+		wants.SetAuthorizer(i.authorizer)
 	}
 	if wants, ok := plugin.(WantsRESTMapper); ok {
 		wants.SetRESTMapper(i.restMapper)

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer_test.go
@@ -31,6 +31,17 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+// TestWantsUnconditionalAuthorizer ensures that the authorizer is injected
+// when the WantsUnconditionalAuthorizer interface is implemented by a plugin.
+func TestWantsUnconditionalAuthorizer(t *testing.T) {
+	target := initializer.New(nil, nil, nil, &TestAuthorizer{}, nil, nil, nil, nil)
+	wantUnconditionalAuthorizerAdmission := &WantUnconditionalAuthorizerAdmission{}
+	target.Initialize(wantUnconditionalAuthorizerAdmission)
+	if wantUnconditionalAuthorizerAdmission.auth == nil {
+		t.Errorf("expected unconditional authorizer to be initialized but found nil")
+	}
+}
+
 // TestWantsAuthorizer ensures that the authorizer is injected
 // when the WantsAuthorizer interface is implemented by a plugin.
 func TestWantsAuthorizer(t *testing.T) {
@@ -113,12 +124,29 @@ func (self *WantExternalKubeClientSet) ValidateInitialization() error      { ret
 var _ admission.Interface = &WantExternalKubeClientSet{}
 var _ initializer.WantsExternalKubeClientSet = &WantExternalKubeClientSet{}
 
-// WantAuthorizerAdmission is a test stub that fulfills the WantsAuthorizer interface.
-type WantAuthorizerAdmission struct {
+// WantUnconditionalAuthorizerAdmission is a test stub that fulfills the WantsUnconditionalAuthorizer interface.
+type WantUnconditionalAuthorizerAdmission struct {
 	auth authorizer.UnconditionalAuthorizer
 }
 
-func (self *WantAuthorizerAdmission) SetUnconditionalAuthorizer(a authorizer.UnconditionalAuthorizer) {
+func (self *WantUnconditionalAuthorizerAdmission) SetUnconditionalAuthorizer(a authorizer.UnconditionalAuthorizer) {
+	self.auth = a
+}
+func (self *WantUnconditionalAuthorizerAdmission) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	return nil
+}
+func (self *WantUnconditionalAuthorizerAdmission) Handles(o admission.Operation) bool { return false }
+func (self *WantUnconditionalAuthorizerAdmission) ValidateInitialization() error      { return nil }
+
+var _ admission.Interface = &WantUnconditionalAuthorizerAdmission{}
+var _ initializer.WantsUnconditionalAuthorizer = &WantUnconditionalAuthorizerAdmission{}
+
+// WantAuthorizerAdmission is a test stub that fulfills the WantsAuthorizer interface.
+type WantAuthorizerAdmission struct {
+	auth authorizer.Authorizer
+}
+
+func (self *WantAuthorizerAdmission) SetAuthorizer(a authorizer.Authorizer) {
 	self.auth = a
 }
 func (self *WantAuthorizerAdmission) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
@@ -128,7 +156,7 @@ func (self *WantAuthorizerAdmission) Handles(o admission.Operation) bool { retur
 func (self *WantAuthorizerAdmission) ValidateInitialization() error      { return nil }
 
 var _ admission.Interface = &WantAuthorizerAdmission{}
-var _ initializer.WantsUnconditionalAuthorizer = &WantAuthorizerAdmission{}
+var _ initializer.WantsAuthorizer = &WantAuthorizerAdmission{}
 
 // WantDrainedNotification is a test stub that filfills the WantsDrainedNotification interface.
 type WantDrainedNotification struct {
@@ -147,11 +175,21 @@ func (self *WantDrainedNotification) ValidateInitialization() error      { retur
 var _ admission.Interface = &WantDrainedNotification{}
 var _ initializer.WantsDrainedNotification = &WantDrainedNotification{}
 
-// TestAuthorizer is a test stub that fulfills the WantsAuthorizer interface.
+// TestAuthorizer is a test stub that fulfills the full Authorizer interface.
 type TestAuthorizer struct{}
 
 func (t *TestAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorized authorizer.Decision, reason string, err error) {
 	return authorizer.DecisionNoOpinion, "", nil
+}
+
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (t *TestAuthorizer) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(t.Authorize(ctx, a))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (*TestAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
 }
 
 func TestRESTMapperAdmissionPlugin(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
@@ -43,9 +43,15 @@ type WantsExternalKubeInformerFactory interface {
 	admission.InitializationValidator
 }
 
-// WantsUnconditionalAuthorizer defines a function which sets authorizer.UnconditionalAuthorizer for admission plugins that need it.
+// WantsUnconditionalAuthorizer defines a function which sets a narrower, conditions-unaware UnconditionalAuthorizer for admission plugins that need it.
 type WantsUnconditionalAuthorizer interface {
 	SetUnconditionalAuthorizer(authorizer.UnconditionalAuthorizer)
+	admission.InitializationValidator
+}
+
+// WantsAuthorizer defines a function which sets a standard, possibly conditions-aware Authorizer for admission plugins that need it.
+type WantsAuthorizer interface {
+	SetAuthorizer(authorizer.Authorizer)
 	admission.InitializationValidator
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_test_context.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_test_context.go
@@ -644,3 +644,13 @@ type fakeAuthorizer struct{}
 func (f fakeAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 	return authorizer.DecisionAllow, "", nil
 }
+
+// ConditionsAwareAuthorize is not conditions-aware, converts the Authorize decision.
+func (f fakeAuthorizer) ConditionsAwareAuthorize(ctx context.Context, a authorizer.Attributes) authorizer.ConditionsAwareDecision {
+	return authorizer.ConditionsAwareDecisionFromParts(f.Authorize(ctx, a))
+}
+
+// EvaluateConditions is not supported by this authorizer.
+func (fakeAuthorizer) EvaluateConditions(_ context.Context, _ authorizer.ConditionsAwareDecision, _ authorizer.ConditionsData) (authorizer.Decision, string, error) {
+	return authorizer.DecisionDeny, "", authorizer.ErrorConditionEvaluationNotSupported
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Ensures that existing admission plugins that use an authorizer keep working in v1.37 (i.e. that the partially-merged Conditional Authorization changes do not interfere with existing code).

This is not new feature code, but more of cleanup or a bug fix for v1.37.

/kind cleanup
/sig auth
/milestone v1.37
/assign @liggitt @deads2k 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

KEP: https://github.com/kubernetes/enhancements/issues/5681
Fixes: https://github.com/kubernetes/kubernetes/issues/140915

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
