### PR TITLE
Fix flaky TestValidateEvictionStatusUpdate/mark_active_and_started

### DIFF
--- a/pkg/apis/lifecycle/validation/validation_test.go
+++ b/pkg/apis/lifecycle/validation/validation_test.go
@@ -440,7 +440,7 @@ func TestValidateEvictionStatusUpdate(t *testing.T) {
 		},
 		// Full Eviction progression/lifecycle
 		"mark active and started": {
-			oldInput: mkValidEvictionStatus(2),
+			oldInput: mkValidEvictionStatus(0),
 			input: mkValidEvictionStatus(2,
 				setStateFor(lifecycle.ResponderStateActive, 0),
 				setRespondersStartTime(clock, 0, 1)),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
The test's oldInput used metav1.Now() (wall clock) for Responder[0].StartTime while input used clock.Now() (fake clock initialized from time.Now()). On Windows, where the system clock resolution is ~15ms, both calls could return the same timestamp, making oldInput and input semantically equal and triggering the "Expected oldInput and input to differ" assertion.

Use clockBefore(time.Minute) for oldInput's StartTime to guarantee a deterministic difference between old and new state.

#### Which issue(s) this PR is related to:
Fixes #140924

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
