### PR TITLE
Remove retired Go Report Card badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kubernetes (K8s)
 
-[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/569/badge)](https://bestpractices.coreinfrastructure.org/projects/569) [![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes/kubernetes)](https://goreportcard.com/report/github.com/kubernetes/kubernetes) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/kubernetes/kubernetes?sort=semver)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/569/badge)](https://bestpractices.coreinfrastructure.org/projects/569) ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/kubernetes/kubernetes?sort=semver)
 
 <img src="https://github.com/kubernetes/kubernetes/raw/master/logo/logo.png" width="100">
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**

Go Report Card has been sunset — the badge and report URLs now serve a retirement notice instead of a grade, so the badge in README.md links nowhere useful. This removes it.

**Which issue(s) this PR is related to**

Fixes #140940

**Special notes for your reviewer**

README-only change.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)