### PR TITLE
pkg/registry/flowcontrol/ensurer: fix typo unwatned -> unwanted

### DIFF
--- a/pkg/registry/flowcontrol/ensurer/strategy.go
+++ b/pkg/registry/flowcontrol/ensurer/strategy.go
@@ -347,7 +347,7 @@ func RemoveUnwantedObjects[ObjectType configurationObjectType](ctx context.Conte
 		if apierrors.IsNotFound(err) {
 			klog.V(5).InfoS("Unwanted APF object was concurrently deleted", "name", name)
 		} else {
-			return fmt.Errorf("failed to delete unwatned APF object %q - %w", name, err)
+			return fmt.Errorf("failed to delete unwanted APF object %q - %w", name, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Fixes a spelling typo ("unwatned" -> "unwanted") in `pkg/registry/flowcontrol/ensurer/strategy.go`.

#### Which issue(s) this PR fixes:
NONE

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?
```release-note
Fixed a typo in the API Priority and Fairness (APF) ensurer error message when failing to delete an unwanted object ("unwatned" -> "unwanted").