### PR TITLE
kubeadm: Clarify bootstrap token generation

### DIFF
--- a/cmd/kubeadm/app/apis/bootstraptoken/v1/types.go
+++ b/cmd/kubeadm/app/apis/bootstraptoken/v1/types.go
@@ -25,6 +25,8 @@ import (
 type BootstrapToken struct {
 	// Token is used for establishing bidirectional trust between nodes and control-planes.
 	// Used for joining nodes in the cluster.
+	// If this field is not specified in an InitConfiguration, kubeadm generates
+	// a random token at runtime.
 	Token *BootstrapTokenString `json:"token" datapolicy:"token"`
 	// Description sets a human-friendly message why this token exists and what it's used
 	// for, so other administrators can know its purpose.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/sig cluster-lifecycle
/area kubeadm

#### What this PR does / why we need it:

The generated kubeadm configuration API reference marks
`BootstrapToken.token` as required. However, when this field is omitted
from an `InitConfiguration`, `kubeadm init` generates a random token at
runtime.

This PR documents that behavior where the field is declared, allowing the
generated reference documentation to explain that users do not need to
provide the token themselves.

This is a documentation-only change and does not modify kubeadm behavior.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The `SetDefaults_BootstrapTokens` implementation already explains that the
token is not generated in the API defaulting layer, but is assigned a random
value later at runtime if it was not provided.

The new comment scopes this behavior specifically to an
`InitConfiguration` passed to `kubeadm init`; it does not describe bootstrap
tokens created by other Kubernetes deployment tools.

This PR was prepared in part with assistance from generative AI. I reviewed
and verified the proposed change and its supporting behavior.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```