### PR TITLE
[wontfix] Fix ExpectNoError and Expect(err).NotTo(HaveOccurred()) anti-pattern in e2e tests (api)

### DIFF
--- a/test/e2e/apimachinery/aggregated_discovery.go
+++ b/test/e2e/apimachinery/aggregated_discovery.go
@@ -193,11 +193,11 @@ var _ = SIGDescribe("AggregatedDiscovery", func() {
 	*/
 	framework.ConformanceIt("should support raw aggregated discovery request for CRDs", func(ctx context.Context) {
 		config, err := framework.LoadConfig()
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to framework.LoadConfig()")
 		apiExtensionClient, err := apiextensionclientset.NewForConfig(config)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to apiextensionclientset.NewForConfig(config)")
 		dynamicClient, err := dynamic.NewForConfig(config)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to dynamic.NewForConfig(config)")
 		resourceName := "testcrd"
 		// Generate a CRD with random group name to avoid group conflict with other tests that run in parallel.
 		groupName := fmt.Sprintf("%s.example.com", names.SimpleNameGenerator.GenerateName("group"))
@@ -224,7 +224,7 @@ var _ = SIGDescribe("AggregatedDiscovery", func() {
 		}
 		gvr := schema.GroupVersionResource{Group: crd.Spec.Group, Version: crd.Spec.Versions[0].Name, Resource: resourceName + "s"}
 		_, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamic...")
 		defer func() {
 			_ = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
 		}()
@@ -302,11 +302,11 @@ var _ = SIGDescribe("AggregatedDiscovery", func() {
 	*/
 	framework.ConformanceIt("should support aggregated discovery interface for CRDs", func(ctx context.Context) {
 		config, err := framework.LoadConfig()
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to framework.LoadConfig()")
 		apiExtensionClient, err := apiextensionclientset.NewForConfig(config)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to apiextensionclientset.NewForConfig(config)")
 		dynamicClient, err := dynamic.NewForConfig(config)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to dynamic.NewForConfig(config)")
 		resourceName := "testcrd"
 		// Generate a CRD with random group name to avoid group conflict with other tests that run in parallel.
 		groupName := fmt.Sprintf("%s.example.com", names.SimpleNameGenerator.GenerateName("group"))
@@ -333,7 +333,7 @@ var _ = SIGDescribe("AggregatedDiscovery", func() {
 		}
 		gvr := schema.GroupVersionResource{Group: crd.Spec.Group, Version: crd.Spec.Versions[0].Name, Resource: resourceName + "s"}
 		_, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamicClient)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamic...")
 		defer func() {
 			_ = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
 		}()

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -660,7 +660,7 @@ func TestSampleAPIServer(ctx context.Context, f *framework.Framework, aggrclient
 		updatedApiService, err = apiServiceClient.Update(ctx, currentApiService, metav1.UpdateOptions{})
 		return err
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to apiServiceClient.Update(ctx, currentApiService, metav1.UpdateOptions{})")
 	gomega.Expect(updatedApiService.Labels).To(gomega.HaveKeyWithValue(apiServiceName, "updated"), "should have the updated label but have %q", updatedApiService.Labels[apiServiceName])
 	framework.Logf("Found updated apiService label for %q", apiServiceName)
 

--- a/test/e2e/apimachinery/apiserver_identity.go
+++ b/test/e2e/apimachinery/apiserver_identity.go
@@ -88,7 +88,7 @@ var _ = SIGDescribe("kube-apiserver identity", feature.APIServerIdentity, func()
 
 		var controlPlaneNodes []v1.Node
 		nodes, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})")
 
 		for _, node := range nodes.Items {
 			if _, ok := node.Labels["node-role.kubernetes.io/control-plane"]; ok {
@@ -117,12 +117,12 @@ var _ = SIGDescribe("kube-apiserver identity", feature.APIServerIdentity, func()
 		leases, err := client.CoordinationV1().Leases(metav1.NamespaceSystem).List(context.TODO(), metav1.ListOptions{
 			LabelSelector: "apiserver.kubernetes.io/identity=kube-apiserver",
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.CoordinationV1().Leases(metav1.NamespaceSystem).List(context.TODO(), m...")
 		gomega.Expect(leases.Items).To(gomega.HaveLen(len(controlPlaneNodes)), "unexpected number of leases")
 
 		for _, node := range controlPlaneNodes {
 			hostname, err := getControlPlaneHostname(ctx, &node)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to getControlPlaneHostname(ctx, &node)")
 
 			b := cryptobyte.NewBuilder(nil)
 			b.AddUint16LengthPrefixed(func(b *cryptobyte.Builder) {
@@ -133,17 +133,17 @@ var _ = SIGDescribe("kube-apiserver identity", feature.APIServerIdentity, func()
 			})
 
 			hashData, err := b.Bytes()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to b.Bytes()")
 			hash := sha256.Sum256(hashData)
 			leaseName := "apiserver-" + strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(hash[:16]))
 
 			lease, err := client.CoordinationV1().Leases(metav1.NamespaceSystem).Get(context.TODO(), leaseName, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.CoordinationV1().Leases(metav1.NamespaceSystem).Get(context.TODO(), le...")
 			oldHolderIdentity := lease.Spec.HolderIdentity
 			lastRenewedTime := lease.Spec.RenewTime
 
 			err = restartAPIServer(ctx, &node)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to restartAPIServer(ctx, &node)")
 
 			err = wait.PollImmediate(time.Second, wait.ForeverTestTimeout, func() (bool, error) {
 				lease, err = client.CoordinationV1().Leases(metav1.NamespaceSystem).Get(context.TODO(), leaseName, metav1.GetOptions{})
@@ -173,7 +173,7 @@ var _ = SIGDescribe("kube-apiserver identity", feature.APIServerIdentity, func()
 		leases, err = client.CoordinationV1().Leases(metav1.NamespaceSystem).List(context.TODO(), metav1.ListOptions{
 			LabelSelector: "apiserver.kubernetes.io/identity=kube-apiserver",
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.CoordinationV1().Leases(metav1.NamespaceSystem).List(context.TODO(), m...")
 		gomega.Expect(leases.Items).To(gomega.HaveLen(len(controlPlaneNodes)), "unexpected number of leases")
 	})
 })

--- a/test/e2e/apimachinery/apply.go
+++ b/test/e2e/apimachinery/apply.go
@@ -1013,7 +1013,7 @@ spec:
 		_, err = e2edeployment.UpdateDeploymentWithRetries(client, ns, "deployment-shared-map-item-removal", func(update *appsv1.Deployment) {
 			update.Spec.Replicas = &replicas
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edeployment.UpdateDeploymentWithRetries(client, ns, 'deployment-shared-map-...")
 
 		// applier omits replicas
 		apply = []byte(`{

--- a/test/e2e/apimachinery/coordinatedleaderelection.go
+++ b/test/e2e/apimachinery/coordinatedleaderelection.go
@@ -221,7 +221,7 @@ func (t *cleTest) createAndRunFakeController(name string, namespace string, targ
 		compatibilityVersion,
 		preferredStrategy,
 	)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to leaderelection.NewCandidate(")
 	ctx, cancel := context.WithCancel(t.ctx)
 	t.mu.Lock()
 	t.ctxList[name+"/"+namespace] = ctxCancelPair{ctx, cancel}
@@ -291,7 +291,7 @@ func (t *cleTest) pollForLease(ctx context.Context, name, namespace string, hold
 		}
 		return lease.Spec.HolderIdentity != nil && *lease.Spec.HolderIdentity == *holder, nil
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to t.clientset.CoordinationV1().Leases(namespace).Get(ctx, n...")
 
 }
 

--- a/test/e2e/apimachinery/crd_conversion_webhook.go
+++ b/test/e2e/apimachinery/crd_conversion_webhook.go
@@ -396,7 +396,7 @@ func testCustomResourceConversionWebhook(ctx context.Context, f *framework.Frame
 		},
 	}
 	_, err := customResourceClients["v1"].Create(ctx, crInstance, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to customResourceClients['v1'].Create(ctx, crInstance, metav1.CreateOptions{})")
 	ginkgo.By("v2 custom resource should be converted")
 	v2crd, err := customResourceClients["v2"].Get(ctx, name, metav1.GetOptions{})
 	framework.ExpectNoError(err, "Getting v2 of custom resource %s", name)
@@ -421,13 +421,13 @@ func testCRListConversion(ctx context.Context, f *framework.Framework, testCrd *
 		},
 	}
 	_, err := customResourceClients["v1"].Create(ctx, crInstance, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to customResourceClients['v1'].Create(ctx, crInstance, metav1.CreateOptions{})")
 
 	// Now cr-instance-1 is stored as v1. lets change storage version
 	crd, err = integration.UpdateV1CustomResourceDefinitionWithRetry(testCrd.APIExtensionClient, crd.Name, func(c *apiextensionsv1.CustomResourceDefinition) {
 		c.Spec.Versions = alternativeAPIVersions
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to integration.UpdateV1CustomResourceDefinitionWithRetry(testCrd.APIExtensionCli...")
 	ginkgo.By("Create a v2 custom resource")
 	crInstance = &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -452,13 +452,13 @@ func testCRListConversion(ctx context.Context, f *framework.Framework, testCrd *
 			break
 		}
 	}
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to = nil")
 
 	// Now that we have a v1 and v2 object, both list operation in v1 and v2 should work as expected.
 
 	ginkgo.By("List CRs in v1")
 	list, err := customResourceClients["v1"].List(ctx, metav1.ListOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to customResourceClients['v1'].List(ctx, metav1.ListOptions{})")
 	gomega.Expect(list.Items).To(gomega.HaveLen(2))
 	if !((list.Items[0].GetName() == name1 && list.Items[1].GetName() == name2) ||
 		(list.Items[0].GetName() == name2 && list.Items[1].GetName() == name1)) {
@@ -469,7 +469,7 @@ func testCRListConversion(ctx context.Context, f *framework.Framework, testCrd *
 
 	ginkgo.By("List CRs in v2")
 	list, err = customResourceClients["v2"].List(ctx, metav1.ListOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to customResourceClients['v2'].List(ctx, metav1.ListOptions{})")
 	gomega.Expect(list.Items).To(gomega.HaveLen(2))
 	if !((list.Items[0].GetName() == name1 && list.Items[1].GetName() == name2) ||
 		(list.Items[0].GetName() == name2 && list.Items[1].GetName() == name1)) {
@@ -502,5 +502,5 @@ func waitWebhookConversionReady(ctx context.Context, f *framework.Framework, crd
 
 		framework.ExpectNoError(customResourceClients[version].Delete(ctx, crInstance.GetName(), metav1.DeleteOptions{}), "cleaning up stub object")
 		return true, nil
-	}))
+	}), "failed to customResourceClients[version].Create(ctx, crInstance, me...")
 }

--- a/test/e2e/apimachinery/discovery.go
+++ b/test/e2e/apimachinery/discovery.go
@@ -56,25 +56,25 @@ var _ = SIGDescribe("Discovery", func() {
 	ginkgo.It("should accurately determine present and missing resources", func(ctx context.Context) {
 		// checks that legacy api group resources function
 		ok, err := clientdiscovery.IsResourceEnabled(f.ClientSet.Discovery(), schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to clientdiscovery.IsResourceEnabled(f.ClientSet.Discovery(), schema.GroupVersio...")
 		if !ok {
 			framework.Failf("namespace.v1 should always be present")
 		}
 		// checks that non-legacy api group resources function
 		ok, err = clientdiscovery.IsResourceEnabled(f.ClientSet.Discovery(), schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to clientdiscovery.IsResourceEnabled(f.ClientSet.Discovery(), schema.GroupVersio...")
 		if !ok {
 			framework.Failf("deployments.v1.apps should always be present")
 		}
 		// checks that nonsense resources in existing api groups function
 		ok, err = clientdiscovery.IsResourceEnabled(f.ClientSet.Discovery(), schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "please-dont-ever-create-this"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to clientdiscovery.IsResourceEnabled(f.ClientSet.Discovery(), schema.GroupVersio...")
 		if ok {
 			framework.Failf("please-dont-ever-create-this.v1.apps should never be present")
 		}
 		// checks that resources resources in nonsense api groups function
 		ok, err = clientdiscovery.IsResourceEnabled(f.ClientSet.Discovery(), schema.GroupVersionResource{Group: "not-these-apps", Version: "v1", Resource: "deployments"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to clientdiscovery.IsResourceEnabled(f.ClientSet.Discovery(), schema.GroupVersio...")
 		if ok {
 			framework.Failf("deployments.v1.not-these-apps should never be present")
 		}

--- a/test/e2e/apimachinery/etcd_failure.go
+++ b/test/e2e/apimachinery/etcd_failure.go
@@ -57,7 +57,7 @@ var _ = SIGDescribe("Etcd failure", framework.WithDisruptive(), framework.WithPr
 			Image:     imageutils.GetPauseImageName(),
 			Replicas:  1,
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2erc.RunRC(ctx, testutils.RCConfig{")
 	})
 
 	ginkgo.It("should recover from network partition with master", func(ctx context.Context) {
@@ -143,7 +143,7 @@ func checkExistingRCRecovers(ctx context.Context, f *framework.Framework) {
 		}
 		framework.Logf("apiserver has recovered")
 		return true, nil
-	}))
+	}), "failed to podClient.Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))")
 
 	ginkgo.By("waiting for replication controller to recover")
 	framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, time.Millisecond*500, time.Second*60, false, func(ctx context.Context) (bool, error) {
@@ -156,5 +156,5 @@ func checkExistingRCRecovers(ctx context.Context, f *framework.Framework) {
 			}
 		}
 		return false, nil
-	}))
+	}), "failed to podClient.List(ctx, options)")
 }

--- a/test/e2e/apimachinery/flowcontrol.go
+++ b/test/e2e/apimachinery/flowcontrol.go
@@ -152,7 +152,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		ginkgo.By("getting request concurrency from metrics")
 		for i := range clients {
 			realConcurrency, err := getPriorityLevelNominalConcurrency(ctx, f.ClientSet, clients[i].priorityLevelName)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to getPriorityLevelNominalConcurrency(ctx, f.ClientSet, clients[i].priorityLevel...")
 			clients[i].concurrency = int32(float64(realConcurrency) * clients[i].concurrencyMultiplier)
 			if clients[i].concurrency < 1 {
 				clients[i].concurrency = 1
@@ -223,7 +223,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 
 		framework.Logf("getting real concurrency")
 		realConcurrency, err := getPriorityLevelNominalConcurrency(ctx, f.ClientSet, priorityLevelName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to getPriorityLevelNominalConcurrency(ctx, f.ClientSet, priorityLevelName)")
 		for i := range clients {
 			clients[i].concurrency = int32(float64(realConcurrency) * clients[i].concurrencyMultiplier)
 			if clients[i].concurrency < 1 {
@@ -274,7 +274,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		ginkgo.By("getting /apis")
 		{
 			discoveryGroups, err := f.ClientSet.Discovery().ServerGroups()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerGroups()")
 			found := false
 			for _, group := range discoveryGroups.Groups {
 				if group.Name == flowcontrol.GroupName {
@@ -295,7 +295,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		{
 			group := &metav1.APIGroup{}
 			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/flowcontrol.apiserver.k8s.io").Do(ctx).Into(group)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().RESTClient().Get().AbsPath('/apis/flowcontrol.apiserv...")
 			found := false
 			for _, version := range group.Versions {
 				if version.Version == fsVersion {
@@ -311,7 +311,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		ginkgo.By("getting /apis/flowcontrol.apiserver.k8s.io/" + fsVersion)
 		{
 			resources, err := f.ClientSet.Discovery().ServerResourcesForGroupVersion(flowcontrol.SchemeGroupVersion.String())
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerResourcesForGroupVersion(flowcontrol.SchemeGrou...")
 			foundFS, foundFSStatus := false, false
 			for _, resource := range resources.APIResources {
 				switch resource.Name {
@@ -371,37 +371,37 @@ var _ = SIGDescribe("API priority and fairness", func() {
 
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			err := client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 		})
 
 		ginkgo.By("creating")
 		_, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		_, err = client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		fsCreated, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 
 		ginkgo.By("getting")
 		fsRead, err := client.Get(ctx, fsCreated.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Get(ctx, fsCreated.Name, metav1.GetOptions{})")
 		gomega.Expect(fsRead.UID).To(gomega.Equal(fsCreated.UID))
 		gomega.Expect(fsRead).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		list, err := client.List(ctx, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(list.Items).To(gomega.HaveLen(3), "filtered list should have 3 items")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
 		fsWatch, err := client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, L...")
 
 		ginkgo.By("patching")
 		patchBytes := []byte(`{"metadata":{"annotations":{"patched":"true"}},"spec":{"matchingPrecedence":9999}}`)
 		fsPatched, err := client.Patch(ctx, fsCreated.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Patch(ctx, fsCreated.Name, types.MergePatchType, patchBytes, metav1.Pa...")
 		gomega.Expect(fsPatched.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(fsPatched.Spec.MatchingPrecedence).To(gomega.Equal(int32(9999)), "patched object should have the applied spec")
 		gomega.Expect(resourceversion.CompareResourceVersion(fsCreated.ResourceVersion, fsPatched.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
@@ -410,7 +410,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		var fsUpdated *flowcontrol.FlowSchema
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			fs, err := client.Get(ctx, fsCreated.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.Get(ctx, fsCreated.Name, metav1.GetOptions{})")
 
 			fsToUpdate := fs.DeepCopy()
 			fsToUpdate.Annotations["updated"] = "true"
@@ -449,14 +449,14 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		ginkgo.By("getting /status")
 		resource := flowcontrol.SchemeGroupVersion.WithResource("flowschemas")
 		fsStatusRead, err := f.DynamicClient.Resource(resource).Get(ctx, fsCreated.Name, metav1.GetOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.DynamicClient.Resource(resource).Get(ctx, fsCreated.Name, metav1.GetOptions...")
 		gomega.Expect(fsStatusRead.GetObjectKind().GroupVersionKind()).To(gomega.Equal(flowcontrol.SchemeGroupVersion.WithKind("FlowSchema")))
 		gomega.Expect(fsStatusRead.GetUID()).To(gomega.Equal(fsCreated.UID))
 
 		ginkgo.By("patching /status")
 		patchBytes = []byte(`{"status":{"conditions":[{"type":"PatchStatusFailed","status":"False","reason":"e2e"}]}}`)
 		fsStatusPatched, err := client.Patch(ctx, fsCreated.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Patch(ctx, fsCreated.Name, types.MergePatchType, patchBytes, metav1.Pa...")
 		condition := apihelpers.GetFlowSchemaConditionByType(fsStatusPatched, flowcontrol.FlowSchemaConditionType("PatchStatusFailed"))
 		gomega.Expect(condition).NotTo(gomega.BeNil())
 
@@ -464,7 +464,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		var fsStatusUpdated *flowcontrol.FlowSchema
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			fs, err := client.Get(ctx, fsCreated.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.Get(ctx, fsCreated.Name, metav1.GetOptions{})")
 
 			fsStatusToUpdate := fs.DeepCopy()
 			fsStatusToUpdate.Status.Conditions = append(fsStatusToUpdate.Status.Conditions, flowcontrol.FlowSchemaCondition{
@@ -482,22 +482,22 @@ var _ = SIGDescribe("API priority and fairness", func() {
 
 		ginkgo.By("deleting")
 		err = client.Delete(ctx, fsCreated.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Delete(ctx, fsCreated.Name, metav1.DeleteOptions{})")
 		_, err = client.Get(ctx, fsCreated.Name, metav1.GetOptions{})
 		if !apierrors.IsNotFound(err) {
 			framework.Failf("expected 404, got %#v", err)
 		}
 
 		list, err = client.List(ctx, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(list.Items).To(gomega.HaveLen(2), "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
 		err = client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 
 		list, err = client.List(ctx, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(list.Items).To(gomega.BeEmpty(), "filtered list should have 0 items")
 	})
 
@@ -520,7 +520,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		ginkgo.By("getting /apis")
 		{
 			discoveryGroups, err := f.ClientSet.Discovery().ServerGroups()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerGroups()")
 			found := false
 			for _, group := range discoveryGroups.Groups {
 				if group.Name == flowcontrol.GroupName {
@@ -541,7 +541,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		{
 			group := &metav1.APIGroup{}
 			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/flowcontrol.apiserver.k8s.io").Do(ctx).Into(group)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().RESTClient().Get().AbsPath('/apis/flowcontrol.apiserv...")
 			found := false
 			for _, version := range group.Versions {
 				if version.Version == plVersion {
@@ -557,7 +557,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		ginkgo.By("getting /apis/flowcontrol.apiserver.k8s.io/" + plVersion)
 		{
 			resources, err := f.ClientSet.Discovery().ServerResourcesForGroupVersion(flowcontrol.SchemeGroupVersion.String())
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerResourcesForGroupVersion(flowcontrol.SchemeGrou...")
 			foundPL, foundPLStatus := false, false
 			for _, resource := range resources.APIResources {
 				switch resource.Name {
@@ -599,37 +599,37 @@ var _ = SIGDescribe("API priority and fairness", func() {
 
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			err := client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 		})
 
 		ginkgo.By("creating")
 		_, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		_, err = client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		plCreated, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 
 		ginkgo.By("getting")
 		plRead, err := client.Get(ctx, plCreated.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Get(ctx, plCreated.Name, metav1.GetOptions{})")
 		gomega.Expect(plRead.UID).To(gomega.Equal(plCreated.UID))
 		gomega.Expect(plRead).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		list, err := client.List(ctx, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(list.Items).To(gomega.HaveLen(3), "filtered list should have 3 items")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
 		plWatch, err := client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, L...")
 
 		ginkgo.By("patching")
 		patchBytes := []byte(`{"metadata":{"annotations":{"patched":"true"}},"spec":{"limited":{"nominalConcurrencyShares":4}}}`)
 		plPatched, err := client.Patch(ctx, plCreated.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Patch(ctx, plCreated.Name, types.MergePatchType, patchBytes, metav1.Pa...")
 		gomega.Expect(plPatched.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(plPatched.Spec.Limited.NominalConcurrencyShares).To(gomega.Equal(ptr.To(int32(4))), "patched object should have the applied spec")
 		gomega.Expect(resourceversion.CompareResourceVersion(plCreated.ResourceVersion, plPatched.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
@@ -638,7 +638,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		var plUpdated *flowcontrol.PriorityLevelConfiguration
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			pl, err := client.Get(ctx, plCreated.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.Get(ctx, plCreated.Name, metav1.GetOptions{})")
 
 			plToUpdate := pl.DeepCopy()
 			plToUpdate.Annotations["updated"] = "true"
@@ -677,14 +677,14 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		ginkgo.By("getting /status")
 		resource := flowcontrol.SchemeGroupVersion.WithResource("prioritylevelconfigurations")
 		plStatusRead, err := f.DynamicClient.Resource(resource).Get(ctx, plCreated.Name, metav1.GetOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.DynamicClient.Resource(resource).Get(ctx, plCreated.Name, metav1.GetOptions...")
 		gomega.Expect(plStatusRead.GetObjectKind().GroupVersionKind()).To(gomega.Equal(flowcontrol.SchemeGroupVersion.WithKind("PriorityLevelConfiguration")))
 		gomega.Expect(plStatusRead.GetUID()).To(gomega.Equal(plCreated.UID))
 
 		ginkgo.By("patching /status")
 		patchBytes = []byte(`{"status":{"conditions":[{"type":"PatchStatusFailed","status":"False","reason":"e2e"}]}}`)
 		plStatusPatched, err := client.Patch(ctx, plCreated.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Patch(ctx, plCreated.Name, types.MergePatchType, patchBytes, metav1.Pa...")
 		condition := apihelpers.GetPriorityLevelConfigurationConditionByType(plStatusPatched, flowcontrol.PriorityLevelConfigurationConditionType("PatchStatusFailed"))
 		gomega.Expect(condition).NotTo(gomega.BeNil())
 
@@ -692,7 +692,7 @@ var _ = SIGDescribe("API priority and fairness", func() {
 		var plStatusUpdated *flowcontrol.PriorityLevelConfiguration
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			pl, err := client.Get(ctx, plCreated.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.Get(ctx, plCreated.Name, metav1.GetOptions{})")
 
 			plStatusToUpdate := pl.DeepCopy()
 			plStatusToUpdate.Status.Conditions = append(plStatusToUpdate.Status.Conditions, flowcontrol.PriorityLevelConfigurationCondition{
@@ -710,22 +710,22 @@ var _ = SIGDescribe("API priority and fairness", func() {
 
 		ginkgo.By("deleting")
 		err = client.Delete(ctx, plCreated.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Delete(ctx, plCreated.Name, metav1.DeleteOptions{})")
 		_, err = client.Get(ctx, plCreated.Name, metav1.GetOptions{})
 		if !apierrors.IsNotFound(err) {
 			framework.Failf("expected 404, got %#v", err)
 		}
 
 		list, err = client.List(ctx, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(list.Items).To(gomega.HaveLen(2), "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
 		err = client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 
 		list, err = client.List(ctx, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(list.Items).To(gomega.BeEmpty(), "filtered list should have 0 items")
 	})
 })
@@ -750,7 +750,7 @@ func createPriorityLevel(ctx context.Context, f *framework.Framework, priorityLe
 			},
 		},
 		metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.FlowcontrolV1().PriorityLevelConfigurations()...")
 	ginkgo.DeferCleanup(f.ClientSet.FlowcontrolV1().PriorityLevelConfigurations().Delete, priorityLevelName, metav1.DeleteOptions{})
 	return createdPriorityLevel
 }
@@ -828,7 +828,7 @@ func createFlowSchema(ctx context.Context, f *framework.Framework, flowSchemaNam
 			},
 		},
 		metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.FlowcontrolV1().FlowSchemas().Create(")
 	ginkgo.DeferCleanup(f.ClientSet.FlowcontrolV1().FlowSchemas().Delete, flowSchemaName, metav1.DeleteOptions{})
 	return createdFlowSchema
 }
@@ -859,7 +859,7 @@ func waitForSteadyState(ctx context.Context, f *framework.Framework, flowSchemaN
 			return false, err
 		}
 		return true, nil
-	}))
+	}), "failed to getPriorityLevelNominalConcurrency(ctx, f.ClientSet, prio...")
 }
 
 // makeRequests creates a request to the API server and returns the response.
@@ -869,13 +869,13 @@ func makeRequest(f *framework.Framework, username string) *http.Response {
 	config.RateLimiter = clientsideflowcontrol.NewFakeAlwaysRateLimiter()
 	config.Impersonate.Groups = []string{"system:authenticated"}
 	roundTripper, err := rest.TransportFor(config)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to rest.TransportFor(config)")
 
 	req, err := http.NewRequest(http.MethodGet, f.ClientSet.CoreV1().RESTClient().Get().AbsPath("version").URL().String(), nil)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to http.NewRequest(http.MethodGet, f.ClientSet.CoreV1().RESTClient().Get().AbsPa...")
 
 	response, err := roundTripper.RoundTrip(req)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to roundTripper.RoundTrip(req)")
 	return response
 }
 

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -59,7 +59,7 @@ import (
 // safe to run concurrently as they consume a large number of pods.
 func estimateMaximumPods(ctx context.Context, c clientset.Interface, min, max int32) int32 {
 	nodes, err := e2enode.GetReadySchedulableNodes(ctx, c)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2enode.GetReadySchedulableNodes(ctx, c)")
 
 	availablePods := int32(0)
 	// estimate some reasonable overhead per-node for pods that are non-test

--- a/test/e2e/apimachinery/generated_clientset.go
+++ b/test/e2e/apimachinery/generated_clientset.go
@@ -149,7 +149,7 @@ var _ = SIGDescribe("Generated clientset", func() {
 
 		// We need to wait for the pod to be scheduled, otherwise the deletion
 		// will be carried out immediately rather than gracefully.
-		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name))
+		framework.ExpectNoError(e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name), "failed to e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, pod.Name, f.Namespa...")
 
 		ginkgo.By("deleting the pod gracefully")
 		gracePeriod := int64(31)

--- a/test/e2e/apimachinery/health_handlers.go
+++ b/test/e2e/apimachinery/health_handlers.go
@@ -140,14 +140,14 @@ var _ = SIGDescribe("health handlers", func() {
 
 		ginkgo.By("/health")
 		err := testPath(ctx, f.ClientSet, "/healthz?verbose=1", requiredHealthzChecks)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to testPath(ctx, f.ClientSet, '/healthz?verbose=1', requiredHealthzChecks)")
 
 		ginkgo.By("/livez")
 		err = testPath(ctx, f.ClientSet, "/livez?verbose=1", requiredLivezChecks)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to testPath(ctx, f.ClientSet, '/livez?verbose=1', requiredLivezChecks)")
 
 		ginkgo.By("/readyz")
 		err = testPath(ctx, f.ClientSet, "/readyz?verbose=1", requiredReadyzChecks)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to testPath(ctx, f.ClientSet, '/readyz?verbose=1', requiredReadyzChecks)")
 	})
 })

--- a/test/e2e/apimachinery/mutatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/mutatingadmissionpolicy.go
@@ -194,7 +194,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 		ginkgo.By("getting /apis")
 		{
 			discoveryGroups, err := f.ClientSet.Discovery().ServerGroups()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerGroups()")
 			found := false
 			for _, group := range discoveryGroups.Groups {
 				if group.Name == admissionregistrationv1.GroupName {
@@ -215,7 +215,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 		{
 			group := &metav1.APIGroup{}
 			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/admissionregistration.k8s.io").Do(ctx).Into(group)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().RESTClient().Get().AbsPath('/apis/admissionregistrati...")
 			found := false
 			for _, version := range group.Versions {
 				if version.Version == mapVersion {
@@ -231,7 +231,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 		ginkgo.By("getting /apis/admissionregistration.k8s.io/" + mapVersion)
 		{
 			resources, err := f.ClientSet.Discovery().ServerResourcesForGroupVersion(admissionregistrationv1.SchemeGroupVersion.String())
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerResourcesForGroupVersion(admissionregistrationv...")
 			foundMAP := false
 			for _, resource := range resources.APIResources {
 				switch resource.Name {
@@ -284,36 +284,36 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			err := client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 		})
 
 		ginkgo.By("creating")
 		_, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		_, err = client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		mapCreated, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 
 		ginkgo.By("getting")
 		mapRead, err := client.Get(ctx, mapCreated.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Get(ctx, mapCreated.Name, metav1.GetOptions{})")
 		gomega.Expect(mapRead.UID).To(gomega.Equal(mapCreated.UID))
 		gomega.Expect(mapRead).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		list, err := client.List(ctx, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
 		mapWatch, err := client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, L...")
 
 		ginkgo.By("patching")
 		patchBytes := []byte(`{"metadata":{"annotations":{"patched":"true"}},"spec":{"reinvocationPolicy":"IfNeeded"}}`)
 		mapPatched, err := client.Patch(ctx, mapCreated.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Patch(ctx, mapCreated.Name, types.MergePatchType, patchBytes, metav1.P...")
 		gomega.Expect(mapPatched.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(mapPatched.Spec.ReinvocationPolicy).To(gomega.Equal(admissionregistrationv1.IfNeededReinvocationPolicy), "patched object should have the applied spec")
 		gomega.Expect(resourceversion.CompareResourceVersion(mapRead.ResourceVersion, mapPatched.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
@@ -322,7 +322,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 		var mapUpdated *admissionregistrationv1.MutatingAdmissionPolicy
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			mp, err := client.Get(ctx, mapCreated.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.Get(ctx, mapCreated.Name, metav1.GetOptions{})")
 
 			mapToUpdate := mp.DeepCopy()
 			mapToUpdate.Annotations["updated"] = "true"
@@ -360,7 +360,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 
 		ginkgo.By("deleting")
 		err = client.Delete(ctx, mapCreated.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Delete(ctx, mapCreated.Name, metav1.DeleteOptions{})")
 		mapTmp, err := client.Get(ctx, mapCreated.Name, metav1.GetOptions{})
 		switch {
 		case err == nil && mapTmp.GetDeletionTimestamp() != nil && len(mapTmp.GetFinalizers()) > 0:
@@ -380,12 +380,12 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 				itemsWithoutFinalizer = append(itemsWithoutFinalizer, item)
 			}
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(itemsWithoutFinalizer).To(gomega.HaveLen(2), "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
 		err = client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 
 		list, err = client.List(ctx, metav1.ListOptions{LabelSelector: label})
 		var itemsColWithoutFinalizer []admissionregistrationv1.MutatingAdmissionPolicy
@@ -394,7 +394,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 				itemsColWithoutFinalizer = append(itemsColWithoutFinalizer, item)
 			}
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(itemsColWithoutFinalizer).To(gomega.BeEmpty(), "filtered list should have 0 items")
 	})
 
@@ -416,7 +416,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 		ginkgo.By("getting /apis")
 		{
 			discoveryGroups, err := f.ClientSet.Discovery().ServerGroups()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerGroups()")
 			found := false
 			for _, group := range discoveryGroups.Groups {
 				if group.Name == admissionregistrationv1.GroupName {
@@ -437,7 +437,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 		{
 			group := &metav1.APIGroup{}
 			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/admissionregistration.k8s.io").Do(ctx).Into(group)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().RESTClient().Get().AbsPath('/apis/admissionregistrati...")
 			found := false
 			for _, version := range group.Versions {
 				if version.Version == mapbVersion {
@@ -453,7 +453,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 		ginkgo.By("getting /apis/admissionregistration.k8s.io/" + mapbVersion)
 		{
 			resources, err := f.ClientSet.Discovery().ServerResourcesForGroupVersion(admissionregistrationv1.SchemeGroupVersion.String())
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerResourcesForGroupVersion(admissionregistrationv...")
 			foundMAPB := false
 			for _, resource := range resources.APIResources {
 				switch resource.Name {
@@ -484,36 +484,36 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			err := client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 		})
 
 		ginkgo.By("creating")
 		_, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		_, err = client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		mapbCreated, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 
 		ginkgo.By("getting")
 		mapbRead, err := client.Get(ctx, mapbCreated.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Get(ctx, mapbCreated.Name, metav1.GetOptions{})")
 		gomega.Expect(mapbRead.UID).To(gomega.Equal(mapbCreated.UID))
 		gomega.Expect(mapbRead).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		list, err := client.List(ctx, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
 		mapbWatch, err := client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, L...")
 
 		ginkgo.By("patching")
 		patchBytes := []byte(`{"metadata":{"annotations":{"patched":"true"}},"spec":{"policyName":"new-policy.example.com"}}`)
 		mapbPatched, err := client.Patch(ctx, mapbCreated.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Patch(ctx, mapbCreated.Name, types.MergePatchType, patchBytes, metav1....")
 		gomega.Expect(mapbPatched.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(mapbPatched.Spec.PolicyName).To(gomega.Equal("new-policy.example.com"), "patched object should have the applied spec")
 		gomega.Expect(resourceversion.CompareResourceVersion(mapbRead.ResourceVersion, mapbPatched.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
@@ -522,7 +522,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 		var mapbUpdated *admissionregistrationv1.MutatingAdmissionPolicyBinding
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			mp, err := client.Get(ctx, mapbCreated.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.Get(ctx, mapbCreated.Name, metav1.GetOptions{})")
 
 			mapbToUpdate := mp.DeepCopy()
 			mapbToUpdate.Annotations["updated"] = "true"
@@ -559,7 +559,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 		}
 		ginkgo.By("deleting")
 		err = client.Delete(ctx, mapbCreated.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Delete(ctx, mapbCreated.Name, metav1.DeleteOptions{})")
 		mapbTmp, err := client.Get(ctx, mapbCreated.Name, metav1.GetOptions{})
 		switch {
 		case err == nil && mapbTmp.GetDeletionTimestamp() != nil && len(mapbTmp.GetFinalizers()) > 0:
@@ -579,12 +579,12 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 				itemsWithoutFinalizer = append(itemsWithoutFinalizer, item)
 			}
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(itemsWithoutFinalizer).To(gomega.HaveLen(2), "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
 		err = client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 
 		list, err = client.List(ctx, metav1.ListOptions{LabelSelector: label})
 		var itemsColWithoutFinalizer []admissionregistrationv1.MutatingAdmissionPolicyBinding
@@ -593,7 +593,7 @@ var _ = SIGDescribe("MutatingAdmissionPolicy [Privileged:ClusterAdmin]", func() 
 				itemsColWithoutFinalizer = append(itemsColWithoutFinalizer, item)
 			}
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(itemsColWithoutFinalizer).To(gomega.BeEmpty(), "filtered list should have 0 items")
 	})
 })

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -90,7 +90,7 @@ func extinguish(ctx context.Context, f *framework.Framework, totalNS int, maxAll
 				return false, nil
 			}
 			return true, nil
-		}))
+		}), "failed to f.ClientSet.CoreV1().Namespaces().List(ctx, metav1.ListOp...")
 }
 
 func ensurePodsAreRemovedWhenNamespaceIsDeleted(ctx context.Context, f *framework.Framework) {
@@ -122,7 +122,7 @@ func ensurePodsAreRemovedWhenNamespaceIsDeleted(ctx context.Context, f *framewor
 	framework.ExpectNoError(err, "failed to create pod %s in namespace: %s", podName, namespace.Name)
 
 	ginkgo.By("Waiting for the pod to have running status")
-	framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
+	framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod), "failed to e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)")
 
 	ginkgo.By("Deleting the namespace")
 	err = f.ClientSet.CoreV1().Namespaces().Delete(ctx, namespace.Name, metav1.DeleteOptions{})
@@ -137,7 +137,7 @@ func ensurePodsAreRemovedWhenNamespaceIsDeleted(ctx context.Context, f *framewor
 				return true, nil
 			}
 			return false, nil
-		}))
+		}), "failed to f.ClientSet.CoreV1().Namespaces().Get(ctx, namespace.Name...")
 
 	ginkgo.By("Recreating the namespace")
 	namespace, err = f.CreateNamespace(ctx, namespaceName, nil)
@@ -194,7 +194,7 @@ func ensureServicesAreRemovedWhenNamespaceIsDeleted(ctx context.Context, f *fram
 				return true, nil
 			}
 			return false, nil
-		}))
+		}), "failed to f.ClientSet.CoreV1().Namespaces().Get(ctx, namespace.Name...")
 
 	ginkgo.By("Recreating the namespace")
 	namespace, err = f.CreateNamespace(ctx, namespaceName, nil)
@@ -527,7 +527,7 @@ func ensurePodsAreRemovedFirstInOrderedNamespaceDeletion(ctx context.Context, f 
 	framework.ExpectNoError(err, "failed to create pod %s in namespace: %s", podName, nsName)
 
 	ginkgo.By("Waiting for the pod to have running status")
-	framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
+	framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod), "failed to e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod)")
 
 	configMapName := "test-configmap"
 	ginkgo.By(fmt.Sprintf("Creating a configmap %q in namespace %q", configMapName, nsName))
@@ -622,7 +622,7 @@ func ensurePodsAreRemovedFirstInOrderedNamespaceDeletion(ctx context.Context, f 
 	framework.ExpectNoError(err, "failed to update pod %q and remove finalizer in namespace %q", podName, nsName)
 
 	ginkgo.By("Waiting for the pod to not be present in the namespace")
-	framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, podName, nsName, f.Timeouts.PodDelete))
+	framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, podName, nsName, f.Timeouts.PodDelete), "failed to e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, podName, nsName, f.Tim...")
 
 	ginkgo.By("Waiting for the namespace to be removed.")
 	framework.ExpectNoError(wait.PollUntilContextTimeout(ctx, 1*time.Second, framework.DefaultNamespaceDeletionTimeout, true,
@@ -632,5 +632,5 @@ func ensurePodsAreRemovedFirstInOrderedNamespaceDeletion(ctx context.Context, f 
 				return true, nil
 			}
 			return false, nil
-		}))
+		}), "failed to f.ClientSet.CoreV1().Namespaces().Get(ctx, namespace.Name...")
 }

--- a/test/e2e/apimachinery/openapiv3.go
+++ b/test/e2e/apimachinery/openapiv3.go
@@ -56,7 +56,7 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 	ginkgo.It("should round trip OpenAPI V3 for all built-in group versions", func(ctx context.Context) {
 		c := openapi3.NewRoot(f.ClientSet.Discovery().OpenAPIV3())
 		gvs, err := c.GroupVersions()
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.GroupVersions()")
 		// List of built in types that do not contain the k8s.io suffix
 		builtinGVs := map[string]bool{
 			"apps":        true,
@@ -72,9 +72,9 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 				continue
 			}
 			spec1, err := c.GVSpec(gv)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.GVSpec(gv)")
 			specMarshalled, err := json.Marshal(spec1)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to json.Marshal(spec1)")
 			var spec2 spec3.OpenAPI
 			json.Unmarshal(specMarshalled, &spec2)
 
@@ -92,11 +92,11 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 	*/
 	ginkgo.It("should publish OpenAPI V3 for CustomResourceDefinition", func(ctx context.Context) {
 		config, err := framework.LoadConfig()
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to framework.LoadConfig()")
 		apiExtensionClient, err := apiextensionclientset.NewForConfig(config)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to apiextensionclientset.NewForConfig(config)")
 		dynamicClient, err := dynamic.NewForConfig(config)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to dynamic.NewForConfig(config)")
 		resourceName := "testcrd"
 		// Generate a CRD with random group name to avoid group conflict with other tests that run in parallel.
 		groupName := fmt.Sprintf("%s.example.com", names.SimpleNameGenerator.GenerateName("group"))
@@ -127,7 +127,7 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 			_ = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
 		}()
 
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, dynamic...")
 		c := openapi3.NewRoot(f.ClientSet.Discovery().OpenAPIV3())
 		var openAPISpec *spec3.OpenAPI
 		// Poll for the OpenAPI to be updated with the new CRD
@@ -141,7 +141,7 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 		framework.ExpectNoError(err, "timed out getting new CustomResourceDefinition")
 
 		specMarshalled, err := json.Marshal(openAPISpec)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to json.Marshal(openAPISpec)")
 		var spec2 spec3.OpenAPI
 		json.Unmarshal(specMarshalled, &spec2)
 
@@ -174,9 +174,9 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 	*/
 	f.It("should contain OpenAPI V3 for Aggregated APIServer", f.WithSerial(), func(ctx context.Context) {
 		config, err := framework.LoadConfig()
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to framework.LoadConfig()")
 		aggrclient, err := aggregatorclient.NewForConfig(config)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to aggregatorclient.NewForConfig(config)")
 		names := generateSampleAPIServerObjectNames(f.Namespace.Name)
 		SetUpSampleAPIServer(ctx, f, aggrclient, imageutils.GetE2EImage(imageutils.APIServer), names, samplev1beta1.GroupName, "v1beta1")
 		defer cleanupSampleAPIServer(ctx, f.ClientSet, aggrclient, names, "v1beta1.wardle.example.com")
@@ -194,7 +194,7 @@ var _ = SIGDescribe("OpenAPIV3", func() {
 		})
 
 		specMarshalled, err := json.Marshal(openAPISpec)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to json.Marshal(openAPISpec)")
 		var spec2 spec3.OpenAPI
 		json.Unmarshal(specMarshalled, &spec2)
 

--- a/test/e2e/apimachinery/protocol.go
+++ b/test/e2e/apimachinery/protocol.go
@@ -60,9 +60,9 @@ var _ = SIGDescribe("client-go should negotiate", func() {
 			configMapName := "e2e-client-go-test-negotiation"
 			testConfigMap := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: configMapName}}
 			before, err := client.List(context.TODO(), metav1.ListOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.List(context.TODO(), metav1.ListOptions{})")
 			_, err = client.Create(context.TODO(), testConfigMap, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.Create(context.TODO(), testConfigMap, metav1.CreateOptions{})")
 			opts := metav1.ListOptions{
 				ResourceVersion: before.ResourceVersion,
 				FieldSelector:   fields.SelectorFromSet(fields.Set{"metadata.name": configMapName}).String(),
@@ -70,13 +70,13 @@ var _ = SIGDescribe("client-go should negotiate", func() {
 
 			g.By("watching for changes on the object")
 			cfg, err := framework.LoadConfig()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to framework.LoadConfig()")
 
 			cfg.AcceptContentTypes = accept
 
 			c := kubernetes.NewForConfigOrDie(cfg)
 			w, err := c.CoreV1().ConfigMaps(ns).Watch(context.TODO(), opts)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().ConfigMaps(ns).Watch(context.TODO(), opts)")
 			defer w.Stop()
 
 			evt, ok := <-w.ResultChan()
@@ -115,13 +115,13 @@ var _ = SIGDescribe("CBOR", feature.CBOR, func() {
 		clientfeaturestesting.SetFeatureDuringTest(g.GinkgoTB(), clientfeatures.ClientsPreferCBOR, true)
 
 		clientConfig, err := framework.LoadConfig()
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to framework.LoadConfig()")
 
 		aggregatorClient, err := aggregatorclientset.NewForConfig(clientConfig)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to aggregatorclientset.NewForConfig(clientConfig)")
 
 		dynamicClient, err := dynamic.NewForConfig(clientConfig)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to dynamic.NewForConfig(clientConfig)")
 
 		objectNames := generateSampleAPIServerObjectNames(f.Namespace.Name)
 		g.DeferCleanup(func(ctx context.Context) {
@@ -137,7 +137,7 @@ var _ = SIGDescribe("CBOR", feature.CBOR, func() {
 
 		g.By("making requests with a generated client", func() {
 			sampleClient, err := samplev1alpha1client.NewForConfig(clientConfig)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to samplev1alpha1client.NewForConfig(clientConfig)")
 
 			_, err = sampleClient.Flunders(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: "a,!a"})
 			framework.ExpectNoError(err, "Failed to list with generated client")
@@ -151,7 +151,7 @@ var _ = SIGDescribe("CBOR", feature.CBOR, func() {
 
 		g.By("making requests with a dynamic client", func() {
 			unstructuredFlunderContent, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&flunder)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to runtime.DefaultUnstructuredConverter.ToUnstructured(&flunder)")
 			unstructuredFlunder := &unstructured.Unstructured{Object: unstructuredFlunderContent}
 
 			flunderDynamicClient := dynamicClient.Resource(samplev1alpha1.SchemeGroupVersion.WithResource("flunders")).Namespace(f.Namespace.Name)

--- a/test/e2e/apimachinery/request_timeout.go
+++ b/test/e2e/apimachinery/request_timeout.go
@@ -41,7 +41,7 @@ var _ = SIGDescribe("Server request timeout", func() {
 		req := newRequest(f, "invalid")
 
 		response, err := rt.RoundTrip(req)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rt.RoundTrip(req)")
 		defer response.Body.Close()
 
 		if response.StatusCode != http.StatusBadRequest {
@@ -60,7 +60,7 @@ var _ = SIGDescribe("Server request timeout", func() {
 		req := newRequest(f, "3m")
 
 		response, err := rt.RoundTrip(req)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rt.RoundTrip(req)")
 		defer response.Body.Close()
 
 		if response.StatusCode != http.StatusOK {
@@ -73,7 +73,7 @@ var _ = SIGDescribe("Server request timeout", func() {
 		req := newRequest(f, "0s")
 
 		response, err := rt.RoundTrip(req)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rt.RoundTrip(req)")
 		defer response.Body.Close()
 
 		if response.StatusCode != http.StatusOK {
@@ -89,7 +89,7 @@ func getRoundTripper(f *framework.Framework) http.RoundTripper {
 	config.Timeout = 0
 
 	roundTripper, err := rest.TransportFor(config)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to rest.TransportFor(config)")
 
 	return roundTripper
 }
@@ -97,14 +97,14 @@ func getRoundTripper(f *framework.Framework) http.RoundTripper {
 func newRequest(f *framework.Framework, timeout string) *http.Request {
 	req, err := http.NewRequest(http.MethodGet, f.ClientSet.CoreV1().RESTClient().Get().
 		Param("timeout", timeout).AbsPath("version").URL().String(), nil)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to http.NewRequest(http.MethodGet, f.ClientSet.CoreV1().RESTClient().Get().")
 
 	return req
 }
 
 func readBody(response *http.Response) string {
 	raw, err := io.ReadAll(response.Body)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to io.ReadAll(response.Body)")
 
 	return string(raw)
 }

--- a/test/e2e/apimachinery/resource_quota.go
+++ b/test/e2e/apimachinery/resource_quota.go
@@ -87,19 +87,19 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	framework.ConformanceIt("should create a ResourceQuota and ensure its status is promptly calculated.", func(ctx context.Context) {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)")
 
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
 		_, err = createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)")
 
 		ginkgo.By("Ensuring resource quota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 	})
 
 	/*
@@ -112,29 +112,29 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	framework.ConformanceIt("should create a ResourceQuota and capture the life of a service.", func(ctx context.Context) {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)")
 
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
 		_, err = createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)")
 
 		ginkgo.By("Ensuring resource quota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Creating a Service")
 		service := newTestServiceForQuota("test-service", v1.ServiceTypeClusterIP, false)
 		service, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, service, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, service, metav1.C...")
 
 		ginkgo.By("Creating a NodePort Service")
 		nodeport := newTestServiceForQuota("test-service-np", v1.ServiceTypeNodePort, false)
 		nodeport, err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, nodeport, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(ctx, nodeport, metav1....")
 
 		ginkgo.By("Not allowing a LoadBalancer Service with NodePort to be created that exceeds remaining quota")
 		loadbalancer := newTestServiceForQuota("test-service-lb", v1.ServiceTypeLoadBalancer, true)
@@ -147,19 +147,19 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceServices] = resource.MustParse("2")
 		usedResources[v1.ResourceServicesNodePorts] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Deleting Services")
 		err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(ctx, service.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(ctx, service.Name, met...")
 		err = f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(ctx, nodeport.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(ctx, nodeport.Name, me...")
 
 		ginkgo.By("Ensuring resource quota status released usage")
 		usedResources[v1.ResourceServices] = resource.MustParse("0")
 		usedResources[v1.ResourceServicesNodePorts] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 	})
 
 	/*
@@ -176,7 +176,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		// Wait up to 5s for the count to stabilize, assuming that updates come at a consistent rate, and are not held indefinitely.
 		err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 			secrets, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).List(ctx, metav1.ListOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Secrets(f.Namespace.Name).List(ctx, metav1.ListOptions{})")
 			if len(secrets.Items) == found {
 				// loop until the number of secrets has stabilized for 5 seconds
 				unchanged++
@@ -186,32 +186,32 @@ var _ = SIGDescribe("ResourceQuota", func() {
 			found = len(secrets.Items)
 			return false, nil
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Secrets(f.Namespace.Name).List(ctx, ...")
 		defaultSecrets := fmt.Sprintf("%d", found)
 		hardSecrets := fmt.Sprintf("%d", found+1)
 
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)")
 
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
 		resourceQuota.Spec.Hard[v1.ResourceSecrets] = resource.MustParse(hardSecrets)
 		_, err = createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)")
 
 		ginkgo.By("Ensuring resource quota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
 		usedResources[v1.ResourceSecrets] = resource.MustParse(defaultSecrets)
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Creating a Secret")
 		secret := newTestSecretForQuota("test-secret")
 		secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, secret, metav1.Cre...")
 
 		ginkgo.By("Ensuring resource quota status captures secret creation")
 		usedResources = v1.ResourceList{}
@@ -219,16 +219,16 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		// we expect there to be two secrets because each namespace will receive
 		// a service account token secret by default
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Deleting a secret")
 		err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, secret.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(ctx, secret.Name, metav...")
 
 		ginkgo.By("Ensuring resource quota status released usage")
 		usedResources[v1.ResourceSecrets] = resource.MustParse(defaultSecrets)
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 	})
 
 	/*
@@ -243,19 +243,19 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	framework.ConformanceIt("should create a ResourceQuota and capture the life of a pod.", func(ctx context.Context) {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)")
 
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
 		_, err = createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)")
 
 		ginkgo.By("Ensuring resource quota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Creating a Pod that fits quota")
 		podName := "test-pod"
@@ -268,7 +268,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		limits[v1.ResourceName(extendedResourceName)] = resource.MustParse("2")
 		pod := newTestPodForQuota(f, podName, requests, limits)
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 		podToUpdate := pod
 
 		ginkgo.By("Ensuring ResourceQuota status captures the pod usage")
@@ -279,7 +279,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceEphemeralStorage] = requests[v1.ResourceEphemeralStorage]
 		usedResources[v1.ResourceName(v1.DefaultResourceRequestsPrefix+extendedResourceName)] = requests[v1.ResourceName(extendedResourceName)]
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Not allowing a pod to be created that exceeds remaining quota")
 		requests = v1.ResourceList{}
@@ -313,11 +313,11 @@ var _ = SIGDescribe("ResourceQuota", func() {
 
 		ginkgo.By("Ensuring attempts to update pod resource requirements did not change quota usage")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podName, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podName, *metav1.NewD...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
@@ -327,7 +327,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceEphemeralStorage] = resource.MustParse("0")
 		usedResources[v1.ResourceName(v1.DefaultResourceRequestsPrefix+extendedResourceName)] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 	})
 	/*
 		Release: v1.16
@@ -342,7 +342,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		// Wait up to 15s for the count to stabilize, assuming that updates come at a consistent rate, and are not held indefinitely.
 		err := wait.PollUntilContextTimeout(ctx, 1*time.Second, time.Minute, false, func(ctx context.Context) (bool, error) {
 			configmaps, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).List(ctx, metav1.ListOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).List(ctx, metav1.ListOption...")
 			if len(configmaps.Items) == found {
 				// loop until the number of configmaps has stabilized for 15 seconds
 				unchanged++
@@ -352,48 +352,48 @@ var _ = SIGDescribe("ResourceQuota", func() {
 			found = len(configmaps.Items)
 			return false, nil
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).List(ct...")
 		defaultConfigMaps := fmt.Sprintf("%d", found)
 		hardConfigMaps := fmt.Sprintf("%d", found+1)
 
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)")
 
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
 		resourceQuota.Spec.Hard[v1.ResourceConfigMaps] = resource.MustParse(hardConfigMaps)
 		_, err = createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)")
 
 		ginkgo.By("Ensuring resource quota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
 		usedResources[v1.ResourceConfigMaps] = resource.MustParse(defaultConfigMaps)
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Creating a ConfigMap")
 		configMap := newTestConfigMapForQuota("test-configmap")
 		configMap, err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, meta...")
 
 		ginkgo.By("Ensuring resource quota status captures configMap creation")
 		usedResources = v1.ResourceList{}
 		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
 		usedResources[v1.ResourceConfigMaps] = resource.MustParse(hardConfigMaps)
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Deleting a ConfigMap")
 		err = f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, configMap.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, configMap.Name,...")
 
 		ginkgo.By("Ensuring resource quota status released usage")
 		usedResources[v1.ResourceConfigMaps] = resource.MustParse(defaultConfigMaps)
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 	})
 
 	/*
@@ -406,31 +406,31 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	framework.ConformanceIt("should create a ResourceQuota and capture the life of a replication controller.", func(ctx context.Context) {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)")
 
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
 		_, err = createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)")
 
 		ginkgo.By("Ensuring resource quota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
 		usedResources[v1.ResourceReplicationControllers] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Creating a ReplicationController")
 		replicationController := newTestReplicationControllerForQuota("test-rc", "nginx", 0)
 		replicationController, err = f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, replicationController, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(ctx, rep...")
 
 		ginkgo.By("Ensuring resource quota status captures replication controller creation")
 		usedResources = v1.ResourceList{}
 		usedResources[v1.ResourceReplicationControllers] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Deleting a ReplicationController")
 		// Without the delete options, the object isn't actually
@@ -444,12 +444,12 @@ var _ = SIGDescribe("ResourceQuota", func() {
 				return &p
 			}(),
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.N...")
 
 		ginkgo.By("Ensuring resource quota status released usage")
 		usedResources[v1.ResourceReplicationControllers] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 	})
 
 	/*
@@ -462,40 +462,40 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	framework.ConformanceIt("should create a ResourceQuota and capture the life of a replica set.", func(ctx context.Context) {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)")
 
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
 		_, err = createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)")
 
 		ginkgo.By("Ensuring resource quota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
 		usedResources[v1.ResourceName("count/replicasets.apps")] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Creating a ReplicaSet")
 		replicaSet := newTestReplicaSetForQuota("test-rs", "nginx", 0)
 		replicaSet, err = f.ClientSet.AppsV1().ReplicaSets(f.Namespace.Name).Create(ctx, replicaSet, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.AppsV1().ReplicaSets(f.Namespace.Name).Create(ctx, replicaSet, me...")
 
 		ginkgo.By("Ensuring resource quota status captures replicaset creation")
 		usedResources = v1.ResourceList{}
 		usedResources[v1.ResourceName("count/replicasets.apps")] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Deleting a ReplicaSet")
 		err = f.ClientSet.AppsV1().ReplicaSets(f.Namespace.Name).Delete(ctx, replicaSet.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.AppsV1().ReplicaSets(f.Namespace.Name).Delete(ctx, replicaSet.Nam...")
 
 		ginkgo.By("Ensuring resource quota status released usage")
 		usedResources[v1.ResourceName("count/replicasets.apps")] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 	})
 
 	/*
@@ -509,13 +509,13 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	f.It("should create a ResourceQuota and capture the life of a ResourceClaim", f.WithFeatureGate(features.DynamicResourceAllocation), f.WithLabel("DRA"), func(ctx context.Context) {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)")
 
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuotaDRA(quotaName)
 		_, err = createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)")
 
 		ginkgo.By("Ensuring resource quota status is calculated")
 		usedResources := v1.ResourceList{}
@@ -523,29 +523,29 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[core.ClaimObjectCountName] = resource.MustParse("0")
 		usedResources[core.V1ResourceByDeviceClass(classGold)] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Creating a ResourceClaim")
 		claim := newTestResourceClaimForQuota("test-claim")
 		claim, err = f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Create(ctx, claim, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Create(ctx, claim, ...")
 
 		ginkgo.By("Ensuring resource quota status captures resource claim creation")
 		usedResources = v1.ResourceList{}
 		usedResources[core.ClaimObjectCountName] = resource.MustParse("1")
 		usedResources[core.V1ResourceByDeviceClass(classGold)] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Deleting a ResourceClaim")
 		err = f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Delete(ctx, claim.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.ResourceV1().ResourceClaims(f.Namespace.Name).Delete(ctx, claim.N...")
 
 		ginkgo.By("Ensuring resource quota status released usage")
 		usedResources[core.ClaimObjectCountName] = resource.MustParse("0")
 		usedResources[core.V1ResourceByDeviceClass(classGold)] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 	})
 
 	/*
@@ -559,13 +559,13 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	ginkgo.It("should create a ResourceQuota and capture the life of a persistent volume claim", func(ctx context.Context) {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)")
 
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
 		_, err = createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)")
 
 		ginkgo.By("Ensuring resource quota status is calculated")
 		usedResources := v1.ResourceList{}
@@ -573,29 +573,29 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("0")
 		usedResources[v1.ResourceRequestsStorage] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Creating a PersistentVolumeClaim")
 		pvc := newTestPersistentVolumeClaimForQuota("test-claim")
 		pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc...")
 
 		ginkgo.By("Ensuring resource quota status captures persistent volume claim creation")
 		usedResources = v1.ResourceList{}
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("1")
 		usedResources[v1.ResourceRequestsStorage] = resource.MustParse("1Gi")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Deleting a PersistentVolumeClaim")
 		err = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(ctx, pvc.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(ctx, pvc...")
 
 		ginkgo.By("Ensuring resource quota status released usage")
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("0")
 		usedResources[v1.ResourceRequestsStorage] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 	})
 
 	/*
@@ -609,13 +609,13 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	ginkgo.It("should create a ResourceQuota and capture the life of a persistent volume claim with a storage class", func(ctx context.Context) {
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)")
 
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
 		_, err = createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)")
 
 		ginkgo.By("Ensuring resource quota status is calculated")
 		usedResources := v1.ResourceList{}
@@ -626,13 +626,13 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[core.V1ResourceByStorageClass(classGold, v1.ResourceRequestsStorage)] = resource.MustParse("0")
 
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Creating a PersistentVolumeClaim with storage class")
 		pvc := newTestPersistentVolumeClaimForQuota("test-claim")
 		pvc.Spec.StorageClassName = &classGold
 		pvc, err = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc...")
 
 		ginkgo.By("Ensuring resource quota status captures persistent volume claim creation")
 		usedResources = v1.ResourceList{}
@@ -642,11 +642,11 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[core.V1ResourceByStorageClass(classGold, v1.ResourceRequestsStorage)] = resource.MustParse("1Gi")
 
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Deleting a PersistentVolumeClaim")
 		err = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(ctx, pvc.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(ctx, pvc...")
 
 		ginkgo.By("Ensuring resource quota status released usage")
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("0")
@@ -655,13 +655,13 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[core.V1ResourceByStorageClass(classGold, v1.ResourceRequestsStorage)] = resource.MustParse("0")
 
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 	})
 
 	ginkgo.It("should create a ResourceQuota and capture the life of a custom resource.", func(ctx context.Context) {
 		ginkgo.By("Creating a Custom Resource Definition")
 		testcrd, err := crd.CreateTestCRD(f)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to crd.CreateTestCRD(f)")
 		ginkgo.DeferCleanup(testcrd.CleanUp)
 		countResourceName := "count/" + testcrd.Crd.Spec.Names.Plural + "." + testcrd.Crd.Spec.Group
 		// resourcequota controller needs to take 30 seconds at most to detect the new custom resource.
@@ -676,29 +676,29 @@ var _ = SIGDescribe("ResourceQuota", func() {
 				},
 			},
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, &...")
 		err = updateResourceQuotaUntilUsageAppears(ctx, f.ClientSet, f.Namespace.Name, quotaName, v1.ResourceName(countResourceName))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateResourceQuotaUntilUsageAppears(ctx, f.ClientSet, f.Namespace.Name, quot...")
 		err = f.ClientSet.CoreV1().ResourceQuotas(f.Namespace.Name).Delete(ctx, quotaName, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ResourceQuotas(f.Namespace.Name).Delete(ctx, quotaName, ...")
 
 		ginkgo.By("Counting existing ResourceQuota")
 		c, err := countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to countResourceQuota(ctx, f.ClientSet, f.Namespace.Name)")
 
 		ginkgo.By("Creating a ResourceQuota")
 		quotaName = "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
 		resourceQuota.Spec.Hard[v1.ResourceName(countResourceName)] = resource.MustParse("1")
 		_, err = createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuota)")
 
 		ginkgo.By("Ensuring resource quota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourceQuotas] = resource.MustParse(strconv.Itoa(c + 1))
 		usedResources[v1.ResourceName(countResourceName)] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Creating a custom resource")
 		resourceClient := testcrd.DynamicClients["v1"]
@@ -711,13 +711,13 @@ var _ = SIGDescribe("ResourceQuota", func() {
 				},
 			},
 		}, resourceClient, testcrd.Crd)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to instantiateCustomResource(ctx, &unstructured.Unstructured{")
 
 		ginkgo.By("Ensuring resource quota status captures custom resource creation")
 		usedResources = v1.ResourceList{}
 		usedResources[v1.ResourceName(countResourceName)] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 
 		ginkgo.By("Creating a second custom resource")
 		_, err = instantiateCustomResource(ctx, &unstructured.Unstructured{
@@ -734,12 +734,12 @@ var _ = SIGDescribe("ResourceQuota", func() {
 
 		ginkgo.By("Deleting a custom resource")
 		err = deleteCustomResource(ctx, resourceClient, testcr.GetName())
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to deleteCustomResource(ctx, resourceClient, testcr.GetName())")
 
 		ginkgo.By("Ensuring resource quota status released usage")
 		usedResources[v1.ResourceName(countResourceName)] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaName, usedResou...")
 	})
 
 	/*
@@ -755,22 +755,22 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		ginkgo.By("Creating a ResourceQuota with terminating scope")
 		quotaTerminatingName := "quota-terminating"
 		resourceQuotaTerminating, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScope(quotaTerminatingName, v1.ResourceQuotaScopeTerminating))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTermina...")
 
 		ginkgo.By("Creating a ResourceQuota with not terminating scope")
 		quotaNotTerminatingName := "quota-not-terminating"
 		resourceQuotaNotTerminating, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScope(quotaNotTerminatingName, v1.ResourceQuotaScopeNotTerminating))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerm...")
 
 		ginkgo.By("Creating a long running pod")
 		podName := "test-pod"
@@ -782,7 +782,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		limits[v1.ResourceMemory] = resource.MustParse("400Mi")
 		pod := newTestPodForQuota(f, podName, requests, limits)
 		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with not terminating scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -791,7 +791,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = limits[v1.ResourceCPU]
 		usedResources[v1.ResourceLimitsMemory] = limits[v1.ResourceMemory]
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerm...")
 
 		ginkgo.By("Ensuring resource quota with terminating scope ignored the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -800,11 +800,11 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = ensureResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to ensureResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminat...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podName, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podName, *metav1.NewD...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -813,7 +813,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerm...")
 
 		ginkgo.By("Creating a terminating pod")
 		podName = "terminating-pod"
@@ -821,7 +821,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		activeDeadlineSeconds := int64(3600)
 		pod.Spec.ActiveDeadlineSeconds = &activeDeadlineSeconds
 		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with terminating scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -830,7 +830,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = limits[v1.ResourceCPU]
 		usedResources[v1.ResourceLimitsMemory] = limits[v1.ResourceMemory]
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTermina...")
 
 		ginkgo.By("Ensuring resource quota with not terminating scope ignored the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -839,13 +839,13 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerm...")
 		err = ensureResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to ensureResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTermi...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podName, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podName, *metav1.NewD...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -854,7 +854,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTermina...")
 	})
 
 	/*
@@ -869,45 +869,45 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	framework.ConformanceIt("should verify ResourceQuota with best effort scope.", func(ctx context.Context) {
 		ginkgo.By("Creating a ResourceQuota with best effort scope")
 		resourceQuotaBestEffort, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScope("quota-besteffort", v1.ResourceQuotaScopeBestEffort))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEff...")
 
 		ginkgo.By("Creating a ResourceQuota with not best effort scope")
 		resourceQuotaNotBestEffort, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScope("quota-not-besteffort", v1.ResourceQuotaScopeNotBestEffort))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBest...")
 
 		ginkgo.By("Creating a best-effort pod")
 		pod := newTestPodForQuota(f, podName, v1.ResourceList{}, v1.ResourceList{})
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with best effort scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEff...")
 
 		ginkgo.By("Ensuring resource quota with not best effort ignored the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBest...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEff...")
 
 		ginkgo.By("Creating a not best-effort pod")
 		requests := v1.ResourceList{}
@@ -918,26 +918,26 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		limits[v1.ResourceMemory] = resource.MustParse("400Mi")
 		pod = newTestPodForQuota(f, "burstable-pod", requests, limits)
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with not best effort scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBest...")
 
 		ginkgo.By("Ensuring resource quota with best effort scope ignored the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEff...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBest...")
 	})
 
 	/*
@@ -962,11 +962,11 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		resourceQuota.Spec.Hard[v1.ResourceCPU] = resource.MustParse("1")
 		resourceQuota.Spec.Hard[v1.ResourceMemory] = resource.MustParse("500Mi")
 		_, err := createResourceQuota(ctx, client, ns, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, client, ns, resourceQuota)")
 
 		ginkgo.By("Getting a ResourceQuota")
 		resourceQuotaResult, err := client.CoreV1().ResourceQuotas(ns).Get(ctx, quotaName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.CoreV1().ResourceQuotas(ns).Get(ctx, quotaName, metav1.GetOptions{})")
 		gomega.Expect(resourceQuotaResult.Spec.Hard).To(gomega.HaveKeyWithValue(v1.ResourceCPU, resource.MustParse("1")))
 		gomega.Expect(resourceQuotaResult.Spec.Hard).To(gomega.HaveKeyWithValue(v1.ResourceMemory, resource.MustParse("500Mi")))
 
@@ -974,19 +974,19 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		resourceQuota.Spec.Hard[v1.ResourceCPU] = resource.MustParse("2")
 		resourceQuota.Spec.Hard[v1.ResourceMemory] = resource.MustParse("1Gi")
 		resourceQuotaResult, err = client.CoreV1().ResourceQuotas(ns).Update(ctx, resourceQuota, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.CoreV1().ResourceQuotas(ns).Update(ctx, resourceQuota, metav1.UpdateOp...")
 		gomega.Expect(resourceQuotaResult.Spec.Hard).To(gomega.HaveKeyWithValue(v1.ResourceCPU, resource.MustParse("2")))
 		gomega.Expect(resourceQuotaResult.Spec.Hard).To(gomega.HaveKeyWithValue(v1.ResourceMemory, resource.MustParse("1Gi")))
 
 		ginkgo.By("Verifying a ResourceQuota was modified")
 		resourceQuotaResult, err = client.CoreV1().ResourceQuotas(ns).Get(ctx, quotaName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.CoreV1().ResourceQuotas(ns).Get(ctx, quotaName, metav1.GetOptions{})")
 		gomega.Expect(resourceQuotaResult.Spec.Hard).To(gomega.HaveKeyWithValue(v1.ResourceCPU, resource.MustParse("2")))
 		gomega.Expect(resourceQuotaResult.Spec.Hard).To(gomega.HaveKeyWithValue(v1.ResourceMemory, resource.MustParse("1Gi")))
 
 		ginkgo.By("Deleting a ResourceQuota")
 		err = deleteResourceQuota(ctx, client, ns, quotaName)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to deleteResourceQuota(ctx, client, ns, quotaName)")
 
 		ginkgo.By("Verifying the deleted ResourceQuota")
 		_, err = client.CoreV1().ResourceQuotas(ns).Get(ctx, quotaName, metav1.GetOptions{})
@@ -1027,11 +1027,11 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		resourceQuota.Spec.Hard[v1.ResourceCPU] = resource.MustParse("1")
 		resourceQuota.Spec.Hard[v1.ResourceMemory] = resource.MustParse("500Mi")
 		_, err := createResourceQuota(ctx, client, ns, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, client, ns, resourceQuota)")
 
 		ginkgo.By("Getting a ResourceQuota")
 		resourceQuotaResult, err := client.CoreV1().ResourceQuotas(ns).Get(ctx, rqName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.CoreV1().ResourceQuotas(ns).Get(ctx, rqName, metav1.GetOptions{})")
 		gomega.Expect(resourceQuotaResult.Spec.Hard[v1.ResourceCPU]).To(gomega.Equal(resource.MustParse("1")))
 		gomega.Expect(resourceQuotaResult.Spec.Hard[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("500Mi")))
 		gomega.Expect(resourceQuotaResult).To(apimachineryutils.HaveValidResourceVersion())
@@ -1051,7 +1051,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 
 		ginkgo.By("Deleting a Collection of ResourceQuotas")
 		err = client.CoreV1().ResourceQuotas(ns).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: labelSelector})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.CoreV1().ResourceQuotas(ns).DeleteCollection(ctx, metav1.DeleteOptions...")
 
 		ginkgo.By("Verifying the deleted ResourceQuota")
 		_, err = client.CoreV1().ResourceQuotas(ns).Get(ctx, rqName, metav1.GetOptions{})
@@ -1106,10 +1106,10 @@ var _ = SIGDescribe("ResourceQuota", func() {
 			},
 		}
 		_, err = createResourceQuota(ctx, f.ClientSet, ns, resourceQuota)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, ns, resourceQuota)")
 
 		initialResourceQuota, err := rqClient.Get(ctx, rqName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rqClient.Get(ctx, rqName, metav1.GetOptions{})")
 		gomega.Expect(*initialResourceQuota.Spec.Hard.Cpu()).To(gomega.Equal(resource.MustParse("500m")), "Hard cpu value for ResourceQuota %q is %s not 500m.", initialResourceQuota.Name, initialResourceQuota.Spec.Hard.Cpu().String())
 		framework.Logf("Resource quota %q reports spec: hard cpu limit of %s", rqName, initialResourceQuota.Spec.Hard.Cpu())
 		gomega.Expect(*initialResourceQuota.Spec.Hard.Memory()).To(gomega.Equal(resource.MustParse("500Mi")), "Hard memory value for ResourceQuota %q is %s not 500Mi.", initialResourceQuota.Name, initialResourceQuota.Spec.Hard.Memory().String())
@@ -1168,11 +1168,11 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		hardLimits = quota.Add(v1.ResourceList{}, xResourceQuota.Spec.Hard)
 
 		rqStatusJSON, err := json.Marshal(hardLimits)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to json.Marshal(hardLimits)")
 		patchedResourceQuota, err := rqClient.Patch(ctx, rqName, types.StrategicMergePatchType,
 			[]byte(`{"status": {"hard": `+string(rqStatusJSON)+`}}`),
 			metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rqClient.Patch(ctx, rqName, types.StrategicMergePatchType,")
 
 		ginkgo.By(fmt.Sprintf("Confirm /status for %q resourceQuota via watch", rqName))
 		ctxUntil, cancel = context.WithTimeout(ctx, f.Timeouts.PodStartShort)
@@ -1199,7 +1199,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		ginkgo.By(fmt.Sprintf("Get %q /status", rqName))
 		rqResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "resourcequotas"}
 		unstruct, err := f.DynamicClient.Resource(rqResource).Namespace(ns).Get(ctx, resourceQuota.Name, metav1.GetOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.DynamicClient.Resource(rqResource).Namespace(ns).Get(ctx, resourceQuota.Nam...")
 
 		rq, err := unstructuredToResourceQuota(unstruct)
 		framework.ExpectNoError(err, "Getting the status of the resource quota %q", rq.Name)
@@ -1219,12 +1219,12 @@ var _ = SIGDescribe("ResourceQuota", func() {
 			v1.ResourceMemory: resource.MustParse("2Gi"),
 		}
 		rqStatusJSON, err = json.Marshal(newHardLimits)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to json.Marshal(newHardLimits)")
 
 		repatchedResourceQuota, err := rqClient.Patch(ctx, rqName, types.StrategicMergePatchType,
 			[]byte(`{"status": {"hard": `+string(rqStatusJSON)+`}}`),
 			metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rqClient.Patch(ctx, rqName, types.StrategicMergePatchType,")
 
 		gomega.Expect(*repatchedResourceQuota.Status.Hard.Cpu()).To(gomega.Equal(resource.MustParse("2")), "Hard cpu value for ResourceQuota %q is %s not 2.", repatchedResourceQuota.Name, repatchedResourceQuota.Status.Hard.Cpu().String())
 		framework.Logf("Resourcequota %q reports status: hard cpu of %s", repatchedResourceQuota.Name, repatchedResourceQuota.Status.Hard.Cpu())
@@ -1293,27 +1293,27 @@ var _ = SIGDescribe("ResourceQuota", framework.WithFeatureGate(features.VolumeAt
 
 		ginkgo.By("Creating a ResourceQuota with volume attributes class scope")
 		quota, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeForVolumeAttributesClass("quota-volumeattributesclass", hard, v1.ScopeSelectorOpIn, []string{classGold}))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourceRequestsStorage] = resource.MustParse("0")
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, usedReso...")
 
 		ginkgo.By("Creating a pvc with volume attributes class")
 		pvc1 := newTestPersistentVolumeClaimForQuota("test-claim-1")
 		pvc1.Spec.StorageClassName = ptr.To("")
 		pvc1.Spec.VolumeAttributesClassName = &classGold
 		pvc1, err = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc1, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc...")
 
 		ginkgo.By("Ensuring resource quota with volume attributes class scope captures the pvc usage")
 		usedResources[v1.ResourceRequestsStorage] = resource.MustParse("1Gi")
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, usedReso...")
 
 		ginkgo.By("Creating 2nd pod with priority class should fail")
 		pvc2 := newTestPersistentVolumeClaimForQuota("test-claim-2")
@@ -1324,13 +1324,13 @@ var _ = SIGDescribe("ResourceQuota", framework.WithFeatureGate(features.VolumeAt
 
 		ginkgo.By("Deleting first pvc")
 		err = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(ctx, pvc1.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Delete(ctx, pvc...")
 
 		ginkgo.By("Ensuring resource quota status released the pvc usage")
 		usedResources[v1.ResourceRequestsStorage] = resource.MustParse("0")
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, usedReso...")
 	})
 
 	ginkgo.It("should verify ResourceQuota's volume attributes class scope (quota set to pvc count: 1) against a pvc with different volume attributes class.", func(ctx context.Context) {
@@ -1340,31 +1340,31 @@ var _ = SIGDescribe("ResourceQuota", framework.WithFeatureGate(features.VolumeAt
 
 		ginkgo.By("Creating 2 ResourceQuotas with volume attributes class scope")
 		quotaGold, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeForVolumeAttributesClass("quota-volumeattributesclass-gold", hard, v1.ScopeSelectorOpIn, []string{classGold}))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 		quotaSilver, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeForVolumeAttributesClass("quota-volumeattributesclass-silver", hard, v1.ScopeSelectorOpIn, []string{classSilver}))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring all ResourceQuotas status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourceRequestsStorage] = resource.MustParse("0")
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaGold.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaGold.Name, used...")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaSilver.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaSilver.Name, us...")
 
 		ginkgo.By("Creating a pvc with volume attributes class gold")
 		pvcName := "test-claim"
 		pvc, pv := newTestPersistentVolumeClaimWithFakeCSIVolumeForQuota(f.Namespace.Name, pvcName, &classGold)
 		_, err = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Create(ctx, pvc...")
 		_, err = f.ClientSet.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().PersistentVolumes().Create(ctx, pv, metav1.CreateOptions{})")
 		ginkgo.DeferCleanup(framework.IgnoreNotFound(f.ClientSet.CoreV1().PersistentVolumes().Delete), pv.Name, metav1.DeleteOptions{})
 
 		ginkgo.By("Waiting for the PVC to be bound")
 		pvs, err := e2epv.WaitForPVClaimBoundPhase(ctx, f.ClientSet, []*v1.PersistentVolumeClaim{pvc}, framework.ClaimProvisionTimeout)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epv.WaitForPVClaimBoundPhase(ctx, f.ClientSet, []*v1.PersistentVolumeClaim{...")
 		gomega.Expect(pvs).To(gomega.HaveLen(1))
 		gomega.Expect(pvs[0].Name).To(gomega.Equal(pv.Name), "Expected PV %q to be bound to PVC %q", pv.Name, pvc.Name)
 
@@ -1372,7 +1372,7 @@ var _ = SIGDescribe("ResourceQuota", framework.WithFeatureGate(features.VolumeAt
 		usedResources[v1.ResourceRequestsStorage] = resource.MustParse("1Gi")
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaGold.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaGold.Name, used...")
 
 		ginkgo.By("Updating the desired volume attributes class of the pvc to silver")
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -1384,7 +1384,7 @@ var _ = SIGDescribe("ResourceQuota", framework.WithFeatureGate(features.VolumeAt
 			_, err = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Update(ctx, gotPVC, metav1.UpdateOptions{})
 			return err
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Update(ctx, got...")
 
 		ginkgo.By("Ensuring resource quota with volume attributes class scope captures the pvc usage")
 		// the pvc references two different classes, one is in the spec which represents the desired class
@@ -1392,9 +1392,9 @@ var _ = SIGDescribe("ResourceQuota", framework.WithFeatureGate(features.VolumeAt
 		usedResources[v1.ResourceRequestsStorage] = resource.MustParse("1Gi")
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaSilver.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaSilver.Name, us...")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaGold.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaGold.Name, used...")
 
 		ginkgo.By("Update the pv to have the volume attributes class silver")
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -1406,7 +1406,7 @@ var _ = SIGDescribe("ResourceQuota", framework.WithFeatureGate(features.VolumeAt
 			_, err = f.ClientSet.CoreV1().PersistentVolumes().Update(ctx, gotPV, metav1.UpdateOptions{})
 			return err
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().PersistentVolumes().Update(ctx, gotPV, metav1.UpdateOpti...")
 
 		ginkgo.By("Update the current volume attributes class of the pvc to silver")
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error { // no real driver, so we have to simulate the driver behavior
@@ -1418,17 +1418,17 @@ var _ = SIGDescribe("ResourceQuota", framework.WithFeatureGate(features.VolumeAt
 			_, err = f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).UpdateStatus(ctx, gotPVC, metav1.UpdateOptions{})
 			return err
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().PersistentVolumeClaims(f.Namespace.Name).UpdateStatus(ct...")
 
 		ginkgo.By("Ensuring resource quota with volume attributes class scope captures the pvc usage")
 		usedResources[v1.ResourceRequestsStorage] = resource.MustParse("0")
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaGold.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaGold.Name, used...")
 		usedResources[v1.ResourceRequestsStorage] = resource.MustParse("1Gi")
 		usedResources[v1.ResourcePersistentVolumeClaims] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaSilver.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quotaSilver.Name, us...")
 	})
 })
 
@@ -1438,45 +1438,45 @@ var _ = SIGDescribe("ResourceQuota", func() {
 	ginkgo.It("should verify ResourceQuota with best effort scope using scope-selectors.", func(ctx context.Context) {
 		ginkgo.By("Creating a ResourceQuota with best effort scope")
 		resourceQuotaBestEffort, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeSelector("quota-besteffort", v1.ResourceQuotaScopeBestEffort))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEff...")
 
 		ginkgo.By("Creating a ResourceQuota with not best effort scope")
 		resourceQuotaNotBestEffort, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeSelector("quota-not-besteffort", v1.ResourceQuotaScopeNotBestEffort))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBest...")
 
 		ginkgo.By("Creating a best-effort pod")
 		pod := newTestPodForQuota(f, podName, v1.ResourceList{}, v1.ResourceList{})
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with best effort scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEff...")
 
 		ginkgo.By("Ensuring resource quota with not best effort ignored the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBest...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEff...")
 
 		ginkgo.By("Creating a not best-effort pod")
 		requests := v1.ResourceList{}
@@ -1487,47 +1487,47 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		limits[v1.ResourceMemory] = resource.MustParse("400Mi")
 		pod = newTestPodForQuota(f, "burstable-pod", requests, limits)
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with not best effort scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBest...")
 
 		ginkgo.By("Ensuring resource quota with best effort scope ignored the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaBestEff...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBestEffort.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotBest...")
 	})
 	ginkgo.It("should verify ResourceQuota with terminating scopes through scope selectors.", func(ctx context.Context) {
 		ginkgo.By("Creating a ResourceQuota with terminating scope")
 		quotaTerminatingName := "quota-terminating"
 		resourceQuotaTerminating, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeSelector(quotaTerminatingName, v1.ResourceQuotaScopeTerminating))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTermina...")
 
 		ginkgo.By("Creating a ResourceQuota with not terminating scope")
 		quotaNotTerminatingName := "quota-not-terminating"
 		resourceQuotaNotTerminating, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeSelector(quotaNotTerminatingName, v1.ResourceQuotaScopeNotTerminating))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerm...")
 
 		requests := v1.ResourceList{}
 		requests[v1.ResourceCPU] = resource.MustParse("500m")
@@ -1546,7 +1546,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 
 		ginkgo.By("Creating a long running pod")
 		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod1, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod1, metav1.CreateOp...")
 
 		ginkgo.By("Ensuring resource quota with not terminating scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1555,7 +1555,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = limits[v1.ResourceCPU]
 		usedResources[v1.ResourceLimitsMemory] = limits[v1.ResourceMemory]
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerm...")
 
 		ginkgo.By("Ensuring resource quota with terminating scope ignored the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -1564,7 +1564,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = ensureResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to ensureResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminat...")
 
 		ginkgo.By("Updating the pod to have an active deadline")
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -1576,7 +1576,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 			_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, gotPod, metav1.UpdateOptions{})
 			return err
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Update(ctx, gotPod, metav1.Update...")
 
 		ginkgo.By("Creating second terminating pod")
 		_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOptions{})
@@ -1589,7 +1589,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = limits[v1.ResourceCPU]
 		usedResources[v1.ResourceLimitsMemory] = limits[v1.ResourceMemory]
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTermina...")
 
 		ginkgo.By("Ensuring resource quota with not terminating scope ignored the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -1598,11 +1598,11 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerm...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podName1, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podName1, *metav1.New...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -1611,7 +1611,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTermina...")
 
 		ginkgo.By("Creating a terminating pod")
 		// Retry creating the pod as the admission controller's view of the quota usage may lag behind the ResourceQuota status.
@@ -1625,7 +1625,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 			}
 			return true, nil
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, p...")
 
 		ginkgo.By("Ensuring resource quota with terminating scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1634,7 +1634,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = limits[v1.ResourceCPU]
 		usedResources[v1.ResourceLimitsMemory] = limits[v1.ResourceMemory]
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTermina...")
 
 		ginkgo.By("Ensuring resource quota with not terminating scope ignored the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -1643,11 +1643,11 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaNotTerm...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podName2, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podName2, *metav1.New...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -1656,7 +1656,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTerminating.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaTermina...")
 	})
 })
 
@@ -1676,33 +1676,33 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 
 		ginkgo.By("Creating a ResourceQuota with priority class scope")
 		resourceQuotaPriorityClass, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeForPriorityClass("quota-priorityclass", hard, v1.ScopeSelectorOpIn, []string{"pclass1"}))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Creating a pod with priority class")
 		podName := "testpod-pclass1"
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass1")
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with priority class scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 	})
 
 	ginkgo.It("should verify ResourceQuota's priority class scope (quota set to pod count: 1) against 2 pods with same priority class.", func(ctx context.Context) {
@@ -1717,24 +1717,24 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 
 		ginkgo.By("Creating a ResourceQuota with priority class scope")
 		resourceQuotaPriorityClass, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeForPriorityClass("quota-priorityclass", hard, v1.ScopeSelectorOpIn, []string{"pclass2"}))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Creating first pod with priority class should pass")
 		podName := "testpod-pclass2-1"
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass2")
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with priority class scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Creating 2nd pod with priority class should fail")
 		podName2 := "testpod-pclass2-2"
@@ -1744,12 +1744,12 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 
 		ginkgo.By("Deleting first pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 	})
 
 	ginkgo.It("should verify ResourceQuota's priority class scope (quota set to pod count: 1) against 2 pods with different priority class.", func(ctx context.Context) {
@@ -1764,41 +1764,41 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 
 		ginkgo.By("Creating a ResourceQuota with priority class scope")
 		resourceQuotaPriorityClass, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeForPriorityClass("quota-priorityclass", hard, v1.ScopeSelectorOpIn, []string{"pclass4"}))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Creating a pod with priority class with pclass3")
 		podName := "testpod-pclass3-1"
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass3")
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with priority class scope remains same")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Creating a 2nd pod with priority class pclass3")
 		podName2 := "testpod-pclass2-2"
 		pod2 := newTestPodForQuotaWithPriority(f, podName2, v1.ResourceList{}, v1.ResourceList{}, "pclass3")
 		pod2, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOp...")
 
 		ginkgo.By("Ensuring resource quota with priority class scope remains same")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Deleting both pods")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod2.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod2.Name, *metav1.Ne...")
 	})
 
 	ginkgo.It("should verify ResourceQuota's multiple priority class scope (quota set to pod count: 2) against 2 pods with same priority classes.", func(ctx context.Context) {
@@ -1817,46 +1817,46 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 
 		ginkgo.By("Creating a ResourceQuota with priority class scope")
 		resourceQuotaPriorityClass, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeForPriorityClass("quota-priorityclass", hard, v1.ScopeSelectorOpIn, []string{"pclass5", "pclass6"}))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Creating a pod with priority class pclass5")
 		podName := "testpod-pclass5"
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass5")
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with priority class is updated with the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Creating 2nd pod with priority class pclass6")
 		podName2 := "testpod-pclass6"
 		pod2 := newTestPodForQuotaWithPriority(f, podName2, v1.ResourceList{}, v1.ResourceList{}, "pclass6")
 		pod2, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod2, metav1.CreateOp...")
 
 		ginkgo.By("Ensuring resource quota with priority class scope is updated with the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("2")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Deleting both pods")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod2.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod2.Name, *metav1.Ne...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 	})
 
 	ginkgo.It("should verify ResourceQuota's priority class scope (quota set to pod count: 1) against a pod with different priority class (ScopeSelectorOpNotIn).", func(ctx context.Context) {
@@ -1871,28 +1871,28 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 
 		ginkgo.By("Creating a ResourceQuota with priority class scope")
 		resourceQuotaPriorityClass, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeForPriorityClass("quota-priorityclass", hard, v1.ScopeSelectorOpNotIn, []string{"pclass7"}))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Creating a pod with priority class pclass7")
 		podName := "testpod-pclass7"
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass7")
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with priority class is not used")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 	})
 
 	ginkgo.It("should verify ResourceQuota's priority class scope (quota set to pod count: 1) against a pod with different priority class (ScopeSelectorOpExists).", func(ctx context.Context) {
@@ -1907,33 +1907,33 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 
 		ginkgo.By("Creating a ResourceQuota with priority class scope")
 		resourceQuotaPriorityClass, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeForPriorityClass("quota-priorityclass", hard, v1.ScopeSelectorOpExists, []string{}))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Creating a pod with priority class pclass8")
 		podName := "testpod-pclass8"
 		pod := newTestPodForQuotaWithPriority(f, podName, v1.ResourceList{}, v1.ResourceList{}, "pclass8")
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with priority class is updated with the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 	})
 
 	ginkgo.It("should verify ResourceQuota's priority class scope (cpu, memory quota set) against a pod with same priority class.", func(ctx context.Context) {
@@ -1952,7 +1952,7 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 
 		ginkgo.By("Creating a ResourceQuota with priority class scope")
 		resourceQuotaPriorityClass, err := createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeForPriorityClass("quota-priorityclass", hard, v1.ScopeSelectorOpIn, []string{"pclass9"}))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaW...")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		usedResources := v1.ResourceList{}
@@ -1962,7 +1962,7 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0Gi")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Creating a pod with priority class")
 		podName := "testpod-pclass9"
@@ -1975,7 +1975,7 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 
 		pod := newTestPodForQuotaWithPriority(f, podName, request, limit, "pclass9")
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Ensuring resource quota with priority class scope captures the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("1")
@@ -1984,11 +1984,11 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("2")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("2Gi")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 
 		ginkgo.By("Deleting the pod")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		usedResources[v1.ResourcePods] = resource.MustParse("0")
@@ -1997,7 +1997,7 @@ var _ = SIGDescribe("ResourceQuota", feature.PodPriority, func() {
 		usedResources[v1.ResourceLimitsCPU] = resource.MustParse("0")
 		usedResources[v1.ResourceLimitsMemory] = resource.MustParse("0Gi")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorityClass.Name, usedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, resourceQuotaPriorit...")
 	})
 
 })
@@ -2009,12 +2009,12 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		ginkgo.By("Creating a ResourceQuota with cross namespace pod affinity scope")
 		quota, err := createResourceQuota(
 			ctx, f.ClientSet, f.Namespace.Name, newTestResourceQuotaWithScopeSelector("quota-cross-namespace-pod-affinity", v1.ResourceQuotaScopeCrossNamespacePodAffinity))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createResourceQuota(")
 
 		ginkgo.By("Ensuring ResourceQuota status is calculated")
 		wantUsedResources := v1.ResourceList{v1.ResourcePods: resource.MustParse("0")}
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, wantUsedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, wantUsed...")
 
 		ginkgo.By("Creating a pod that does not use cross namespace affinity")
 		pod := newTestPodWithAffinityForQuota(f, "no-cross-namespace-affinity", &v1.Affinity{
@@ -2023,7 +2023,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 					TopologyKey: "region",
 				}}}})
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		ginkgo.By("Creating a pod that uses namespaces field")
 		podWithNamespaces := newTestPodWithAffinityForQuota(f, "with-namespaces", &v1.Affinity{
@@ -2033,12 +2033,12 @@ var _ = SIGDescribe("ResourceQuota", func() {
 					Namespaces:  []string{"ns1"},
 				}}}})
 		podWithNamespaces, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, podWithNamespaces, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, podWithNamespaces, me...")
 
 		ginkgo.By("Ensuring resource quota captures podWithNamespaces usage")
 		wantUsedResources[v1.ResourcePods] = resource.MustParse("1")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, wantUsedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, wantUsed...")
 
 		ginkgo.By("Creating a pod that uses namespaceSelector field")
 		podWithNamespaceSelector := newTestPodWithAffinityForQuota(f, "with-namespace-selector", &v1.Affinity{
@@ -2055,25 +2055,25 @@ var _ = SIGDescribe("ResourceQuota", func() {
 						},
 					}}}}})
 		podWithNamespaceSelector, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, podWithNamespaceSelector, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, podWithNamespaceSelec...")
 
 		ginkgo.By("Ensuring resource quota captures podWithNamespaceSelector usage")
 		wantUsedResources[v1.ResourcePods] = resource.MustParse("2")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, wantUsedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, wantUsed...")
 
 		ginkgo.By("Deleting the pods")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, pod.Name, *metav1.New...")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podWithNamespaces.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podWithNamespaces.Nam...")
 		err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podWithNamespaceSelector.Name, *metav1.NewDeleteOptions(0))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(ctx, podWithNamespaceSelec...")
 
 		ginkgo.By("Ensuring resource quota status released the pod usage")
 		wantUsedResources[v1.ResourcePods] = resource.MustParse("0")
 		err = waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, wantUsedResources)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to waitForResourceQuota(ctx, f.ClientSet, f.Namespace.Name, quota.Name, wantUsed...")
 	})
 })
 
@@ -2488,7 +2488,7 @@ func countResourceQuota(ctx context.Context, c clientset.Interface, namespace st
 	found, unchanged := 0, 0
 	return found, wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, false, func(ctx context.Context) (bool, error) {
 		resourceQuotas, err := c.CoreV1().ResourceQuotas(namespace).List(ctx, metav1.ListOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.CoreV1().ResourceQuotas(namespace).List(ctx, metav1.ListOptions{})")
 		if len(resourceQuotas.Items) == found {
 			// loop until the number of resource quotas has stabilized for 5 seconds
 			unchanged++

--- a/test/e2e/apimachinery/validatingadmissionpolicy.go
+++ b/test/e2e/apimachinery/validatingadmissionpolicy.go
@@ -415,7 +415,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		ginkgo.By("getting /apis")
 		{
 			discoveryGroups, err := f.ClientSet.Discovery().ServerGroups()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerGroups()")
 			found := false
 			for _, group := range discoveryGroups.Groups {
 				if group.Name == admissionregistrationv1.GroupName {
@@ -436,7 +436,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		{
 			group := &metav1.APIGroup{}
 			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/admissionregistration.k8s.io").Do(ctx).Into(group)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().RESTClient().Get().AbsPath('/apis/admissionregistrati...")
 			found := false
 			for _, version := range group.Versions {
 				if version.Version == vapVersion {
@@ -452,7 +452,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		ginkgo.By("getting /apis/admissionregistration.k8s.io/" + vapVersion)
 		{
 			resources, err := f.ClientSet.Discovery().ServerResourcesForGroupVersion(admissionregistrationv1.SchemeGroupVersion.String())
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerResourcesForGroupVersion(admissionregistrationv...")
 			foundVAP, foundVAPStatus := false, false
 			for _, resource := range resources.APIResources {
 				switch resource.Name {
@@ -506,36 +506,36 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			err := client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 		})
 
 		ginkgo.By("creating")
 		_, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		_, err = client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		vapCreated, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 
 		ginkgo.By("getting")
 		vapRead, err := client.Get(ctx, vapCreated.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Get(ctx, vapCreated.Name, metav1.GetOptions{})")
 		gomega.Expect(vapRead.UID).To(gomega.Equal(vapCreated.UID))
 		gomega.Expect(vapRead).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		list, err := client.List(ctx, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
 		vapWatch, err := client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, L...")
 
 		ginkgo.By("patching")
 		patchBytes := []byte(`{"metadata":{"annotations":{"patched":"true"}},"spec":{"failurePolicy":"Ignore"}}`)
 		vapPatched, err := client.Patch(ctx, vapCreated.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Patch(ctx, vapCreated.Name, types.MergePatchType, patchBytes, metav1.P...")
 		gomega.Expect(vapPatched.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(vapPatched.Spec.FailurePolicy).To(gomega.HaveValue(gomega.Equal(admissionregistrationv1.Ignore)), "patched object should have the applied spec")
 		gomega.Expect(resourceversion.CompareResourceVersion(vapRead.ResourceVersion, vapPatched.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
@@ -544,7 +544,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		var vapUpdated *admissionregistrationv1.ValidatingAdmissionPolicy
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			vap, err := client.Get(ctx, vapCreated.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.Get(ctx, vapCreated.Name, metav1.GetOptions{})")
 
 			vapToUpdate := vap.DeepCopy()
 			vapToUpdate.Annotations["updated"] = "true"
@@ -584,14 +584,14 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		ginkgo.By("getting /status")
 		resource := admissionregistrationv1.SchemeGroupVersion.WithResource("validatingadmissionpolicies")
 		vapStatusRead, err := f.DynamicClient.Resource(resource).Get(ctx, vapCreated.Name, metav1.GetOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.DynamicClient.Resource(resource).Get(ctx, vapCreated.Name, metav1.GetOption...")
 		gomega.Expect(vapStatusRead.GetObjectKind().GroupVersionKind()).To(gomega.Equal(admissionregistrationv1.SchemeGroupVersion.WithKind("ValidatingAdmissionPolicy")))
 		gomega.Expect(vapStatusRead.GetUID()).To(gomega.Equal(vapCreated.UID))
 
 		ginkgo.By("patching /status")
 		patchBytes = []byte(`{"status":{"conditions":[{"type":"PatchStatusFailed","status":"False","reason":"e2e","message":"Set from an e2e test","lastTransitionTime":"2024-01-01T00:00:00Z"}]}}`)
 		vapStatusPatched, err := client.Patch(ctx, vapCreated.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Patch(ctx, vapCreated.Name, types.MergePatchType, patchBytes, metav1.P...")
 		hasCondition := false
 		for i := range vapStatusPatched.Status.Conditions {
 			if vapStatusPatched.Status.Conditions[i].Type == "PatchStatusFailed" {
@@ -604,7 +604,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		var vapStatusUpdated *admissionregistrationv1.ValidatingAdmissionPolicy
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			vap, err := client.Get(ctx, vapCreated.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.Get(ctx, vapCreated.Name, metav1.GetOptions{})")
 
 			vapStatusToUpdate := vap.DeepCopy()
 			vapStatusToUpdate.Status.Conditions = append(vapStatusToUpdate.Status.Conditions, metav1.Condition{
@@ -628,7 +628,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 
 		ginkgo.By("deleting")
 		err = client.Delete(ctx, vapCreated.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Delete(ctx, vapCreated.Name, metav1.DeleteOptions{})")
 		vapTmp, err := client.Get(ctx, vapCreated.Name, metav1.GetOptions{})
 		switch {
 		case err == nil && vapTmp.GetDeletionTimestamp() != nil && len(vapTmp.GetFinalizers()) > 0:
@@ -648,12 +648,12 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 				itemsWithoutFinalizer = append(itemsWithoutFinalizer, item)
 			}
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(itemsWithoutFinalizer).To(gomega.HaveLen(2), "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
 		err = client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 
 		list, err = client.List(ctx, metav1.ListOptions{LabelSelector: label})
 		var itemsColWithoutFinalizer []admissionregistrationv1.ValidatingAdmissionPolicy
@@ -662,7 +662,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 				itemsColWithoutFinalizer = append(itemsColWithoutFinalizer, item)
 			}
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(itemsColWithoutFinalizer).To(gomega.BeEmpty(), "filtered list should have 0 items")
 	})
 
@@ -684,7 +684,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		ginkgo.By("getting /apis")
 		{
 			discoveryGroups, err := f.ClientSet.Discovery().ServerGroups()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerGroups()")
 			found := false
 			for _, group := range discoveryGroups.Groups {
 				if group.Name == admissionregistrationv1.GroupName {
@@ -705,7 +705,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		{
 			group := &metav1.APIGroup{}
 			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/admissionregistration.k8s.io").Do(ctx).Into(group)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().RESTClient().Get().AbsPath('/apis/admissionregistrati...")
 			found := false
 			for _, version := range group.Versions {
 				if version.Version == vapbVersion {
@@ -721,7 +721,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		ginkgo.By("getting /apis/admissionregistration.k8s.io/" + vapbVersion)
 		{
 			resources, err := f.ClientSet.Discovery().ServerResourcesForGroupVersion(admissionregistrationv1.SchemeGroupVersion.String())
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerResourcesForGroupVersion(admissionregistrationv...")
 			foundVAPB := false
 			for _, resource := range resources.APIResources {
 				switch resource.Name {
@@ -753,36 +753,36 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 
 		ginkgo.DeferCleanup(func(ctx context.Context) {
 			err := client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 		})
 
 		ginkgo.By("creating")
 		_, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		_, err = client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 		vapbCreated, err := client.Create(ctx, template, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Create(ctx, template, metav1.CreateOptions{})")
 
 		ginkgo.By("getting")
 		vapbRead, err := client.Get(ctx, vapbCreated.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Get(ctx, vapbCreated.Name, metav1.GetOptions{})")
 		gomega.Expect(vapbRead.UID).To(gomega.Equal(vapbCreated.UID))
 		gomega.Expect(vapbRead).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		list, err := client.List(ctx, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
 		vapbWatch, err := client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Watch(ctx, metav1.ListOptions{ResourceVersion: list.ResourceVersion, L...")
 
 		ginkgo.By("patching")
 		patchBytes := []byte(`{"metadata":{"annotations":{"patched":"true"}},"spec":{"validationActions":["Warn"]}}`)
 		vapbPatched, err := client.Patch(ctx, vapbCreated.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Patch(ctx, vapbCreated.Name, types.MergePatchType, patchBytes, metav1....")
 		gomega.Expect(vapbPatched.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(vapbPatched.Spec.ValidationActions).To(gomega.Equal([]admissionregistrationv1.ValidationAction{admissionregistrationv1.Warn}), "patched object should have the applied spec")
 		gomega.Expect(resourceversion.CompareResourceVersion(vapbRead.ResourceVersion, vapbPatched.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
@@ -791,7 +791,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		var vapbUpdated *admissionregistrationv1.ValidatingAdmissionPolicyBinding
 		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			vap, err := client.Get(ctx, vapbCreated.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.Get(ctx, vapbCreated.Name, metav1.GetOptions{})")
 
 			vapbToUpdate := vap.DeepCopy()
 			vapbToUpdate.Annotations["updated"] = "true"
@@ -828,7 +828,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 		}
 		ginkgo.By("deleting")
 		err = client.Delete(ctx, vapbCreated.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.Delete(ctx, vapbCreated.Name, metav1.DeleteOptions{})")
 		vapbTmp, err := client.Get(ctx, vapbCreated.Name, metav1.GetOptions{})
 		switch {
 		case err == nil && vapbTmp.GetDeletionTimestamp() != nil && len(vapbTmp.GetFinalizers()) > 0:
@@ -848,12 +848,12 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 				itemsWithoutFinalizer = append(itemsWithoutFinalizer, item)
 			}
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(itemsWithoutFinalizer).To(gomega.HaveLen(2), "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
 		err = client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: label})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Label...")
 
 		list, err = client.List(ctx, metav1.ListOptions{LabelSelector: label})
 		var itemsColWithoutFinalizer []admissionregistrationv1.ValidatingAdmissionPolicyBinding
@@ -862,7 +862,7 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy [Privileged:ClusterAdmin]", func(
 				itemsColWithoutFinalizer = append(itemsColWithoutFinalizer, item)
 			}
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.List(ctx, metav1.ListOptions{LabelSelector: label})")
 		gomega.Expect(itemsColWithoutFinalizer).To(gomega.BeEmpty(), "filtered list should have 0 items")
 	})
 })

--- a/test/e2e/apimachinery/watchlist.go
+++ b/test/e2e/apimachinery/watchlist.go
@@ -86,17 +86,17 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithFeatureGate(
 
 		ginkgo.By("Modifying a secret and checking if the update was picked up by the secret informer")
 		secret, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(ctx, "secret-1", metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(ctx, 'secret-1', metav1.Ge...")
 		secret.StringData = map[string]string{"foo": "bar"}
 		secret, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Update(ctx, secret, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Update(ctx, secret, metav1.Upd...")
 
 		expectedSecrets[0] = secret
 		verifyStoreFor(ctx, verifyStoreForMetaObject(expectedSecrets, secretInformer.GetStore()))
 	})
 	ginkgo.It("should be requested by metadatainformer when WatchListClient is enabled", func(ctx context.Context) {
 		metadataClient, err := metadata.NewForConfig(f.ClientConfig())
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to metadata.NewForConfig(f.ClientConfig())")
 		secretMetaInformer := metadatainformer.NewFilteredMetadataInformer(
 			metadataClient,
 			v1.SchemeGroupVersion.WithResource("secrets"),
@@ -110,7 +110,7 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithFeatureGate(
 
 		_ = addWellKnownSecrets(ctx, f)
 		expectedSecrets, err := metadataClient.Resource(v1.SchemeGroupVersion.WithResource("secrets")).Namespace(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: "watchlist=true"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to metadataClient.Resource(v1.SchemeGroupVersion.WithResource('secrets')).Namesp...")
 
 		ginkgo.By("Starting the secret meta informer")
 		stopCh := make(chan struct{})
@@ -128,13 +128,13 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithFeatureGate(
 
 		ginkgo.By("Modifying a secret and checking if the update was picked up by the secret meta informer")
 		secret, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(ctx, "secret-1", metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(ctx, 'secret-1', metav1.Ge...")
 		secret.StringData = map[string]string{"foo": "bar"}
 		_, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Update(ctx, secret, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Update(ctx, secret, metav1.Upd...")
 
 		expectedSecrets, err = metadataClient.Resource(v1.SchemeGroupVersion.WithResource("secrets")).Namespace(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: "watchlist=true"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to metadataClient.Resource(v1.SchemeGroupVersion.WithResource('secrets')).Namesp...")
 		verifyStoreFor(ctx, verifyPartialObjectMetadataStore(toPointerSlice(expectedSecrets.Items), secretMetaInformer.Informer().GetStore()))
 	})
 	ginkgo.It("should NOT be requested by client-go's List method when WatchListClient is enabled", func(ctx context.Context) {
@@ -142,11 +142,11 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithFeatureGate(
 
 		rt, clientConfig := clientConfigWithRoundTripper(f)
 		wrappedKubeClient, err := kubernetes.NewForConfig(clientConfig)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to kubernetes.NewForConfig(clientConfig)")
 
 		ginkgo.By("Getting secrets from the server")
 		secretList, err := wrappedKubeClient.CoreV1().Secrets(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: "watchlist=true"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to wrappedKubeClient.CoreV1().Secrets(f.Namespace.Name).List(ctx, metav1.ListOpt...")
 
 		ginkgo.By("Verifying retrieved secrets")
 		actualSecrets := secretList.Items
@@ -162,11 +162,11 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithFeatureGate(
 
 		rt, clientConfig := clientConfigWithRoundTripper(f)
 		wrappedDynamicClient, err := dynamic.NewForConfig(clientConfig)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to dynamic.NewForConfig(clientConfig)")
 
 		ginkgo.By("Getting secrets from the server")
 		secretList, err := wrappedDynamicClient.Resource(v1.SchemeGroupVersion.WithResource("secrets")).Namespace(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: "watchlist=true"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to wrappedDynamicClient.Resource(v1.SchemeGroupVersion.WithResource('secrets'))....")
 
 		ginkgo.By("verifying retrieved secrets")
 		actualSecrets := secretList.Items
@@ -179,21 +179,21 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithFeatureGate(
 	})
 	ginkgo.It("should NOT be requested by metadata client's List method when WatchListClient is enabled", func(ctx context.Context) {
 		metaClient, err := metadata.NewForConfig(f.ClientConfig())
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to metadata.NewForConfig(f.ClientConfig())")
 		expectedMetaSecrets := []metav1.PartialObjectMetadata{}
 		for _, addedSecret := range addWellKnownSecrets(ctx, f) {
 			addedSecretMeta, err := metaClient.Resource(v1.SchemeGroupVersion.WithResource("secrets")).Namespace(f.Namespace.Name).Get(ctx, addedSecret.Name, metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to metaClient.Resource(v1.SchemeGroupVersion.WithResource('secrets')).Namespace(...")
 			expectedMetaSecrets = append(expectedMetaSecrets, *addedSecretMeta)
 		}
 
 		rt, clientConfig := clientConfigWithRoundTripper(f)
 		wrappedMetaClient, err := metadata.NewForConfig(clientConfig)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to metadata.NewForConfig(clientConfig)")
 
 		ginkgo.By("Getting secrets metadata from the server")
 		secretMetaList, err := wrappedMetaClient.Resource(v1.SchemeGroupVersion.WithResource("secrets")).Namespace(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: "watchlist=true"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to wrappedMetaClient.Resource(v1.SchemeGroupVersion.WithResource('secrets')).Nam...")
 
 		ginkgo.By("verifying retrieved secrets")
 		actualMetaSecrets := secretMetaList.Items
@@ -211,11 +211,11 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithFeatureGate(
 		}, ",")
 		modifiedClientConfig.GroupVersion = &v1.SchemeGroupVersion
 		restClient, err := rest.RESTClientFor(modifiedClientConfig)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to rest.RESTClientFor(modifiedClientConfig)")
 		dynamicClient := dynamic.New(restClient)
 
 		opts, hasPreparedOptions, err := watchlist.PrepareWatchListOptionsFromListOptions(metav1.ListOptions{LabelSelector: "watchlist=true"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to watchlist.PrepareWatchListOptionsFromListOptions(metav1.ListOptions{LabelSele...")
 		gomega.Expect(hasPreparedOptions).To(gomega.BeTrueBecause("it should be possible to prepare watchlist opts from an empty ListOptions"))
 
 		ginkgo.By(fmt.Sprintf("Adding 5 secrets to %s namespace", f.Namespace.Name))
@@ -225,7 +225,7 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithFeatureGate(
 		expectedSecrets := []*unstructured.Unstructured{}
 		for i, wellKnownSecret := range wellKnownSecrets {
 			actualSecret, err := dynamicClient.Resource(v1.SchemeGroupVersion.WithResource("secrets")).Namespace(f.Namespace.Name).Get(ctx, wellKnownSecret.GetName(), metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to dynamicClient.Resource(v1.SchemeGroupVersion.WithResource('secrets')).Namespa...")
 			if i != 0 {
 				// only the first obj has
 				// the column definition
@@ -236,7 +236,7 @@ var _ = SIGDescribe("API Streaming (aka. WatchList)", framework.WithFeatureGate(
 
 		ginkgo.By("Verifying if the secrets can be streamed in table format")
 		w, err := dynamicClient.Resource(v1.SchemeGroupVersion.WithResource("secrets")).Namespace(f.Namespace.Name).Watch(ctx, opts)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to dynamicClient.Resource(v1.SchemeGroupVersion.WithResource('secrets')).Namespa...")
 		defer w.Stop()
 
 		var ageColIndex int
@@ -323,7 +323,7 @@ func setupDynamicTableClient(f *framework.Framework) dynamic.Interface {
 	}, ",")
 	modifiedClientConfig.GroupVersion = &v1.SchemeGroupVersion
 	restClient, err := rest.RESTClientFor(modifiedClientConfig)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to rest.RESTClientFor(modifiedClientConfig)")
 	return dynamic.New(restClient)
 }
 
@@ -357,15 +357,15 @@ func verifyStoreFor(ctx context.Context, verifier func() bool) {
 
 		return verifier(), nil
 	})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 30*time.Second, true,...")
 }
 
 func verifyStoreForMetaObject[T any](expectedSecrets []*T, store cache.Store) func() bool {
 	return func() bool {
 		expectedSecretsAsMetaObject, err := toMetaObjectSlice(expectedSecrets)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to toMetaObjectSlice(expectedSecrets)")
 		actualSecretsAsMetaObject, err := toMetaObjectSlice(store.List())
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to toMetaObjectSlice(store.List())")
 
 		sort.Sort(byName(expectedSecretsAsMetaObject))
 		sort.Sort(byName(actualSecretsAsMetaObject))
@@ -377,7 +377,7 @@ func verifyStoreForMetaObject[T any](expectedSecrets []*T, store cache.Store) fu
 func verifyPartialObjectMetadataStore(expected []*metav1.PartialObjectMetadata, store cache.Store) func() bool {
 	return func() bool {
 		actual, err := toPartialObjectMetadata(store.List())
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to toPartialObjectMetadata(store.List())")
 
 		sort.Sort(byPartialObjectMetadataName(expected))
 		sort.Sort(byPartialObjectMetadataName(actual))
@@ -397,7 +397,7 @@ func addWellKnownSecrets(ctx context.Context, f *framework.Framework) []*v1.Secr
 	var secrets []*v1.Secret
 	for i := 1; i <= 5; i++ {
 		secret, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, newSecret(fmt.Sprintf("secret-%d", i)), metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Create(ctx, newSecret(fmt.Spri...")
 		secrets = append(secrets, secret)
 	}
 	return secrets
@@ -409,9 +409,9 @@ func addWellKnownUnstructuredSecrets(ctx context.Context, f *framework.Framework
 	var secrets []*unstructured.Unstructured
 	for i := 1; i <= 5; i++ {
 		unstructuredSecret, err := runtime.DefaultUnstructuredConverter.ToUnstructured(newSecret(fmt.Sprintf("secret-%d", i)))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to runtime.DefaultUnstructuredConverter.ToUnstructured(newSecret(fmt.Sprintf('se...")
 		secret, err := f.DynamicClient.Resource(v1.SchemeGroupVersion.WithResource("secrets")).Namespace(f.Namespace.Name).Create(ctx, &unstructured.Unstructured{Object: unstructuredSecret}, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.DynamicClient.Resource(v1.SchemeGroupVersion.WithResource('secrets')).Names...")
 		secrets = append(secrets, secret)
 	}
 	return secrets
@@ -489,7 +489,7 @@ func retrieveObjFromEventOfType(watch watch.Interface, expectedType watch.EventT
 
 func hasTableObjectInitialEventsAnnotationInBookmarkObj(rawObject runtime.Object) bool {
 	table, err := decodeIntoTable(rawObject)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to decodeIntoTable(rawObject)")
 	if len(table.Rows) == 0 {
 		framework.Failf("table has no rows")
 	}
@@ -498,7 +498,7 @@ func hasTableObjectInitialEventsAnnotationInBookmarkObj(rawObject runtime.Object
 	}
 
 	internalObjMeta, err := extractMetadataFromTableRowObject(table.Rows[0])
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to extractMetadataFromTableRowObject(table.Rows[0])")
 	return internalObjMeta.GetAnnotations()[metav1.InitialEventsAnnotationKey] == "true"
 }
 
@@ -525,7 +525,7 @@ func extractMetadataFromTableRowObject(row metav1.TableRow) (metav1.Object, erro
 	}
 
 	internalObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, row.Object.Raw)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to runtime.Decode(unstructured.UnstructuredJSONScheme, row.Object.Raw)")
 	return meta.Accessor(internalObj)
 }
 
@@ -541,23 +541,23 @@ func decodeIntoTable(rawObject runtime.Object) (*metav1.Table, error) {
 
 	var table metav1.Table
 	err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, &table)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object,...")
 	return &table, nil
 }
 
 func removeColumnDefinitionsFromTable(rawObject *unstructured.Unstructured) *unstructured.Unstructured {
 	table, err := decodeIntoTable(rawObject)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to decodeIntoTable(rawObject)")
 	table.ColumnDefinitions = nil
 
 	rawTable, err := runtime.DefaultUnstructuredConverter.ToUnstructured(table)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to runtime.DefaultUnstructuredConverter.ToUnstructured(table)")
 	return &unstructured.Unstructured{Object: rawTable}
 }
 
 func getAgeColumnIndex(rawObj runtime.Object) int {
 	table, err := decodeIntoTable(rawObj)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to decodeIntoTable(rawObj)")
 
 	for i, col := range table.ColumnDefinitions {
 		if col.Name == "Age" {
@@ -573,7 +573,7 @@ func removeAgeColumnValueAtIndex(rawObj runtime.Object, ageColIndex int) runtime
 	}
 
 	table, err := decodeIntoTable(rawObj)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to decodeIntoTable(rawObj)")
 
 	for i := range table.Rows {
 		cells := table.Rows[i].Cells

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -408,7 +408,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		// Get the active webhook pod details
 		ginkgo.By("Getting the current webhook pod details")
 		pods, err := client.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: "app=sample-webhook"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSele...")
 		gomega.Expect(pods.Items).To(gomega.HaveLen(1))
 		oldPod := pods.Items[0]
 		oldIP := oldPod.Status.PodIP
@@ -417,7 +417,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		// Recreate/restart the webhook pod by rolling out a change to the deployment
 		ginkgo.By("Triggering a rolling update of the webhook deployment")
 		deployment, err := client.AppsV1().Deployments(f.Namespace.Name).Get(ctx, deploymentName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.AppsV1().Deployments(f.Namespace.Name).Get(ctx, deploymentName, metav1...")
 
 		// Update the deployment template labels or env to trigger a rolling update
 		if deployment.Spec.Template.Annotations == nil {
@@ -426,16 +426,16 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		deployment.Spec.Template.Annotations["restartedAt"] = time.Now().Format(time.RFC3339)
 
 		deployment, err = client.AppsV1().Deployments(f.Namespace.Name).Update(ctx, deployment, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.AppsV1().Deployments(f.Namespace.Name).Update(ctx, deployment, metav1....")
 
 		ginkgo.By("Wait for the deployment rolling update to complete")
 		err = e2edeployment.WaitForDeploymentComplete(client, deployment)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2edeployment.WaitForDeploymentComplete(client, deployment)")
 
 		// Get the new webhook pod details
 		ginkgo.By("Getting the new webhook pod details")
 		newPods, err := client.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSelector: "app=sample-webhook"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.CoreV1().Pods(f.Namespace.Name).List(ctx, metav1.ListOptions{LabelSele...")
 		gomega.Expect(newPods.Items).To(gomega.HaveLen(1))
 		newPod := newPods.Items[0]
 		newIP := newPod.Status.PodIP
@@ -797,11 +797,11 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		validatingWebhookConfiguration := newValidatingWebhookWithMatchConditions(f, servicePort, certCtx, initalMatchConditions)
 
 		_, err := createValidatingWebhookConfiguration(ctx, f, validatingWebhookConfiguration)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createValidatingWebhookConfiguration(ctx, f, validatingWebhookConfiguration)")
 
 		ginkgo.By("verifying the validating webhook match conditions")
 		validatingWebhookConfiguration, err = client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, f.UniqueName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, f...")
 		gomega.Expect(validatingWebhookConfiguration.Webhooks[0].MatchConditions).To(gomega.Equal(initalMatchConditions), "verifying that match conditions are created")
 		defer func() {
 			err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, validatingWebhookConfiguration.Name, metav1.DeleteOptions{})
@@ -828,7 +828,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("verifying the validating webhook match conditions")
 		validatingWebhookConfiguration, err = client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, f.UniqueName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, f...")
 		gomega.Expect(validatingWebhookConfiguration.Webhooks[0].MatchConditions).To(gomega.Equal(updatedMatchConditions), "verifying that match conditions are updated")
 	})
 
@@ -851,11 +851,11 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		mutatingWebhookConfiguration := newMutatingWebhookWithMatchConditions(f, servicePort, certCtx, initalMatchConditions)
 
 		_, err := createMutatingWebhookConfiguration(ctx, f, mutatingWebhookConfiguration)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to createMutatingWebhookConfiguration(ctx, f, mutatingWebhookConfiguration)")
 
 		ginkgo.By("verifying the mutating webhook match conditions")
 		mutatingWebhookConfiguration, err = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, f.UniqueName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, f.U...")
 		gomega.Expect(mutatingWebhookConfiguration.Webhooks[0].MatchConditions).To(gomega.Equal(initalMatchConditions), "verifying that match conditions are created")
 		defer func() {
 			err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(ctx, mutatingWebhookConfiguration.Name, metav1.DeleteOptions{})
@@ -878,11 +878,11 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 			c.Webhooks[0].MatchConditions = updatedMatchConditions
 		}
 		_, err = updateMutatingWebhookConfigurations(ctx, client, f.UniqueName, updateMatchConditionsFn)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to updateMutatingWebhookConfigurations(ctx, client, f.UniqueName, updateMatchCon...")
 
 		ginkgo.By("verifying the mutating webhook match conditions")
 		mutatingWebhookConfiguration, err = client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, f.UniqueName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, f.U...")
 		gomega.Expect(mutatingWebhookConfiguration.Webhooks[0].MatchConditions).To(gomega.Equal(updatedMatchConditions), "verifying that match conditions are updated")
 	})
 
@@ -1346,7 +1346,7 @@ func testMutatingConfigMapWebhook(ctx context.Context, f *framework.Framework) {
 	client := f.ClientSet
 	configMap := toBeMutatedConfigMap(f)
 	mutatedConfigMap, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, configMap, metav1.Cr...")
 	expectedConfigMapData := map[string]string{
 		"mutation-start":   "yes",
 		"mutation-stage-1": "yes",
@@ -1412,7 +1412,7 @@ func testMutatingPodWebhook(ctx context.Context, f *framework.Framework) {
 	client := f.ClientSet
 	pod := toBeMutatedPod(f)
 	mutatedPod, err := client.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to client.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})")
 	if len(mutatedPod.Spec.InitContainers) != 1 {
 		framework.Failf("expect pod to have 1 init container, got %#v", mutatedPod.Spec.InitContainers)
 	}
@@ -2538,7 +2538,7 @@ func registerSlowWebhook(ctx context.Context, f *framework.Framework, markersNam
 	cleanup := func(ctx context.Context) {
 		err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx, configName, metav1.DeleteOptions{})
 		if !apierrors.IsNotFound(err) {
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(ctx...")
 		}
 	}
 
@@ -2567,9 +2567,9 @@ func testSlowWebhookTimeoutNoError(ctx context.Context, f *framework.Framework) 
 	client := f.ClientSet
 	name := "e2e-test-slow-webhook-configmap"
 	_, err := client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name}}, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to client.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, &v1.ConfigMap{Object...")
 	err = client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, name, metav1.DeleteOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to client.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, name, metav1.DeleteO...")
 }
 
 // createAdmissionWebhookMultiVersionTestCRDWithV1Storage creates a new CRD specifically

--- a/test/e2e/architecture/conformance.go
+++ b/test/e2e/architecture/conformance.go
@@ -38,9 +38,9 @@ var _ = SIGDescribe("Conformance Tests", func() {
 	*/
 	framework.ConformanceIt("should have at least two untainted nodes", func(ctx context.Context) {
 		ginkgo.By("Getting node addresses")
-		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 10*time.Minute))
+		framework.ExpectNoError(e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 10*time.Minute), "failed to e2enode.WaitForAllNodesSchedulable(ctx, f.ClientSet, 10*time.Minute)")
 		nodeList, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)")
 		if len(nodeList.Items) < 2 {
 			framework.Failf("Conformance requires at least two nodes")
 		}

--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -64,7 +64,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		csrClient := f.ClientSet.CertificatesV1().CertificateSigningRequests()
 
 		pk, err := utils.NewPrivateKey()
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to utils.NewPrivateKey()")
 
 		pkder := x509.MarshalPKCS1PrivateKey(pk)
 		pkpem := pem.EncodeToMemory(&pem.Block{
@@ -73,7 +73,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		})
 
 		csrb, err := cert.MakeCSR(pk, &pkix.Name{CommonName: commonName}, nil, nil)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cert.MakeCSR(pk, &pkix.Name{CommonName: commonName}, nil, nil)")
 
 		csrTemplate := &certificatesv1.CertificateSigningRequest{
 			ObjectMeta: metav1.ObjectMeta{
@@ -101,7 +101,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 			framework.Logf("error granting permissions to %s, create certificatesigningrequests permissions must be granted out of band: %v", commonName, err)
 		} else {
 			defer func() {
-				framework.ExpectNoError(f.ClientSet.RbacV1().ClusterRoles().Delete(ctx, clusterRole.Name, metav1.DeleteOptions{}))
+				framework.ExpectNoError(f.ClientSet.RbacV1().ClusterRoles().Delete(ctx, clusterRole.Name, metav1.DeleteOptions{}), "failed to f.ClientSet.RbacV1().ClusterRoles().Delete(ctx, clusterRole.Name, metav1.Dele...")
 			}()
 		}
 
@@ -115,15 +115,15 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 			framework.Logf("error granting permissions to %s, create certificatesigningrequests permissions must be granted out of band: %v", commonName, err)
 		} else {
 			defer func() {
-				framework.ExpectNoError(f.ClientSet.RbacV1().ClusterRoleBindings().Delete(ctx, clusterRoleBinding.Name, metav1.DeleteOptions{}))
+				framework.ExpectNoError(f.ClientSet.RbacV1().ClusterRoleBindings().Delete(ctx, clusterRoleBinding.Name, metav1.DeleteOptions{}), "failed to f.ClientSet.RbacV1().ClusterRoleBindings().Delete(ctx, clusterRoleBinding.Nam...")
 			}()
 		}
 
 		framework.Logf("creating CSR")
 		csr, err := csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})")
 		defer func() {
-			framework.ExpectNoError(csrClient.Delete(ctx, csr.Name, metav1.DeleteOptions{}))
+			framework.ExpectNoError(csrClient.Delete(ctx, csr.Name, metav1.DeleteOptions{}), "failed to csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})")
 		}()
 
 		framework.Logf("approving CSR")
@@ -143,7 +143,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 				return false, nil
 			}
 			return true, nil
-		}))
+		}), "failed to csrClient.UpdateApproval(ctx, csr.Name, csr, metav1.Updat...")
 
 		framework.Logf("waiting for CSR to be signed")
 		framework.ExpectNoError(wait.Poll(5*time.Second, time.Minute, func() (bool, error) {
@@ -157,17 +157,17 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 				return false, nil
 			}
 			return true, nil
-		}))
+		}), "failed to csrClient.Get(ctx, csr.Name, metav1.GetOptions{})")
 
 		framework.Logf("testing the client")
 		rcfg, err := framework.LoadConfig()
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to framework.LoadConfig()")
 		rcfg = rest.AnonymousClientConfig(rcfg)
 		rcfg.TLSClientConfig.CertData = csr.Status.Certificate
 		rcfg.TLSClientConfig.KeyData = pkpem
 
 		certs, err := cert.ParseCertsPEM(csr.Status.Certificate)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cert.ParseCertsPEM(csr.Status.Certificate)")
 		gomega.Expect(certs).To(gomega.HaveLen(1), "expected a single cert, got %#v", certs)
 		cert := certs[0]
 		// make sure the cert is not valid for longer than our requested time (plus allowance for backdating)
@@ -176,13 +176,13 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		}
 
 		newClient, err := certificatesclient.NewForConfig(rcfg)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to certificatesclient.NewForConfig(rcfg)")
 
 		framework.Logf("creating CSR as new client")
 		newCSR, err := newClient.CertificateSigningRequests().Create(ctx, csrTemplate, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to newClient.CertificateSigningRequests().Create(ctx, csrTemplate, metav1.Create...")
 		defer func() {
-			framework.ExpectNoError(csrClient.Delete(ctx, newCSR.Name, metav1.DeleteOptions{}))
+			framework.ExpectNoError(csrClient.Delete(ctx, newCSR.Name, metav1.DeleteOptions{}), "failed to newClient.CertificateSigningRequests().Create(ctx, csrTemplate, metav1.Create...")
 		}()
 		gomega.Expect(newCSR.Spec.Username).To(gomega.Equal(commonName))
 	})
@@ -207,15 +207,15 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		csrResource := certificatesv1.SchemeGroupVersion.WithResource("certificatesigningrequests")
 
 		pk, err := utils.NewPrivateKey()
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to utils.NewPrivateKey()")
 
 		csrData, err := cert.MakeCSR(pk, &pkix.Name{CommonName: "e2e.example.com"}, []string{"e2e.example.com"}, nil)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cert.MakeCSR(pk, &pkix.Name{CommonName: 'e2e.example.com'}, []string{'e2e.exa...")
 
 		certificateData, _, err := cert.GenerateSelfSignedCertKey("e2e.example.com", nil, []string{"e2e.example.com"})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to cert.GenerateSelfSignedCertKey('e2e.example.com', nil, []string{'e2e.example....")
 		certificateDataJSON, err := json.Marshal(certificateData)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to json.Marshal(certificateData)")
 
 		signerName := "example.com/e2e-" + f.UniqueName
 		csrTemplate := &certificatesv1.CertificateSigningRequest{
@@ -233,7 +233,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		ginkgo.By("getting /apis")
 		{
 			discoveryGroups, err := f.ClientSet.Discovery().ServerGroups()
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerGroups()")
 			found := false
 			for _, group := range discoveryGroups.Groups {
 				if group.Name == certificatesv1.GroupName {
@@ -254,7 +254,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		{
 			group := &metav1.APIGroup{}
 			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/certificates.k8s.io").Do(ctx).Into(group)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().RESTClient().Get().AbsPath('/apis/certificates.k8s.io...")
 			found := false
 			for _, version := range group.Versions {
 				if version.Version == csrVersion {
@@ -270,7 +270,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		ginkgo.By("getting /apis/certificates.k8s.io/" + csrVersion)
 		{
 			resources, err := f.ClientSet.Discovery().ServerResourcesForGroupVersion(certificatesv1.SchemeGroupVersion.String())
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerResourcesForGroupVersion(certificatesv1.SchemeG...")
 			foundCSR, foundApproval, foundStatus := false, false, false
 			for _, resource := range resources.APIResources {
 				switch resource.Name {
@@ -297,32 +297,32 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("creating")
 		_, err = csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})")
 		_, err = csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})")
 		createdCSR, err := csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.Create(ctx, csrTemplate, metav1.CreateOptions{})")
 
 		ginkgo.By("getting")
 		gottenCSR, err := csrClient.Get(ctx, createdCSR.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.Get(ctx, createdCSR.Name, metav1.GetOptions{})")
 		gomega.Expect(gottenCSR.UID).To(gomega.Equal(createdCSR.UID))
 		gomega.Expect(gottenCSR.Spec.ExpirationSeconds).To(gomega.Equal(csr.DurationToExpirationSeconds(time.Hour)))
 		gomega.Expect(gottenCSR).To(apimachineryutils.HaveValidResourceVersion())
 
 		ginkgo.By("listing")
 		csrs, err := csrClient.List(ctx, metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.List(ctx, metav1.ListOptions{FieldSelector: 'spec.signerName=' + si...")
 		gomega.Expect(csrs.Items).To(gomega.HaveLen(3), "filtered list should have 3 items")
 
 		ginkgo.By("watching")
 		framework.Logf("starting watch")
 		csrWatch, err := csrClient.Watch(ctx, metav1.ListOptions{ResourceVersion: csrs.ResourceVersion, FieldSelector: "metadata.name=" + createdCSR.Name})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.Watch(ctx, metav1.ListOptions{ResourceVersion: csrs.ResourceVersion...")
 
 		ginkgo.By("patching")
 		patchedCSR, err := csrClient.Patch(ctx, createdCSR.Name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"patched":"true"}}}`), metav1.PatchOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.Patch(ctx, createdCSR.Name, types.MergePatchType, []byte(`{'metadat...")
 		gomega.Expect(patchedCSR.Annotations).To(gomega.HaveKeyWithValue("patched", "true"), "patched object should have the applied annotation")
 		gomega.Expect(resourceversion.CompareResourceVersion(gottenCSR.ResourceVersion, patchedCSR.ResourceVersion)).To(gomega.BeNumerically("==", -1), "patched object should have a larger resource version")
 
@@ -330,7 +330,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		csrToUpdate := patchedCSR.DeepCopy()
 		csrToUpdate.Annotations["updated"] = "true"
 		updatedCSR, err := csrClient.Update(ctx, csrToUpdate, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.Update(ctx, csrToUpdate, metav1.UpdateOptions{})")
 		gomega.Expect(updatedCSR.Annotations).To(gomega.HaveKeyWithValue("updated", "true"), "updated object should have the applied annotation")
 
 		framework.Logf("waiting for watch events with expected annotations")
@@ -361,7 +361,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("getting /approval")
 		gottenApproval, err := f.DynamicClient.Resource(csrResource).Get(ctx, createdCSR.Name, metav1.GetOptions{}, "approval")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.DynamicClient.Resource(csrResource).Get(ctx, createdCSR.Name, metav1.GetOpt...")
 		gomega.Expect(gottenApproval.GetObjectKind().GroupVersionKind()).To(gomega.Equal(certificatesv1.SchemeGroupVersion.WithKind("CertificateSigningRequest")))
 		gomega.Expect(gottenApproval.GetUID()).To(gomega.Equal(createdCSR.UID))
 
@@ -369,7 +369,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		patchedApproval, err := csrClient.Patch(ctx, createdCSR.Name, types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"patchedapproval":"true"}},"status":{"conditions":[{"type":"ApprovalPatch","status":"True","reason":"e2e"}]}}`),
 			metav1.PatchOptions{}, "approval")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.Patch(ctx, createdCSR.Name, types.MergePatchType,")
 		gomega.Expect(patchedApproval.Status.Conditions).To(gomega.HaveLen(1), "patched object should have the applied condition")
 		gomega.Expect(string(patchedApproval.Status.Conditions[0].Type)).To(gomega.Equal("ApprovalPatch"), "patched object should have the applied condition, got %#v", patchedApproval.Status.Conditions)
 		gomega.Expect(patchedApproval.Annotations).To(gomega.HaveKeyWithValue("patchedapproval", "true"), "patched object should have the applied annotation")
@@ -383,7 +383,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 			Message: "Set from an e2e test",
 		})
 		updatedApproval, err := csrClient.UpdateApproval(ctx, approvalToUpdate.Name, approvalToUpdate, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.UpdateApproval(ctx, approvalToUpdate.Name, approvalToUpdate, metav1...")
 		gomega.Expect(updatedApproval.Status.Conditions).To(gomega.HaveLen(2), "updated object should have the applied condition, got %#v", updatedApproval.Status.Conditions)
 		gomega.Expect(updatedApproval.Status.Conditions[1].Type).To(gomega.Equal(certificatesv1.CertificateApproved), "updated object should have the approved condition, got %#v", updatedApproval.Status.Conditions)
 
@@ -391,7 +391,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("getting /status")
 		gottenStatus, err := f.DynamicClient.Resource(csrResource).Get(ctx, createdCSR.Name, metav1.GetOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.DynamicClient.Resource(csrResource).Get(ctx, createdCSR.Name, metav1.GetOpt...")
 		gomega.Expect(gottenStatus.GetObjectKind().GroupVersionKind()).To(gomega.Equal(certificatesv1.SchemeGroupVersion.WithKind("CertificateSigningRequest")))
 		gomega.Expect(gottenStatus.GetUID()).To(gomega.Equal(createdCSR.UID))
 
@@ -399,7 +399,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 		patchedStatus, err := csrClient.Patch(ctx, createdCSR.Name, types.MergePatchType,
 			[]byte(`{"metadata":{"annotations":{"patchedstatus":"true"}},"status":{"certificate":`+string(certificateDataJSON)+`}}`),
 			metav1.PatchOptions{}, "status")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.Patch(ctx, createdCSR.Name, types.MergePatchType,")
 		gomega.Expect(patchedStatus.Status.Certificate).To(gomega.Equal(certificateData), "patched object should have the applied certificate")
 		gomega.Expect(patchedStatus.Annotations).To(gomega.HaveKeyWithValue("patchedstatus", "true"), "patched object should have the applied annotation")
 
@@ -412,7 +412,7 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 			Message: "Set from an e2e test",
 		})
 		updatedStatus, err := csrClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.UpdateStatus(ctx, statusToUpdate, metav1.UpdateOptions{})")
 		gomega.Expect(updatedStatus.Status.Conditions).To(gomega.HaveLen(len(statusToUpdate.Status.Conditions)), "updated object should have the applied condition, got %#v", updatedStatus.Status.Conditions)
 		gomega.Expect(string(updatedStatus.Status.Conditions[len(updatedStatus.Status.Conditions)-1].Type)).To(gomega.Equal("StatusUpdate"), "updated object should have the approved condition, got %#v", updatedStatus.Status.Conditions)
 
@@ -420,20 +420,20 @@ var _ = SIGDescribe("Certificates API [Privileged:ClusterAdmin]", func() {
 
 		ginkgo.By("deleting")
 		err = csrClient.Delete(ctx, createdCSR.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.Delete(ctx, createdCSR.Name, metav1.DeleteOptions{})")
 		_, err = csrClient.Get(ctx, createdCSR.Name, metav1.GetOptions{})
 		if !apierrors.IsNotFound(err) {
 			framework.Failf("expected 404, got %#v", err)
 		}
 		csrs, err = csrClient.List(ctx, metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.List(ctx, metav1.ListOptions{FieldSelector: 'spec.signerName=' + si...")
 		gomega.Expect(csrs.Items).To(gomega.HaveLen(2), "filtered list should have 2 items")
 
 		ginkgo.By("deleting a collection")
 		err = csrClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{Fi...")
 		csrs, err = csrClient.List(ctx, metav1.ListOptions{FieldSelector: "spec.signerName=" + signerName})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to csrClient.List(ctx, metav1.ListOptions{FieldSelector: 'spec.signerName=' + si...")
 		gomega.Expect(csrs.Items).To(gomega.BeEmpty(), "filtered list should have 0 items")
 	})
 })

--- a/test/e2e/auth/node_authn.go
+++ b/test/e2e/auth/node_authn.go
@@ -44,7 +44,7 @@ var _ = SIGDescribe("NodeAuthenticator", func() {
 		ns = f.Namespace.Name
 
 		nodes, err := e2enode.GetBoundedReadySchedulableNodes(ctx, f.ClientSet, 1)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetBoundedReadySchedulableNodes(ctx, f.ClientSet, 1)")
 
 		family := v1.IPv4Protocol
 		if framework.TestContext.ClusterIsIPv6() {

--- a/test/e2e/auth/per_node_update.go
+++ b/test/e2e/auth/per_node_update.go
@@ -111,27 +111,27 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy", func() {
 
 		var err error
 		_, err = f.ClientSet.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(ctx, admissionToCreate, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(ct...")
 		g.DeferCleanup(f.ClientSet.AdmissionregistrationV1().ValidatingAdmissionPolicies().Delete, admissionToCreate.Name, metav1.DeleteOptions{})
 
 		_, err = f.ClientSet.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Create(ctx, admissionBindingToCreate, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Cre...")
 		g.DeferCleanup(f.ClientSet.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Delete, admissionBindingToCreate.Name, metav1.DeleteOptions{})
 
 		// create permissions that will allow unrestricted access to mutate configmaps in this namespace.
 		// We limited these permissions in the step above.
 		// This means the admission policy must fail closed or permissions will be too broad.
 		_, err = f.ClientSet.RbacV1().RoleBindings(f.Namespace.Name).Create(ctx, saTokenRoleBinding, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.RbacV1().RoleBindings(f.Namespace.Name).Create(ctx, saTokenRoleBi...")
 
 		// run an actual pod to prove that the token is injected, not just creatable via the API
 		actualPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, sleeperPod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, sleeperPod, metav1.Cr...")
 		err = e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, actualPod.Name, actualPod.Namespace)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.WaitForPodNameRunningInNamespace(ctx, f.ClientSet, actualPod.Name, act...")
 		// need the pod that contains the node name
 		actualPod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, actualPod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, actualPod.Name, metav1.G...")
 
 		// get the actual projected token from the pod.
 		nodeScopedSAToken, stderr, err := e2epod.Exec(f.TContext(ctx), e2epod.ExecOptions{
@@ -143,16 +143,16 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy", func() {
 			CaptureStderr:      true,
 			PreserveWhitespace: true,
 		})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2epod.Exec(f.TContext(ctx), e2epod.ExecOptions{")
 		o.Expect(stderr).To(o.BeEmpty(), "stderr from cat")
 
 		// make a kubeconfig with the token and confirm the kube-apiserver has the expected claims
 		nodeScopedClientConfig := rest.AnonymousClientConfig(f.ClientConfig())
 		nodeScopedClientConfig.BearerToken = nodeScopedSAToken
 		nodeScopedClient, err := kubernetes.NewForConfig(nodeScopedClientConfig)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to kubernetes.NewForConfig(nodeScopedClientConfig)")
 		saUser, err := nodeScopedClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to nodeScopedClient.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authent...")
 		expectedUser := serviceaccount.MakeUsername(f.Namespace.Name, "default")
 		o.Expect(saUser.Status.UserInfo.Username).To(o.Equal(expectedUser))
 		expectedNode := authenticationv1.ExtraValue([]string{actualPod.Spec.NodeName})
@@ -173,30 +173,30 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy", func() {
 		disallowedMessage := fmt.Sprintf("this user running on node '%s' may not modify ConfigMap '%s' because the name does not match the node name", actualPod.Spec.NodeName, disallowedConfigMap.Name)
 
 		actualAllowedConfigMap, err := nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, allowedConfigMap, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, allowedCon...")
 		_, err = nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, disallowedConfigMap, metav1.CreateOptions{})
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(err.Error()).To(o.ContainSubstring(disallowedMessage))
 
 		// now create so we can see the update cases
 		actualDisallowedConfigMap, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, disallowedConfigMap, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, disallowedConfi...")
 
 		actualAllowedConfigMap, err = nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, actualAllowedConfigMap, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, actualAllo...")
 		_, err = nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, actualDisallowedConfigMap, metav1.UpdateOptions{})
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(err.Error()).To(o.ContainSubstring(disallowedMessage))
 
 		err = nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, actualAllowedConfigMap.Name, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, actualAllo...")
 		err = nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, actualDisallowedConfigMap.Name, metav1.DeleteOptions{})
 		o.Expect(err).To(o.HaveOccurred())
 		o.Expect(err.Error()).To(o.ContainSubstring(disallowedMessage))
 
 		// recreate the allowedConfigMap and then do a delete collection
 		_, err = nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, allowedConfigMap, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).Create(ctx, allowedCon...")
 		err = nodeScopedClient.CoreV1().ConfigMaps(f.Namespace.Name).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{})
 		o.Expect(err).To(o.HaveOccurred())
 		// Delete collection can happen in random/racy orders.  We'll match on everything except the name
@@ -210,15 +210,15 @@ var _ = SIGDescribe("ValidatingAdmissionPolicy", func() {
 			},
 		}
 		tokenRequestResponse, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).CreateToken(ctx, "default", tokenRequest, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).CreateToken(ctx, 'defa...")
 		serviceAccountConfigWithoutNodeClaim := rest.AnonymousClientConfig(f.ClientConfig())
 		serviceAccountConfigWithoutNodeClaim.BearerToken = tokenRequestResponse.Status.Token
 		serviceAccountClientWithoutNodeClaim, err := kubernetes.NewForConfig(serviceAccountConfigWithoutNodeClaim)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to kubernetes.NewForConfig(serviceAccountConfigWithoutNodeClaim)")
 		// now confirm this token lacks a node name claim.
 		selfSubjectResults, err := serviceAccountClientWithoutNodeClaim.AuthenticationV1().SelfSubjectReviews().Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
 		framework.Logf("Token: %q expires at %v", serviceAccountConfigWithoutNodeClaim.BearerToken, tokenRequestResponse.Status.ExpirationTimestamp)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to serviceAccountClientWithoutNodeClaim.AuthenticationV1().SelfSubjectReviews()....")
 		o.Expect(selfSubjectResults.Status.UserInfo.Extra["authentication.kubernetes.io/node-name"]).To(o.BeEmpty())
 
 		noNodeAssociationMessage := "no node association found for user, this user must run in a pod on a node and ServiceAccountTokenPodNodeInfo must be enabled"

--- a/test/e2e/auth/podcertificaterequest.go
+++ b/test/e2e/auth/podcertificaterequest.go
@@ -50,7 +50,7 @@ var _ = SIGDescribe("PodCertificateRequest API [Privileged:ClusterAdmin]", func(
 	*/
 	framework.ConformanceIt("should support PodCertificateRequest API operations", func(ctx context.Context) {
 		_, csrData, pemCert, notBefore, notAfter, err := generateKeyCSRAndCert()
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to generateKeyCSRAndCert()")
 
 		nowTime := metav1.NewTime(time.Now())
 		notBeforeTime := metav1.NewTime(notBefore)
@@ -78,7 +78,7 @@ var _ = SIGDescribe("PodCertificateRequest API [Privileged:ClusterAdmin]", func(
 			},
 		}
 		statusPatchJSON, err := json.Marshal(statusPatch)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to json.Marshal(statusPatch)")
 		statusPatchStr := string(statusPatchJSON)
 
 		strategicStatusPatchStr := statusPatchStr

--- a/test/e2e/auth/selfsubjectreviews.go
+++ b/test/e2e/auth/selfsubjectreviews.go
@@ -57,7 +57,7 @@ var _ = SIGDescribe("SelfSubjectReview", func() {
 			ginkgo.By("getting /apis")
 			{
 				discoveryGroups, err := f.ClientSet.Discovery().ServerGroups()
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerGroups()")
 				found := false
 				for _, group := range discoveryGroups.Groups {
 					if group.Name == authenticationv1alpha1.GroupName {
@@ -78,7 +78,7 @@ var _ = SIGDescribe("SelfSubjectReview", func() {
 			{
 				group := &metav1.APIGroup{}
 				err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/authentication.k8s.io").Do(ctx).Into(group)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().RESTClient().Get().AbsPath('/apis/authentication.k8s....")
 				found := false
 				for _, version := range group.Versions {
 					if version.Version == apiVersion {
@@ -94,7 +94,7 @@ var _ = SIGDescribe("SelfSubjectReview", func() {
 			ginkgo.By("getting /apis/authentication.k8s.io/" + apiVersion)
 			{
 				resources, err := f.ClientSet.Discovery().ServerResourcesForGroupVersion(gv)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to f.ClientSet.Discovery().ServerResourcesForGroupVersion(gv)")
 				found := false
 				for _, resource := range resources.APIResources {
 					switch resource.Name {
@@ -125,7 +125,7 @@ var _ = SIGDescribe("SelfSubjectReview", func() {
 				return // Alpha API is disabled
 			}
 
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to ssrClient.Create(ctx, &authenticationv1alpha1.SelfSubjectReview{}, metav1.Cre...")
 			gomega.Expect(config.Impersonate.UserName).To(gomega.Equal(res.Status.UserInfo.Username))
 			gomega.Expect(config.Impersonate.UID).To(gomega.Equal(res.Status.UserInfo.UID))
 			gomega.Expect(config.Impersonate.Groups).To(gomega.Equal(res.Status.UserInfo.Groups))
@@ -148,7 +148,7 @@ var _ = SIGDescribe("SelfSubjectReview", func() {
 				return // Beta API is disabled
 			}
 
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to ssrClient.Create(ctx, &authenticationv1beta1.SelfSubjectReview{}, metav1.Crea...")
 			gomega.Expect(config.Impersonate.UserName).To(gomega.Equal(res.Status.UserInfo.Username))
 			gomega.Expect(config.Impersonate.UID).To(gomega.Equal(res.Status.UserInfo.UID))
 			gomega.Expect(config.Impersonate.Groups).To(gomega.Equal(res.Status.UserInfo.Groups))
@@ -167,7 +167,7 @@ var _ = SIGDescribe("SelfSubjectReview", func() {
 
 			ssrClient := kubernetes.NewForConfigOrDie(config).AuthenticationV1().SelfSubjectReviews()
 			res, err := ssrClient.Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to ssrClient.Create(ctx, &authenticationv1.SelfSubjectReview{}, metav1.CreateOpt...")
 
 			gomega.Expect(config.Impersonate.UserName).To(gomega.Equal(res.Status.UserInfo.Username))
 			gomega.Expect(config.Impersonate.UID).To(gomega.Equal(res.Status.UserInfo.UID))

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -65,7 +65,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			ginkgo.By("ensuring no secret-based service account token exists")
 			time.Sleep(10 * time.Second)
 			sa, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Get(ctx, "default", metav1.GetOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Get(ctx, 'default', me...")
 			gomega.Expect(sa.Secrets).To(gomega.BeEmpty())
 		}
 	})
@@ -81,7 +81,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 	*/
 	framework.ConformanceIt("should mount an API token into pods", func(ctx context.Context) {
 		sa, err := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Create(ctx, &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "mount-test"}}, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Create(ctx, &v1.Servic...")
 
 		zero := int64(0)
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, &v1.Pod{
@@ -99,33 +99,33 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				RestartPolicy:                 v1.RestartPolicyNever,
 			},
 		}, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
-		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, &...")
+		framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod), "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, &...")
 
 		// Read the running pod to get the current node name
 		pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, pod.Name, metav1.GetOpti...")
 		node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})")
 
 		tk := e2ekubectl.NewTestKubeconfig(framework.TestContext.CertDir, framework.TestContext.Host, framework.TestContext.KubeConfig, framework.TestContext.KubeContext, framework.TestContext.KubectlPath, f.Namespace.Name)
 		mountedToken, err := tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, path.Join(serviceaccount.DefaultAPITokenMountPath, v1.ServiceAccountTokenKey))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, path.Join(serv...")
 		mountedCA, err := tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, path.Join(serviceaccount.DefaultAPITokenMountPath, v1.ServiceAccountRootCAKey))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, path.Join(serv...")
 		mountedNamespace, err := tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, path.Join(serviceaccount.DefaultAPITokenMountPath, v1.ServiceAccountNamespaceKey))
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to tk.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, path.Join(serv...")
 
 		// CA and namespace should be identical
 		rootCA, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx, rootCAConfigMapName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx, rootCAConfigMapNam...")
 		framework.Logf("Got root ca configmap in namespace %q", f.Namespace.Name)
 		gomega.Expect(mountedCA).To(gomega.Equal(rootCA.Data["ca.crt"]))
 		gomega.Expect(mountedNamespace).To(gomega.Equal(f.Namespace.Name))
 		// Token should be a valid credential that identifies the pod's service account
 		tokenReview := &authenticationv1.TokenReview{Spec: authenticationv1.TokenReviewSpec{Token: mountedToken}}
 		tokenReview, err = f.ClientSet.AuthenticationV1().TokenReviews().Create(ctx, tokenReview, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.AuthenticationV1().TokenReviews().Create(ctx, tokenReview, metav1...")
 		if !tokenReview.Status.Authenticated {
 			framework.Fail("tokenReview is not authenticated")
 		}
@@ -199,9 +199,9 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		mountSA := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "mount"}, AutomountServiceAccountToken: &trueValue}
 		nomountSA := &v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "nomount"}, AutomountServiceAccountToken: &falseValue}
 		mountSA, err = f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Create(ctx, mountSA, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Create(ctx, mountSA, m...")
 		nomountSA, err = f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Create(ctx, nomountSA, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.Name).Create(ctx, nomountSA,...")
 
 		testcases := []struct {
 			PodName            string
@@ -280,7 +280,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				},
 			}
 			createdPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 			framework.Logf("created pod %s", tc.PodName)
 
 			hasServiceAccountTokenVolume := false
@@ -635,10 +635,10 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			},
 		}
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		framework.Logf("created pod")
-		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, time.Minute))
+		framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name, time.Minute), "failed to e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, pod.Name, f.Namesp...")
 
 		framework.Logf("pod is ready")
 
@@ -708,7 +708,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				framework.ExpectNoError(
 					f.ClientSet.RbacV1().ClusterRoleBindings().Delete(
 						ctx,
-						crb.Name, metav1.DeleteOptions{}))
+						crb.Name, metav1.DeleteOptions{}), "failed to f.ClientSet.RbacV1().ClusterRoleBindings().Create(")
 			}()
 		}
 
@@ -756,7 +756,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			},
 		}
 		pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 
 		framework.Logf("created pod")
 		podErr := e2epod.WaitForPodSuccessInNamespace(ctx, f.ClientSet, pod.Name, f.Namespace.Name)
@@ -777,7 +777,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			framework.Logf("Pod logs: \n%v", logs)
 		}
 
-		framework.ExpectNoError(podErr)
+		framework.ExpectNoError(podErr, "failed to podErr")
 		framework.Logf("completed pod")
 	})
 
@@ -896,10 +896,10 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				return false, nil
 			}
 			return false, err
-		}))
+		}), "failed to f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx...")
 		framework.Logf("Got root ca configmap in namespace %q", f.Namespace.Name)
 
-		framework.ExpectNoError(f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, rootCAConfigMapName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)}))
+		framework.ExpectNoError(f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, rootCAConfigMapName, metav1.DeleteOptions{GracePeriodSeconds: ptr.To[int64](0)}), "failed to f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Delete(ctx, rootCAConfigMap...")
 		framework.Logf("Deleted root ca configmap in namespace %q", f.Namespace.Name)
 
 		framework.ExpectNoError(wait.Poll(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
@@ -913,7 +913,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				return false, nil
 			}
 			return false, err
-		}))
+		}), "failed to f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx...")
 		framework.Logf("Recreated root ca configmap in namespace %q", f.Namespace.Name)
 
 		_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(ctx, &v1.ConfigMap{
@@ -924,7 +924,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				"ca.crt": "",
 			},
 		}, metav1.UpdateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(...")
 		framework.Logf("Updated root ca configmap in namespace %q", f.Namespace.Name)
 
 		framework.ExpectNoError(wait.Poll(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
@@ -942,7 +942,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				return false, nil
 			}
 			return true, nil
-		}))
+		}), "failed to f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Get(ctx...")
 		framework.Logf("Reconciled root ca configmap in namespace %q", f.Namespace.Name)
 	})
 
@@ -966,7 +966,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 
 		ginkgo.By(fmt.Sprintf("Creating ServiceAccount %q ", saName))
 		createdServiceAccount, err := saClient.Create(ctx, initialServiceAccount, metav1.CreateOptions{})
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to saClient.Create(ctx, initialServiceAccount, metav1.CreateOptions{})")
 		gomega.Expect(createdServiceAccount.AutomountServiceAccountToken).To(gomega.Equal(ptr.To(false)), "Failed to set AutomountServiceAccountToken")
 		framework.Logf("AutomountServiceAccountToken: %v", *createdServiceAccount.AutomountServiceAccountToken)
 

--- a/test/e2e/framework/expect.go
+++ b/test/e2e/framework/expect.go
@@ -259,7 +259,7 @@ func (a asyncAssertion) WithPolling(interval time.Duration) AsyncAssertion {
 }
 
 // FailureError is an error where the error string is meant to be passed to
-// ginkgo.Fail directly, i.e. adding some prefix like "unexpected error" is not
+// ginkgo.Fail directly, i.e. adding some prefix like "failed to execute test operation" is not
 // necessary. It is also not necessary to dump the error struct.
 type FailureError struct {
 	msg            string

--- a/test/e2e/instrumentation/logging/generic_soak.go
+++ b/test/e2e/instrumentation/logging/generic_soak.go
@@ -84,7 +84,7 @@ var _ = instrumentation.SIGDescribe("Logging soak [Performance]", framework.With
 func RunLogPodsWithSleepOf(ctx context.Context, f *framework.Framework, sleep time.Duration, podname string, timeout time.Duration) {
 
 	nodes, err := e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2enode.GetReadySchedulableNodes(ctx, f.ClientSet)")
 	totalPods := len(nodes.Items)
 	gomega.Expect(nodes.Items).ToNot(gomega.BeEmpty())
 

--- a/test/e2e/instrumentation/metrics.go
+++ b/test/e2e/instrumentation/metrics.go
@@ -56,12 +56,12 @@ var _ = common.SIGDescribe("Metrics", func() {
 	ginkgo.It("should grab all metrics from kubelet /metrics/resource endpoint", func(ctx context.Context) {
 		ginkgo.By("Connecting to kubelet's /metrics/resource endpoint")
 		node, err := e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 		response, err := grabber.GrabResourceMetricsFromKubelet(ctx, node.Name)
 		if errors.Is(err, e2emetrics.MetricsGrabbingDisabledError) {
 			e2eskipper.Skipf("%v", err)
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to grabber.GrabResourceMetricsFromKubelet(ctx, node.Name)")
 		gomega.Expect(response).NotTo(gomega.BeEmpty())
 	})
 })

--- a/test/e2e/instrumentation/monitoring/metrics_grabber.go
+++ b/test/e2e/instrumentation/monitoring/metrics_grabber.go
@@ -58,7 +58,7 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 		if errors.Is(err, e2emetrics.MetricsGrabbingDisabledError) {
 			e2eskipper.Skipf("%v", err)
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to grabber.GrabFromAPIServer(ctx)")
 		gomega.Expect(response).NotTo(gomega.BeEmpty())
 	})
 
@@ -68,9 +68,9 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 		if errors.Is(err, e2emetrics.MetricsGrabbingDisabledError) {
 			e2eskipper.Skipf("%v", err)
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to e2enode.GetRandomReadySchedulableNode(ctx, f.ClientSet)")
 		response, err := grabber.GrabFromKubelet(ctx, node.Name)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to grabber.GrabFromKubelet(ctx, node.Name)")
 		gomega.Expect(response).NotTo(gomega.BeEmpty())
 	})
 
@@ -80,7 +80,7 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 		if errors.Is(err, e2emetrics.MetricsGrabbingDisabledError) {
 			e2eskipper.Skipf("%v", err)
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to grabber.GrabFromScheduler(ctx)")
 		gomega.Expect(response).NotTo(gomega.BeEmpty())
 	})
 
@@ -90,7 +90,7 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 		if errors.Is(err, e2emetrics.MetricsGrabbingDisabledError) {
 			e2eskipper.Skipf("%v", err)
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to grabber.GrabFromControllerManager(ctx)")
 		gomega.Expect(response).NotTo(gomega.BeEmpty())
 	})
 
@@ -100,7 +100,7 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 		if errors.Is(err, e2emetrics.MetricsGrabbingDisabledError) {
 			e2eskipper.Skipf("%v", err)
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to grabber.GrabMetricsSLIsFromAPIServer(ctx)")
 		gomega.Expect(response).NotTo(gomega.BeEmpty())
 	})
 })

--- a/test/e2e/instrumentation/native_histograms.go
+++ b/test/e2e/instrumentation/native_histograms.go
@@ -54,7 +54,7 @@ var _ = common.SIGDescribe("NativeHistograms", framework.WithFeatureGate(metrics
 			RequestURI("/metrics").
 			SetHeader("Accept", "application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited").
 			DoRaw(ctx)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.CoreV1().RESTClient().Get().")
 		gomega.Expect(body).NotTo(gomega.BeEmpty())
 
 		ginkgo.By("Parsing Protobuf payload and asserting native histogram schema")
@@ -69,7 +69,7 @@ var _ = common.SIGDescribe("NativeHistograms", framework.WithFeatureGate(metrics
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to dec.Decode(&mf)")
 
 			if mf.GetName() == "apiserver_request_duration_seconds" {
 				targetMetricFamily = &mf

--- a/test/e2e/kubectl/debug.go
+++ b/test/e2e/kubectl/debug.go
@@ -68,7 +68,7 @@ var _ = SIGDescribe("kubectl debug", func() {
 			}
 
 			tmpDir, err := os.MkdirTemp("", "test-custom-profile-debug")
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to os.MkdirTemp('', 'test-custom-profile-debug')")
 			defer os.Remove(tmpDir) //nolint:errcheck
 			customProfileFile := "custom.yaml"
 			framework.ExpectNoError(os.WriteFile(filepath.Join(tmpDir, customProfileFile), []byte(`
@@ -92,7 +92,7 @@ env:
 				"sleep 3600")
 
 			ginkgo.By("verifying the container debugger is running")
-			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, c, ns, debugPodName, "debugger", framework.PodStartShortTimeout))
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, c, ns, debugPodName, "debugger", framework.PodStartShortTimeout), "failed to e2epod.WaitForContainerRunning(ctx, c, ns, debugPodName, 'debugger', framewor...")
 			output := e2ekubectl.RunKubectlOrDie(ns, "get", "pod", debugPodName, "-o", "jsonpath={.spec.ephemeralContainers[*]}")
 			ginkgo.By("verifying NET_ADMIN is added")
 			gomega.Expect(output).To(gomega.ContainSubstring("NET_ADMIN"))
@@ -122,7 +122,7 @@ env:
 			}
 
 			tmpDir, err := os.MkdirTemp("", "test-custom-profile-debug")
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to os.MkdirTemp('', 'test-custom-profile-debug')")
 			defer os.Remove(tmpDir) //nolint:errcheck
 			customProfileFile := "custom.yaml"
 			framework.ExpectNoError(os.WriteFile(filepath.Join(tmpDir, customProfileFile), []byte(`
@@ -147,7 +147,7 @@ env:
 				"sleep 3600")
 
 			ginkgo.By("verifying the container in pod my-debugger is running")
-			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, c, ns, "my-debugger", "debugger", framework.PodStartShortTimeout))
+			framework.ExpectNoError(e2epod.WaitForContainerRunning(ctx, c, ns, "my-debugger", "debugger", framework.PodStartShortTimeout), "failed to e2epod.WaitForContainerRunning(ctx, c, ns, 'my-debugger', 'debugger', framewo...")
 
 			output := e2ekubectl.RunKubectlOrDie(ns, "get", "pod", "my-debugger", "-o", "jsonpath={.spec.containers[*]}")
 			ginkgo.By("verifying NET_ADMIN is added")

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -248,7 +248,7 @@ func runKubectlRetryOrDie(ns string, args ...string) string {
 	// Expect no errors to be present after retries are finished
 	// Copied from framework #ExecOrDie
 	framework.Logf("stdout: %q", output)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to e2ekubectl.RunKubectl(ns, args...)")
 	return output
 }
 
@@ -430,7 +430,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			ginkgo.By(fmt.Sprintf("creating the pod from %v", podYaml))
 			podYaml = commonutils.SubstituteImageName(string(readTestFileOrDie("pod-with-readiness-probe.yaml.in")))
 			e2ekubectl.RunKubectlOrDieInput(ns, podYaml, "create", "-f", "-")
-			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, simplePodName, ns, framework.PodStartTimeout))
+			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, simplePodName, ns, framework.PodStartTimeout), "failed to e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, simplePodName, ns, framework...")
 		})
 		ginkgo.AfterEach(func() {
 			cleanupKubectlInputs(podYaml, ns, simplePodSelector)
@@ -546,7 +546,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 
 			ginkgo.By("Starting kubectl proxy")
 			port, proxyCmd, err := startProxyServer(ns)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to startProxyServer(ns)")
 			defer framework.TryKill(proxyCmd)
 
 			//proxyLogs.Reset()
@@ -567,7 +567,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 		ginkgo.Context("should return command exit codes", func() {
 			ginkgo.It("execing into a container with a successful command", func(ctx context.Context) {
 				_, err := e2ekubectl.NewKubectlCommand(ns, "exec", simplePodName, podRunningTimeoutArg, "--", "/bin/sh", "-c", "exit 0").Exec()
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to e2ekubectl.NewKubectlCommand(ns, 'exec', simplePodName, podRunningTimeoutArg,...")
 			})
 
 			ginkgo.It("execing into a container with a failing command", func(ctx context.Context) {
@@ -605,13 +605,13 @@ var _ = SIGDescribe("Kubectl client", func() {
 				// grant the view permission widely to allow inspection of the `invalid` namespace and the default namespace
 				cleanupFunc, err := e2eauth.BindClusterRole(ctx, f.ClientSet.RbacV1(), "view", f.Namespace.Name,
 					rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Namespace: f.Namespace.Name, Name: "default"})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to e2eauth.BindClusterRole(ctx, f.ClientSet.RbacV1(), 'view', f.Namespace.Name,")
 				defer cleanupFunc(ctx)
 
 				err = e2eauth.WaitForAuthorizationUpdate(ctx, f.ClientSet.AuthorizationV1(),
 					serviceaccount.MakeUsername(f.Namespace.Name, "default"),
 					f.Namespace.Name, "list", schema.GroupResource{Resource: "pods"}, true)
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to e2eauth.WaitForAuthorizationUpdate(ctx, f.ClientSet.AuthorizationV1(),")
 
 				ginkgo.By("overriding icc with values provided by flags")
 				kubectlPath := framework.TestContext.KubectlPath
@@ -621,7 +621,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 					kubectlPathNormalizer = exec.Command(kubectlPath, "path")
 				}
 				kubectlPathNormalized, err := kubectlPathNormalizer.Output()
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to kubectlPathNormalizer.Output()")
 				kubectlPath = strings.TrimSpace(string(kubectlPathNormalized))
 
 				inClusterHost := strings.TrimSpace(e2eoutput.RunHostCmdOrDie(ns, simplePodName, "printenv KUBERNETES_SERVICE_HOST"))
@@ -634,7 +634,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 				// but point at the DNS host and the default namespace
 				tmpDir, err := os.MkdirTemp("", "icc-override")
 				overrideKubeconfigName := "icc-override.kubeconfig"
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to os.MkdirTemp('', 'icc-override')")
 				defer func() { os.Remove(tmpDir) }()
 				framework.ExpectNoError(os.WriteFile(filepath.Join(tmpDir, overrideKubeconfigName), []byte(`
 kind: Config
@@ -656,7 +656,7 @@ users:
 - name: kubeconfig-user
   user:
     tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-`), os.FileMode(0755)))
+`), os.FileMode(0755)), "failed to os.MkdirTemp('', 'icc-override')")
 				framework.Logf("copying override kubeconfig to the %s pod", simplePodName)
 				e2ekubectl.RunKubectlOrDie(ns, "cp", filepath.Join(tmpDir, overrideKubeconfigName), ns+"/"+simplePodName+":/tmp/")
 
@@ -666,13 +666,13 @@ apiVersion: v1
 metadata:
   name: "configmap with namespace and invalid name"
   namespace: configmap-namespace
-`), os.FileMode(0755)))
+`), os.FileMode(0755)), "failed to os.MkdirTemp('', 'icc-override')")
 				framework.ExpectNoError(os.WriteFile(filepath.Join(tmpDir, "invalid-configmap-without-namespace.yaml"), []byte(`
 kind: ConfigMap
 apiVersion: v1
 metadata:
   name: "configmap without namespace and invalid name"
-`), os.FileMode(0755)))
+`), os.FileMode(0755)), "failed to os.MkdirTemp('', 'icc-override')")
 				framework.Logf("copying configmap manifests to the %s pod", simplePodName)
 				e2ekubectl.RunKubectlOrDie(ns, "cp", filepath.Join(tmpDir, "invalid-configmap-with-namespace.yaml"), ns+"/"+simplePodName+":/tmp/")
 				e2ekubectl.RunKubectlOrDie(ns, "cp", filepath.Join(tmpDir, "invalid-configmap-without-namespace.yaml"), ns+"/"+simplePodName+":/tmp/")
@@ -729,7 +729,7 @@ metadata:
 		ginkgo.Describe("Kubectl run", func() {
 			ginkgo.It("running a successful command", func(ctx context.Context) {
 				_, err := e2ekubectl.NewKubectlCommand(ns, "run", "-i", "--image="+imageutils.GetE2EImage(imageutils.BusyBox), "--restart=Never", podRunningTimeoutArg, "success", "--", "/bin/sh", "-c", "exit 0").Exec()
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to e2ekubectl.NewKubectlCommand(ns, 'run', '-i', '--image='+imageutils.GetE2EIma...")
 			})
 
 			ginkgo.It("running a failing command", func(ctx context.Context) {
@@ -765,14 +765,14 @@ metadata:
 				if !strings.Contains(ee.String(), "timed out") {
 					framework.Failf("Missing expected 'timed out' error, got: %#v", ee)
 				}
-				framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, "failure-3", ns, 2*v1.DefaultTerminationGracePeriodSeconds*time.Second))
+				framework.ExpectNoError(e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, "failure-3", ns, 2*v1.DefaultTerminationGracePeriodSeconds*time.Second), "failed to e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, 'failure-3', ns, 2*v1....")
 			})
 
 			f.It(f.WithSlow(), "running a failing command with --leave-stdin-open", func(ctx context.Context) {
 				_, err := e2ekubectl.NewKubectlCommand(ns, "run", "-i", "--image="+imageutils.GetE2EImage(imageutils.BusyBox), "--restart=Never", podRunningTimeoutArg, "failure-4", "--leave-stdin-open", "--", "/bin/sh", "-c", "exit 42").
 					WithStdinData("abcd1234").
 					Exec()
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to e2ekubectl.NewKubectlCommand(ns, 'run', '-i', '--image='+imageutils.GetE2EIma...")
 			})
 		})
 
@@ -799,7 +799,7 @@ metadata:
 			gomega.Expect(runOutput).To(gomega.ContainSubstring("abcd1234"))
 			gomega.Expect(runOutput).To(gomega.ContainSubstring("stdin closed"))
 
-			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test", metav1.DeleteOptions{}))
+			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test", metav1.DeleteOptions{}), "failed to c.CoreV1().Pods(ns).Delete(ctx, 'run-test', metav1.DeleteOptions{})")
 
 			ginkgo.By("executing a command with run and attach without stdin")
 			// There is a race on this scenario described in #73099
@@ -815,7 +815,7 @@ metadata:
 			gomega.Expect(runOutput).ToNot(gomega.ContainSubstring("abcd1234"))
 			gomega.Expect(runOutput).To(gomega.ContainSubstring("stdin closed"))
 
-			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test-2", metav1.DeleteOptions{}))
+			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test-2", metav1.DeleteOptions{}), "failed to c.CoreV1().Pods(ns).Delete(ctx, 'run-test-2', metav1.DeleteOptions{})")
 
 			ginkgo.By("executing a command with run and attach with stdin with open stdin should remain running")
 			e2ekubectl.NewKubectlCommand(ns, "run", "run-test-3", "--image="+imageutils.GetE2EImage(imageutils.BusyBox), "--restart=OnFailure", podRunningTimeoutArg, "--attach=true", "--leave-stdin-open=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
@@ -828,10 +828,10 @@ metadata:
 
 			g := func(pods []*v1.Pod) sort.Interface { return sort.Reverse(controller.ActivePods(pods)) }
 			runTestPod, _, err := polymorphichelpers.GetFirstPod(f.ClientSet.CoreV1(), ns, "run=run-test-3", 1*time.Minute, g)
-			framework.ExpectNoError(err)
-			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, runTestPod.Name, ns, time.Minute))
+			framework.ExpectNoError(err, "failed to polymorphichelpers.GetFirstPod(f.ClientSet.CoreV1(), ns, 'run=run-test-3', 1*...")
+			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, runTestPod.Name, ns, time.Minute), "failed to polymorphichelpers.GetFirstPod(f.ClientSet.CoreV1(), ns, 'run=run-test-3', 1*...")
 
-			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test-3", metav1.DeleteOptions{}))
+			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test-3", metav1.DeleteOptions{}), "failed to c.CoreV1().Pods(ns).Delete(ctx, 'run-test-3', metav1.DeleteOptions{})")
 		})
 
 		ginkgo.It("should support inline execution and attach with websockets or fallback to spdy", func(ctx context.Context) {
@@ -856,7 +856,7 @@ metadata:
 			gomega.Expect(runOutput).To(gomega.ContainSubstring("abcd1234"))
 			gomega.Expect(runOutput).To(gomega.ContainSubstring("stdin closed"))
 
-			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test", metav1.DeleteOptions{}))
+			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test", metav1.DeleteOptions{}), "failed to c.CoreV1().Pods(ns).Delete(ctx, 'run-test', metav1.DeleteOptions{})")
 
 			ginkgo.By("executing a command with run and attach without stdin")
 			// There is a race on this scenario described in #73099
@@ -872,7 +872,7 @@ metadata:
 			gomega.Expect(runOutput).ToNot(gomega.ContainSubstring("abcd1234"))
 			gomega.Expect(runOutput).To(gomega.ContainSubstring("stdin closed"))
 
-			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test-2", metav1.DeleteOptions{}))
+			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test-2", metav1.DeleteOptions{}), "failed to c.CoreV1().Pods(ns).Delete(ctx, 'run-test-2', metav1.DeleteOptions{})")
 
 			ginkgo.By("executing a command with run and attach with stdin with open stdin should remain running")
 			e2ekubectl.NewKubectlCommand(ns, "run", "run-test-3", "--image="+imageutils.GetE2EImage(imageutils.BusyBox), "--restart=OnFailure", podRunningTimeoutArg, "--attach=true", "--leave-stdin-open=true", "--stdin", "--", "sh", "-c", "cat && echo 'stdin closed'").
@@ -885,10 +885,10 @@ metadata:
 
 			g := func(pods []*v1.Pod) sort.Interface { return sort.Reverse(controller.ActivePods(pods)) }
 			runTestPod, _, err := polymorphichelpers.GetFirstPod(f.ClientSet.CoreV1(), ns, "run=run-test-3", 1*time.Minute, g)
-			framework.ExpectNoError(err)
-			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, runTestPod.Name, ns, time.Minute))
+			framework.ExpectNoError(err, "failed to polymorphichelpers.GetFirstPod(f.ClientSet.CoreV1(), ns, 'run=run-test-3', 1*...")
+			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, runTestPod.Name, ns, time.Minute), "failed to polymorphichelpers.GetFirstPod(f.ClientSet.CoreV1(), ns, 'run=run-test-3', 1*...")
 
-			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test-3", metav1.DeleteOptions{}))
+			framework.ExpectNoError(c.CoreV1().Pods(ns).Delete(ctx, "run-test-3", metav1.DeleteOptions{}), "failed to c.CoreV1().Pods(ns).Delete(ctx, 'run-test-3', metav1.DeleteOptions{})")
 		})
 
 		ginkgo.It("should contain last line of the log", func(ctx context.Context) {
@@ -1351,7 +1351,7 @@ metadata:
 			nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{
 				FieldSelector: "spec.unschedulable=false",
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Nodes().List(ctx, metav1.ListOptions")
 			node := nodes.Items[0]
 			output = e2ekubectl.RunKubectlOrDie(ns, "describe", "node", node.Name)
 			requiredStrings = [][]string{
@@ -1396,7 +1396,7 @@ metadata:
 				}
 				return len(cj.Items) > 0, nil
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.BatchV1().CronJobs(ns).List(ctx, metav1.ListOptions{})")
 
 			ginkgo.By("verifying kubectl describe prints")
 			output := e2ekubectl.RunKubectlOrDie(ns, "describe", "cronjob", "cronjob-test")
@@ -1473,10 +1473,10 @@ metadata:
 					}
 					return true, nil
 				})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to nil")
 
 				e2eservice, err := c.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
-				framework.ExpectNoError(err)
+				framework.ExpectNoError(err, "failed to c.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})")
 
 				if len(e2eservice.Spec.Ports) != 1 {
 					framework.Failf("1 port is expected")
@@ -1492,12 +1492,12 @@ metadata:
 
 			ginkgo.By("exposing RC")
 			e2ekubectl.RunKubectlOrDie(ns, "expose", "rc", "agnhost-primary", "--name=rm2", "--port=1234", fmt.Sprintf("--target-port=%d", agnhostPort))
-			framework.ExpectNoError(e2enetwork.WaitForService(ctx, c, ns, "rm2", true, framework.Poll, framework.ServiceStartTimeout))
+			framework.ExpectNoError(e2enetwork.WaitForService(ctx, c, ns, "rm2", true, framework.Poll, framework.ServiceStartTimeout), "failed to e2enetwork.WaitForService(ctx, c, ns, 'rm2', true, framework.Poll, framework....")
 			validateService("rm2", 1234, framework.ServiceStartTimeout)
 
 			ginkgo.By("exposing service")
 			e2ekubectl.RunKubectlOrDie(ns, "expose", "service", "rm2", "--name=rm3", "--port=2345", fmt.Sprintf("--target-port=%d", agnhostPort))
-			framework.ExpectNoError(e2enetwork.WaitForService(ctx, c, ns, "rm3", true, framework.Poll, framework.ServiceStartTimeout))
+			framework.ExpectNoError(e2enetwork.WaitForService(ctx, c, ns, "rm3", true, framework.Poll, framework.ServiceStartTimeout), "failed to e2enetwork.WaitForService(ctx, c, ns, 'rm3', true, framework.Poll, framework....")
 			validateService("rm3", 2345, framework.ServiceStartTimeout)
 		})
 	})
@@ -1508,7 +1508,7 @@ metadata:
 			ginkgo.By("creating the pod")
 			podYaml = commonutils.SubstituteImageName(string(readTestFileOrDie("pause-pod.yaml.in")))
 			e2ekubectl.RunKubectlOrDieInput(ns, podYaml, "create", "-f", "-")
-			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, pausePodName, ns, framework.PodStartTimeout))
+			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, pausePodName, ns, framework.PodStartTimeout), "failed to e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, pausePodName, ns, framework....")
 		})
 		ginkgo.AfterEach(func() {
 			cleanupKubectlInputs(podYaml, ns, pausePodSelector)
@@ -1547,7 +1547,7 @@ metadata:
 			ginkgo.By("creating the pod")
 			podYaml = commonutils.SubstituteImageName(string(readTestFileOrDie("busybox-pod.yaml.in")))
 			e2ekubectl.RunKubectlOrDieInput(ns, podYaml, "create", "-f", "-")
-			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, busyboxPodName, ns, framework.PodStartTimeout))
+			framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, busyboxPodName, ns, framework.PodStartTimeout), "failed to e2epod.WaitTimeoutForPodReadyInNamespace(ctx, c, busyboxPodName, ns, framewor...")
 		})
 		ginkgo.AfterEach(func() {
 			cleanupKubectlInputs(podYaml, ns, busyboxPodSelector)
@@ -2004,7 +2004,7 @@ metadata:
 			nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{
 				FieldSelector: "spec.unschedulable=false",
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to c.CoreV1().Nodes().List(ctx, metav1.ListOptions")
 			gomega.Expect(nodes.Items).ToNot(gomega.BeEmpty())
 			node := nodes.Items[0]
 			// Avoid comparing values of fields that might end up
@@ -2172,7 +2172,7 @@ func validateGuestbookApp(ctx context.Context, c clientset.Interface, ns string)
 	framework.Logf("Waiting for all frontend pods to be Running.")
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"tier": "frontend", "app": "guestbook"}))
 	err := testutils.WaitForPodsWithLabelRunning(c, ns, label)
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to testutils.WaitForPodsWithLabelRunning(c, ns, label)")
 	framework.Logf("Waiting for frontend to serve content.")
 	if !waitForGuestbookResponse(ctx, c, "get", "", `{"data":""}`, guestbookStartupTimeout, ns) {
 		framework.Failf("Frontend service did not start serving content in %v seconds.", guestbookStartupTimeout.Seconds())
@@ -2256,7 +2256,7 @@ func forEachReplicationController(ctx context.Context, c clientset.Interface, ns
 		label := labels.SelectorFromSet(labels.Set(map[string]string{selectorKey: selectorValue}))
 		options := metav1.ListOptions{LabelSelector: label.String()}
 		rcs, err = c.CoreV1().ReplicationControllers(ns).List(ctx, options)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to c.CoreV1().ReplicationControllers(ns).List(ctx, options)")
 		if len(rcs.Items) > 0 {
 			break
 		}

--- a/test/e2e/kubectl/kuberc.go
+++ b/test/e2e/kubectl/kuberc.go
@@ -99,7 +99,7 @@ var _ = SIGDescribe("kubectl kuberc", func() {
 	ginkgo.Describe("given preferences", func() {
 		kubercContent := fmt.Sprintf(kuberc, imageutils.GetE2EImage(imageutils.BusyBox), ns, ns)
 		tmpDir, err := os.MkdirTemp("", "test-kuberc")
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(err, "failed to os.MkdirTemp('', 'test-kuberc')")
 		defer os.Remove(tmpDir) //nolint:errcheck
 		kubercFile := filepath.Join(tmpDir, "kuberc.yaml")
 		framework.ExpectNoError(os.WriteFile(kubercFile, []byte(kubercContent), os.FileMode(0755)), "creating a kuberc.yaml in temp directory")
@@ -110,7 +110,7 @@ var _ = SIGDescribe("kubectl kuberc", func() {
 			output := e2ekubectl.NewKubectlCommand(ns, args...).ExecOrDie(ns)
 			var namespace v1.Namespace
 			err = json.Unmarshal([]byte(output), &namespace)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to json.Unmarshal([]byte(output), &namespace)")
 			gomega.Expect(namespace.Name).To(gomega.Equal(ns))
 
 			ginkgo.By("verifying that alias for run is working")
@@ -121,7 +121,7 @@ var _ = SIGDescribe("kubectl kuberc", func() {
 			podOutput := e2ekubectl.NewKubectlCommand(ns, args...).ExecOrDie(ns)
 			var pod v1.Pod
 			err = json.Unmarshal([]byte(podOutput), &pod)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to json.Unmarshal([]byte(podOutput), &pod)")
 			gomega.Expect(pod.Spec.Containers[0].Image).To(gomega.Equal(imageutils.GetE2EImage(imageutils.BusyBox)))
 			gomega.Expect(pod.Labels).To(gomega.HaveKeyWithValue("app", "test"))
 			gomega.Expect(pod.Labels).To(gomega.HaveKeyWithValue("env", "test"))
@@ -140,7 +140,7 @@ var _ = SIGDescribe("kubectl kuberc", func() {
 			output := e2ekubectl.NewKubectlCommand(ns, args...).ExecOrDie(ns)
 			var namespace v1.Namespace
 			err = yaml.Unmarshal([]byte(output), &namespace)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to yaml.Unmarshal([]byte(output), &namespace)")
 			gomega.Expect(namespace.Name).To(gomega.Equal(ns))
 
 			ginkgo.By("verifying that explicitly passed flag surpasses the flag in kuberc alias")
@@ -150,7 +150,7 @@ var _ = SIGDescribe("kubectl kuberc", func() {
 			podOutput := e2ekubectl.NewKubectlCommand(ns, args...).ExecOrDie(ns)
 			var pod v1.Pod
 			err = yaml.Unmarshal([]byte(podOutput), &pod)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to yaml.Unmarshal([]byte(podOutput), &pod)")
 			gomega.Expect(pod.Spec.Containers[0].Image).To(gomega.Equal(imageutils.GetE2EImage(imageutils.Nginx)))
 			gomega.Expect(pod.Labels).To(gomega.HaveKeyWithValue("app", "test"))
 			gomega.Expect(pod.Labels).To(gomega.HaveKeyWithValue("env", "test"))
@@ -170,12 +170,12 @@ var _ = SIGDescribe("kubectl kuberc", func() {
 		ginkgo.BeforeEach(func() {
 			var err error
 			tmpDir, err = os.MkdirTemp("", "test-kuberc-cmd")
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to os.MkdirTemp('', 'test-kuberc-cmd')")
 			kubercFile = filepath.Join(tmpDir, "kuberc.yaml")
 			minimalKuberc := `apiVersion: kubectl.config.k8s.io/v1beta1
 kind: Preference
 `
-			framework.ExpectNoError(os.WriteFile(kubercFile, []byte(minimalKuberc), os.FileMode(0644)))
+			framework.ExpectNoError(os.WriteFile(kubercFile, []byte(minimalKuberc), os.FileMode(0644)), "failed to os.WriteFile(kubercFile, []byte(minimalKuberc), os.FileMode(0644))")
 		})
 
 		ginkgo.AfterEach(func() {
@@ -187,7 +187,7 @@ kind: Preference
 		ginkgo.It("view should display kuberc file", func(ctx context.Context) {
 			ginkgo.By("creating a kuberc file with defaults and aliases")
 			kubercContent := fmt.Sprintf(kuberc, imageutils.GetE2EImage(imageutils.BusyBox), ns, ns)
-			framework.ExpectNoError(os.WriteFile(kubercFile, []byte(kubercContent), os.FileMode(0755)))
+			framework.ExpectNoError(os.WriteFile(kubercFile, []byte(kubercContent), os.FileMode(0755)), "failed to os.WriteFile(kubercFile, []byte(kubercContent), os.FileMode(0755))")
 
 			ginkgo.By("viewing the kuberc file and parsing as Preference")
 			output := e2ekubectl.RunKubectlOrDie(ns, "kuberc", "view", fmt.Sprintf("--kuberc=%s", kubercFile))
@@ -276,7 +276,7 @@ kind: Preference
 			output := e2ekubectl.RunKubectlOrDie(ns, "get", "pod", "test-pod", "-n", ns, "-oyaml")
 			var pod v1.Pod
 			err := yaml.Unmarshal([]byte(output), &pod)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to yaml.Unmarshal([]byte(output), &pod)")
 
 			if len(pod.Spec.Containers) == 0 {
 				framework.Failf("expected pod to have at least one container")

--- a/test/e2e/kubectl/logs.go
+++ b/test/e2e/kubectl/logs.go
@@ -173,7 +173,7 @@ var _ = SIGDescribe("Kubectl logs", func() {
 
 			ginkgo.By("checking for a matching strings")
 			_, err := e2eoutput.LookForStringInLog(ns, podName, containerName, "/api/v1/namespaces/kube-system", framework.PodStartTimeout)
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed to e2eoutput.LookForStringInLog(ns, podName, containerName, '/api/v1/namespaces/...")
 
 			ginkgo.By("limiting log lines")
 			out := e2ekubectl.RunKubectlOrDie(ns, "logs", podName, containerName, "--tail=1")

--- a/test/e2e/upgrades/auth/serviceaccount_admission_controller_migration.go
+++ b/test/e2e/upgrades/auth/serviceaccount_admission_controller_migration.go
@@ -63,7 +63,7 @@ func (t *ServiceAccountAdmissionControllerMigrationTest) Test(ctx context.Contex
 	ginkgo.By("Starting post-upgrade check")
 	ginkgo.By("Checking pod-before-migration makes successful requests using in cluster config")
 	podBeforeMigration, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, podBeforeMigrationName, metav1.GetOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(ctx, podBeforeMigrationName, ...")
 	if podBeforeMigration.GetUID() != t.pod.GetUID() {
 		framework.Failf("Pod %q GetUID() = %q, want %q.", podBeforeMigration.Name, podBeforeMigration.GetUID(), t.pod.GetUID())
 	}
@@ -130,7 +130,7 @@ func createPod(ctx context.Context, f *framework.Framework, podName string) *v1.
 	}
 
 	createdPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOptions{})
-	framework.ExpectNoError(err)
+	framework.ExpectNoError(err, "failed to f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(ctx, pod, metav1.CreateOpt...")
 	framework.Logf("Created pod %s", podName)
 
 	if !e2epod.CheckPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, []string{pod.Name}, time.Minute) {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This PR replaces the ExpectNoError and Expect NotTo HaveOccurred anti-patterns across the `api` tests by providing an explanation string to avoid swallowing contexts in errors. This is part of a split of a larger PR to make it easier to review.

#### Which issue(s) this PR is related to:
Related to: #109600

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```