### PR TITLE
Make MoreImportantVictim deterministic for equal start times

### DIFF
--- a/pkg/scheduler/framework/preemption/util.go
+++ b/pkg/scheduler/framework/preemption/util.go
@@ -80,7 +80,31 @@ func MoreImportantVictim(vi1, vi2 Victim) bool {
 		return len(vi1.Pods()) > len(vi2.Pods())
 	}
 
-	return vi1.EarliestStartTime().Before(vi2.EarliestStartTime())
+	return lessByStartTimeThenIdentity(vi1, vi2)
+}
+
+// lessByStartTimeThenIdentity ranks vi1 as more important than vi2 when vi1's
+// earliest start time is earlier. When the start times are equal (which happens
+// for pods without a recorded start time, whose start time falls back to the
+// current clock and can coincide on low-resolution timers), it falls back to a
+// deterministic comparison by pod identity. This keeps the victim ordering
+// stable across platforms instead of depending on the order in which victims
+// were constructed.
+func lessByStartTimeThenIdentity(vi1, vi2 Victim) bool {
+	t1, t2 := vi1.EarliestStartTime(), vi2.EarliestStartTime()
+	if t1 != nil && t2 != nil {
+		if !t1.Equal(t2) {
+			return t1.Before(t2)
+		}
+	}
+	return podIdentityLess(vi1, vi2)
+}
+
+// podIdentityLess provides a deterministic, stable ordering of victims based on
+// the representative pod's UID. The first pod in a victim's list is stable once
+// the victim is constructed, so a direct comparison is sufficient.
+func podIdentityLess(vi1, vi2 Victim) bool {
+	return vi1.Pods()[0].GetPod().UID < vi2.Pods()[0].GetPod().UID
 }
 
 func victimRank(vi Victim) int {

--- a/pkg/scheduler/framework/preemption/util.go
+++ b/pkg/scheduler/framework/preemption/util.go
@@ -80,23 +80,11 @@ func MoreImportantVictim(vi1, vi2 Victim) bool {
 		return len(vi1.Pods()) > len(vi2.Pods())
 	}
 
-	return lessByStartTimeThenIdentity(vi1, vi2)
-}
-
-// lessByStartTimeThenIdentity ranks vi1 as more important than vi2 when vi1's
-// earliest start time is earlier. When the start times are equal (which happens
-// for pods without a recorded start time, whose start time falls back to the
-// current clock and can coincide on low-resolution timers), it falls back to a
-// deterministic comparison by pod identity. This keeps the victim ordering
-// stable across platforms instead of depending on the order in which victims
-// were constructed.
-func lessByStartTimeThenIdentity(vi1, vi2 Victim) bool {
 	t1, t2 := vi1.EarliestStartTime(), vi2.EarliestStartTime()
-	if t1 != nil && t2 != nil {
-		if !t1.Equal(t2) {
-			return t1.Before(t2)
-		}
+	if t1 != nil && t2 != nil && !t1.Equal(t2) {
+		return t1.Before(t2)
 	}
+
 	return podIdentityLess(vi1, vi2)
 }
 

--- a/pkg/scheduler/framework/preemption/util_test.go
+++ b/pkg/scheduler/framework/preemption/util_test.go
@@ -704,9 +704,9 @@ func TestLessByStartTimeThenIdentity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := lessByStartTimeThenIdentity(tt.vi1, tt.vi2)
+			got := MoreImportantVictim(tt.vi1, tt.vi2)
 			if got != tt.want {
-				t.Errorf("lessByStartTimeThenIdentity() = %v, want %v", got, tt.want)
+				t.Errorf("MoreImportantVictim() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/scheduler/framework/preemption/util_test.go
+++ b/pkg/scheduler/framework/preemption/util_test.go
@@ -603,6 +603,115 @@ func TestMoreImportantVictim(t *testing.T) {
 	}
 }
 
+func TestLessByStartTimeThenIdentity(t *testing.T) {
+	newPodInfo := func(p *v1.Pod) fwk.PodInfo {
+		pi, _ := framework.NewPodInfo(p)
+		return pi
+	}
+
+	now := &metav1.Time{Time: time.Unix(1000, 0)}
+	before := &metav1.Time{Time: time.Unix(500, 0)}
+
+	tests := []struct {
+		name string
+		vi1  *victim
+		vi2  *victim
+		want bool
+	}{
+		{
+			name: "earlier start time wins",
+			vi1: &victim{
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().Name("a").UID("uid-a").Obj())},
+				earliestStartTime: before,
+				keyType:           fwk.PodKeyType,
+			},
+			vi2: &victim{
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().Name("b").UID("uid-b").Obj())},
+				earliestStartTime: now,
+				keyType:           fwk.PodKeyType,
+			},
+			want: true,
+		},
+		{
+			name: "later start time loses",
+			vi1: &victim{
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().Name("a").UID("uid-a").Obj())},
+				earliestStartTime: now,
+				keyType:           fwk.PodKeyType,
+			},
+			vi2: &victim{
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().Name("b").UID("uid-b").Obj())},
+				earliestStartTime: before,
+				keyType:           fwk.PodKeyType,
+			},
+			want: false,
+		},
+		{
+			name: "equal start time, lower UID wins",
+			vi1: &victim{
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().Name("a").UID("aaa").Obj())},
+				earliestStartTime: now,
+				keyType:           fwk.PodKeyType,
+			},
+			vi2: &victim{
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().Name("b").UID("zzz").Obj())},
+				earliestStartTime: now,
+				keyType:           fwk.PodKeyType,
+			},
+			want: true,
+		},
+		{
+			name: "equal start time, higher UID loses",
+			vi1: &victim{
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().Name("a").UID("zzz").Obj())},
+				earliestStartTime: now,
+				keyType:           fwk.PodKeyType,
+			},
+			vi2: &victim{
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().Name("b").UID("aaa").Obj())},
+				earliestStartTime: now,
+				keyType:           fwk.PodKeyType,
+			},
+			want: false,
+		},
+		{
+			name: "equal start time, equal UID returns false",
+			vi1: &victim{
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().Name("a").UID("same-uid").Obj())},
+				earliestStartTime: now,
+				keyType:           fwk.PodKeyType,
+			},
+			vi2: &victim{
+				pods:              []fwk.PodInfo{newPodInfo(st.MakePod().Name("b").UID("same-uid").Obj())},
+				earliestStartTime: now,
+				keyType:           fwk.PodKeyType,
+			},
+			want: false,
+		},
+		{
+			name: "nil start times, falls back to UID comparison",
+			vi1: &victim{
+				pods:    []fwk.PodInfo{newPodInfo(st.MakePod().Name("a").UID("aaa").Obj())},
+				keyType: fwk.PodKeyType,
+			},
+			vi2: &victim{
+				pods:    []fwk.PodInfo{newPodInfo(st.MakePod().Name("b").UID("zzz").Obj())},
+				keyType: fwk.PodKeyType,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := lessByStartTimeThenIdentity(tt.vi1, tt.vi2)
+			if got != tt.want {
+				t.Errorf("lessByStartTimeThenIdentity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPodTerminatingByPreemption(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
/kind cleanup

**What this PR does / why we need it**
`MoreImportantVictim` compared victims by `EarliestStartTime` with `Before`, which returns false (treats them as equal) when the start times are equal. For pods without a recorded `Status.StartTime`, `GetPodStartTime` falls back to `time.Now()`, so on platforms with low-resolution timers (e.g. Windows) two victims built close together could get the same start time and the victim ordering became non-deterministic, flaking `TestPodGroupEvaluator_SelectVictimsOnDomain/Efficiency: Preempt minimum number of victims`.

This PR adds a deterministic tie-breaker by pod UID for the equal-start-time case, so the comparator is now a total order and the result no longer depends on the clock resolution or the order in which victims were constructed. The existing priority / workload-type / group-size / start-time semantics are preserved.

Replaces #140454 (closed due to a bad force-push that corrupted the branch history).
Related-to: #140423

**Special notes for your reviewer**
- Pure ordering-logic change; no change to the actual preemption decision for victims that differ in priority, workload type, group size, or start time.
- Verified `TestPodGroupEvaluator_SelectVictimsOnDomain` passes repeatedly (`-count=10`) and the full `pkg/scheduler/framework/preemption` package tests pass.
- Includes dedicated `TestLessByStartTimeThenIdentity` test cases.

**Does this PR introduce a user-facing change?**
None

/sig scheduling