### PR TITLE
Mark long-running node serial tests slow

### DIFF
--- a/test/e2e_node/image_gc_test.go
+++ b/test/e2e_node/image_gc_test.go
@@ -57,7 +57,7 @@ var _ = SIGDescribe("ImageGarbageCollect", framework.WithSerial(), framework.Wit
 			initialConfig.ImageMaximumGCAge = metav1.Duration{Duration: time.Duration(time.Minute * 1)}
 			initialConfig.ImageMinimumGCAge = metav1.Duration{Duration: time.Duration(time.Second * 1)}
 		})
-		ginkgo.It("should GC unused images", func(ctx context.Context) {
+		ginkgo.It("should GC unused images", f.WithSlow(), func(ctx context.Context) {
 			pod := innocentPod()
 			e2epod.NewPodClient(f).CreateBatch(ctx, []*v1.Pod{pod})
 
@@ -77,7 +77,7 @@ var _ = SIGDescribe("ImageGarbageCollect", framework.WithSerial(), framework.Wit
 				return len(gcdImageList)
 			}, checkGCUntil, checkGCFreq).Should(gomega.BeNumerically("<", len(allImages)))
 		})
-		ginkgo.It("should not GC unused images prematurely", func(ctx context.Context) {
+		ginkgo.It("should not GC unused images prematurely", f.WithSlow(), func(ctx context.Context) {
 			pod := innocentPod()
 			e2epod.NewPodClient(f).CreateBatch(ctx, []*v1.Pod{pod})
 

--- a/test/e2e_node/mirror_pod_test.go
+++ b/test/e2e_node/mirror_pod_test.go
@@ -204,7 +204,7 @@ var _ = SIGDescribe("MirrorPod", func() {
 	})
 	ginkgo.Context("when recreating a static pod", func() {
 		var ns, podPath, staticPodName, mirrorPodName string
-		f.It("it should launch successfully even if it temporarily failed termination due to volume failing to unmount", f.WithNodeConformance(), f.WithSerial(), func(ctx context.Context) {
+		f.It("it should launch successfully even if it temporarily failed termination due to volume failing to unmount", f.WithNodeConformance(), f.WithSerial(), f.WithSlow(), func(ctx context.Context) {
 			node := getNodeName(ctx, f)
 			ns = f.Namespace.Name
 			c := f.ClientSet


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The `ci-node-crio-kubelet-serial` Prow artifact recorded three individual tests taking longer than the five-minute target:

| Test | Recorded duration |
|---|---:|
| `ImageGarbageCollect` — should GC unused images | 7m 42.96s |
| `ImageGarbageCollect` — should not GC unused images prematurely | 8m 11.87s |
| `MirrorPod` — should launch successfully even if it temporarily failed termination due to volume failing to unmount | 6m 02.63s |

Mark these tests with `[Slow]` so the regular serial job, which excludes slow tests, does not spend several minutes on tests that exceed its normal runtime target. The tests remain covered by jobs that include slow tests.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The source artifact is [Prow job 2081318383143358464](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-node-crio-kubelet-serial/2081318383143358464). Eviction tests were skipped by this job and were already marked slow, so they are not changed here.

Ai was used in the making of this PR.

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```

#### Additional documentation e.g., KEPs, usage docs, etc.:

```docs
NONE
```
