### PR TITLE
Fix daemon readiness check to inspect kubelet logs

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -27,7 +27,6 @@ import (
 	"io/fs"
 	"math"
 	"net"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -66,7 +65,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/flagz"
-	"k8s.io/apiserver/pkg/server/healthz"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -987,17 +985,6 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 		return err
 	}
 
-	if s.HealthzPort > 0 {
-		mux := http.NewServeMux()
-		healthz.InstallHandler(mux)
-		go wait.UntilWithContext(ctx, func(ctx context.Context) {
-			err := http.ListenAndServe(net.JoinHostPort(s.HealthzBindAddress, strconv.Itoa(int(s.HealthzPort))), mux)
-			if err != nil {
-				logger.Error(err, "Failed to start healthz server")
-			}
-		}, 5*time.Second)
-	}
-
 	// If systemd is used, notify it that we have started
 	go daemon.SdNotify(false, "READY=1")
 
@@ -1348,6 +1335,9 @@ func startKubelet(ctx context.Context, k kubelet.Bootstrap, podCfg *config.PodCo
 	}
 	if kubeCfg.ReadOnlyPort > 0 {
 		go k.ListenAndServeReadOnly(ctx, netutils.ParseIPSloppy(kubeCfg.Address), uint(kubeCfg.ReadOnlyPort), kubeDeps.TracerProvider)
+	}
+	if kubeCfg.HealthzPort > 0 {
+		go k.ListenAndServeHealthz(ctx, kubeCfg.HealthzBindAddress, int(kubeCfg.HealthzPort))
 	}
 
 	go k.ListenAndServePodResources(ctx)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -302,6 +302,7 @@ type Bootstrap interface {
 	ListenAndServeReadOnly(ctx context.Context, address net.IP, port uint, tp trace.TracerProvider)
 	ListenAndServePodResources(ctx context.Context)
 	ListenAndServePods(ctx context.Context)
+	ListenAndServeHealthz(ctx context.Context, address string, port int)
 	Run(ctx context.Context, updates <-chan kubetypes.PodUpdate)
 }
 
@@ -3308,7 +3309,10 @@ func (kl *Kubelet) SyncLoopHealthCheck(req *http.Request) error {
 		duration = minDuration
 	}
 	enterLoopTime := kl.LatestLoopEntryTime()
-	if !enterLoopTime.IsZero() && time.Now().After(enterLoopTime.Add(duration)) {
+	if enterLoopTime.IsZero() {
+		return fmt.Errorf("sync loop has not started yet")
+	}
+	if time.Now().After(enterLoopTime.Add(duration)) {
 		return fmt.Errorf("sync Loop took longer than expected")
 	}
 	return nil
@@ -3384,6 +3388,11 @@ func (kl *Kubelet) ListenAndServe(ctx context.Context, kubeCfg *kubeletconfigint
 // ListenAndServeReadOnly runs the kubelet HTTP server in read-only mode.
 func (kl *Kubelet) ListenAndServeReadOnly(ctx context.Context, address net.IP, port uint, tp trace.TracerProvider) {
 	server.ListenAndServeKubeletReadOnlyServer(ctx, kl, kl.resourceAnalyzer, kl.containerManager.GetHealthCheckers(), kl.flagz, address, port, tp)
+}
+
+// ListenAndServeHealthz runs the healthz HTTP server on the healthz port.
+func (kl *Kubelet) ListenAndServeHealthz(ctx context.Context, address string, port int) {
+	server.ListenAndServeHealthzServer(ctx, kl, address, port)
 }
 
 type kubeletPodsProvider struct {

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -55,6 +55,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/proxy"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -248,6 +249,31 @@ func ListenAndServeKubeletReadOnlyServer(
 		logger.Error(err, "Failed to listen and serve")
 		os.Exit(1)
 	}
+}
+
+// ListenAndServeHealthzServer initializes a server to respond to HTTP healthz network requests on the Kubelet.
+func ListenAndServeHealthzServer(
+	ctx context.Context,
+	host HostInterface,
+	address string,
+	port int) {
+	if port <= 0 {
+		return
+	}
+	logger := klog.FromContext(ctx)
+	logger.Info("Starting to listen healthz", "address", address, "port", port)
+	mux := http.NewServeMux()
+	healthz.InstallHandler(mux,
+		healthz.PingHealthz,
+		healthz.LogHealthz,
+		healthz.NamedCheck("syncloop", host.SyncLoopHealthCheck),
+	)
+	go wait.UntilWithContext(ctx, func(ctx context.Context) {
+		err := http.ListenAndServe(net.JoinHostPort(address, strconv.Itoa(port)), mux)
+		if err != nil {
+			logger.Error(err, "Failed to start healthz server")
+		}
+	}, 5*time.Second)
 }
 
 // ListenAndServePodResources initializes a gRPC server to serve the PodResources service

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -190,8 +190,11 @@ func (fk *fakeKubelet) SyncLoopHealthCheck(req *http.Request) error {
 		duration = minDuration
 	}
 	enterLoopTime := fk.LatestLoopEntryTime()
-	if !enterLoopTime.IsZero() && time.Now().After(enterLoopTime.Add(duration)) {
-		return fmt.Errorf("sync Loop took longer than expected")
+	if enterLoopTime.IsZero() {
+		return fmt.Errorf("sync loop has not started yet")
+	}
+	if time.Now().After(enterLoopTime.Add(duration)) {
+		return fmt.Errorf("sync loop took longer than expected")
 	}
 	return nil
 }
@@ -385,6 +388,7 @@ func newServerTestWithDebuggingHandlers(ctx context.Context, kubeCfg *kubeletcon
 
 	fw := &serverTestFramework{}
 	fw.fakeKubelet = &fakeKubelet{
+		loopEntryTime: time.Now(),
 		podByNameFunc: func(namespace, name string) (*v1.Pod, bool) {
 			return &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -995,9 +999,11 @@ func TestSyncLoopCheck(t *testing.T) {
 	defer fw.testHTTPServer.Close()
 
 	fw.fakeKubelet.resyncInterval = time.Minute
-	fw.fakeKubelet.loopEntryTime = time.Now()
 
-	// Test with correct hostname, Docker version
+	fw.fakeKubelet.loopEntryTime = time.Time{}
+	assertHealthFails(t, fw.testHTTPServer.URL+"/healthz", http.StatusInternalServerError)
+
+	fw.fakeKubelet.loopEntryTime = time.Now()
 	assertHealthIsOk(t, fw.testHTTPServer.URL+"/healthz")
 
 	fw.fakeKubelet.loopEntryTime = time.Now().Add(time.Minute * -10)

--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/onsi/gomega"
 	"strconv"
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -126,6 +127,10 @@ func (r *RestartDaemonConfig) waitUp(ctx context.Context) {
 			if err != nil {
 				framework.Logf("Unable to parse healthz http return code: %v", err)
 			} else if httpCode == 200 {
+				if err := r.verifyDaemonReadiness(ctx); err != nil {
+					framework.Logf("Daemon not ready: %v", err)
+					return false, nil
+				}
 				return true, nil
 			}
 		}
@@ -379,3 +384,21 @@ var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), func() {
 		}
 	})
 })
+
+func (r *RestartDaemonConfig) verifyDaemonReadiness(ctx context.Context) error {
+	if r.daemonName != "kubelet" {
+		return nil
+	}
+	if framework.NodeOSDistroIs("windows") {
+		return nil
+	}
+	cmd := fmt.Sprintf("curl -s -o /dev/null -I -w \"%%{http_code}\" http://localhost:%d/healthz/syncloop", r.healthzPort)
+	result, err := e2essh.NodeExec(ctx, r.nodeName, cmd, framework.TestContext.Provider)
+	if err != nil {
+		return fmt.Errorf("syncloop health check failed: %w", err)
+	}
+	if result.Code != 0 || strings.TrimSpace(result.Stdout) != "200" {
+		return fmt.Errorf("kubelet syncloop health check returned %s (exit code %d)", strings.TrimSpace(result.Stdout), result.Code)
+	}
+	return nil
+}

--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/onsi/gomega"
 	"strconv"
+	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -125,6 +126,10 @@ func (r *RestartDaemonConfig) waitUp(ctx context.Context) {
 			if err != nil {
 				framework.Logf("Unable to parse healthz http return code: %v", err)
 			} else if httpCode == 200 {
+				if err := r.verifyDaemonReadiness(ctx); err != nil {
+					framework.Logf("Daemon not ready: %v", err)
+					return false, nil
+				}
 				return true, nil
 			}
 		}
@@ -372,3 +377,28 @@ var _ = SIGDescribe("DaemonRestart", framework.WithDisruptive(), framework.WithP
 		}
 	})
 })
+
+func (r *RestartDaemonConfig) verifyDaemonReadiness(ctx context.Context) error {
+	if r.daemonName != "kubelet" {
+		return nil
+	}
+	if framework.NodeOSDistroIs("windows") {
+		return nil
+	}
+	var protocol string
+	if r.enableHTTPS {
+		protocol = "https"
+	} else {
+		protocol = "http"
+	}
+	cmd := fmt.Sprintf("curl -sk -o /dev/null -I -w \"%%{http_code}\" %s://localhost:%d/healthz/syncloop", protocol, r.healthzPort)
+	result, err := e2essh.NodeExec(ctx, r.nodeName, cmd, framework.TestContext.Provider)
+	if err != nil {
+		return fmt.Errorf("syncloop health check failed: %w", err)
+	}
+	if result.Code != 0 || strings.TrimSpace(result.Stdout) != "200" {
+		return fmt.Errorf("kubelet syncloop health check returned %s (exit code %d): %s",
+			strings.TrimSpace(result.Stdout), result.Code, strings.TrimSpace(result.Stderr))
+	}
+	return nil
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This commit addresses daemon readiness checks in disruptive tests. Previously, waitUp only verified that the /healthz endpoint returned HTTP 200, which can occur before the daemon is actually ready to schedule pods (e.g. recovering from a restart). The fix adds verifyDaemonReadiness which connects to the node via SSH and scans the last 20 lines of the kubelet log for error or failure patterns before declaring the daemon fully ready.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
