### PR TITLE
kubectl: include kuberc aliases in command typo suggestions

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
@@ -247,14 +247,11 @@ func (p *Preferences) applyAliases(rootCmd *cobra.Command, kuberc *config.Prefer
 
 	for _, alias := range kuberc.Aliases {
 		p.aliases[alias.Name] = struct{}{}
-		if alias.Name != commandName {
-			continue
-		}
 
 		// do not allow shadowing built-ins
 		if _, _, err := rootCmd.Find([]string{alias.Name}); err == nil {
 			fmt.Fprintf(errOut, "Warning: Setting alias %q to a built-in command is not supported\n", alias.Name)
-			break
+			continue
 		}
 
 		commands := strings.Fields(alias.Command)
@@ -268,24 +265,24 @@ func (p *Preferences) applyAliases(rootCmd *cobra.Command, kuberc *config.Prefer
 		newCmd.Aliases = []string{}
 		aliasCmd := &newCmd
 
-		if alias.Name == commandName {
-			aliasArgs = &aliasing{
-				prependArgs:     alias.PrependArgs,
-				appendArgs:      alias.AppendArgs,
-				flags:           alias.Options,
-				command:         aliasCmd,
-				originalCommand: bytes.Buffer{},
-			}
-			aliasArgs.originalCommand.WriteString(alias.Command)
+		// register every defined alias on the root command, not just the one
+		// currently being invoked - making aliases discoverable in "help"
+		rootCmd.AddCommand(aliasCmd)
+
+		if alias.Name != commandName {
+			// this alias isn't the one being invoked; it has been registered
+			// above for suggestions - nothing more to do.
+			continue
 		}
 
-		if aliasArgs == nil {
-			// pursue with the current behavior.
-			// This might be a built-in command, external plugin, etc.
-			return args, nil
+		aliasArgs = &aliasing{
+			prependArgs:     alias.PrependArgs,
+			appendArgs:      alias.AppendArgs,
+			flags:           alias.Options,
+			command:         aliasCmd,
+			originalCommand: bytes.Buffer{},
 		}
-
-		rootCmd.AddCommand(aliasArgs.command)
+		aliasArgs.originalCommand.WriteString(alias.Command)
 
 		foundAliasCmd, _, err := rootCmd.Find([]string{commandName})
 		if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
@@ -2672,6 +2672,60 @@ func TestApplyAlias(t *testing.T) {
 	}
 }
 
+// TestApplyAliasSuggestsOnTypo aims to cover issues/1795:
+func TestApplyAliasSuggestsOnTypo(t *testing.T) {
+	rootCmd := &cobra.Command{
+		Use: "root",
+	}
+	prefHandler := NewPreferences()
+	prefHandler.AddFlags(rootCmd.PersistentFlags())
+	pref, ok := prefHandler.(*Preferences)
+	if !ok {
+		t.Fatal("unexpected type. Expected *Preferences")
+	}
+	// Runnable is required so cobra's suggestion engine considers it.
+	rootCmd.AddCommand(&cobra.Command{
+		Use: "run",
+		Run: func(cmd *cobra.Command, args []string) {},
+	})
+	pref.getPreferencesFunc = func(kuberc string, errOut io.Writer) (*config.Preference, error) {
+		return &config.Preference{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Preference",
+				APIVersion: "kubectl.config.k8s.io/v1alpha1",
+			},
+			Aliases: []config.AliasOverride{
+				{
+					Name:    "runx",
+					Command: "run",
+				},
+			},
+		}, nil
+	}
+
+	errWriter := &bytes.Buffer{}
+	opts := genericclioptions.NewConfigFlags(false)
+	// "runc" is a typo of the "runx" alias
+	_, err := pref.Apply(rootCmd, opts, []string{"root", "runc"}, errWriter)
+	require.NoError(t, err)
+
+	if _, _, err := rootCmd.Find([]string{"runx"}); err != nil {
+		t.Fatalf("expected alias %q to be registered on root command, got error: %v", "runx", err)
+	}
+
+	suggestions := rootCmd.SuggestionsFor("runc")
+	found := false
+	for _, s := range suggestions {
+		if s == "runx" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected suggestions for %q to include alias %q, got %v", "runc", "runx", suggestions)
+	}
+}
+
 func TestGetExplicitKuberc(t *testing.T) {
 	tests := []struct {
 		args        []string


### PR DESCRIPTION
kuberc aliases were only registered as cobra subcommands when the typed command name exactly matched the alias, so a mistyped alias never showed up.

Fixes kubernetes/kubectl#1795

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kuberc aliases were only registered as cobra subcommands when the typed command name exactly matched the alias, so a mistyped alias never showed up.

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubectl#1795

```
$ go build -o /tmp/kubectl-test ./cmd/kubectl

$ mkdir -p /tmp/kuberc-test
cat > /tmp/kuberc-test/kuberc <<'EOF'
apiVersion: kubectl.config.k8s.io/v1alpha1
kind: Preference
aliases:
  - name: runx
    command: run
EOF

## Current kubectl 
$ KUBECTL_KUBERC=true KUBERC=/tmp/kuberc-test/kuberc kubectl runc
error: unknown command "runc" for "kubectl"

Did you mean this?
	run

# PR kubectl 	
$ KUBECTL_KUBERC=true KUBERC=/tmp/kuberc-test/kuberc /tmp/kubectl-test runc
error: unknown command "runc" for "kubectl"

Did you mean this?
	run
	runx
```

#### Special notes for your reviewer:

manually verified against a built cmd/kubectl cli; also added new unit test TestApplyAliasSuggestsOnTypo

#### Does this PR introduce a user-facing change?
```release-note
kubectl: "Did you mean this?" suggestions for mistyped commands now also consider kuberc aliases, not just built-in commands.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
