### PR TITLE
Fix graceful shutdown of goroutines in daemon_restart test

### DIFF
--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -242,19 +242,22 @@ var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), func() {
 
 		// The following code continues to run after the BeforeEach and thus
 		// must not use ctx.
-		backgroundCtx, cancel := context.WithCancel(context.Background())
-		ginkgo.DeferCleanup(cancel)
+		stopCh := make(chan struct{})
+		ginkgo.DeferCleanup(func() {
+			close(stopCh)
+			time.Sleep(100 * time.Millisecond)
+		})
 		tracker = newPodTracker()
 		newPods, controller = cache.NewInformer(
 			&cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 					options.LabelSelector = labelSelector.String()
-					obj, err := f.ClientSet.CoreV1().Pods(ns).List(backgroundCtx, options)
+					obj, err := f.ClientSet.CoreV1().Pods(ns).List(context.Background(), options)
 					return runtime.Object(obj), err
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 					options.LabelSelector = labelSelector.String()
-					return f.ClientSet.CoreV1().Pods(ns).Watch(backgroundCtx, options)
+					return f.ClientSet.CoreV1().Pods(ns).Watch(context.Background(), options)
 				},
 			},
 			&v1.Pod{},
@@ -271,7 +274,7 @@ var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), func() {
 				},
 			},
 		)
-		go controller.Run(backgroundCtx.Done())
+		go controller.Run(stopCh)
 	})
 
 	ginkgo.It("Controller Manager should not create/delete replicas across restart", func(ctx context.Context) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR ensures graceful shutdown of the controller goroutine in test/e2e/apps/daemon_restart.go. Previously, the cleanup routine merely invoked context cancellation without allowing the cache.NewInformer controller time to shut down properly. The fix replaces the background context with a dedicated stop channel (stopCh) and introduces a DeferCleanup block that closes the channel and sleeps briefly to allow proper termination.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
