### PR TITLE
lifecycle: restrict EvictionRequest responder status on first sync

### DIFF
--- a/pkg/apis/lifecycle/validation/validation.go
+++ b/pkg/apis/lifecycle/validation/validation.go
@@ -488,8 +488,28 @@ func ValidateEvictionStatusResponder(status, oldStatus *lifecycle.ResponderStatu
 	}
 
 	if oldStatus != nil && !validate.SemanticDeepEqual(status, oldStatus) && opts.responderState != lifecycle.ResponderStateActive {
-		// immutable; changes to the ResponderStatus are only allowed by the active responder or during initialization
+		// immutable; changes to the ResponderStatus are only allowed by the active responder
 		return append(allErrs, field.Invalid(fldPath, status, validation.FieldImmutableErrorMsg).WithOrigin("immutable"))
+	}
+
+	// First sync: non-active responders may only set name; active responders may only set
+	// name and startTime. Otherwise a racing writer can pre-populate completionTime and
+	// later skip heartbeat deadline checks that gate state transitions.
+	if oldStatus == nil {
+		allowed := lifecycle.ResponderStatus{Name: status.Name}
+		if opts.responderState == lifecycle.ResponderStateActive {
+			allowed.StartTime = status.StartTime
+		}
+		if !validate.SemanticDeepEqual(status, &allowed) {
+			msg := "can only set name during initialization when not active"
+			if opts.responderState == lifecycle.ResponderStateActive {
+				msg = "can only set name and startTime during initialization when active"
+			}
+			return append(allErrs, field.Invalid(fldPath, status, msg))
+		}
+		if opts.responderState != lifecycle.ResponderStateActive {
+			return allErrs
+		}
 	}
 
 	// name covered by DV

--- a/pkg/apis/lifecycle/validation/validation_test.go
+++ b/pkg/apis/lifecycle/validation/validation_test.go
@@ -1417,6 +1417,39 @@ func TestValidateEvictionStatusUpdate(t *testing.T) {
 				field.Invalid(field.NewPath("status", "responders").Index(1), "", validation.FieldImmutableErrorMsg).WithOrigin("immutable"),
 			},
 		},
+		"first sync cannot pre-populate inactive responder times": {
+			oldInput: mkValidEvictionStatus(0),
+			input: mkValidEvictionStatus(3,
+				setRespondersStartTime(clock, 1, 2),
+				setRespondersCompletionTime(clock, 1, 2)),
+			errors: []*field.Error{
+				field.Invalid(field.NewPath("status", "responders").Index(1), "", "can only set name during initialization when not active"),
+			},
+		},
+		"first sync cannot pre-populate active responder completionTime": {
+			oldInput: mkValidEvictionStatus(0),
+			input: mkValidEvictionStatus(3,
+				setRespondersCompletionTime(clock, 0, 1)),
+			errors: []*field.Error{
+				field.Invalid(field.NewPath("status", "responders").Index(0), "", "can only set name and startTime during initialization when active"),
+			},
+		},
+		"first sync cannot pre-populate active responder heartbeatTime": {
+			oldInput: mkValidEvictionStatus(0),
+			input: mkValidEvictionStatus(3,
+				setRespondersHeartBeatTime(clock, 0, 1)),
+			errors: []*field.Error{
+				field.Invalid(field.NewPath("status", "responders").Index(0), "", "can only set name and startTime during initialization when active"),
+			},
+		},
+		"first sync cannot pre-populate active responder message": {
+			oldInput: mkValidEvictionStatus(0),
+			input: mkValidEvictionStatus(2,
+				setRespondersMessage(0, 1)),
+			errors: []*field.Error{
+				field.Invalid(field.NewPath("status", "responders").Index(0), "", "can only set name and startTime during initialization when active"),
+			},
+		},
 		// status responder name
 		"invalid status responders names - short circuited by targetResponders key order": {
 			oldInput: mkValidEvictionStatus(0),
@@ -1481,8 +1514,7 @@ func TestValidateEvictionStatusUpdate(t *testing.T) {
 				setStateFor(lifecycle.ResponderStateActive, 0),
 				setRespondersHeartBeatTime(clockBefore(2*time.Second), 0, 1)),
 			errors: []*field.Error{
-				field.Required(field.NewPath("status", "responders").Index(0).Child("startTime"), "is required for an active responder"),
-				field.Invalid(field.NewPath("status", "responders").Index(0).Child("heartbeatTime"), "", "cannot be set before status.responders[0].startTime"),
+				field.Invalid(field.NewPath("status", "responders").Index(0), "", "can only set name and startTime during initialization when active"),
 			},
 		},
 		"heartbeatTime cannot be decreased": {
@@ -1531,8 +1563,7 @@ func TestValidateEvictionStatusUpdate(t *testing.T) {
 				setStateFor(lifecycle.ResponderStateActive, 0),
 				setRespondersExpectedCompletionTime(clockBefore(2*time.Second), 0, 1)),
 			errors: []*field.Error{
-				field.Required(field.NewPath("status", "responders").Index(0).Child("startTime"), "is required for an active responder"),
-				field.Invalid(field.NewPath("status", "responders").Index(0).Child("expectedCompletionTime"), "", "cannot be set before status.responders[0].startTime"),
+				field.Invalid(field.NewPath("status", "responders").Index(0), "", "can only set name and startTime during initialization when active"),
 			},
 		},
 		"expectedCompletionTime cannot be set before startTime even with a skew": {
@@ -1579,8 +1610,7 @@ func TestValidateEvictionStatusUpdate(t *testing.T) {
 				setStateFor(lifecycle.ResponderStateActive, 0),
 				setRespondersCompletionTime(clockBefore(2*time.Second), 0, 1)),
 			errors: []*field.Error{
-				field.Required(field.NewPath("status", "responders").Index(0).Child("startTime"), "is required for an active responder"),
-				field.Invalid(field.NewPath("status", "responders").Index(0).Child("completionTime"), "", "cannot be set before status.responders[0].startTime"),
+				field.Invalid(field.NewPath("status", "responders").Index(0), "", "can only set name and startTime during initialization when active"),
 			},
 		},
 		"completionTime cannot be set before startTime even with a skew": {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

On first sync of `EvictionRequest` / `Eviction` status responders, validation previously allowed progress fields (`startTime`, `heartbeatTime`, `expectedCompletionTime`, `completionTime`, `message`) to be set even when the corresponding target responder was not active.

A racing status writer could pre-populate `completionTime` during initialization. Later state transitions then skipped the heartbeat deadline checks (which are only enforced when `completionTime` is unset), allowing the responder chain to be walked to `Completed` without any real responder work.

This change matches the intended anti-spoofing behavior called out in review of #137050:
- first sync for non-active responders: only `name` may be set
- first sync for active responders: only `name` and `startTime` may be set

#### Which issue(s) this PR is related to:

Fixes #140804

#### Special notes for your reviewer:

- Validation lives in `ValidateEvictionStatusResponder`
- Unit coverage added/updated in `pkg/apis/lifecycle/validation`
- Verified that without this guard the inactive first-sync spoof is accepted; with it, the spoof is rejected and legitimate first sync still succeeds

```bash
go test ./pkg/apis/lifecycle/validation/ -count=1
```

#### Does this PR introduce a user-facing change?

```release-note
Fixed a race where EvictionRequest/Eviction status responders could have progress fields pre-populated on first sync, bypassing heartbeat deadline checks.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
N/A
```