### PR TITLE
client-go: restore FakeCustomStore conformance to cache.Store

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/fake_custom_store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/fake_custom_store.go
@@ -18,16 +18,20 @@ package cache
 
 // FakeCustomStore lets you define custom functions for store operations.
 type FakeCustomStore struct {
-	AddFunc      func(obj interface{}) error
-	UpdateFunc   func(obj interface{}) error
-	DeleteFunc   func(obj interface{}) error
-	ListFunc     func() []interface{}
-	ListKeysFunc func() []string
-	GetFunc      func(obj interface{}) (item interface{}, exists bool, err error)
-	GetByKeyFunc func(key string) (item interface{}, exists bool, err error)
-	ReplaceFunc  func(list []interface{}, resourceVersion string) error
-	ResyncFunc   func() error
+	AddFunc                          func(obj interface{}) error
+	UpdateFunc                       func(obj interface{}) error
+	DeleteFunc                       func(obj interface{}) error
+	ListFunc                         func() []interface{}
+	ListKeysFunc                     func() []string
+	GetFunc                          func(obj interface{}) (item interface{}, exists bool, err error)
+	GetByKeyFunc                     func(key string) (item interface{}, exists bool, err error)
+	ReplaceFunc                      func(list []interface{}, resourceVersion string) error
+	ResyncFunc                       func() error
+	BookmarkFunc                     func(rv string)
+	LastStoreSyncResourceVersionFunc func() string
 }
+
+var _ Store = &FakeCustomStore{}
 
 // Add calls the custom Add function if defined
 func (f *FakeCustomStore) Add(obj interface{}) error {
@@ -99,4 +103,19 @@ func (f *FakeCustomStore) Resync() error {
 		return f.ResyncFunc()
 	}
 	return nil
+}
+
+// Bookmark calls the custom Bookmark function if defined
+func (f *FakeCustomStore) Bookmark(rv string) {
+	if f.BookmarkFunc != nil {
+		f.BookmarkFunc(rv)
+	}
+}
+
+// LastStoreSyncResourceVersion calls the custom LastStoreSyncResourceVersion function if defined
+func (f *FakeCustomStore) LastStoreSyncResourceVersion() string {
+	if f.LastStoreSyncResourceVersionFunc != nil {
+		return f.LastStoreSyncResourceVersionFunc()
+	}
+	return ""
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#134827 added two methods to the `cache.Store` interface — `Bookmark(rv string)` and `LastStoreSyncResourceVersion() string` — but did not update `FakeCustomStore`, so the fake no longer satisfies `cache.Store` and downstream test code that passes a `FakeCustomStore` where a `Store` is expected fails to compile:

```
cannot use &cache.FakeCustomStore{...} (value of type *cache.FakeCustomStore) as cache.Store value:
	*cache.FakeCustomStore does not implement cache.Store (missing method Bookmark)
```

This adds the two missing func fields and delegating methods (no-op / `""` when the func is nil), following the file's existing pattern. Backward compatible: existing struct literals keep compiling unchanged.

#### Which issue(s) this PR fixes:

Fixes #140965

#### Special notes for your reviewer:

Hit in the wild during KubeVirt's bump to client-go v0.36.2 (kubevirt/kubevirt#18315), which had to carry a local wrapper to keep its test suite compiling.

#### Does this PR introduce a user-facing change?

```release-note
client-go: FakeCustomStore implements the Bookmark and LastStoreSyncResourceVersion methods added to the cache.Store interface in v0.36, so it satisfies cache.Store again
```
