### PR TITLE
util/net: skip IPv6 LLA with zone ID in getMatchingGlobalIP

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
@@ -222,7 +222,17 @@ func getMatchingGlobalIP(logger klog.Logger, addrs []net.Addr, family AddressFam
 	if len(addrs) > 0 {
 		for i := range addrs {
 			logger.V(4).Info("Checking for matching global IP", "address", addrs[i])
-			ip, _, err := netutils.ParseCIDRSloppy(addrs[i].String())
+			addrStr := addrs[i].String()
+			// IPv6 link-local addresses on physical interfaces include a zone ID
+			// (e.g. "fe80::1%eth0/64"). ParseCIDRSloppy cannot handle the '%' zone
+			// delimiter, so skip these addresses. They are unroutable and will never
+			// be selected as a node IP; the valid global address will be found on a
+			// subsequent interface or on the loopback (RFC 5549 / BGP-unnumbered).
+			if strings.Contains(addrStr, "%") {
+				logger.V(4).Info("Skipping IPv6 link-local address with zone ID", "address", addrStr)
+				continue
+			}
+			ip, _, err := netutils.ParseCIDRSloppy(addrStr)
 			if err != nil {
 				return nil, err
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
@@ -347,7 +347,16 @@ func chooseIPFromHostInterfaces(logger klog.Logger, nw networkInterfacer, addres
 				continue
 			}
 			for _, addr := range addrs {
-				ip, _, err := netutils.ParseCIDRSloppy(addr.String())
+				addrStr := addr.String()
+				// IPv6 link-local addresses on physical interfaces include a zone ID
+				// (e.g. "fe80::1%eth0/64"). ParseCIDRSloppy cannot handle the '%' zone
+				// delimiter, so skip these addresses. They are unroutable and will never
+				// be selected as a node IP.
+				if strings.Contains(addrStr, "%") {
+					logger.V(4).Info("Skipping IPv6 link-local address with zone ID", "interface", intf.Name, "address", addrStr)
+					continue
+				}
+				ip, _, err := netutils.ParseCIDRSloppy(addrStr)
 				if err != nil {
 					return nil, fmt.Errorf("unable to parse CIDR for interface %q: %s", intf.Name, err)
 				}

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
@@ -222,7 +222,14 @@ func getMatchingGlobalIP(logger klog.Logger, addrs []net.Addr, family AddressFam
 	if len(addrs) > 0 {
 		for i := range addrs {
 			logger.V(4).Info("Checking for matching global IP", "address", addrs[i])
-			ip, _, err := netutils.ParseCIDRSloppy(addrs[i].String())
+			addrStr := addrs[i].String()
+			// Skip addresses with a zone ID (e.g. "fe80::1%eth0/64");
+			// ParseCIDRSloppy cannot handle the '%' delimiter.
+			if strings.Contains(addrStr, "%") {
+				logger.V(4).Info("Skipping IPv6 link-local address with zone ID", "address", addrStr)
+				continue
+			}
+			ip, _, err := netutils.ParseCIDRSloppy(addrStr)
 			if err != nil {
 				return nil, err
 			}
@@ -337,7 +344,14 @@ func chooseIPFromHostInterfaces(logger klog.Logger, nw networkInterfacer, addres
 				continue
 			}
 			for _, addr := range addrs {
-				ip, _, err := netutils.ParseCIDRSloppy(addr.String())
+				addrStr := addr.String()
+				// Skip addresses with a zone ID (e.g. "fe80::1%eth0/64");
+				// ParseCIDRSloppy cannot handle the '%' delimiter.
+				if strings.Contains(addrStr, "%") {
+					logger.V(4).Info("Skipping IPv6 link-local address with zone ID", "interface", intf.Name, "address", addrStr)
+					continue
+				}
+				ip, _, err := netutils.ParseCIDRSloppy(addrStr)
 				if err != nil {
 					return nil, fmt.Errorf("unable to parse CIDR for interface %q: %s", intf.Name, err)
 				}

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
@@ -288,6 +288,12 @@ func TestFinalIP(t *testing.T) {
 		{"link local v6", []net.Addr{addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}}, familyIPv6, nil},
 		{"ip4", []net.Addr{addrStruct{val: "10.254.12.132/17"}}, familyIPv4, netutils.ParseIPSloppy("10.254.12.132")},
 		{"ip6", []net.Addr{addrStruct{val: "2001::5/64"}}, familyIPv6, netutils.ParseIPSloppy("2001::5")},
+		// IPv6 LLA with zone ID (e.g. as produced by intf.Addrs() on Linux for BGP-unnumbered
+		// interfaces) cannot be parsed by ParseCIDRSloppy. The function must skip it and
+		// continue scanning rather than returning an error.
+		{"ipv6 LLA with zone ID skipped", []net.Addr{addrStruct{val: "fe80::1%eth0/64"}}, familyIPv6, nil},
+		// Zone-ID address followed by a valid global address — the global address must be returned.
+		{"ipv6 LLA with zone ID, then global", []net.Addr{addrStruct{val: "fe80::1%eth0/64"}, addrStruct{val: "2001::5/64"}}, familyIPv6, netutils.ParseIPSloppy("2001::5")},
 
 		{"no addresses", []net.Addr{}, familyIPv4, nil},
 	}
@@ -551,6 +557,38 @@ func (_ networkInterfaceWithInvalidAddr) Interfaces() ([]net.Interface, error) {
 	return []net.Interface{upIntf}, nil
 }
 
+// bgpUnnumberedNetworkInterface simulates a BGP-unnumbered / RFC 5549 node where:
+//   - The physical interface (eth3) peers with a ToR switch using IPv6 link-local
+//     addresses as BGP nexthops. On Linux, intf.Addrs() returns these with a zone ID
+//     (e.g. "fe80::1%eth3/64") which ParseCIDRSloppy cannot parse.
+//   - The node's stable IPv4 identity (e.g. 10.244.0.1/32) lives on the loopback (lo).
+//
+// getMatchingGlobalIP must skip the zone-ID LLA so that chooseHostInterfaceFromRoute
+// can fall through to getIPFromLoopbackInterface and return the loopback IPv4 address.
+type bgpUnnumberedNetworkInterface struct{}
+
+func (_ bgpUnnumberedNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	if intfName == LoopbackInterfaceName {
+		return &loopbackIntf, nil
+	}
+	return &upIntf, nil
+}
+func (_ bgpUnnumberedNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	if intf.Name == LoopbackInterfaceName {
+		// Stable node IPv4 identity + standard loopback addresses.
+		return []net.Addr{
+			addrStruct{val: "127.0.0.1/8"},
+			addrStruct{val: "::1/128"},
+			addrStruct{val: "10.244.0.1/32"},
+		}, nil
+	}
+	// Physical interface: only an IPv6 LLA with a zone ID used as BGP nexthop.
+	return []net.Addr{addrStruct{val: "fe80::1%eth3/64"}}, nil
+}
+func (_ bgpUnnumberedNetworkInterface) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{upIntf, loopbackIntf}, nil
+}
+
 func TestGetIPFromInterface(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
@@ -569,6 +607,10 @@ func TestGetIPFromInterface(t *testing.T) {
 		{"I/F get fail", "eth3", familyIPv4, noNetworkInterface{}, nil, "no such network interface"},
 		{"fail get addr", "eth3", familyIPv4, networkInterfaceFailGetAddrs{}, nil, "unable to get Addrs"},
 		{"bad addr", "eth3", familyIPv4, networkInterfaceWithInvalidAddr{}, nil, "invalid CIDR"},
+		// BGP-unnumbered: eth3 carries only an IPv6 LLA with a zone ID used as BGP nexthop
+		// to the ToR. getMatchingGlobalIP must skip it; no global address is found on eth3
+		// itself (the IPv4 node identity lives on lo, handled by chooseHostInterfaceFromRoute).
+		{"BGP-unnumbered eth3: IPv6 LLA with zone ID skipped, no global found", "eth3", familyIPv4, bgpUnnumberedNetworkInterface{}, nil, ""},
 	}
 	for _, tc := range testCases {
 		ip, err := getIPFromInterface(logger, tc.nwname, tc.family, tc.nw)
@@ -640,6 +682,14 @@ func TestChooseHostInterfaceFromRoute(t *testing.T) {
 		{"all LLA", routeV4, networkInterfaceWithOnlyLinkLocals{}, preferIPv4, nil},
 		{"no routes", noRoutes, validNetworkInterface{}, preferIPv4, nil},
 		{"fail get IP", routeV4, networkInterfaceFailGetAddrs{}, preferIPv4, nil},
+		// BGP-unnumbered / RFC 5549 with IPv4-on-loopback topology:
+		// The node peers with the ToR L3 switch over a point-to-point link whose only
+		// addresses are IPv6 link-locals with zone IDs (e.g. "fe80::1%eth3/64").
+		// The stable IPv4 node identity (10.244.0.1/32) is assigned to lo.
+		// The IPv4 default route transits eth3 via BGP-unnumbered.
+		// Expected: getMatchingGlobalIP skips the zone-ID LLA on eth3, the route scan
+		// falls through to getIPFromLoopbackInterface, and returns the loopback IPv4.
+		{"BGP-unnumbered IPv6 LLA nexthop, IPv4 identity on loopback", routeV4, bgpUnnumberedNetworkInterface{}, preferIPv4, netutils.ParseIPSloppy("10.244.0.1")},
 	}
 	for _, tc := range testCases {
 		ip, err := chooseHostInterfaceFromRoute(logger, tc.routes, tc.nw, tc.order)

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
@@ -567,13 +567,13 @@ func (_ networkInterfaceWithInvalidAddr) Interfaces() ([]net.Interface, error) {
 // can fall through to getIPFromLoopbackInterface and return the loopback IPv4 address.
 type bgpUnnumberedNetworkInterface struct{}
 
-func (_ bgpUnnumberedNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+func (bgpUnnumberedNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
 	if intfName == LoopbackInterfaceName {
 		return &loopbackIntf, nil
 	}
 	return &upIntf, nil
 }
-func (_ bgpUnnumberedNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+func (bgpUnnumberedNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
 	if intf.Name == LoopbackInterfaceName {
 		// Stable node IPv4 identity + standard loopback addresses.
 		return []net.Addr{
@@ -585,7 +585,7 @@ func (_ bgpUnnumberedNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, e
 	// Physical interface: only an IPv6 LLA with a zone ID used as BGP nexthop.
 	return []net.Addr{addrStruct{val: "fe80::1%eth3/64"}}, nil
 }
-func (_ bgpUnnumberedNetworkInterface) Interfaces() ([]net.Interface, error) {
+func (bgpUnnumberedNetworkInterface) Interfaces() ([]net.Interface, error) {
 	return []net.Interface{upIntf, loopbackIntf}, nil
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
@@ -742,6 +742,9 @@ func TestGetIPFromHostInterfaces(t *testing.T) {
 		{"single-stack ipv6, prefer ipv6", ipv6NetworkInterface{}, preferIPv6, netutils.ParseIPSloppy("2001::200"), ""},
 		{"dual stack", v4v6NetworkInterface{}, preferIPv4, netutils.ParseIPSloppy("10.254.71.145"), ""},
 		{"dual stack, prefer ipv6", v4v6NetworkInterface{}, preferIPv6, netutils.ParseIPSloppy("2001::10"), ""},
+		// BGP-unnumbered: physical interface has only an IPv6 LLA with zone ID.
+		// chooseIPFromHostInterfaces must skip it (no acceptable global address found).
+		{"BGP-unnumbered: IPv6 LLA with zone ID skipped", bgpUnnumberedNetworkInterface{}, preferIPv6, nil, "no acceptable"},
 	}
 
 	for _, tc := range testCases {

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
@@ -288,6 +288,12 @@ func TestFinalIP(t *testing.T) {
 		{"link local v6", []net.Addr{addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}}, familyIPv6, nil},
 		{"ip4", []net.Addr{addrStruct{val: "10.254.12.132/17"}}, familyIPv4, netutils.ParseIPSloppy("10.254.12.132")},
 		{"ip6", []net.Addr{addrStruct{val: "2001::5/64"}}, familyIPv6, netutils.ParseIPSloppy("2001::5")},
+		// IPv6 LLA with zone ID (e.g. as produced by intf.Addrs() on Linux for BGP-unnumbered
+		// interfaces) cannot be parsed by ParseCIDRSloppy. The function must skip it and
+		// continue scanning rather than returning an error.
+		{"ipv6 LLA with zone ID skipped", []net.Addr{addrStruct{val: "fe80::1%eth0/64"}}, familyIPv6, nil},
+		// Zone-ID address followed by a valid global address — the global address must be returned.
+		{"ipv6 LLA with zone ID, then global", []net.Addr{addrStruct{val: "fe80::1%eth0/64"}, addrStruct{val: "2001::5/64"}}, familyIPv6, netutils.ParseIPSloppy("2001::5")},
 
 		{"no addresses", []net.Addr{}, familyIPv4, nil},
 	}
@@ -551,6 +557,44 @@ func (_ networkInterfaceWithInvalidAddr) Interfaces() ([]net.Interface, error) {
 	return []net.Interface{upIntf}, nil
 }
 
+// bgpUnnumberedNetworkInterface simulates a BGP-unnumbered / RFC 5549 node where:
+//   - The physical interface (eth3) peers with a ToR switch using IPv6 link-local
+//     addresses as BGP nexthops. On Linux, intf.Addrs() returns these with a zone ID
+//     (e.g. "fe80::1%eth3/64") which ParseCIDRSloppy cannot parse.
+//   - The node's stable IPv4 identity (e.g. 10.244.0.1/32) lives on the loopback (lo).
+//
+// getMatchingGlobalIP must skip the zone-ID LLA so that chooseHostInterfaceFromRoute
+// can fall through to getIPFromLoopbackInterface and return the loopback IPv4 address.
+type bgpUnnumberedNetworkInterface struct{}
+
+func (bgpUnnumberedNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	switch intfName {
+	case LoopbackInterfaceName:
+		return &loopbackIntf, nil
+	case upIntf.Name:
+		return &upIntf, nil
+	default:
+		return nil, fmt.Errorf("unrecognized interface name %q", intfName)
+	}
+}
+func (bgpUnnumberedNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	switch intf.Name {
+	case LoopbackInterfaceName:
+		return []net.Addr{
+			addrStruct{val: "127.0.0.1/8"},
+			addrStruct{val: "::1/128"},
+			addrStruct{val: "10.244.0.1/32"},
+		}, nil
+	case upIntf.Name:
+		return []net.Addr{addrStruct{val: "fe80::1%eth3/64"}}, nil
+	default:
+		return nil, fmt.Errorf("unrecognized interface %q", intf.Name)
+	}
+}
+func (bgpUnnumberedNetworkInterface) Interfaces() ([]net.Interface, error) {
+	return []net.Interface{upIntf, loopbackIntf}, nil
+}
+
 func TestGetIPFromInterface(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {
@@ -569,6 +613,7 @@ func TestGetIPFromInterface(t *testing.T) {
 		{"I/F get fail", "eth3", familyIPv4, noNetworkInterface{}, nil, "no such network interface"},
 		{"fail get addr", "eth3", familyIPv4, networkInterfaceFailGetAddrs{}, nil, "unable to get Addrs"},
 		{"bad addr", "eth3", familyIPv4, networkInterfaceWithInvalidAddr{}, nil, "invalid CIDR"},
+		{"BGP-unnumbered eth3: IPv6 LLA with zone ID skipped, no global found", "eth3", familyIPv4, bgpUnnumberedNetworkInterface{}, nil, ""},
 	}
 	for _, tc := range testCases {
 		ip, err := getIPFromInterface(logger, tc.nwname, tc.family, tc.nw)
@@ -640,6 +685,7 @@ func TestChooseHostInterfaceFromRoute(t *testing.T) {
 		{"all LLA", routeV4, networkInterfaceWithOnlyLinkLocals{}, preferIPv4, nil},
 		{"no routes", noRoutes, validNetworkInterface{}, preferIPv4, nil},
 		{"fail get IP", routeV4, networkInterfaceFailGetAddrs{}, preferIPv4, nil},
+		{"BGP-unnumbered IPv6 LLA nexthop, IPv4 identity on loopback", routeV4, bgpUnnumberedNetworkInterface{}, preferIPv4, netutils.ParseIPSloppy("10.244.0.1")},
 	}
 	for _, tc := range testCases {
 		ip, err := chooseHostInterfaceFromRoute(logger, tc.routes, tc.nw, tc.order)
@@ -692,6 +738,7 @@ func TestGetIPFromHostInterfaces(t *testing.T) {
 		{"single-stack ipv6, prefer ipv6", ipv6NetworkInterface{}, preferIPv6, netutils.ParseIPSloppy("2001::200"), ""},
 		{"dual stack", v4v6NetworkInterface{}, preferIPv4, netutils.ParseIPSloppy("10.254.71.145"), ""},
 		{"dual stack, prefer ipv6", v4v6NetworkInterface{}, preferIPv6, netutils.ParseIPSloppy("2001::10"), ""},
+		{"BGP-unnumbered: IPv6 LLA with zone ID skipped", bgpUnnumberedNetworkInterface{}, preferIPv6, nil, "no acceptable"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig network
/sig node
/area kubelet

#### What this PR does / why we need it:

On Linux, `net.Interface.Addrs()` returns IPv6 link-local addresses
with a zone ID appended to the interface name
(e.g. `fe80::1%eth3/64`). `ParseCIDRSloppy` cannot parse the `%` zone
delimiter and returns an error.

Before this fix, `getMatchingGlobalIP` propagated that error all the way
up through `getIPFromInterface` and `chooseHostInterfaceFromRoute`,
aborting the entire node-IP auto-detection scan. This caused kubelet to
fail to determine the node IP on **BGP-unnumbered / RFC 5549** nodes
with the following topology:

```
Topology
--------
eth3:  fe80::1%eth3/64   (IPv6 LLA, BGP nexthop toward ToR L3 switch)
lo:    127.0.0.1/8
       10.244.0.1/32     (stable node IPv4 identity, announced via BGP)
```

In this setup the node peers with its Top-of-Rack switch over a
point-to-point link using IPv6 link-local addresses as BGP nexthops
(RFC 5549). The stable IPv4 identity of the node lives on the loopback.
Because the IPv4 default route transits `eth3`,
`chooseHostInterfaceFromRoute` scans `eth3` first, hits the unparseable
LLA, and aborts — `getIPFromLoopbackInterface` is never reached and
`10.244.0.1` is never discovered.

**Fix:** In `getMatchingGlobalIP`, detect addresses that contain `%`
(the RFC 4007 zone-ID delimiter) and skip them with a `V(4)` log line
instead of returning an error. Zone-scoped link-locals are unroutable
and will never be selected as a node IP. The valid global address is
found on a subsequent interface or on the loopback. All other parse
errors (genuinely malformed CIDRs) still surface as before, so existing
behaviour is unchanged.

Changed function: `getMatchingGlobalIP` in
`staging/src/k8s.io/apimachinery/pkg/util/net/interface.go`

#### Which issue(s) this PR is related to:

Fixes #130409

#### Special notes for your reviewer:

The change is deliberately minimal — one `strings.Contains(addrStr, "%")`
guard added before the `ParseCIDRSloppy` call in `getMatchingGlobalIP`.
No other function is modified. Existing error-return behaviour for all
other malformed CIDR strings is preserved.

`chooseIPFromHostInterfaces` (the fallback path used when no routing
table is present) is **not** changed because it already skips loopback
and point-to-point interfaces via `isLoopbackOrPointToPoint`, so it
never reaches the LLA-with-zone-ID case in practice.

Three new test cases cover the fix:

| Test | Function under test |
|---|---|
| `TestFinalIP / "ipv6 LLA with zone ID skipped"` | `getMatchingGlobalIP` directly — zone-ID addr returns nil, no error |
| `TestFinalIP / "ipv6 LLA with zone ID, then global"` | `getMatchingGlobalIP` — zone-ID addr skipped, subsequent global addr returned |
| `TestGetIPFromInterface / "BGP-unnumbered eth3: IPv6 LLA with zone ID skipped"` | `getIPFromInterface` — no global found on eth3, no error |
| `TestChooseHostInterfaceFromRoute / "BGP-unnumbered IPv6 LLA nexthop, IPv4 identity on loopback"` | end-to-end route scan — `10.244.0.1` returned from loopback |

The existing `"bad addr"` / `"invalid addr"` test cases are unchanged
and still assert that genuinely malformed CIDRs return an error.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where kubelet failed to auto-detect the node IP on
BGP-unnumbered (RFC 5549) nodes. When physical interfaces carry only
IPv6 link-local addresses with zone IDs (e.g. fe80::1%eth3/64) as BGP
nexthops and the node's IPv4 identity is on the loopback interface,
the interface scan in `getMatchingGlobalIP` now skips unparseable
zone-scoped addresses instead of aborting, allowing kubelet to fall
through to the loopback and find the correct node IP.
```

#### Additional documentation

- [Issue #130409](https://github.com/kubernetes/kubernetes/issues/130409)
- [RFC 5549 — Advertising IPv4 Network Layer Reachability Information with an IPv6 Next Hop](https://www.rfc-editor.org/rfc/rfc5549)
- [RFC 4007 — IPv6 Scoped Address Architecture (zone IDs)](https://www.rfc-editor.org/rfc/rfc4007)
