### PR TITLE
storage/cacher/consistency: export DiffDetail and NamespaceNameRV types

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/consistency/checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/consistency/checker.go
@@ -117,31 +117,29 @@ func (c *Checker) CalculateDigests(ctx context.Context) (*Digest, error) {
 	if !c.cacher.Ready() {
 		return nil, fmt.Errorf("cache is not ready")
 	}
-	// variables for tracking the diff in consistency checker
-	cacheItems := []namespaceNameRV{}
-	var foundDiff *diffDetail
+	// snapshot cache items for positional comparison against etcd below.
+	cacheItems := []NamespaceNameRV{}
+	var foundDiff *DiffDetail
 	var etcdIndex int
 
 	cacheDigest, cacheResourceVersion, err := c.calculateStoreDigest(ctx, c.cacher, "0", 0, func(obj metav1.Object) {
-		// collect items from cacher's list
-		cacheItems = append(cacheItems, namespaceNameRV{Namespace: obj.GetNamespace(), Name: obj.GetName(), RV: obj.GetResourceVersion()})
+		cacheItems = append(cacheItems, NamespaceNameRV{Namespace: obj.GetNamespace(), Name: obj.GetName(), RV: obj.GetResourceVersion()})
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed calculating cache digest: %w", err)
 	}
 	etcdDigest, etcdResourceVersion, err := c.calculateStoreDigest(ctx, c.etcd, cacheResourceVersion, checkerListPageSize, func(obj metav1.Object) {
-		// compare the item in etcd's list against cacheItems which is cacher's list
 		if foundDiff != nil {
 			return
 		}
-		etcdItem := namespaceNameRV{Namespace: obj.GetNamespace(), Name: obj.GetName(), RV: obj.GetResourceVersion()}
+		etcdItem := NamespaceNameRV{Namespace: obj.GetNamespace(), Name: obj.GetName(), RV: obj.GetResourceVersion()}
 		if len(cacheItems) <= etcdIndex {
-			foundDiff = &diffDetail{Index: etcdIndex, EtcdItem: &etcdItem}
+			foundDiff = &DiffDetail{Index: etcdIndex, EtcdItem: &etcdItem}
 			cacheItems = nil // don't need it any more and nil it to allow GC to collect it
 			return
 		}
 		if cacheItem := cacheItems[etcdIndex]; cacheItem != etcdItem {
-			foundDiff = &diffDetail{Index: etcdIndex, EtcdItem: &etcdItem, CacheItem: &cacheItem}
+			foundDiff = &DiffDetail{Index: etcdIndex, EtcdItem: &etcdItem, CacheItem: &cacheItem}
 			cacheItems = nil // don't need it any more and nil it to allow GC to collect it
 			return
 		}
@@ -152,7 +150,7 @@ func (c *Checker) CalculateDigests(ctx context.Context) (*Digest, error) {
 	}
 	if len(cacheItems) > etcdIndex {
 		cacheItem := cacheItems[etcdIndex]
-		foundDiff = &diffDetail{Index: etcdIndex, CacheItem: &cacheItem}
+		foundDiff = &DiffDetail{Index: etcdIndex, CacheItem: &cacheItem}
 	}
 	if cacheResourceVersion != etcdResourceVersion {
 		return nil, fmt.Errorf("etcd returned different resource version then expected, cache: %q, etcd: %q", cacheResourceVersion, etcdResourceVersion)
@@ -165,23 +163,43 @@ func (c *Checker) CalculateDigests(ctx context.Context) (*Digest, error) {
 	}, nil
 }
 
-type namespaceNameRV struct {
+// NamespaceNameRV is the minimal identity of an object used during consistency checks.
+type NamespaceNameRV struct {
 	Namespace string
 	Name      string
 	RV        string
 }
 
-type diffDetail struct {
-	Index     int
-	CacheItem *namespaceNameRV
-	EtcdItem  *namespaceNameRV
+func (n *NamespaceNameRV) String() string {
+	if n == nil {
+		return "<nil>"
+	}
+	return n.Namespace + "/" + n.Name + "@" + n.RV
 }
 
+// DiffDetail is the first position where etcd and the watch cache diverge.
+type DiffDetail struct {
+	// Index is the position of the diverging item in the sorted list.
+	Index     int
+	// CacheItem is what the watch cache has at Index; nil means the cache is missing it.
+	CacheItem *NamespaceNameRV
+	// EtcdItem is what etcd has at Index; nil means etcd is missing it.
+	EtcdItem  *NamespaceNameRV
+}
+
+func (d *DiffDetail) String() string {
+	if d == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("index=%d cache=%s etcd=%s", d.Index, d.CacheItem, d.EtcdItem)
+}
+
+// Digest is the result of a single consistency check run.
 type Digest struct {
 	ResourceVersion string
 	CacheDigest     string
 	EtcdDigest      string
-	DiffDetail      *diffDetail
+	DiffDetail      *DiffDetail
 }
 
 func (c *Checker) calculateStoreDigest(ctx context.Context, store getLister, resourceVersion string, limit int64, metaVisitor func(objectMeta metav1.Object)) (digest, rv string, err error) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/consistency/checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/consistency/checker_test.go
@@ -96,10 +96,10 @@ func TestConsistencyCheckerDigest(t *testing.T) {
 				ResourceVersion: "2",
 				CacheDigest:     "4ae4e750bd825b17",
 				EtcdDigest:      "f940a60af965b03",
-				DiffDetail: &diffDetail{
+				DiffDetail: &DiffDetail{
 					Index:     0,
-					CacheItem: &namespaceNameRV{Namespace: "kube-system", Name: "pod", RV: "2"},
-					EtcdItem:  &namespaceNameRV{Namespace: "kube-public", Name: "pod", RV: "2"},
+					CacheItem: &NamespaceNameRV{Namespace: "kube-system", Name: "pod", RV: "2"},
+					EtcdItem:  &NamespaceNameRV{Namespace: "kube-public", Name: "pod", RV: "2"},
 				},
 			},
 			expectConsistent: false,
@@ -118,10 +118,10 @@ func TestConsistencyCheckerDigest(t *testing.T) {
 				ResourceVersion: "2",
 				CacheDigest:     "c9120494e4c1897d",
 				EtcdDigest:      "c9156494e4c46274",
-				DiffDetail: &diffDetail{
+				DiffDetail: &DiffDetail{
 					Index:     0,
-					CacheItem: &namespaceNameRV{Namespace: "default", Name: "pod2", RV: "2"},
-					EtcdItem:  &namespaceNameRV{Namespace: "default", Name: "pod3", RV: "2"},
+					CacheItem: &NamespaceNameRV{Namespace: "default", Name: "pod2", RV: "2"},
+					EtcdItem:  &NamespaceNameRV{Namespace: "default", Name: "pod3", RV: "2"},
 				},
 			},
 			expectConsistent: false,
@@ -140,10 +140,10 @@ func TestConsistencyCheckerDigest(t *testing.T) {
 				ResourceVersion: "4",
 				CacheDigest:     "86bf3a5e80d1c5ca",
 				EtcdDigest:      "86bf3a5e80d1c5cd",
-				DiffDetail: &diffDetail{
+				DiffDetail: &DiffDetail{
 					Index:     0,
-					CacheItem: &namespaceNameRV{Namespace: "default", Name: "pod", RV: "3"},
-					EtcdItem:  &namespaceNameRV{Namespace: "default", Name: "pod", RV: "4"},
+					CacheItem: &NamespaceNameRV{Namespace: "default", Name: "pod", RV: "3"},
+					EtcdItem:  &NamespaceNameRV{Namespace: "default", Name: "pod", RV: "4"},
 				},
 			},
 			expectConsistent: false,
@@ -163,10 +163,10 @@ func TestConsistencyCheckerDigest(t *testing.T) {
 				ResourceVersion: "3",
 				CacheDigest:     "1859bac707c2cb2b",
 				EtcdDigest:      "11d147fc800df0e0",
-				DiffDetail: &diffDetail{
+				DiffDetail: &DiffDetail{
 					Index:     1,
 					CacheItem: nil,
-					EtcdItem:  &namespaceNameRV{Namespace: "Default", Name: "pod", RV: "3"},
+					EtcdItem:  &NamespaceNameRV{Namespace: "Default", Name: "pod", RV: "3"},
 				},
 			},
 			expectConsistent: false,
@@ -186,9 +186,9 @@ func TestConsistencyCheckerDigest(t *testing.T) {
 				ResourceVersion: "3",
 				CacheDigest:     "11d147fc800df0e0",
 				EtcdDigest:      "1859bac707c2cb2b",
-				DiffDetail: &diffDetail{
+				DiffDetail: &DiffDetail{
 					Index:     1,
-					CacheItem: &namespaceNameRV{Namespace: "Default", Name: "pod", RV: "3"},
+					CacheItem: &NamespaceNameRV{Namespace: "Default", Name: "pod", RV: "3"},
 					EtcdItem:  nil,
 				},
 			},


### PR DESCRIPTION
## Summary

Improve the watch-cache consistency checker by exporting the diff types and making consistency mismatch logs human-readable.

## Problem

The consistency checker logs `Digest.DiffDetail` when a cache mismatch is detected. Since `diffDetail` and `namespaceNameRV` were unexported types without `String()` implementations, the logs only contained pointer addresses, for example:

```text
diffDetail=&{1 0xc0004a2180 0xc0004a2240}
```

This made it difficult to determine which object diverged or compare the cache and etcd states during debugging.

Additionally, `Digest.DiffDetail` is part of the exported `Digest` type returned by `CalculateDigests()`, but its type (`*diffDetail`) was unexported, preventing callers outside the `consistency` package from inspecting its contents.

## Changes

- Export `diffDetail` as `DiffDetail`
- Export `namespaceNameRV` as `NamespaceNameRV`
- Add `String()` implementations for both types
- Update internal references and unit tests

## Output

Before:

```text
diffDetail=&{0 0xc0004a2180 0xc0004a2240}
```

After:

```text
diffDetail=index=0 cache=default/my-deploy@11 etcd=default/my-deploy@12
```

The existing log and panic paths now produce meaningful diagnostic output without requiring any changes to the logging code.

## Testing

- Updated the affected unit tests.
- Verified existing tests pass.
- No functional behavior changes.

## Special notes for your reviewer

This PR was prepared with AI assistance. I reviewed every suggested change,
understood each modification, ran the relevant tests locally, and manually
verified the resulting behavior before submitting this PR.

The code changes are limited to:
- `checker.go`: export `diffDetail` → `DiffDetail`, export `namespaceNameRV` → `NamespaceNameRV`, and add `String()` implementations.
- `checker_test.go`: update test literals to use the exported type names.

```release-note
NONE
```