### PR TITLE
Add retry logic for transient API server errors in e2e framework

### DIFF
--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -188,6 +188,9 @@ func RestartNodes(c clientset.Interface, nodes []v1.Node) error {
 		if err := wait.Poll(30*time.Second, framework.RestartNodeReadyAgainTimeout, func() (bool, error) {
 			newNode, err := c.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
 			if err != nil {
+				if framework.IsRetryableAPIError(err) {
+					return false, nil
+				}
 				return false, fmt.Errorf("error getting node info after reboot: %w", err)
 			}
 			return node.Status.NodeInfo.BootID != newNode.Status.NodeInfo.BootID, nil

--- a/test/e2e/framework/node/helper.go
+++ b/test/e2e/framework/node/helper.go
@@ -132,6 +132,9 @@ func allNodesReady(ctx context.Context, c clientset.Interface, timeout time.Dura
 		// It should be OK to list unschedulable Nodes here.
 		nodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		if err != nil {
+			if framework.IsRetryableAPIError(err) {
+				return false, nil
+			}
 			return false, err
 		}
 		for i := range nodes.Items {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -594,28 +594,62 @@ func GetNodeExternalIPs(node *v1.Node) (ips []string) {
 func GetControlPlaneNodes(ctx context.Context, c clientset.Interface) *v1.NodeList {
 	allNodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	ExpectNoError(err, "error reading all nodes")
+	return filterControlPlaneNodes(allNodes)
+}
 
+
+// IsRetryableAPIError checks if an error from the API server is transient and should be retried.
+func IsRetryableAPIError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apierrors.IsServerTimeout(err) || apierrors.IsTooManyRequests(err) || apierrors.IsInternalError(err) || apierrors.IsServiceUnavailable(err) || apierrors.IsUnexpectedServerError(err) {
+		return true
+	}
+	errString := err.Error()
+	if strings.Contains(errString, "connection refused") || strings.Contains(errString, "connection reset by peer") {
+		return true
+	}
+	return false
+}
+
+func filterControlPlaneNodes(allNodes *v1.NodeList) *v1.NodeList {
 	var cpNodes v1.NodeList
-
 	for _, node := range allNodes.Items {
-		// Check for the control plane label
 		if _, hasLabel := node.Labels[ControlPlaneLabel]; hasLabel {
 			cpNodes.Items = append(cpNodes.Items, node)
 			continue
 		}
-
-		// Check for the specific taint
 		for _, taint := range node.Spec.Taints {
-			// NOTE the taint key is the same as the control plane label
 			if taint.Key == ControlPlaneLabel && taint.Effect == v1.TaintEffectNoSchedule {
 				cpNodes.Items = append(cpNodes.Items, node)
-				continue
+				break
 			}
 		}
 	}
-
 	return &cpNodes
 }
+
+// WaitForControlPlaneNodes returns a list of control plane nodes, retrying transient API errors.
+func WaitForControlPlaneNodes(ctx context.Context, c clientset.Interface) (*v1.NodeList, error) {
+	var cpNodes *v1.NodeList
+	err := wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, true, func(ctx context.Context) (bool, error) {
+		allNodes, err := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if IsRetryableAPIError(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		cpNodes = filterControlPlaneNodes(allNodes)
+		return true, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error waiting for control plane nodes: %w", err)
+	}
+	return cpNodes, nil
+}
+
 
 // PrettyPrintJSON converts metrics to JSON format.
 func PrettyPrintJSON(metrics interface{}) string {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This commit introduces an IsRetryableAPIError function to correctly identify transient API server errors such as connection refused, 503, and server timeouts. It wraps the GetControlPlaneNodes call in a polling loop using WaitForControlPlaneNodes and also applies the retry logic to allNodesReady and RestartNodes. This ensures that disruptive tests do not fail completely upon hitting a temporary API server disconnection. It also extracts duplicated control plane filtering logic into a shared helper function.

#### Which issue(s) this PR is related to:
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
