### PR TITLE
Automated cherry pick of #140274: kubelet/dra: reset devices before processing gRPC response

### DIFF
--- a/pkg/kubelet/cm/dra/claiminfo.go
+++ b/pkg/kubelet/cm/dra/claiminfo.go
@@ -94,6 +94,22 @@ func (info *ClaimInfo) addDevice(driverName string, deviceState state.Device) {
 	info.DriverState[driverName] = driverState
 }
 
+// resetDevices clears the device list for a given driver, keeping the
+// entry present in DriverState. Used to discard stale devices left over
+// from a previous NodePrepareResources attempt before applying the
+// new response.
+func (info *ClaimInfo) resetDevices(driverName string) {
+	if info.DriverState == nil {
+		return
+	}
+	driverState, ok := info.DriverState[driverName]
+	if !ok {
+		return
+	}
+	driverState.Devices = nil
+	info.DriverState[driverName] = driverState
+}
+
 // addPodReference adds a pod reference to the claim info.
 func (info *ClaimInfo) addPodReference(podUID types.UID) {
 	info.PodUIDs.Insert(string(podUID))

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -410,12 +410,19 @@ func (m *Manager) prepareResources(ctx context.Context, pod *v1.Pod) error {
 
 			claim := resourceClaims[types.UID(claimUID)]
 
-			// Add the prepared CDI devices to the claim info
+			// Add the prepared CDI devices to the claim info. The
+			// driver's response is authoritative for this (claim, driver)
+			// pair, so drop any previously appended devices before
+			// rebuilding the list. Otherwise a retry of a prepare that
+			// had partially succeeded (this driver appended devices,
+			// another driver in the batch failed, setPrepared was
+			// skipped) would end up with the devices duplicated.
 			err := m.cache.withLock(func() error {
 				info, exists := m.cache.get(claim.Name, claim.Namespace)
 				if !exists {
 					return fmt.Errorf("internal error: unable to get claim info for ResourceClaim %s", claim.Name)
 				}
+				info.resetDevices(plugin.DriverName())
 				for _, device := range result.GetDevices() {
 					info.addDevice(plugin.DriverName(), state.Device{PoolName: device.PoolName,
 						DeviceName: device.DeviceName, ShareID: (*types.UID)(device.ShareId),

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -785,6 +785,24 @@ func TestPrepareResources(t *testing.T) {
 			resp:                   genPrepareResourcesResponse(claimUID),
 		},
 		{
+			// Regression test: if a previous PrepareResources attempt
+			// appended devices to the cached ClaimInfo but returned before
+			// reaching setPrepared (e.g. a driver in the same batch failed),
+			// a retry must not duplicate those devices in the cache. The
+			// seeded ClaimInfo mimics that leftover state: prepared=false,
+			// DriverState already populated with the device the fake driver
+			// will return on retry. After the retry, DriverState must
+			// contain exactly one device, not two.
+			description:            "should not duplicate devices on prepare retry",
+			driverName:             driverName,
+			pod:                    genTestPod(),
+			claim:                  genTestClaim(claimName, driverName, deviceName, podUID),
+			claimInfo:              genTestClaimInfo(claimUID, []string{podUID}, false),
+			resp:                   genPrepareResourcesResponse(claimUID),
+			expectedClaimInfoState: genClaimInfoState(cdiID),
+			expectedPrepareCalls:   1,
+		},
+		{
 			description:          "should timeout",
 			driverName:           driverName,
 			pod:                  genTestPod(),


### PR DESCRIPTION
Cherry pick of #140274 on release-1.35.

#140274: kubelet/dra: reset devices before processing gRPC response

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
kubelet/DRA: fixed a bug where retrying a partially-failed PrepareResources caused duplicate CDI device IDs to be passed to the CRI runtime, which could cause container start to fail.
```