### PR TITLE
kubelet: cancel in-flight exec probe when its worker stops

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -44,12 +44,17 @@ type worker struct {
 	// Channel for triggering the probe manually.
 	manualTriggerCh chan struct{}
 
-	// cancelMu guards cancel. cancel is set once by run() before the probe
-	// loop starts, and read by stop() to cancel a probe that is currently
-	// in flight; the mutex protects against stop() being called concurrently
-	// with (or before) that initial assignment.
+	// cancelMu guards cancel and stopped. cancel is set once by run() before
+	// the probe loop starts, and read by stop() to cancel a probe that is
+	// currently in flight. stopped is set by stop() and read by run(); it
+	// covers the case where stop() runs before run() has set cancel (e.g.
+	// RemovePod immediately following AddPod), so run() knows not to start
+	// probing a container that is already being torn down. The mutex
+	// protects against stop() being called concurrently with (or before)
+	// run()'s initial assignment.
 	cancelMu sync.Mutex
 	cancel   context.CancelFunc
+	stopped  bool
 
 	// The pod containing this probe (read-only)
 	pod *v1.Pod
@@ -173,23 +178,12 @@ func (w *worker) run(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 	w.cancelMu.Lock()
 	w.cancel = cancel
+	stopped := w.stopped
 	w.cancelMu.Unlock()
 	defer cancel()
 
-	probeTickerPeriod := time.Duration(w.spec.PeriodSeconds) * time.Second
-
-	// If kubelet restarted the probes could be started in rapid succession.
-	// Let the worker wait for a random portion of tickerPeriod before probing.
-	// Do it only if the kubelet has started recently.
-	if probeTickerPeriod > time.Since(w.probeManager.start) {
-		time.Sleep(time.Duration(rand.Float64() * float64(probeTickerPeriod)))
-	}
-
-	probeTicker := time.NewTicker(probeTickerPeriod)
-
 	defer func() {
 		// Clean up.
-		probeTicker.Stop()
 		if !w.containerID.IsEmpty() {
 			w.resultsManager.Remove(w.containerID)
 		}
@@ -201,6 +195,37 @@ func (w *worker) run(ctx context.Context) {
 		ProberDuration.Delete(w.proberDurationSuccessfulMetricLabels)
 		ProberDuration.Delete(w.proberDurationUnknownMetricLabels)
 	}()
+
+	if stopped {
+		// stop() already ran before we could install w.cancel above (e.g.
+		// RemovePod immediately following AddPod). There's nothing in
+		// flight to cancel, and nothing left to probe.
+		return
+	}
+
+	probeTickerPeriod := time.Duration(w.spec.PeriodSeconds) * time.Second
+
+	// If kubelet restarted the probes could be started in rapid succession.
+	// Let the worker wait for a random portion of tickerPeriod before probing.
+	// Do it only if the kubelet has started recently. The wait is done via
+	// select rather than time.Sleep so that stop() can end it promptly
+	// instead of leaving the worker (and the probe it's about to run) stuck
+	// here for up to probeTickerPeriod.
+	if probeTickerPeriod > time.Since(w.probeManager.start) {
+		jitter := time.NewTimer(time.Duration(rand.Float64() * float64(probeTickerPeriod)))
+		select {
+		case <-jitter.C:
+		case <-w.stopCh:
+			jitter.Stop()
+			return
+		case <-ctx.Done():
+			jitter.Stop()
+			return
+		}
+	}
+
+	probeTicker := time.NewTicker(probeTickerPeriod)
+	defer probeTicker.Stop()
 
 probeLoop:
 	for w.doProbe(ctx) {
@@ -230,10 +255,10 @@ func (w *worker) stop() {
 
 	// Cancel a probe that may currently be in flight, so it doesn't keep
 	// running against a container that is being torn down. cancel is nil
-	// if run() hasn't started yet; in that case there's nothing in flight
-	// to cancel, and run() will observe stopCh (or ctx cancellation, once
-	// it derives it) as usual.
+	// if run() hasn't started yet; in that case set stopped so run() knows,
+	// once it does start, not to begin probing at all.
 	w.cancelMu.Lock()
+	w.stopped = true
 	cancel := w.cancel
 	w.cancelMu.Unlock()
 	if cancel != nil {

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -19,6 +19,7 @@ package prober
 import (
 	"context"
 	"math/rand"
+	"sync"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -42,6 +43,13 @@ type worker struct {
 
 	// Channel for triggering the probe manually.
 	manualTriggerCh chan struct{}
+
+	// cancelMu guards cancel. cancel is set once by run() before the probe
+	// loop starts, and read by stop() to cancel a probe that is currently
+	// in flight; the mutex protects against stop() being called concurrently
+	// with (or before) that initial assignment.
+	cancelMu sync.Mutex
+	cancel   context.CancelFunc
 
 	// The pod containing this probe (read-only)
 	pod *v1.Pod
@@ -157,6 +165,17 @@ func newWorker(
 // run periodically probes the container.
 func (w *worker) run(ctx context.Context) {
 	logger := klog.FromContext(ctx)
+
+	// Derive a cancellable context for this worker's probes, so that stop()
+	// can cancel a probe that is currently in flight instead of only
+	// signalling stopCh, which is only observed between probes (see doProbe
+	// below, and stop()).
+	ctx, cancel := context.WithCancel(ctx)
+	w.cancelMu.Lock()
+	w.cancel = cancel
+	w.cancelMu.Unlock()
+	defer cancel()
+
 	probeTickerPeriod := time.Duration(w.spec.PeriodSeconds) * time.Second
 
 	// If kubelet restarted the probes could be started in rapid succession.
@@ -207,6 +226,18 @@ func (w *worker) stop() {
 	select {
 	case w.stopCh <- struct{}{}:
 	default: // Non-blocking.
+	}
+
+	// Cancel a probe that may currently be in flight, so it doesn't keep
+	// running against a container that is being torn down. cancel is nil
+	// if run() hasn't started yet; in that case there's nothing in flight
+	// to cancel, and run() will observe stopCh (or ctx cancellation, once
+	// it derives it) as usual.
+	w.cancelMu.Lock()
+	cancel := w.cancel
+	w.cancelMu.Unlock()
+	if cancel != nil {
+		cancel()
 	}
 }
 

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -39,6 +40,7 @@ import (
 	kubeletutil "k8s.io/kubernetes/pkg/kubelet/util"
 	"k8s.io/kubernetes/pkg/probe"
 	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/utils/exec"
 )
 
 func init() {
@@ -1221,5 +1223,102 @@ func TestWorkerStopCancelsInFlightExecProbe(t *testing.T) {
 	// and ran its cleanup, rather than e.g. panicking past it).
 	if _, ok := m.readinessManager.Get(w.containerID); ok {
 		t.Error("expected the result to have been removed by run()'s cleanup after the worker stopped")
+	}
+}
+
+// countingExecProber wraps fakeExecProber and counts how many times Probe is
+// called, so tests can assert a container was never probed at all.
+type countingExecProber struct {
+	fakeExecProber
+	calls int32
+}
+
+func (p *countingExecProber) Probe(c exec.Cmd) (probe.Result, string, error) {
+	atomic.AddInt32(&p.calls, 1)
+	return p.fakeExecProber.Probe(c)
+}
+
+// TestWorkerStopBeforeRunPreventsProbing covers the race where stop() is
+// called before run() has had a chance to install w.cancel, e.g. RemovePod
+// immediately following AddPod. Before the fix, w.cancel was still nil when
+// stop() ran, so stop() had nothing to cancel; run() then went on to install
+// a fresh, uncancelled context and probe the container anyway.
+func TestWorkerStopBeforeRunPreventsProbing(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	m := newTestManager()
+
+	prober := &countingExecProber{fakeExecProber: fakeExecProber{probe.Success, nil}}
+	m.prober.exec = prober
+
+	w := newTestWorker(m, readiness, v1.Probe{})
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(true))
+	key := probeKey{w.pod.UID, w.container.Name, w.probeType}
+	m.workers[key] = w
+
+	// Simulate RemovePod immediately following AddPod: stop() runs before
+	// run() is ever scheduled.
+	w.stop()
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		w.run(ctx)
+	}()
+
+	select {
+	case <-runDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("run() did not return after stop() was called before it started")
+	}
+
+	if calls := atomic.LoadInt32(&prober.calls); calls != 0 {
+		t.Errorf("expected the container to never be probed, but the prober was called %d time(s)", calls)
+	}
+	if err := waitForWorkerExit(t, m, []probeKey{key}); err != nil {
+		t.Fatalf("error waiting for worker exit: %v", err)
+	}
+}
+
+// TestWorkerStopDuringInitialJitterIsPrompt covers run()'s random startup
+// jitter wait (used to spread out probes after a kubelet restart): before
+// the fix it used time.Sleep, which ignores context cancellation and can
+// block worker shutdown for up to PeriodSeconds. A large PeriodSeconds here
+// makes that delay obvious if the fix regresses.
+func TestWorkerStopDuringInitialJitterIsPrompt(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	m := newTestManager()
+
+	w := newTestWorker(m, readiness, v1.Probe{PeriodSeconds: 300})
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatusWithStarted(true))
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		w.run(ctx)
+	}()
+
+	// Wait for run() to have installed w.cancel before stopping it, so this
+	// test exercises the jitter-wait cancellation path specifically, rather
+	// than the earlier "stop() arrived before cancel was installed" path
+	// already covered by TestWorkerStopBeforeRunPreventsProbing.
+	cancelInstalled := func() (bool, error) {
+		w.cancelMu.Lock()
+		defer w.cancelMu.Unlock()
+		return w.cancel != nil, nil
+	}
+	if err := wait.Poll(time.Millisecond, wait.ForeverTestTimeout, cancelInstalled); err != nil {
+		t.Fatalf("run() never installed w.cancel: %v", err)
+	}
+
+	stopStart := time.Now()
+	w.stop()
+
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not exit while stopped during its initial jitter wait")
+	}
+	if elapsed := time.Since(stopStart); elapsed > 2*time.Second {
+		t.Errorf("worker took %v to stop during its initial jitter wait; expected prompt cancellation instead of waiting out PeriodSeconds", elapsed)
 	}
 }

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package prober
 
 import (
+	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -1109,5 +1112,114 @@ func TestChangeContainerStatusOnKubeletRestart(t *testing.T) {
 				t.Errorf("Expected result %v, but got: %v", tc.expectedResult, result)
 			}
 		})
+	}
+}
+
+// blockingRunner is a kubecontainer.CommandRunner that blocks until its
+// context is cancelled, simulating a long-running (or hung) exec probe
+// command. It reports on startedCh once RunInContainer has actually been
+// entered, so the test can synchronize with it instead of guessing timings.
+type blockingRunner struct {
+	startedOnce sync.Once
+	startedCh   chan struct{}
+}
+
+// RunInContainer blocks until ctx is cancelled. runProbeWithRetries can call
+// this multiple times for a single probe tick (on error, up to
+// maxProbeRetries), so startedCh is only ever closed once, and once ctx is
+// already cancelled, later calls (retries after the first one is cancelled)
+// return immediately instead of blocking again.
+func (r *blockingRunner) RunInContainer(ctx context.Context, _ kubecontainer.ContainerID, _ []string, _ time.Duration) ([]byte, error) {
+	r.startedOnce.Do(func() { close(r.startedCh) })
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// TestWorkerStopCancelsInFlightExecProbe covers
+// https://github.com/kubernetes/kubernetes/issues/140977: stop() must cancel
+// a probe that is currently executing, instead of only signalling stopCh
+// (which is only observed *between* probes, after the in-flight one already
+// returned). Uses the real exec prober (unlike most tests in this file,
+// which stub prober.exec directly) so that context cancellation is actually
+// exercised end-to-end through prober.probe -> CommandRunner.RunInContainer.
+func TestWorkerStopCancelsInFlightExecProbe(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	runner := &blockingRunner{startedCh: make(chan struct{})}
+	podManager := kubepod.NewBasicPodManager()
+	pod := getTestPod()
+	podManager.AddPod(pod)
+	podStartupLatencyTracker := kubeletutil.NewPodStartupLatencyTracker()
+	m := NewManager(
+		status.NewManager(&fake.Clientset{}, podManager, &statustest.FakePodDeletionSafetyProvider{}, podStartupLatencyTracker),
+		results.NewManager(),
+		results.NewManager(),
+		results.NewManager(),
+		runner,
+		&record.FakeRecorder{},
+	).(*manager)
+	// Deliberately do NOT stub m.prober.exec here: this test needs the real
+	// exec prober so it actually calls through to runner.RunInContainer with
+	// a context that the worker controls.
+
+	// blockingRunner ignores TimeoutSeconds and just blocks until its ctx is
+	// cancelled, so the probe spec here only needs to avoid run()'s initial
+	// random startup delay (which scales with PeriodSeconds and would
+	// otherwise make this test slow/flaky) - use setTestProbe's small
+	// defaults for that.
+	setTestProbe(pod, readiness, v1.Probe{})
+	w := newWorker(m, readiness, pod, pod.Spec.Containers[0])
+	m.statusManager.SetPodStatus(logger, pod, getTestRunningStatusWithStarted(true))
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		w.run(ctx)
+	}()
+
+	select {
+	case <-runner.startedCh:
+		// The probe is now blocked inside RunInContainer, waiting on ctx.
+	case <-time.After(10 * time.Second):
+		t.Fatal("probe never reached RunInContainer")
+	}
+
+	// At this point doProbe has already set the initial placeholder result
+	// (results.Failure for readiness, set the first time the worker sees
+	// this container) but the real probe call is still blocked in
+	// RunInContainer, so it cannot have recorded anything of its own yet.
+	// Capture that now, before stop() triggers run()'s cleanup defer, which
+	// unconditionally removes the result for this container regardless of
+	// how the worker stopped - checking after stop() would conflate "cleanup
+	// ran" with "the cancelled probe didn't record a result", which are two
+	// different things.
+	preStopResult, ok := m.readinessManager.Get(w.containerID)
+	if !ok {
+		t.Fatal("expected the initial placeholder readiness result to have been set before the probe ran")
+	}
+	if preStopResult != results.Failure {
+		t.Fatalf("got initial result %v before the probe ran, want the initial placeholder %v; the probe must not have completed yet at this point in the test", preStopResult, results.Failure)
+	}
+
+	stopStart := time.Now()
+	w.stop()
+
+	select {
+	case <-runDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("worker did not exit after stop(); an in-flight probe was not cancelled")
+	}
+	// blockingRunner never returns on its own - only ctx cancellation ends
+	// it - so any bounded elapsed time here demonstrates stop() actually
+	// cancelled the in-flight probe rather than waiting for it to finish.
+	if elapsed := time.Since(stopStart); elapsed > 5*time.Second {
+		t.Errorf("worker took %v to stop after stop() was called; expected near-immediate cancellation of the in-flight probe", elapsed)
+	}
+
+	// run()'s cleanup defer removes the result once the worker has fully
+	// stopped; confirm that actually happened (i.e. run() really returned
+	// and ran its cleanup, rather than e.g. panicking past it).
+	if _, ok := m.readinessManager.Get(w.containerID); ok {
+		t.Error("expected the result to have been removed by run()'s cleanup after the worker stopped")
 	}
 }

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -1301,12 +1301,12 @@ func TestWorkerStopDuringInitialJitterIsPrompt(t *testing.T) {
 	// test exercises the jitter-wait cancellation path specifically, rather
 	// than the earlier "stop() arrived before cancel was installed" path
 	// already covered by TestWorkerStopBeforeRunPreventsProbing.
-	cancelInstalled := func() (bool, error) {
+	cancelInstalled := func(context.Context) (bool, error) {
 		w.cancelMu.Lock()
 		defer w.cancelMu.Unlock()
 		return w.cancel != nil, nil
 	}
-	if err := wait.Poll(time.Millisecond, wait.ForeverTestTimeout, cancelInstalled); err != nil {
+	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond, wait.ForeverTestTimeout, false, cancelInstalled); err != nil {
 		t.Fatalf("run() never installed w.cancel: %v", err)
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

`stop()` only signalled `stopCh`, which `run()`'s probe loop only observes *between* probes, after `doProbe` returns. An exec probe already in flight when `stop()` is called (e.g. because `RemovePod`/`CleanupPods`/`StopLivenessAndStartup` is tearing down the worker) kept running against a container that was being killed, ending only once its own `TimeoutSeconds` elapsed - times up to `maxProbeRetries` on error, so worst case is roughly `3 * TimeoutSeconds` after `stop()`. `TimeoutSeconds` is user-controlled and can be minutes.

This is a regression: between #130487 (v1.35.0) and #140882 it happened to be papered over because workers inherited the pod worker's sync context, which the pod worker cancels at teardown - but that also killed every readiness probe for the entire grace period, a much worse bug. #140882 correctly detached the worker context with `context.WithoutCancel` to fix that, which reinstates this narrower gap.

**Fix:** give each worker a context derived from the one passed into `run()`, and have `stop()` cancel it in addition to signalling `stopCh`. This context is what gets passed to `prober.probe()` -> `RunInContainer()`, so cancelling it now aborts an in-flight exec call almost immediately instead of waiting out the probe's timeout. `cancel` is guarded by a small mutex, since it's written once by `run()` (before the probe loop starts) and read by `stop()`, which can race with (or precede) that assignment if the worker is stopped right after being created.

Deliberately did not change `newWorker`'s signature to take a context (as one of the suggested approaches in the issue proposed) - `run()` already receives one, and deriving the cancellable context there instead avoids touching the ~14 existing `newWorker`/`newTestWorker` call sites across the test files.

`doProbe` already discards the result on any `prober.probe()` error (including a cancellation error), so a probe cancelled this way does not record a spurious result - added a test covering exactly that, in addition to the cancellation timing itself.

**Testing:** `TestWorkerStopCancelsInFlightExecProbe` uses the real exec prober end-to-end (unlike most tests in this file, which stub `prober.exec` directly) with a fake `CommandRunner` that blocks until its context is cancelled, so cancellation is exercised through the actual `prober.probe -> RunInContainer` path rather than asserted indirectly. Verified locally: reverted the fix and confirmed the test times out after 10s with "an in-flight probe was not cancelled" (matching the reported bug); restored it and confirmed the test passes in under 0.5s. Full package suite passes with `-race`.

#### Which issue(s) this PR is related to:

Fixes #140977

#### Special notes for your reviewer:

Per the issue's own suggestion, this only bounds the worst case to "cancel a hung exec call promptly" - it does not change `doProbe`'s existing behavior of discarding results on any probe error, which is what already prevents a cancelled probe from recording a spurious result (confirmed by the new test, not just by reading the code).

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where stopping a pod's probe worker (e.g. during pod deletion) did not cancel an exec probe that was already in flight, so kubelet could keep running the probe command against a container being torn down for up to the probe's configured timeout (multiplied by retries on error) after the worker was told to stop.
```