### PR TITLE
kubectl config: unify exit code of delete-cluster and delete-context

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster.go
@@ -59,8 +59,7 @@ func runDeleteCluster(out io.Writer, configAccess clientcmd.ConfigAccess, cmd *c
 
 	args := cmd.Flags().Args()
 	if len(args) != 1 {
-		cmd.Help()
-		return nil
+		return cmdutil.UsageErrorf(cmd, "cluster to delete is required")
 	}
 
 	configFile := configAccess.GetDefaultFilename()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_cluster_test.go
@@ -22,10 +22,12 @@ import (
 	utiltesting "k8s.io/client-go/util/testing"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 type deleteClusterTest struct {
@@ -50,6 +52,59 @@ func TestDeleteCluster(t *testing.T) {
 	}
 
 	test.run(t)
+}
+
+func TestDeleteClusterWithoutArgs(t *testing.T) {
+	conf := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"minikube": {Server: "https://192.168.0.99"},
+		},
+	}
+
+	fakeKubeFile, err := os.CreateTemp(os.TempDir(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer utiltesting.CloseAndRemove(t, fakeKubeFile)
+	err = clientcmd.WriteToFile(conf, fakeKubeFile.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	pathOptions := clientcmd.NewDefaultPathOptions()
+	pathOptions.GlobalFile = fakeKubeFile.Name()
+	pathOptions.EnvVar = ""
+
+	defer cmdutil.DefaultBehaviorOnFatal()
+	fatalCalled := false
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		fatalCalled = true
+		if code != 1 {
+			t.Errorf("expected exit code 1, got %d", code)
+		}
+		if !strings.Contains(str, "cluster to delete is required") {
+			t.Errorf("expected error to contain %q, got %q", "cluster to delete is required", str)
+		}
+	})
+
+	buf := bytes.NewBuffer([]byte{})
+	cmd := NewCmdConfigDeleteCluster(buf, pathOptions)
+	cmd.SetArgs([]string{})
+	cmd.Execute()
+
+	if !fatalCalled {
+		t.Fatal("expected a usage error when no cluster name is provided, got none")
+	}
+
+	// Verify no clusters were removed from the kubeconfig file
+	config, err := clientcmd.LoadFromFile(fakeKubeFile.Name())
+	if err != nil {
+		t.Fatalf("unexpected error loading kubeconfig file: %v", err)
+	}
+
+	if _, ok := config.Clusters["minikube"]; !ok {
+		t.Errorf("expected cluster minikube to still exist in kubeconfig")
+	}
 }
 
 func (test deleteClusterTest) run(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context.go
@@ -59,8 +59,7 @@ func runDeleteContext(out, errOut io.Writer, configAccess clientcmd.ConfigAccess
 
 	args := cmd.Flags().Args()
 	if len(args) != 1 {
-		cmd.Help()
-		return nil
+		return cmdutil.UsageErrorf(cmd, "context to delete is required")
 	}
 
 	configFile := configAccess.GetDefaultFilename()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/delete_context_test.go
@@ -22,10 +22,12 @@ import (
 	utiltesting "k8s.io/client-go/util/testing"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 type deleteContextTest struct {
@@ -50,6 +52,60 @@ func TestDeleteContext(t *testing.T) {
 	}
 
 	test.run(t)
+}
+
+func TestDeleteContextWithoutArgs(t *testing.T) {
+	conf := clientcmdapi.Config{
+		Contexts: map[string]*clientcmdapi.Context{
+			"minikube": {Cluster: "minikube"},
+		},
+	}
+
+	fakeKubeFile, err := os.CreateTemp(os.TempDir(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer utiltesting.CloseAndRemove(t, fakeKubeFile)
+	err = clientcmd.WriteToFile(conf, fakeKubeFile.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	pathOptions := clientcmd.NewDefaultPathOptions()
+	pathOptions.GlobalFile = fakeKubeFile.Name()
+	pathOptions.EnvVar = ""
+
+	defer cmdutil.DefaultBehaviorOnFatal()
+	fatalCalled := false
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		fatalCalled = true
+		if code != 1 {
+			t.Errorf("expected exit code 1, got %d", code)
+		}
+		if !strings.Contains(str, "context to delete is required") {
+			t.Errorf("expected error to contain %q, got %q", "context to delete is required", str)
+		}
+	})
+
+	buf := bytes.NewBuffer([]byte{})
+	errBuf := bytes.NewBuffer([]byte{})
+	cmd := NewCmdConfigDeleteContext(buf, errBuf, pathOptions)
+	cmd.SetArgs([]string{})
+	cmd.Execute()
+
+	if !fatalCalled {
+		t.Fatal("expected a usage error when no context name is provided, got none")
+	}
+
+	// Verify no contexts were removed from the kubeconfig file
+	config, err := clientcmd.LoadFromFile(fakeKubeFile.Name())
+	if err != nil {
+		t.Fatalf("unexpected error loading kubeconfig file: %v", err)
+	}
+
+	if _, ok := config.Contexts["minikube"]; !ok {
+		t.Errorf("expected context minikube to still exist in kubeconfig")
+	}
 }
 
 func (test deleteContextTest) run(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig cli

#### What this PR does / why we need it:

`kubectl config delete-cluster` and `kubectl config delete-context`, when invoked without the required NAME argument, print the command help and exit `0`, while `kubectl config delete-user` returns a usage error and exits `1`:

```console
$ kubectl config delete-cluster; echo $?
Delete the specified cluster from the kubeconfig.
...
0
$ kubectl config delete-user; echo $?
error: user to delete is required
See 'kubectl config delete-user -h' for help and examples
1
```

This PR makes `delete-cluster` and `delete-context` return a usage error too, so all three `config delete-*` subcommands consistently exit `1` when the required NAME argument is missing:

```console
$ kubectl config delete-cluster; echo $?
error: cluster to delete is required
See 'kubectl config delete-cluster -h' for help and examples
1
$ kubectl config delete-context; echo $?
error: context to delete is required
See 'kubectl config delete-context -h' for help and examples
1
```

Normalizing on a non-zero exit code (rather than making all three exit `0`) follows the maintainer guidance in the linked issue that kubectl's convention for usage errors is exit code `1` (see e.g. `kubectl get`, `kubectl label`, `kubectl create` with missing required arguments), and the direction of the exit code normalization umbrella kubernetes/enhancements#2551.

New unit tests `TestDeleteClusterWithoutArgs` and `TestDeleteContextWithoutArgs` verify the exit code, the error message, and that the kubeconfig file is left unmodified; both fail without this change.

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubectl#1641

#### Special notes for your reviewer:

- The error messages (`cluster to delete is required` / `context to delete is required`) intentionally mirror the existing `user to delete is required` from `delete_user.go`.
- An earlier attempt (#126071, rot-closed without review) unified in the opposite direction, making `delete-user` exit `0`; this PR follows the exit-1 convention discussed in the issue instead.
- Tested with `go test k8s.io/kubectl/pkg/cmd/config` (all pass) plus a manual smoke test of the built binary against a throwaway kubeconfig; `gofmt` and `go vet` are clean on the package.

#### Does this PR introduce a user-facing change?

```release-note
`kubectl config delete-cluster` and `kubectl config delete-context` now return a usage error and exit code 1, instead of printing help and exiting 0, when the name of the cluster/context to delete is not provided. This makes them consistent with `kubectl config delete-user`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

This change was developed with AI assistance (Claude Code); I have reviewed and tested it.
