### PR TITLE
kubelet/dra: add regression test for re-prepare-after-restart device duplication

### DIFF
--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -1393,6 +1393,65 @@ func TestPrepareResourcesWithPreparedAndNewClaim(t *testing.T) {
 	}
 }
 
+// TestPrepareResourcesAfterRestartIsIdempotent is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/140471: re-preparing an
+// already-prepared claim after a kubelet restart used to append the
+// NodePrepareResources response onto the checkpoint-restored device list
+// instead of replacing it, so the device list (and the checkpoint) doubled
+// on every restart. A second Manager built on the same state directory
+// simulates the restart, since it restores ClaimInfo from the checkpoint
+// with prepared=false.
+func TestPrepareResourcesAfterRestartIsIdempotent(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
+	fakeKubeClient := fake.NewClientset()
+	stateDir := t.TempDir()
+
+	pod := genTestPodWithClaims(claimName)
+	claim := genTestClaim(claimName, driverName, deviceName, string(pod.ObjectMeta.UID))
+	_, err := fakeKubeClient.ResourceV1().ResourceClaims(namespace).Create(tCtx, claim, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	resp := genPrepareResourcesResponse(claim.UID)
+	draServerInfo, err := setupFakeDRADriverGRPCServer(tCtx, false, nil, resp, nil, nil)
+	require.NoError(t, err)
+	defer draServerInfo.teardownFn()
+
+	firstManager, err := NewManager(logger, fakeKubeClient, stateDir)
+	require.NoError(t, err)
+	firstManager.initDRAPluginManager(tCtx, getFakeNode, time.Second)
+	plg := firstManager.GetWatcherHandler()
+	require.NoError(t, plg.RegisterPlugin(tCtx, driverName, draServerInfo.socketName, []string{drapb.DRAPluginService}, nil))
+
+	require.NoError(t, firstManager.PrepareResources(tCtx, pod))
+
+	claimInfo, exists := firstManager.cache.get(claim.Name, namespace)
+	require.True(t, exists)
+	require.Len(t, claimInfo.DriverState[driverName].Devices, 1, "one device after first prepare")
+
+	// Simulate a kubelet restart: build a second Manager on the same state
+	// directory. It restores ClaimInfo from the checkpoint, always with
+	// prepared=false, so PrepareResources will call NodePrepareResources again.
+	firstManager.Stop()
+
+	secondManager, err := NewManager(logger, fakeKubeClient, stateDir)
+	require.NoError(t, err)
+	defer secondManager.Stop()
+	secondManager.initDRAPluginManager(tCtx, getFakeNode, time.Second)
+	plg = secondManager.GetWatcherHandler()
+	require.NoError(t, plg.RegisterPlugin(tCtx, driverName, draServerInfo.socketName, []string{drapb.DRAPluginService}, nil))
+
+	restoredClaimInfo, exists := secondManager.cache.get(claim.Name, namespace)
+	require.True(t, exists, "claim info should be restored from checkpoint")
+	assert.False(t, restoredClaimInfo.prepared, "restored claim info is never marked prepared")
+
+	require.NoError(t, secondManager.PrepareResources(tCtx, pod))
+
+	claimInfo, exists = secondManager.cache.get(claim.Name, namespace)
+	require.True(t, exists)
+	assert.Len(t, claimInfo.DriverState[driverName].Devices, 1,
+		"device list must stay at one entry after restart + re-prepare, not double")
+}
+
 // TestPrepareResourcesWithUnpreparingClaim is a regression test for the race
 // where reconcileLoop-initiated (or otherwise concurrent) unprepareResources
 // has committed to calling NodeUnprepareResources on a claim, released the


### PR DESCRIPTION
## What this PR does / why we need it

I looked into #140471, which reports that re-preparing an already-prepared claim after a kubelet restart appends the `NodePrepareResources` response onto the checkpoint-restored device list instead of replacing it, so `DriverState.Devices` (and the checkpoint) doubles on every restart.

Tracing it, the fix is already on master via cdb7e7b760c (`kubelet/dra: reset devices before processing response`, #140274) - `manager.go`'s `prepareResources` already calls `info.resetDevices(plugin.DriverName())` right before `addDevice()`. I confirmed this by temporarily disabling that call locally: the device list does double, and restoring it keeps the list at one entry.

What I found missing was test coverage for this exact path. The existing tests cover partial-batch-failure retries, but not the checkpoint-restore-after-restart scenario the issue describes, so I'm adding a regression test for it: build a `Manager`, prepare a claim, stop it, build a second `Manager` on the same state directory (simulating a restart via checkpoint restore, since `newClaimInfoFromState` always restores with `prepared: false`), then prepare the same pod again. Asserts the device list stays at one entry.

I'd suggest closing #140471 as already fixed by #140274, with this PR just locking in the regression coverage so it can't come back silently.

## Which issue(s) this PR is related to

Relates to #140471 (already fixed by #140274; this adds the missing regression test)

## Type of change

/kind cleanup
/sig node
/wg device-management

## Does this PR introduce a user-facing change?

```release-note
NONE
```

## Testing

I verified the test actually catches the regression: temporarily commented out the `info.resetDevices()` call in `manager.go` and re-ran the new test - it failed with the device list growing to 2 entries. Restored the call and it passes at 1 entry.

- `go build ./pkg/kubelet/cm/dra/...`
- `go test ./pkg/kubelet/cm/dra/... -run TestPrepareResourcesAfterRestartIsIdempotent -v` - passes
- `go test ./pkg/kubelet/cm/dra/...` - full package suite, 241 passed, no regressions