### PR TITLE
Fix PVC deletion race condition during StatefulSet cleanup

### DIFF
--- a/test/e2e/framework/statefulset/rest.go
+++ b/test/e2e/framework/statefulset/rest.go
@@ -105,11 +105,28 @@ func DeleteAllStatefulSets(ctx context.Context, c clientset.Interface, ns string
 			framework.Logf("WARNING: Failed to list pvcs, retrying %v", err)
 			return false, nil
 		}
+		podList, err := c.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			framework.Logf("WARNING: Failed to list pods, retrying %v", err)
+			return false, nil
+		}
+		inUsePVCs := sets.NewString()
+		for _, pod := range podList.Items {
+			for _, vol := range pod.Spec.Volumes {
+				if vol.PersistentVolumeClaim != nil {
+					inUsePVCs.Insert(vol.PersistentVolumeClaim.ClaimName)
+				}
+			}
+		}
 		for _, pvc := range pvcList.Items {
 			pvNames.Insert(pvc.Spec.VolumeName)
-			// TODO: Double check that there are no pods referencing the pvc
+			if inUsePVCs.Has(pvc.Name) {
+				framework.Logf("Skipping deletion of pvc %v as it is still in use", pvc.Name)
+				continue
+			}
 			framework.Logf("Deleting pvc: %v with volume %v", pvc.Name, pvc.Spec.VolumeName)
-			if err := c.CoreV1().PersistentVolumeClaims(ns).Delete(ctx, pvc.Name, metav1.DeleteOptions{}); err != nil {
+			policy := metav1.DeletePropagationForeground
+			if err := c.CoreV1().PersistentVolumeClaims(ns).Delete(ctx, pvc.Name, metav1.DeleteOptions{PropagationPolicy: &policy}); err != nil {
 				return false, nil
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This commit resolves a race condition in the e2e test framework during StatefulSet cleanup. Previously, DeleteAllStatefulSets immediately deleted PVCs without checking if active pods still referenced them, which could result in failures or orphaned PersistentVolumes. This fix explicitly lists all active pods, cross-references their PersistentVolumeClaim volumes, and delays PVC deletion if they are still in use, propagating deletions in the foreground.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
