### PR TITLE
Fix ExpectNoError and Expect(err).NotTo(HaveOccurred()) anti-pattern in e2e tests (apps)

### DIFF
--- a/test/e2e/apps/controller_revision.go
+++ b/test/e2e/apps/controller_revision.go
@@ -66,7 +66,7 @@ var _ = SIGDescribe("ControllerRevision", framework.WithSerial(), func() {
 		if daemonsets != nil && len(daemonsets.Items) > 0 {
 			for _, ds := range daemonsets.Items {
 				ginkgo.By(fmt.Sprintf("Deleting DaemonSet %q", ds.Name))
-				framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, extensionsinternal.Kind("DaemonSet"), f.Namespace.Name, ds.Name))
+				framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, extensionsinternal.Kind("DaemonSet"), f.Namespace.Name, ds.Name), "failed to e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, extensionsinternal.K...")
 				err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnNoNodes(f, &ds))
 				framework.ExpectNoError(err, "error waiting for daemon pod to be reaped")
 			}
@@ -82,7 +82,7 @@ var _ = SIGDescribe("ControllerRevision", framework.WithSerial(), func() {
 			framework.Logf("unable to dump pods: %v", err)
 		}
 		err = clearDaemonSetNodeLabels(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to clearDaemonSetNodeLabels(ctx, f.ClientSet)")
 	})
 
 	f = framework.NewDefaultFramework("controllerrevisions")
@@ -100,12 +100,12 @@ var _ = SIGDescribe("ControllerRevision", framework.WithSerial(), func() {
 		c = f.ClientSet
 
 		updatedNS, err := patchNamespaceAnnotations(ctx, c, ns)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to patchNamespaceAnnotations(ctx, c, ns)")
 
 		ns = updatedNS.Name
 
 		err = clearDaemonSetNodeLabels(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to clearDaemonSetNodeLabels(ctx, c)")
 	})
 
 	/*
@@ -133,13 +133,13 @@ var _ = SIGDescribe("ControllerRevision", framework.WithSerial(), func() {
 
 		ginkgo.By(fmt.Sprintf("Creating DaemonSet %q", dsName))
 		testDaemonset, err := csAppsV1.DaemonSets(ns).Create(ctx, newDaemonSetWithLabel(dsName, image, dsLabel), metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csAppsV1.DaemonSets(ns).Create(ctx, newDaemonSetWithLabel(dsName, image, dsLa...")
 
 		ginkgo.By("Check that daemon pods launch on every node of the cluster.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, testDaemonset))
 		framework.ExpectNoError(err, "error waiting for daemon pod to start")
 		err = e2edaemonset.CheckDaemonStatus(ctx, f, dsName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edaemonset.CheckDaemonStatus(ctx, f, dsName)")
 
 		ginkgo.By(fmt.Sprintf("Confirm DaemonSet %q successfully created with %q label", dsName, dsLabelSelector))
 		dsList, err := csAppsV1.DaemonSets("").List(ctx, metav1.ListOptions{LabelSelector: dsLabelSelector})
@@ -147,7 +147,7 @@ var _ = SIGDescribe("ControllerRevision", framework.WithSerial(), func() {
 		gomega.Expect(dsList.Items).To(gomega.HaveLen(1), "filtered list wasn't found")
 
 		ds, err := c.AppsV1().DaemonSets(ns).Get(ctx, dsName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Get(ctx, dsName, metav1.GetOptions{})")
 
 		// Listing across all namespaces to verify api endpoint: listAppsV1ControllerRevisionForAllNamespaces
 		ginkgo.By(fmt.Sprintf("Listing all ControllerRevisions with label %q", dsLabelSelector))

--- a/test/e2e/apps/cronjob.go
+++ b/test/e2e/apps/cronjob.go
@@ -307,7 +307,7 @@ var _ = SIGDescribe("CronJob", func() {
 
 		ginkgo.By("Deleting the job")
 		job := cronJob.Status.Active[0]
-		framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, batchinternal.Kind("Job"), f.Namespace.Name, job.Name))
+		framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, batchinternal.Kind("Job"), f.Namespace.Name, job.Name), "failed to e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, batchinternal.Kind('...")
 
 		ginkgo.By("Ensuring job was deleted")
 		_, err = e2ejob.GetJob(ctx, f.ClientSet, f.Namespace.Name, job.Name)
@@ -381,40 +381,40 @@ var _ = SIGDescribe("CronJob", func() {
 
 		ginkgo.By("creating")
 		createdCronJob, err := cjClient.Create(ctx, cjTemplate, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.Create(ctx, cjTemplate, metav1.CreateOptions{})")
 		gomega.Expect(createdCronJob).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("getting")
 		gottenCronJob, err := cjClient.Get(ctx, createdCronJob.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.Get(ctx, createdCronJob.Name, metav1.GetOptions{})")
 		gomega.Expect(gottenCronJob.UID).To(gomega.Equal(createdCronJob.UID))
 
 		ginkgo.By("listing")
 		cjs, err := cjClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.List(ctx, metav1.ListOptions{LabelSelector: 'special-label=' + f.Uni...")
 		gomega.Expect(cjs.Items).To(gomega.HaveLen(1), "filtered list should have 1 item")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
 		cjWatch, err := cjClient.Watch(ctx, metav1.ListOptions{ResourceVersion: cjs.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.Watch(ctx, metav1.ListOptions{ResourceVersion: cjs.ResourceVersion, ...")
 
 		// Test cluster-wide list and watch
 		clusterCJClient := f.ClientSet.BatchV1().CronJobs("")
 		ginkgo.By("cluster-wide listing")
 		clusterCJs, err := clusterCJClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to clusterCJClient.List(ctx, metav1.ListOptions{LabelSelector: 'special-label=' ...")
 		gomega.Expect(clusterCJs.Items).To(gomega.HaveLen(1), "filtered list should have 1 item")
 
 		ginkgo.By("cluster-wide watching")
 		framework.Logf("starting watch")
 		_, err = clusterCJClient.Watch(ctx, metav1.ListOptions{ResourceVersion: cjs.ResourceVersion, LabelSelector: "special-label=" + f.UniqueName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to clusterCJClient.Watch(ctx, metav1.ListOptions{ResourceVersion: cjs.ResourceVe...")
 
 		ginkgo.By("patching")
 		patchedCronJob, err := cjClient.Patch(ctx, createdCronJob.Name, types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.Patch(ctx, createdCronJob.Name, types.MergePatchType,")
 		gomega.Expect(patchedCronJob.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(resourceversion.CompareResourceVersion(createdCronJob.ResourceVersion, patchedCronJob.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
@@ -429,7 +429,7 @@ var _ = SIGDescribe("CronJob", func() {
 			updatedCronJob, err = cjClient.Update(ctx, cjToUpdate, metav1.UpdateOptions{})
 			return err
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.Update(ctx, cjToUpdate, metav1.UpdateOptions{})")
 		gomega.Expect(updatedCronJob.Annotations).To(gomega.HaveKeyWithValue("updated", "true"), "updated object should have the applied annotation")
 
 		framework.Logf("waiting for watch events with expected annotations")
@@ -465,11 +465,11 @@ var _ = SIGDescribe("CronJob", func() {
 			LastScheduleTime: &now1,
 		}
 		cjStatusJSON, err := json.Marshal(cjStatus)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to json.Marshal(cjStatus)")
 		patchedStatus, err := cjClient.Patch(ctx, createdCronJob.Name, types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"patchedstatus":"true"}},"status":`+string(cjStatusJSON)+`}`),
 			metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.Patch(ctx, createdCronJob.Name, types.MergePatchType,")
 		if !patchedStatus.Status.LastScheduleTime.Equal(&now1) {
 			framework.Failf("patched object should have the applied lastScheduleTime %#v, got %#v instead", cjStatus.LastScheduleTime, patchedStatus.Status.LastScheduleTime)
 		}
@@ -488,7 +488,7 @@ var _ = SIGDescribe("CronJob", func() {
 			updatedStatus, err = cjClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})
 			return err
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})")
 
 		if !updatedStatus.Status.LastScheduleTime.Equal(&now2) {
 			framework.Failf("updated object status expected to have updated lastScheduleTime %#v, got %#v", statusToUpdate.Status.LastScheduleTime, updatedStatus.Status.LastScheduleTime)
@@ -497,9 +497,9 @@ var _ = SIGDescribe("CronJob", func() {
 		ginkgo.By("get /status")
 		cjResource := schema.GroupVersionResource{Group: "batch", Version: cjVersion, Resource: "cronjobs"}
 		gottenStatus, err := f.DynamicClient.Resource(cjResource).Namespace(ns).Get(ctx, createdCronJob.Name, metav1.GetOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.DynamicClient.Resource(cjResource).Namespace(ns).Get(ctx, createdCronJob.Na...")
 		statusUID, _, err := unstructured.NestedFieldCopy(gottenStatus.Object, "metadata", "uid")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to unstructured.NestedFieldCopy(gottenStatus.Object, 'metadata', 'uid')")
 		gomega.Expect(string(createdCronJob.UID)).To(gomega.Equal(statusUID), "createdCronJob.UID: %v expected to match statusUID: %v ", createdCronJob.UID, statusUID)
 
 		// CronJob resource delete operations
@@ -511,9 +511,9 @@ var _ = SIGDescribe("CronJob", func() {
 		ginkgo.By("deleting")
 		cjTemplate.Name = "for-removal"
 		forRemovalCronJob, err := cjClient.Create(ctx, cjTemplate, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.Create(ctx, cjTemplate, metav1.CreateOptions{})")
 		err = cjClient.Delete(ctx, forRemovalCronJob.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.Delete(ctx, forRemovalCronJob.Name, metav1.DeleteOptions{})")
 		cj, err := cjClient.Get(ctx, forRemovalCronJob.Name, metav1.GetOptions{})
 		// If controller does not support finalizers, we expect a 404.  Otherwise we validate finalizer behavior.
 		if err == nil {
@@ -524,9 +524,9 @@ var _ = SIGDescribe("CronJob", func() {
 
 		ginkgo.By("deleting a collection")
 		err = cjClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Lab...")
 		cjs, err = cjClient.List(ctx, metav1.ListOptions{LabelSelector: "special-label=" + f.UniqueName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cjClient.List(ctx, metav1.ListOptions{LabelSelector: 'special-label=' + f.Uni...")
 		// Should have <= 2 items since some cronjobs might not have been deleted yet due to finalizers
 		gomega.Expect(len(cjs.Items)).To(gomega.BeNumerically("<=", 2), "filtered list length should be <= 2, got:\n%s", format.Object(cjs.Items, 1))
 		// Validate finalizers

--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -143,7 +143,7 @@ func (r *RestartDaemonConfig) kill(ctx context.Context) {
 	}
 	framework.Logf("Killing %v", r)
 	_, err := e2essh.NodeExec(ctx, r.nodeName, killCmd, framework.TestContext.Provider)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2essh.NodeExec(ctx, r.nodeName, killCmd, framework.TestContext.Provider)")
 }
 
 // Restart checks if the daemon is up, kills it, and waits till it comes back up
@@ -188,7 +188,7 @@ func replacePods(pods []*v1.Pod, store cache.Store) {
 	for i := range pods {
 		found = append(found, pods[i])
 	}
-	framework.ExpectNoError(store.Replace(found, "0"))
+	framework.ExpectNoError(store.Replace(found, "0"), "failed to store.Replace(found, '0')")
 }
 
 // getContainerRestarts returns the count of container restarts across all pods matching the given labelSelector,
@@ -196,7 +196,7 @@ func replacePods(pods []*v1.Pod, store cache.Store) {
 func getContainerRestarts(ctx context.Context, c clientset.Interface, ns string, labelSelector labels.Selector) (int, []string) {
 	options := metav1.ListOptions{LabelSelector: labelSelector.String()}
 	pods, err := c.CoreV1().Pods(ns).List(ctx, options)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).List(ctx, options)")
 	failedContainers := 0
 	containerRestartNodes := sets.NewString()
 	for _, p := range pods.Items {
@@ -234,7 +234,7 @@ var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), framework.WithP
 			Replicas:    numPods,
 			CreatedPods: &[]*v1.Pod{},
 		}
-		framework.ExpectNoError(e2erc.RunRC(ctx, config))
+		framework.ExpectNoError(e2erc.RunRC(ctx, config), "failed to e2erc.RunRC(ctx, config)")
 		replacePods(*config.CreatedPods, existingPods)
 
 		// The following code continues to run after the BeforeEach and thus
@@ -292,7 +292,7 @@ var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), framework.WithP
 			// that it had the opportunity to create/delete pods, if it were going to do so. Scaling the RC
 			// to the same size achieves this, because the scale operation advances the RC's sequence number
 			// and awaits it to be observed and reported back in the RC's status.
-			framework.ExpectNoError(e2erc.ScaleRC(ctx, f.ClientSet, f.ScalesGetter, ns, rcName, numPods, true))
+			framework.ExpectNoError(e2erc.ScaleRC(ctx, f.ClientSet, f.ScalesGetter, ns, rcName, numPods, true), "failed to e2erc.ScaleRC(ctx, f.ClientSet, f.ScalesGetter, ns, rcName, numPods, true)")
 
 			// Only check the keys, the pods can be different if the kubelet updated it.
 			// TODO: Can it really?
@@ -330,9 +330,9 @@ var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), framework.WithP
 			restarter.kill(ctx)
 			// This is best effort to try and create pods while the scheduler is down,
 			// since we don't know exactly when it is restarted after the kill signal.
-			framework.ExpectNoError(e2erc.ScaleRC(ctx, f.ClientSet, f.ScalesGetter, ns, rcName, numPods+5, false))
+			framework.ExpectNoError(e2erc.ScaleRC(ctx, f.ClientSet, f.ScalesGetter, ns, rcName, numPods+5, false), "failed to e2erc.ScaleRC(ctx, f.ClientSet, f.ScalesGetter, ns, rcName, numPods+5, false)")
 			restarter.waitUp(ctx)
-			framework.ExpectNoError(e2erc.ScaleRC(ctx, f.ClientSet, f.ScalesGetter, ns, rcName, numPods+5, true))
+			framework.ExpectNoError(e2erc.ScaleRC(ctx, f.ClientSet, f.ScalesGetter, ns, rcName, numPods+5, true), "failed to e2erc.ScaleRC(ctx, f.ClientSet, f.ScalesGetter, ns, rcName, numPods+5, true)")
 		}
 	})
 

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -128,7 +128,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		if daemonsets != nil && len(daemonsets.Items) > 0 {
 			for _, ds := range daemonsets.Items {
 				ginkgo.By(fmt.Sprintf("Deleting DaemonSet %q", ds.Name))
-				framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, extensionsinternal.Kind("DaemonSet"), f.Namespace.Name, ds.Name))
+				framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, extensionsinternal.Kind("DaemonSet"), f.Namespace.Name, ds.Name), "failed to e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, extensionsinternal.K...")
 				err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnNoNodes(f, &ds))
 				framework.ExpectNoError(err, "error waiting for daemon pod to be reaped")
 			}
@@ -144,7 +144,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 			framework.Logf("unable to dump pods: %v", err)
 		}
 		err = clearDaemonSetNodeLabels(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to clearDaemonSetNodeLabels(ctx, f.ClientSet)")
 	})
 
 	f = framework.NewDefaultFramework("daemonsets")
@@ -162,12 +162,12 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		c = f.ClientSet
 
 		updatedNS, err := patchNamespaceAnnotations(ctx, c, ns)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to patchNamespaceAnnotations(ctx, c, ns)")
 
 		ns = updatedNS.Name
 
 		err = clearDaemonSetNodeLabels(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to clearDaemonSetNodeLabels(ctx, c)")
 	})
 
 	/*
@@ -181,19 +181,19 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		ginkgo.By(fmt.Sprintf("Creating simple DaemonSet %q", dsName))
 		ds, err := c.AppsV1().DaemonSets(ns).Create(ctx, newDaemonSet(dsName, image, label), metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Create(ctx, newDaemonSet(dsName, image, label), met...")
 
 		ginkgo.By("Check that daemon pods launch on every node of the cluster.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, ds))
 		framework.ExpectNoError(err, "error waiting for daemon pod to start")
 		err = e2edaemonset.CheckDaemonStatus(ctx, f, dsName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edaemonset.CheckDaemonStatus(ctx, f, dsName)")
 
 		ginkgo.By("Stop a daemon pod, check that the daemon pod is revived.")
 		podList := listDaemonPods(ctx, c, ns, label)
 		pod := podList.Items[0]
 		err = c.CoreV1().Pods(ns).Delete(ctx, pod.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).Delete(ctx, pod.Name, metav1.DeleteOptions{})")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, ds))
 		framework.ExpectNoError(err, "error waiting for daemon pod to revive")
 	})
@@ -211,7 +211,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		ds := newDaemonSet(dsName, image, complexLabel)
 		ds.Spec.Template.Spec.NodeSelector = nodeSelector
 		ds, err := c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})")
 
 		ginkgo.By("Initially, daemon pods should not be running on any nodes.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnNoNodes(f, ds))
@@ -219,7 +219,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		ginkgo.By("Change node label to blue, check that daemon pod is launched.")
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 		newNode, err := setDaemonSetNodeLabels(ctx, c, node.Name, nodeSelector)
 		framework.ExpectNoError(err, "error setting labels on node")
 		daemonSetLabels, _ := separateDaemonSetNodeLabels(newNode.Labels)
@@ -227,7 +227,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, e2edaemonset.CheckDaemonPodOnNodes(f, ds, []string{newNode.Name}))
 		framework.ExpectNoError(err, "error waiting for daemon pods to be running on new nodes")
 		err = e2edaemonset.CheckDaemonStatus(ctx, f, dsName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edaemonset.CheckDaemonStatus(ctx, f, dsName)")
 
 		ginkgo.By("Update the node label to green, and wait for daemons to be unscheduled")
 		nodeSelector[daemonsetColorLabel] = "green"
@@ -246,7 +246,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, e2edaemonset.CheckDaemonPodOnNodes(f, ds, []string{greenNode.Name}))
 		framework.ExpectNoError(err, "error waiting for daemon pods to be running on new nodes")
 		err = e2edaemonset.CheckDaemonStatus(ctx, f, dsName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edaemonset.CheckDaemonStatus(ctx, f, dsName)")
 	})
 
 	// We defer adding this test to conformance pending the disposition of moving DaemonSet scheduling logic to the
@@ -274,7 +274,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 			},
 		}
 		ds, err := c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})")
 
 		ginkgo.By("Initially, daemon pods should not be running on any nodes.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnNoNodes(f, ds))
@@ -282,7 +282,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		ginkgo.By("Change node label to blue, check that daemon pod is launched.")
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 		newNode, err := setDaemonSetNodeLabels(ctx, c, node.Name, nodeSelector)
 		framework.ExpectNoError(err, "error setting labels on node")
 		daemonSetLabels, _ := separateDaemonSetNodeLabels(newNode.Labels)
@@ -290,7 +290,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, e2edaemonset.CheckDaemonPodOnNodes(f, ds, []string{newNode.Name}))
 		framework.ExpectNoError(err, "error waiting for daemon pods to be running on new nodes")
 		err = e2edaemonset.CheckDaemonStatus(ctx, f, dsName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edaemonset.CheckDaemonStatus(ctx, f, dsName)")
 
 		ginkgo.By("Remove the node label and wait for daemons to be unscheduled")
 		_, err = setDaemonSetNodeLabels(ctx, c, node.Name, map[string]string{})
@@ -309,13 +309,13 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		ginkgo.By(fmt.Sprintf("Creating a simple DaemonSet %q", dsName))
 		ds, err := c.AppsV1().DaemonSets(ns).Create(ctx, newDaemonSet(dsName, image, label), metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Create(ctx, newDaemonSet(dsName, image, label), met...")
 
 		ginkgo.By("Check that daemon pods launch on every node of the cluster.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, ds))
 		framework.ExpectNoError(err, "error waiting for daemon pod to start")
 		err = e2edaemonset.CheckDaemonStatus(ctx, f, dsName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edaemonset.CheckDaemonStatus(ctx, f, dsName)")
 
 		ginkgo.By("Set a daemon pod's phase to 'Failed', check that the daemon pod is revived.")
 		podList := listDaemonPods(ctx, c, ns, label)
@@ -341,7 +341,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		ds := newDaemonSet(dsName, image, label)
 		ds.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{Type: appsv1.OnDeleteDaemonSetStrategyType}
 		ds, err := c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})")
 
 		ginkgo.By("Check that daemon pods launch on every node of the cluster.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, ds))
@@ -349,7 +349,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		// Check history and labels
 		ds, err = c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})")
 		waitForHistoryCreated(ctx, c, ns, label, 1)
 		first := curHistory(listDaemonHistories(ctx, c, ns, label), ds)
 		firstHash := first.Labels[appsv1.DefaultDaemonSetUniqueLabelKey]
@@ -359,11 +359,11 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		ginkgo.By("Update daemon pods image.")
 		patch := getDaemonSetImagePatch(ds.Spec.Template.Spec.Containers[0].Name, PrevAgnhostImage)
 		ds, err = c.AppsV1().DaemonSets(ns).Patch(ctx, dsName, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Patch(ctx, dsName, types.StrategicMergePatchType, [...")
 
 		ginkgo.By("Check that daemon pods images aren't updated.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkDaemonPodsImageAndAvailability(c, ds, image, 0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkD...")
 
 		ginkgo.By("Check that daemon pods are still running on every node of the cluster.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, ds))
@@ -371,7 +371,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		// Check history and labels
 		ds, err = c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})")
 		waitForHistoryCreated(ctx, c, ns, label, 2)
 		cur := curHistory(listDaemonHistories(ctx, c, ns, label), ds)
 		gomega.Expect(cur.Revision).To(gomega.Equal(int64(2)))
@@ -391,7 +391,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		ds := newDaemonSet(dsName, image, label)
 		ds.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType}
 		ds, err := c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})")
 		gomega.Expect(ds).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("Check that daemon pods launch on every node of the cluster.")
@@ -400,7 +400,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		// Check history and labels
 		ds, err = c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})")
 		waitForHistoryCreated(ctx, c, ns, label, 1)
 		cur := curHistory(listDaemonHistories(ctx, c, ns, label), ds)
 		hash := cur.Labels[appsv1.DefaultDaemonSetUniqueLabelKey]
@@ -411,19 +411,19 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		oldDsResourceVersion := ds.ResourceVersion
 		patch := getDaemonSetImagePatch(ds.Spec.Template.Spec.Containers[0].Name, PrevAgnhostImage)
 		ds, err = c.AppsV1().DaemonSets(ns).Patch(ctx, dsName, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Patch(ctx, dsName, types.StrategicMergePatchType, [...")
 		gomega.Expect(resourceversion.CompareResourceVersion(oldDsResourceVersion, ds.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
 		// Time to complete the rolling upgrade is proportional to the number of nodes in the cluster.
 		// Get the number of nodes, and set the timeout appropriately.
 		nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})")
 		nodeCount := len(nodes.Items)
 		retryTimeout := dsRetryTimeout + time.Duration(nodeCount*30)*time.Second
 
 		ginkgo.By("Check that daemon pods images are updated.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, retryTimeout, true, checkDaemonPodsImageAndAvailability(c, ds, PrevAgnhostImage, 1))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to wait.PollUntilContextTimeout(ctx, dsRetryPeriod, retryTimeout, true, checkDae...")
 
 		ginkgo.By("Check that daemon pods are still running on every node of the cluster.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, ds))
@@ -431,7 +431,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		// Check history and labels
 		ds, err = c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})")
 		waitForHistoryCreated(ctx, c, ns, label, 2)
 		cur = curHistory(listDaemonHistories(ctx, c, ns, label), ds)
 		hash = cur.Labels[appsv1.DefaultDaemonSetUniqueLabelKey]
@@ -447,14 +447,14 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 	*/
 	framework.ConformanceIt("should rollback without unnecessary restarts", func(ctx context.Context) {
 		schedulableNodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetReadySchedulableNodes(ctx, c)")
 		gomega.Expect(len(schedulableNodes.Items)).To(gomega.BeNumerically(">", 1), "Conformance test suite needs a cluster with at least 2 nodes.")
 		framework.Logf("Create a RollingUpdate DaemonSet")
 		label := map[string]string{daemonsetNameLabel: dsName}
 		ds := newDaemonSet(dsName, image, label)
 		ds.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType}
 		ds, err = c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})")
 
 		framework.Logf("Check that daemon pods launch on every node of the cluster")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, ds))
@@ -466,11 +466,11 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		newDS, err := updateDaemonSetWithRetries(ctx, c, ns, ds.Name, func(update *appsv1.DaemonSet) {
 			update.Spec.Template.Spec.Containers[0].Image = newImage
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateDaemonSetWithRetries(ctx, c, ns, ds.Name, func(update *appsv1.DaemonSet)")
 
 		// Make sure we're in the middle of a rollout
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkAtLeastOneNewPod(c, ns, label, newImage))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkA...")
 
 		pods := listDaemonPods(ctx, c, ns, label)
 		var existingPods, newPods []*v1.Pod
@@ -487,7 +487,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 			}
 		}
 		schedulableNodes, err = e2enode.GetReadySchedulableNodes(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetReadySchedulableNodes(ctx, c)")
 		if len(schedulableNodes.Items) < 2 {
 			gomega.Expect(existingPods).To(gomega.BeEmpty())
 		} else {
@@ -499,11 +499,11 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		rollbackDS, err := updateDaemonSetWithRetries(ctx, c, ns, ds.Name, func(update *appsv1.DaemonSet) {
 			update.Spec.Template.Spec.Containers[0].Image = image
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateDaemonSetWithRetries(ctx, c, ns, ds.Name, func(update *appsv1.DaemonSet)")
 
 		framework.Logf("Make sure DaemonSet rollback is complete")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkDaemonPodsImageAndAvailability(c, rollbackDS, image, 1))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkD...")
 
 		// After rollback is done, compare current pods with previous old pods during rollout, to make sure they're not restarted
 		pods = listDaemonPods(ctx, c, ns, label)
@@ -564,7 +564,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		ds.Spec.MinReadySeconds = 10
 
 		ds, err := c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Create(ctx, ds, metav1.CreateOptions{})")
 
 		ginkgo.By("Check that daemon pods launch on every node of the cluster.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, ds))
@@ -572,7 +572,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		// Check history and labels
 		ds, err = c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})")
 		waitForHistoryCreated(ctx, c, ns, label, 1)
 		cur := curHistory(listDaemonHistories(ctx, c, ns, label), ds)
 		hash := cur.Labels[appsv1.DefaultDaemonSetUniqueLabelKey]
@@ -583,12 +583,12 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 		ginkgo.By("Update daemon pods environment var")
 		patch := fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"name":"%s","env":[{"name":"VERSION","value":"%s"}]}]}}}}`, ds.Spec.Template.Spec.Containers[0].Name, newVersion)
 		ds, err = c.AppsV1().DaemonSets(ns).Patch(ctx, dsName, types.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Patch(ctx, dsName, types.StrategicMergePatchType, [...")
 
 		// Time to complete the rolling upgrade is proportional to the number of nodes in the cluster.
 		// Get the number of nodes, and set the timeout appropriately.
 		nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})")
 		nodeCount := len(nodes.Items)
 		// We disturb daemonset progress by randomly terminating pods.
 		randomPodTerminationTimeout := 5 * time.Minute
@@ -830,7 +830,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 			}
 			return true, nil
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ds.Namespace).Delete(ctx, pod.Name, metav...")
 
 		ginkgo.By("Check that daemon pods are still running on every node of the cluster.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, ds))
@@ -838,7 +838,7 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		// Check history and labels
 		ds, err = c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Get(ctx, ds.Name, metav1.GetOptions{})")
 		waitForHistoryCreated(ctx, c, ns, label, 2)
 		cur = curHistory(listDaemonHistories(ctx, c, ns, label), ds)
 		hash = cur.Labels[appsv1.DefaultDaemonSetUniqueLabelKey]
@@ -863,13 +863,13 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		ginkgo.By(fmt.Sprintf("Creating simple DaemonSet %q", dsName))
 		testDaemonset, err := c.AppsV1().DaemonSets(ns).Create(ctx, newDaemonSetWithLabel(dsName, image, label), metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Create(ctx, newDaemonSetWithLabel(dsName, image, la...")
 
 		ginkgo.By("Check that daemon pods launch on every node of the cluster.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, testDaemonset))
 		framework.ExpectNoError(err, "error waiting for daemon pod to start")
 		err = e2edaemonset.CheckDaemonStatus(ctx, f, dsName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edaemonset.CheckDaemonStatus(ctx, f, dsName)")
 
 		ginkgo.By("listing all DaemonSets")
 		dsList, err := cs.AppsV1().DaemonSets("").List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
@@ -911,13 +911,13 @@ var _ = SIGDescribe("Daemon set", framework.WithSerial(), func() {
 
 		ginkgo.By(fmt.Sprintf("Creating simple DaemonSet %q", dsName))
 		testDaemonset, err := c.AppsV1().DaemonSets(ns).Create(ctx, newDaemonSetWithLabel(dsName, image, label), metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().DaemonSets(ns).Create(ctx, newDaemonSetWithLabel(dsName, image, la...")
 
 		ginkgo.By("Check that daemon pods launch on every node of the cluster.")
 		err = wait.PollUntilContextTimeout(ctx, dsRetryPeriod, dsRetryTimeout, true, checkRunningOnAllNodes(f, testDaemonset))
 		framework.ExpectNoError(err, "error waiting for daemon pod to start")
 		err = e2edaemonset.CheckDaemonStatus(ctx, f, dsName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edaemonset.CheckDaemonStatus(ctx, f, dsName)")
 
 		ginkgo.By("Getting /status")
 		dsResource := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}
@@ -1061,7 +1061,7 @@ func listDaemonPods(ctx context.Context, c clientset.Interface, ns string, label
 		FieldSelector: nonTerminalPhaseSelector.String(),
 	}
 	podList, err := c.CoreV1().Pods(ns).List(ctx, options)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).List(ctx, options)")
 	gomega.Expect(podList.Items).ToNot(gomega.BeEmpty())
 	return podList
 }
@@ -1254,7 +1254,7 @@ func listDaemonHistories(ctx context.Context, c clientset.Interface, ns string, 
 	selector := labels.Set(label).AsSelector()
 	options := metav1.ListOptions{LabelSelector: selector.String()}
 	historyList, err := c.AppsV1().ControllerRevisions(ns).List(ctx, options)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ControllerRevisions(ns).List(ctx, options)")
 	gomega.Expect(historyList.Items).ToNot(gomega.BeEmpty())
 	return historyList
 }
@@ -1267,7 +1267,7 @@ func curHistory(historyList *appsv1.ControllerRevisionList, ds *appsv1.DaemonSet
 		// Every history should have the hash label
 		gomega.Expect(history.Labels[appsv1.DefaultDaemonSetUniqueLabelKey]).ToNot(gomega.BeEmpty())
 		match, err := daemon.Match(ds, history)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to daemon.Match(ds, history)")
 		if match {
 			curHistory = history
 			foundCurHistories++

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -165,7 +165,7 @@ var _ = SIGDescribe("Deployment", func() {
 	f.It("should not disrupt a cloud load-balancer's connectivity during rollout", f.WithProvider("aws", "azure", "gce"), func(ctx context.Context) {
 		e2eskipper.SkipIfIPv6("aws")
 		nodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetReadySchedulableNodes(ctx, c)")
 		e2eskipper.SkipUnlessAtLeast(len(nodes.Items), 3, "load-balancer test requires at least 3 schedulable nodes")
 		testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(ctx, f)
 	})
@@ -407,7 +407,7 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.ExpectNoError(err, "failed to Marshal Deployment JSON patch")
 
 		_, err = dc.Resource(deploymentResource).Namespace(testNamespaceName).Patch(ctx, testDeploymentName, types.StrategicMergePatchType, []byte(deploymentStatusPatch), metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to dc.Resource(deploymentResource).Namespace(testNamespaceName).Patch(ctx, testD...")
 
 		ctxUntil, cancel = context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
@@ -509,17 +509,17 @@ var _ = SIGDescribe("Deployment", func() {
 		framework.Logf("Creating simple deployment %s", dName)
 		d := e2edeployment.NewDeployment(dName, replicas, podLabels, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
 		deploy, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})")
 
 		// Wait for it to be updated to revision 1
 		err = e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, dName, "1", AgnhostImage)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, dName, '1', AgnhostImage)")
 
 		err = e2edeployment.WaitForDeploymentComplete(c, deploy)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentComplete(c, deploy)")
 
 		testDeployment, err := dClient.Get(ctx, dName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to dClient.Get(ctx, dName, metav1.GetOptions{})")
 
 		ginkgo.By("Getting /status")
 		dResource := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
@@ -675,21 +675,21 @@ func failureTrap(ctx context.Context, c clientset.Interface, ns string) {
 
 func stopDeployment(ctx context.Context, c clientset.Interface, ns, deploymentName string) {
 	deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})")
 
 	framework.Logf("Deleting deployment %s", deploymentName)
 	err = e2eresource.DeleteResourceAndWaitForGC(ctx, c, appsinternal.Kind("Deployment"), ns, deployment.Name)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2eresource.DeleteResourceAndWaitForGC(ctx, c, appsinternal.Kind('Deployment'...")
 
 	framework.Logf("Ensuring deployment %s was deleted", deploymentName)
 	_, err = c.AppsV1().Deployments(ns).Get(ctx, deployment.Name, metav1.GetOptions{})
 	gomega.Expect(err).To(gomega.MatchError(apierrors.IsNotFound, fmt.Sprintf("Expected deployment %s to be deleted", deploymentName)))
 	framework.Logf("Ensuring deployment %s's RSes were deleted", deploymentName)
 	selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to metav1.LabelSelectorAsSelector(deployment.Spec.Selector)")
 	options := metav1.ListOptions{LabelSelector: selector.String()}
 	rss, err := c.AppsV1().ReplicaSets(ns).List(ctx, options)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).List(ctx, options)")
 	gomega.Expect(rss.Items).Should(gomega.BeEmpty())
 	framework.Logf("Ensuring deployment %s's Pods were deleted", deploymentName)
 	var pods *v1.PodList
@@ -719,19 +719,19 @@ func testDeleteDeployment(ctx context.Context, f *framework.Framework) {
 	d := e2edeployment.NewDeployment(deploymentName, replicas, podLabels, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
 	d.Annotations = map[string]string{"test": "should-copy-to-replica-set", v1.LastAppliedConfigAnnotation: "should-not-copy-to-replica-set"}
 	deploy, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})")
 
 	// Wait for it to be updated to revision 1
 	err = e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", AgnhostImage)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, '1', A...")
 
 	err = e2edeployment.WaitForDeploymentComplete(c, deploy)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentComplete(c, deploy)")
 
 	deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})")
 	newRS, err := testutil.GetNewReplicaSet(deployment, c)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to testutil.GetNewReplicaSet(deployment, c)")
 	gomega.Expect(newRS).NotTo(gomega.Equal(nilRs))
 	stopDeployment(ctx, c, ns, deploymentName)
 }
@@ -756,7 +756,7 @@ func testRollingUpdateDeployment(ctx context.Context, f *framework.Framework) {
 	rs.Annotations = annotations
 	framework.Logf("Creating replica set %q (going to be adopted)", rs.Name)
 	_, err := c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})")
 	// Verify that the required pods have come up.
 	err = e2epod.VerifyPodsRunning(ctx,
 		c,
@@ -772,23 +772,23 @@ func testRollingUpdateDeployment(ctx context.Context, f *framework.Framework) {
 	framework.Logf("Creating deployment %q", deploymentName)
 	d := e2edeployment.NewDeployment(deploymentName, replicas, deploymentPodLabels, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
 	deploy, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})")
 
 	// Wait for it to be updated to revision 3546343826724305833.
 	framework.Logf("Ensuring deployment %q gets the next revision from the one the adopted replica set %q has", deploy.Name, rs.Name)
 	err = e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "3546343826724305833", AgnhostImage)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, '35463...")
 
 	framework.Logf("Ensuring status for deployment %q is the expected", deploy.Name)
 	err = e2edeployment.WaitForDeploymentComplete(c, deploy)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentComplete(c, deploy)")
 
 	// There should be 1 old RS (webserver-controller, which is adopted)
 	framework.Logf("Ensuring deployment %q has one old replica set (the one it adopted)", deploy.Name)
 	deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})")
 	_, allOldRSs, err := testutil.GetOldReplicaSets(deployment, c)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to testutil.GetOldReplicaSets(deployment, c)")
 	gomega.Expect(allOldRSs).To(gomega.HaveLen(1))
 }
 
@@ -801,16 +801,16 @@ func testRecreateDeployment(ctx context.Context, f *framework.Framework) {
 	framework.Logf("Creating deployment %q", deploymentName)
 	d := e2edeployment.NewDeployment(deploymentName, int32(1), map[string]string{"name": "sample-pod-3"}, AgnhostImageName, PrevAgnhostImage, appsv1.RecreateDeploymentStrategyType)
 	deployment, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})")
 
 	// Wait for it to be updated to revision 1
 	framework.Logf("Waiting deployment %q to be updated to revision 1", deploymentName)
 	err = e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", PrevAgnhostImage)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, '1', P...")
 
 	framework.Logf("Waiting deployment %q to complete", deploymentName)
 	err = e2edeployment.WaitForDeploymentComplete(c, deployment)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentComplete(c, deployment)")
 
 	// Update deployment to delete agnhost pods and bring up webserver pods.
 	framework.Logf("Triggering a new rollout for deployment %q", deploymentName)
@@ -818,11 +818,11 @@ func testRecreateDeployment(ctx context.Context, f *framework.Framework) {
 		update.Spec.Template.Spec.Containers[0].Name = AgnhostImageName
 		update.Spec.Template.Spec.Containers[0].Image = AgnhostImage
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, deploymentName, func(update ...")
 
 	framework.Logf("Watching deployment %q to verify that new pods will not run with olds pods", deploymentName)
 	err = watchRecreateDeployment(ctx, c, deployment)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to watchRecreateDeployment(ctx, c, deployment)")
 }
 
 // testDeploymentCleanUpPolicy tests that deployment supports cleanup policy
@@ -840,7 +840,7 @@ func testDeploymentCleanUpPolicy(ctx context.Context, f *framework.Framework) {
 	replicas := int32(1)
 	revisionHistoryLimit := ptr.To[int32](0)
 	_, err := c.AppsV1().ReplicaSets(ns).Create(ctx, newRS(rsName, replicas, rsPodLabels, AgnhostImageName, AgnhostImage, nil), metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Create(ctx, newRS(rsName, replicas, rsPodLabels, A...")
 
 	// Verify that the required pods have come up.
 	err = e2epod.VerifyPodsRunning(ctx,
@@ -865,7 +865,7 @@ func testDeploymentCleanUpPolicy(ctx context.Context, f *framework.Framework) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	w, err := c.CoreV1().Pods(ns).Watch(ctx, options)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).Watch(ctx, options)")
 	go func() {
 		defer ginkgo.GinkgoRecover()
 		// There should be only one pod being created, which is the pod with the agnhost image.
@@ -896,11 +896,11 @@ func testDeploymentCleanUpPolicy(ctx context.Context, f *framework.Framework) {
 	d := e2edeployment.NewDeployment(deploymentName, replicas, deploymentPodLabels, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
 	d.Spec.RevisionHistoryLimit = revisionHistoryLimit
 	_, err = c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})")
 
 	ginkgo.By(fmt.Sprintf("Waiting for deployment %s history to be cleaned up", deploymentName))
 	err = waitForDeploymentOldRSsNum(ctx, c, ns, deploymentName, int(*revisionHistoryLimit))
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForDeploymentOldRSsNum(ctx, c, ns, deploymentName, int(*revisionHistoryLi...")
 }
 
 // testRolloverDeployment tests that deployment supports rollover.
@@ -918,7 +918,7 @@ func testRolloverDeployment(ctx context.Context, f *framework.Framework) {
 	rsName := "test-rollover-controller"
 	rsReplicas := int32(1)
 	_, err := c.AppsV1().ReplicaSets(ns).Create(ctx, newRS(rsName, rsReplicas, rsPodLabels, AgnhostImageName, AgnhostImage, nil), metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Create(ctx, newRS(rsName, rsReplicas, rsPodLabels,...")
 	// Verify that the required pods have come up.
 	err = e2epod.VerifyPodsRunning(ctx,
 		c,
@@ -932,7 +932,7 @@ func testRolloverDeployment(ctx context.Context, f *framework.Framework) {
 	// Wait for replica set to become ready before adopting it.
 	framework.Logf("Waiting for pods owned by replica set %q to become ready", rsName)
 	err = e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName)")
 
 	// Create a deployment to delete webserver pods and instead bring up redis-slave pods.
 	// We use a nonexistent image here, so that we make sure it won't finish
@@ -948,26 +948,26 @@ func testRolloverDeployment(ctx context.Context, f *framework.Framework) {
 	}
 	newDeployment.Spec.MinReadySeconds = int32(10)
 	_, err = c.AppsV1().Deployments(ns).Create(ctx, newDeployment, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, newDeployment, metav1.CreateOptions{})")
 
 	// Verify that the pods were scaled up and down as expected.
 	deployment, err := c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})")
 	framework.Logf("Make sure deployment %q performs scaling operations", deploymentName)
 	// Make sure the deployment starts to scale up and down replica sets by checking if its updated replicas >= 1
 	err = waitForDeploymentUpdatedReplicasGTE(c, ns, deploymentName, deploymentReplicas, deployment.Generation)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForDeploymentUpdatedReplicasGTE(c, ns, deploymentName, deploymentReplicas...")
 	// Check if it's updated to revision 1 correctly
 	framework.Logf("Check revision of new replica set for deployment %q", deploymentName)
 	err = checkDeploymentRevisionAndImage(c, ns, deploymentName, "1", deploymentImage)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to checkDeploymentRevisionAndImage(c, ns, deploymentName, '1', deploymentImage)")
 
 	framework.Logf("Ensure that both replica sets have 1 created replica")
 	oldRS, err := c.AppsV1().ReplicaSets(ns).Get(ctx, rsName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Get(ctx, rsName, metav1.GetOptions{})")
 	ensureReplicas(oldRS, int32(1))
 	newRS, err := testutil.GetNewReplicaSet(deployment, c)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to testutil.GetNewReplicaSet(deployment, c)")
 	ensureReplicas(newRS, int32(1))
 
 	// The deployment is stuck, update it to rollover the above 2 ReplicaSets and bring up agnhost pods.
@@ -977,29 +977,29 @@ func testRolloverDeployment(ctx context.Context, f *framework.Framework) {
 		update.Spec.Template.Spec.Containers[0].Name = updatedDeploymentImageName
 		update.Spec.Template.Spec.Containers[0].Image = updatedDeploymentImage
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, newDeployment.Name, func(upd...")
 
 	// Use observedGeneration to determine if the controller noticed the pod template update.
 	framework.Logf("Wait deployment %q to be observed by the deployment controller", deploymentName)
 	err = waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)")
 
 	// Wait for it to be updated to revision 2
 	framework.Logf("Wait for revision update of deployment %q to 2", deploymentName)
 	err = e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "2", updatedDeploymentImage)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, '2', u...")
 
 	framework.Logf("Make sure deployment %q is complete", deploymentName)
 	err = waitForDeploymentCompleteAndCheckRolling(c, deployment)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForDeploymentCompleteAndCheckRolling(c, deployment)")
 
 	framework.Logf("Ensure that both old replica sets have no replicas")
 	oldRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, rsName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Get(ctx, rsName, metav1.GetOptions{})")
 	ensureReplicas(oldRS, int32(0))
 	// Not really the new replica set anymore but we GET by name so that's fine.
 	newRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, newRS.Name, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Get(ctx, newRS.Name, metav1.GetOptions{})")
 	ensureReplicas(newRS, int32(0))
 }
 
@@ -1039,7 +1039,7 @@ func testIterativeDeployments(ctx context.Context, f *framework.Framework) {
 	d.Spec.Template.Spec.TerminationGracePeriodSeconds = &zero
 	framework.Logf("Creating deployment %q", deploymentName)
 	deployment, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})")
 
 	iterations := 20
 	for i := range iterations {
@@ -1056,7 +1056,7 @@ func testIterativeDeployments(ctx context.Context, f *framework.Framework) {
 				update.Spec.Template.Spec.Containers[0].Env = append(update.Spec.Template.Spec.Containers[0].Env, newEnv)
 				randomScale(update, i)
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update...")
 
 		case n < 0.4:
 			// rollback to the previous version
@@ -1067,7 +1067,7 @@ func testIterativeDeployments(ctx context.Context, f *framework.Framework) {
 				}
 				update.Annotations[appsv1.DeprecatedRollbackTo] = "0"
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, deployme...")
 
 		case n < 0.6:
 			// just scaling
@@ -1075,7 +1075,7 @@ func testIterativeDeployments(ctx context.Context, f *framework.Framework) {
 			deployment, err = e2edeployment.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update *appsv1.Deployment) {
 				randomScale(update, i)
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update...")
 
 		case n < 0.8:
 			// toggling the deployment
@@ -1085,24 +1085,24 @@ func testIterativeDeployments(ctx context.Context, f *framework.Framework) {
 					update.Spec.Paused = false
 					randomScale(update, i)
 				})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update...")
 			} else {
 				framework.Logf("%02d: pausing deployment %q", i, deployment.Name)
 				deployment, err = e2edeployment.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update *appsv1.Deployment) {
 					update.Spec.Paused = true
 					randomScale(update, i)
 				})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update...")
 			}
 
 		default:
 			// arbitrarily delete deployment pods
 			framework.Logf("%02d: arbitrarily deleting one or more deployment pods for deployment %q", i, deployment.Name)
 			selector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to metav1.LabelSelectorAsSelector(deployment.Spec.Selector)")
 			opts := metav1.ListOptions{LabelSelector: selector.String()}
 			podList, err := c.CoreV1().Pods(ns).List(ctx, opts)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).List(ctx, opts)")
 			if len(podList.Items) == 0 {
 				framework.Logf("%02d: no deployment pods to delete", i)
 				continue
@@ -1115,7 +1115,7 @@ func testIterativeDeployments(ctx context.Context, f *framework.Framework) {
 				framework.Logf("%02d: deleting deployment pod %q", i, name)
 				err := c.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{})
 				if err != nil && !apierrors.IsNotFound(err) {
-					framework.ExpectNoError(err)
+					framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{})")
 				}
 			}
 		}
@@ -1123,26 +1123,26 @@ func testIterativeDeployments(ctx context.Context, f *framework.Framework) {
 
 	// unpause the deployment if we end up pausing it
 	deployment, err = c.AppsV1().Deployments(ns).Get(ctx, deployment.Name, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Get(ctx, deployment.Name, metav1.GetOptions{})")
 	if deployment.Spec.Paused {
 		framework.Logf("Resuming deployment %q", deployment.Name)
 		deployment, err = e2edeployment.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update *appsv1.Deployment) {
 			update.Spec.Paused = false
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update...")
 	}
 
 	framework.Logf("Waiting for deployment %q to be observed by the controller", deploymentName)
 	err = waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)")
 
 	framework.Logf("Waiting for deployment %q status", deploymentName)
 	err = e2edeployment.WaitForDeploymentComplete(c, deployment)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentComplete(c, deployment)")
 
 	framework.Logf("Checking deployment %q for a complete condition", deploymentName)
 	err = waitForDeploymentWithCondition(c, ns, deploymentName, deploymentutil.NewRSAvailableReason, appsv1.DeploymentProgressing)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForDeploymentWithCondition(c, ns, deploymentName, deploymentutil.NewRSAva...")
 }
 
 func testDeploymentsControllerRef(ctx context.Context, f *framework.Framework) {
@@ -1155,9 +1155,9 @@ func testDeploymentsControllerRef(ctx context.Context, f *framework.Framework) {
 	replicas := int32(1)
 	d := e2edeployment.NewDeployment(deploymentName, replicas, podLabels, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
 	deploy, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})")
 	err = e2edeployment.WaitForDeploymentComplete(c, deploy)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentComplete(c, deploy)")
 
 	framework.Logf("Verifying Deployment %q has only one ReplicaSet", deploymentName)
 	rsList := listDeploymentReplicaSets(ctx, c, ns, podLabels)
@@ -1168,11 +1168,11 @@ func testDeploymentsControllerRef(ctx context.Context, f *framework.Framework) {
 
 	framework.Logf("Checking the ReplicaSet has the right controllerRef")
 	err = checkDeploymentReplicaSetsControllerRef(ctx, c, ns, deploy.UID, podLabels)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to checkDeploymentReplicaSetsControllerRef(ctx, c, ns, deploy.UID, podLabels)")
 
 	framework.Logf("Deleting Deployment %q and orphaning its ReplicaSet", deploymentName)
 	err = orphanDeploymentReplicaSets(ctx, c, deploy)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to orphanDeploymentReplicaSets(ctx, c, deploy)")
 
 	ginkgo.By("Wait for the ReplicaSet to be orphaned")
 	err = wait.PollUntilContextTimeout(ctx, dRetryPeriod, dRetryTimeout, false, waitDeploymentReplicaSetsOrphaned(c, ns, podLabels))
@@ -1182,13 +1182,13 @@ func testDeploymentsControllerRef(ctx context.Context, f *framework.Framework) {
 	framework.Logf("Creating Deployment %q to adopt the ReplicaSet", deploymentName)
 	d = e2edeployment.NewDeployment(deploymentName, replicas, podLabels, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
 	deploy, err = c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})")
 	err = e2edeployment.WaitForDeploymentComplete(c, deploy)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentComplete(c, deploy)")
 
 	framework.Logf("Waiting for the ReplicaSet to have the right controllerRef")
 	err = checkDeploymentReplicaSetsControllerRef(ctx, c, ns, deploy.UID, podLabels)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to checkDeploymentReplicaSetsControllerRef(ctx, c, ns, deploy.UID, podLabels)")
 
 	framework.Logf("Verifying no extra ReplicaSet is created (Deployment %q still has only one ReplicaSet after adoption)", deploymentName)
 	rsList = listDeploymentReplicaSets(ctx, c, ns, podLabels)
@@ -1217,11 +1217,11 @@ func testProportionalScalingDeployment(ctx context.Context, f *framework.Framewo
 
 	framework.Logf("Creating deployment %q", deploymentName)
 	deployment, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})")
 
 	framework.Logf("Waiting for observed generation %d", deployment.Generation)
 	err = waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)")
 
 	// Verify that the required pods have come up.
 	framework.Logf("Waiting for all required pods to come up")
@@ -1230,10 +1230,10 @@ func testProportionalScalingDeployment(ctx context.Context, f *framework.Framewo
 
 	framework.Logf("Waiting for deployment %q to complete", deployment.Name)
 	err = e2edeployment.WaitForDeploymentComplete(c, deployment)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentComplete(c, deployment)")
 
 	firstRS, err := testutil.GetNewReplicaSet(deployment, c)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to testutil.GetNewReplicaSet(deployment, c)")
 
 	// Update the deployment with a non-existent image so that the new replica set
 	// will be blocked to simulate a partial rollout.
@@ -1241,40 +1241,40 @@ func testProportionalScalingDeployment(ctx context.Context, f *framework.Framewo
 	deployment, err = e2edeployment.UpdateDeploymentWithRetries(c, ns, d.Name, func(update *appsv1.Deployment) {
 		update.Spec.Template.Spec.Containers[0].Image = "webserver:404"
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, d.Name, func(update *appsv1....")
 
 	framework.Logf("Waiting for observed generation %d", deployment.Generation)
 	err = waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForObservedDeployment(c, ns, deploymentName, deployment.Generation)")
 
 	// Checking state of first rollout's replicaset.
 	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(deployment.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*(deployment.Spec.Replicas)), false)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to intstr.GetScaledValueFromIntOrPercent(deployment.Spec.Strategy.RollingUpdate....")
 
 	// First rollout's replicaset should have Deployment's (replicas - maxUnavailable) = 10 - 2 = 8 available replicas.
 	minAvailableReplicas := replicas - int32(maxUnavailable)
 	framework.Logf("Waiting for the first rollout's replicaset to have .status.availableReplicas = %d", minAvailableReplicas)
 	err = e2ereplicaset.WaitForReplicaSetTargetAvailableReplicas(ctx, c, firstRS, minAvailableReplicas)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2ereplicaset.WaitForReplicaSetTargetAvailableReplicas(ctx, c, firstRS, minAv...")
 
 	// First rollout's replicaset should have .spec.replicas = 8 too.
 	framework.Logf("Waiting for the first rollout's replicaset to have .spec.replicas = %d", minAvailableReplicas)
 	err = waitForReplicaSetTargetSpecReplicas(ctx, c, firstRS, minAvailableReplicas)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForReplicaSetTargetSpecReplicas(ctx, c, firstRS, minAvailableReplicas)")
 
 	// The desired replicas wait makes sure that the RS controller has created expected number of pods.
 	framework.Logf("Waiting for the first rollout's replicaset of deployment %q to have desired number of replicas", deploymentName)
 	firstRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, firstRS.Name, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Get(ctx, firstRS.Name, metav1.GetOptions{})")
 	err = waitForReplicaSetDesiredReplicas(ctx, c.AppsV1(), firstRS)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForReplicaSetDesiredReplicas(ctx, c.AppsV1(), firstRS)")
 
 	// Checking state of second rollout's replicaset.
 	secondRS, err := testutil.GetNewReplicaSet(deployment, c)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to testutil.GetNewReplicaSet(deployment, c)")
 
 	maxSurge, err := intstr.GetScaledValueFromIntOrPercent(deployment.Spec.Strategy.RollingUpdate.MaxSurge, int(*(deployment.Spec.Replicas)), false)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to intstr.GetScaledValueFromIntOrPercent(deployment.Spec.Strategy.RollingUpdate....")
 
 	// Second rollout's replicaset should have 0 available replicas.
 	framework.Logf("Verifying that the second rollout's replicaset has .status.availableReplicas = 0")
@@ -1284,20 +1284,20 @@ func testProportionalScalingDeployment(ctx context.Context, f *framework.Framewo
 	newReplicas := replicas + int32(maxSurge) - minAvailableReplicas
 	framework.Logf("Waiting for the second rollout's replicaset to have .spec.replicas = %d", newReplicas)
 	err = waitForReplicaSetTargetSpecReplicas(ctx, c, secondRS, newReplicas)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForReplicaSetTargetSpecReplicas(ctx, c, secondRS, newReplicas)")
 
 	// The desired replicas wait makes sure that the RS controller has created expected number of pods.
 	framework.Logf("Waiting for the second rollout's replicaset of deployment %q to have desired number of replicas", deploymentName)
 	secondRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, secondRS.Name, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Get(ctx, secondRS.Name, metav1.GetOptions{})")
 	err = waitForReplicaSetDesiredReplicas(ctx, c.AppsV1(), secondRS)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForReplicaSetDesiredReplicas(ctx, c.AppsV1(), secondRS)")
 
 	// Check the deployment's minimum availability.
 	framework.Logf("Verifying that deployment %q has minimum required number of available replicas", deploymentName)
 	if deployment.Status.AvailableReplicas < minAvailableReplicas {
 		err = fmt.Errorf("observed %d available replicas, less than min required %d", deployment.Status.AvailableReplicas, minAvailableReplicas)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to fmt.Errorf('observed %d available replicas, less than min required %d', deplo...")
 	}
 
 	// Scale the deployment to 30 replicas.
@@ -1306,25 +1306,25 @@ func testProportionalScalingDeployment(ctx context.Context, f *framework.Framewo
 	_, err = e2edeployment.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update *appsv1.Deployment) {
 		update.Spec.Replicas = &newReplicas
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, deployment.Name, func(update...")
 
 	framework.Logf("Waiting for the replicasets of deployment %q to have desired number of replicas", deploymentName)
 	firstRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, firstRS.Name, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Get(ctx, firstRS.Name, metav1.GetOptions{})")
 	secondRS, err = c.AppsV1().ReplicaSets(ns).Get(ctx, secondRS.Name, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Get(ctx, secondRS.Name, metav1.GetOptions{})")
 
 	// First rollout's replicaset should have .spec.replicas = 8 + (30-10)*(8/13) = 8 + 12 = 20 replicas.
 	// Note that 12 comes from rounding (30-10)*(8/13) to nearest integer.
 	framework.Logf("Verifying that first rollout's replicaset has .spec.replicas = 20")
 	err = waitForReplicaSetTargetSpecReplicas(ctx, c, firstRS, 20)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForReplicaSetTargetSpecReplicas(ctx, c, firstRS, 20)")
 
 	// Second rollout's replicaset should have .spec.replicas = 5 + (30-10)*(5/13) = 5 + 8 = 13 replicas.
 	// Note that 8 comes from rounding (30-10)*(5/13) to nearest integer.
 	framework.Logf("Verifying that second rollout's replicaset has .spec.replicas = 13")
 	err = waitForReplicaSetTargetSpecReplicas(ctx, c, secondRS, 13)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForReplicaSetTargetSpecReplicas(ctx, c, secondRS, 13)")
 }
 
 func checkDeploymentReplicaSetsControllerRef(ctx context.Context, c clientset.Interface, ns string, uid types.UID, label map[string]string) error {
@@ -1355,7 +1355,7 @@ func listDeploymentReplicaSets(ctx context.Context, c clientset.Interface, ns st
 	selector := labels.Set(label).AsSelector()
 	options := metav1.ListOptions{LabelSelector: selector.String()}
 	rsList, err := c.AppsV1().ReplicaSets(ns).List(ctx, options)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).List(ctx, options)")
 	gomega.Expect(rsList.Items).ToNot(gomega.BeEmpty())
 	return rsList
 }
@@ -1399,9 +1399,9 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(ctx context.Context
 		MaxUnavailable: ptr.To(intstr.FromInt32(0)),
 	}
 	deployment, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})")
 	err = e2edeployment.WaitForDeploymentComplete(c, deployment)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentComplete(c, deployment)")
 
 	framework.Logf("Creating a service %s with type=LoadBalancer and externalTrafficPolicy=Local in namespace %s", name, ns)
 	jig := e2eservice.NewTestJig(c, ns, name)
@@ -1409,7 +1409,7 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(ctx context.Context
 	service, err := jig.CreateLoadBalancerService(ctx, e2eservice.GetServiceLoadBalancerCreationTimeout(ctx, c), func(svc *v1.Service) {
 		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyLocal
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to jig.CreateLoadBalancerService(ctx, e2eservice.GetServiceLoadBalancerCreationT...")
 
 	lbNameOrAddress := e2eservice.GetIngressPoint(&service.Status.LoadBalancer.Ingress[0])
 	svcPort := int(service.Spec.Ports[0].Port)
@@ -1422,7 +1422,7 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(ctx context.Context
 	e2eservice.TestReachableHTTP(ctx, lbNameOrAddress, svcPort, timeout)
 
 	expectedNodes, err := jig.GetEndpointNodeNames(ctx)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to jig.GetEndpointNodeNames(ctx)")
 
 	framework.Logf("Starting a goroutine to watch the service's endpoints in the background")
 	done := make(chan struct{})
@@ -1455,15 +1455,15 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(ctx context.Context
 			update.Spec.Template.Labels["iteration"] = fmt.Sprintf("%d", i)
 			setAffinities(update, true)
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, d.Name, func(update *appsv1....")
 
 		framework.Logf("Waiting for observed generation %d", deployment.Generation)
 		err = waitForObservedDeployment(c, ns, name, deployment.Generation)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForObservedDeployment(c, ns, name, deployment.Generation)")
 
 		framework.Logf("Make sure deployment %q is complete", name)
 		err = waitForDeploymentCompleteAndCheckRolling(c, deployment)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForDeploymentCompleteAndCheckRolling(c, deployment)")
 	}
 
 	select {
@@ -1667,17 +1667,17 @@ func testDeploymentSubresources(ctx context.Context, f *framework.Framework) {
 	framework.Logf("Creating simple deployment %s", deploymentName)
 	d := e2edeployment.NewDeployment("test-new-deployment", int32(1), map[string]string{"name": AgnhostImageName}, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
 	deploy, err := c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Create(ctx, d, metav1.CreateOptions{})")
 
 	// Wait for it to be updated to revision 1
 	err = e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", AgnhostImage)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, '1', A...")
 
 	err = e2edeployment.WaitForDeploymentComplete(c, deploy)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentComplete(c, deploy)")
 
 	_, err = c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})")
 
 	ginkgo.By("getting scale subresource")
 	scale, err := c.AppsV1().Deployments(ns).GetScale(ctx, deploymentName, metav1.GetOptions{})

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -160,7 +160,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 			}
 			return pdb.Status.DisruptionsAllowed > 0, nil
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cs.PolicyV1().PodDisruptionBudgets(ns).Get(ctx, defaultNa...")
 	})
 
 	/*
@@ -313,7 +313,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 
 			// Locate a running pod.
 			pod, err := locateRunningPod(ctx, cs, ns)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to locateRunningPod(ctx, cs, ns)")
 
 			e := &policyv1.Eviction{
 				ObjectMeta: metav1.ObjectMeta{
@@ -342,7 +342,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 					}
 					return true, nil
 				})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(ns).EvictV1(ctx, e)")
 			}
 		})...)
 	}
@@ -361,7 +361,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 		waitForPodsOrDie(ctx, cs, ns, 3) // make sure that they are running and so would be evictable with a different pdb
 
 		pod, err := locateRunningPod(ctx, cs, ns)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to locateRunningPod(ctx, cs, ns)")
 		e := &policyv1.Eviction{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pod.Name,
@@ -384,7 +384,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 		waitForPodsOrDie(ctx, cs, ns, 3)
 		waitForPdbToObserveHealthyPods(ctx, cs, ns, 3, 2)
 		err = cs.CoreV1().Pods(ns).EvictV1(ctx, e)
-		framework.ExpectNoError(err) // the eviction is now allowed
+		framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(ns).EvictV1(ctx, e)") // the eviction is now allowed
 
 		ginkgo.By("Patching the pdb to disallow a pod to be evicted")
 		patchPDBOrDie(ctx, cs, dc, ns, defaultName, func(old *policyv1.PodDisruptionBudget) (bytes []byte, err error) {
@@ -400,7 +400,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 
 		waitForPodsOrDie(ctx, cs, ns, 3)
 		pod, err = locateRunningPod(ctx, cs, ns) // locate a new running pod
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to locateRunningPod(ctx, cs, ns)")
 		e = &policyv1.Eviction{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pod.Name,
@@ -418,7 +418,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 		ginkgo.By("Trying to evict the same pod we tried earlier which should now be evictable")
 		waitForPodsOrDie(ctx, cs, ns, 3)
 		err = cs.CoreV1().Pods(ns).EvictV1(ctx, e)
-		framework.ExpectNoError(err) // the eviction is now allowed
+		framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(ns).EvictV1(ctx, e)") // the eviction is now allowed
 	})
 
 	unhealthyPodEvictionPolicyCases := []struct {
@@ -500,13 +500,13 @@ var _ = SIGDescribe("DisruptionController", func() {
 			} else {
 				ginkgo.By("Wait for pods to be running and not ready")
 				err := e2epod.VerifyPodsRunning(ctx, cs, ns, rsName, labels.SelectorFromSet(rs.Labels), false, replicas)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to e2epod.VerifyPodsRunning(ctx, cs, ns, rsName, labels.SelectorFromSet(rs.Label...")
 				waitForPdbToObserveHealthyPods(ctx, cs, ns, 0, replicas-1)
 			}
 
 			ginkgo.By("Try to evict all pods guarded by a PDB")
 			podList, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})")
 
 			evictedPods := sets.New[string]()
 			for _, pod := range podList.Items {
@@ -528,7 +528,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 			_, err = e2epod.WaitForPods(ctx, cs, ns, metav1.ListOptions{}, e2epod.Range{NoneMatching: true}, framework.PodDeleteTimeout, "evicted pods should be deleted", func(pod *v1.Pod) bool {
 				return evictedPods.Has(pod.Name) && pod.DeletionTimestamp == nil
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2epod.WaitForPods(ctx, cs, ns, metav1.ListOptions{}, e2epod.Range{NoneMatchi...")
 		})
 	}
 })
@@ -593,11 +593,11 @@ func patchPDBOrDie(ctx context.Context, cs kubernetes.Interface, dc dynamic.Inte
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		old := getPDBStatusOrDie(ctx, dc, ns, name)
 		patchBytes, err := f(old)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f(old)")
 		if updated, err = cs.PolicyV1().PodDisruptionBudgets(ns).Patch(ctx, old.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, subresources...); err != nil {
 			return err
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cs.PolicyV1().PodDisruptionBudgets(ns).Patch(ctx, old.Name, types.MergePatchT...")
 		return nil
 	})
 
@@ -809,7 +809,7 @@ func waitForPdbToObserveHealthyPods(ctx context.Context, cs kubernetes.Interface
 func getPDBStatusOrDie(ctx context.Context, dc dynamic.Interface, ns string, name string) *policyv1.PodDisruptionBudget {
 	pdbStatusResource := policyv1.SchemeGroupVersion.WithResource("poddisruptionbudgets")
 	unstruct, err := dc.Resource(pdbStatusResource).Namespace(ns).Get(ctx, name, metav1.GetOptions{}, "status")
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to dc.Resource(pdbStatusResource).Namespace(ns).Get(ctx, name, metav1.GetOptions...")
 	pdb, err := unstructuredToPDB(unstruct)
 	framework.ExpectNoError(err, "Getting the status of the pdb %s in namespace %s", name, ns)
 	return pdb

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -270,7 +270,7 @@ var _ = SIGDescribe("Job", func() {
 		// volume to persist data across new Pods.
 		ginkgo.By("Looking for a node to schedule job pod")
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 
 		parallelism := int32(2)
 		completions := int32(4)
@@ -315,7 +315,7 @@ var _ = SIGDescribe("Job", func() {
 
 		ginkgo.By("Looking for a node to schedule job pods")
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 
 		ginkgo.By("Creating a job")
 		job := e2ejob.NewTestJobOnNode("failOncePerIndex", "fail-pod-ignore-on-exit-code", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit, node.Name)
@@ -360,7 +360,7 @@ var _ = SIGDescribe("Job", func() {
 
 		ginkgo.By("Looking for a node to schedule job pods")
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 
 		ginkgo.By("Creating a job")
 		job := e2ejob.NewTestJobOnNode("notTerminateOncePerIndex", "evicted-pod-ignore-on-disruption-condition", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit, node.Name)
@@ -981,7 +981,7 @@ done`}
 		// and use a hostPath volume to persist data across new Pods.
 		ginkgo.By("Looking for a node to schedule job pod")
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 
 		parallelism := int32(2)
 		completions := int32(4)
@@ -1055,7 +1055,7 @@ done`}
 		framework.ExpectNoError(err, "failed to ensure active pods == parallelism in namespace: %s", f.Namespace.Name)
 
 		ginkgo.By("delete a job")
-		framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, batchinternal.Kind("Job"), f.Namespace.Name, job.Name))
+		framework.ExpectNoError(e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, batchinternal.Kind("Job"), f.Namespace.Name, job.Name), "failed to e2eresource.DeleteResourceAndWaitForGC(ctx, f.ClientSet, batchinternal.Kind('...")
 
 		ginkgo.By("Ensuring job was deleted")
 		_, err = e2ejob.GetJob(ctx, f.ClientSet, f.Namespace.Name, job.Name)
@@ -1250,11 +1250,11 @@ done`}
 		}
 
 		jStatusJSON, err := json.Marshal(jStatus)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to json.Marshal(jStatus)")
 		patchedStatus, err := jClient.Patch(ctx, job.Name, types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"patchedstatus":"true"}},"status":`+string(jStatusJSON)+`}`),
 			metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to jClient.Patch(ctx, job.Name, types.MergePatchType,")
 		if condition := findConditionByType(patchedStatus.Status.Conditions, customConditionType); condition != nil {
 			if !condition.LastTransitionTime.Equal(&now1) {
 				framework.Failf("patched object should have the applied condition with LastTransitionTime %#v, got %#v instead", now1, condition.LastTransitionTime)
@@ -1281,7 +1281,7 @@ done`}
 			updatedStatus, err = jClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})
 			return err
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to jClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})")
 		if condition := findConditionByType(updatedStatus.Status.Conditions, customConditionType); condition != nil {
 			if !condition.LastTransitionTime.Equal(&now2) {
 				framework.Failf("patched object should have the applied condition with LastTransitionTime %#v, got %#v instead", now2, condition.LastTransitionTime)
@@ -1293,9 +1293,9 @@ done`}
 		ginkgo.By("get /status")
 		jResource := schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}
 		gottenStatus, err := f.DynamicClient.Resource(jResource).Namespace(ns).Get(ctx, job.Name, metav1.GetOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.DynamicClient.Resource(jResource).Namespace(ns).Get(ctx, job.Name, metav1.G...")
 		statusUID, _, err := unstructured.NestedFieldCopy(gottenStatus.Object, "metadata", "uid")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to unstructured.NestedFieldCopy(gottenStatus.Object, 'metadata', 'uid')")
 		gomega.Expect(string(job.UID)).To(gomega.Equal(statusUID), fmt.Sprintf("job.UID: %v expected to match statusUID: %v ", job.UID, statusUID))
 	})
 
@@ -1493,7 +1493,7 @@ done`}
 
 		ginkgo.By("Looking for a node to schedule job pod")
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 
 		ginkgo.By("Creating a job with container-level RestartPolicy and PodFailurePolicy")
 		job := e2ejob.NewTestJobOnNode("failOnce", "managed-by", v1.RestartPolicyNever, parallelism, completions, nil, backoffLimit, node.Name)

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -498,12 +498,12 @@ func TestReplicationControllerServeImageOrFail(ctx context.Context, f *framework
 	newRC := newRC(name, replicas, rcLabels, name, image, []string{"serve-hostname"})
 	newRC.Spec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{{ContainerPort: 9376}}
 	_, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, newRC, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, new...")
 
 	// Check that pods for the new RC were created.
 	// TODO: Maybe switch PodsCreated to just check owner references.
 	pods, err := e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, name, replicas, labels.SelectorFromSet(rcLabels))
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, name, replicas,...")
 
 	// Wait for the pods to enter the running state and are Ready. Waiting loops until the pods
 	// are running so non-running pods cause a timeout for this test.
@@ -522,7 +522,7 @@ func TestReplicationControllerServeImageOrFail(ctx context.Context, f *framework
 				err = fmt.Errorf("pod %q never run: %w", pod.Name, err)
 			}
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to fmt.Errorf('pod %q never run: %w', pod.Name, err)")
 		framework.Logf("Pod %q is running and ready(conditions: %+v)", pod.Name, pod.Status.Conditions)
 		running++
 	}
@@ -532,7 +532,7 @@ func TestReplicationControllerServeImageOrFail(ctx context.Context, f *framework
 
 	// Verify that something is listening.
 	framework.Logf("Trying to dial the pod")
-	framework.ExpectNoError(e2epod.WaitForPodsResponding(ctx, f.ClientSet, f.Namespace.Name, name, labels.SelectorFromSet(rcLabels), true, 2*time.Minute, pods))
+	framework.ExpectNoError(e2epod.WaitForPodsResponding(ctx, f.ClientSet, f.Namespace.Name, name, labels.SelectorFromSet(rcLabels), true, 2*time.Minute, pods), "failed to e2epod.WaitForPodsResponding(ctx, f.ClientSet, f.Namespace.Name, name, labels...")
 }
 
 // 1. Create a quota restricting pods in the current namespace to 2.
@@ -547,7 +547,7 @@ func testReplicationControllerConditionCheck(ctx context.Context, f *framework.F
 	framework.Logf("Creating quota %q that allows only two pods to run in the current namespace", name)
 	quota := newPodQuota(name, "2")
 	_, err := c.CoreV1().ResourceQuotas(namespace).Create(ctx, quota, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.CoreV1().ResourceQuotas(namespace).Create(ctx, quota, metav1.CreateOptions{})")
 
 	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
 		quota, err = c.CoreV1().ResourceQuotas(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -561,12 +561,12 @@ func testReplicationControllerConditionCheck(ctx context.Context, f *framework.F
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("resource quota %q never synced", name)
 	}
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to fmt.Errorf('resource quota %q never synced', name)")
 
 	ginkgo.By(fmt.Sprintf("Creating rc %q that asks for more than the allowed pod quota", name))
 	rc := newRC(name, 3, map[string]string{"name": name}, AgnhostImageName, AgnhostImage, nil)
 	rc, err = c.CoreV1().ReplicationControllers(namespace).Create(ctx, rc, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.CoreV1().ReplicationControllers(namespace).Create(ctx, rc, metav1.CreateOpt...")
 
 	ginkgo.By(fmt.Sprintf("Checking rc %q has the desired failure condition set", name))
 	generation := rc.Generation
@@ -588,14 +588,14 @@ func testReplicationControllerConditionCheck(ctx context.Context, f *framework.F
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("rc manager never added the failure condition for rc %q: %#v", name, conditions)
 	}
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to fmt.Errorf('rc manager never added the failure condition for rc %q: %#v', nam...")
 
 	ginkgo.By(fmt.Sprintf("Scaling down rc %q to satisfy pod quota", name))
 	rc, err = updateReplicationControllerWithRetries(ctx, c, namespace, name, func(update *v1.ReplicationController) {
 		x := int32(2)
 		update.Spec.Replicas = &x
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to updateReplicationControllerWithRetries(ctx, c, namespace, name, func(update *...")
 
 	ginkgo.By(fmt.Sprintf("Checking rc %q has no failure condition set", name))
 	generation = rc.Generation
@@ -617,7 +617,7 @@ func testReplicationControllerConditionCheck(ctx context.Context, f *framework.F
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("rc manager never removed the failure condition for rc %q: %#v", name, conditions)
 	}
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to fmt.Errorf('rc manager never removed the failure condition for rc %q: %#v', n...")
 }
 
 func testRCAdoptMatchingOrphans(ctx context.Context, f *framework.Framework) {
@@ -645,7 +645,7 @@ func testRCAdoptMatchingOrphans(ctx context.Context, f *framework.Framework) {
 	rcSt := newRC(name, replicas, map[string]string{"name": name}, name, AgnhostImage, nil)
 	rcSt.Spec.Selector = map[string]string{"name": name}
 	rc, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, rcSt, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, rcS...")
 
 	ginkgo.By("Then the orphan pod is adopted")
 	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
@@ -654,7 +654,7 @@ func testRCAdoptMatchingOrphans(ctx context.Context, f *framework.Framework) {
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOption...")
 		for _, owner := range p2.OwnerReferences {
 			if *owner.Controller && owner.UID == rc.UID {
 				// pod adopted
@@ -664,7 +664,7 @@ func testRCAdoptMatchingOrphans(ctx context.Context, f *framework.Framework) {
 		// pod still not adopted
 		return false, nil
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Na...")
 }
 
 func testRCReleaseControlledNotMatching(ctx context.Context, f *framework.Framework) {
@@ -675,16 +675,16 @@ func testRCReleaseControlledNotMatching(ctx context.Context, f *framework.Framew
 	rcSt := newRC(name, replicas, rcLabels, name, AgnhostImage, nil)
 	rcSt.Spec.Selector = rcLabels
 	rc, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, rcSt, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, rcS...")
 
 	ginkgo.By("When the matched label of one of its pods change")
 	pods, err := e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, rc.Name, replicas, labels.SelectorFromSet(rcLabels))
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, rc.Name, replic...")
 
 	p := pods.Items[0]
 	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOption...")
 
 		pod.Labels = map[string]string{"name": "not-matching-name"}
 		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, pod, metav1.UpdateOptions{})
@@ -696,12 +696,12 @@ func testRCReleaseControlledNotMatching(ctx context.Context, f *framework.Framew
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, p...")
 
 	ginkgo.By("Then the pod is released")
 	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
 		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOption...")
 		for _, owner := range p2.OwnerReferences {
 			if *owner.Controller && owner.UID == rc.UID {
 				// pod still belonging to the replication controller
@@ -711,7 +711,7 @@ func testRCReleaseControlledNotMatching(ctx context.Context, f *framework.Framew
 		// pod already released
 		return true, nil
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Na...")
 }
 
 type updateRcFunc func(d *v1.ReplicationController)

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -192,12 +192,12 @@ func testReplicaSetServeImageOrFail(ctx context.Context, f *framework.Framework,
 	newRS := newRS(name, replicas, rsLabels, name, image, []string{"serve-hostname"})
 	newRS.Spec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{{ContainerPort: 9376}}
 	_, err := f.ClientSet.AppsV1().ReplicaSets(f.Namespace.Name).Create(ctx, newRS, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.AppsV1().ReplicaSets(f.Namespace.Name).Create(ctx, newRS, metav1....")
 
 	// Check that pods for the new RS were created.
 	// TODO: Maybe switch PodsCreated to just check owner references.
 	pods, err := e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, name, replicas, labels.SelectorFromSet(rsLabels))
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, name, replicas,...")
 
 	// Wait for the pods to enter the running state. Waiting loops until the pods
 	// are running so non-running pods cause a timeout for this test.
@@ -216,7 +216,7 @@ func testReplicaSetServeImageOrFail(ctx context.Context, f *framework.Framework,
 				err = fmt.Errorf("pod %q never run: %w", pod.Name, err)
 			}
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to fmt.Errorf('pod %q never run: %w', pod.Name, err)")
 		framework.Logf("Pod %q is running (conditions: %+v)", pod.Name, pod.Status.Conditions)
 		running++
 	}
@@ -226,7 +226,7 @@ func testReplicaSetServeImageOrFail(ctx context.Context, f *framework.Framework,
 
 	// Verify that something is listening.
 	framework.Logf("Trying to dial the pod")
-	framework.ExpectNoError(e2epod.WaitForPodsResponding(ctx, f.ClientSet, f.Namespace.Name, name, labels.SelectorFromSet(rsLabels), true, 2*time.Minute, pods))
+	framework.ExpectNoError(e2epod.WaitForPodsResponding(ctx, f.ClientSet, f.Namespace.Name, name, labels.SelectorFromSet(rsLabels), true, 2*time.Minute, pods), "failed to e2epod.WaitForPodsResponding(ctx, f.ClientSet, f.Namespace.Name, name, labels...")
 }
 
 // 1. Create a quota restricting pods in the current namespace to 2.
@@ -241,7 +241,7 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	ginkgo.By(fmt.Sprintf("Creating quota %q that allows only two pods to run in the current namespace", name))
 	quota := newPodQuota(name, "2")
 	_, err := c.CoreV1().ResourceQuotas(namespace).Create(ctx, quota, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.CoreV1().ResourceQuotas(namespace).Create(ctx, quota, metav1.CreateOptions{})")
 
 	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
 		quota, err = c.CoreV1().ResourceQuotas(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -255,12 +255,12 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("resource quota %q never synced", name)
 	}
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to fmt.Errorf('resource quota %q never synced', name)")
 
 	ginkgo.By(fmt.Sprintf("Creating replica set %q that asks for more than the allowed pod quota", name))
 	rs := newRS(name, 3, map[string]string{"name": name}, AgnhostImageName, AgnhostImage, nil)
 	rs, err = c.AppsV1().ReplicaSets(namespace).Create(ctx, rs, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(namespace).Create(ctx, rs, metav1.CreateOptions{})")
 
 	ginkgo.By(fmt.Sprintf("Checking replica set %q has the desired failure condition set", name))
 	generation := rs.Generation
@@ -283,14 +283,14 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("rs controller never added the failure condition for replica set %q: %#v", name, conditions)
 	}
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to fmt.Errorf('rs controller never added the failure condition for replica set %...")
 
 	ginkgo.By(fmt.Sprintf("Scaling down replica set %q to satisfy pod quota", name))
 	rs, err = e2ereplicaset.UpdateReplicaSetWithRetries(c, namespace, name, func(update *appsv1.ReplicaSet) {
 		x := int32(2)
 		update.Spec.Replicas = &x
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2ereplicaset.UpdateReplicaSetWithRetries(c, namespace, name, func(update *ap...")
 
 	ginkgo.By(fmt.Sprintf("Checking replica set %q has no failure condition set", name))
 	generation = rs.Generation
@@ -312,7 +312,7 @@ func testReplicaSetConditionCheck(ctx context.Context, f *framework.Framework) {
 	if wait.Interrupted(err) {
 		err = fmt.Errorf("rs controller never removed the failure condition for rs %q: %#v", name, conditions)
 	}
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to fmt.Errorf('rs controller never removed the failure condition for rs %q: %#v'...")
 }
 
 func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.Framework) {
@@ -339,7 +339,7 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 	rsSt := newRS(name, replicas, rsLabels, name, AgnhostImage, nil)
 	rsSt.Spec.Selector = &metav1.LabelSelector{MatchLabels: rsLabels}
 	rs, err := f.ClientSet.AppsV1().ReplicaSets(f.Namespace.Name).Create(ctx, rsSt, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.AppsV1().ReplicaSets(f.Namespace.Name).Create(ctx, rsSt, metav1.C...")
 
 	ginkgo.By("Then the orphan pod is adopted")
 	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
@@ -348,7 +348,7 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOption...")
 		for _, owner := range p2.OwnerReferences {
 			if *owner.Controller && owner.UID == rs.UID {
 				// pod adopted
@@ -358,16 +358,16 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 		// pod still not adopted
 		return false, nil
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Na...")
 
 	ginkgo.By("When the matched label of one of its pods change")
 	pods, err := e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, rs.Name, replicas, labels.SelectorFromSet(rsLabels))
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, rs.Name, replic...")
 
 	p = &pods.Items[0]
 	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOption...")
 
 		pod.Labels = map[string]string{"name": "not-matching-name"}
 		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, pod, metav1.UpdateOptions{})
@@ -379,12 +379,12 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, p...")
 
 	ginkgo.By("Then the pod is released")
 	err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
 		p2, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Name, metav1.GetOption...")
 		for _, owner := range p2.OwnerReferences {
 			if *owner.Controller && owner.UID == rs.UID {
 				// pod still belonging to the replicaset
@@ -394,7 +394,7 @@ func testRSAdoptMatchingAndReleaseNotMatching(ctx context.Context, f *framework.
 		// pod already released
 		return true, nil
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, p.Na...")
 }
 
 func testRSScaleSubresources(ctx context.Context, f *framework.Framework) {
@@ -413,7 +413,7 @@ func testRSScaleSubresources(ctx context.Context, f *framework.Framework) {
 	ginkgo.By(fmt.Sprintf("Creating replica set %q that asks for more than the allowed pod quota", rsName))
 	rs := newRS(rsName, replicas, rsPodLabels, AgnhostImageName, AgnhostImage, nil)
 	createdRS, err := c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})")
 
 	// Verify that the required pods have come up.
 	err = e2ereplicaset.WaitForReplicaSetTargetAvailableReplicas(ctx, c, createdRS, replicas)
@@ -492,7 +492,7 @@ func testRSLifeCycle(ctx context.Context, f *framework.Framework) {
 	// Create a ReplicaSet
 	rs := newRS(rsName, replicas, rsPodLabels, AgnhostImageName, AgnhostImage, nil)
 	createdRS, err := c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})")
 	gomega.Expect(createdRS).To(apimachineryutils.HaveValidResourceVersion())
 
 	// Verify that the required pods have come up.
@@ -579,7 +579,7 @@ func listRSDeleteCollection(ctx context.Context, f *framework.Framework) {
 	ginkgo.By("Create a ReplicaSet")
 	rs := newRS(rsName, replicas, rsPodLabels, AgnhostImageName, AgnhostImage, nil)
 	_, err := rsClient.Create(ctx, rs, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to rsClient.Create(ctx, rs, metav1.CreateOptions{})")
 
 	ginkgo.By("Verify that the required pods have come up")
 	err = e2epod.VerifyPodsRunning(ctx, c, ns, podName, labels.SelectorFromSet(map[string]string{"name": podName}), false, replicas)
@@ -631,7 +631,7 @@ func testRSStatus(ctx context.Context, f *framework.Framework) {
 	ginkgo.By("Create a Replicaset")
 	rs := newRS(rsName, replicas, rsPodLabels, AgnhostImageName, AgnhostImage, nil)
 	testReplicaSet, err := c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})")
 
 	ginkgo.By("Verify that the required pods have come up.")
 	err = e2epod.VerifyPodsRunning(ctx, c, ns, podName, labels.SelectorFromSet(map[string]string{"name": podName}), false, replicas)

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -126,7 +126,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("Creating service " + headlessSvcName + " in namespace " + ns)
 			headlessService := e2eservice.CreateServiceSpec(headlessSvcName, "", true, labels)
 			_, err := c.CoreV1().Services(ns).Create(ctx, headlessService, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Services(ns).Create(ctx, headlessService, metav1.CreateOptions{})")
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
@@ -146,45 +146,45 @@ var _ = SIGDescribe("StatefulSet", func() {
 			e2estatefulset.PauseNewPods(ss)
 
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 
 			ginkgo.By("Saturating stateful set " + ss.Name)
 			e2estatefulset.Saturate(ctx, c, ss)
 
 			ginkgo.By("Verifying statefulset mounted data directory is usable")
-			framework.ExpectNoError(e2estatefulset.CheckMount(ctx, c, ss, "/data"))
+			framework.ExpectNoError(e2estatefulset.CheckMount(ctx, c, ss, "/data"), "failed to e2estatefulset.CheckMount(ctx, c, ss, '/data')")
 
 			ginkgo.By("Verifying statefulset provides a stable hostname for each pod")
-			framework.ExpectNoError(e2estatefulset.CheckHostname(ctx, c, ss))
+			framework.ExpectNoError(e2estatefulset.CheckHostname(ctx, c, ss), "failed to e2estatefulset.CheckHostname(ctx, c, ss)")
 
 			ginkgo.By("Verifying statefulset set proper service name")
-			framework.ExpectNoError(e2estatefulset.CheckServiceName(ss, headlessSvcName))
+			framework.ExpectNoError(e2estatefulset.CheckServiceName(ss, headlessSvcName), "failed to e2estatefulset.CheckServiceName(ss, headlessSvcName)")
 
 			ginkgo.By("checking the index label and value of all pods")
-			framework.ExpectNoError(e2estatefulset.CheckPodIndexLabel(ctx, c, ss))
+			framework.ExpectNoError(e2estatefulset.CheckPodIndexLabel(ctx, c, ss), "failed to e2estatefulset.CheckPodIndexLabel(ctx, c, ss)")
 
 			cmd := "echo $(hostname) | dd of=/data/hostname conv=fsync"
 			ginkgo.By("Running " + cmd + " in all stateful pods")
-			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd))
+			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd), "failed to e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd)")
 
 			cmd = "ln -s /data/hostname /data/hostname-symlink"
 			ginkgo.By("Running " + cmd + " in all stateful pods")
-			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd))
+			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd), "failed to e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd)")
 
 			ginkgo.By("Restarting statefulset " + ss.Name)
 			e2estatefulset.Restart(ctx, c, ss)
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 
 			ginkgo.By("Verifying statefulset mounted data directory is usable")
-			framework.ExpectNoError(e2estatefulset.CheckMount(ctx, c, ss, "/data"))
+			framework.ExpectNoError(e2estatefulset.CheckMount(ctx, c, ss, "/data"), "failed to e2estatefulset.CheckMount(ctx, c, ss, '/data')")
 
 			cmd = "if [ \"$(cat /data/hostname)\" = \"$(hostname)\" ]; then exit 0; else exit 1; fi"
 			ginkgo.By("Running " + cmd + " in all stateful pods")
-			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd))
+			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd), "failed to e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd)")
 
 			cmd = "if [ \"$(cat /data/hostname-symlink)\" = \"$(hostname)\" ]; then exit 0; else exit 1; fi"
 			ginkgo.By("Running " + cmd + " in all stateful pods")
-			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd))
+			framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd), "failed to e2estatefulset.ExecInStatefulPods(ctx, c, ss, cmd)")
 		})
 
 		// This can't be Conformance yet because it depends on a default
@@ -199,13 +199,13 @@ var _ = SIGDescribe("StatefulSet", func() {
 			// Save Kind since it won't be populated in the returned ss.
 			kind := ss.Kind
 			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			ss.Kind = kind
 
 			ginkgo.By("Saturating stateful set " + ss.Name)
 			e2estatefulset.Saturate(ctx, c, ss)
 			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			gomega.Expect(pods.Items).To(gomega.HaveLen(int(*ss.Spec.Replicas)))
 
@@ -283,7 +283,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			e2estatefulset.PauseNewPods(ss)
 
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 
 			e2estatefulset.WaitForRunning(ctx, c, 1, 0, ss)
 
@@ -348,14 +348,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 				}(),
 			}
 			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 			ss = waitForStatus(ctx, c, ss)
 			currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), "StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 				ss.Namespace, ss.Name, updateRevision, currentRevision)
 			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to currentRevision %s",
@@ -372,7 +372,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 				update.Spec.Template.Spec.Containers[0].Image = newImage
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 
 			ginkgo.By("Creating a new revision")
 			ss = waitForStatus(ctx, c, ss)
@@ -412,7 +412,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					}(),
 				}
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(up...")
 			ss, pods = waitForPartitionedRollingUpdate(ctx, c, ss)
 			for i := range pods.Items {
 				if i < int(*ss.Spec.UpdateStrategy.RollingUpdate.Partition) {
@@ -446,7 +446,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			e2estatefulset.WaitForRunningAndReady(ctx, c, 3, ss)
 			ss = getStatefulSet(ctx, c, ss.Namespace, ss.Name)
 			pods, err = e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			for i := range pods.Items {
 				if i < int(*ss.Spec.UpdateStrategy.RollingUpdate.Partition) {
@@ -487,7 +487,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 						}(),
 					}
 				})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(up...")
 				ss, pods = waitForPartitionedRollingUpdate(ctx, c, ss)
 				for i := range pods.Items {
 					if i < int(*ss.Spec.UpdateStrategy.RollingUpdate.Partition) {
@@ -579,14 +579,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 				},
 			}
 			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 			ss = waitForStatus(ctx, c, ss)
 			currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), "StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 				ss.Namespace, ss.Name, updateRevision, currentRevision)
 			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to currentRevision %s",
@@ -603,7 +603,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 				update.Spec.Template.Spec.Containers[0].Image = newImage
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 
 			ginkgo.By("Creating a new revision")
 			ss = waitForStatus(ctx, c, ss)
@@ -646,14 +646,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			}
 			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 			ss = waitForStatus(ctx, c, ss)
 			currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), "StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 				ss.Namespace, ss.Name, updateRevision, currentRevision)
 			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to current revision %s",
@@ -670,7 +670,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			e2estatefulset.WaitForRunningAndReady(ctx, c, 3, ss)
 			ss = getStatefulSet(ctx, c, ss.Namespace, ss.Name)
 			pods, err = e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to current revision %s",
@@ -687,7 +687,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 				update.Spec.Template.Spec.Containers[0].Image = newImage
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 
 			ginkgo.By("Creating a new revision")
 			ss = waitForStatus(ctx, c, ss)
@@ -701,7 +701,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			e2estatefulset.WaitForRunningAndReady(ctx, c, 3, ss)
 			ss = getStatefulSet(ctx, c, ss.Namespace, ss.Name)
 			pods, err = e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Spec.Containers[0].Image).To(gomega.Equal(newImage), "Pod %s/%s has image %s not equal to new image %s",
@@ -734,7 +734,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			pl, err := f.ClientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 				LabelSelector: psLabels.AsSelector().String(),
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions")
 
 			// Verify that stateful set will be scaled up in order.
 			wg := sync.WaitGroup{}
@@ -764,7 +764,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, psLabels)
 			setHTTPProbe(ss)
 			ss, err = c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 
 			ginkgo.By("Waiting until all stateful set " + ssName + " replicas will be running in namespace " + ns)
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
@@ -782,13 +782,13 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("Verifying that stateful set " + ssName + " was scaled up in order")
 			wg.Wait()
-			framework.ExpectNoError(orderErr)
+			framework.ExpectNoError(orderErr, "failed to orderErr")
 
 			ginkgo.By("Scale down will halt with unhealthy stateful pod")
 			pl, err = f.ClientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 				LabelSelector: psLabels.AsSelector().String(),
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions")
 
 			// Verify that stateful set will be scaled down in order.
 			wg.Add(1)
@@ -824,7 +824,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("Verifying that stateful set " + ssName + " was scaled down in reverse order")
 			wg.Wait()
-			framework.ExpectNoError(orderErr)
+			framework.ExpectNoError(orderErr, "failed to orderErr")
 		})
 
 		/*
@@ -840,7 +840,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 			setHTTPProbe(ss)
 			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 
 			ginkgo.By("Waiting until all stateful set " + ssName + " replicas will be running in namespace " + ns)
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
@@ -879,7 +879,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			statefulPodName := ssName + "-0"
 			ginkgo.By("Looking for a node to schedule stateful set and pod")
 			node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 
 			ginkgo.By("Creating pod with conflicting port in namespace " + f.Namespace.Name)
 			conflictingPort := v1.ContainerPort{HostPort: 21017, ContainerPort: 21017, Name: "conflict"}
@@ -899,7 +899,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				},
 			}
 			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 			ginkgo.By("Waiting until pod " + podName + " will start running in namespace " + f.Namespace.Name)
 			if err := e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, podName, f.Namespace.Name); err != nil {
 				framework.Failf("Pod %v did not start running: %v", podName, err)
@@ -911,7 +911,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			statefulPodContainer.Ports = append(statefulPodContainer.Ports, conflictingPort)
 			ss.Spec.Template.Spec.NodeName = node.Name
 			_, err = f.ClientSet.AppsV1().StatefulSets(f.Namespace.Name).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.AppsV1().StatefulSets(f.Namespace.Name).Create(ctx, ss, metav1.Cr...")
 
 			var initialStatefulPodUID types.UID
 			ginkgo.By("Waiting until stateful pod " + statefulPodName + " will be recreated and deleted at least once in namespace " + f.Namespace.Name)
@@ -920,7 +920,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			pl, err := f.ClientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 				FieldSelector: fieldSelector,
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(ns).List(ctx, metav1.ListOptions")
 			if len(pl.Items) > 0 {
 				pod := pl.Items[0]
 				framework.Logf("Observed stateful pod in namespace: %v, name: %v, uid: %v, status phase: %v. Waiting for statefulset controller to delete.",
@@ -958,7 +958,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("Removing pod with conflicting port in namespace " + f.Namespace.Name)
 			err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 
 			ginkgo.By("Waiting when stateful pod " + statefulPodName + " will be recreated in namespace " + f.Namespace.Name + " and will be in running state")
 			// we may catch delete event, that's why we are waiting for running phase like this, and not with watchtools.UntilWithoutRetry
@@ -988,7 +988,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, labels)
 			setHTTPProbe(ss)
 			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 			waitForStatus(ctx, c, ss)
 
@@ -1058,7 +1058,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, ssPodLabels)
 			setHTTPProbe(ss)
 			ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			gomega.Expect(ss).To(apimachineryutils.HaveValidResourceVersion())
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 			waitForStatus(ctx, c, ss)
@@ -1131,14 +1131,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, labels)
 			setHTTPProbe(ss)
 			ss, err = c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 			waitForStatus(ctx, c, ss)
 
 			ginkgo.By("Patch Statefulset to include a label")
 			payload := []byte(`{"metadata":{"labels":{"e2e":"testing"}}}`)
 			ss, err = ssClient.Patch(ctx, ssName, types.StrategicMergePatchType, payload, metav1.PatchOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to ssClient.Patch(ctx, ssName, types.StrategicMergePatchType, payload, metav1.Pa...")
 
 			ginkgo.By("Getting /status")
 			ssResource := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
@@ -1253,7 +1253,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("Creating service " + headlessSvcName + " in namespace " + ns)
 			headlessService := e2eservice.CreateServiceSpec(headlessSvcName, "", true, labels)
 			_, err := c.CoreV1().Services(ns).Create(ctx, headlessService, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Services(ns).Create(ctx, headlessService, metav1.CreateOptions{})")
 			ss = e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 5, nil, nil, labels)
 			setHTTPProbe(ss)
 			ss.Spec.UpdateStrategy = appsv1.StatefulSetUpdateStrategy{
@@ -1272,14 +1272,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("Creating a new StatefulSet")
 			var err error
 			ss, err = c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 			ss = waitForStatus(ctx, c, ss)
 			currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), "StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 				ss.Namespace, ss.Name, updateRevision, currentRevision)
 			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to currentRevision %s",
 					pods.Items[i].Namespace,
@@ -1296,12 +1296,12 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 				update.Spec.Template.Spec.Containers[0].Image = newImage
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 
 			ginkgo.By("Creating a new revision")
 			ss = waitForStatus(ctx, c, ss)
 			pods, err = e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			ginkgo.By("Verifying StatefulSet status reflects completed update")
 			for i := range pods.Items {
@@ -1332,14 +1332,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("Creating a new StatefulSet")
 			var err error
 			ss, err = c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 			ss = waitForStatus(ctx, c, ss)
 			currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), "StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 				ss.Namespace, ss.Name, updateRevision, currentRevision)
 			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to currentRevision %s",
 					pods.Items[i].Namespace,
@@ -1356,7 +1356,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 				update.Spec.Template.Spec.Containers[0].Image = newImage
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 			ss = waitForStatus(ctx, c, ss)
 
 			ginkgo.By("Waiting for pods to be stuck in ImagePullBackOff")
@@ -1372,12 +1372,12 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 				update.Spec.Template.Spec.Containers[0].Image = newImage
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 
 			ginkgo.By("Creating a new revision")
 			ss = waitForStatus(ctx, c, ss)
 			pods, err = e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			ginkgo.By("Verifying StatefulSet status reflects completed update")
 			for i := range pods.Items {
@@ -1414,14 +1414,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
 			var err error
 			ss, err = c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 			ss = waitForStatus(ctx, c, ss)
 			currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 			gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), "StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 				ss.Namespace, ss.Name, updateRevision, currentRevision)
 			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 			for i := range pods.Items {
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to currentRevision %s",
 					pods.Items[i].Namespace,
@@ -1438,7 +1438,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 				update.Spec.Template.Spec.Containers[0].Image = newImage
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 			ss = waitForStatus(ctx, c, ss)
 			e2estatefulset.WaitForFailedWithImagePullErr(ctx, c, 5, ss)
 
@@ -1450,10 +1450,10 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 				update.Spec.Template.Spec.Containers[0].Image = newImage
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 			ss = waitForStatus(ctx, c, ss)
 			pods, err = e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			ginkgo.By("Verifying StatefulSet status reflects completed update")
 			for i := range pods.Items {
@@ -1534,7 +1534,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 		ss := e2estatefulset.NewStatefulSet(ssName, ns, headlessSvcName, 1, nil, nil, ssPodLabels)
 		setHTTPProbe(ss)
 		ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 		e2estatefulset.WaitForStatusAvailableReplicas(ctx, c, ss, 1)
 	})
 
@@ -1550,12 +1550,12 @@ var _ = SIGDescribe("StatefulSet", func() {
 		ss.Spec.MinReadySeconds = 30
 		setHTTPProbe(ss)
 		ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 		e2estatefulset.WaitForStatusAvailableReplicas(ctx, c, ss, 0)
 		// let's check that the availableReplicas have still not updated
 		time.Sleep(5 * time.Second)
 		ss, err = c.AppsV1().StatefulSets(ns).Get(ctx, ss.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Get(ctx, ss.Name, metav1.GetOptions{})")
 		if ss.Status.AvailableReplicas != 0 {
 			framework.Failf("invalid number of availableReplicas: expected=%v received=%v", 0, ss.Status.AvailableReplicas)
 		}
@@ -1564,19 +1564,19 @@ var _ = SIGDescribe("StatefulSet", func() {
 		ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 			update.Spec.MinReadySeconds = 3600
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 		// We don't expect replicas to be updated till 1 hour, so the availableReplicas should be 0
 		e2estatefulset.WaitForStatusAvailableReplicas(ctx, c, ss, 0)
 
 		ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 			update.Spec.MinReadySeconds = 0
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 		e2estatefulset.WaitForStatusAvailableReplicas(ctx, c, ss, 2)
 
 		ginkgo.By("check availableReplicas are shown in status")
 		out, err := e2ekubectl.RunKubectl(ns, "get", "statefulset", ss.Name, "-o=yaml")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2ekubectl.RunKubectl(ns, 'get', 'statefulset', ss.Name, '-o=yaml')")
 		if !strings.Contains(out, "availableReplicas: 2") {
 			framework.Failf("invalid number of availableReplicas: expected=%v received=%v", 2, out)
 		}
@@ -1600,7 +1600,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("Creating service " + headlessSvcName + " in namespace " + ns)
 			headlessService := e2eservice.CreateServiceSpec(headlessSvcName, "", true, labels)
 			_, err := c.CoreV1().Services(ns).Create(ctx, headlessService, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Services(ns).Create(ctx, headlessService, metav1.CreateOptions{})")
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
@@ -1619,19 +1619,19 @@ var _ = SIGDescribe("StatefulSet", func() {
 				WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 			}
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 
 			ginkgo.By("Confirming all 3 PVCs exist with their owner refs")
 			err = verifyStatefulSetPVCsExistWithOwnerRefs(ctx, c, ss, []int{0, 1, 2}, true, false)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExistWithOwnerRefs(ctx, c, ss, []int{0, 1, 2}, true, false)")
 
 			ginkgo.By("Deleting stateful set " + ss.Name)
 			err = c.AppsV1().StatefulSets(ns).Delete(ctx, ss.Name, metav1.DeleteOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Delete(ctx, ss.Name, metav1.DeleteOptions{})")
 
 			ginkgo.By("Verifying PVCs deleted")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{})")
 		})
 
 		ginkgo.It("should delete PVCs with a OnScaledown policy", func(ctx context.Context) {
@@ -1642,19 +1642,19 @@ var _ = SIGDescribe("StatefulSet", func() {
 				WhenScaled: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 			}
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 
 			ginkgo.By("Confirming all 3 PVCs exist")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1, 2})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1, 2})")
 
 			ginkgo.By("Scaling stateful set " + ss.Name + " to one replica")
 			ss, err = e2estatefulset.Scale(ctx, c, ss, 1)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.Scale(ctx, c, ss, 1)")
 
 			ginkgo.By("Verifying all but one PVC deleted")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})")
 		})
 
 		ginkgo.It("should not delete PVC with OnScaledown policy if another controller owns the PVC", func(ctx context.Context) {
@@ -1662,11 +1662,11 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			*(ss.Spec.Replicas) = 3
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 
 			ginkgo.By("Confirm PVC has been created")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1, 2})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1, 2})")
 
 			ginkgo.By("Create configmap to use as dummy controller")
 			dummyConfigMap, err := c.CoreV1().ConfigMaps(ns).Create(ctx, &v1.ConfigMap{
@@ -1675,7 +1675,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					Namespace:    ns,
 				},
 			}, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().ConfigMaps(ns).Create(ctx, &v1.ConfigMap{")
 			defer func() {
 				// Will be cleaned up with the namespace if this fails.
 				_ = c.CoreV1().ConfigMaps(ns).Delete(ctx, dummyConfigMap.Name, metav1.DeleteOptions{})
@@ -1694,7 +1694,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					},
 				}
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updatePVCWithRetries(ctx, c, ns, pvc1Name, func(update *v...")
 
 			ginkgo.By("Update StatefulSet retention policy")
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
@@ -1702,37 +1702,37 @@ var _ = SIGDescribe("StatefulSet", func() {
 					WhenScaled: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 				}
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 
 			ginkgo.By("Scale StatefulSet down to 0")
 			_, err = e2estatefulset.Scale(ctx, c, ss, 0)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.Scale(ctx, c, ss, 0)")
 
 			ginkgo.By("Verify PVC 1 still exists")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{1})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{1})")
 
 			ginkgo.By("Remove PVC 1 owner ref")
 			_, err = updatePVCWithRetries(ctx, c, ns, pvc1Name, func(update *v1.PersistentVolumeClaim) {
 				update.OwnerReferences = nil
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updatePVCWithRetries(ctx, c, ns, pvc1Name, func(update *v1.PersistentVolumeCl...")
 
 			ginkgo.By("Scale set back up to 2")
 			_, err = e2estatefulset.Scale(ctx, c, ss, 2)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.Scale(ctx, c, ss, 2)")
 
 			ginkgo.By("Confirm PVCs scaled up as well")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1})")
 
 			ginkgo.By("Scale set down to 1")
 			_, err = e2estatefulset.Scale(ctx, c, ss, 1)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.Scale(ctx, c, ss, 1)")
 
 			ginkgo.By("Confirm PVC 1 deleted this time")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})")
 		})
 
 		ginkgo.It("should delete PVCs after adopting pod (WhenDeleted)", func(ctx context.Context) {
@@ -1743,11 +1743,11 @@ var _ = SIGDescribe("StatefulSet", func() {
 				WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 			}
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 
 			ginkgo.By("Confirming all 3 PVCs exist with their owner refs")
 			err = verifyStatefulSetPVCsExistWithOwnerRefs(ctx, c, ss, []int{0, 1, 2}, true, false)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExistWithOwnerRefs(ctx, c, ss, []int{0, 1, 2}, true, false)")
 
 			ginkgo.By("Orphaning the 3rd pod")
 			patch, err := json.Marshal(metav1.ObjectMeta{
@@ -1759,11 +1759,11 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("Deleting stateful set " + ss.Name)
 			err = c.AppsV1().StatefulSets(ns).Delete(ctx, ss.Name, metav1.DeleteOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Delete(ctx, ss.Name, metav1.DeleteOptions{})")
 
 			ginkgo.By("Verifying PVCs deleted")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{})")
 		})
 
 		ginkgo.It("should delete PVCs after adopting pod (WhenScaled)", func(ctx context.Context) {
@@ -1774,11 +1774,11 @@ var _ = SIGDescribe("StatefulSet", func() {
 				WhenScaled: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 			}
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 
 			ginkgo.By("Confirming all 3 PVCs exist")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1, 2})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1, 2})")
 
 			ginkgo.By("Confirming all pods are running and ready")
 			e2estatefulset.WaitForStatusAvailableReplicas(ctx, c, ss, 3)
@@ -1793,11 +1793,11 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("Scaling stateful set " + ss.Name + " to one replica")
 			ss, err = e2estatefulset.Scale(ctx, c, ss, 1)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.Scale(ctx, c, ss, 1)")
 
 			ginkgo.By("Verifying all but one PVC deleted")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})")
 		})
 
 		ginkgo.It("should not delete PVCs when there is another controller", func(ctx context.Context) {
@@ -1806,11 +1806,11 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			*(ss.Spec.Replicas) = 4
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 
 			ginkgo.By("Confirming all 4 PVCs exist")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1, 2, 3})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{0, 1, 2, 3})")
 
 			claimNames := make([]string, 4)
 			for i := range 4 {
@@ -1824,7 +1824,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					Namespace:    ns,
 				},
 			}, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().ConfigMaps(ns).Create(ctx, &v1.ConfigMap{")
 			defer func() {
 				// Will be cleaned up by the namespace delete if this fails
 				_ = c.CoreV1().ConfigMaps(ns).Delete(ctx, randomConfigMap.Name, metav1.DeleteOptions{})
@@ -1842,7 +1842,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			_, err = updatePVCWithRetries(ctx, c, ns, claimNames[1], func(update *v1.PersistentVolumeClaim) {
 				update.SetOwnerReferences(expectedExternalRef)
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updatePVCWithRetries(ctx, c, ns, claimNames[1], func(update *v1.PersistentVol...")
 
 			ginkgo.By("Add stale statefulset controller to PVC 3, with finalizer to prevent garbage collection")
 			expectedStaleRef := []metav1.OwnerReference{
@@ -1859,7 +1859,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				update.SetOwnerReferences(expectedStaleRef)
 				update.SetFinalizers([]string{"keep-with/stale-ref"})
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updatePVCWithRetries(ctx, c, ns, claimNames[3], func(update *v1.PersistentVol...")
 
 			defer func() {
 				if _, err := c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, claimNames[3], metav1.GetOptions{}); apierrors.IsNotFound(err) {
@@ -1868,7 +1868,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				_, err := updatePVCWithRetries(ctx, c, ns, claimNames[3], func(update *v1.PersistentVolumeClaim) {
 					update.SetFinalizers([]string{})
 				})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to updatePVCWithRetries(ctx, c, ns, claimNames[3], func(update *v1.PersistentVol...")
 			}()
 
 			ginkgo.By("Check references updated")
@@ -1889,7 +1889,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				}
 				return true, nil // found them all!
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, claimNames...")
 
 			ginkgo.By("Update retention policy to delete to force claims to resync")
 			var ssUID types.UID
@@ -1899,7 +1899,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				}
 				ssUID = update.GetUID()
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ssName, func(upd...")
 
 			expectedOwnerRef := []metav1.OwnerReference{
 				{
@@ -1939,7 +1939,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				}
 				return true, nil // found them all!
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, claimNames...")
 
 			ginkgo.By("Remove controller flag from claim 0")
 			_, err = updatePVCWithRetries(ctx, c, ns, claimNames[0], func(update *v1.PersistentVolumeClaim) {
@@ -1954,7 +1954,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					},
 				})
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updatePVCWithRetries(ctx, c, ns, claimNames[0], func(upda...")
 
 			ginkgo.By("Update statefulset to provoke a reconcile")
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ssName, func(update *appsv1.StatefulSet) {
@@ -1963,7 +1963,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 				}
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ssName, func(upd...")
 			ginkgo.By("Expect controller flag for claim 0 to reconcile back to true")
 			err = wait.PollUntilContextTimeout(ctx, e2estatefulset.StatefulSetPoll, e2estatefulset.StatefulSetTimeout, true, func(ctx context.Context) (bool, error) {
 				claim, err := c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, claimNames[0], metav1.GetOptions{})
@@ -1975,14 +1975,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 				}
 				return false, nil // retry
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().PersistentVolumeClaims(ns).Get(ctx, claimNames...")
 
 			// Claim 1 has an external owner, and 3 has a finalizer still, so they will not be deleted.
 			ginkgo.By("Delete the stateful set and wait for claims 0 and 2 but not 1 and 3 to disappear")
 			err = c.AppsV1().StatefulSets(ns).Delete(ctx, ssName, metav1.DeleteOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Delete(ctx, ssName, metav1.DeleteOptions{})")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{1, 3})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{1, 3})")
 		})
 	})
 
@@ -2013,44 +2013,44 @@ var _ = SIGDescribe("StatefulSet", func() {
 			e2epv.SkipIfNoDefaultStorageClass(ctx, c)
 
 			readyNode, err := e2enode.GetRandomReadySchedulableNode(ctx, c)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, c)")
 			hostLabel := "kubernetes.io/hostname"
 			hostLabelVal := readyNode.Labels[hostLabel]
 
 			ss.Spec.Template.Spec.NodeSelector = map[string]string{hostLabel: hostLabelVal} // force the pod on a specific node
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			_, err = c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 
 			ginkgo.By("Confirming PVC exists")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})")
 
 			ginkgo.By("Confirming Pod is ready")
 			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 1)
 			podName := getStatefulSetPodNameAtIndex(0, ss)
 			pod, err := c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})")
 
 			nodeName := pod.Spec.NodeName
 			gomega.Expect(nodeName).To(gomega.Equal(readyNode.Name))
 			node, err := c.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})")
 
 			oldData, err := json.Marshal(node)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to json.Marshal(node)")
 
 			node.Spec.Unschedulable = true
 
 			newData, err := json.Marshal(node)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to json.Marshal(node)")
 
 			// cordon node, to make sure pod does not get scheduled to the node until the pvc is deleted
 			patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})")
 			ginkgo.By("Cordoning Node")
 			_, err = c.CoreV1().Nodes().Patch(ctx, nodeName, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Nodes().Patch(ctx, nodeName, types.StrategicMergePatchType, patchB...")
 			cordoned := true
 
 			defer func() {
@@ -2064,33 +2064,33 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("Deleting Pod")
 			err = c.CoreV1().Pods(ns).Delete(ctx, podName, metav1.DeleteOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).Delete(ctx, podName, metav1.DeleteOptions{})")
 
 			// wait for the pod to be recreated
 			waitForStatusCurrentReplicas(ctx, c, ss, 1)
 			_, err = c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})")
 
 			pvcList, err := c.CoreV1().PersistentVolumeClaims(ns).List(ctx, metav1.ListOptions{LabelSelector: klabels.Everything().String()})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().PersistentVolumeClaims(ns).List(ctx, metav1.ListOptions{LabelSelec...")
 			gomega.Expect(pvcList.Items).To(gomega.HaveLen(1))
 			pvcName := pvcList.Items[0].Name
 
 			ginkgo.By("Deleting PVC")
 			err = c.CoreV1().PersistentVolumeClaims(ns).Delete(ctx, pvcName, metav1.DeleteOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().PersistentVolumeClaims(ns).Delete(ctx, pvcName, metav1.DeleteOptio...")
 
 			uncordonNode(ctx, c, oldData, newData, nodeName)
 			cordoned = false
 
 			ginkgo.By("Confirming PVC recreated")
 			err = verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to verifyStatefulSetPVCsExist(ctx, c, ss, []int{0})")
 
 			ginkgo.By("Confirming Pod is ready after being recreated")
 			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 1)
 			pod, err = c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})")
 			gomega.Expect(pod.Spec.NodeName).To(gomega.Equal(readyNode.Name)) // confirm the pod was scheduled back to the original node
 		})
 	})
@@ -2110,7 +2110,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("Creating service " + headlessSvcName + " in namespace " + ns)
 			headlessService := e2eservice.CreateServiceSpec(headlessSvcName, "", true, labels)
 			_, err := c.CoreV1().Services(ns).Create(ctx, headlessService, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Services(ns).Create(ctx, headlessService, metav1.CreateOptions{})")
 		})
 
 		ginkgo.AfterEach(func(ctx context.Context) {
@@ -2125,17 +2125,17 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			*(ss.Spec.Replicas) = 2
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			waitForStatus(ctx, c, ss)
 			e2estatefulset.WaitForStatusReplicas(ctx, c, ss, 2)
 			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 2)
 
 			ginkgo.By("Confirming 2 replicas, with start ordinal 0")
 			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			err = expectPodNames(pods, []string{"ss-0", "ss-1"})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to expectPodNames(pods, []string{'ss-0', 'ss-1'})")
 
 			ginkgo.By("Setting .spec.replicas = 3 .spec.ordinals.start = 2")
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
@@ -2144,7 +2144,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				}
 				*(update.Spec.Replicas) = 3
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(up...")
 
 			// we need to ensure we wait for all the new ones to show up, not
 			// just for any random 3
@@ -2162,17 +2162,17 @@ var _ = SIGDescribe("StatefulSet", func() {
 				Start: 2,
 			}
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			waitForStatus(ctx, c, ss)
 			e2estatefulset.WaitForStatusReplicas(ctx, c, ss, 2)
 			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 2)
 
 			ginkgo.By("Confirming 2 replicas, with start ordinal 2")
 			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			err = expectPodNames(pods, []string{"ss-2", "ss-3"})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to expectPodNames(pods, []string{'ss-2', 'ss-3'})")
 
 			ginkgo.By("Increasing .spec.ordinals.start = 4")
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ssName, func(update *appsv1.StatefulSet) {
@@ -2180,7 +2180,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					Start: 4,
 				}
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ssName, func(update *appsv1.Stateful...")
 
 			// since we are replacing 2 pods for 2, we need to ensure we wait
 			// for the new ones to show up, not just for any random 2
@@ -2198,17 +2198,17 @@ var _ = SIGDescribe("StatefulSet", func() {
 				Start: 3,
 			}
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			waitForStatus(ctx, c, ss)
 			e2estatefulset.WaitForStatusReplicas(ctx, c, ss, 2)
 			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 2)
 
 			ginkgo.By("Confirming 2 replicas, with start ordinal 3")
 			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			err = expectPodNames(pods, []string{"ss-3", "ss-4"})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to expectPodNames(pods, []string{'ss-3', 'ss-4'})")
 
 			ginkgo.By("Decreasing .spec.ordinals.start = 2")
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ssName, func(update *appsv1.StatefulSet) {
@@ -2216,7 +2216,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					Start: 2,
 				}
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ssName, func(update *appsv1.Stateful...")
 
 			// since we are replacing 2 pods for 2, we need to ensure we wait
 			// for the new ones to show up, not just for any random 2
@@ -2234,22 +2234,22 @@ var _ = SIGDescribe("StatefulSet", func() {
 				Start: 3,
 			}
 			_, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 			e2estatefulset.WaitForStatusReplicas(ctx, c, ss, 2)
 			e2estatefulset.WaitForStatusReadyReplicas(ctx, c, ss, 2)
 
 			ginkgo.By("Confirming 2 replicas, with start ordinal 3")
 			pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 			err = expectPodNames(pods, []string{"ss-3", "ss-4"})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to expectPodNames(pods, []string{'ss-3', 'ss-4'})")
 
 			ginkgo.By("Removing .spec.ordinals")
 			ss, err = updateStatefulSetWithRetries(ctx, c, ns, ssName, func(update *appsv1.StatefulSet) {
 				update.Spec.Ordinals = nil
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ssName, func(update *appsv1.Stateful...")
 
 			// since we are replacing 2 pods for 2, we need to ensure we wait
 			// for the new ones to show up, not just for any random 2
@@ -2266,9 +2266,9 @@ func uncordonNode(ctx context.Context, c clientset.Interface, oldData, newData [
 	ginkgo.By("Uncordoning Node")
 	// uncordon node, by reverting patch
 	revertPatchBytes, err := strategicpatch.CreateTwoWayMergePatch(newData, oldData, v1.Node{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to strategicpatch.CreateTwoWayMergePatch(newData, oldData, v1.Node{})")
 	_, err = c.CoreV1().Nodes().Patch(ctx, nodeName, types.StrategicMergePatchType, revertPatchBytes, metav1.PatchOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.CoreV1().Nodes().Patch(ctx, nodeName, types.StrategicMergePatchType, revert...")
 }
 
 func kubectlExecWithRetries(ns string, args ...string) (out string) {
@@ -2456,14 +2456,14 @@ func pollReadWithTimeout(ctx context.Context, statefulPod statefulPodTester, sta
 func rollbackTest(ctx context.Context, c clientset.Interface, ns string, ss *appsv1.StatefulSet) {
 	setHTTPProbe(ss)
 	ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 	e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 	ss = waitForStatus(ctx, c, ss)
 	currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 	gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), "StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 		ss.Namespace, ss.Name, updateRevision, currentRevision)
 	pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 	for i := range pods.Items {
 		gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, currentRevision), "Pod %s/%s revision %s is not equal to current revision %s",
@@ -2474,7 +2474,7 @@ func rollbackTest(ctx context.Context, c clientset.Interface, ns string, ss *app
 	}
 	e2estatefulset.SortStatefulPods(pods)
 	err = breakPodHTTPProbe(ss, &pods.Items[1])
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to breakPodHTTPProbe(ss, &pods.Items[1])")
 	ss, _ = waitForPodNotReady(ctx, c, ss, pods.Items[1].Name)
 	newImage := AgnhostImage
 	oldImage := ss.Spec.Template.Spec.Containers[0].Image
@@ -2484,7 +2484,7 @@ func rollbackTest(ctx context.Context, c clientset.Interface, ns string, ss *app
 	ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 		update.Spec.Template.Spec.Containers[0].Image = newImage
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 
 	ginkgo.By("Creating a new revision")
 	ss = waitForStatus(ctx, c, ss)
@@ -2493,11 +2493,11 @@ func rollbackTest(ctx context.Context, c clientset.Interface, ns string, ss *app
 
 	ginkgo.By("Updating Pods in reverse ordinal order")
 	pods, err = e2estatefulset.GetPodList(ctx, c, ss)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 	e2estatefulset.SortStatefulPods(pods)
 	err = restorePodHTTPProbe(ss, &pods.Items[1])
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to restorePodHTTPProbe(ss, &pods.Items[1])")
 	ss, _ = e2estatefulset.WaitForPodReady(ctx, c, ss, pods.Items[1].Name)
 	ss, pods = waitForRollingUpdate(ctx, c, ss)
 	gomega.Expect(ss.Status.CurrentRevision).To(gomega.Equal(updateRevision), "StatefulSet %s/%s current revision %s does not equal update revision %s on update completion",
@@ -2520,13 +2520,13 @@ func rollbackTest(ctx context.Context, c clientset.Interface, ns string, ss *app
 
 	ginkgo.By("Rolling back to a previous revision")
 	err = breakPodHTTPProbe(ss, &pods.Items[1])
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to breakPodHTTPProbe(ss, &pods.Items[1])")
 	ss, _ = waitForPodNotReady(ctx, c, ss, pods.Items[1].Name)
 	priorRevision := currentRevision
 	ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 		update.Spec.Template.Spec.Containers[0].Image = oldImage
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 	ss = waitForStatus(ctx, c, ss)
 	currentRevision, updateRevision = ss.Status.CurrentRevision, ss.Status.UpdateRevision
 	gomega.Expect(priorRevision).To(gomega.Equal(updateRevision), "Prior revision should equal update revision during roll back")
@@ -2534,7 +2534,7 @@ func rollbackTest(ctx context.Context, c clientset.Interface, ns string, ss *app
 
 	ginkgo.By("Rolling back update in reverse ordinal order")
 	pods, err = e2estatefulset.GetPodList(ctx, c, ss)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 	e2estatefulset.SortStatefulPods(pods)
 	restorePodHTTPProbe(ss, &pods.Items[1])
@@ -2572,14 +2572,14 @@ func deletingPodForRollingUpdatePartitionTest(ctx context.Context, f *framework.
 		}(),
 	}
 	ss, err := c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().StatefulSets(ns).Create(ctx, ss, metav1.CreateOptions{})")
 	e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 	ss = waitForStatus(ctx, c, ss)
 	currentRevision, updateRevision := ss.Status.CurrentRevision, ss.Status.UpdateRevision
 	gomega.Expect(currentRevision).To(gomega.Equal(updateRevision), fmt.Sprintf("StatefulSet %s/%s created with update revision %s not equal to current revision %s",
 		ss.Namespace, ss.Name, updateRevision, currentRevision))
 	pods, err := e2estatefulset.GetPodList(ctx, c, ss)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 	for i := range pods.Items {
 		gomega.Expect(pods.Items[i].Labels[appsv1.StatefulSetRevisionLabel]).To(gomega.Equal(currentRevision), fmt.Sprintf("Pod %s/%s revision %s is not equal to currentRevision %s",
@@ -2592,10 +2592,10 @@ func deletingPodForRollingUpdatePartitionTest(ctx context.Context, f *framework.
 	ginkgo.By("Adding finalizer for pod-0")
 	pod0name := getStatefulSetPodNameAtIndex(0, ss)
 	pod0, err := c.CoreV1().Pods(ns).Get(ctx, pod0name, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).Get(ctx, pod0name, metav1.GetOptions{})")
 	pod0.Finalizers = append(pod0.Finalizers, testFinalizer)
 	pod0, err = c.CoreV1().Pods(ss.Namespace).Update(ctx, pod0, metav1.UpdateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ss.Namespace).Update(ctx, pod0, metav1.UpdateOptions{})")
 	pods.Items[0] = *pod0
 	defer e2epod.NewPodClient(f).RemoveFinalizer(ctx, pod0.Name, testFinalizer)
 
@@ -2607,7 +2607,7 @@ func deletingPodForRollingUpdatePartitionTest(ctx context.Context, f *framework.
 	ss, err = updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.StatefulSet) {
 		update.Spec.Template.Spec.Containers[0].Image = newImage
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to updateStatefulSetWithRetries(ctx, c, ns, ss.Name, func(update *appsv1.Statefu...")
 
 	ginkgo.By("Creating a new revision")
 	ss = waitForStatus(ctx, c, ss)
@@ -2673,7 +2673,7 @@ func deletingPodForRollingUpdatePartitionTest(ctx context.Context, f *framework.
 
 	ginkgo.By("Verify pod images after pod-0 deletion and recreation")
 	pods, err = e2estatefulset.GetPodList(ctx, c, ss)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 	for i := range pods.Items {
 		if i < int(*ss.Spec.UpdateStrategy.RollingUpdate.Partition) {
@@ -2709,7 +2709,7 @@ func confirmStatefulPodCount(ctx context.Context, c clientset.Interface, count i
 	deadline := start.Add(timeout)
 	for t := time.Now(); t.Before(deadline) && ctx.Err() == nil; t = time.Now() {
 		podList, err := e2estatefulset.GetPodList(ctx, c, ss)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2estatefulset.GetPodList(ctx, c, ss)")
 
 		statefulPodCount := len(podList.Items)
 		if statefulPodCount != count {

--- a/test/e2e/apps/ttl_after_finished.go
+++ b/test/e2e/apps/ttl_after_finished.go
@@ -60,11 +60,11 @@ func cleanupJob(ctx context.Context, f *framework.Framework, job *batchv1.Job) {
 		j.ObjectMeta.Finalizers = slices.DeleteFunc(j.ObjectMeta.Finalizers, func(actual string) bool { return actual == dummyFinalizer })
 	}
 	_, err := updateJobWithRetries(ctx, c, ns, job.Name, removeFinalizerFunc)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to updateJobWithRetries(ctx, c, ns, job.Name, removeFinalizerFunc)")
 	e2ejob.WaitForJobGone(ctx, c, ns, job.Name, wait.ForeverTestTimeout)
 
 	err = e2ejob.WaitForAllJobPodsGone(ctx, c, ns, job.Name)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2ejob.WaitForAllJobPodsGone(ctx, c, ns, job.Name)")
 }
 
 func testFinishedJob(ctx context.Context, f *framework.Framework) {
@@ -83,19 +83,19 @@ func testFinishedJob(ctx context.Context, f *framework.Framework) {
 
 	framework.Logf("Create a Job %s/%s with TTL", ns, job.Name)
 	job, err := e2ejob.CreateJob(ctx, c, ns, job)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2ejob.CreateJob(ctx, c, ns, job)")
 
 	framework.Logf("Wait for the Job to finish")
 	err = e2ejob.WaitForJobFinish(ctx, c, ns, job.Name)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2ejob.WaitForJobFinish(ctx, c, ns, job.Name)")
 
 	framework.Logf("Wait for TTL after finished controller to delete the Job")
 	err = waitForJobDeleting(ctx, c, ns, job.Name)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to waitForJobDeleting(ctx, c, ns, job.Name)")
 
 	framework.Logf("Check Job's deletionTimestamp and compare with the time when the Job finished")
 	job, err = e2ejob.GetJob(ctx, c, ns, job.Name)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2ejob.GetJob(ctx, c, ns, job.Name)")
 	jobFinishTime := finishTime(job)
 	finishTimeUTC := jobFinishTime.UTC()
 	if jobFinishTime.IsZero() {

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -158,7 +158,7 @@ func increaseClusterSizeWithTimeout(ctx context.Context, f *framework.Framework,
 	labels := map[string]string{
 		"anti-affinity": "yes",
 	}
-	framework.ExpectNoError(runAntiAffinityPods(ctx, f, f.Namespace.Name, targetNodeCount, "increase-size-pod", labels, labels))
+	framework.ExpectNoError(runAntiAffinityPods(ctx, f, f.Namespace.Name, targetNodeCount, "increase-size-pod", labels, labels), "failed to runAntiAffinityPods(ctx, f, f.Namespace.Name, targetNodeCount, 'increase-size...")
 	cleanupFunc := func() error {
 		return e2erc.DeleteRCAndWaitForGC(ctx, f.ClientSet, f.Namespace.Name, "increase-size-pod")
 	}
@@ -171,8 +171,8 @@ func increaseClusterSizeWithTimeout(ctx context.Context, f *framework.Framework,
 
 	// Verify that cluster size is increased
 	framework.ExpectNoError(WaitForClusterSizeFuncWithUnready(ctx, f.ClientSet,
-		func(size int) bool { return size >= targetNodeCount }, timeout, 0))
-	framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c))
+		func(size int) bool { return size >= targetNodeCount }, timeout, 0), "failed to cleanupFunc()")
+	framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(ctx, f, c), "failed to waitForAllCaPodsReadyInNamespace(ctx, f, c)")
 	return cleanupFunc
 }
 

--- a/test/e2e/autoscaling/dns_autoscaling.go
+++ b/test/e2e/autoscaling/dns_autoscaling.go
@@ -64,7 +64,7 @@ var _ = SIGDescribe(feature.KubeDNSAutoscaler, "DNS horizontal autoscaling", fun
 		c = f.ClientSet
 
 		nodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetReadySchedulableNodes(ctx, c)")
 		nodeCount := len(nodes.Items)
 
 		ginkgo.By("Collecting original replicas count and DNS scaling params")
@@ -77,7 +77,7 @@ var _ = SIGDescribe(feature.KubeDNSAutoscaler, "DNS horizontal autoscaling", fun
 		}
 
 		originDNSReplicasCount, err = getDNSReplicas(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to getDNSReplicas(ctx, c)")
 		configMapNames = map[string]string{
 			"kube-dns": "kube-dns-autoscaler",
 			"coredns":  "coredns-autoscaler",
@@ -85,7 +85,7 @@ var _ = SIGDescribe(feature.KubeDNSAutoscaler, "DNS horizontal autoscaling", fun
 
 		pcm, err := fetchDNSScalingConfigMap(ctx, c, configMapNames[provider])
 		framework.Logf("original DNS scaling params: %v", pcm)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to fetchDNSScalingConfigMap(ctx, c, configMapNames[provider])")
 		previousParams = pcm.Data
 
 		if nodeCount <= 500 {
@@ -122,59 +122,59 @@ var _ = SIGDescribe(feature.KubeDNSAutoscaler, "DNS horizontal autoscaling", fun
 	// Will take around 5 minutes to run on a 4 nodes cluster.
 	f.It(f.WithSerial(), f.WithSlow(), "kube-dns-autoscaler should scale kube-dns pods when cluster size changed", func(ctx context.Context) {
 		numNodes, err := e2enode.TotalRegistered(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.TotalRegistered(ctx, c)")
 
 		configMapNames = map[string]string{
 			"kube-dns": "kube-dns-autoscaler",
 			"coredns":  "coredns-autoscaler",
 		}
 		provider, err := detectDNSProvider(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to detectDNSProvider(ctx, c)")
 
 		ginkgo.By("Replace the dns autoscaling parameters with testing parameters")
 		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams1)))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[prov...")
 		defer func() {
 			ginkgo.By("Restoring initial dns autoscaling parameters")
 			err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], previousParams))
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[prov...")
 
 			ginkgo.By("Wait for number of running and ready kube-dns pods recover")
 			label := labels.SelectorFromSet(labels.Set(map[string]string{ClusterAddonLabelKey: DNSLabelName}))
 			_, err := e2epod.WaitForPodsWithLabelRunningReady(ctx, c, metav1.NamespaceSystem, label, originDNSReplicasCount, DNSdefaultTimeout)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2epod.WaitForPodsWithLabelRunningReady(ctx, c, metav1.NamespaceSystem, label...")
 		}()
 		ginkgo.By("Wait for kube-dns scaled to expected number")
 		getExpectReplicasLinear := getExpectReplicasFuncLinear(ctx, c, &DNSParams1)
 		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)")
 
 		ginkgo.By("Manually increase cluster size")
 		cleanupIncreasedSizeFunc := increaseClusterSize(ctx, f, c, numNodes+1)
 		err = WaitForClusterSizeFunc(ctx, c,
 			func(size int) bool { return size == numNodes+1 }, scaleUpTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to WaitForClusterSizeFunc(ctx, c,")
 
 		ginkgo.By("Wait for kube-dns scaled to expected number")
 		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams1)
 		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)")
 
 		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
 		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams3)))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[prov...")
 
 		ginkgo.By("Wait for kube-dns scaled to expected number")
 		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams3)
 		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)")
 
 		ginkgo.By("Restoring cluster size")
-		framework.ExpectNoError(cleanupIncreasedSizeFunc())
+		framework.ExpectNoError(cleanupIncreasedSizeFunc(), "failed to cleanupIncreasedSizeFunc()")
 
 		ginkgo.By("Wait for kube-dns scaled to expected number")
 		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)")
 	})
 
 	ginkgo.It("kube-dns-autoscaler should scale kube-dns pods in both nonfaulty and faulty scenarios", func(ctx context.Context) {
@@ -184,61 +184,61 @@ var _ = SIGDescribe(feature.KubeDNSAutoscaler, "DNS horizontal autoscaling", fun
 			"coredns":  "coredns-autoscaler",
 		}
 		provider, err := detectDNSProvider(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to detectDNSProvider(ctx, c)")
 
 		ginkgo.By("Replace the dns autoscaling parameters with testing parameters")
 		cm := packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams1))
 		framework.Logf("Updating the following cm: %v", cm)
 		err = updateDNSScalingConfigMap(ctx, c, cm)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateDNSScalingConfigMap(ctx, c, cm)")
 		defer func() {
 			ginkgo.By("Restoring initial dns autoscaling parameters")
 			err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], previousParams))
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[prov...")
 		}()
 		ginkgo.By("Wait for kube-dns scaled to expected number")
 		getExpectReplicasLinear := getExpectReplicasFuncLinear(ctx, c, &DNSParams1)
 		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)")
 
 		ginkgo.By("--- Scenario: should scale kube-dns based on changed parameters ---")
 		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
 		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams3)))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[prov...")
 		ginkgo.By("Wait for kube-dns scaled to expected number")
 		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams3)
 		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)")
 
 		ginkgo.By("--- Scenario: should re-create scaling parameters with default value when parameters got deleted ---")
 		ginkgo.By("Delete the ConfigMap for autoscaler")
 		err = deleteDNSScalingConfigMap(ctx, c, configMapNames[provider])
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to deleteDNSScalingConfigMap(ctx, c, configMapNames[provider])")
 
 		ginkgo.By("Wait for the ConfigMap got re-created")
 		_, err = waitForDNSConfigMapCreated(ctx, c, DNSdefaultTimeout, configMapNames[provider])
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForDNSConfigMapCreated(ctx, c, DNSdefaultTimeout, configMapNames[provider])")
 
 		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
 		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams2)))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[prov...")
 		ginkgo.By("Wait for kube-dns/coredns scaled to expected number")
 		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams2)
 		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)")
 
 		ginkgo.By("--- Scenario: should recover after autoscaler pod got deleted ---")
 		ginkgo.By("Delete the autoscaler pod for kube-dns/coredns")
 		err = deleteDNSAutoscalerPod(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to deleteDNSAutoscalerPod(ctx, c)")
 
 		ginkgo.By("Replace the dns autoscaling parameters with another testing parameters")
 		err = updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[provider], packLinearParams(&DNSParams1)))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateDNSScalingConfigMap(ctx, c, packDNSScalingConfigMap(configMapNames[prov...")
 		ginkgo.By("Wait for kube-dns/coredns scaled to expected number")
 		getExpectReplicasLinear = getExpectReplicasFuncLinear(ctx, c, &DNSParams1)
 		err = waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForDNSReplicasSatisfied(ctx, c, getExpectReplicasLinear, DNSdefaultTimeout)")
 	})
 })
 
@@ -257,7 +257,7 @@ func getExpectReplicasFuncLinear(ctx context.Context, c clientset.Interface, par
 		var replicasFromNodes float64
 		var replicasFromCores float64
 		nodes, err := e2enode.GetReadyNodesIncludingTainted(ctx, c)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetReadyNodesIncludingTainted(ctx, c)")
 		if params.nodesPerReplica > 0 {
 			replicasFromNodes = math.Ceil(float64(len(nodes.Items)) / params.nodesPerReplica)
 		}

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_behavior.go
@@ -172,7 +172,7 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (non-default behavi
 
 			ginkgo.By("verifying number of replicas")
 			replicas, err := rc.GetReplicas(ctx)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to rc.GetReplicas(ctx)")
 			gomega.Expect(replicas).To(gomega.BeNumerically("==", initPods), "had %s replicas, still have %s replicas after time deadline", initPods, replicas)
 		})
 
@@ -209,7 +209,7 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (non-default behavi
 
 			ginkgo.By("verifying number of replicas")
 			replicas, err := rc.GetReplicas(ctx)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to rc.GetReplicas(ctx)")
 			gomega.Expect(replicas).To(gomega.BeNumerically("==", initPods), "had %s replicas, still have %s replicas after time deadline", initPods, replicas)
 		})
 
@@ -541,7 +541,7 @@ var _ = SIGDescribe(feature.HPA, framework.WithSlow(), framework.WithFeatureGate
 
 				ginkgo.By("verifying number of replicas")
 				replicas, err := rc.GetReplicas(ctx)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to rc.GetReplicas(ctx)")
 				gomega.Expect(replicas).To(gomega.BeNumerically("==", initPods), "had %s replicas, still have %s replicas after time deadline", initPods, replicas)
 			})
 		})

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling_external_metrics.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling_external_metrics.go
@@ -79,7 +79,7 @@ var _ = SIGDescribe(feature.HPA, "Horizontal pod autoscaling (external metrics)"
 
 		ginkgo.By(fmt.Sprintf("Setting %s metric value to 0", metricName))
 		err := metricsController.SetMetricValue(ctx, metricName, 0, nil)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to metricsController.SetMetricValue(ctx, metricName, 0, nil)")
 
 		ginkgo.By("Waiting for HPA to scale down to min replicas")
 		rc.WaitForReplicas(ctx, int(*hpa.Spec.MinReplicas), maxResourceConsumerDelay+waitBuffer)
@@ -133,14 +133,14 @@ var _ = SIGDescribe(feature.HPA, framework.WithFeatureGate(features.HPAScaleToZe
 
 			ginkgo.By(fmt.Sprintf("Setting %s metric value to 0 to trigger scale to zero", metricName))
 			err := metricsController.SetMetricValue(ctx, metricName, 0, nil)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to metricsController.SetMetricValue(ctx, metricName, 0, nil)")
 
 			ginkgo.By("Waiting for HPA to scale down to zero replicas")
 			rc.WaitForReplicas(ctx, 0, maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)
 
 			ginkgo.By("Verifying the ScaledToZero condition is True")
 			updatedHPA, err := f.ClientSet.AutoscalingV2().HorizontalPodAutoscalers(f.Namespace.Name).Get(ctx, hpa.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.AutoscalingV2().HorizontalPodAutoscalers(f.Namespace.Name).Get(ct...")
 			var scaledToZeroCondition *v2.HorizontalPodAutoscalerCondition
 			for i := range updatedHPA.Status.Conditions {
 				if updatedHPA.Status.Conditions[i].Type == v2.ScaledToZero {
@@ -153,7 +153,7 @@ var _ = SIGDescribe(feature.HPA, framework.WithFeatureGate(features.HPAScaleToZe
 
 			ginkgo.By(fmt.Sprintf("Setting %s metric value to 200 to trigger scale from zero", metricName))
 			err = metricsController.SetMetricValue(ctx, metricName, 200, nil)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to metricsController.SetMetricValue(ctx, metricName, 200, nil)")
 
 			ginkgo.By("Waiting for HPA to scale back up from zero")
 			rc.WaitForReplicas(ctx, int(hpa.Spec.MaxReplicas), maxHPAReactionTime+maxResourceConsumerDelay+waitBuffer)

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -73,12 +73,12 @@ var _ = SIGDescribe("Probing container", func() {
 	framework.ConformanceIt("with readiness probe should not be ready before initial delay and never restart", f.WithNodeConformance(), func(ctx context.Context) {
 		containerName := "test-webserver"
 		p := podClient.Create(ctx, testWebServerPodSpec(probe.withInitialDelay().build(), nil, containerName, 80))
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, p.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, p.Name, f.Namespace.Name, framework.PodStartTimeout), "failed to e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, p.Name, f.Namespac...")
 
 		p, err := podClient.Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Get(ctx, p.Name, metav1.GetOptions{})")
 		isReady, err := testutils.PodRunningReady(p)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to testutils.PodRunningReady(p)")
 		if !isReady {
 			framework.Failf("pod %s/%s should be ready", f.Namespace.Name, p.Name)
 		}
@@ -86,9 +86,9 @@ var _ = SIGDescribe("Probing container", func() {
 		// We assume the pod became ready when the container became ready. This
 		// is true for a single container pod.
 		readyTime, err := GetTransitionTimeForReadyCondition(p)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to GetTransitionTimeForReadyCondition(p)")
 		startedTime, err := GetContainerStartedTime(p, containerName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to GetContainerStartedTime(p, containerName)")
 
 		framework.Logf("Container started at %v, pod became ready at %v", startedTime, readyTime)
 		initialDelay := probeTestInitialDelaySeconds * time.Second
@@ -117,7 +117,7 @@ var _ = SIGDescribe("Probing container", func() {
 		}, 1*time.Minute, 1*time.Second).ShouldNot(gomega.BeTrueBecause("pod should not be ready"))
 
 		p, err := podClient.Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Get(ctx, p.Name, metav1.GetOptions{})")
 
 		isReady, _ := testutils.PodRunningReady(p)
 		if isReady {
@@ -311,7 +311,7 @@ var _ = SIGDescribe("Probing container", func() {
 			"reason":                   events.ContainerProbeWarning,
 		}.AsSelector().String()
 		framework.ExpectNoError(e2eevents.WaitTimeoutForEvent(
-			ctx, f.ClientSet, f.Namespace.Name, expectedEvent, "Probe terminated redirects, Response body: <a href=\"http://0.0.0.0/\">Found</a>.", framework.PodEventTimeout))
+			ctx, f.ClientSet, f.Namespace.Name, expectedEvent, "Probe terminated redirects, Response body: <a href=\"http://0.0.0.0/\">Found</a>.", framework.PodEventTimeout), "failed to execute test operation")
 	})
 
 	/*
@@ -425,23 +425,23 @@ var _ = SIGDescribe("Probing container", func() {
 		p := podClient.Create(ctx, startupPodSpec(startupProbe, readinessProbe, nil, cmd))
 
 		p, err := podClient.Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Get(ctx, p.Name, metav1.GetOptions{})")
 
 		err = e2epod.WaitForPodContainerStarted(ctx, f.ClientSet, f.Namespace.Name, p.Name, 0, framework.PodStartTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodContainerStarted(ctx, f.ClientSet, f.Namespace.Name, p.Name,...")
 		startedTime := time.Now()
 
 		// We assume the pod became ready when the container became ready. This
 		// is true for a single container pod.
 		err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, p.Name, f.Namespace.Name, framework.PodStartTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, p.Name, f.Namespac...")
 		readyTime := time.Now()
 
 		p, err = podClient.Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Get(ctx, p.Name, metav1.GetOptions{})")
 
 		isReady, err := testutils.PodRunningReady(p)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to testutils.PodRunningReady(p)")
 		if !isReady {
 			framework.Failf("pod %s/%s should be ready", f.Namespace.Name, p.Name)
 		}
@@ -826,11 +826,11 @@ done
 
 		// verify pods are running and ready
 		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeouts.PodStart)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeo...")
 
 		// Shutdown pod. Readiness should change to false
 		err = podClient.Delete(ctx, podName, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Delete(ctx, podName, metav1.DeleteOptions{})")
 
 		err = waitForPodStatusByInformer(ctx, f.ClientSet, f.Namespace.Name, podName, f.Timeouts.PodDelete, func(pod *v1.Pod) (bool, error) {
 			if !podutil.IsPodReady(pod) {
@@ -839,7 +839,7 @@ done
 			framework.Logf("pod %s/%s is still ready, waiting until is not ready", pod.Namespace, pod.Name)
 			return false, nil
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForPodStatusByInformer(ctx, f.ClientSet, f.Namespace....")
 	})
 
 	f.It("should mark readiness on pods to false and disable liveness probes while pod is in progress of terminating", f.WithNodeConformance(), func(ctx context.Context) {
@@ -908,11 +908,11 @@ done
 
 		// verify pods are running and ready
 		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeouts.PodStart)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeo...")
 
 		// Shutdown pod. Readiness should change to false
 		err = podClient.Delete(ctx, podName, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Delete(ctx, podName, metav1.DeleteOptions{})")
 
 		// Wait for pod to go unready
 		err = waitForPodStatusByInformer(ctx, f.ClientSet, f.Namespace.Name, podName, f.Timeouts.PodDelete, func(pod *v1.Pod) (bool, error) {
@@ -922,13 +922,13 @@ done
 			framework.Logf("pod %s/%s is still ready, waiting until is not ready", pod.Namespace, pod.Name)
 			return false, nil
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForPodStatusByInformer(ctx, f.ClientSet, f.Namespace....")
 
 		// Verify there are zero liveness failures since they are turned off
 		// during pod termination
 		gomega.Consistently(ctx, func(ctx context.Context) (bool, error) {
 			items, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})")
 			for _, event := range items.Items {
 				// Search only for the pod we are interested in
 				if event.InvolvedObject.Name != podName {
@@ -963,12 +963,12 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Probing restartable init c
 	ginkgo.It("with readiness probe should not be ready before initial delay and never restart", func(ctx context.Context) {
 		containerName := "test-webserver"
 		p := podClient.Create(ctx, testWebServerSidecarPodSpec(probe.withInitialDelay().build(), nil, containerName, 80))
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, p.Name, f.Namespace.Name, framework.PodStartTimeout))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, p.Name, f.Namespace.Name, framework.PodStartTimeout), "failed to e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, p.Name, f.Namespac...")
 
 		p, err := podClient.Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Get(ctx, p.Name, metav1.GetOptions{})")
 		isReady, err := testutils.PodRunningReady(p)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to testutils.PodRunningReady(p)")
 		if !isReady {
 			framework.Failf("pod %s/%s should be ready", f.Namespace.Name, p.Name)
 		}
@@ -976,9 +976,9 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Probing restartable init c
 		// We assume the pod became ready when the container became ready. This
 		// is true for a single container pod.
 		readyTime, err := GetTransitionTimeForReadyCondition(p)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to GetTransitionTimeForReadyCondition(p)")
 		startedTime, err := GetContainerStartedTime(p, containerName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to GetContainerStartedTime(p, containerName)")
 
 		framework.Logf("Container started at %v, pod became ready at %v", startedTime, readyTime)
 		initialDelay := probeTestInitialDelaySeconds * time.Second
@@ -1008,7 +1008,7 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Probing restartable init c
 		}, 1*time.Minute, 1*time.Second).ShouldNot(gomega.BeTrueBecause("pod should not be ready"))
 
 		p, err := podClient.Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Get(ctx, p.Name, metav1.GetOptions{})")
 
 		isReady, _ := testutils.PodRunningReady(p)
 		if isReady {
@@ -1238,7 +1238,7 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Probing restartable init c
 			"reason":                   events.ContainerProbeWarning,
 		}.AsSelector().String()
 		framework.ExpectNoError(e2eevents.WaitTimeoutForEvent(
-			ctx, f.ClientSet, f.Namespace.Name, expectedEvent, "Probe terminated redirects, Response body: <a href=\"http://0.0.0.0/\">Found</a>.", framework.PodEventTimeout))
+			ctx, f.ClientSet, f.Namespace.Name, expectedEvent, "Probe terminated redirects, Response body: <a href=\"http://0.0.0.0/\">Found</a>.", framework.PodEventTimeout), "failed to execute test operation")
 	})
 
 	/*
@@ -1362,23 +1362,23 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Probing restartable init c
 		p := podClient.Create(ctx, startupSidecarPodSpec(startupProbe, readinessProbe, nil, cmd))
 
 		p, err := podClient.Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Get(ctx, p.Name, metav1.GetOptions{})")
 
 		err = e2epod.WaitForPodContainerStarted(ctx, f.ClientSet, f.Namespace.Name, p.Name, 0, framework.PodStartTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodContainerStarted(ctx, f.ClientSet, f.Namespace.Name, p.Name,...")
 		startedTime := time.Now()
 
 		// We assume the pod became ready when the container became ready. This
 		// is true for a single container pod.
 		err = e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, p.Name, f.Namespace.Name, framework.PodStartTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, p.Name, f.Namespac...")
 		readyTime := time.Now()
 
 		p, err = podClient.Get(ctx, p.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Get(ctx, p.Name, metav1.GetOptions{})")
 
 		isReady, err := testutils.PodRunningReady(p)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to testutils.PodRunningReady(p)")
 		if !isReady {
 			framework.Failf("pod %s/%s should be ready", f.Namespace.Name, p.Name)
 		}
@@ -1571,11 +1571,11 @@ done
 
 		// verify pods are running and ready
 		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeouts.PodStart)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeo...")
 
 		// Shutdown pod. Readiness should change to false
 		err = podClient.Delete(ctx, podName, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Delete(ctx, podName, metav1.DeleteOptions{})")
 
 		err = waitForPodStatusByInformer(ctx, f.ClientSet, f.Namespace.Name, podName, f.Timeouts.PodDelete, func(pod *v1.Pod) (bool, error) {
 			if !podutil.IsPodReady(pod) {
@@ -1584,7 +1584,7 @@ done
 			framework.Logf("pod %s/%s is still ready, waiting until is not ready", pod.Namespace, pod.Name)
 			return false, nil
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForPodStatusByInformer(ctx, f.ClientSet, f.Namespace....")
 	})
 
 	ginkgo.It("should mark readiness on pods to false and disable liveness probes while pod is in progress of terminating", func(ctx context.Context) {
@@ -1664,11 +1664,11 @@ done
 
 		// verify pods are running and ready
 		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeouts.PodStart)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeo...")
 
 		// Shutdown pod. Readiness should change to false
 		err = podClient.Delete(ctx, podName, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Delete(ctx, podName, metav1.DeleteOptions{})")
 
 		// Wait for pod to go unready
 		err = waitForPodStatusByInformer(ctx, f.ClientSet, f.Namespace.Name, podName, f.Timeouts.PodDelete, func(pod *v1.Pod) (bool, error) {
@@ -1678,13 +1678,13 @@ done
 			framework.Logf("pod %s/%s is still ready, waiting until is not ready", pod.Namespace, pod.Name)
 			return false, nil
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForPodStatusByInformer(ctx, f.ClientSet, f.Namespace....")
 
 		// Verify there are zero liveness failures since they are turned off
 		// during pod termination
 		gomega.Consistently(ctx, func(ctx context.Context) (bool, error) {
 			items, err := f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Events(f.Namespace.Name).List(ctx, metav1.ListOptions{})")
 			for _, event := range items.Items {
 				// Search only for the pod we are interested in
 				if event.InvolvedObject.Name != podName {
@@ -1950,7 +1950,7 @@ func runLivenessTest(ctx context.Context, f *framework.Framework, pod *v1.Pod, e
 			}
 		}
 		return false, nil
-	}))
+	}), "failed to execute test operation")
 
 	// Check the pod's current state and verify that restartCount is present.
 	ginkgo.By("checking the pod's current state and verifying that restartCount is present")

--- a/test/e2e/common/node/container_restart_policy.go
+++ b/test/e2e/common/node/container_restart_policy.go
@@ -253,8 +253,8 @@ var _ = SIGDescribe("Pod Extended (RestartAllContainers)", framework.WithSlow(),
 				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			})
 			validateAllContainersRestarted(ctx, f, pod, []string{"init", "sidecar", "source-container", "regular"})
-			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "source-container", 3*time.Minute))
-			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "regular", 3*time.Minute))
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "source-container", 3*time.Minute), "failed to e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, '...")
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "regular", 3*time.Minute), "failed to e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, '...")
 		})
 
 		ginkgo.It("should restart all containers on sidecar container exit", func(ctx context.Context) {
@@ -317,8 +317,8 @@ var _ = SIGDescribe("Pod Extended (RestartAllContainers)", framework.WithSlow(),
 				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			})
 			validateAllContainersRestarted(ctx, f, pod, []string{"init", "sidecar", "source-sidecar", "regular"})
-			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "regular", 3*time.Minute))
-			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "source-sidecar", 3*time.Minute))
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "regular", 3*time.Minute), "failed to e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, '...")
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "source-sidecar", 3*time.Minute), "failed to e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, '...")
 		})
 
 		ginkgo.It("should restart init and sidecar containers on init container exit", func(ctx context.Context) {
@@ -381,7 +381,7 @@ var _ = SIGDescribe("Pod Extended (RestartAllContainers)", framework.WithSlow(),
 				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			})
 			validateAllContainersRestarted(ctx, f, pod, []string{"init", "sidecar", "source-init"})
-			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "regular", 3*time.Minute))
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "regular", 3*time.Minute), "failed to e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, '...")
 		})
 
 		ginkgo.It("should allow multiple RestartAllContainers actions and not introduce a loop", func(ctx context.Context) {
@@ -433,8 +433,8 @@ var _ = SIGDescribe("Pod Extended (RestartAllContainers)", framework.WithSlow(),
 				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			})
 			validateAllContainersRestarted(ctx, f, pod, []string{"source-container", "regular"})
-			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "source-container", 3*time.Minute))
-			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "regular", 3*time.Minute))
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "source-container", 3*time.Minute), "failed to e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, '...")
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "regular", 3*time.Minute), "failed to e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, '...")
 		})
 
 		ginkgo.It("should restart all containers on a previously restarted regular container exit", func(ctx context.Context) {
@@ -483,8 +483,8 @@ var _ = SIGDescribe("Pod Extended (RestartAllContainers)", framework.WithSlow(),
 				return podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
 			})
 			validateAllContainersRestarted(ctx, f, pod, []string{"source-container", "regular"})
-			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "source-container", 3*time.Minute))
-			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "regular", 3*time.Minute))
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "source-container", 3*time.Minute), "failed to e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, '...")
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, "regular", 3*time.Minute), "failed to e2epod.WaitForContainerRunning(ctx, f.ClientSet, f.Namespace.Name, podName, '...")
 		})
 	})
 })

--- a/test/e2e/common/node/downwardapi.go
+++ b/test/e2e/common/node/downwardapi.go
@@ -549,16 +549,16 @@ var _ = SIGDescribe("Downward API", feature.PodLevelResources, framework.WithFea
 
 			// Wait for client pod to complete.
 			err := e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, createdPod.Name, f.Namespace.Name, f.Timeouts.PodStart)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2epod.WaitForPodSuccessInNamespaceTimeout(ctx, f.ClientSet, createdPod.Name,...")
 
 			// Grab its logs.  Get host first.
 			podStatus, err := podClient.Get(ctx, createdPod.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to podClient.Get(ctx, createdPod.Name, metav1.GetOptions{})")
 
 			// Get the node allocatable resources
 			nodeName := podStatus.Spec.NodeName
 			node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})")
 			// Prepare expectations based on node allocatable resources
 			expectations := []string{
 				// Although the CPU limit for Pod Level Resources is set to 1250m (which would be 1.25),
@@ -570,13 +570,13 @@ var _ = SIGDescribe("Downward API", feature.PodLevelResources, framework.WithFea
 			}
 
 			logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, podStatus.Name, cName)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, podStatus.Name, cName)")
 
 			ginkgo.By(fmt.Sprintf("Checking logs from node %s pod %s container %s", nodeName, podStatus.Name, cName))
 			for _, expected := range expectations {
 				m := gomega.MatchRegexp(expected)
 				matches, err := m.Match(logs)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to m.Match(logs)")
 				gomega.Expect(matches).To(gomega.BeTrueBecause("expected %q in container output: %s", expected, logs))
 			}
 		})

--- a/test/e2e/common/node/dra_node_allocatable_resources.go
+++ b/test/e2e/common/node/dra_node_allocatable_resources.go
@@ -592,7 +592,7 @@ func doNodeAllocatableCgroupsTests(f *framework.Framework) {
 			nodes := drautils.NewNodesNow(tCtx, 1, 4)
 			if tc.requiresHugepages {
 				node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodes.NodeNames[0], metav1.GetOptions{})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Nodes().Get(ctx, nodes.NodeNames[0], metav1.GetOptions{})")
 				if limit, exists := node.Status.Allocatable[v1.ResourceName("hugepages-2Mi")]; !exists || limit.IsZero() {
 					ginkgo.Skip("Skipping hugepages test because Node does not support hugepages-2Mi")
 				}
@@ -630,7 +630,7 @@ func doNodeAllocatableCgroupsTests(f *framework.Framework) {
 			// Verify Pod-level cgroups on the node
 			ginkgo.By("verifying pod cgroup limits on the node")
 			err := cgroups.VerifyPodCgroups(ctx, f, pod, &tc.expectedPodCgroup)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to cgroups.VerifyPodCgroups(ctx, f, pod, &tc.expectedPodCgroup)")
 
 			ginkgo.By("verifying containers cgroup limits on the node")
 			onCgroupV2 := cgroups.IsPodOnCgroupv2Node(f, pod.Name, pod.Spec.Containers[0].Name)
@@ -643,25 +643,25 @@ func doNodeAllocatableCgroupsTests(f *framework.Framework) {
 					expectedContainer.Resources.Requests = container.Resources.Requests
 				}
 				err = cgroups.VerifyContainerCgroupValues(ctx, f, pod, expectedContainer, onCgroupV2)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to cgroups.VerifyContainerCgroupValues(ctx, f, pod, expectedContainer, onCgroupV2)")
 			}
 
 			if tc.requiresHugepages {
 				ginkgo.By("verifying pod hugepages limits on the node")
 				err = cgroups.VerifyPodHugepagesLimit(ctx, f, pod, "2MB", tc.expectedPodHugepagesLimit, onCgroupV2)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to cgroups.VerifyPodHugepagesLimit(ctx, f, pod, '2MB', tc.expectedPodHugepagesLi...")
 
 				ginkgo.By("verifying containers hugepages limits on the node")
 				for i, container := range pod.Spec.Containers {
 					err = cgroups.VerifyContainerHugepagesLimit(ctx, f, pod, container.Name, "2MB", tc.expectedContainerHugepagesLimits[i], onCgroupV2)
-					framework.ExpectNoError(err)
+					framework.ExpectNoError(err, "failed to cgroups.VerifyContainerHugepagesLimit(ctx, f, pod, container.Name, '2MB', tc....")
 				}
 			}
 
 			ginkgo.By("verifying containers oom_score_adj matches QoS rules with overhead")
 			// Retrieve node capacity to check exact adjustment
 			node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})")
 			nodeMemBytes := node.Status.Capacity.Memory().Value()
 
 			qosClass := v1qos.GetPodQOS(pod)
@@ -676,7 +676,7 @@ func doNodeAllocatableCgroupsTests(f *framework.Framework) {
 					expectedScore = computeExpectedOomScoreAdj(tc.expectedContainersScoreMemRequest[i], nodeMemBytes)
 				}
 				err = cgroups.VerifyOomScoreAdjValue(f, pod, container.Name, fmt.Sprintf("%d", expectedScore))
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to cgroups.VerifyOomScoreAdjValue(f, pod, container.Name, fmt.Sprintf('%d', expe...")
 			}
 
 			ginkgo.By("deleting pods")
@@ -886,14 +886,14 @@ func doNodeAllocatableResizeTests(f *framework.Framework) {
 
 			ginkgo.By("patching the pod for resize")
 			patchedPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Patch(ctx, pod.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "resize")
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Patch(ctx, pod.Name, types.Strate...")
 
 			ginkgo.By("waiting for resize actuation to complete")
 			resizedPod := podresize.WaitForPodResizeActuation(ctx, f, podClient, pod, desiredContainers)
 
 			ginkgo.By("verifying updated pod cgroup limits after resize")
 			err = cgroups.VerifyPodCgroups(ctx, f, resizedPod, &tc.expectedPodCgroupAfterResize)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to cgroups.VerifyPodCgroups(ctx, f, resizedPod, &tc.expectedPodCgroupAfterResize)")
 
 			ginkgo.By("verifying updated container cgroup limits after resize")
 			onCgroupV2 := cgroups.IsPodOnCgroupv2Node(f, resizedPod.Name, resizedPod.Spec.Containers[0].Name)
@@ -906,11 +906,11 @@ func doNodeAllocatableResizeTests(f *framework.Framework) {
 					expectedContainer.Resources.Requests = container.Resources.Requests
 				}
 				err = cgroups.VerifyContainerCgroupValues(ctx, f, resizedPod, expectedContainer, onCgroupV2)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to cgroups.VerifyContainerCgroupValues(ctx, f, resizedPod, expectedContainer, on...")
 			}
 
 			ginkgo.By("verifying pod status updates match spec after resize")
-			framework.ExpectNoError(verifyDRAPodLevelStatusResources(resizedPod, tc.expectedPodAllocatedResourcesAfterResize))
+			framework.ExpectNoError(verifyDRAPodLevelStatusResources(resizedPod, tc.expectedPodAllocatedResourcesAfterResize), "failed to verifyDRAPodLevelStatusResources(resizedPod, tc.expectedPodAllocatedResources...")
 
 			ginkgo.By("verifying pod spec resources after patch")
 			podresize.VerifyPodResources(patchedPod, desiredContainers, desiredPodResources)

--- a/test/e2e/common/node/file_key.go
+++ b/test/e2e/common/node/file_key.go
@@ -365,11 +365,11 @@ var _ = SIGDescribe("FileKeyRef", feature.EnvFiles, framework.WithFeatureGate(fe
 		pod = podClient.Create(ctx, pod)
 		ginkgo.By("Waiting for pod to complete")
 		err := e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Nam...")
 
 		// Check logs for lifecycle hook output
 		rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(ctx)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(ctx)")
 		defer func() { _ = rc.Close() }()
 		buf := new(bytes.Buffer)
 		_, _ = buf.ReadFrom(rc)
@@ -445,11 +445,11 @@ var _ = SIGDescribe("FileKeyRef", feature.EnvFiles, framework.WithFeatureGate(fe
 		podClient := e2epod.NewPodClient(f)
 		pod = podClient.CreateSync(ctx, pod)
 		err := podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Delete(ctx, pod.Name, metav1.DeleteOptions{})")
 
 		gomega.Eventually(ctx, func(g gomega.Gomega) {
 			rc, err := podClient.GetLogs(pod.Name, &v1.PodLogOptions{}).Stream(ctx)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to podClient.GetLogs(pod.Name, &v1.PodLogOptions{}).Stream(ctx)")
 			defer func() { _ = rc.Close() }()
 			buf := new(bytes.Buffer)
 			_, _ = buf.ReadFrom(rc)
@@ -659,7 +659,7 @@ var _ = SIGDescribe("FileKeyRef", feature.EnvFiles, framework.WithFeatureGate(fe
 				}
 			}
 			return false, nil
-		}))
+		}), "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, p...")
 	})
 
 	/*
@@ -786,9 +786,9 @@ var _ = SIGDescribe("FileKeyRef", feature.EnvFiles, framework.WithFeatureGate(fe
 		podClient := e2epod.NewPodClient(f)
 		pod = podClient.Create(ctx, pod)
 		err := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.N...")
 		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "use-envfile1")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, 'use-envfile1')")
 		gomega.Expect(logs).To(gomega.ContainSubstring("CONFIG_1=value1"))
 	})
 
@@ -894,9 +894,9 @@ var _ = SIGDescribe("FileKeyRef", feature.EnvFiles, framework.WithFeatureGate(fe
 			},
 		}
 		err := podClient.AddEphemeralContainerSync(ctx, pod, &ec, time.Minute)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.AddEphemeralContainerSync(ctx, pod, &ec, time.Minute)")
 		logs, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "debugger")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, 'debugger')")
 		gomega.Expect(logs).To(gomega.ContainSubstring("CONFIG_EPH_MAIN=ephemeral"))
 	})
 })

--- a/test/e2e/common/node/framework/podresize/resize.go
+++ b/test/e2e/common/node/framework/podresize/resize.go
@@ -398,7 +398,7 @@ func WaitForPodResizeActuation(ctx context.Context, f *framework.Framework, podC
 				return func() string { return "pod is not ready" }, nil
 			}
 			return nil, nil
-		})),
+		})), "failed to f.ClientSet.CoreV1().Nodes().Get(context.Background(), po...",
 	)
 
 	resizedPod, err := framework.GetObject(podClient.Get, pod.Name, metav1.GetOptions{})(ctx)
@@ -463,13 +463,13 @@ func ExpectPodResized(ctx context.Context, f *framework.Framework, resizedPod *v
 
 func MakeResizePatch(originalContainers, desiredContainers []ResizableContainerInfo, originPodResources, desiredPodResources *v1.ResourceRequirements) []byte {
 	original, err := json.Marshal(MakePodWithResizableContainers("", "", "", originalContainers, originPodResources))
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to json.Marshal(MakePodWithResizableContainers('', '', '', originalContainers, o...")
 
 	desired, err := json.Marshal(MakePodWithResizableContainers("", "", "", desiredContainers, desiredPodResources))
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to json.Marshal(MakePodWithResizableContainers('', '', '', desiredContainers, de...")
 
 	patch, err := strategicpatch.CreateTwoWayMergePatch(original, desired, v1.Pod{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to strategicpatch.CreateTwoWayMergePatch(original, desired, v1.Pod{})")
 
 	return patch
 }

--- a/test/e2e/common/node/image_credential_provider.go
+++ b/test/e2e/common/node/image_credential_provider.go
@@ -65,7 +65,7 @@ var _ = SIGDescribe("ImageCredentialProvider", feature.KubeletCredentialProvider
 			},
 		}
 		_, err := serviceAccountClient.Create(ctx, serviceAccount, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to serviceAccountClient.Create(ctx, serviceAccount, metav1.CreateOptions{})")
 
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/common/node/init_container.go
+++ b/test/e2e/common/node/init_container.go
@@ -226,7 +226,7 @@ var _ = SIGDescribe("InitContainer", framework.WithNodeConformance(), func() {
 		event, err := watchtools.Until(ctx, startedPod.ResourceVersion, w,
 			recordEvents(events, conditions.PodCompleted),
 		)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to watchtools.Until(ctx, startedPod.ResourceVersion, w,")
 
 		checkInvariants(events, containerInitInvariant)
 		endPod := event.Object.(*v1.Pod)
@@ -305,7 +305,7 @@ var _ = SIGDescribe("InitContainer", framework.WithNodeConformance(), func() {
 		ctx, cancel := watchtools.ContextWithOptionalTimeout(ctx, framework.PodStartTimeout)
 		defer cancel()
 		event, err := watchtools.Until(ctx, startedPod.ResourceVersion, w, recordEvents(events, conditions.PodRunning))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to watchtools.Until(ctx, startedPod.ResourceVersion, w, recordEvents(events, con...")
 
 		checkInvariants(events, containerInitInvariant)
 		endPod := event.Object.(*v1.Pod)
@@ -437,7 +437,7 @@ var _ = SIGDescribe("InitContainer", framework.WithNodeConformance(), func() {
 				}
 			},
 		)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to watchtools.Until(")
 
 		checkInvariants(events, containerInitInvariant)
 		endPod := event.Object.(*v1.Pod)
@@ -552,7 +552,7 @@ var _ = SIGDescribe("InitContainer", framework.WithNodeConformance(), func() {
 				}),
 			recordEvents(events, conditions.PodCompleted),
 		)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to watchtools.Until(")
 
 		checkInvariants(events, containerInitInvariant)
 		endPod := event.Object.(*v1.Pod)

--- a/test/e2e/common/node/kubelet.go
+++ b/test/e2e/common/node/kubelet.go
@@ -159,10 +159,10 @@ var _ = SIGDescribe("Kubelet", func() {
 			pod = podClient.Create(ctx, pod)
 			ginkgo.By("Waiting for pod completion")
 			err := e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Nam...")
 
 			rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(ctx)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(ctx)")
 			defer rc.Close()
 			buf := new(bytes.Buffer)
 			buf.ReadFrom(rc)
@@ -245,14 +245,14 @@ var _ = SIGDescribe("Kubelet with pods in a privileged namespace", func() {
 			pod = podClient.Create(ctx, pod)
 			ginkgo.By("Waiting for pod completion")
 			err := e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Nam...")
 
 			rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(ctx)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(ctx)")
 			defer rc.Close() // nolint:errcheck
 			buf := new(bytes.Buffer)
 			_, err = buf.ReadFrom(rc)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to buf.ReadFrom(rc)")
 			hostsFileContent := buf.String()
 
 			errMsg := fmt.Sprintf("expected hosts file to contain entries from HostAliases. Got:\n%+v", hostsFileContent)

--- a/test/e2e/common/node/lifecycle_hook.go
+++ b/test/e2e/common/node/lifecycle_hook.go
@@ -85,7 +85,7 @@ var _ = SIGDescribe("Container Lifecycle Hook", func() {
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 			targetNode = node.Name
 			nodeSelection := e2epod.NodeSelection{}
 			e2epod.SetAffinity(&nodeSelection, targetNode)
@@ -305,7 +305,7 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Restartable Init Container
 
 		ginkgo.BeforeEach(func(ctx context.Context) {
 			node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 			targetNode = node.Name
 			nodeSelection := e2epod.NodeSelection{}
 			e2epod.SetAffinity(&nodeSelection, targetNode)
@@ -719,7 +719,7 @@ var _ = SIGDescribe("Lifecycle Sleep Hook", framework.WithNodeConformance(), fun
 			// transition through Terminated. The actual correctness check below uses
 			// the container's intrinsic StartedAt/FinishedAt timestamps and is unaffected
 			// by how long we waited here.
-			framework.ExpectNoError(e2epod.WaitForContainerTerminated(ctx, f.ClientSet, f.Namespace.Name, p.Name, name, f.Timeouts.PodDelete))
+			framework.ExpectNoError(e2epod.WaitForContainerTerminated(ctx, f.ClientSet, f.Namespace.Name, p.Name, name, f.Timeouts.PodDelete), "failed to e2epod.WaitForContainerTerminated(ctx, f.ClientSet, f.Namespace.Name, p.Name,...")
 
 			p, err := podClient.Get(ctx, p.Name, metav1.GetOptions{})
 			if err != nil {

--- a/test/e2e/common/node/node_lease.go
+++ b/test/e2e/common/node/node_lease.go
@@ -45,7 +45,7 @@ var _ = SIGDescribe("NodeLease", framework.WithNodeConformance(), func() {
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 		nodeName = node.Name
 	})
 
@@ -65,7 +65,7 @@ var _ = SIGDescribe("NodeLease", framework.WithNodeConformance(), func() {
 				return nil
 			}, 5*time.Minute, 5*time.Second).Should(gomega.BeNil())
 			// check basic expectations for the lease
-			framework.ExpectNoError(expectLease(lease, nodeName))
+			framework.ExpectNoError(expectLease(lease, nodeName), "failed to expectLease(lease, nodeName)")
 
 			ginkgo.By("check that node lease is updated at least once within the lease duration")
 			gomega.Eventually(ctx, func() error {
@@ -127,7 +127,7 @@ var _ = SIGDescribe("NodeLease", framework.WithNodeConformance(), func() {
 				return nil
 			}, 5*time.Minute, 5*time.Second).Should(gomega.BeNil())
 			// check basic expectations for the lease
-			framework.ExpectNoError(expectLease(lease, nodeName))
+			framework.ExpectNoError(expectLease(lease, nodeName), "failed to expectLease(lease, nodeName)")
 			leaseDuration := time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second
 
 			ginkgo.By("verify NodeStatus report period is longer than lease duration")
@@ -180,7 +180,7 @@ var _ = SIGDescribe("NodeLease", framework.WithNodeConformance(), func() {
 			// running as cluster e2e test, because node e2e test does not create and
 			// run controller manager, i.e., no node lifecycle controller.
 			node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})")
 			_, readyCondition := testutils.GetNodeCondition(&node.Status, v1.NodeReady)
 			gomega.Expect(readyCondition.Status).To(gomega.Equal(v1.ConditionTrue))
 		})
@@ -189,7 +189,7 @@ var _ = SIGDescribe("NodeLease", framework.WithNodeConformance(), func() {
 
 func getHeartbeatTimeAndStatus(ctx context.Context, clientSet clientset.Interface, nodeName string) (time.Time, v1.NodeStatus) {
 	node, err := clientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to clientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})")
 	_, readyCondition := testutils.GetNodeCondition(&node.Status, v1.NodeReady)
 	gomega.Expect(readyCondition.Status).To(gomega.Equal(v1.ConditionTrue))
 	heartbeatTime := readyCondition.LastHeartbeatTime.Time

--- a/test/e2e/common/node/pod_admission.go
+++ b/test/e2e/common/node/pod_admission.go
@@ -39,7 +39,7 @@ var _ = SIGDescribe("PodOSRejection", framework.WithNodeConformance(), func() {
 	ginkgo.Context("Kubelet", func() {
 		ginkgo.It("[LinuxOnly] should reject pod when the node OS doesn't match pod's OS", func(ctx context.Context) {
 			linuxNode, err := findLinuxNode(ctx, f)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to findLinuxNode(ctx, f)")
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "wrong-pod-os",
@@ -61,7 +61,7 @@ var _ = SIGDescribe("PodOSRejection", framework.WithNodeConformance(), func() {
 			pod = e2epod.NewPodClient(f).Create(ctx, pod)
 			// Check the pod is still not running
 			err = e2epod.WaitForPodFailedReason(ctx, f.ClientSet, pod, "PodOSNotSupported", f.Timeouts.PodStartShort)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2epod.WaitForPodFailedReason(ctx, f.ClientSet, pod, 'PodOSNotSupported', f.T...")
 		})
 	})
 })

--- a/test/e2e/common/node/pod_level_resources.go
+++ b/test/e2e/common/node/pod_level_resources.go
@@ -49,7 +49,7 @@ var _ = SIGDescribe("Pod Level Resources", framework.WithSerial(), feature.PodLe
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		_, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 
 		if framework.NodeOSDistroIs("windows") {
 			e2eskipper.Skipf("not supported on windows -- skipping")
@@ -550,7 +550,7 @@ var _ = SIGDescribe("Pod Level Resources Fix Defaulting", framework.WithSerial()
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		_, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 
 		if framework.NodeOSDistroIs("windows") {
 			e2eskipper.Skipf("not supported on windows -- skipping")

--- a/test/e2e/common/node/pod_level_resources_resize.go
+++ b/test/e2e/common/node/pod_level_resources_resize.go
@@ -51,7 +51,7 @@ func doGuaranteedPodLevelResizeTests(f *framework.Framework) {
 
 			// The tests for guaranteed pods include extended resources.
 			nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)")
 			for _, node := range nodes.Items {
 				e2enode.AddExtendedResource(ctx, f.ClientSet, node.Name, fakeExtendedResource, resource.MustParse("123"))
 			}
@@ -442,7 +442,7 @@ var _ = SIGDescribe("PLR Pod InPlace Resize", framework.WithSlow(), framework.Wi
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		_, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 		if framework.NodeOSDistroIs("windows") {
 			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
 		}
@@ -622,10 +622,10 @@ func doPodLevelResourcesMemoryLimitDecreaseTest(f *framework.Framework) {
 					}, nil
 				}
 				return nil, nil
-			})),
+			})), "failed to framework.Gomega().Expect(gotPod.Status.AllocatedResource...",
 		)
 		ginkgo.By("verifying pod status resources still match the viable resize")
-		framework.ExpectNoError(podresize.VerifyPodStatusResources(testPod, containers))
+		framework.ExpectNoError(podresize.VerifyPodStatusResources(testPod, containers), "failed to podresize.VerifyPodStatusResources(testPod, containers)")
 
 		// 3. Revert the limit back to the original value - should succeed
 		ginkgo.By("Patching pod to revert to original state")
@@ -685,7 +685,7 @@ func doPatchAndRollbackPLR(ctx context.Context, f *framework.Framework, original
 	newPod := createAndVerifyPodPLR(ctx, f, podClient, originalContainers, originalPodResources, mountPodCgroup)
 
 	if expectedPodResources != nil {
-		framework.ExpectNoError(VerifyPodLevelStatus(newPod))
+		framework.ExpectNoError(VerifyPodLevelStatus(newPod), "failed to VerifyPodLevelStatus(newPod)")
 	}
 	ginkgo.By(fmt.Sprintf("patching and verifying pod for resize %s: %v", newPod.Name, newPod.UID))
 	patchAndVerifyPLR(ctx, f, podClient, newPod, originalContainers, expectedContainers, originalPodResources, expectedPodResources, "resize")
@@ -740,7 +740,7 @@ func patchAndVerifyPLR(ctx context.Context, f *framework.Framework, podClient *e
 	// resulting in values off by a small number.
 	// framework.ExpectNoError(VerifyPodLevelStatus(resizedPod))
 	if expectedPodResources != nil {
-		framework.ExpectNoError(podresize.VerifyPodCgroupValues(ctx, f, resizedPod))
+		framework.ExpectNoError(podresize.VerifyPodCgroupValues(ctx, f, resizedPod), "failed to podresize.VerifyPodCgroupValues(ctx, f, resizedPod)")
 	}
 
 	// Verify CPU weight moved in the right direction
@@ -800,11 +800,11 @@ func createAndVerifyPodPLR(ctx context.Context, f *framework.Framework, podClien
 	podresize.VerifyPodResources(newPod, originalContainers, podResources)
 
 	podresize.VerifyPodResizePolicy(newPod, originalContainers)
-	framework.ExpectNoError(podresize.VerifyPodStatusResources(newPod, originalContainers))
+	framework.ExpectNoError(podresize.VerifyPodStatusResources(newPod, originalContainers), "failed to podresize.VerifyPodStatusResources(newPod, originalContainers)")
 
-	framework.ExpectNoError(podresize.VerifyPodContainersCgroupValues(ctx, f, newPod, originalContainers))
+	framework.ExpectNoError(podresize.VerifyPodContainersCgroupValues(ctx, f, newPod, originalContainers), "failed to podresize.VerifyPodContainersCgroupValues(ctx, f, newPod, originalContainers)")
 	if podResources != nil {
-		framework.ExpectNoError(podresize.VerifyPodCgroupValues(ctx, f, newPod))
+		framework.ExpectNoError(podresize.VerifyPodCgroupValues(ctx, f, newPod), "failed to podresize.VerifyPodCgroupValues(ctx, f, newPod)")
 	}
 	return newPod
 }

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -88,7 +88,7 @@ func doGuaranteedPodResizeTests(f *framework.Framework) {
 
 			// The tests for guaranteed pods include extended resources.
 			nodes, err := e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2enode.GetReadySchedulableNodes(context.Background(), f.ClientSet)")
 			for _, node := range nodes.Items {
 				e2enode.AddExtendedResource(ctx, f.ClientSet, node.Name, fakeExtendedResource, resource.MustParse("123"))
 			}
@@ -391,14 +391,14 @@ func doPodResizePatchErrorTests(f *framework.Framework) {
 		gomega.Expect(pErr.Error()).To(gomega.ContainSubstring(patchError))
 
 		patchedPod, getErr := f.ClientSet.CoreV1().Pods(newPod.Namespace).Get(ctx, newPod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(getErr)
+		framework.ExpectNoError(getErr, "failed to getErr")
 
 		ginkgo.By("verifying pod resources after patch")
 		podresize.VerifyPodResources(patchedPod, originalContainers, nil)
 
 		if waitForStart {
 			ginkgo.By("verifying pod status resources after patch")
-			framework.ExpectNoError(podresize.VerifyPodStatusResources(patchedPod, originalContainers))
+			framework.ExpectNoError(podresize.VerifyPodStatusResources(patchedPod, originalContainers), "failed to podresize.VerifyPodStatusResources(patchedPod, originalContainers)")
 		}
 
 		ginkgo.By("deleting pod")
@@ -668,10 +668,10 @@ func doPodResizeMemoryLimitDecreaseTest(f *framework.Framework) {
 					}, nil
 				}
 				return nil, nil
-			})),
+			})), "failed to execute test operation",
 		)
 		ginkgo.By("verifying pod status resources still match the viable resize")
-		framework.ExpectNoError(podresize.VerifyPodStatusResources(testPod, viableLoweredLimit))
+		framework.ExpectNoError(podresize.VerifyPodStatusResources(testPod, viableLoweredLimit), "failed to podresize.VerifyPodStatusResources(testPod, viableLoweredLimit)")
 
 		// 3. Revert the limit back to the original value - should succeed
 		ginkgo.By("Patching pod to revert to original state")
@@ -850,7 +850,7 @@ func doPodResizeReadAndReplaceTests(f *framework.Framework) {
 				}
 
 				return nil, nil
-			})),
+			})), "failed to unstructuredToPod(unstruct)",
 		)
 	})
 }
@@ -1103,7 +1103,7 @@ func doPodResizeMemoryVolumeSizeLimitDecreaseTest(f *framework.Framework) {
 					return func() string { return "expected a non-empty error message in PodResizeInProgress condition" }, nil
 				}
 				return nil, nil
-			})),
+			})), "failed to e2epod.ExecCommandInContainerWithFullOutput(f, newPod.Nam...",
 		)
 
 		ginkgo.By("verifying the volume still holds the original size and c1 didn't restart")
@@ -1112,7 +1112,7 @@ func doPodResizeMemoryVolumeSizeLimitDecreaseTest(f *framework.Framework) {
 		gomega.Expect(stdout).To(gomega.ContainSubstring(strconv.FormatInt(qty128Mi.Value()/(1024*1024), 10)))
 
 		gotPod, getErr := podClient.Get(ctx, newPod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(getErr)
+		framework.ExpectNoError(getErr, "failed to getErr")
 		expected := podresize.UpdateExpectedContainerRestarts(ctx, gotPod, original)
 		gomega.Expect(gotPod.Status.ContainerStatuses[0].RestartCount).To(gomega.Equal(expected[0].RestartCount))
 
@@ -1133,7 +1133,7 @@ var _ = SIGDescribe("Pod InPlace Resize Container", func() {
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		_, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 		if framework.NodeOSDistroIs("windows") {
 			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
 		}
@@ -1151,7 +1151,7 @@ var _ = SIGDescribe("Pod InPlace Resize Init Container", framework.WithSlow(), f
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		_, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 		if framework.NodeOSDistroIs("windows") {
 			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
 		}
@@ -1165,7 +1165,7 @@ var _ = SIGDescribe("Pod InPlace Resize Memory-Backed Volume", framework.WithFea
 
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		_, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 		if framework.NodeOSDistroIs("windows") {
 			e2eskipper.Skipf("runtime does not support InPlacePodVerticalScaling -- skipping")
 		}
@@ -1230,7 +1230,7 @@ func patchAndVerify(ctx context.Context, f *framework.Framework, podClient *e2ep
 
 	podresize.ExpectPodResized(ctx, f, resizedPod, expected)
 	if expectedPodResources != nil {
-		framework.ExpectNoError(podresize.VerifyPodCgroupValues(ctx, f, resizedPod))
+		framework.ExpectNoError(podresize.VerifyPodCgroupValues(ctx, f, resizedPod), "failed to podresize.VerifyPodCgroupValues(ctx, f, resizedPod)")
 	}
 
 	// Verify CPU weight moved in the right direction
@@ -1290,10 +1290,10 @@ func createAndVerifyPod(ctx context.Context, f *framework.Framework, podClient *
 
 	podresize.VerifyPodResources(newPod, originalContainers, podResources)
 	podresize.VerifyPodResizePolicy(newPod, originalContainers)
-	framework.ExpectNoError(podresize.VerifyPodStatusResources(newPod, originalContainers))
-	framework.ExpectNoError(podresize.VerifyPodContainersCgroupValues(ctx, f, newPod, originalContainers))
+	framework.ExpectNoError(podresize.VerifyPodStatusResources(newPod, originalContainers), "failed to podresize.VerifyPodStatusResources(newPod, originalContainers)")
+	framework.ExpectNoError(podresize.VerifyPodContainersCgroupValues(ctx, f, newPod, originalContainers), "failed to podresize.VerifyPodContainersCgroupValues(ctx, f, newPod, originalContainers)")
 	if podResources != nil {
-		framework.ExpectNoError(podresize.VerifyPodCgroupValues(ctx, f, newPod))
+		framework.ExpectNoError(podresize.VerifyPodCgroupValues(ctx, f, newPod), "failed to podresize.VerifyPodCgroupValues(ctx, f, newPod)")
 	}
 	return newPod
 }
@@ -1397,6 +1397,6 @@ func verifyInitContainerResources(ctx context.Context, f *framework.Framework, p
 				}, nil
 			}
 			return nil, nil
-		})),
+		})), "failed to cgroups.VerifyContainerCgroupValues(ctx, f, pod, &expecte...",
 	)
 }

--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -298,7 +298,7 @@ var _ = SIGDescribe("Pods", func() {
 
 		// We need to wait for the pod to be running, otherwise the deletion
 		// may be carried out immediately rather than gracefully.
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name), "failed to e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespa...")
 		// save the running pod
 		pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to GET scheduled pod")
@@ -383,7 +383,7 @@ var _ = SIGDescribe("Pods", func() {
 			pod.Labels["time"] = value
 		})
 
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name), "failed to e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespa...")
 
 		ginkgo.By("verifying the updated pod is in kubernetes")
 		selector = labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
@@ -437,7 +437,7 @@ var _ = SIGDescribe("Pods", func() {
 			pod.Spec.ActiveDeadlineSeconds = &newDeadline
 		})
 
-		framework.ExpectNoError(e2epod.WaitForPodTerminatedInNamespace(ctx, f.ClientSet, pod.Name, "DeadlineExceeded", f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodTerminatedInNamespace(ctx, f.ClientSet, pod.Name, "DeadlineExceeded", f.Namespace.Name), "failed to e2epod.WaitForPodTerminatedInNamespace(ctx, f.ClientSet, pod.Name, 'DeadlineE...")
 	})
 
 	/*
@@ -714,7 +714,7 @@ var _ = SIGDescribe("Pods", func() {
 		})
 
 		time.Sleep(syncLoopFrequency)
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name), "failed to e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespa...")
 
 		ginkgo.By("get restart delay after image update")
 		delayAfterUpdate, err := getRestartDelay(ctx, podClient, podName, containerName)
@@ -810,7 +810,7 @@ var _ = SIGDescribe("Pods", func() {
 		validatePodReadiness := func(expectReady bool) {
 			err := wait.Poll(time.Second, time.Minute, func() (bool, error) {
 				pod, err := podClient.Get(ctx, podName, metav1.GetOptions{})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to podClient.Get(ctx, podName, metav1.GetOptions{})")
 				podReady := podutils.IsPodReady(pod)
 				res := expectReady == podReady
 				if !res {
@@ -818,19 +818,19 @@ var _ = SIGDescribe("Pods", func() {
 				}
 				return res, nil
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to podClient.Get(ctx, podName, metav1.GetOptions{})")
 		}
 
 		ginkgo.By("submitting the pod to kubernetes")
 		e2epod.NewPodClient(f).Create(ctx, pod)
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name), "failed to e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespa...")
 		if podClient.PodIsReady(ctx, podName) {
 			framework.Failf("Expect pod(%s/%s)'s Ready condition to be false initially.", f.Namespace.Name, pod.Name)
 		}
 
 		ginkgo.By(fmt.Sprintf("patching pod status with condition %q to true", readinessGate1))
 		_, err := podClient.Patch(ctx, podName, types.StrategicMergePatchType, []byte(fmt.Sprintf(patchStatusFmt, readinessGate1, "True")), metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Patch(ctx, podName, types.StrategicMergePatchType, []byte(fmt.Sprin...")
 		// Sleep for 10 seconds.
 		time.Sleep(syncLoopFrequency)
 		// Verify the pod is still not ready
@@ -840,12 +840,12 @@ var _ = SIGDescribe("Pods", func() {
 
 		ginkgo.By(fmt.Sprintf("patching pod status with condition %q to true", readinessGate2))
 		_, err = podClient.Patch(ctx, podName, types.StrategicMergePatchType, []byte(fmt.Sprintf(patchStatusFmt, readinessGate2, "True")), metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Patch(ctx, podName, types.StrategicMergePatchType, []byte(fmt.Sprin...")
 		validatePodReadiness(true)
 
 		ginkgo.By(fmt.Sprintf("patching pod status with condition %q to false", readinessGate1))
 		_, err = podClient.Patch(ctx, podName, types.StrategicMergePatchType, []byte(fmt.Sprintf(patchStatusFmt, readinessGate1, "False")), metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Patch(ctx, podName, types.StrategicMergePatchType, []byte(fmt.Sprin...")
 		validatePodReadiness(false)
 
 	})

--- a/test/e2e/common/node/podtemplates.go
+++ b/test/e2e/common/node/podtemplates.go
@@ -209,7 +209,7 @@ var _ = SIGDescribe("PodTemplates", func() {
 			updatedPT, err = ptClient.Update(ctx, ptResource, metav1.UpdateOptions{})
 			return err
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to ptClient.Update(ctx, ptResource, metav1.UpdateOptions{})")
 		gomega.Expect(updatedPT.Annotations).To(gomega.HaveKeyWithValue("updated", "true"), "updated object should have the applied annotation")
 		framework.Logf("Found updated podtemplate annotation: %#v\n", updatedPT.Annotations["updated"])
 	})

--- a/test/e2e/common/node/runtime.go
+++ b/test/e2e/common/node/runtime.go
@@ -123,7 +123,7 @@ while true; do sleep 1; done
 					}, ContainerStatusRetryTimeout, ContainerStatusPollInterval).Should(gomega.Equal(testCase.Ready))
 
 					status, err := terminateContainer.GetStatus(ctx)
-					framework.ExpectNoError(err)
+					framework.ExpectNoError(err, "failed to terminateContainer.GetStatus(ctx)")
 
 					ginkgo.By(fmt.Sprintf("Container '%s': should get the expected 'State'", testContainer.Name))
 					gomega.Expect(GetContainerState(status.State)).To(gomega.Equal(testCase.State))
@@ -159,7 +159,7 @@ while true; do sleep 1; done
 
 				ginkgo.By("get the container status")
 				status, err := c.GetStatus(ctx)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to c.GetStatus(ctx)")
 
 				ginkgo.By("the container should be terminated")
 				gomega.Expect(GetContainerState(status.State)).To(gomega.Equal(ContainerStateTerminated))
@@ -266,7 +266,7 @@ while true; do sleep 1; done
 				var err error
 
 				registryAddress, registryNodeNames, err = e2eregistry.SetupRegistry(ctx, f, true)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to e2eregistry.SetupRegistry(ctx, f, true)")
 				gomega.Expect(registryNodeNames).ToNot(gomega.BeEmpty())
 				// we need to wait for the registry to be removed and so we need to delete the whole NS ourselves
 				ginkgo.DeferCleanup(func(ctx context.Context) {
@@ -278,12 +278,12 @@ while true; do sleep 1; done
 				// we might be told to use a different docker config JSON.
 				if framework.TestContext.DockerConfigFile != "" {
 					contents, err := os.ReadFile(framework.TestContext.DockerConfigFile)
-					framework.ExpectNoError(err)
+					framework.ExpectNoError(err, "failed to os.ReadFile(framework.TestContext.DockerConfigFile)")
 					secret.Data[v1.DockerConfigJsonKey] = contents
 				}
 				ginkgo.By("create image pull secret")
 				pullSecret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.Cre...")
 			})
 
 			f.It("should not be able to pull image from invalid registry", f.WithNodeConformance(), func(ctx context.Context) {

--- a/test/e2e/common/node/runtimeclass.go
+++ b/test/e2e/common/node/runtimeclass.go
@@ -176,7 +176,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 					return true, err // stop wait with error
 				}
 				return false, nil
-			}))
+			}), "failed to rcClient.Get(ctx, rcName, metav1.GetOptions{})")
 		})
 
 		gomega.Eventually(ctx, func() error {
@@ -214,7 +214,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		ginkgo.By("getting /apis")
 		{
 			discoveryGroups, err := f.ClientSet.Discovery().ServerGroups()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerGroups()")
 			found := false
 			for _, group := range discoveryGroups.Groups {
 				if group.Name == nodev1.GroupName {
@@ -235,7 +235,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		{
 			group := &metav1.APIGroup{}
 			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/node.k8s.io").Do(ctx).Into(group)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().RESTClient().Get().AbsPath('/apis/node.k8s.io').Do(ct...")
 			found := false
 			for _, version := range group.Versions {
 				if version.Version == rcVersion {
@@ -251,7 +251,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		ginkgo.By("getting /apis/node.k8s.io/" + rcVersion)
 		{
 			resources, err := f.ClientSet.Discovery().ServerResourcesForGroupVersion(nodev1.SchemeGroupVersion.String())
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerResourcesForGroupVersion(nodev1.SchemeGroupVers...")
 			found := false
 			for _, resource := range resources.APIResources {
 				switch resource.Name {
@@ -268,37 +268,37 @@ var _ = SIGDescribe("RuntimeClass", func() {
 
 		ginkgo.By("creating")
 		createdRC, err := rcClient.Create(ctx, rc, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.Create(ctx, rc, metav1.CreateOptions{})")
 		_, err = rcClient.Create(ctx, rc, metav1.CreateOptions{})
 		if !apierrors.IsAlreadyExists(err) {
 			framework.Failf("expected 409, got %#v", err)
 		}
 		_, err = rcClient.Create(ctx, rc2, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.Create(ctx, rc2, metav1.CreateOptions{})")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
 		rcWatch, err := rcClient.Watch(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.Watch(ctx, metav1.ListOptions{LabelSelector: 'test=' + f.UniqueName})")
 
 		// added for a watch
 		_, err = rcClient.Create(ctx, rc3, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.Create(ctx, rc3, metav1.CreateOptions{})")
 
 		ginkgo.By("getting")
 		gottenRC, err := rcClient.Get(ctx, rc.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.Get(ctx, rc.Name, metav1.GetOptions{})")
 		gomega.Expect(gottenRC.UID).To(gomega.Equal(createdRC.UID))
 		gomega.Expect(gottenRC).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		rcs, err := rcClient.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.List(ctx, metav1.ListOptions{LabelSelector: 'test=' + f.UniqueName})")
 		gomega.Expect(rcs.Items).To(gomega.HaveLen(3), "filtered list should have 3 items")
 
 		ginkgo.By("patching")
 		patchedRC, err := rcClient.Patch(ctx, createdRC.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.Patch(ctx, createdRC.Name, types.MergePatchType, []byte(`{'metadata'...")
 		gomega.Expect(patchedRC.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(resourceversion.CompareResourceVersion(gottenRC.ResourceVersion, patchedRC.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
@@ -306,7 +306,7 @@ var _ = SIGDescribe("RuntimeClass", func() {
 		csrToUpdate := patchedRC.DeepCopy()
 		csrToUpdate.Annotations["updated"] = "true"
 		updatedRC, err := rcClient.Update(ctx, csrToUpdate, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.Update(ctx, csrToUpdate, metav1.UpdateOptions{})")
 		gomega.Expect(updatedRC.Annotations).To(gomega.HaveKeyWithValue("updated", "true"), "updated object should have the applied annotation")
 
 		framework.Logf("waiting for watch events with expected annotations")
@@ -348,20 +348,20 @@ var _ = SIGDescribe("RuntimeClass", func() {
 
 		ginkgo.By("deleting")
 		err = rcClient.Delete(ctx, createdRC.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.Delete(ctx, createdRC.Name, metav1.DeleteOptions{})")
 		_, err = rcClient.Get(ctx, createdRC.Name, metav1.GetOptions{})
 		if !apierrors.IsNotFound(err) {
 			framework.Failf("expected 404, got %#v", err)
 		}
 		rcs, err = rcClient.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.List(ctx, metav1.ListOptions{LabelSelector: 'test=' + f.UniqueName})")
 		gomega.Expect(rcs.Items).To(gomega.HaveLen(2), "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
 		err = rcClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Lab...")
 		rcs, err = rcClient.List(ctx, metav1.ListOptions{LabelSelector: "test=" + f.UniqueName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rcClient.List(ctx, metav1.ListOptions{LabelSelector: 'test=' + f.UniqueName})")
 		gomega.Expect(rcs.Items).To(gomega.BeEmpty(), "filtered list should have 0 items")
 	})
 })
@@ -400,5 +400,5 @@ func expectPodRejection(ctx context.Context, f *framework.Framework, rcName stri
 // expectPodSuccess waits for the given pod to terminate successfully.
 func expectPodSuccess(ctx context.Context, f *framework.Framework, pod *v1.Pod) {
 	framework.ExpectNoError(e2epod.WaitForPodSuccessInNamespace(
-		ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+		ctx, f.ClientSet, pod.Name, f.Namespace.Name), "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, p...")
 }

--- a/test/e2e/common/node/security_context.go
+++ b/test/e2e/common/node/security_context.go
@@ -111,9 +111,9 @@ var _ = SIGDescribe("Security Context", func() {
 			}
 
 			logs1, err := getLogs(createdPod1)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to getLogs(createdPod1)")
 			logs2, err := getLogs(createdPod2)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to getLogs(createdPod2)")
 
 			// 65536 is the size used for a user namespace.  Verify that the value is present
 			// in the /proc/self/uid_map file.
@@ -154,7 +154,7 @@ var _ = SIGDescribe("Security Context", func() {
 				}
 
 				logs, err := getLogs(createdPod)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to getLogs(createdPod)")
 
 				// The hostUID is the second field in the /proc/self/uid_map file.
 				hostMap := strings.Fields(logs)
@@ -403,7 +403,7 @@ var _ = SIGDescribe("Security Context", func() {
 
 			createdPod = e2epod.NewPodClient(f).Create(ctx, createdPod)
 			ev, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, createdPod)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, createdPod)")
 			gomega.Expect(ev).NotTo(gomega.BeNil())
 			gomega.Expect(ev.Reason).To(gomega.Equal(events.FailedToCreateContainer))
 
@@ -506,7 +506,7 @@ var _ = SIGDescribe("Security Context", func() {
 			podClient.Create(ctx, pod)
 
 			podClient.WaitForSuccess(ctx, name, framework.PodStartTimeout)
-			framework.ExpectNoError(podClient.MatchContainerOutput(ctx, name, name, "1000"))
+			framework.ExpectNoError(podClient.MatchContainerOutput(ctx, name, name, "1000"), "failed to podClient.MatchContainerOutput(ctx, name, name, '1000')")
 		})
 		ginkgo.It("should not run with an explicit root user ID [LinuxOnly]", func(ctx context.Context) {
 			// creates a pod with RunAsUser, which is not supported on Windows.
@@ -516,7 +516,7 @@ var _ = SIGDescribe("Security Context", func() {
 			pod = podClient.Create(ctx, pod)
 
 			ev, err := podClient.WaitForErrorEventOrSuccess(ctx, pod)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to podClient.WaitForErrorEventOrSuccess(ctx, pod)")
 			gomega.Expect(ev).NotTo(gomega.BeNil())
 			gomega.Expect(ev.Reason).To(gomega.Equal(events.FailedToCreateContainer))
 		})
@@ -526,7 +526,7 @@ var _ = SIGDescribe("Security Context", func() {
 			podClient.Create(ctx, pod)
 
 			podClient.WaitForSuccess(ctx, name, framework.PodStartTimeout)
-			framework.ExpectNoError(podClient.MatchContainerOutput(ctx, name, name, "1234"))
+			framework.ExpectNoError(podClient.MatchContainerOutput(ctx, name, name, "1234"), "failed to podClient.MatchContainerOutput(ctx, name, name, '1234')")
 		})
 		ginkgo.It("should not run without a specified user ID", func(ctx context.Context) {
 			name := "implicit-root-uid"
@@ -534,7 +534,7 @@ var _ = SIGDescribe("Security Context", func() {
 			pod = podClient.Create(ctx, pod)
 
 			ev, err := podClient.WaitForErrorEventOrSuccess(ctx, pod)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to podClient.WaitForErrorEventOrSuccess(ctx, pod)")
 			gomega.Expect(ev).NotTo(gomega.BeNil())
 			gomega.Expect(ev.Reason).To(gomega.Equal(events.FailedToCreateContainer))
 		})
@@ -790,7 +790,7 @@ var _ = SIGDescribe("Security Context", func() {
 		}
 		nodeSupportsSupplementalGroupsPolicy := func(ctx context.Context, f *framework.Framework, nodeName string) bool {
 			node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})")
 			gomega.Expect(node).NotTo(gomega.BeNil())
 			if node.Status.Features != nil {
 				supportsSupplementalGroupsPolicy := node.Status.Features.SupplementalGroupsPolicy
@@ -836,9 +836,9 @@ var _ = SIGDescribe("Security Context", func() {
 			}
 
 			if featureSupportedOnNode {
-				framework.ExpectNoError(waitForContainerUser(ctx, f, podName, containerName, expectedContainerUser))
+				framework.ExpectNoError(waitForContainerUser(ctx, f, podName, containerName, expectedContainerUser), "failed to waitForContainerUser(ctx, f, podName, containerName, expectedContainerUser)")
 			}
-			framework.ExpectNoError(waitForPodLogs(ctx, f, podName, containerName, expectedOutput+"\n"))
+			framework.ExpectNoError(waitForPodLogs(ctx, f, podName, containerName, expectedOutput+"\n"), "failed to waitForPodLogs(ctx, f, podName, containerName, expectedOutput+'n')")
 
 			stdout := e2epod.ExecCommandInContainer(f, podName, containerName, "id", "-G")
 			gomega.Expect(stdout).To(gomega.Equal(expectedOutput))
@@ -854,9 +854,9 @@ var _ = SIGDescribe("Security Context", func() {
 			}
 
 			if featureSupportedOnNode {
-				framework.ExpectNoError(waitForContainerUser(ctx, f, podName, containerName, expectedContainerUser))
+				framework.ExpectNoError(waitForContainerUser(ctx, f, podName, containerName, expectedContainerUser), "failed to waitForContainerUser(ctx, f, podName, containerName, expectedContainerUser)")
 			}
-			framework.ExpectNoError(waitForPodLogs(ctx, f, podName, containerName, expectedOutput+"\n"))
+			framework.ExpectNoError(waitForPodLogs(ctx, f, podName, containerName, expectedOutput+"\n"), "failed to waitForPodLogs(ctx, f, podName, containerName, expectedOutput+'n')")
 
 			stdout := e2epod.ExecCommandInContainer(f, podName, containerName, "id", "-G")
 			gomega.Expect(stdout).To(gomega.Equal(expectedOutput))
@@ -900,10 +900,10 @@ var _ = SIGDescribe("Security Context", func() {
 				ginkgo.BeforeEach(func(ctx context.Context) {
 					ginkgo.By("creating a pod", func() {
 						pod = e2epod.NewPodClient(f).Create(ctx, mkPod(ptr.To(v1.SupplementalGroupsPolicyStrict)))
-						framework.ExpectNoError(e2epod.WaitForPodScheduled(ctx, f.ClientSet, pod.Namespace, pod.Name))
+						framework.ExpectNoError(e2epod.WaitForPodScheduled(ctx, f.ClientSet, pod.Namespace, pod.Name), "failed to e2epod.WaitForPodScheduled(ctx, f.ClientSet, pod.Namespace, pod.Name)")
 						var err error
 						pod, err = e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})
-						framework.ExpectNoError(err)
+						framework.ExpectNoError(err, "failed to e2epod.NewPodClient(f).Get(ctx, pod.Name, metav1.GetOptions{})")
 					})
 					if !nodeSupportsSupplementalGroupsPolicy(ctx, f, pod.Spec.NodeName) {
 						e2eskipper.Skipf("scheduled node does not support SupplementalGroupsPolicy")

--- a/test/e2e/common/node/sysctl.go
+++ b/test/e2e/common/node/sysctl.go
@@ -96,21 +96,21 @@ var _ = SIGDescribe("Sysctls [LinuxOnly]", framework.WithNodeConformance(), func
 		// failed pods without running containers. This would create a race as the pod
 		// might have already been deleted here.
 		ev, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, pod)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, pod)")
 		gomega.Expect(ev).To(gomega.BeNil())
 
 		ginkgo.By("Waiting for pod completion")
 		err = e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Nam...")
 		pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Get(ctx, pod.Name, metav1.GetOptions{})")
 
 		ginkgo.By("Checking that the pod succeeded")
 		gomega.Expect(pod.Status.Phase).To(gomega.Equal(v1.PodSucceeded))
 
 		ginkgo.By("Getting logs from the pod")
 		log, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Cont...")
 
 		ginkgo.By("Checking that the sysctl is actually updated")
 		gomega.Expect(log).To(gomega.ContainSubstring("kernel.shm_rmid_forced = 1"))
@@ -176,7 +176,7 @@ var _ = SIGDescribe("Sysctls [LinuxOnly]", framework.WithNodeConformance(), func
 		ginkgo.By("Wait for pod failed reason")
 		// watch for pod failed reason instead of termination of pod
 		err := e2epod.WaitForPodFailedReason(ctx, f.ClientSet, pod, "SysctlForbidden", f.Timeouts.PodStart)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodFailedReason(ctx, f.ClientSet, pod, 'SysctlForbidden', f.Tim...")
 	})
 
 	/*
@@ -206,21 +206,21 @@ var _ = SIGDescribe("Sysctls [LinuxOnly]", framework.WithNodeConformance(), func
 		// failed pods without running containers. This would create a race as the pod
 		// might have already been deleted here.
 		ev, err := e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, pod)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.NewPodClient(f).WaitForErrorEventOrSuccess(ctx, pod)")
 		gomega.Expect(ev).To(gomega.BeNil())
 
 		ginkgo.By("Waiting for pod completion")
 		err = e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodNoLongerRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Nam...")
 		pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to podClient.Get(ctx, pod.Name, metav1.GetOptions{})")
 
 		ginkgo.By("Checking that the pod succeeded")
 		gomega.Expect(pod.Status.Phase).To(gomega.Equal(v1.PodSucceeded))
 
 		ginkgo.By("Getting logs from the pod")
 		log, err := e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Cont...")
 
 		ginkgo.By("Checking that the sysctl is actually updated")
 		// Note that either "/" or "."  may be used as separators within sysctl variable names.

--- a/test/e2e/common/storage/configmap_volume.go
+++ b/test/e2e/common/storage/configmap_volume.go
@@ -232,7 +232,7 @@ var _ = SIGDescribe("ConfigMap", func() {
 
 		ginkgo.By("Creating the pod")
 		e2epod.NewPodClient(f).Create(ctx, pod)
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name), "failed to e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespa...")
 
 		pollLogs1 := func() (string, error) {
 			return e2epod.GetPodLogs(ctx, f.ClientSet, f.Namespace.Name, pod.Name, pod.Spec.Containers[0].Name)

--- a/test/e2e/common/storage/empty_dir.go
+++ b/test/e2e/common/storage/empty_dir.go
@@ -289,7 +289,7 @@ var _ = SIGDescribe("EmptyDir volumes", func() {
 
 		ginkgo.By("Creating Pod")
 		e2epod.NewPodClient(f).Create(ctx, pod)
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name), "failed to e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespa...")
 
 		ginkgo.By("Reading file content from the nginx-container")
 		result := e2epod.ExecShellInContainer(f, pod.Name, busyBoxMainContainerName, fmt.Sprintf("cat %s", busyBoxMainVolumeFilePath))

--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -259,7 +259,7 @@ func (a asyncAssertion) WithPolling(interval time.Duration) AsyncAssertion {
 }
 
 // FailureError is an error where the error string is meant to be passed to
-// ginkgo.Fail directly, i.e. adding some prefix like "unexpected error" is not
+// ginkgo.Fail directly, i.e. adding some prefix like "failed to execute test operation" is not
 // necessary. It is also not necessary to dump the error struct.
 type FailureError struct {
 	msg            string

--- a/test/e2e/scheduling/limit_range.go
+++ b/test/e2e/scheduling/limit_range.go
@@ -105,7 +105,7 @@ var _ = SIGDescribe("LimitRange", func() {
 
 		ginkgo.By("Submitting a LimitRange")
 		limitRange, err = f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Create(ctx, limitRange, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Create(ctx, limitRange, me...")
 
 		ginkgo.By("Verifying LimitRange creation was observed")
 		select {
@@ -119,37 +119,37 @@ var _ = SIGDescribe("LimitRange", func() {
 
 		ginkgo.By("Fetching the LimitRange to ensure it has proper values")
 		limitRange, err = f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Get(ctx, limitRange.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Get(ctx, limitRange.Name, ...")
 		expected := v1.ResourceRequirements{Requests: defaultRequest, Limits: defaultLimit}
 		actual := v1.ResourceRequirements{Requests: limitRange.Spec.Limits[0].DefaultRequest, Limits: limitRange.Spec.Limits[0].Default}
 		err = equalResourceRequirement(expected, actual)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to equalResourceRequirement(expected, actual)")
 
 		ginkgo.By("Creating a Pod with no resource requirements")
 		pod := newTestPod("pod-no-resources", v1.ResourceList{}, v1.ResourceList{})
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring Pod has resource requirements applied from LimitRange")
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOpti...")
 		for i := range pod.Spec.Containers {
 			err = equalResourceRequirement(expected, pod.Spec.Containers[i].Resources)
 			if err != nil {
 				// Print the pod to help in debugging.
 				framework.Logf("Pod %+v does not have the expected requirements", pod)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to equalResourceRequirement(expected, pod.Spec.Containers[i].Resources)")
 			}
 		}
 
 		ginkgo.By("Creating a Pod with partial resource requirements")
 		pod = newTestPod("pod-partial-resources", getResourceList("", "150Mi", "150Gi"), getResourceList("300m", "", ""))
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring Pod has merged resource requirements applied from LimitRange")
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOpti...")
 		// This is an interesting case, so it's worth a comment
 		// If you specify a Limit, and no Request, the Limit will default to the Request
 		// This means that the LimitRange.DefaultRequest will ONLY take affect if a container.resources.limit is not supplied
@@ -159,7 +159,7 @@ var _ = SIGDescribe("LimitRange", func() {
 			if err != nil {
 				// Print the pod to help in debugging.
 				framework.Logf("Pod %+v does not have the expected requirements", pod)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to equalResourceRequirement(expected, pod.Spec.Containers[i].Resources)")
 			}
 		}
 
@@ -177,20 +177,20 @@ var _ = SIGDescribe("LimitRange", func() {
 		newMin := getResourceList("9m", "49Mi", "49Gi")
 		limitRange.Spec.Limits[0].Min = newMin
 		limitRange, err = f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Update(ctx, limitRange, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Update(ctx, limitRange, me...")
 
 		ginkgo.By("Verifying LimitRange updating is effective")
 		err = wait.PollUntilContextTimeout(ctx, time.Second*2, time.Second*20, false, func(ctx context.Context) (bool, error) {
 			limitRange, err = f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Get(ctx, limitRange.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Get(ctx, limitRange.Name, ...")
 			return reflect.DeepEqual(limitRange.Spec.Limits[0].Min, newMin), nil
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Get(ctx, limitRange.Name, ...")
 
 		ginkgo.By("Creating a Pod with less than former min resources")
 		pod = newTestPod(podName, getResourceList("10m", "50Mi", "50Gi"), v1.ResourceList{})
 		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Failing to create a Pod with more than max resources")
 		pod = newTestPod(podName, getResourceList("600m", "600Mi", "600Gi"), v1.ResourceList{})
@@ -199,7 +199,7 @@ var _ = SIGDescribe("LimitRange", func() {
 
 		ginkgo.By("Deleting a LimitRange")
 		err = f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Delete(ctx, limitRange.Name, *metav1.NewDeleteOptions(30))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).Delete(ctx, limitRange.Nam...")
 
 		ginkgo.By("Verifying the LimitRange was deleted")
 		err = wait.PollUntilContextTimeout(ctx, time.Second*5, e2eservice.RespondingTimeout, false, func(ctx context.Context) (bool, error) {
@@ -222,7 +222,7 @@ var _ = SIGDescribe("LimitRange", func() {
 
 			return false, nil
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().LimitRanges(f.Namespace.Name).List(c...")
 
 		ginkgo.By("Creating a Pod with more than former max resources")
 		pod = newTestPod(podName+"2", getResourceList("600m", "600Mi", "600Gi"), v1.ResourceList{})
@@ -240,7 +240,7 @@ var _ = SIGDescribe("LimitRange", func() {
 			_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
 			return err
 		}).WithPolling(5 * time.Second).WithTimeout(30 * time.Second).ShouldNot(gomega.HaveOccurred())
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 	})
 
 	/*

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -92,7 +92,7 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 		if err == nil && *(rc.Spec.Replicas) != 0 {
 			ginkgo.By("Cleaning up the replication controller")
 			err := e2erc.DeleteRCAndWaitForGC(ctx, f.ClientSet, ns, RCName)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2erc.DeleteRCAndWaitForGC(ctx, f.ClientSet, ns, RCName)")
 		}
 	})
 
@@ -114,7 +114,7 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 		}
 
 		err = framework.CheckTestingNSDeletedExcept(ctx, cs, ns)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to framework.CheckTestingNSDeletedExcept(ctx, cs, ns)")
 
 		for _, node := range nodeList.Items {
 			framework.Logf("\nLogging pods the apiserver thinks is on node %v before test", node.Name)
@@ -146,7 +146,7 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 		WaitForStableCluster(cs, workerNodes)
 
 		pods, err := cs.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})")
 		for _, pod := range pods.Items {
 			_, found := nodeToAllocatableMap[pod.Spec.NodeName]
 			if found && pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
@@ -183,7 +183,7 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 							v1.ResourceEphemeralStorage: *resource.NewQuantity(ephemeralStoragePerPod, "DecimalSI"),
 						},
 					},
-				}), true, framework.Logf))
+				}), true, framework.Logf), "failed to cs.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.Li...")
 		}
 		podName := "additional-pod"
 		conf := pausePodConfig{
@@ -292,7 +292,7 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 			})
 
 			// Wait for filler pod to schedule.
-			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, fillerPod))
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, fillerPod), "failed to e2epod.WaitForPodRunningInNamespace(ctx, cs, fillerPod)")
 
 			ginkgo.By("Creating another pod that requires unavailable amount of resources.")
 			// Create another pod that requires 20% of available beard-seconds, but utilizes the RuntimeClass
@@ -366,7 +366,7 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 		}()
 
 		pods, err := cs.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})")
 		for _, pod := range pods.Items {
 			_, found := nodeToAllocatableMap[pod.Spec.NodeName]
 			if found && pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
@@ -412,7 +412,7 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 		}
 		// Wait for filler pods to schedule.
 		for _, pod := range fillerPods {
-			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod))
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod), "failed to e2epod.WaitForPodRunningInNamespace(ctx, cs, pod)")
 		}
 		ginkgo.By("Creating another pod that requires unavailable amount of CPU.")
 		// Create another pod that requires 50% of the largest node CPU resources.
@@ -489,9 +489,9 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 		// kubelet and the scheduler: the scheduler might have scheduled a pod
 		// already when the kubelet does not know about its new label yet. The
 		// kubelet will then refuse to launch the pod.
-		framework.ExpectNoError(e2epod.WaitForPodNotPending(ctx, cs, ns, labelPodName))
+		framework.ExpectNoError(e2epod.WaitForPodNotPending(ctx, cs, ns, labelPodName), "failed to e2epod.WaitForPodNotPending(ctx, cs, ns, labelPodName)")
 		labelPod, err := cs.CoreV1().Pods(ns).Get(ctx, labelPodName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(ns).Get(ctx, labelPodName, metav1.GetOptions{})")
 		gomega.Expect(labelPod.Spec.NodeName).To(gomega.Equal(nodeName))
 	})
 
@@ -576,9 +576,9 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 		// kubelet and the scheduler: the scheduler might have scheduled a pod
 		// already when the kubelet does not know about its new label yet. The
 		// kubelet will then refuse to launch the pod.
-		framework.ExpectNoError(e2epod.WaitForPodNotPending(ctx, cs, ns, labelPodName))
+		framework.ExpectNoError(e2epod.WaitForPodNotPending(ctx, cs, ns, labelPodName), "failed to e2epod.WaitForPodNotPending(ctx, cs, ns, labelPodName)")
 		labelPod, err := cs.CoreV1().Pods(ns).Get(ctx, labelPodName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(ns).Get(ctx, labelPodName, metav1.GetOptions{})")
 		gomega.Expect(labelPod.Spec.NodeName).To(gomega.Equal(nodeName))
 	})
 
@@ -619,9 +619,9 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 		// kubelet and the scheduler: the scheduler might have scheduled a pod
 		// already when the kubelet does not know about its new taint yet. The
 		// kubelet will then refuse to launch the pod.
-		framework.ExpectNoError(e2epod.WaitForPodNotPending(ctx, cs, ns, tolerationPodName))
+		framework.ExpectNoError(e2epod.WaitForPodNotPending(ctx, cs, ns, tolerationPodName), "failed to e2epod.WaitForPodNotPending(ctx, cs, ns, tolerationPodName)")
 		deployedPod, err := cs.CoreV1().Pods(ns).Get(ctx, tolerationPodName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(ns).Get(ctx, tolerationPodName, metav1.GetOptions{})")
 		gomega.Expect(deployedPod.Spec.NodeName).To(gomega.Equal(nodeName))
 	})
 
@@ -792,7 +792,7 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 			}
 			runPauseRS(ctx, f, rsConfig)
 			podList, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})")
 			numInNode1, numInNode2 := 0, 0
 			for _, pod := range podList.Items {
 				if pod.Spec.NodeName == nodeNames[0] {
@@ -827,8 +827,8 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 
 		ginkgo.By("Expect all pods stay in pending state")
 		podList, err := e2epod.WaitForNumberOfPods(ctx, cs, ns, replicas, time.Minute)
-		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitForPodsSchedulingGated(ctx, cs, ns, replicas, time.Minute))
+		framework.ExpectNoError(err, "failed to e2epod.WaitForNumberOfPods(ctx, cs, ns, replicas, time.Minute)")
+		framework.ExpectNoError(e2epod.WaitForPodsSchedulingGated(ctx, cs, ns, replicas, time.Minute), "failed to e2epod.WaitForNumberOfPods(ctx, cs, ns, replicas, time.Minute)")
 
 		ginkgo.By("Remove one scheduling gate")
 		want := []v1.PodSchedulingGate{{Name: "bar"}}
@@ -837,24 +837,24 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 			clone := pod.DeepCopy()
 			clone.Spec.SchedulingGates = want
 			live, err := patchPod(cs, &pod, clone)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to patchPod(cs, &pod, clone)")
 			pods = append(pods, live)
 		}
 
 		ginkgo.By("Expect all pods carry one scheduling gate and are still in pending state")
-		framework.ExpectNoError(e2epod.WaitForPodsWithSchedulingGates(ctx, cs, ns, replicas, time.Minute, want))
-		framework.ExpectNoError(e2epod.WaitForPodsSchedulingGated(ctx, cs, ns, replicas, time.Minute))
+		framework.ExpectNoError(e2epod.WaitForPodsWithSchedulingGates(ctx, cs, ns, replicas, time.Minute, want), "failed to e2epod.WaitForPodsWithSchedulingGates(ctx, cs, ns, replicas, time.Minute, want)")
+		framework.ExpectNoError(e2epod.WaitForPodsSchedulingGated(ctx, cs, ns, replicas, time.Minute), "failed to e2epod.WaitForPodsSchedulingGated(ctx, cs, ns, replicas, time.Minute)")
 
 		ginkgo.By("Remove the remaining scheduling gates")
 		for _, pod := range pods {
 			clone := pod.DeepCopy()
 			clone.Spec.SchedulingGates = nil
 			_, err := patchPod(cs, pod, clone)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to patchPod(cs, pod, clone)")
 		}
 
 		ginkgo.By("Expect all pods are scheduled and running")
-		framework.ExpectNoError(e2epod.WaitForPodsRunning(ctx, cs, ns, replicas, time.Minute))
+		framework.ExpectNoError(e2epod.WaitForPodsRunning(ctx, cs, ns, replicas, time.Minute), "failed to e2epod.WaitForPodsRunning(ctx, cs, ns, replicas, time.Minute)")
 	})
 
 	// Regression test for an extended scenario for https://issues.k8s.io/123465
@@ -894,7 +894,7 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 		}, e2epv.PersistentVolumeClaimConfig{
 			Name: pvcName,
 		}, ns, true)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epv.CreatePVPVC(ctx, cs, f.Timeouts, e2epv.PersistentVo...")
 		bindPvPod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: podName,
@@ -925,8 +925,8 @@ var _ = SIGDescribe("SchedulerPredicates", framework.WithSerial(), func() {
 			},
 		}
 		_, err = f.ClientSet.CoreV1().Pods(ns).Create(ctx, bindPvPod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitForPodNotPending(ctx, f.ClientSet, ns, podName))
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(ns).Create(ctx, bindPvPod, metav1.CreateOptions{})")
+		framework.ExpectNoError(e2epod.WaitForPodNotPending(ctx, f.ClientSet, ns, podName), "failed to f.ClientSet.CoreV1().Pods(ns).Create(ctx, bindPvPod, metav1.CreateOptions{})")
 	})
 })
 
@@ -1032,15 +1032,15 @@ func createPausePod(ctx context.Context, f *framework.Framework, conf pausePodCo
 		namespace = f.Namespace.Name
 	}
 	pod, err := f.ClientSet.CoreV1().Pods(namespace).Create(ctx, initPausePod(f, conf), metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(namespace).Create(ctx, initPausePod(f, conf), metav...")
 	return pod
 }
 
 func runPausePod(ctx context.Context, f *framework.Framework, conf pausePodConfig) *v1.Pod {
 	pod := createPausePod(ctx, f, conf)
-	framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodStartShort))
+	framework.ExpectNoError(e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, pod.Name, pod.Namespace, f.Timeouts.PodStartShort), "failed to e2epod.WaitTimeoutForPodRunningInNamespace(ctx, f.ClientSet, pod.Name, pod.Na...")
 	pod, err := f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, conf.Name, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(pod.Namespace).Get(ctx, conf.Name, metav1.GetOption...")
 	return pod
 }
 
@@ -1053,7 +1053,7 @@ func runPodAndGetNodeName(ctx context.Context, f *framework.Framework, conf paus
 
 	ginkgo.By("Explicitly delete pod here to free the resource it takes.")
 	err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 
 	return pod.Spec.NodeName
 }
@@ -1099,7 +1099,7 @@ func WaitForSchedulerAfterAction(ctx context.Context, f *framework.Framework, ac
 		predicate = scheduleSuccessEvent(ns, podName, "" /* any node */)
 	}
 	observed, err := observeEventAfterAction(ctx, f.ClientSet, f.Namespace.Name, predicate, action)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to observeEventAfterAction(ctx, f.ClientSet, f.Namespace.Name, predicate, action)")
 	if expectSuccess && !observed {
 		framework.Failf("Did not observe success event after performing the supplied action for pod %v", podName)
 	}
@@ -1111,7 +1111,7 @@ func WaitForSchedulerAfterAction(ctx context.Context, f *framework.Framework, ac
 // TODO: upgrade calls in PodAffinity tests when we're able to run them
 func verifyResult(ctx context.Context, c clientset.Interface, expectedScheduled int, expectedNotScheduled int, ns string) {
 	allPods, err := c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})")
 	scheduledPods, notScheduledPods := GetPodsScheduled(workerNodes, allPods)
 
 	gomega.Expect(notScheduledPods).To(gomega.HaveLen(expectedNotScheduled), fmt.Sprintf("Not scheduled Pods: %#v", notScheduledPods))
@@ -1167,7 +1167,7 @@ func CreateHostPortPods(ctx context.Context, f *framework.Framework, id string, 
 	}
 	err := e2erc.RunRC(ctx, *config)
 	if expectRunning {
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2erc.RunRC(ctx, *config)")
 	}
 }
 
@@ -1230,11 +1230,11 @@ func createHostPortPodOnNode(ctx context.Context, f *framework.Framework, podNam
 		},
 	}
 	_, err := f.ClientSet.CoreV1().Pods(ns).Create(ctx, hostPortPod, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(ns).Create(ctx, hostPortPod, metav1.CreateOptions{})")
 
 	err = e2epod.WaitForPodNotPending(ctx, f.ClientSet, ns, podName)
 	if expectScheduled {
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodNotPending(ctx, f.ClientSet, ns, podName)")
 	}
 }
 
@@ -1265,7 +1265,7 @@ func getNodeHostIP(ctx context.Context, f *framework.Framework, nodeName string)
 		family = v1.IPv6Protocol
 	}
 	node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})")
 	ips := e2enode.GetAddressesByTypeAndFamily(node, v1.NodeInternalIP, family)
 	if len(ips) == 0 {
 		ips = e2enode.GetAddressesByTypeAndFamily(node, v1.NodeExternalIP, family)

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -115,7 +115,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 		}
 
 		err = framework.CheckTestingNSDeletedExcept(ctx, cs, ns)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to framework.CheckTestingNSDeletedExcept(ctx, cs, ns)")
 	})
 
 	/*
@@ -178,7 +178,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 		}
 		ginkgo.By("Wait for pods to be scheduled.")
 		for _, pod := range pods {
-			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod))
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod), "failed to e2epod.WaitForPodRunningInNamespace(ctx, cs, pod)")
 		}
 
 		// Set the pod request to the first pod's resources (should be low priority pod)
@@ -203,7 +203,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 		}
 		for i := 1; i < len(pods); i++ {
 			livePod, err := cs.CoreV1().Pods(pods[i].Namespace).Get(ctx, pods[i].Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(pods[i].Namespace).Get(ctx, pods[i].Name, metav1.GetOptions{})")
 			gomega.Expect(livePod.DeletionTimestamp).To(gomega.BeNil())
 		}
 	})
@@ -265,7 +265,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 		}
 		ginkgo.By("Wait for pods to be scheduled.")
 		for _, pod := range pods {
-			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod))
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod), "failed to e2epod.WaitForPodRunningInNamespace(ctx, cs, pod)")
 		}
 
 		// We want this pod to be preempted
@@ -293,7 +293,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 		defer func() {
 			// Clean-up the critical pod
 			err := f.ClientSet.CoreV1().Pods(metav1.NamespaceSystem).Delete(ctx, "critical-pod", *metav1.NewDeleteOptions(0))
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(metav1.NamespaceSystem).Delete(ctx, 'critical-pod',...")
 		}()
 		// Make sure that the lowest priority pod is deleted.
 		preemptedPod, err := cs.CoreV1().Pods(pods[0].Namespace).Get(ctx, pods[0].Name, metav1.GetOptions{})
@@ -301,7 +301,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 			(err == nil && preemptedPod.DeletionTimestamp != nil)
 		for i := 1; i < len(pods); i++ {
 			livePod, err := cs.CoreV1().Pods(pods[i].Namespace).Get(ctx, pods[i].Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(pods[i].Namespace).Get(ctx, pods[i].Name, metav1.GetOptions{})")
 			gomega.Expect(livePod.DeletionTimestamp).To(gomega.BeNil())
 		}
 
@@ -369,7 +369,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 
 		ginkgo.By("Wait for lower priority pods to be scheduled.")
 		for _, pod := range lowPriorityPods {
-			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod))
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod), "failed to e2epod.WaitForPodRunningInNamespace(ctx, cs, pod)")
 		}
 
 		highPriorityPods := make([]*v1.Pod, 0, 5*nodeListLen)
@@ -405,7 +405,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 					return false, err
 				}
 				return preemptedPod.DeletionTimestamp != nil, nil
-			}))
+			}), "failed to cs.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1...")
 		}
 
 		ginkgo.By("Run high priority pods that have same requirements as that of lower priority pod")
@@ -433,7 +433,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 					return false, err
 				}
 				return highPod.Status.NominatedNodeName != "", nil
-			}))
+			}), "failed to cs.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1...")
 		}
 
 		ginkgo.By("Delete all low priority pods to proceed the preemption faster.")
@@ -446,7 +446,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 
 		ginkgo.By("Wait for high priority pods to be scheduled.")
 		for _, pod := range highPriorityPods {
-			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod))
+			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, pod), "failed to e2epod.WaitForPodRunningInNamespace(ctx, cs, pod)")
 		}
 
 		ginkgo.By(fmt.Sprintf("Wait for %v medium priority pods to be scheduled.", 5*nodeListLen))
@@ -467,7 +467,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 			}
 
 			return scheduled == 5*nodeListLen, nil
-		}))
+		}), "failed to cs.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1...")
 	})
 
 	/*
@@ -516,7 +516,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 		framework.Logf("Created pod: %v", victimPod.Name)
 
 		ginkgo.By("Wait for the victim pod to be scheduled")
-		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, victimPod))
+		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, cs, victimPod), "failed to e2epod.WaitForPodRunningInNamespace(ctx, cs, victimPod)")
 
 		// Remove the finalizer so that the victim pod can be GCed
 		defer e2epod.NewPodClient(f).RemoveFinalizer(ctx, victimPod.Name, testFinalizer)
@@ -535,7 +535,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 
 		ginkgo.By("Waiting for the victim pod to be terminating")
 		err := e2epod.WaitForPodTerminatingInNamespaceTimeout(ctx, f.ClientSet, victimPod.Name, victimPod.Namespace, framework.PodDeleteTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodTerminatingInNamespaceTimeout(ctx, f.ClientSet, victimPod.Na...")
 
 		ginkgo.By("Verifying the pod has the pod disruption condition")
 		e2epod.VerifyPodHasConditionWithType(ctx, f, victimPod, v1.DisruptionTarget)
@@ -558,7 +558,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 				e2enode.AddOrUpdateLabelOnNode(cs, nodeName, topologyKey, nodeName)
 
 				node, err := cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})")
 				// update Node API object with a fake resource
 				ginkgo.By(fmt.Sprintf("Apply 10 fake resource to node %v.", node.Name))
 				e2enode.AddExtendedResource(ctx, cs, node.Name, fakeRes, resource.MustParse("10"))
@@ -662,7 +662,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 			// Wait until the number of pods stabilizes. Note that `medium` pod can get scheduled once the
 			// second low priority pod is marked as terminating.
 			pods, err := e2epod.WaitForNumberOfPods(ctx, cs, ns, 3, framework.PollShortTimeout)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2epod.WaitForNumberOfPods(ctx, cs, ns, 3, framework.PollShortTimeout)")
 
 			for _, pod := range pods.Items {
 				// Remove the ordinal index for low pod.
@@ -950,7 +950,7 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 
 			// Collection deletion on created PriorityClasses.
 			err := cs.SchedulingV1().PriorityClasses().DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: fmt.Sprintf("e2e=%v", testUUID)})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to cs.SchedulingV1().PriorityClasses().DeleteCollection(ctx, metav1.DeleteOption...")
 		})
 
 		/*
@@ -979,21 +979,21 @@ var _ = SIGDescribe("SchedulerPreemption", framework.WithSerial(), func() {
 			pcCopy = pcs[0].DeepCopy()
 			pcCopy.Description = newDesc
 			err = patchPriorityClass(ctx, cs, pcs[0], pcCopy)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to patchPriorityClass(ctx, cs, pcs[0], pcCopy)")
 
 			pcCopy = pcs[1].DeepCopy()
 			pcCopy.Description = newDesc
 			_, err = cs.SchedulingV1().PriorityClasses().Update(ctx, pcCopy, metav1.UpdateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to cs.SchedulingV1().PriorityClasses().Update(ctx, pcCopy, metav1.UpdateOptions{})")
 
 			// 3. List existing PriorityClasses.
 			_, err = cs.SchedulingV1().PriorityClasses().List(ctx, metav1.ListOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to cs.SchedulingV1().PriorityClasses().List(ctx, metav1.ListOptions{})")
 
 			// 4. Verify fields of updated PriorityClasses.
 			for _, pc := range pcs {
 				livePC, err := cs.SchedulingV1().PriorityClasses().Get(ctx, pc.Name, metav1.GetOptions{})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to cs.SchedulingV1().PriorityClasses().Get(ctx, pc.Name, metav1.GetOptions{})")
 				gomega.Expect(livePC.Value).To(gomega.Equal(pc.Value))
 				gomega.Expect(livePC.Description).To(gomega.Equal(newDesc))
 				gomega.Expect(livePC).To(apimachineryutils.HaveValidResourceVersion())
@@ -1035,13 +1035,13 @@ func createPauseRS(ctx context.Context, f *framework.Framework, conf pauseRSConf
 		namespace = f.Namespace.Name
 	}
 	rs, err := f.ClientSet.AppsV1().ReplicaSets(namespace).Create(ctx, initPauseRS(f, conf), metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.AppsV1().ReplicaSets(namespace).Create(ctx, initPauseRS(f, conf),...")
 	return rs
 }
 
 func runPauseRS(ctx context.Context, f *framework.Framework, conf pauseRSConfig) *appsv1.ReplicaSet {
 	rs := createPauseRS(ctx, f, conf)
-	framework.ExpectNoError(e2ereplicaset.WaitForReplicaSetTargetAvailableReplicasWithTimeout(ctx, f.ClientSet, rs, conf.Replicas, framework.PodGetTimeout))
+	framework.ExpectNoError(e2ereplicaset.WaitForReplicaSetTargetAvailableReplicasWithTimeout(ctx, f.ClientSet, rs, conf.Replicas, framework.PodGetTimeout), "failed to e2ereplicaset.WaitForReplicaSetTargetAvailableReplicasWithTimeout(ctx, f.Clie...")
 	return rs
 }
 
@@ -1051,7 +1051,7 @@ func createPod(ctx context.Context, f *framework.Framework, conf pausePodConfig)
 		namespace = f.Namespace.Name
 	}
 	pod, err := f.ClientSet.CoreV1().Pods(namespace).Create(ctx, initPausePod(f, conf), metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(namespace).Create(ctx, initPausePod(f, conf), metav...")
 	return pod
 }
 

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -105,9 +105,9 @@ var _ = SIGDescribe("SchedulerPriorities", framework.WithSerial(), func() {
 		framework.ExpectNoErrorWithOffset(0, err)
 
 		err = framework.CheckTestingNSDeletedExcept(ctx, cs, ns)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to framework.CheckTestingNSDeletedExcept(ctx, cs, ns)")
 		err = e2epod.WaitForPodsRunningReady(ctx, cs, metav1.NamespaceSystem, systemPodsNo, framework.PodReadyBeforeTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodsRunningReady(ctx, cs, metav1.NamespaceSystem, systemPodsNo,...")
 
 		// skip if the most utilized node has less than the cri-o minMemLimit available
 		// otherwise we will not be able to run the test pod once all nodes are balanced
@@ -130,7 +130,7 @@ var _ = SIGDescribe("SchedulerPriorities", framework.WithSerial(), func() {
 		k := v1.LabelHostname
 		ginkgo.By("Verifying the node has a label " + k)
 		node, err := cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})")
 		if _, hasLabel := node.Labels[k]; !hasLabel {
 			// If the label is not exists, label all nodes for testing.
 
@@ -154,7 +154,7 @@ var _ = SIGDescribe("SchedulerPriorities", framework.WithSerial(), func() {
 
 		// make the nodes have balanced cpu,mem usage
 		err = createBalancedPodForNodes(ctx, f, cs, ns, nodeList.Items, podRequestedResource, 0.6)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createBalancedPodForNodes(ctx, f, cs, ns, nodeList.Items, podRequestedResourc...")
 		ginkgo.By("Trying to launch the pod with podAntiAffinity.")
 		labelPodName := "pod-with-pod-antiaffinity"
 		pod = createPausePod(ctx, f, pausePodConfig{
@@ -192,9 +192,9 @@ var _ = SIGDescribe("SchedulerPriorities", framework.WithSerial(), func() {
 			},
 		})
 		ginkgo.By("Wait the pod becomes running")
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name), "failed to e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespa...")
 		labelPod, err := cs.CoreV1().Pods(ns).Get(ctx, labelPodName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(ns).Get(ctx, labelPodName, metav1.GetOptions{})")
 		ginkgo.By("Verify the pod was scheduled to the expected node.")
 		gomega.Expect(labelPod.Spec.NodeName).ToNot(gomega.Equal(nodeName))
 	})
@@ -202,7 +202,7 @@ var _ = SIGDescribe("SchedulerPriorities", framework.WithSerial(), func() {
 	ginkgo.It("Pod should be preferably scheduled to nodes pod can tolerate", func(ctx context.Context) {
 		// make the nodes have balanced cpu,mem usage ratio
 		err := createBalancedPodForNodes(ctx, f, cs, ns, nodeList.Items, podRequestedResource, 0.5)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createBalancedPodForNodes(ctx, f, cs, ns, nodeList.Items, podRequestedResourc...")
 		// Apply 10 taints to first node
 		nodeName := nodeList.Items[0].Name
 
@@ -249,11 +249,11 @@ var _ = SIGDescribe("SchedulerPriorities", framework.WithSerial(), func() {
 			Name:        tolerationPodName,
 			Tolerations: tolerations,
 		})
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name), "failed to e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespa...")
 
 		ginkgo.By("Pod should prefer scheduled to the node that pod can tolerate.")
 		tolePod, err := cs.CoreV1().Pods(ns).Get(ctx, tolerationPodName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cs.CoreV1().Pods(ns).Get(ctx, tolerationPodName, metav1.GetOptions{})")
 		gomega.Expect(tolePod.Spec.NodeName).To(gomega.Equal(nodeName))
 	})
 
@@ -282,13 +282,13 @@ var _ = SIGDescribe("SchedulerPriorities", framework.WithSerial(), func() {
 			var nodes []v1.Node
 			for _, nodeName := range nodeNames {
 				node, err := cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to cs.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})")
 				nodes = append(nodes, *node)
 			}
 
 			// Make the nodes have balanced cpu,mem usage.
 			err := createBalancedPodForNodes(ctx, f, cs, ns, nodes, podRequestedResource, 0.5)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to createBalancedPodForNodes(ctx, f, cs, ns, nodes, podRequestedResource, 0.5)")
 
 			replicas := 4
 			podLabel := "e2e-pts-score"

--- a/test/e2e/scheduling/ubernetes_lite.go
+++ b/test/e2e/scheduling/ubernetes_lite.go
@@ -53,7 +53,7 @@ var _ = SIGDescribe("Multi-AZ Clusters", func() {
 
 		if zoneCount <= 0 {
 			zoneNames, err = e2enode.GetSchedulableClusterZones(ctx, cs)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2enode.GetSchedulableClusterZones(ctx, cs)")
 			zoneCount = len(zoneNames)
 		}
 		ginkgo.By(fmt.Sprintf("Checking for multi-zone cluster. Schedulable zone count = %d", zoneCount))
@@ -63,11 +63,11 @@ var _ = SIGDescribe("Multi-AZ Clusters", func() {
 
 		e2enode.WaitForTotalHealthy(ctx, cs, time.Minute)
 		nodeList, err := e2enode.GetReadySchedulableNodes(ctx, cs)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetReadySchedulableNodes(ctx, cs)")
 
 		// make the nodes have balanced cpu,mem usage
 		err = createBalancedPodForNodes(ctx, f, cs, f.Namespace.Name, nodeList.Items, podRequestedResource, 0.0)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createBalancedPodForNodes(ctx, f, cs, f.Namespace.Name, nodeList.Items, podRe...")
 	})
 	f.It("should spread the pods of a service across zones", f.WithSerial(), func(ctx context.Context) {
 		SpreadServiceOrFail(ctx, f, 5*zoneCount, zoneNames, imageutils.GetPauseImageName())
@@ -99,7 +99,7 @@ func SpreadServiceOrFail(ctx context.Context, f *framework.Framework, replicaCou
 		},
 	}
 	_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, serviceSpec, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, serviceSpec, meta...")
 
 	// Now create some pods behind the service
 	podSpec := &v1.Pod{
@@ -121,12 +121,12 @@ func SpreadServiceOrFail(ctx context.Context, f *framework.Framework, replicaCou
 	// Based on the callers, replicas is always positive number: zoneCount >= 0 implies (2*zoneCount)+1 > 0.
 	// Thus, no need to test for it. Once the precondition changes to zero number of replicas,
 	// test for replicaCount > 0. Otherwise, StartPods panics.
-	framework.ExpectNoError(testutils.StartPods(f.ClientSet, replicaCount, f.Namespace.Name, serviceName, *podSpec, false, framework.Logf))
+	framework.ExpectNoError(testutils.StartPods(f.ClientSet, replicaCount, f.Namespace.Name, serviceName, *podSpec, false, framework.Logf), "failed to testutils.StartPods(f.ClientSet, replicaCount, f.Namespace.Name, serviceName,...")
 
 	// Wait for all of them to be scheduled
 	selector := labels.SelectorFromSet(labels.Set(map[string]string{"service": serviceName}))
 	pods, err := e2epod.WaitForPodsWithLabelScheduled(ctx, f.ClientSet, f.Namespace.Name, selector)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2epod.WaitForPodsWithLabelScheduled(ctx, f.ClientSet, f.Namespace.Name, sele...")
 
 	// Now make sure they're spread across zones
 	checkZoneSpreading(ctx, f.ClientSet, pods, sets.List(zoneNames))
@@ -147,7 +147,7 @@ func getZoneNameForNode(node v1.Node) (string, error) {
 func getZoneNameForPod(ctx context.Context, c clientset.Interface, pod v1.Pod) (string, error) {
 	ginkgo.By(fmt.Sprintf("Getting zone name for pod %s, on node %s", pod.Name, pod.Spec.NodeName))
 	node, err := c.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})")
 	return getZoneNameForNode(*node)
 }
 
@@ -163,7 +163,7 @@ func checkZoneSpreading(ctx context.Context, c clientset.Interface, pods *v1.Pod
 			continue
 		}
 		zoneName, err := getZoneNameForPod(ctx, c, pod)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to getZoneNameForPod(ctx, c, pod)")
 		podsPerZone[zoneName] = podsPerZone[zoneName] + 1
 	}
 	minPodsPerZone := math.MaxInt32
@@ -213,7 +213,7 @@ func SpreadRCOrFail(ctx context.Context, f *framework.Framework, replicaCount in
 			},
 		},
 	}, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.N...")
 	// Cleanup the replication controller when we are done.
 	defer func() {
 		// Resize the replication controller to zero to get rid of pods.
@@ -224,12 +224,12 @@ func SpreadRCOrFail(ctx context.Context, f *framework.Framework, replicaCount in
 	// List the pods, making sure we observe all the replicas.
 	selector := labels.SelectorFromSet(rcLabels)
 	_, err = e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, name, replicaCount, selector)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2epod.PodsCreatedByLabel(ctx, f.ClientSet, f.Namespace.Name, name, replicaCo...")
 
 	// Wait for all of them to be scheduled
 	ginkgo.By(fmt.Sprintf("Waiting for %d replicas of %s to be scheduled.  Selector: %v", replicaCount, name, selector))
 	pods, err := e2epod.WaitForPodsWithLabelScheduled(ctx, f.ClientSet, f.Namespace.Name, selector)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2epod.WaitForPodsWithLabelScheduled(ctx, f.ClientSet, f.Namespace.Name, sele...")
 
 	// Now make sure they're spread across zones
 	checkZoneSpreading(ctx, f.ClientSet, pods, sets.List(zoneNames))

--- a/test/e2e/upgrades/apps/cassandra.go
+++ b/test/e2e/upgrades/apps/cassandra.go
@@ -104,19 +104,19 @@ func (t *CassandraUpgradeTest) Setup(ctx context.Context, f *framework.Framework
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.listUsers(); err != nil {")
 	framework.Logf("Service endpoint is up")
 
 	ginkgo.By("Adding 2 dummy users")
 	err = t.addUser("Alice")
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.addUser('Alice')")
 	err = t.addUser("Bob")
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.addUser('Bob')")
 	t.successfulWrites = 2
 
 	ginkgo.By("Verifying that the users exist")
 	users, err := t.listUsers()
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.listUsers()")
 	gomega.Expect(users).To(gomega.HaveLen(2))
 }
 
@@ -163,7 +163,7 @@ func (t *CassandraUpgradeTest) addUser(name string) error {
 // getServiceIP is a helper method to extract the Ingress IP from the service.
 func (t *CassandraUpgradeTest) getServiceIP(ctx context.Context, f *framework.Framework, ns, svcName string) string {
 	svc, err := f.ClientSet.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})")
 	ingress := svc.Status.LoadBalancer.Ingress
 	if len(ingress) == 0 {
 		return ""
@@ -223,6 +223,6 @@ func (t *CassandraUpgradeTest) Test(ctx context.Context, f *framework.Framework,
 // Teardown does one final check of the data's availability.
 func (t *CassandraUpgradeTest) Teardown(ctx context.Context, f *framework.Framework) {
 	users, err := t.listUsers()
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.listUsers()")
 	gomega.Expect(len(users)).To(gomega.BeNumerically(">=", t.successfulWrites), "len(users) is too small")
 }

--- a/test/e2e/upgrades/apps/daemonsets.go
+++ b/test/e2e/upgrades/apps/daemonsets.go
@@ -63,7 +63,7 @@ func (t *DaemonSetUpgradeTest) Setup(ctx context.Context, f *framework.Framework
 	err = wait.PollUntilContextTimeout(ctx, framework.Poll, framework.PodStartTimeout, false, func(ctx context.Context) (bool, error) {
 		return e2edaemonset.CheckRunningOnAllNodes(ctx, f, t.daemonSet)
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to wait.PollUntilContextTimeout(ctx, framework.Poll, framework.PodStartTimeout, ...")
 
 	ginkgo.By("Validating the DaemonSet after creation")
 	t.validateRunningDaemonSet(ctx, f)
@@ -87,7 +87,7 @@ func (t *DaemonSetUpgradeTest) Teardown(ctx context.Context, f *framework.Framew
 func (t *DaemonSetUpgradeTest) validateRunningDaemonSet(ctx context.Context, f *framework.Framework) {
 	ginkgo.By("confirming the DaemonSet pods are running on all expected nodes")
 	res, err := e2edaemonset.CheckRunningOnAllNodes(ctx, f, t.daemonSet)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edaemonset.CheckRunningOnAllNodes(ctx, f, t.daemonSet)")
 	if !res {
 		framework.Failf("expected DaemonSet pod to be running on all nodes, it was not")
 	}
@@ -96,6 +96,6 @@ func (t *DaemonSetUpgradeTest) validateRunningDaemonSet(ctx context.Context, f *
 	ginkgo.By("confirming the DaemonSet resource is in a good state")
 
 	err = e2edaemonset.CheckDaemonStatus(ctx, f, t.daemonSet.Name)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edaemonset.CheckDaemonStatus(ctx, f, t.daemonSet.Name)")
 
 }

--- a/test/e2e/upgrades/apps/deployments.go
+++ b/test/e2e/upgrades/apps/deployments.go
@@ -70,36 +70,36 @@ func (t *DeploymentUpgradeTest) Setup(ctx context.Context, f *framework.Framewor
 	ginkgo.By(fmt.Sprintf("Creating a deployment %q with 1 replica in namespace %q", deploymentName, ns))
 	d := e2edeployment.NewDeployment(deploymentName, int32(1), map[string]string{"test": "upgrade"}, "nginx", nginxImage, appsv1.RollingUpdateDeploymentStrategyType)
 	deployment, err := deploymentClient.Create(ctx, d, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to deploymentClient.Create(ctx, d, metav1.CreateOptions{})")
 
 	ginkgo.By(fmt.Sprintf("Waiting deployment %q to complete", deploymentName))
-	framework.ExpectNoError(e2edeployment.WaitForDeploymentComplete(c, deployment))
+	framework.ExpectNoError(e2edeployment.WaitForDeploymentComplete(c, deployment), "failed to e2edeployment.WaitForDeploymentComplete(c, deployment)")
 
 	ginkgo.By(fmt.Sprintf("Getting replicaset revision 1 of deployment %q", deploymentName))
 	rsSelector, err := metav1.LabelSelectorAsSelector(d.Spec.Selector)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to metav1.LabelSelectorAsSelector(d.Spec.Selector)")
 	rsList, err := rsClient.List(ctx, metav1.ListOptions{LabelSelector: rsSelector.String()})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to rsClient.List(ctx, metav1.ListOptions{LabelSelector: rsSelector.String()})")
 	rss := rsList.Items
 	gomega.Expect(rss).To(gomega.HaveLen(1), "expected one replicaset, got %d", len(rss))
 	t.oldRSUID = rss[0].UID
 
 	ginkgo.By(fmt.Sprintf("Waiting for revision of the deployment %q to become 1", deploymentName))
-	framework.ExpectNoError(waitForDeploymentRevision(ctx, c, deployment, "1"))
+	framework.ExpectNoError(waitForDeploymentRevision(ctx, c, deployment, "1"), "failed to waitForDeploymentRevision(ctx, c, deployment, '1')")
 
 	// Trigger a new rollout so that we have some history.
 	ginkgo.By(fmt.Sprintf("Triggering a new rollout for deployment %q", deploymentName))
 	deployment, err = e2edeployment.UpdateDeploymentWithRetries(c, ns, deploymentName, func(update *appsv1.Deployment) {
 		update.Spec.Template.Spec.Containers[0].Name = "updated-name"
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, deploymentName, func(update ...")
 
 	ginkgo.By(fmt.Sprintf("Waiting deployment %q to complete", deploymentName))
-	framework.ExpectNoError(e2edeployment.WaitForDeploymentComplete(c, deployment))
+	framework.ExpectNoError(e2edeployment.WaitForDeploymentComplete(c, deployment), "failed to e2edeployment.WaitForDeploymentComplete(c, deployment)")
 
 	ginkgo.By(fmt.Sprintf("Getting replicasets revision 1 and 2 of deployment %q", deploymentName))
 	rsList, err = rsClient.List(ctx, metav1.ListOptions{LabelSelector: rsSelector.String()})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to rsClient.List(ctx, metav1.ListOptions{LabelSelector: rsSelector.String()})")
 	rss = rsList.Items
 	gomega.Expect(rss).To(gomega.HaveLen(2), "expected 2 replicaset, got %d", len(rss))
 
@@ -110,11 +110,11 @@ func (t *DeploymentUpgradeTest) Setup(ctx context.Context, f *framework.Framewor
 	case rss[1].UID:
 		t.newRSUID = rss[0].UID
 	default:
-		framework.ExpectNoError(fmt.Errorf("old replicaset with UID %q does not survive rollout", t.oldRSUID))
+		framework.ExpectNoError(fmt.Errorf("old replicaset with UID %q does not survive rollout", t.oldRSUID), "failed to fmt.Errorf('old replicaset with UID %q does not survive rollout', t.oldRSUID)")
 	}
 
 	ginkgo.By(fmt.Sprintf("Waiting for revision of the deployment %q to become 2", deploymentName))
-	framework.ExpectNoError(waitForDeploymentRevision(ctx, c, deployment, "2"))
+	framework.ExpectNoError(waitForDeploymentRevision(ctx, c, deployment, "2"), "failed to waitForDeploymentRevision(ctx, c, deployment, '2')")
 
 	t.oldDeploymentUID = deployment.UID
 }
@@ -131,16 +131,16 @@ func (t *DeploymentUpgradeTest) Test(ctx context.Context, f *framework.Framework
 	rsClient := c.AppsV1().ReplicaSets(ns)
 
 	deployment, err := deploymentClient.Get(ctx, deploymentName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to deploymentClient.Get(ctx, deploymentName, metav1.GetOptions{})")
 
 	ginkgo.By(fmt.Sprintf("Checking UID to verify deployment %q survives upgrade", deploymentName))
 	gomega.Expect(deployment.UID).To(gomega.Equal(t.oldDeploymentUID))
 
 	ginkgo.By(fmt.Sprintf("Verifying deployment %q does not create new replicasets", deploymentName))
 	rsSelector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to metav1.LabelSelectorAsSelector(deployment.Spec.Selector)")
 	rsList, err := rsClient.List(ctx, metav1.ListOptions{LabelSelector: rsSelector.String()})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to rsClient.List(ctx, metav1.ListOptions{LabelSelector: rsSelector.String()})")
 	rss := rsList.Items
 	gomega.Expect(rss).To(gomega.HaveLen(2), "expected 2 replicaset, got %d", len(rss))
 
@@ -150,24 +150,24 @@ func (t *DeploymentUpgradeTest) Test(ctx context.Context, f *framework.Framework
 	case rss[1].UID:
 		gomega.Expect(rss[0].UID).To(gomega.Equal(t.newRSUID))
 	default:
-		framework.ExpectNoError(fmt.Errorf("new replicasets are created during upgrade of deployment %q", deploymentName))
+		framework.ExpectNoError(fmt.Errorf("new replicasets are created during upgrade of deployment %q", deploymentName), "failed to fmt.Errorf('new replicasets are created during upgrade of deployment %q', dep...")
 	}
 
 	ginkgo.By(fmt.Sprintf("Verifying revision of the deployment %q is still 2", deploymentName))
 	gomega.Expect(deployment.Annotations).To(gomega.HaveKeyWithValue(deploymentutil.RevisionAnnotation, "2"))
 
 	ginkgo.By(fmt.Sprintf("Waiting for deployment %q to complete adoption", deploymentName))
-	framework.ExpectNoError(e2edeployment.WaitForDeploymentComplete(c, deployment))
+	framework.ExpectNoError(e2edeployment.WaitForDeploymentComplete(c, deployment), "failed to e2edeployment.WaitForDeploymentComplete(c, deployment)")
 
 	// Verify the upgraded deployment is active by scaling up the deployment by 1
 	ginkgo.By(fmt.Sprintf("Scaling up replicaset of deployment %q by 1", deploymentName))
 	deploymentWithUpdatedReplicas, err := e2edeployment.UpdateDeploymentWithRetries(c, ns, deploymentName, func(deployment *appsv1.Deployment) {
 		*deployment.Spec.Replicas = *deployment.Spec.Replicas + 1
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(c, ns, deploymentName, func(deploym...")
 
 	ginkgo.By(fmt.Sprintf("Waiting for deployment %q to complete after scaling", deploymentName))
-	framework.ExpectNoError(e2edeployment.WaitForDeploymentComplete(c, deploymentWithUpdatedReplicas))
+	framework.ExpectNoError(e2edeployment.WaitForDeploymentComplete(c, deploymentWithUpdatedReplicas), "failed to e2edeployment.WaitForDeploymentComplete(c, deploymentWithUpdatedReplicas)")
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/e2e/upgrades/apps/etcd.go
+++ b/test/e2e/upgrades/apps/etcd.go
@@ -99,19 +99,19 @@ func (t *EtcdUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.listUsers(); err != nil {")
 	framework.Logf("Service endpoint is up")
 
 	ginkgo.By("Adding 2 dummy users")
 	err = t.addUser("Alice")
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.addUser('Alice')")
 	err = t.addUser("Bob")
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.addUser('Bob')")
 	t.successfulWrites = 2
 
 	ginkgo.By("Verifying that the users exist")
 	users, err := t.listUsers()
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.listUsers()")
 	gomega.Expect(users).To(gomega.HaveLen(2))
 }
 
@@ -154,7 +154,7 @@ func (t *EtcdUpgradeTest) addUser(name string) error {
 
 func (t *EtcdUpgradeTest) getServiceIP(ctx context.Context, f *framework.Framework, ns, svcName string) string {
 	svc, err := f.ClientSet.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})")
 	ingress := svc.Status.LoadBalancer.Ingress
 	if len(ingress) == 0 {
 		return ""
@@ -210,6 +210,6 @@ func (t *EtcdUpgradeTest) Test(ctx context.Context, f *framework.Framework, done
 // Teardown does one final check of the data's availability.
 func (t *EtcdUpgradeTest) Teardown(ctx context.Context, f *framework.Framework) {
 	users, err := t.listUsers()
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.listUsers()")
 	gomega.Expect(len(users)).To(gomega.BeNumerically(">=", t.successfulWrites), "len(users) is too small")
 }

--- a/test/e2e/upgrades/apps/job.go
+++ b/test/e2e/upgrades/apps/job.go
@@ -50,11 +50,11 @@ func (t *JobUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 	t.job = e2ejob.NewTestJob("neverTerminate", "foo", v1.RestartPolicyOnFailure, 2, 2, nil, 6)
 	job, err := e2ejob.CreateJob(ctx, f.ClientSet, t.namespace, t.job)
 	t.job = job
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2ejob.CreateJob(ctx, f.ClientSet, t.namespace, t.job)")
 
 	ginkgo.By("Ensuring active pods == parallelism")
 	err = e2ejob.WaitForJobPodsRunning(ctx, f.ClientSet, t.namespace, job.Name, 2)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2ejob.WaitForJobPodsRunning(ctx, f.ClientSet, t.namespace, job.Name, 2)")
 }
 
 // Test verifies that the Jobs Pods are running after the an upgrade
@@ -62,10 +62,10 @@ func (t *JobUpgradeTest) Test(ctx context.Context, f *framework.Framework, done 
 	<-done
 	ginkgo.By("Ensuring job is running")
 	err := ensureJobRunning(ctx, f.ClientSet, t.namespace, t.job.Name)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to ensureJobRunning(ctx, f.ClientSet, t.namespace, t.job.Name)")
 	ginkgo.By("Ensuring active pods == parallelism")
 	err = ensureAllJobPodsRunning(ctx, f.ClientSet, t.namespace, t.job.Name, 2)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to ensureAllJobPodsRunning(ctx, f.ClientSet, t.namespace, t.job.Name, 2)")
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/e2e/upgrades/apps/mysql.go
+++ b/test/e2e/upgrades/apps/mysql.go
@@ -77,7 +77,7 @@ func mysqlKubectlCreate(ns, file string) {
 
 func (t *MySQLUpgradeTest) getServiceIP(ctx context.Context, f *framework.Framework, ns, svcName string) string {
 	svc, err := f.ClientSet.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Services(ns).Get(ctx, svcName, metav1.GetOptions{})")
 	ingress := svc.Status.LoadBalancer.Ingress
 	if len(ingress) == 0 {
 		return ""
@@ -114,18 +114,18 @@ func (t *MySQLUpgradeTest) Setup(ctx context.Context, f *framework.Framework) {
 		}
 		return true, nil
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.countNames(); err != nil {")
 	framework.Logf("Service endpoint is up")
 
 	ginkgo.By("Adding 2 names to the database")
 	err = t.addName(strconv.Itoa(t.nextWrite))
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.addName(strconv.Itoa(t.nextWrite))")
 	err = t.addName(strconv.Itoa(t.nextWrite))
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.addName(strconv.Itoa(t.nextWrite))")
 
 	ginkgo.By("Verifying that the 2 names have been inserted")
 	count, err := t.countNames()
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.countNames()")
 	gomega.Expect(count).To(gomega.Equal(2))
 }
 
@@ -177,7 +177,7 @@ func (t *MySQLUpgradeTest) Test(ctx context.Context, f *framework.Framework, don
 // Teardown performs one final check of the data's availability.
 func (t *MySQLUpgradeTest) Teardown(ctx context.Context, f *framework.Framework) {
 	count, err := t.countNames()
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.countNames()")
 	gomega.Expect(count).To(gomega.BeNumerically(">=", t.successfulWrites), "count is too small")
 }
 

--- a/test/e2e/upgrades/apps/replicasets.go
+++ b/test/e2e/upgrades/apps/replicasets.go
@@ -57,10 +57,10 @@ func (r *ReplicaSetUpgradeTest) Setup(ctx context.Context, f *framework.Framewor
 	ginkgo.By(fmt.Sprintf("Creating replicaset %s in namespace %s", rsName, ns))
 	replicaSet := newReplicaSet(rsName, ns, 1, map[string]string{"test": "upgrade"}, "nginx", nginxImage)
 	rs, err := c.AppsV1().ReplicaSets(ns).Create(ctx, replicaSet, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to c.AppsV1().ReplicaSets(ns).Create(ctx, replicaSet, metav1.CreateOptions{})")
 
 	ginkgo.By(fmt.Sprintf("Waiting for replicaset %s to have all of its replicas ready", rsName))
-	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName))
+	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName), "failed to e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName)")
 
 	r.UID = rs.UID
 }
@@ -78,23 +78,23 @@ func (r *ReplicaSetUpgradeTest) Test(ctx context.Context, f *framework.Framework
 	// Verify the RS is the same (survives) after the upgrade
 	ginkgo.By(fmt.Sprintf("Checking UID to verify replicaset %s survives upgrade", rsName))
 	upgradedRS, err := rsClient.Get(ctx, rsName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to rsClient.Get(ctx, rsName, metav1.GetOptions{})")
 	if upgradedRS.UID != r.UID {
-		framework.ExpectNoError(fmt.Errorf("expected same replicaset UID: %v got: %v", r.UID, upgradedRS.UID))
+		framework.ExpectNoError(fmt.Errorf("expected same replicaset UID: %v got: %v", r.UID, upgradedRS.UID), "failed to rsClient.Get(ctx, rsName, metav1.GetOptions{})")
 	}
 
 	ginkgo.By(fmt.Sprintf("Waiting for replicaset %s to have all of its replicas ready after upgrade", rsName))
-	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName))
+	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName), "failed to e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName)")
 
 	// Verify the upgraded RS is active by scaling up the RS to scaleNum and ensuring all pods are Ready
 	ginkgo.By(fmt.Sprintf("Scaling up replicaset %s to %d", rsName, scaleNum))
 	_, err = e2ereplicaset.UpdateReplicaSetWithRetries(c, ns, rsName, func(rs *appsv1.ReplicaSet) {
 		*rs.Spec.Replicas = scaleNum
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2ereplicaset.UpdateReplicaSetWithRetries(c, ns, rsName, func(rs *appsv1.Repl...")
 
 	ginkgo.By(fmt.Sprintf("Waiting for replicaset %s to have all of its replicas ready after scaling", rsName))
-	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName))
+	framework.ExpectNoError(e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName), "failed to e2ereplicaset.WaitForReadyReplicaSet(ctx, c, ns, rsName)")
 }
 
 // Teardown cleans up any remaining resources.

--- a/test/e2e/upgrades/apps/statefulset.go
+++ b/test/e2e/upgrades/apps/statefulset.go
@@ -87,12 +87,12 @@ func (t *StatefulSetUpgradeTest) Setup(ctx context.Context, f *framework.Framewo
 
 	ginkgo.By("Creating service " + headlessSvcName + " in namespace " + ns)
 	_, err := f.ClientSet.CoreV1().Services(ns).Create(ctx, t.service, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Services(ns).Create(ctx, t.service, metav1.CreateOptions{})")
 
 	ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 	*(t.set.Spec.Replicas) = 3
 	_, err = f.ClientSet.AppsV1().StatefulSets(ns).Create(ctx, t.set, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.AppsV1().StatefulSets(ns).Create(ctx, t.set, metav1.CreateOptions{})")
 
 	ginkgo.By("Saturating stateful set " + t.set.Name)
 	e2estatefulset.Saturate(ctx, f.ClientSet, t.set)
@@ -114,17 +114,17 @@ func (t *StatefulSetUpgradeTest) Teardown(ctx context.Context, f *framework.Fram
 
 func (t *StatefulSetUpgradeTest) verify(ctx context.Context, f *framework.Framework) {
 	ginkgo.By("Verifying statefulset mounted data directory is usable")
-	framework.ExpectNoError(e2estatefulset.CheckMount(ctx, f.ClientSet, t.set, "/data"))
+	framework.ExpectNoError(e2estatefulset.CheckMount(ctx, f.ClientSet, t.set, "/data"), "failed to e2estatefulset.CheckMount(ctx, f.ClientSet, t.set, '/data')")
 
 	ginkgo.By("Verifying statefulset provides a stable hostname for each pod")
-	framework.ExpectNoError(e2estatefulset.CheckHostname(ctx, f.ClientSet, t.set))
+	framework.ExpectNoError(e2estatefulset.CheckHostname(ctx, f.ClientSet, t.set), "failed to e2estatefulset.CheckHostname(ctx, f.ClientSet, t.set)")
 
 	ginkgo.By("Verifying statefulset set proper service name")
-	framework.ExpectNoError(e2estatefulset.CheckServiceName(t.set, t.set.Spec.ServiceName))
+	framework.ExpectNoError(e2estatefulset.CheckServiceName(t.set, t.set.Spec.ServiceName), "failed to e2estatefulset.CheckServiceName(t.set, t.set.Spec.ServiceName)")
 
 	cmd := "echo $(hostname) > /data/hostname; sync;"
 	ginkgo.By("Running " + cmd + " in all stateful pods")
-	framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, f.ClientSet, t.set, cmd))
+	framework.ExpectNoError(e2estatefulset.ExecInStatefulPods(ctx, f.ClientSet, t.set, cmd), "failed to e2estatefulset.ExecInStatefulPods(ctx, f.ClientSet, t.set, cmd)")
 }
 
 func (t *StatefulSetUpgradeTest) restart(ctx context.Context, f *framework.Framework) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR replaces the ExpectNoError and Expect NotTo HaveOccurred anti-patterns across the `apps` tests by providing an explanation string to avoid swallowing contexts in errors. This is part of a split of a larger PR to make it easier to review.

#### Which issue(s) this PR is related to:
Related to: #109600

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```