### PR TITLE
Fix silent error suppression causing resource leaks in e2e tests

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -107,16 +107,16 @@ var _ = SIGDescribe("Aggregator", func() {
 
 func cleanupSampleAPIServer(ctx context.Context, client clientset.Interface, aggrclient *aggregatorclient.Clientset, n sampleAPIServerObjectNames, apiServiceName string) {
 	// delete the APIService first to avoid causing discovery errors
-	_ = aggrclient.ApiregistrationV1().APIServices().Delete(ctx, apiServiceName, metav1.DeleteOptions{})
+	framework.ExpectNoError(aggrclient.ApiregistrationV1().APIServices().Delete(ctx, apiServiceName, metav1.DeleteOptions{}), "deleting APIService %s", apiServiceName)
 
-	_ = client.AppsV1().Deployments(n.namespace).Delete(ctx, "sample-apiserver-deployment", metav1.DeleteOptions{})
-	_ = client.CoreV1().Secrets(n.namespace).Delete(ctx, "sample-apiserver-secret", metav1.DeleteOptions{})
-	_ = client.CoreV1().Services(n.namespace).Delete(ctx, "sample-api", metav1.DeleteOptions{})
-	_ = client.CoreV1().ServiceAccounts(n.namespace).Delete(ctx, "sample-apiserver", metav1.DeleteOptions{})
-	_ = client.RbacV1().RoleBindings("kube-system").Delete(ctx, n.roleBinding, metav1.DeleteOptions{})
-	_ = client.RbacV1().ClusterRoleBindings().Delete(ctx, "wardler:"+n.namespace+":auth-delegator", metav1.DeleteOptions{})
-	_ = client.RbacV1().ClusterRoles().Delete(ctx, n.clusterRole, metav1.DeleteOptions{})
-	_ = client.RbacV1().ClusterRoleBindings().Delete(ctx, n.clusterRoleBinding, metav1.DeleteOptions{})
+	framework.ExpectNoError(client.AppsV1().Deployments(n.namespace).Delete(ctx, "sample-apiserver-deployment", metav1.DeleteOptions{}), "deleting deployment sample-apiserver-deployment")
+	framework.ExpectNoError(client.CoreV1().Secrets(n.namespace).Delete(ctx, "sample-apiserver-secret", metav1.DeleteOptions{}), "deleting secret sample-apiserver-secret")
+	framework.ExpectNoError(client.CoreV1().Services(n.namespace).Delete(ctx, "sample-api", metav1.DeleteOptions{}), "deleting service sample-api")
+	framework.ExpectNoError(client.CoreV1().ServiceAccounts(n.namespace).Delete(ctx, "sample-apiserver", metav1.DeleteOptions{}), "deleting service account sample-apiserver")
+	framework.ExpectNoError(client.RbacV1().RoleBindings("kube-system").Delete(ctx, n.roleBinding, metav1.DeleteOptions{}), "deleting role binding %s", n.roleBinding)
+	framework.ExpectNoError(client.RbacV1().ClusterRoleBindings().Delete(ctx, "wardler:"+n.namespace+":auth-delegator", metav1.DeleteOptions{}), "deleting cluster role binding wardler:"+n.namespace+":auth-delegator")
+	framework.ExpectNoError(client.RbacV1().ClusterRoles().Delete(ctx, n.clusterRole, metav1.DeleteOptions{}), "deleting cluster role %s", n.clusterRole)
+	framework.ExpectNoError(client.RbacV1().ClusterRoleBindings().Delete(ctx, n.clusterRoleBinding, metav1.DeleteOptions{}), "deleting cluster role binding %s", n.clusterRoleBinding)
 }
 
 type sampleAPIServerObjectNames struct {

--- a/test/e2e/apimachinery/apply.go
+++ b/test/e2e/apimachinery/apply.go
@@ -54,10 +54,10 @@ var _ = SIGDescribe("ServerSideApply", func() {
 	})
 
 	ginkgo.AfterEach(func(ctx context.Context) {
-		_ = client.AppsV1().Deployments(ns).Delete(ctx, "deployment", metav1.DeleteOptions{})
-		_ = client.AppsV1().Deployments(ns).Delete(ctx, "deployment-shared-unset", metav1.DeleteOptions{})
-		_ = client.AppsV1().Deployments(ns).Delete(ctx, "deployment-shared-map-item-removal", metav1.DeleteOptions{})
-		_ = client.CoreV1().Pods(ns).Delete(ctx, "test-pod", metav1.DeleteOptions{})
+		framework.ExpectNoError(client.AppsV1().Deployments(ns).Delete(ctx, "deployment", metav1.DeleteOptions{}), "deleting deployment deployment")
+		framework.ExpectNoError(client.AppsV1().Deployments(ns).Delete(ctx, "deployment-shared-unset", metav1.DeleteOptions{}), "deleting deployment deployment-shared-unset")
+		framework.ExpectNoError(client.AppsV1().Deployments(ns).Delete(ctx, "deployment-shared-map-item-removal", metav1.DeleteOptions{}), "deleting deployment deployment-shared-map-item-removal")
+		framework.ExpectNoError(client.CoreV1().Pods(ns).Delete(ctx, "test-pod", metav1.DeleteOptions{}), "deleting pod test-pod")
 	})
 
 	/*

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -415,7 +415,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 			}
 			return actualWatchEvents
 		}, func() (err error) {
-			_ = f.ClientSet.CoreV1().ReplicationControllers(testRcNamespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test-rc-static=true"})
+			framework.ExpectNoError(f.ClientSet.CoreV1().ReplicationControllers(testRcNamespace).DeleteCollection(ctx, metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test-rc-static=true"}), "deleting replication controllers")
 			return err
 		})
 	})

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -1438,7 +1438,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			framework.ExpectNoError(err)
 			defer func() {
 				// Will be cleaned up with the namespace if this fails.
-				_ = c.CoreV1().ConfigMaps(ns).Delete(ctx, dummyConfigMap.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(c.CoreV1().ConfigMaps(ns).Delete(ctx, dummyConfigMap.Name, metav1.DeleteOptions{}), "deleting config map %s", dummyConfigMap.Name)
 			}()
 
 			ginkgo.By("Update PVC 1 owner ref")
@@ -1587,7 +1587,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			framework.ExpectNoError(err)
 			defer func() {
 				// Will be cleaned up by the namespace delete if this fails
-				_ = c.CoreV1().ConfigMaps(ns).Delete(ctx, randomConfigMap.Name, metav1.DeleteOptions{})
+				framework.ExpectNoError(c.CoreV1().ConfigMaps(ns).Delete(ctx, randomConfigMap.Name, metav1.DeleteOptions{}), "deleting config map %s", randomConfigMap.Name)
 			}()
 
 			ginkgo.By("Add external owner to PVC 1")


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This change wraps several Delete and DeleteCollection calls in the e2e test suite with framework.ExpectNoError to prevent silent resource leaks. Previously error returns were completely discarded using an empty assignment which caused test failures to be masked and orphaned resources to be left in the cluster after tests.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
