### PR TITLE
e2e: assert readiness probes run during graceful pod termination

### DIFF
--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -53,6 +54,19 @@ const (
 	probeTestInitialDelaySeconds = 15
 
 	defaultObservationTimeout = time.Minute * 4
+
+	// Twice terminationProbeUnreadyTimeout, so the container is still running
+	// when the assertion completes.
+	terminationProbeGracePeriodSeconds = 60
+
+	// Slack over the ~2s the kubelet needs at periodSeconds=1, for slow CI.
+	terminationProbeUnreadyTimeout = 30 * time.Second
+
+	// The 1s default is aggressive on a loaded node, and the kubelet discards
+	// errored (timed out) probe results rather than failing the container.
+	terminationProbeTimeoutSeconds = 5
+
+	terminationProbeContainerName = "probe-target"
 )
 
 var _ = SIGDescribe("Probing container", func() {
@@ -777,69 +791,27 @@ var _ = SIGDescribe("Probing container", func() {
 		})
 
 	f.It("should mark readiness on pods to false while pod is in progress of terminating when a pod has a readiness probe", f.WithNodeConformance(), func(ctx context.Context) {
-		podName := "probe-test-" + string(uuid.NewUUID())
-		podClient := e2epod.NewPodClient(f)
-		terminationGracePeriod := int64(30)
+		// Trapping TERM without exiting keeps the container alive until the
+		// kubelet SIGKILLs it, so the probe still has a live target.
 		script := `
 _term() {
 	rm -f /tmp/ready
-	sleep 30
-	exit 0
 }
-trap _term SIGTERM
+trap _term TERM
 
 touch /tmp/ready
 
+# Short sleeps: the shell runs the handler only once the current foreground
+# command returns.
 while true; do
-  echo \"hello\"
-  sleep 10
+	sleep 1
 done
-			`
+`
+		container := terminationProbeContainer(execHandler([]string{"cat", "/tmp/ready"}))
+		container.Command = []string{"/bin/bash"}
+		container.Args = []string{"-c", script}
 
-		// Create Pod
-		podClient.Create(ctx, &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: podName,
-			},
-			Spec: v1.PodSpec{
-				Containers: []v1.Container{
-					{
-						Image:   imageutils.GetE2EImage(imageutils.Agnhost),
-						Name:    podName,
-						Command: []string{"/bin/bash"},
-						Args:    []string{"-c", script},
-						ReadinessProbe: &v1.Probe{
-							ProbeHandler: v1.ProbeHandler{
-								Exec: &v1.ExecAction{
-									Command: []string{"cat", "/tmp/ready"},
-								},
-							},
-							FailureThreshold:    1,
-							InitialDelaySeconds: 5,
-							PeriodSeconds:       2,
-						},
-					},
-				},
-				TerminationGracePeriodSeconds: &terminationGracePeriod,
-			},
-		})
-
-		// verify pods are running and ready
-		err := e2epod.WaitForPodsRunningReady(ctx, f.ClientSet, f.Namespace.Name, 1, f.Timeouts.PodStart)
-		framework.ExpectNoError(err)
-
-		// Shutdown pod. Readiness should change to false
-		err = podClient.Delete(ctx, podName, metav1.DeleteOptions{})
-		framework.ExpectNoError(err)
-
-		err = waitForPodStatusByInformer(ctx, f.ClientSet, f.Namespace.Name, podName, f.Timeouts.PodDelete, func(pod *v1.Pod) (bool, error) {
-			if !podutil.IsPodReady(pod) {
-				return true, nil
-			}
-			framework.Logf("pod %s/%s is still ready, waiting until is not ready", pod.Namespace, pod.Name)
-			return false, nil
-		})
-		framework.ExpectNoError(err)
+		runTerminationReadinessTest(ctx, f, podClient, container)
 	})
 
 	f.It("should mark readiness on pods to false and disable liveness probes while pod is in progress of terminating", f.WithNodeConformance(), func(ctx context.Context) {
@@ -941,7 +913,134 @@ done
 			return false, nil
 		}, 1*time.Minute, framework.Poll).ShouldNot(gomega.BeTrueBecause("should not see liveness probes"))
 	})
+
+	f.It("should mark readiness on pods to false while pod is in progress of terminating when a pod has an http readiness probe", f.WithNodeConformance(), func(ctx context.Context) {
+		// Same behavior expected for httpGet as for exec. netexec answers
+		// /readyz with 503 on SIGTERM; --delay-shutdown keeps it serving.
+		container := terminationProbeContainer(httpGetHandler("/readyz", 8080))
+		container.Args = []string{"netexec", "--http-port=8080",
+			fmt.Sprintf("--delay-shutdown=%d", terminationProbeGracePeriodSeconds)}
+
+		runTerminationReadinessTest(ctx, f, podClient, container)
+	})
+
+	f.It("should mark readiness on pods to false while a preStop hook fails the readiness probe during termination", f.WithNodeConformance(), func(ctx context.Context) {
+		// Only the preStop hook fails readiness here, the documented way to
+		// drain a pod before its containers are signaled. The container itself
+		// never stops passing its probe.
+		script := `
+touch /tmp/ready
+
+while true; do
+	sleep 1
+done
+`
+		container := terminationProbeContainer(execHandler([]string{"cat", "/tmp/ready"}))
+		container.Command = []string{"/bin/bash"}
+		container.Args = []string{"-c", script}
+		container.Lifecycle = &v1.Lifecycle{
+			PreStop: &v1.LifecycleHandler{
+				// Blocking holds off SIGTERM. The kubelet caps this at the
+				// grace period.
+				Exec: &v1.ExecAction{
+					Command: []string{"/bin/bash", "-c", fmt.Sprintf("rm -f /tmp/ready; sleep %d", terminationProbeGracePeriodSeconds)},
+				},
+			},
+		}
+
+		runTerminationReadinessTest(ctx, f, podClient, container)
+	})
 })
+
+// terminationProbeContainer returns an agnhost container with a readiness probe
+// tuned to react within a couple of seconds, so the assertion window can stay
+// short. Callers set Command, Args and Lifecycle.
+func terminationProbeContainer(handler v1.ProbeHandler) v1.Container {
+	container := e2epod.NewAgnhostContainer(terminationProbeContainerName, nil, nil)
+	container.ReadinessProbe = &v1.Probe{
+		ProbeHandler:        handler,
+		FailureThreshold:    1,
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       1,
+		TimeoutSeconds:      terminationProbeTimeoutSeconds,
+	}
+	return container
+}
+
+// runTerminationReadinessTest waits for a single-container pod to be Ready,
+// deletes it, and asserts it goes NotReady while the container is still running.
+func runTerminationReadinessTest(ctx context.Context, f *framework.Framework, podClient *e2epod.PodClient, container v1.Container) {
+	podName := "probe-test-" + string(uuid.NewUUID())
+	gracePeriod := int64(terminationProbeGracePeriodSeconds)
+
+	podClient.Create(ctx, &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: podName,
+		},
+		Spec: v1.PodSpec{
+			Containers:                    []v1.Container{container},
+			TerminationGracePeriodSeconds: &gracePeriod,
+		},
+	})
+	ginkgo.DeferCleanup(deletePodImmediately, podClient, podName)
+
+	framework.ExpectNoError(e2epod.WaitTimeoutForPodReadyInNamespace(ctx, f.ClientSet, podName, f.Namespace.Name, f.Timeouts.PodStart))
+	framework.ExpectNoError(podClient.Delete(ctx, podName, metav1.DeleteOptions{}))
+
+	waitForTerminatingPodNotReady(ctx, podClient, podName, container.Name, terminationProbeUnreadyTimeout)
+}
+
+// waitForTerminatingPodNotReady waits for the pod to go NotReady while it is
+// still terminating and containerName is still running.
+//
+// Both conditions matter, see https://issue.k8s.io/140978. EndpointSlice
+// membership is no substitute: the deletionTimestamp withdraws the endpoint
+// regardless of readiness. And once the container stops, the pod goes NotReady
+// with or without a working probe.
+func waitForTerminatingPodNotReady(ctx context.Context, podClient *e2epod.PodClient, podName, containerName string, timeout time.Duration) {
+	ginkgo.By(fmt.Sprintf("waiting up to %v for terminating pod %q to report NotReady", timeout, podName))
+	gomega.Eventually(ctx, func(ctx context.Context) error {
+		pod, err := podClient.Get(ctx, podName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return gomega.StopTrying(fmt.Sprintf("pod %q was removed before it was observed NotReady", podName)).Wrap(err)
+		}
+		if err != nil {
+			return err
+		}
+		if pod.DeletionTimestamp == nil {
+			return fmt.Errorf("pod %s/%s is not terminating yet", pod.Namespace, pod.Name)
+		}
+		status, ok := podutil.GetContainerStatus(pod.Status.ContainerStatuses, containerName)
+		if !ok {
+			return fmt.Errorf("pod %s/%s has no status for container %q yet", pod.Namespace, pod.Name, containerName)
+		}
+		if status.State.Running == nil {
+			return gomega.StopTrying(fmt.Sprintf("container %q stopped first, so this proves nothing about probing", containerName)).
+				Wrap(fmt.Errorf("state: %+v", status.State))
+		}
+		// The prober sets container readiness; the pod condition is derived
+		// from it. Assert both, so a broken derivation is not mistaken for a
+		// broken probe.
+		if status.Ready {
+			return fmt.Errorf("container %q of terminating pod %s/%s is still Ready", containerName, pod.Namespace, pod.Name)
+		}
+		if podutil.IsPodReady(pod) {
+			return fmt.Errorf("terminating pod %s/%s is still Ready", pod.Namespace, pod.Name)
+		}
+		framework.Logf("terminating pod %s/%s is NotReady while container %q is still running", pod.Namespace, pod.Name, containerName)
+		return nil
+	}).WithTimeout(timeout).WithPolling(time.Second).Should(gomega.Succeed())
+}
+
+// deletePodImmediately keeps namespace teardown from blocking on a container
+// that intentionally outlives SIGTERM. NotFound: the spec already deleted it.
+func deletePodImmediately(ctx context.Context, podClient *e2epod.PodClient, podName string) error {
+	err := podClient.Delete(ctx, podName, *metav1.NewDeleteOptions(0))
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
 
 var _ = SIGDescribe(framework.WithNodeConformance(), "Probing restartable init container", func() {
 	f := framework.NewDefaultFramework("container-probe")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Adds e2e coverage for readiness probing during graceful pod termination. The probe path and the termination path were each well covered and the intersection was not, which is how #140881 shipped in v1.35.0 and was caught by a user instead of CI.

There was already a test named `should mark readiness on pods to false while pod is in progress of terminating when a pod has a readiness probe`, and it stayed green through the entire regression. It gave the container a 30s `terminationGracePeriodSeconds` and then waited up to `f.Timeouts.PodDelete` (5m) for `Ready=False`. So it passed the moment the container was SIGKILLed at the grace boundary, whether or not the readiness probe ever ran during termination. On a v1.35.0 kubelet I watched it hold `Ready=True` for the full grace period and then flip to `False` at the exact second the container died:

```
DELETE at 01:25:28
01:25:28  probe-exec=ready:True/running
01:25:30  probe-exec=ready:True/running
...
01:26:01  probe-exec=ready:True/running
01:27:28  ready=False container=STOPPED   <- grace period expired, SIGKILL
```

That is the test passing for the wrong reason. This PR tightens it and adds two more:

- `...when a pod has a readiness probe` (rewritten) — exec readiness probe during termination, the actual regression. `terminationGracePeriodSeconds` now outlasts the assertion, and the assertion requires the probed container to still be `Running`, so the pod can only be NotReady because the probe said so.
- `...when a pod has an http readiness probe` (new) — same contract over `httpGet`, using `agnhost netexec --delay-shutdown`, whose `/readyz` returns 503 on SIGTERM while the server keeps serving. Not affected by #140881 because the HTTP prober does not take the probe context, but nothing pinned it.
- `should mark readiness on pods to false while a preStop hook fails the readiness probe during termination` (new) — the documented drain pattern, where only the preStop hook fails readiness and the container itself never stops passing its probe.

The shared `waitForTerminatingPodNotReady` helper carries both traps as comments so the next person does not re-learn them:

1. Assert on the pod `Ready` condition, not EndpointSlice membership. The `deletionTimestamp` withdraws the endpoint immediately regardless of readiness, which masks the bug completely.
2. Require the probed container to still be `Running` at the moment `Ready=False` is observed. Otherwise the pod goes NotReady because there is no running container left. The helper calls `gomega.StopTrying` with a diagnostic if the container stopped first, rather than silently passing.

Not `ConformanceIt`. These assert kubelet timing behavior rather than an API guarantee. Reasonable promotion candidate later.

#### Which issue(s) this PR is related to:

Fixes #140978
xref #140881
xref #140882
xref #130487

#### Special notes for your reviewer:

#140882 has merged, so these are green. Before it merged they were red, which is the coverage claim demonstrating itself in CI rather than in my local clusters. Same tests, same suites, base SHA is the only variable:

| test | base 7bd662ff, pre-fix | base 7ed622c8, the #140882 merge commit |
| --- | --- | --- |
| exec readiness during termination | fail, 36.3s | pass, 9.1s |
| preStop drain | fail, 36.4s | pass, 10.3s |
| httpGet readiness during termination | pass, 7.2s | pass, 8.2s |

Both exec failures on the pre-fix base were the intended assertion, `terminating pod ... is still Ready` after the full 30s, not the `gomega.StopTrying` guard that fires when the container stopped early. So the container was `Running` the whole window and the kubelet held `Ready=True` anyway. Breakdown in https://github.com/kubernetes/kubernetes/pull/140980#issuecomment-5107376025.

Which kubelet is affected turns out to depend on how `pod_workers.go` manages `status.ctx`, and it is not a simple "broken since 1.35" story:

| release | `startPodSync` context handling | affected |
| --- | --- | --- |
| v1.35.x | `status.ctx` stored and reused across syncs | yes, verified on kindest/node:v1.35.0 |
| v1.36.0 - v1.36.2 | fresh ctx every sync, `status.ctx` never stored | no, verified on kindest/node:v1.36.1 |
| v1.36.3+ | reuse restored by ccca5a96bfb (#140066, cherry-pick of #139850) | yes |
| master, v1.37.0-alpha.3+ | reuse restored by 83c796592b2 (#139850) | yes |

v1.36.0 through v1.36.2 pass by accident. They leak a context per sync, so the ctx the probe worker captured in `AddPod` is not the one cancelled at teardown. The memory-leak fix restored the reuse and re-armed #140881 along with it. So the coverage gap matters more now, not less, and a run against v1.36.1 or v1.36.2 will look green on a branch that is not actually clean. Details in https://github.com/kubernetes/kubernetes/pull/140882#issuecomment-5099162179.

That table matches what I saw building the tests, on kind clusters with the pod specs applied by hand:

- kindest/node:v1.35.0 (same context-reuse semantics as master): exec and preStop hold `Ready=True` with the container still `Running` for the whole window. Both assertions fail, correctly. httpGet flips to `Ready=False` in ~2s and passes.
- kindest/node:v1.36.1 (probe worker's context survives teardown, so it stands in for a fixed kubelet): all three flip to `Ready=False` within ~2s with the container still `Running`. All three pass.

Confirmed on v1.36.1 at `--v=4` that the probe genuinely runs during termination rather than the pod going NotReady for some other reason. `Cancelling current pod sync` fires, and exec probes keep landing in the container afterwards with real output:

```
01:04:49.945 pod_workers.go:991] "Cancelling current pod sync" pod="probe-term/probe-exec" workType="terminating"
01:04:50.885 kuberuntime_container.go:908] "Killing container with a grace period" gracePeriod=120
01:04:51.871 prober.go:156] "Exec-Probe runProbe" pod="probe-term/probe-exec" execCommand=["cat","/tmp/ready"]
01:04:51.889 prober.go:122] "Probe failed" probeType="Readiness" probeResult="failure" output=<
        Readiness probe failed: cat: can't open '/tmp/ready': No such file or directory
```

Two things I deliberately left out of scope:

- The `Probing restartable init container` copies of these tests have the same weakness, plus a `pause` main container that exits on SIGTERM, so the pod goes NotReady for two wrong reasons at once. Sidecars were not part of #140881 and fixing them is a bigger change to those specs. Happy to do it in a follow-up if a reviewer wants it.
- The liveness half of `should mark readiness on pods to false and disable liveness probes while pod is in progress of terminating` is untouched. Its readiness assertion has the same weakness, but its actual subject is liveness being disabled, and that part still works.

Grace period is 120s so the container comfortably outlasts the 30s assertion window. Each test force-deletes its pod in a `DeferCleanup` so namespace teardown does not block on a container that intentionally outlives SIGTERM.

/sig node
/sig testing
/area kubelet
/area test

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
