### PR TITLE
fix(volume/csi): check return error of file.Close() in saveVolumeData

### DIFF
--- a/pkg/volume/csi/csi_util.go
+++ b/pkg/volume/csi/csi_util.go
@@ -67,6 +67,9 @@ func saveVolumeData(dir string, fileName string, data map[string]string) error {
 	if err := json.NewEncoder(file).Encode(data); err != nil {
 		return errors.New(log("failed to save volume data file %s: %v", dataFilePath, err))
 	}
+	if err := file.Close(); err != nil {
+		return errors.New(log("failed to close volume data file %s: %v", dataFilePath, err))
+	}
 	klog.V(4).Info(log("volume data file saved successfully [%s]", dataFilePath))
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
In `pkg/volume/csi/csi_util.go`, `saveVolumeData()` relied exclusively on `defer file.Close()`.

When writing to disk (especially on network filesystems or under heavy disk load), write/flush errors like `ENOSPC` (no space left on device) may only be returned when closing the file handle. Relying solely on deferred close ignores the error returned by `Close()`, which can lead to `saveVolumeData()` returning `nil` success even if the volume metadata file was left incomplete or corrupted on disk.

This PR adds an explicit check for `file.Close()` after JSON encoding to ensure any write/flush error is reported.

#### Special notes for your reviewer:
Unit tests for `pkg/volume/csi` verified passing.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```