### PR TITLE
Automated cherry pick of #140966: client-go: restore FakeCustomStore conformance to cache.Store

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/fake_custom_store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/fake_custom_store.go
@@ -18,16 +18,20 @@ package cache
 
 // FakeCustomStore lets you define custom functions for store operations.
 type FakeCustomStore struct {
-	AddFunc      func(obj interface{}) error
-	UpdateFunc   func(obj interface{}) error
-	DeleteFunc   func(obj interface{}) error
-	ListFunc     func() []interface{}
-	ListKeysFunc func() []string
-	GetFunc      func(obj interface{}) (item interface{}, exists bool, err error)
-	GetByKeyFunc func(key string) (item interface{}, exists bool, err error)
-	ReplaceFunc  func(list []interface{}, resourceVersion string) error
-	ResyncFunc   func() error
+	AddFunc                          func(obj interface{}) error
+	UpdateFunc                       func(obj interface{}) error
+	DeleteFunc                       func(obj interface{}) error
+	ListFunc                         func() []interface{}
+	ListKeysFunc                     func() []string
+	GetFunc                          func(obj interface{}) (item interface{}, exists bool, err error)
+	GetByKeyFunc                     func(key string) (item interface{}, exists bool, err error)
+	ReplaceFunc                      func(list []interface{}, resourceVersion string) error
+	ResyncFunc                       func() error
+	BookmarkFunc                     func(rv string)
+	LastStoreSyncResourceVersionFunc func() string
 }
+
+var _ Store = &FakeCustomStore{}
 
 // Add calls the custom Add function if defined
 func (f *FakeCustomStore) Add(obj interface{}) error {
@@ -99,4 +103,19 @@ func (f *FakeCustomStore) Resync() error {
 		return f.ResyncFunc()
 	}
 	return nil
+}
+
+// Bookmark calls the custom Bookmark function if defined
+func (f *FakeCustomStore) Bookmark(rv string) {
+	if f.BookmarkFunc != nil {
+		f.BookmarkFunc(rv)
+	}
+}
+
+// LastStoreSyncResourceVersion calls the custom LastStoreSyncResourceVersion function if defined
+func (f *FakeCustomStore) LastStoreSyncResourceVersion() string {
+	if f.LastStoreSyncResourceVersionFunc != nil {
+		return f.LastStoreSyncResourceVersionFunc()
+	}
+	return ""
 }


### PR DESCRIPTION
Cherry pick of #140966 on release-1.36.

#140966: client-go: restore FakeCustomStore conformance to cache.Store

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
client-go: FakeCustomStore implements the Bookmark and LastStoreSyncResourceVersion methods added to the cache.Store interface in v0.36, so it satisfies cache.Store again
```