### PR TITLE
kubelet: retry pod allocation checkpoint writes that fail to persist

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -126,8 +126,9 @@ type manager struct {
 	getActivePods  func() []*v1.Pod
 	getPodByUID    func(types.UID) (*v1.Pod, bool)
 
-	allocationMutex        sync.Mutex
-	podsWithPendingResizes []types.UID
+	allocationMutex           sync.Mutex
+	podsWithPendingResizes    []types.UID
+	podsWithPendingCheckpoint []types.UID
 
 	recorder record.EventRecorderLogger
 }
@@ -209,6 +210,10 @@ func (m *manager) Run(ctx context.Context) {
 				for _, po := range successfulResizes {
 					logger.Info("Successfully retried resize after timeout", "pod", klog.KObj(po))
 				}
+				successfulCheckpoints := m.retryPendingCheckpoints(ctx)
+				for _, po := range successfulCheckpoints {
+					logger.Info("Successfully persisted pod allocation checkpoint after previous failure", "pod", klog.KObj(po))
+				}
 			case <-ctx.Done():
 				m.ticker.Stop()
 				return
@@ -275,6 +280,49 @@ func (m *manager) retryPendingResizes(ctx context.Context, trigger string) []*v1
 
 	m.podsWithPendingResizes = newPendingResizes
 	return successfulResizes
+}
+
+// retryPendingCheckpoints retries persisting the allocation checkpoint for any pod whose
+// SetAllocatedResources call previously failed to write to disk (the in-memory allocation
+// was already updated at that point, so this only needs to retry the write). Returns the
+// pods that were successfully persisted.
+func (m *manager) retryPendingCheckpoints(ctx context.Context) []*v1.Pod {
+	logger := klog.FromContext(ctx)
+	m.allocationMutex.Lock()
+	defer m.allocationMutex.Unlock()
+
+	if len(m.podsWithPendingCheckpoint) == 0 {
+		return nil
+	}
+
+	var stillPending []types.UID
+	var successful []*v1.Pod
+	for _, uid := range m.podsWithPendingCheckpoint {
+		pod, found := m.getPodByUID(uid)
+		if !found {
+			logger.V(4).Info("Pod not found; removing from pending checkpoint retries", "podUID", uid)
+			continue
+		}
+
+		if err := m.SetAllocatedResources(logger, pod); err != nil {
+			logger.Error(err, "Retry of pod allocation checkpoint failed; will retry again later", "pod", klog.KObj(pod))
+			stillPending = append(stillPending, uid)
+			continue
+		}
+		successful = append(successful, pod)
+	}
+
+	m.podsWithPendingCheckpoint = stillPending
+	return successful
+}
+
+// pushPendingCheckpointLocked queues a pod whose allocation checkpoint failed to persist for
+// later retry. Callers must already hold allocationMutex.
+func (m *manager) pushPendingCheckpointLocked(uid types.UID) {
+	if slices.Contains(m.podsWithPendingCheckpoint, uid) {
+		return
+	}
+	m.podsWithPendingCheckpoint = append(m.podsWithPendingCheckpoint, uid)
 }
 
 func (m *manager) PushPendingResize(logger klog.Logger, uid types.UID) {
@@ -580,8 +628,14 @@ func (m *manager) AddPod(ctx context.Context, activePods []*v1.Pod, pod *v1.Pod)
 	if ok && utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		// Checkpoint the resource values at which the Pod has been admitted or resized.
 		if err := m.SetAllocatedResources(logger, pod); err != nil {
-			// TODO(vinaykul,InPlacePodVerticalScaling): Can we recover from this in some way? Investigate
-			logger.Error(err, "SetPodAllocation failed", "pod", klog.KObj(pod))
+			// The in-memory allocation is already updated at this point (SetPodResourceInfo
+			// updates the cache before attempting to persist it), so the pod is admitted with
+			// the correct resources for this kubelet's lifetime; only the on-disk checkpoint
+			// write failed. Queue it for periodic retry so a transient write failure (e.g. a
+			// full disk) doesn't leave the checkpoint permanently stale, which would surface
+			// stale allocations after a kubelet restart.
+			logger.Error(err, "SetPodAllocation failed; will retry persisting the checkpoint periodically", "pod", klog.KObj(pod))
+			m.pushPendingCheckpointLocked(pod.UID)
 		}
 	}
 
@@ -593,6 +647,12 @@ func (m *manager) RemovePod(logger klog.Logger, uid types.UID) {
 		// If the deletion fails, it will be retried by RemoveOrphanedPods, so we can safely ignore the error.
 		logger.V(3).Info("Failed to delete pod allocation", "podUID", uid, "err", err)
 	}
+
+	m.allocationMutex.Lock()
+	defer m.allocationMutex.Unlock()
+	m.podsWithPendingCheckpoint = slices.DeleteFunc(m.podsWithPendingCheckpoint, func(pending types.UID) bool {
+		return pending == uid
+	})
 }
 
 func (m *manager) RemoveOrphanedPods(remainingPods sets.Set[types.UID]) {

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -2218,6 +2218,182 @@ func TestAllocationManagerAddPod(t *testing.T) {
 	}
 }
 
+// failNTimesState wraps a state.State and reports a failure from the first n
+// calls to SetPodResourceInfo, used to simulate a transient checkpoint
+// persistence failure (e.g. a disk write error). The real stateCheckpoint
+// always updates its in-memory cache before attempting to persist to disk, so
+// only the persistence step can fail; this always applies the write to the
+// wrapped state and only fakes the returned error, to match that behavior.
+type failNTimesState struct {
+	state.State
+	n int
+}
+
+func (f *failNTimesState) SetPodResourceInfo(logger klog.Logger, uid types.UID, info state.PodResourceInfo) error {
+	err := f.State.SetPodResourceInfo(logger, uid, info)
+	if err != nil {
+		return err
+	}
+	if f.n > 0 {
+		f.n--
+		return fmt.Errorf("simulated checkpoint write failure")
+	}
+	return nil
+}
+
+// TestAllocationManagerAddPodCheckpointFailureIsRetried is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/133538: AddPod used to only log
+// and drop the error when persisting the allocation checkpoint failed, so a
+// transient write failure (the in-memory allocation is already updated by that
+// point) left the on-disk checkpoint permanently stale with no retry. It now
+// queues the pod for periodic retry instead.
+func TestAllocationManagerAddPodCheckpointFailureIsRetried(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	tCtx := ktesting.Init(t)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID("pod1"), Name: "pod1", Namespace: "ns1"},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name: "c1",
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")},
+				},
+			}},
+		},
+	}
+
+	allocatedPods := []*v1.Pod{pod}
+	allocationManager := makeAllocationManager(t, &containertest.FakeRuntime{}, allocatedPods, nil)
+	m := allocationManager.(*manager)
+
+	// Fail exactly the write triggered by AddPod; the retry (below) should succeed.
+	m.allocated = &failNTimesState{State: m.allocated, n: 1}
+
+	ok, _, _ := allocationManager.AddPod(tCtx, []*v1.Pod{}, pod)
+	require.True(t, ok, "pod should still be admitted even though the checkpoint write failed")
+
+	// The in-memory allocation must already reflect the pod's resources: the
+	// pod is correctly admitted for the rest of this kubelet's lifetime even
+	// though the checkpoint write failed.
+	allocated, found := allocationManager.GetContainerResourceAllocation(pod.UID, "c1")
+	require.True(t, found)
+	assert.Equal(t, pod.Spec.Containers[0].Resources, allocated)
+
+	m.allocationMutex.Lock()
+	pending := append([]types.UID(nil), m.podsWithPendingCheckpoint...)
+	m.allocationMutex.Unlock()
+	assert.Equal(t, []types.UID{pod.UID}, pending, "pod should be queued for a checkpoint retry")
+
+	successful := m.retryPendingCheckpoints(tCtx)
+	require.Len(t, successful, 1)
+	assert.Equal(t, pod.UID, successful[0].UID)
+
+	m.allocationMutex.Lock()
+	pending = append([]types.UID(nil), m.podsWithPendingCheckpoint...)
+	m.allocationMutex.Unlock()
+	assert.Empty(t, pending, "pod should no longer be pending after a successful retry")
+}
+
+// TestAllocationManagerRetryPendingCheckpointsKeepsFailingPods verifies that a
+// pod whose checkpoint retry fails again stays queued for a later retry,
+// instead of being dropped.
+func TestAllocationManagerRetryPendingCheckpointsKeepsFailingPods(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	tCtx := ktesting.Init(t)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID("pod1"), Name: "pod1", Namespace: "ns1"},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name: "c1",
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")},
+				},
+			}},
+		},
+	}
+
+	allocatedPods := []*v1.Pod{pod}
+	allocationManager := makeAllocationManager(t, &containertest.FakeRuntime{}, allocatedPods, nil)
+	m := allocationManager.(*manager)
+
+	// Fail the initial write plus the first retry; the second retry succeeds.
+	m.allocated = &failNTimesState{State: m.allocated, n: 2}
+
+	ok, _, _ := allocationManager.AddPod(tCtx, []*v1.Pod{}, pod)
+	require.True(t, ok)
+
+	successful := m.retryPendingCheckpoints(tCtx)
+	assert.Empty(t, successful, "retry should fail again and report no successes")
+
+	m.allocationMutex.Lock()
+	pending := append([]types.UID(nil), m.podsWithPendingCheckpoint...)
+	m.allocationMutex.Unlock()
+	assert.Equal(t, []types.UID{pod.UID}, pending, "pod should still be pending after a second failure")
+
+	successful = m.retryPendingCheckpoints(tCtx)
+	require.Len(t, successful, 1, "third attempt should finally succeed")
+
+	m.allocationMutex.Lock()
+	pending = append([]types.UID(nil), m.podsWithPendingCheckpoint...)
+	m.allocationMutex.Unlock()
+	assert.Empty(t, pending)
+}
+
+// TestAllocationManagerRemovePodClearsPendingCheckpoint verifies that removing a
+// pod also drops it from the pending-checkpoint-retry queue, so a deleted pod
+// isn't retried forever.
+func TestAllocationManagerRemovePodClearsPendingCheckpoint(t *testing.T) {
+	if goruntime.GOOS == "windows" {
+		t.Skip("InPlacePodVerticalScaling is not currently supported for Windows")
+	}
+
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID("pod1"), Name: "pod1", Namespace: "ns1"},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{{
+				Name: "c1",
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")},
+				},
+			}},
+		},
+	}
+
+	allocatedPods := []*v1.Pod{pod}
+	allocationManager := makeAllocationManager(t, &containertest.FakeRuntime{}, allocatedPods, nil)
+	m := allocationManager.(*manager)
+	m.allocated = &failNTimesState{State: m.allocated, n: 1}
+
+	ok, _, _ := allocationManager.AddPod(tCtx, []*v1.Pod{}, pod)
+	require.True(t, ok)
+
+	m.allocationMutex.Lock()
+	pending := len(m.podsWithPendingCheckpoint)
+	m.allocationMutex.Unlock()
+	require.Equal(t, 1, pending, "pod should be queued after the failed write")
+
+	allocationManager.RemovePod(logger, pod.UID)
+
+	m.allocationMutex.Lock()
+	pending = len(m.podsWithPendingCheckpoint)
+	m.allocationMutex.Unlock()
+	assert.Equal(t, 0, pending, "removed pod should no longer be queued for checkpoint retry")
+}
+
 func TestIsResizeIncreasingRequests(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 


### PR DESCRIPTION
## What this PR does / why we need it

I looked into the TODO tracked by #133538. `AddPod` only logged and dropped the error when `SetAllocatedResources` failed to persist the pod's allocation checkpoint, with a comment asking whether recovery was possible:

```go
if err := m.SetAllocatedResources(logger, pod); err != nil {
    // TODO(vinaykul,InPlacePodVerticalScaling): Can we recover from this in some way? Investigate
    logger.Error(err, "SetPodAllocation failed", "pod", klog.KObj(pod))
}
```

Tracing `SetPodResourceInfo` down into `stateCheckpoint`, I found the in-memory cache is always updated *before* the disk write is attempted (`sc.cache.SetPodResourceInfo` runs, then `sc.storeState`). So a failure here isn't just a JSON-marshal edge case - it's most likely a transient `CreateCheckpoint` I/O error (disk full, etc). When that happens, the pod is correctly admitted in memory for the rest of this kubelet's lifetime, but the on-disk checkpoint silently goes stale with no retry. If the kubelet restarts before anything else re-triggers a checkpoint write for that pod, `UpdatePodFromAllocation` restores the stale (or missing) value on restart, which can cause the kubelet's belief about allocated resources to drift from what's actually running.

## What I changed

I added a `podsWithPendingCheckpoint` queue on the manager, mirroring the existing `podsWithPendingResizes` pattern already in this file. It's retried on the same periodic ticker `Run()` already uses for pending resizes (`initialRetryDelay` then `retryDelay`).

I couldn't reuse the resize-retry queue directly for this: replaying `handlePodResourcesResize` on retry would see `desired == allocated` (since the in-memory value is already correct) and skip without ever retrying the write - so it needed its own queue.

Pods are dequeued on a successful retry, or immediately when the pod is removed via `RemovePod`, so a deleted pod isn't retried forever.

## Which issue(s) this PR is related to

Fixes #133538

## Type of change

/kind bug
/sig node

## Does this PR introduce a user-facing change?

```release-note
NONE
```

## Testing

I verified this catches the regression: temporarily disabled the new enqueue call and confirmed my new tests fail (the pod never gets queued for retry); restored it and they pass.

- `go build ./pkg/kubelet/allocation/...` and `go vet ./pkg/kubelet/allocation/...`
- Three new tests: checkpoint-failure gets queued and later retried successfully; a pod that keeps failing stays queued instead of being dropped; removing a pod clears it from the queue
- Full `go test ./pkg/kubelet/allocation/...` - all pass, no regressions
- `go build ./pkg/kubelet/...` - the two external callers of this manager (`kubelet.go`, `pod_workers.go`) still build clean
