### PR TITLE
Clear PlacementCycleState for pods that move to binding

### DIFF
--- a/pkg/scheduler/algorithm_test.go
+++ b/pkg/scheduler/algorithm_test.go
@@ -496,7 +496,7 @@ func TestSchedulingAlgorithmDriver(t *testing.T) {
 
 			state := framework.NewCycleState()
 			if tt.podGroupCycle {
-				state.SetPodGroupSchedulingCycle(framework.NewCycleState())
+				state.SetPodGroupCycleState(framework.NewCycleState())
 			}
 
 			scheduleResult, status := sched.schedulingAlgorithm(ctx, state, schedFwk, queuedPodInfo, time.Now())
@@ -736,6 +736,6 @@ func isPodInSnapshot(snapshot *internalcache.Snapshot, nodeName, podName string)
 
 func newPodGroupCycleState() *framework.CycleState {
 	state := framework.NewCycleState()
-	state.SetPodGroupSchedulingCycle(framework.NewCycleState())
+	state.SetPodGroupCycleState(framework.NewCycleState())
 	return state
 }

--- a/pkg/scheduler/framework/cycle_state.go
+++ b/pkg/scheduler/framework/cycle_state.go
@@ -109,7 +109,7 @@ func (c *CycleState) IsPodGroupSchedulingCycle() bool {
 	return c.podGroupCycleState != nil
 }
 
-func (c *CycleState) SetPodGroupSchedulingCycle(podGroupCycleState fwk.PodGroupCycleState) {
+func (c *CycleState) SetPodGroupCycleState(podGroupCycleState fwk.PodGroupCycleState) {
 	c.podGroupCycleState = podGroupCycleState
 }
 

--- a/pkg/scheduler/framework/cycle_state.go
+++ b/pkg/scheduler/framework/cycle_state.go
@@ -109,11 +109,11 @@ func (c *CycleState) IsPodGroupSchedulingCycle() bool {
 	return c.podGroupCycleState != nil
 }
 
-func (c *CycleState) SetPodGroupSchedulingCycle(podGroupCycleState fwk.PodGroupCycleState) {
+func (c *CycleState) SetPodGroupCycleState(podGroupCycleState fwk.PodGroupCycleState) {
 	c.podGroupCycleState = podGroupCycleState
 }
 
-func (c *CycleState) GetPodGroupSchedulingCycle() fwk.PodGroupCycleState {
+func (c *CycleState) GetPodGroupCycleState() fwk.PodGroupCycleState {
 	return c.podGroupCycleState
 }
 

--- a/pkg/scheduler/framework/cycle_state_test.go
+++ b/pkg/scheduler/framework/cycle_state_test.go
@@ -206,7 +206,7 @@ func TestPlacementCycleState(t *testing.T) {
 		state := NewCycleState()
 		podGroupState := NewCycleState()
 		placementState := NewCycleState()
-		placementState.SetPodGroupSchedulingCycle(podGroupState)
+		placementState.SetPodGroupCycleState(podGroupState)
 		placementState.Write("testkey", &fakeData{data: "placementdata"})
 
 		state.SetPlacementCycleState(placementState)

--- a/pkg/scheduler/framework/cycle_state_test.go
+++ b/pkg/scheduler/framework/cycle_state_test.go
@@ -206,7 +206,7 @@ func TestPlacementCycleState(t *testing.T) {
 		state := NewCycleState()
 		podGroupState := NewCycleState()
 		placementState := NewCycleState()
-		placementState.SetPodGroupSchedulingCycle(podGroupState)
+		placementState.SetPodGroupCycleState(podGroupState)
 		placementState.Write("testkey", &fakeData{data: "placementdata"})
 
 		state.SetPlacementCycleState(placementState)
@@ -223,7 +223,7 @@ func TestPlacementCycleState(t *testing.T) {
 		if data.(*fakeData).data != "placementdata" {
 			t.Errorf("expected 'placementdata', got %q", data.(*fakeData).data)
 		}
-		if got.GetPodGroupSchedulingCycle() != podGroupState {
+		if got.GetPodGroupCycleState() != podGroupState {
 			t.Errorf("expected PlacementCycleState to expose its PodGroupCycleState")
 		}
 	})

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -897,17 +897,17 @@ func getPodGroupStateDataFromPodGroupCycleState(pgState fwk.PodGroupCycleState) 
 func getPodGroupStateData(cs fwk.CycleState) (*podGroupStateData, error) {
 	// This is nil if the GenericWorkload feature is disabled, the Pod does not
 	// belong to a PodGroup, or the PodGroup is in the asynchronous binding phase.
-	podGroupCycleState := cs.GetPodGroupSchedulingCycle()
+	podGroupCycleState := cs.GetPodGroupCycleState()
 	return getPodGroupStateDataFromPodGroupCycleState(podGroupCycleState)
 }
 
 func getOrCreatePodGroupStateData(cs fwk.CycleState) (*podGroupStateData, error) {
 	podGroupState, err := getPodGroupStateData(cs)
 	if errors.Is(err, fwk.ErrNotFound) {
-		podGroupCycleState := cs.GetPodGroupSchedulingCycle()
+		podGroupCycleState := cs.GetPodGroupCycleState()
 		if podGroupCycleState == nil {
 			// This should never happen since [getPodGroupStateData] only returns
-			// [fwk.ErrNotFound] after [fwk.CycleState.GetPodGroupSchedulingCycle]
+			// [fwk.ErrNotFound] after [fwk.CycleState.GetPodGroupCycleState]
 			// already returns non-nil.
 			return nil, err
 		}

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -1312,7 +1312,7 @@ func TestPreFilterReusesPendingAllocationWithNilNodeSelector(t *testing.T) {
 		},
 	})
 	cycleState := framework.NewCycleState()
-	cycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	cycleState.SetPodGroupCycleState(podGroupCycleState)
 	testCtx.state = cycleState
 
 	nodeInfo := framework.NewNodeInfo()
@@ -1372,7 +1372,7 @@ func TestFilterReusesPendingAllocationRequiresDRAOptionalNodeOperations(t *testi
 		},
 	})
 	cycleState := framework.NewCycleState()
-	cycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	cycleState.SetPodGroupCycleState(podGroupCycleState)
 	testCtx.state = cycleState
 
 	nodeInfo := framework.NewNodeInfo()
@@ -4262,7 +4262,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					})
 				} else {
 					// PodGroup cycle state is cleared before asynchronous binding.
-					testCtx.state.(*framework.CycleState).SetPodGroupSchedulingCycle(nil)
+					testCtx.state.(*framework.CycleState).SetPodGroupCycleState(nil)
 
 					if tc.want.unreserveBeforePreBind != nil {
 						initialObjects = testCtx.listAll(tCtx)
@@ -4708,7 +4708,7 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 	state := framework.NewCycleState()
 	if len(podGroups) > 0 {
 		pgCycleState := framework.NewCycleState()
-		state.SetPodGroupSchedulingCycle(pgCycleState)
+		state.SetPodGroupCycleState(pgCycleState)
 	}
 	tc.state = state
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -1312,7 +1312,7 @@ func TestPreFilterReusesPendingAllocationWithNilNodeSelector(t *testing.T) {
 		},
 	})
 	cycleState := framework.NewCycleState()
-	cycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	cycleState.SetPodGroupCycleState(podGroupCycleState)
 	testCtx.state = cycleState
 
 	nodeInfo := framework.NewNodeInfo()
@@ -1372,7 +1372,7 @@ func TestFilterReusesPendingAllocationRequiresDRAOptionalNodeOperations(t *testi
 		},
 	})
 	cycleState := framework.NewCycleState()
-	cycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	cycleState.SetPodGroupCycleState(podGroupCycleState)
 	testCtx.state = cycleState
 
 	nodeInfo := framework.NewNodeInfo()
@@ -4262,7 +4262,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					})
 				} else {
 					// PodGroup cycle state is cleared before asynchronous binding.
-					testCtx.state.(*framework.CycleState).SetPodGroupSchedulingCycle(nil)
+					testCtx.state.(*framework.CycleState).SetPodGroupCycleState(nil)
 
 					if tc.want.unreserveBeforePreBind != nil {
 						initialObjects = testCtx.listAll(tCtx)
@@ -4308,7 +4308,7 @@ func testPlugin(tCtx ktesting.TContext) {
 					mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 						return nil, fwk.NewStatus(fwk.Unschedulable)
 					}
-					podGroupCycleState := testCtx.state.GetPodGroupSchedulingCycle()
+					podGroupCycleState := testCtx.state.GetPodGroupCycleState()
 					result, status := testCtx.p.PodGroupPostFilter(tCtx, podGroupCycleState, pgInfo, mockSchedulingFunc)
 					tCtx.Run("postfilter", func(tCtx ktesting.TContext) {
 						assert.Equal(tCtx, tc.want.podGroupPostFilterResult, result)
@@ -4706,7 +4706,7 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 	state := framework.NewCycleState()
 	if len(podGroups) > 0 {
 		pgCycleState := framework.NewCycleState()
-		state.SetPodGroupSchedulingCycle(pgCycleState)
+		state.SetPodGroupCycleState(pgCycleState)
 	}
 	tc.state = state
 

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -1206,7 +1206,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 
 			cycleState := schedulerframework.NewCycleState()
 			if tt.isDuringPodGroupSchedulingCycle {
-				cycleState.SetPodGroupSchedulingCycle(cycleState)
+				cycleState.SetPodGroupCycleState(cycleState)
 			}
 
 			pod := tt.pod.DeepCopy()
@@ -1815,7 +1815,7 @@ func TestPlacementFeasible(t *testing.T) {
 			pl.snapshotLister = mockLister
 
 			cycleState := schedulerframework.NewCycleState()
-			cycleState.SetPodGroupSchedulingCycle(cycleState)
+			cycleState.SetPodGroupCycleState(cycleState)
 
 			scheduled := tc.initialScheduledCount
 			for i, code := range tc.podStatuses {

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -1070,7 +1070,7 @@ func TestPlacementFeasible(t *testing.T) {
 					pl.snapshotLister = mockLister
 
 					cycleState := schedulerframework.NewCycleState()
-					cycleState.SetPodGroupSchedulingCycle(cycleState)
+					cycleState.SetPodGroupCycleState(cycleState)
 
 					scheduled := tc.initialScheduledCount
 					for i, code := range tc.podStatuses {

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -412,7 +412,7 @@ func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleSt
 
 	podGroupCycleState := placementCycleState.GetPodGroupSchedulingCycle()
 	// Marks this cycle as a pod group scheduling cycle.
-	state.SetPodGroupSchedulingCycle(podGroupCycleState)
+	state.SetPodGroupCycleState(podGroupCycleState)
 	// Set the placement cycle state so per-pod plugins can access placement-scoped data.
 	state.SetPlacementCycleState(placementCycleState)
 
@@ -720,7 +720,7 @@ func completePodGroupAlgorithmResult(ctx context.Context, queuedPodInfos []*fram
 	for i := numInResult; i < numInQueue; i++ {
 		pInfo := queuedPodInfos[i]
 		placementCycleState := framework.NewCycleState()
-		placementCycleState.SetPodGroupSchedulingCycle(podGroupState)
+		placementCycleState.SetPodGroupCycleState(podGroupState)
 		newResults[i] = algorithmResult{
 			podInfo: pInfo,
 			podCtx:  initPodSchedulingContext(ctx, pInfo.Pod, placementCycleState),
@@ -848,7 +848,8 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 				switch {
 				case podGroupResult.status.IsSuccess():
 					// Disable pod group scheduling in cycle state before binding.
-					podCtx.state.SetPodGroupSchedulingCycle(nil)
+					podCtx.state.SetPodGroupCycleState(nil)
+					podCtx.state.SetPlacementCycleState(nil)
 					// Schedule result is applied for pod and its binding cycle executes.
 					assumedPodInfo, status := sched.prepareForBindingCycle(ctx, podCtx.state, schedFwk, pInfo, podCtx.podsToActivate, podResult.scheduleResult)
 					if !status.IsSuccess() {
@@ -1013,7 +1014,7 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 			}, nil
 		}
 		placementCycleState := framework.NewCycleState()
-		placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+		placementCycleState.SetPodGroupCycleState(podGroupCycleState)
 		result, placementRevertFns := sched.podGroupSchedulingDefaultAlgorithm(ctx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo)
 		placementRevertFns.revert()
 
@@ -1116,7 +1117,7 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 			}, nil
 		}
 		placementCycleState := framework.NewCycleState()
-		placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+		placementCycleState.SetPodGroupCycleState(podGroupCycleState)
 		subtreeResult := map[fwk.EntityKey]*podGroupAlgorithmResult{}
 		result, placementRevertFns := sched.compositePodGroupSchedulingDefaultAlgorithm(ctx, schedFwk, placementCycleState, root, podGroupInfo, subtreeResult)
 		placementRevertFns.revert()
@@ -1283,7 +1284,7 @@ func (sched *Scheduler) podGroupSchedulingAlgorithm(ctx context.Context, schedFw
 	// still runs in a single implicit placement context so placement-scoped
 	// extension points can use the same state plumbing as TAS.
 	placementCycleState := framework.NewCycleState()
-	placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	placementCycleState.SetPodGroupCycleState(podGroupCycleState)
 	return sched.podGroupSchedulingDefaultAlgorithm(podGroupCycleCtx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo)
 }
 

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -330,9 +330,9 @@ func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleSt
 	podsToActivate := framework.NewPodsToActivate()
 	state.Write(framework.PodsToActivateKey, podsToActivate)
 
-	podGroupCycleState := placementCycleState.GetPodGroupSchedulingCycle()
+	podGroupCycleState := placementCycleState.GetPodGroupCycleState()
 	// Marks this cycle as a pod group scheduling cycle.
-	state.SetPodGroupSchedulingCycle(podGroupCycleState)
+	state.SetPodGroupCycleState(podGroupCycleState)
 	// Set the placement cycle state so per-pod plugins can access placement-scoped data.
 	state.SetPlacementCycleState(placementCycleState)
 
@@ -569,7 +569,7 @@ func completePodGroupAlgorithmResult(ctx context.Context, queuedPodInfos []*fram
 	for i := numInResult; i < numInQueue; i++ {
 		pInfo := queuedPodInfos[i]
 		placementCycleState := framework.NewCycleState()
-		placementCycleState.SetPodGroupSchedulingCycle(podGroupState)
+		placementCycleState.SetPodGroupCycleState(podGroupState)
 		newResults[i] = algorithmResult{
 			podInfo: pInfo,
 			podCtx:  initPodSchedulingContext(ctx, pInfo.Pod, placementCycleState),
@@ -708,7 +708,8 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 				switch {
 				case podGroupResult.status.IsSuccess():
 					// Disable pod group scheduling in cycle state before binding.
-					podCtx.state.SetPodGroupSchedulingCycle(nil)
+					podCtx.state.SetPodGroupCycleState(nil)
+					podCtx.state.SetPlacementCycleState(nil)
 					// Schedule result is applied for pod and its binding cycle executes.
 					assumedPodInfo, status := sched.prepareForBindingCycle(ctx, podCtx.state, schedFwk, pInfo, podCtx.podsToActivate, podResult.scheduleResult)
 					if !status.IsSuccess() {
@@ -1012,7 +1013,7 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 			}, nil
 		}
 		placementCycleState := framework.NewCycleState()
-		placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+		placementCycleState.SetPodGroupCycleState(podGroupCycleState)
 		subtreeResult := map[fwk.EntityKey]*podGroupAlgorithmResult{}
 		result, placementRevertFns := sched.compositePodGroupSchedulingDefaultAlgorithm(ctx, schedFwk, placementCycleState, root, podGroupInfo, subtreeResult)
 		placementRevertFns.revert()
@@ -1105,7 +1106,7 @@ func (sched *Scheduler) evaluatePlacement(ctx context.Context, schedFwk framewor
 		}
 	}
 	placementCycleState := framework.NewCycleState()
-	placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	placementCycleState.SetPodGroupCycleState(podGroupCycleState)
 	result, placementRevertFns := sched.podGroupSchedulingDefaultAlgorithm(ctx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo)
 	placementRevertFns.revert()
 
@@ -1253,7 +1254,7 @@ func (sched *Scheduler) podGroupSchedulingAlgorithm(ctx context.Context, schedFw
 	// still runs in a single implicit placement context so placement-scoped
 	// extension points can use the same state plumbing as TAS.
 	placementCycleState := framework.NewCycleState()
-	placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	placementCycleState.SetPodGroupCycleState(podGroupCycleState)
 	return sched.podGroupSchedulingDefaultAlgorithm(podGroupCycleCtx, schedFwk, placementCycleState, podGroupInfo, queuedPodGroupInfo)
 }
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -1937,7 +1937,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					continue
 				}
 				placementCycleState := framework.NewCycleState()
-				placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+				placementCycleState.SetPodGroupCycleState(podGroupCycleState)
 				result.podCtx = initPodSchedulingContext(ctx, pod, placementCycleState)
 				algorithmResult.podResults = append(algorithmResult.podResults, result)
 			}
@@ -5047,7 +5047,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 	}
 	t.Logf("Node info list size: %d", func() int { l, _ := snapshot.NodeInfos().List(); return len(l) }())
 	podGroupCycleState := framework.NewCycleState()
-	podGroupCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	podGroupCycleState.SetPodGroupCycleState(podGroupCycleState)
 	sched.podGroupCycle(ctx, schedFwk, podGroupCycleState, podGroupInfo, time.Now())
 
 	lock.Lock()

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -1956,7 +1956,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					continue
 				}
 				placementCycleState := framework.NewCycleState()
-				placementCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+				placementCycleState.SetPodGroupCycleState(podGroupCycleState)
 				result.podCtx = initPodSchedulingContext(ctx, pod, placementCycleState)
 				algorithmResult.podResults = append(algorithmResult.podResults, result)
 			}
@@ -3693,7 +3693,7 @@ func collectHierarchyFromPlacementCycleState(cycleState fwk.PlacementCycleState,
 		return nil
 	}
 
-	err := collectHierarchyFromPodGroupCycleState(cycleState.GetPodGroupSchedulingCycle(), results)
+	err := collectHierarchyFromPodGroupCycleState(cycleState.GetPodGroupCycleState(), results)
 	if err != nil {
 		return err
 	}
@@ -3741,7 +3741,7 @@ func (p *multiLevelPlacementStateTracker) PlacementFeasible(ctx context.Context,
 	if args.Scheduled == 0 {
 		if podGroup.GetPodGroup() != nil {
 			trajectory := []string{}
-			if err := collectHierarchyFromPodGroupCycleState(state.GetPodGroupSchedulingCycle(), &trajectory); err != nil {
+			if err := collectHierarchyFromPodGroupCycleState(state.GetPodGroupCycleState(), &trajectory); err != nil {
 				return fwk.AsStatus(err)
 			}
 			p.placementFeasibleTrajectories = append(p.placementFeasibleTrajectories, trajectory)
@@ -5020,6 +5020,7 @@ type podGroupStateTrackerPlugin struct {
 	asyncPermitCount    int
 	syncUnreserveCount  int
 	asyncUnreserveCount int
+	unreserveError      error
 }
 
 var _ fwk.ReservePlugin = &podGroupStateTrackerPlugin{}
@@ -5032,9 +5033,15 @@ func (u *podGroupStateTrackerPlugin) Reserve(ctx context.Context, state fwk.Cycl
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	if p.Name == u.podToTrack {
-		if state.GetPodGroupSchedulingCycle() != nil {
+		if state.GetPodGroupCycleState() != nil {
+			if state.GetPlacementCycleState() == nil {
+				return fwk.AsStatus(fmt.Errorf("PlacementCycleState should be set in synchronous Reserve"))
+			}
 			u.syncReserveCount++
 		} else {
+			if state.GetPlacementCycleState() != nil {
+				return fwk.AsStatus(fmt.Errorf("PlacementCycleState should not be set in asynchronous Reserve"))
+			}
 			u.asyncReserveCount++
 		}
 	}
@@ -5048,7 +5055,10 @@ func (u *podGroupStateTrackerPlugin) Permit(ctx context.Context, state fwk.Cycle
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	if p.Name == u.podToTrack {
-		if state.GetPodGroupSchedulingCycle() == nil {
+		if state.GetPodGroupCycleState() == nil {
+			if state.GetPlacementCycleState() != nil {
+				return fwk.AsStatus(fmt.Errorf("PlacementCycleState should not be set in Permit")), 0
+			}
 			u.asyncPermitCount++
 		}
 	}
@@ -5059,9 +5069,15 @@ func (u *podGroupStateTrackerPlugin) Unreserve(ctx context.Context, state fwk.Cy
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	if p.Name == u.podToTrack {
-		if state.GetPodGroupSchedulingCycle() != nil {
+		if state.GetPodGroupCycleState() != nil {
+			if state.GetPlacementCycleState() == nil {
+				u.unreserveError = fmt.Errorf("PlacementCycleState should be set in synchronous Reserve")
+			}
 			u.syncUnreserveCount++
 		} else {
+			if state.GetPlacementCycleState() != nil {
+				u.unreserveError = fmt.Errorf("PlacementCycleState should not be set in asynchronous Reserve")
+			}
 			u.asyncUnreserveCount++
 		}
 	}
@@ -5233,6 +5249,7 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 			permitCount := trackerPlugin.asyncPermitCount
 			syncUnreserveCount := trackerPlugin.syncUnreserveCount
 			asyncUnreserveCount := trackerPlugin.asyncUnreserveCount
+			unreserveError := trackerPlugin.unreserveError
 			trackerPlugin.mu.Unlock()
 
 			if syncReserveCount != tt.expectSyncReserve {
@@ -5249,6 +5266,9 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 			}
 			if asyncUnreserveCount != tt.expectAsyncUnreserve {
 				t.Errorf("Expected async Unreserve count to be %d, got %d", tt.expectAsyncUnreserve, asyncUnreserveCount)
+			}
+			if unreserveError != nil {
+				t.Errorf("Unexpected error from Unreserve: %v", unreserveError)
 			}
 		})
 	}
@@ -5670,7 +5690,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 	}
 	t.Logf("Node info list size: %d", func() int { l, _ := snapshot.NodeInfos().List(); return len(l) }())
 	podGroupCycleState := framework.NewCycleState()
-	podGroupCycleState.SetPodGroupSchedulingCycle(podGroupCycleState)
+	podGroupCycleState.SetPodGroupCycleState(podGroupCycleState)
 	sched.podGroupCycle(ctx, schedFwk, podGroupCycleState, podGroupInfo, time.Now())
 
 	lock.Lock()

--- a/staging/src/k8s.io/kube-scheduler/framework/cycle_state.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/cycle_state.go
@@ -98,9 +98,9 @@ type CycleState interface {
 	// or doesn't belong to any pod group.
 	// This field can only be true when GenericWorkload feature flag is enabled.
 	IsPodGroupSchedulingCycle() bool
-	// GetPodGroupSchedulingCycle gets the cycle state of the PodGroup for a Pod.
+	// GetPodGroupCycleState gets the cycle state of the PodGroup for a Pod.
 	// This should be only used when GenericWorkload feature flag is enabled.
-	GetPodGroupSchedulingCycle() PodGroupCycleState
+	GetPodGroupCycleState() PodGroupCycleState
 	// GetPlacementCycleState gets the cycle state of the current Placement for a Pod.
 	// Returns nil if this pod is not being scheduled within a placement context.
 	// This should be only used when GenericWorkload feature flag is enabled.
@@ -131,9 +131,9 @@ type PlacementCycleState interface {
 	//
 	// See PlacementCycleState for notes on concurrency.
 	Delete(key StateKey)
-	// GetPodGroupSchedulingCycle gets the cycle state of the PodGroup for this Placement.
+	// GetPodGroupCycleState gets the cycle state of the PodGroup for this Placement.
 	// This should be only used when GenericWorkload feature flag is enabled.
-	GetPodGroupSchedulingCycle() PodGroupCycleState
+	GetPodGroupCycleState() PodGroupCycleState
 }
 
 // PodGroupCycleState provides a mechanism for plugins that operate on pod groups to store and retrieve arbitrary data.

--- a/test/integration/scheduler/preemption/podgroup/podgrouppreemption_test.go
+++ b/test/integration/scheduler/preemption/podgroup/podgrouppreemption_test.go
@@ -4082,7 +4082,7 @@ func (p *stateSaverPreFilterPlugin) PreFilter(ctx context.Context, state fwk.Cyc
 	if !state.IsPodGroupSchedulingCycle() {
 		return nil, nil
 	}
-	pgState := state.GetPodGroupSchedulingCycle()
+	pgState := state.GetPodGroupCycleState()
 	if pgState == nil {
 		return nil, nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR correctly clears `PlacementCycleState` for pods that move to binding phase. This ensures the `PlacementCycleState` follows the `PodGroupCycleState`.

This PR also features a rename of `SetPodGroupCycleState` to match its use case.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Generative AI was used in the PR preparation. Changes were carefully reviewed before pushing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
