### PR TITLE
apidiff: ignore adding entirely new API groups

### DIFF
--- a/hack/apidiff-changelog/api-changes-allowlist
+++ b/hack/apidiff-changelog/api-changes-allowlist
@@ -15,10 +15,12 @@
 # - ./kubernetes/typed/certificates/v1alpha1.(*CertificatesV1alpha1Client).PodCertificateRequests: removed
 # - ./kubernetes/typed/certificates/v1alpha1.PodCertificateRequestsGetter.PodCertificateRequests, method set of CertificatesV1alpha1Interface: removed
 # - ./kubernetes/typed/certificates/v1alpha1/fake.(*FakeCertificatesV1alpha1).PodCertificateRequests: removed
+# - ./informers.SharedInformerFactory.Lifecycle: added
 
 ^- \./(informers|kubernetes/typed)/[a-z]+/v[a-z0-9]+(\.[a-zA-Z0-9]+)?\.[a-zA-Z0-9]+(, method set of .*)?: (added|removed|old is comparable, new is not)$
 ^- \./kubernetes(\.Interface|/fake...Clientset.|...Clientset.)\.[A-Za-z]+V[a-z0-9]+(, method set of .*)?: (added|removed)$
 ^- \./kubernetes/typed/[a-z]+/v[a-z0-9]+(/fake)?\.(..[a-zA-Z0-9]+.|[a-zA-Z0-9]+)\.[a-zA-Z0-9]+(, method set of .*)?: (added|removed|old is comparable, new is not)$
 ^- \./informers/[a-z]+\.Interface\.V[a-z0-9]+(, method set of .*)?: (added|removed)$
+^- \./informers\.SharedInformerFactory\..*: (added|removed)$
 ^- \./(listers|applyconfigurations)/[a-z]+/v1.*(, method set of .*)?: (added|removed|old is comparable, new is not)$
 ^- package k8s\.io/client-go/(applyconfigurations|informers|kubernetes/typed|listers)/[a-z]+/v[a-z0-9]+(/fake)?: (added|removed)$

--- a/staging/src/k8s.io/client-go/CHANGELOG.md
+++ b/staging/src/k8s.io/client-go/CHANGELOG.md
@@ -4,13 +4,6 @@ Go API changes are typically not included in the Kubernetes release notes, so
 noteworthy Go API changes *may* be documented here. This is currently not
 *required*, so consult the git history to see all changes.
 
-### Introduce Lifecycle API group for v1alpha1 EvictionRequest and Eviction APIs
-
-See [PR #137050](https://github.com/kubernetes/kubernetes/pull/137050)
-```
-- ./informers.SharedInformerFactory.Lifecycle: added
-```
-
 ### Type-safe informers
 
 All code using the result of the generated client-go Informer() methods (a


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adding the new Lifecycle API group caused apidiff to complain because this situation had not been encountered when setting up the initial set of allow rules and wasn't handled.

We don't need a CHANGELOG.md entry for this because it is a normal Go API change, so the entry gets removed.

Before:

    Incompatible changes:
    - ./informers.SharedInformerFactory.Lifecycle: added
    Acceptable incompatible changes:
    - ./kubernetes.Interface.LifecycleV1alpha1: added
After:

    Acceptable incompatible changes:
    - ./informers.SharedInformerFactory.Lifecycle: added
    - ./kubernetes.Interface.LifecycleV1alpha1: added


#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/pull/137050

#### Special notes for your reviewer:

Not strictly needed for the v1.37, but IMHO a nicer client-go README.md is worth it.

@kubernetes/sig-release-leads, let's add the v1.37 milestone.

/assign @Jefftree 

Do you agree that the CHANGELOG.md entry isn't needed? Please confirm with LGTM and we can merge this.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
