### PR TITLE
kubelet: fix eviction-max-pod-grace-period to defer to pod value when negative

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -431,7 +431,13 @@ func (m *managerImpl) synchronize(ctx context.Context, diskInfoProvider DiskInfo
 		gracePeriodOverride := int64(immediateEvictionGracePeriodSeconds)
 		if !isHardEvictionThreshold(thresholdToReclaim) {
 			gracePeriodOverride = m.config.MaxPodGracePeriodSeconds
-			if pod.Spec.TerminationGracePeriodSeconds != nil {
+			if m.config.MaxPodGracePeriodSeconds < 0 {
+				if pod.Spec.TerminationGracePeriodSeconds != nil {
+					gracePeriodOverride = *pod.Spec.TerminationGracePeriodSeconds
+				} else {
+					gracePeriodOverride = 30
+				}
+			} else if pod.Spec.TerminationGracePeriodSeconds != nil {
 				gracePeriodOverride = min(m.config.MaxPodGracePeriodSeconds, *pod.Spec.TerminationGracePeriodSeconds)
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `eviction-max-pod-grace-period` kubelet parameter states in its documentation: *"If negative, defer to pod specified value"*. However, when set to a negative value (e.g. `-1`), the kubelet was incorrectly forwarding the negative value straight down to the CRI runtime, causing the container to be killed immediately (exit 137). 

This PR modifies the eviction manager to correctly defer to the pod's `TerminationGracePeriodSeconds` (or the default 30s) when `MaxPodGracePeriodSeconds` is negative. This aligns the actual code behavior with the documented behavior and user expectations.

#### Which issue(s) this PR is related to:

Fixes #118172

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Fix `eviction-max-pod-grace-period` in Kubelet to properly defer to the pod-specified grace period when configured with a negative value, matching its documented behavior.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
