### PR TITLE
fix: scope etcd3 fatalOnDecodeError to the watcher so a leaked watch goroutine can't panic an unrelated test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -175,6 +175,9 @@ func New(c *kubernetes.Client, compactor Compactor, codec runtime.Codec, newFunc
 		groupResource: groupResource,
 		versioner:     versioner,
 		transformer:   transformer,
+		// Snapshot the testing-only panic-on-decode-error setting so that watch goroutines
+		// belonging to this store are not affected by later changes to the global.
+		fatalOnDecodeError: fatalOnDecodeError.Load(),
 	}
 	if newFunc == nil {
 		w.objectType = "<unknown>"

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -62,7 +62,9 @@ const (
 // defaultWatcherMaxLimit is used to facilitate construction tests
 var defaultWatcherMaxLimit int64 = maxLimit
 
-// fatalOnDecodeError is used during testing to panic the server if watcher encounters a decoding error
+// fatalOnDecodeError is used during testing to panic the server if watcher encounters a decoding error.
+// It is only the default for watchers created from this point on: each watcher captures the value at
+// construction time, see watcher.fatalOnDecodeError.
 var fatalOnDecodeError atomic.Bool
 
 func init() {
@@ -79,6 +81,11 @@ type TestingTB interface {
 }
 
 // TestOnlySetFatalOnDecodeError should only be used for cases where decode errors are expected and need to be tested. e.g. conversion webhooks.
+//
+// The setting is captured by each watcher when it is constructed, so it must be called before the
+// storage under test is created. Watchers created while it is in effect keep the relaxed behavior
+// for their whole lifetime, including on event-processing goroutines that are still draining after
+// the test's cleanup has restored the previous value.
 func TestOnlySetFatalOnDecodeError(tb TestingTB, b bool) {
 	tb.Helper()
 	old := fatalOnDecodeError.Swap(b)
@@ -97,6 +104,14 @@ type watcher struct {
 	transformer              value.Transformer
 	getCurrentStorageRV      func(context.Context) (uint64, error)
 	getResourceSizeEstimator func() *resourceSizeEstimator
+
+	// fatalOnDecodeError is a snapshot of the package-level fatalOnDecodeError taken when this
+	// watcher was constructed. Watch events are decoded on goroutines that outlive the watch
+	// (see concurrentOrderedEventProcessing.scheduleEventProcessing), and in tests those
+	// goroutines can outlive the test that created the watcher. Reading the process-global
+	// value at decode time would let a decode error that one test legitimately expects panic
+	// the whole binary once another test has restored the global to true.
+	fatalOnDecodeError bool
 }
 
 // watchChan implements watch.Interface.
@@ -828,7 +843,7 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 		if err != nil {
 			return nil, nil, err
 		}
-		curObj, err = decodeObj(wc.watcher.codec, wc.watcher.versioner, data, e.rev)
+		curObj, err = decodeObj(wc.watcher.codec, wc.watcher.versioner, data, e.rev, wc.watcher.fatalOnDecodeError)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -845,7 +860,7 @@ func (wc *watchChan) prepareObjs(e *event) (curObj runtime.Object, oldObj runtim
 		}
 		// Note that this sends the *old* object with the etcd revision for the time at
 		// which it gets deleted.
-		oldObj, err = decodeObj(wc.watcher.codec, wc.watcher.versioner, data, e.rev)
+		oldObj, err = decodeObj(wc.watcher.codec, wc.watcher.versioner, data, e.rev, wc.watcher.fatalOnDecodeError)
 		if err != nil {
 			return nil, nil, wc.watcher.transformIfCorruptObjectError(e, err)
 		}
@@ -875,10 +890,10 @@ func (w *watcher) transformIfCorruptObjectError(e *event, err error) error {
 	return &corruptObjectDeletedError{err: corruptObjErr}
 }
 
-func decodeObj(codec runtime.Codec, versioner storage.Versioner, data []byte, rev int64) (_ runtime.Object, err error) {
+func decodeObj(codec runtime.Codec, versioner storage.Versioner, data []byte, rev int64, fatalOnDecodeError bool) (_ runtime.Object, err error) {
 	obj, err := runtime.Decode(codec, []byte(data))
 	if err != nil {
-		if fatalOnDecodeError.Load() {
+		if fatalOnDecodeError {
 			// we are running in a test environment and thus an
 			// error here is due to a coder mistake if the defer
 			// does not catch it

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -32,21 +32,25 @@ import (
 	grpccodes "google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
 
+	"k8s.io/apimachinery/pkg/api/apitesting"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/sharding"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/apis/example"
+	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd3/metrics"
 	"k8s.io/apiserver/pkg/storage/etcd3/testserver"
 	etcdfeature "k8s.io/apiserver/pkg/storage/feature"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
+	"k8s.io/apiserver/pkg/storage/value/encrypt/identity"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -726,5 +730,73 @@ func TestWatchWithShardSelector(t *testing.T) {
 			}
 			expectAddedEvent(t, w, "pod-in")
 		})
+	}
+}
+
+// TestFatalOnDecodeErrorIsPerWatcher verifies that a watcher keeps the fatalOnDecodeError setting
+// it was constructed with, rather than reading the process-global value at decode time.
+//
+// Watch events are decoded on goroutines spawned by concurrentOrderedEventProcessing, and nothing
+// joins those goroutines to the test that created the watcher. Reading the global at decode time
+// let a decode error that one test legitimately expects panic the whole test binary once the
+// global had been restored to true, and the panic was attributed to whichever unrelated test
+// happened to be running. See https://github.com/kubernetes/kubernetes/issues/140979.
+func TestFatalOnDecodeErrorIsPerWatcher(t *testing.T) {
+	codec := &testCodec{Codec: apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)}
+	codec.setFailing(true)
+
+	newWatchChan := func(fatalOnDecodeError bool) *watchChan {
+		w := &watcher{
+			codec:              codec,
+			newFunc:            newPod,
+			objectType:         "*example.Pod",
+			groupResource:      schema.GroupResource{Resource: "pods"},
+			versioner:          storage.APIObjectVersioner{},
+			transformer:        identity.NewEncryptCheckTransformer(),
+			fatalOnDecodeError: fatalOnDecodeError,
+		}
+		wc := w.createWatchChan(context.Background(), "/pods/test-ns/", 0, true, false, false, storage.Everything)
+		t.Cleanup(wc.cancel)
+		return wc
+	}
+
+	e := &event{key: "/pods/test-ns/foo", value: []byte("undecodable"), rev: 1, isCreated: true}
+
+	// Stand in for an unrelated test having restored the global to true while this watcher's
+	// event-processing goroutines are still draining.
+	TestOnlySetFatalOnDecodeError(t, true)
+
+	t.Run("constructed with fatalOnDecodeError=false", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("expected a decode error, got panic: %v", r)
+			}
+		}()
+		if _, _, err := newWatchChan(false).prepareObjs(e); err == nil {
+			t.Error("expected a decode error, got none")
+		}
+	})
+
+	t.Run("constructed with fatalOnDecodeError=true", func(t *testing.T) {
+		defer func() {
+			if recover() == nil {
+				t.Error("expected a panic on decode error, got none")
+			}
+		}()
+		_, _, err := newWatchChan(true).prepareObjs(e)
+		t.Errorf("expected a panic on decode error, got err %v", err)
+	})
+}
+
+// TestNewCapturesFatalOnDecodeError verifies that New snapshots the process-global
+// fatalOnDecodeError, so that TestOnlySetFatalOnDecodeError's opt-out sticks for the lifetime of
+// the storage it was set up for. See https://github.com/kubernetes/kubernetes/issues/140979.
+func TestNewCapturesFatalOnDecodeError(t *testing.T) {
+	TestOnlySetFatalOnDecodeError(t, false)
+
+	_, store, _ := testSetup(t)
+
+	if store.watcher.fatalOnDecodeError {
+		t.Error("watcher.fatalOnDecodeError = true, want false to match the value set before the store was created")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/kind bug

#### What this PR does / why we need it:

`fatalOnDecodeError` is a package-level `atomic.Bool` in `etcd3`, and `decodeObj` read it at decode time:

https://github.com/kubernetes/kubernetes/blob/7bd662ff25e/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go#L878-L888

Watch events are decoded on goroutines spawned by `concurrentOrderedEventProcessing.scheduleEventProcessing`, and nothing joins those goroutines to the test that created the watcher:

https://github.com/kubernetes/kubernetes/blob/7bd662ff25e/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go#L609-L617

So a decode error that one test legitimately expects can be processed on a leaked goroutine after that test's `Cleanup` has already restored the global to `true`, and the panic takes down the whole test binary under an unrelated test's name. That is what happened in the linked flake: `TestDeleteWithSuggestionAndMissingExpectedTransformOrDecodeError` got the blame for a `panic: synthetic error` it has no way to produce — only the sibling `...ExpectedTransformError` / `...ExpectedDecodeError` tests inject that error.

Each `watcher` now snapshots the value at construction, and `decodeObj` takes it as a parameter. A watcher created while the opt-out is in effect keeps the relaxed behavior for its whole lifetime, including on event-processing goroutines still draining after cleanup.

This is option 1 from the issue. Option 2 (recover in the goroutine) would weaken the fatal-on-decode contract in production, and option 3 (drain the goroutines) only fixes one call site.

#### Which issue(s) this PR is related to:

xref #140979

#### Special notes for your reviewer:

All three existing callers of `TestOnlySetFatalOnDecodeError` already set the flag before constructing the storage under test, so none needed changes:

- `staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go` (2 call sites, both before `StartDefaultServer`)
- `staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go` (before `testSetup`)
- `test/integration/storageversionmigrator/storageversionmigrator_test.go` (before `svmSetup`)

I did add a doc comment on `TestOnlySetFatalOnDecodeError` making the ordering requirement explicit, since it is now load-bearing.

The `framework.GoleakCheck` in `storageversionmigrator_test.go:163` was working around this same hazard ("block test clean up and let any lingering watches complete before making decode errors fatal again"). It should be redundant now, but I left it alone — out of scope for a flake fix, and it is doing other useful work.

Two regression tests in `watcher_test.go`:

- `TestFatalOnDecodeErrorIsPerWatcher` sets the global to `true`, then decodes an undecodable event on a watcher constructed with `false`, asserting an error instead of a panic. Plus the converse, so the fatal path stays covered.
- `TestNewCapturesFatalOnDecodeError` asserts `New` snapshots the global.

Verified the first test reproduces the reported failure. Patching the two call sites back to `fatalOnDecodeError.Load()`:

```
--- FAIL: TestFatalOnDecodeErrorIsPerWatcher (0.00s)
    --- FAIL: TestFatalOnDecodeErrorIsPerWatcher/constructed_with_fatalOnDecodeError=false (0.00s)
        watcher_test.go:772: expected a decode error, got panic: synthetic error
FAIL
FAIL	k8s.io/apiserver/pkg/storage/etcd3	0.559s
```

Passing with the fix, all under `KUBE_PANIC_WATCH_DECODE_ERROR=true` to match CI:

```
$ KUBE_PANIC_WATCH_DECODE_ERROR=true go test ./pkg/storage/etcd3/... -count=1
ok  	k8s.io/apiserver/pkg/storage/etcd3	120.228s
ok  	k8s.io/apiserver/pkg/storage/etcd3/metrics	0.328s
ok  	k8s.io/apiserver/pkg/storage/etcd3/preflight	0.852s

$ KUBE_PANIC_WATCH_DECODE_ERROR=true go test ./pkg/storage/cacher/ -run TestDelete -count=5
ok  	k8s.io/apiserver/pkg/storage/cacher	126.193s

$ go test ./pkg/storage/etcd3/ -run 'TestFatalOnDecodeErrorIsPerWatcher|TestNewCapturesFatalOnDecodeError' -race -count=3
ok  	k8s.io/apiserver/pkg/storage/etcd3	2.960s
```

Note that the underlying flake depends on goroutine timing at test teardown, so the `-count=5` cacher run is weak evidence on its own. The deterministic unit test above is the real coverage.

/sig api-machinery

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
