### PR TITLE
Assert SetUp was called in the reconstructed volume unmount test

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -48,6 +48,7 @@ import (
 	volumetesting "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
+	"k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations"
 	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
 	"k8s.io/kubernetes/pkg/volume/util/types"
 )
@@ -2591,18 +2592,25 @@ func TestReconstructedVolumeShouldUnmountSucceedAfterSetupFailed(t *testing.T) {
 	// Act first reconcile to trigger mount reconstructed volume
 	reconciler.reconcile(ctx)
 
-	// Wait for the async mount operation to actually complete before proceeding.
-	// The mount runs in a goroutine and creates directories on disk. We must
-	// wait for it to finish so the subsequent unmount is not blocked by a
-	// pending mount operation.
+	// Wait for the async mount operation to actually complete before proceeding:
+	// unmountVolumes() skips volumes that have a pending operation, so the second
+	// reconcile() below would never call UnmountVolume(). SetUpCallCount is not a
+	// usable signal here, because FakeVolume.SetUp increments it before running
+	// SetUpHook, i.e. while the mount operation is still pending.
 	err = retryWithExponentialBackOff(
 		testOperationBackOffDuration,
 		func() (bool, error) {
-			return volumetesting.VerifySetUpCallCount(1, fakePlugin) == nil, nil
+			return !reconciler.operationExecutor.IsOperationPending(
+				generatedVolumeName, podName, nestedpendingoperations.EmptyNodeName), nil
 		},
 	)
 	if err != nil {
 		t.Fatalf("Timed out waiting for mount operation to complete")
+	}
+	// The mount must have reached SetUp, otherwise the test would not exercise
+	// the failed-setup path it is named after.
+	if err := volumetesting.VerifySetUpCallCount(1, fakePlugin); err != nil {
+		t.Fatalf("Expected SetUp() to be called: %v", err)
 	}
 
 	waitForUncertainPodMount(t, generatedVolumeName, podName, asw)

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -2608,6 +2608,11 @@ func TestReconstructedVolumeShouldUnmountSucceedAfterSetupFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Timed out waiting for failed mount operation to stop being pending")
 	}
+	// The mount must have reached SetUp, otherwise the test would not exercise
+	// the failed-setup path it is named after.
+	if err := volumetesting.VerifySetUpCallCount(1, fakePlugin); err != nil {
+		t.Fatalf("Expected SetUp() to be called: %v", err)
+	}
 
 	waitForUncertainPodMount(t, generatedVolumeName, podName, asw)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig storage

#### What this PR does / why we need it:

The flake in `TestReconstructedVolumeShouldUnmountSucceedAfterSetupFailed` (#140823) was fixed by #141062, which replaced the wait that sits between the two `reconcile()` calls:

* before: `retryWithExponentialBackOff(..., VerifySetUpCallCount(1, fakePlugin) == nil)`
* after: `retryWithExponentialBackOff(..., !oex.IsOperationPending(...))`

That is the right signal for what the second `reconcile()` actually depends on, and the flake is gone. But the old wait was doing two jobs and only one of them was carried over. It also asserted that the mount had reached `SetUp`. After the swap nothing in the test checks that any more.

Nothing downstream restores it either. The test marks the volume uncertain itself via `CheckAndMarkVolumeAsUncertainViaReconstruction` before the first `reconcile()`, so `waitForUncertainPodMount` passes whether or not a mount ran, and the unmount then succeeds because `NewUnmounterError` is only ever set from inside `SetUpHook`.

Concretely, with the first `reconciler.reconcile(ctx)` removed so that no mount is triggered at all:

* on master the test passes, having exercised none of the failed-setup path it is named after
* with this patch it fails with `Expected SetUp() to be called: No Mounters have expected SetUpCallCount. Expected: <1>.`

So this PR adds back just that one assertion, immediately after the new wait. It changes nothing else: 10 of 10 fresh runs of the test pass, and the full `pkg/kubelet/volumemanager/reconciler` package passes.

#### Which issue(s) this PR is related to:

#140823, which #141062 already fixed. This is a follow-up to that fix, not a second fix for the flake.

#### Special notes for your reviewer:

This PR started out as a duplicate deflake of the same test, opened before #141062 and never picked up an `/ok-to-test`. It is now rebased down to the single assertion, which is the only part of it not already covered upstream.

/cc @gnufied

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
