### PR TITLE
Fix emptyDir project quota leak on volume teardown

### DIFF
--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -554,12 +554,11 @@ func (ed *emptyDir) TearDownAt(dir string) error {
 
 func (ed *emptyDir) teardownDefault(dir string) error {
 	if utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolationFSQuotaMonitoring) {
-		// Remove any quota
-		userNamespacesEnabled := false
-		if usernamespacefeature.EnabledUserNamespacesSupport() {
-			userNamespacesEnabled = ed.pod.Spec.HostUsers != nil && !*ed.pod.Spec.HostUsers
-		}
-		err := fsquota.ClearQuota(ed.mounter, dir, userNamespacesEnabled)
+		// Remove any quota.
+		// The unmounter is built from the pod UID alone, so ed.pod carries no
+		// spec here and pod.Spec.HostUsers cannot be consulted.  Always clear
+		// the quota; otherwise the project ID assigned during SetUp is leaked.
+		err := fsquota.ClearQuota(ed.mounter, dir)
 		if err != nil {
 			klog.Warningf("Failed to clear quota on %s: %v", dir, err)
 		}

--- a/pkg/volume/util/fsquota/quota_linux.go
+++ b/pkg/volume/util/fsquota/quota_linux.go
@@ -230,11 +230,11 @@ func GetQuotaOnDir(m mount.Interface, path string) (common.QuotaID, error) {
 	return getApplier(path).GetQuotaOnDir(path)
 }
 
-func clearQuotaOnDir(m mount.Interface, path string, userNamespacesEnabled bool) error {
+func clearQuotaOnDir(m mount.Interface, path string) error {
 	// Since we may be called without path being in the map,
 	// we explicitly have to check in this case.
 	klog.V(4).Infof("clearQuotaOnDir %s", path)
-	supportsQuotas, err := SupportsQuotas(m, path, userNamespacesEnabled)
+	supportsQuotas, err := supportsQuotasForPath(m, path)
 	if err != nil {
 		// Log-and-continue instead of returning an error for now
 		// due to unspecified backwards compatibility concerns (a subject to revise)
@@ -269,11 +269,7 @@ func clearQuotaOnDir(m mount.Interface, path string, userNamespacesEnabled bool)
 	return nil
 }
 
-// SupportsQuotas -- Does the path support quotas
-// Cache the applier for paths that support quotas.  For paths that don't,
-// don't cache the result because nothing will clean it up.
-// However, do cache the device->applier map; the number of devices
-// is bounded.
+// SupportsQuotas -- Should quotas be applied to the path
 // User namespaces prevent changes to project IDs on the filesystem,
 // ensuring xfs-quota metrics' reliability; hence, userNamespacesEnabled is checked.
 func SupportsQuotas(m mount.Interface, path string, userNamespacesEnabled bool) (bool, error) {
@@ -283,6 +279,21 @@ func SupportsQuotas(m mount.Interface, path string, userNamespacesEnabled bool) 
 	}
 	if !userNamespacesEnabled {
 		klog.V(3).Info("SupportQuotas called and LocalStorageCapacityIsolationFSQuotaMonitoring enabled, but pod is not in a user namespace")
+		return false, nil
+	}
+	return supportsQuotasForPath(m, path)
+}
+
+// supportsQuotasForPath -- Does the filesystem backing the path support quotas
+// Unlike SupportsQuotas this ignores whether the pod runs in a user namespace,
+// so it can be used from cleanup paths, which do not have the pod spec.
+// Cache the applier for paths that support quotas.  For paths that don't,
+// don't cache the result because nothing will clean it up.
+// However, do cache the device->applier map; the number of devices
+// is bounded.
+func supportsQuotasForPath(m mount.Interface, path string) (bool, error) {
+	if !enabledQuotasForMonitoring() {
+		klog.V(3).Info("supportsQuotasForPath called, but quotas disabled")
 		return false, nil
 	}
 	supportsQuotasLock.Lock()
@@ -421,7 +432,11 @@ func GetInodes(path string) (*resource.Quantity, error) {
 }
 
 // ClearQuota -- remove the quota assigned to a directory
-func ClearQuota(m mount.Interface, path string, userNamespacesEnabled bool) error {
+// This is called from teardown paths, which only know the pod UID and cannot
+// tell whether the pod ran in a user namespace, so the quota is always cleared
+// when the feature is enabled.  Skipping it would leak the project ID that was
+// assigned when the volume was set up.
+func ClearQuota(m mount.Interface, path string) error {
 	klog.V(3).Infof("ClearQuota %s", path)
 	if !enabledQuotasForMonitoring() {
 		return fmt.Errorf("clearQuota called, but quotas disabled")
@@ -437,7 +452,7 @@ func ClearQuota(m mount.Interface, path string, userNamespacesEnabled bool) erro
 		// be found, which needs to be cleaned up.
 		defer clearSupportsQuotas(path)
 		defer clearApplier(path)
-		return clearQuotaOnDir(m, path, userNamespacesEnabled)
+		return clearQuotaOnDir(m, path)
 	}
 	_, ok = podQuotaMap[poduid]
 	if !ok {
@@ -454,7 +469,7 @@ func ClearQuota(m mount.Interface, path string, userNamespacesEnabled bool) erro
 	}
 	count, ok := podDirCountMap[poduid]
 	if count <= 1 || !ok {
-		err = clearQuotaOnDir(m, path, userNamespacesEnabled)
+		err = clearQuotaOnDir(m, path)
 		// This error should be noted; we still need to clean up
 		// and otherwise handle in the same way.
 		if err != nil {

--- a/pkg/volume/util/fsquota/quota_linux_test.go
+++ b/pkg/volume/util/fsquota/quota_linux_test.go
@@ -375,9 +375,9 @@ func fakeAssignQuota(path string, poduid types.UID, bytes int64, userNamespacesE
 	return AssignQuota(dummyQuotaTest(), path, poduid, resource.NewQuantity(bytes, resource.DecimalSI), userNamespacesEnabled)
 }
 
-func fakeClearQuota(path string, userNamespacesEnabled bool) error {
+func fakeClearQuota(path string) error {
 	dummySetFSInfo(path)
-	return ClearQuota(dummyQuotaTest(), path, userNamespacesEnabled)
+	return ClearQuota(dummyQuotaTest(), path)
 }
 
 type quotaTestCase struct {
@@ -553,7 +553,7 @@ func runCaseEnabled(t *testing.T, testcase quotaTestCase, seq int) bool {
 	case "Set":
 		err = fakeAssignQuota(testcase.path, testcase.poduid, testcase.bytes, testcase.userNamespacesEnabled)
 	case "Clear":
-		err = fakeClearQuota(testcase.path, testcase.userNamespacesEnabled)
+		err = fakeClearQuota(testcase.path)
 	case "GetConsumption":
 		_, err = GetConsumption(testcase.path)
 	case "GetInodes":
@@ -585,7 +585,7 @@ func runCaseDisabled(t *testing.T, testcase quotaTestCase, seq int) bool {
 	case "Set":
 		err = fakeAssignQuota(testcase.path, testcase.poduid, testcase.bytes, testcase.userNamespacesEnabled)
 	case "Clear":
-		err = fakeClearQuota(testcase.path, testcase.userNamespacesEnabled)
+		err = fakeClearQuota(testcase.path)
 	case "GetConsumption":
 		_, err = GetConsumption(testcase.path)
 	case "GetInodes":
@@ -755,4 +755,79 @@ func TestAddRemoveQuotasEnabled(t *testing.T) {
 
 func TestAddRemoveQuotasDisabled(t *testing.T) {
 	testAddRemoveQuotas(t, false)
+}
+
+// readProjectFilesForTest returns the current contents of the project files.
+func readProjectFilesForTest(t *testing.T) (string, string) {
+	t.Helper()
+	projects, err := os.ReadFile(projectsFile)
+	if err != nil {
+		t.Fatalf("Unable to read %s: %v", projectsFile, err)
+	}
+	projid, err := os.ReadFile(projidFile)
+	if err != nil {
+		t.Fatalf("Unable to read %s: %v", projidFile, err)
+	}
+	return string(projects), string(projid)
+}
+
+// TestClearQuotaReclaimsProjectID verifies that clearing a quota removes the
+// project ID mapping from the project files.
+//
+// The emptyDir unmounter is constructed from the pod UID alone, so the pod
+// spec -- and with it pod.Spec.HostUsers -- is not available at teardown time.
+// Clearing a quota therefore must not depend on knowing whether the pod ran in
+// a user namespace, or the project ID assigned during SetUp is leaked.
+func TestClearQuotaReclaimsProjectID(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.LocalStorageCapacityIsolationFSQuotaMonitoring, true)
+
+	tmpProjectsFile, err := os.CreateTemp("", "projects")
+	if err != nil {
+		t.Fatalf("Unable to create fake projects file: %v", err)
+	}
+	if _, err := tmpProjectsFile.WriteString(projectsHeader); err != nil {
+		t.Fatalf("Unable to write fake projects file: %v", err)
+	}
+	tmpProjectsFile.Close()
+	projectsFile = tmpProjectsFile.Name()
+	defer os.Remove(projectsFile)
+
+	tmpProjidFile, err := os.CreateTemp("", "projid")
+	if err != nil {
+		t.Fatalf("Unable to create fake projid file: %v", err)
+	}
+	if _, err := tmpProjidFile.WriteString(projidHeader); err != nil {
+		t.Fatalf("Unable to write fake projid file: %v", err)
+	}
+	tmpProjidFile.Close()
+	projidFile = tmpProjidFile.Name()
+	defer os.Remove(projidFile)
+
+	providers = []common.LinuxVolumeQuotaProvider{
+		&VolumeProvider1{},
+		&VolumeProvider2{},
+	}
+
+	const path = "/quota1/teardown"
+	// Setting the volume up happens while the pod spec is still known, so a
+	// pod that requested a user namespace gets a quota assigned here.
+	if err := fakeAssignQuota(path, "teardownpod", 1024, true); err != nil {
+		t.Fatalf("Unable to assign quota to %s: %v", path, err)
+	}
+	projects, projid := readProjectFilesForTest(t)
+	if projects == projectsHeader || projid == projidHeader {
+		t.Fatalf("Expected a project ID mapping for %s to be recorded, got projects\n`%s`\nprojid\n`%s`", path, projects, projid)
+	}
+
+	// Tearing the volume down happens without the pod spec.
+	if err := fakeClearQuota(path); err != nil {
+		t.Fatalf("Unable to clear quota on %s: %v", path, err)
+	}
+	projects, projid = readProjectFilesForTest(t)
+	if projects != projectsHeader {
+		t.Errorf("Project ID mapping for %s leaked in projects file: expected\n`%s`\ngot\n`%s`", path, projectsHeader, projects)
+	}
+	if projid != projidHeader {
+		t.Errorf("Project ID mapping for %s leaked in projid file: expected\n`%s`\ngot\n`%s`", path, projidHeader, projid)
+	}
 }

--- a/pkg/volume/util/fsquota/quota_linux_test.go
+++ b/pkg/volume/util/fsquota/quota_linux_test.go
@@ -788,9 +788,15 @@ func TestClearQuotaReclaimsProjectID(t *testing.T) {
 	if _, err := tmpProjectsFile.WriteString(projectsHeader); err != nil {
 		t.Fatalf("Unable to write fake projects file: %v", err)
 	}
-	tmpProjectsFile.Close()
+	if err := tmpProjectsFile.Close(); err != nil {
+		t.Fatalf("Unable to close fake projects file: %v", err)
+	}
 	projectsFile = tmpProjectsFile.Name()
-	defer os.Remove(projectsFile)
+	t.Cleanup(func() {
+		if err := os.Remove(projectsFile); err != nil {
+			t.Errorf("Unable to remove fake projects file: %v", err)
+		}
+	})
 
 	tmpProjidFile, err := os.CreateTemp("", "projid")
 	if err != nil {
@@ -799,9 +805,15 @@ func TestClearQuotaReclaimsProjectID(t *testing.T) {
 	if _, err := tmpProjidFile.WriteString(projidHeader); err != nil {
 		t.Fatalf("Unable to write fake projid file: %v", err)
 	}
-	tmpProjidFile.Close()
+	if err := tmpProjidFile.Close(); err != nil {
+		t.Fatalf("Unable to close fake projid file: %v", err)
+	}
 	projidFile = tmpProjidFile.Name()
-	defer os.Remove(projidFile)
+	t.Cleanup(func() {
+		if err := os.Remove(projidFile); err != nil {
+			t.Errorf("Unable to remove fake projid file: %v", err)
+		}
+	})
 
 	providers = []common.LinuxVolumeQuotaProvider{
 		&VolumeProvider1{},

--- a/pkg/volume/util/fsquota/quota_unsupported.go
+++ b/pkg/volume/util/fsquota/quota_unsupported.go
@@ -58,6 +58,6 @@ func GetInodes(_ string) (*resource.Quantity, error) {
 }
 
 // ClearQuota -- dummy implementation
-func ClearQuota(_ mount.Interface, _ string, _ bool) error {
+func ClearQuota(_ mount.Interface, _ string) error {
 	return errNotImplemented
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `LocalStorageCapacityIsolationFSQuotaMonitoring` is enabled, emptyDir volumes get a project quota assigned during `SetUp`, which writes an entry into `/etc/projects` and `/etc/projid`. Those entries were never removed when the pod went away, so every pod permanently leaked a project ID mapping on the node.

The reason is that the user namespace check on the teardown path can never be true:

- `emptyDirPlugin.NewUnmounter()` only receives the volume name and the pod UID, and `newUnmounterInternal()` builds the `emptyDir` with `pod: &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: podUID}}` — an otherwise empty pod, so `pod.Spec.HostUsers` is always `nil`.
- `teardownDefault()` nevertheless derived `userNamespacesEnabled` from `ed.pod.Spec.HostUsers`, so it evaluated to `false` for every teardown, including pods that really did run with `hostUsers: false`.
- `ClearQuota()` passed that `false` down to `clearQuotaOnDir()` → `SupportsQuotas()`, which returns `false` when user namespaces are not enabled. `clearQuotaOnDir()` then hit its `if !supportsQuotas { return nil }` early return, so neither `setQuotaOnDir(path, projid, 0)` nor `removeProjectID(path, projid)` ever ran.

Since teardown fundamentally cannot know whether the pod ran in a user namespace, this drops the check from the cleanup path and always clears the quota, as suggested by @rata in the issue. The user namespace check stays on `SupportsQuotas()`, which still gates whether a quota gets applied in the first place, so quota accounting behaviour is unchanged.

As a side effect the `ClearQuota()` signature now matches the `Interface` declaration in `pkg/volume/util/fsquota/quota.go`, which was never updated when the user namespace parameter was added.

#### Which issue(s) this PR is related to:

Fixes #135063

#### Special notes for your reviewer:

**On @rata's open question about retries and silent leaks** — I looked into it. The leak is silent, and it is not recoverable after the fact:

1. `teardownDefault()` only logs `ClearQuota()` failures via `klog.Warningf` and then returns `os.RemoveAll(dir)`, so teardown reports success regardless. The operation executor sees a successful unmount and never retries.
2. In this particular bug nothing was logged at all above `V(3)`: `clearQuotaOnDir()` returned a plain `nil`, so even that warning never fired. `ClearQuota()` returned success while leaking the project ID.
3. Even if something did retry, there would be nothing left to retry from. By the time `ClearQuota()` returns it has already deleted `dirPodMap[path]`, `dirQuotaMap[path]`, `podQuotaMap`, `podDirCountMap`, ... and `teardownDefault()` has removed the directory. A second `ClearQuota()` call would take the "stale directory" branch, fail to `GetQuotaOnDir()` on a path that no longer exists, and return `nil`. The state needed to reclaim the ID is gone.

So project IDs are consumed monotonically and `/etc/projects` and `/etc/projid` grow without bound for the lifetime of the node.

I deliberately kept this PR to the actual bug rather than also reworking the failure handling, because making teardown fail on a quota-clear error would let a quota problem block pod cleanup. Happy to follow up separately if SIG Storage would like `ClearQuota()` to retain its bookkeeping when `clearQuotaOnDir()` fails so that a retry can succeed.

**On why CI did not catch this** — in addition to the user namespace e2e being skipped that @rata mentioned, the existing unit test passed `userNamespacesEnabled: true` into the `Clear` cases in `quotaTestCases`. That is a value the teardown path can never produce, so the test was asserting against a state unreachable in production. The new test calls the clear path the way `teardownDefault()` actually reaches it.

**Testing and verification boundary — please read:**

- Added `TestClearQuotaReclaimsProjectID` in `pkg/volume/util/fsquota/quota_linux_test.go`. It assigns a quota the way `SetUp` does for a user namespace pod, then clears it the way teardown does, and asserts `/etc/projects` and `/etc/projid` are back to their original contents. It reuses the existing mock applier and temp-file overrides, so it needs neither root nor XFS/ext4.
- I verified the test fails before the fix and passes after. Before the fix it left `1048577:/quota1/teardown` in the projects file and `volume1048577:1048577` in the projid file, which matches exactly what @andy176631 reported.
- **I could not run the prjquota e2e or any real filesystem verification.** I develop on macOS, `pkg/volume/util/fsquota` is Linux-only, and I have no Linux machine or container runtime available. To actually execute the unit test I copied the package into a throwaway build with the `linux` build constraints stripped and a stub provider (the tests use the mock applier regardless); that scratch copy is not part of this PR. For the real tree I verified `GOOS=linux go build`, `GOOS=linux go vet` and `GOOS=linux go test -c` over `pkg/volume/emptydir/...`, `pkg/volume/util/fsquota/...`, `./cmd/kubelet/...`, `./pkg/kubelet/...` and `./test/e2e_node/`, plus a native darwin build to cover the `quota_unsupported.go` path. **Someone with a prjquota-capable node should please confirm end to end using the repro in the issue.**
- One behaviour note: with the feature gate on, `teardownDefault()` now calls into `ClearQuota()` for emptyDir teardowns of non-user-namespace pods too, where it previously short-circuited. For those the directory has no project ID, so `clearQuotaOnDir()` finds `BadQuotaID` and returns without changing anything; the cost is one extra mountpoint and backing-device lookup per teardown. The gate is Beta but still `Default: false`, so this only affects clusters that opt in.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where the project quota mapping for an emptyDir volume was not removed from /etc/projects and /etc/projid when a pod was deleted, leaking a project ID on the node for every pod. This affected clusters with the LocalStorageCapacityIsolationFSQuotaMonitoring feature gate enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```


This PR was written in part with the assistance of generative AI.
