### PR TITLE
Optimize CPUDetails.KeepOnly to iterate over input cpuset

### DIFF
--- a/pkg/kubelet/cm/cpumanager/topology/topology.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology.go
@@ -121,8 +121,8 @@ type CPUInfo struct {
 // KeepOnly returns a new CPUDetails object with only the supplied cpus.
 func (d CPUDetails) KeepOnly(cpus cpuset.CPUSet) CPUDetails {
 	result := CPUDetails{}
-	for cpu, info := range d {
-		if cpus.Contains(cpu) {
+	for _, cpu := range cpus.UnsortedList() {
+		if info, ok := d[cpu]; ok {
 			result[cpu] = info
 		}
 	}

--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -864,6 +864,18 @@ func TestCPUDetailsKeepOnly(t *testing.T) {
 		name: "cpus is not in CPUDetails.",
 		cpus: cpuset.New(3),
 		want: CPUDetails{},
+	}, {
+		name: "empty cpus set.",
+		cpus: cpuset.New(),
+		want: CPUDetails{},
+	}, {
+		name: "cpus equals all CPUDetails.",
+		cpus: cpuset.New(0, 1, 2),
+		want: map[int]CPUInfo{
+			0: {},
+			1: {},
+			2: {},
+		},
 	}}
 
 	for _, tt := range tests {

--- a/pkg/kubelet/cm/cpumanager/topology/topology_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology_test.go
@@ -864,6 +864,26 @@ func TestCPUDetailsKeepOnly(t *testing.T) {
 		name: "cpus is not in CPUDetails.",
 		cpus: cpuset.New(3),
 		want: CPUDetails{},
+	}, {
+		name: "empty cpus set.",
+		cpus: cpuset.New(),
+		want: CPUDetails{},
+	}, {
+		name: "cpus equals all CPUDetails.",
+		cpus: cpuset.New(0, 1, 2),
+		want: map[int]CPUInfo{
+			0: {},
+			1: {},
+			2: {},
+		},
+	}, {
+		name: "cpus is superset of CPUDetails.",
+		cpus: cpuset.New(0, 1, 2, 3, 4, 5),
+		want: map[int]CPUInfo{
+			0: {},
+			1: {},
+			2: {},
+		},
 	}}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR optimizes the `CPUDetails.KeepOnly` function in `pkg/kubelet/cm/cpumanager/topology/topology.go` by changing the iteration strategy from looping over all `CPUDetails` to looping over the input `cpuset.CPUSet`.

**Before:** The function iterated over all entries in `CPUDetails` and checked if each CPU was in the input cpuset.
**After:** The function now iterates only over the input cpuset and looks up each CPU in `CPUDetails`.

This optimization reduces the number of iterations when the input cpuset is a subset of `CPUDetails`, which is the common case in most use cases (e.g., filtering CPUs by NUMA node, socket, or core).

**Performance improvement:**
- When `cpus.Size() < len(d)`: Reduces iterations from `len(d)` to `cpus.Size()`
- Example: If `CPUDetails` has 128 CPUs and the input cpuset has 8 CPUs, iterations reduce from 128 to 8

Additionally, this PR adds 2 new test cases to `TestCPUDetailsKeepOnly` to improve test coverage:
- Empty cpus set
- Cpus equals all CPUDetails

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/140719

#### Special notes for your reviewer:

This is a pure optimization PR with no functional changes. The existing tests already cover the basic functionality, and I've added 2 additional edge case tests to improve coverage.

**Files changed:**
- `pkg/kubelet/cm/cpumanager/topology/topology.go` - Optimized `KeepOnly` function
- `pkg/kubelet/cm/cpumanager/topology/topology_test.go` - Added 2 new test cases

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
