### PR TITLE
kubectl: end-anchor ingress rule validation regex

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress.go
@@ -56,7 +56,7 @@ var (
 
 	// The validation Regex is the concatenation of hostPathSvc validation regex
 	// and the TLS validation regex
-	ruleRegex = regexHostPathSvc + regexTLS
+	ruleRegex = regexHostPathSvc + regexTLS + "$"
 
 	ingressLong = templates.LongDesc(i18n.T(`
 	Create an ingress with the specified name.`))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_ingress_test.go
@@ -130,6 +130,18 @@ func TestCreateIngressValidation(t *testing.T) {
 			},
 			expected: "",
 		},
+		"invalid trailing data after tls secret": {
+			rules: []string{
+				"foo.com/=svc:http,tls=secret123,garbage",
+			},
+			expected: "rule foo.com/=svc:http,tls=secret123,garbage is invalid and should be in format host/path=svcname:svcport[,tls[=secret]]",
+		},
+		"invalid trailing data after tls": {
+			rules: []string{
+				"foo.com/=svc:http,tls,garbage",
+			},
+			expected: "rule foo.com/=svc:http,tls,garbage is invalid and should be in format host/path=svcname:svcport[,tls[=secret]]",
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kubectl create ingress` validation regex (`ruleRegex`) was anchored at the beginning (`^`) but lacked an end anchor (`$`). Because `MatchString` matches valid prefixes, rules containing malformed trailing data (e.g. `foo.com/=svc:http,tls=secret123,garbage`) passed validation, while downstream parsing silently dropped the TLS configuration due to unexpected field lengths.

This PR end-anchors `ruleRegex` with `$` so that the full rule string is validated, properly rejecting malformed trailing fields, and adds corresponding unit test coverage.

#### Which issue(s) this PR fixes:

Fixes #140922

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug in `kubectl create ingress` where malformed trailing data in `--rule` passed validation and silently dropped TLS configuration.
```
