### PR TITLE
kubectl: fix impersonation users/groups resource resolution

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani.go
@@ -314,8 +314,16 @@ func (o *CanIOptions) resourceFor(mapper meta.RESTMapper, resourceArg string) sc
 	if resourceArg == "*" {
 		return schema.GroupVersionResource{Resource: resourceArg}
 	}
+	resourceArg = strings.ToLower(resourceArg)
 
-	fullySpecifiedGVR, groupResource := schema.ParseResourceArg(strings.ToLower(resourceArg))
+	if nonStandardResourceNames.Has(resourceArg) {
+		return schema.GroupVersionResource{
+			Resource: resourceArg,
+		}
+	}
+
+	fullySpecifiedGVR, groupResource := schema.ParseResourceArg(resourceArg)
+
 	gvr := schema.GroupVersionResource{}
 	if fullySpecifiedGVR != nil {
 		gvr, _ = mapper.ResourceFor(*fullySpecifiedGVR)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/cani_test.go
@@ -277,6 +277,14 @@ func TestRunResourceFor(t *testing.T) {
 			},
 		},
 		{
+			name:        "server-supported impersonation groups resource with overlapping discovery",
+			o:           &CanIOptions{},
+			resourceArg: "groups",
+			expectGVR: schema.GroupVersionResource{
+				Resource: "groups",
+			},
+		},
+		{
 			name:        "invalid resources",
 			o:           &CanIOptions{},
 			resourceArg: "invalid",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -833,5 +833,25 @@ func testDynamicResources() []*restmapper.APIGroupResources {
 				},
 			},
 		},
+		{
+			Group: metav1.APIGroup{
+				Name: "group.harbor.crossplane.io",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{
+						GroupVersion: "group.harbor.crossplane.io/v1alpha1",
+						Version:      "v1alpha1",
+					},
+				},
+				PreferredVersion: metav1.GroupVersionForDiscovery{
+					GroupVersion: "group.harbor.crossplane.io/v1alpha1",
+					Version:      "v1alpha1",
+				},
+			},
+			VersionedResources: map[string][]metav1.APIResource{
+				"v1alpha1": {
+					{Name: "groups", Namespaced: false, Kind: "Group"},
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
#### What this PR does

Fixes an issue where `kubectl auth can-i impersonate users` and
`kubectl auth can-i impersonate groups` incorrectly resolve `users` and
`groups` through the RESTMapper.

If the cluster contains discovered resources with the same names (for example,
CRDs named `groups`), `kubectl` may resolve those resources instead of the
built-in impersonation resources, causing the generated
`SelfSubjectAccessReview` to contain an unexpected API group.

This change returns the non-discoverable impersonation resources (`users` and
`groups`) directly instead of resolving them through discovery.

#### Example

Before:

```console
$ kubectl auth can-i impersonate groups
Warning: resource 'groups' is not namespace scoped in group 'group.harbor.crossplane.io'
yes
```

The generated `SelfSubjectAccessReview` uses:

```yaml
resourceAttributes:
  group: group.harbor.crossplane.io
  resource: groups
```

After:

```yaml
resourceAttributes:
  group: ""
  resource: groups
```

#### Testing

```console
go test ./staging/src/k8s.io/kubectl/pkg/cmd/auth
go test ./staging/src/k8s.io/kubectl/pkg/cmd/...
```

Adds a regression test covering a discovered `groups` resource that overlaps
with the built-in impersonation resource.

Fixes #140961

```release-note
NONE
```