### PR TITLE
kubelet: match node log service units exactly

### DIFF
--- a/pkg/kubelet/kubelet_server_journal_linux.go
+++ b/pkg/kubelet/kubelet_server_journal_linux.go
@@ -74,5 +74,17 @@ func checkForNativeLogger(ctx context.Context, service string) bool {
 
 	// journalctl won't return an error if we try to fetch logs for a non-existent service,
 	// hence we search for it in the list of services known to journalctl
-	return strings.Contains(string(output), service+".service")
+	return isNativeLogger(output, service)
+}
+
+// isNativeLogger reports whether output from `journalctl --field _SYSTEMD_UNIT`
+// contains the requested service unit.
+func isNativeLogger(output []byte, service string) bool {
+	serviceUnit := service + ".service"
+	for _, unit := range strings.Fields(string(output)) {
+		if unit == serviceUnit {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/kubelet/kubelet_server_journal_linux_test.go
+++ b/pkg/kubelet/kubelet_server_journal_linux_test.go
@@ -1,0 +1,57 @@
+//go:build linux
+
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import "testing"
+
+func TestIsNativeLogger(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		service string
+		want    bool
+	}{
+		{
+			name:    "matches an exact unit",
+			output:  "containerd.service\nkubelet.service\n",
+			service: "kubelet",
+			want:    true,
+		},
+		{
+			name:    "does not match a unit containing the requested name",
+			output:  "mykubelet.service\n",
+			service: "kubelet",
+			want:    false,
+		},
+		{
+			name:    "does not match a unit with the requested name as a prefix",
+			output:  "kubelet.service.backup\n",
+			service: "kubelet",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNativeLogger([]byte(tt.output), tt.service); got != tt.want {
+				t.Errorf("isNativeLogger(%q, %q) = %t, want %t", tt.output, tt.service, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Fixes false-positive native-journal detection for Linux kubelet NodeLogQuery requests.

`checkForNativeLogger` obtains the known systemd unit names with `journalctl --field _SYSTEMD_UNIT`. Previously it used a substring comparison against that output. A request for `kubelet` could therefore be classified as a native logger when the journal only contained a different unit such as `mykubelet.service`. The subsequent `journalctl --unit=kubelet` call returns no entries, and the handler never tries the file-log fallback.

This change compares each returned unit name with the expected `<service>.service` value. Exact units keep the existing journal query behavior; partial matches now correctly fall back to the file-log heuristics.

## Scope

- Linux kubelet NodeLogQuery handling only
- No API changes
- No changes to Windows logging behavior
- No security boundary or authorization behavior changes

## Testing

- Added regression coverage for exact matches and two partial-match cases.
- Ran `go test ./pkg/kubelet`.

## Release note

```release-note
Fixes a kubelet NodeLogQuery issue on Linux where a requested service could be mistaken for a different journal unit with a matching substring, causing its log query to return no results.
```

##Development assistance

Codex 5.6 Terra High was used as a development assistant during investigation and
implementation. The finaL was reviewed by human before submission.