### PR TITLE
[1.35] Automated cherry pick of #140387: Always set UpdatePodResources when a starting container is resized

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -423,6 +423,7 @@ func (m *kubeGenericRuntimeManager) updateContainerResources(ctx context.Context
 func (m *kubeGenericRuntimeManager) setActuatedContainerResources(pod *v1.Pod, container *v1.Container) error {
 	containerResources := container.Resources
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
+		containerResources = *containerResources.DeepCopy()
 		containerResources.Limits = kubeutil.GetLimits(&kubeutil.ResourceOpts{PodResources: pod.Spec.Resources, ContainerResources: &container.Resources})
 	}
 	return m.actuatedState.SetContainerResources(pod.UID, container.Name, containerResources)
@@ -1286,6 +1287,11 @@ func (m *kubeGenericRuntimeManager) computeInitContainerActions(ctx context.Cont
 	for i := 0; i < l/2; i++ {
 		changes.InitContainersToStart[i], changes.InitContainersToStart[l-1-i] =
 			changes.InitContainersToStart[l-1-i], changes.InitContainersToStart[i]
+	}
+
+	if !changes.UpdatePodLevelResources && !changes.UpdatePodResources {
+		// If any starting containers have resized, we need to resize the pod resources.
+		changes.UpdatePodResources = m.startingResizedContainer(logger, pod, pod.Spec.InitContainers, changes.InitContainersToStart)
 	}
 
 	return podHasInitialized

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1337,7 +1337,33 @@ func (m *kubeGenericRuntimeManager) computePodActions(ctx context.Context, pod *
 	}
 
 	changes.UpdatePodLevelResources = m.computePodLevelResourcesResizeAction(ctx, pod)
+	if !changes.UpdatePodLevelResources && !changes.UpdatePodResources {
+		// If any starting containers have resized, we need to resize the pod resources.
+		changes.UpdatePodResources = m.startingResizedContainer(logger, pod, pod.Spec.Containers, changes.ContainersToStart)
+	}
+
 	return changes
+}
+
+// startingResizedContainer reports whether any of the contaniersToStart have been resized.
+func (m *kubeGenericRuntimeManager) startingResizedContainer(logger klog.Logger, pod *v1.Pod, containers []v1.Container, containersToStart []int) bool {
+	for _, i := range containersToStart {
+		c := containers[i]
+		actuatedResources, ok := m.actuatedState.GetContainerResources(pod.UID, c.Name)
+		if !ok {
+			logger.V(4).Info("Actuated resources missing for container", "pod", format.Pod(pod), "container", c.Name)
+		}
+		var actuatedPodResources *v1.ResourceRequirements
+		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
+			actuatedPodResources, _ = m.actuatedState.GetPodLevelResources(pod.UID)
+		}
+		desired := containerResourcesFromRequirements(pod.Spec.Resources, &c.Resources)
+		actuated := containerResourcesFromRequirements(actuatedPodResources, &actuatedResources)
+		if desired != actuated {
+			return true
+		}
+	}
+	return false
 }
 
 // getContainersToReset returns container info about the containers to remove from the runtime.
@@ -1397,9 +1423,9 @@ func (m *kubeGenericRuntimeManager) computePodLevelResourcesResizeAction(ctx con
 //  2. Kill pod sandbox if necessary.
 //  3. Kill any containers that should not be running.
 //  4. Create sandbox if necessary.
-//  5. Create ephemeral containers.
-//  6. Create init containers.
-//  7. Resize running containers (if InPlacePodVerticalScaling==true)
+//  5. Resize pod & running containers (if InPlacePodVerticalScaling==true)
+//  6. Create ephemeral containers.
+//  7. Create init containers.
 //  8. Create normal containers.
 func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, backOff *flowcontrol.Backoff, restartAllContainers bool) (result kubecontainer.PodSyncResult) {
 	logger := klog.FromContext(ctx)
@@ -1608,6 +1634,13 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		podIP = podIPs[0]
 	}
 
+	// Step 5: Resize pod & running containers (if necessary).
+	if resizable, _, _ := allocation.IsInPlacePodVerticalScalingAllowed(pod); resizable {
+		if len(podContainerChanges.ContainersToUpdate) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources {
+			result.SyncResults = append(result.SyncResults, m.doPodResizeAction(ctx, pod, podStatus, podContainerChanges))
+		}
+	}
+
 	// Get podSandboxConfig for containers to start.
 	configPodSandboxResult := kubecontainer.NewSyncResult(kubecontainer.ConfigPodSandbox, podSandboxID)
 	result.AddSyncResult(configPodSandboxResult)
@@ -1687,15 +1720,14 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 		return nil
 	}
 
-	// Step 5: start ephemeral containers
-	// These are started "prior" to init containers to allow running ephemeral containers even when there
+	// Step 6: start ephemeral containers
 	// are errors starting an init container. In practice init containers will start first since ephemeral
 	// containers cannot be specified on pod creation.
 	for _, idx := range podContainerChanges.EphemeralContainersToStart {
 		start(ctx, "ephemeral container", metrics.EphemeralContainer, ephemeralContainerStartSpec(&pod.Spec.EphemeralContainers[idx]))
 	}
 
-	// Step 6: start init containers.
+	// Step 7: start init containers.
 	for _, idx := range podContainerChanges.InitContainersToStart {
 		container := &pod.Spec.InitContainers[idx]
 		// Start the next init container.
@@ -1724,13 +1756,6 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 					m.podInitContainerTimeRecorder.RecordInitContainerFinished(pod.UID, cs.FinishedAt)
 				}
 			}
-		}
-	}
-
-	// Step 7: For containers in podContainerChanges.ContainersToUpdate[CPU,Memory] list, invoke UpdateContainerResources
-	if resizable, _, _ := allocation.IsInPlacePodVerticalScalingAllowed(pod); resizable {
-		if len(podContainerChanges.ContainersToUpdate) > 0 || podContainerChanges.UpdatePodResources || podContainerChanges.UpdatePodLevelResources {
-			result.SyncResults = append(result.SyncResults, m.doPodResizeAction(ctx, pod, podStatus, podContainerChanges))
 		}
 	}
 
@@ -2114,6 +2139,15 @@ func (m *kubeGenericRuntimeManager) ListPodSandboxMetrics(ctx context.Context) (
 }
 
 func (m *kubeGenericRuntimeManager) UpdateActuatedPodLevelResources(actuatedPod *v1.Pod) error {
+	if _, ok := m.actuatedState.GetPodResourceInfo(actuatedPod.UID); !ok {
+		// This is a new pod. Initialize actuated resources to detect pre-start container resizes to
+		// trigger pod cgroup updates.
+		for c := range podutil.ContainerIter(&actuatedPod.Spec, podutil.InitContainers|podutil.Containers) {
+			if err := m.setActuatedContainerResources(actuatedPod, c); err != nil {
+				klog.TODO().Error(err, "Failed to set container actuated resources", "pod", format.Pod(actuatedPod), "container", c.Name)
+			}
+		}
+	}
 	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		return nil
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -1360,12 +1360,8 @@ func TestComputePodActionsForRestartAllContainers(t *testing.T) {
 		features.NodeDeclaredFeatures:                 true,
 		features.RestartAllContainersOnContainerExits: true,
 	})
-	TestComputePodActions(t)
-	TestComputePodActionsWithInitContainers(t)
-
-	tCtx := ktesting.Init(t)
-	_, _, m, err := createTestRuntimeManager(tCtx)
-	require.NoError(t, err)
+	t.Run("TestComputePodActions", TestComputePodActions)
+	t.Run("TestComputePodActionsWithInitContainers", TestComputePodActionsWithInitContainers)
 
 	allContainersRestartingTrue := []v1.PodCondition{
 		{
@@ -1656,41 +1652,50 @@ func TestComputePodActionsForRestartAllContainers(t *testing.T) {
 			containersToStart: []int{0, 1, 2},
 		},
 	} {
-		pod := test.podFunc()
-		status := test.podStatusFunc()
-		tCtx := ktesting.Init(t)
-		actions := m.computePodActions(tCtx, pod, status, test.restartAllContainers)
+		t.Run(desc, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			_, _, m, err := createTestRuntimeManager(tCtx)
+			require.NoError(t, err)
 
-		expected := &podActions{
-			CreateSandbox:     false,
-			KillPod:           false,
-			SandboxID:         status.SandboxStatuses[0].Id,
-			ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
-			ContainersToStart: []int{},
-		}
-		if test.containersToStart != nil {
-			expected.ContainersToStart = test.containersToStart
-		}
-		if test.initContainersToStart != nil {
-			expected.InitContainersToStart = test.initContainersToStart
-		}
+			pod := test.podFunc()
+			status := test.podStatusFunc()
 
-		containerSpecByName := make(map[string]*v1.Container)
-		for idx, c := range pod.Spec.Containers {
-			containerSpecByName[c.Name] = &pod.Spec.Containers[idx]
-		}
-		for idx, c := range pod.Spec.InitContainers {
-			containerSpecByName[c.Name] = &pod.Spec.InitContainers[idx]
-		}
-		for _, info := range test.containersToRemove {
-			cName := info.container.Name
-			info.container = containerSpecByName[cName]
-			expected.ContainersToReset = append(expected.ContainersToReset, info)
-		}
+			// Initialize the actuated resources.
+			// Note: we call UpdateActuatedPodLevelResources without logger in 1.35
+			require.NoError(t, m.UpdateActuatedPodLevelResources(pod))
 
-		verifyActions(t, expected, &actions, desc)
+			actions := m.computePodActions(tCtx, pod, status, test.restartAllContainers)
+
+			expected := &podActions{
+				CreateSandbox:     false,
+				KillPod:           false,
+				SandboxID:         status.SandboxStatuses[0].Id,
+				ContainersToKill:  map[kubecontainer.ContainerID]containerToKillInfo{},
+				ContainersToStart: []int{},
+			}
+			if test.containersToStart != nil {
+				expected.ContainersToStart = test.containersToStart
+			}
+			if test.initContainersToStart != nil {
+				expected.InitContainersToStart = test.initContainersToStart
+			}
+
+			containerSpecByName := make(map[string]*v1.Container)
+			for idx, c := range pod.Spec.Containers {
+				containerSpecByName[c.Name] = &pod.Spec.Containers[idx]
+			}
+			for idx, c := range pod.Spec.InitContainers {
+				containerSpecByName[c.Name] = &pod.Spec.InitContainers[idx]
+			}
+			for _, info := range test.containersToRemove {
+				cName := info.container.Name
+				info.container = containerSpecByName[cName]
+				expected.ContainersToReset = append(expected.ContainersToReset, info)
+			}
+
+			verifyActions(t, expected, &actions, desc)
+		})
 	}
-
 }
 
 func getKillMap(pod *v1.Pod, status *kubecontainer.PodStatus, cIndexes []int) map[kubecontainer.ContainerID]containerToKillInfo {
@@ -1762,6 +1767,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 		mutatePodFn    func(*v1.Pod)
 		mutateStatusFn func(*kubecontainer.PodStatus)
 		actions        podActions
+		skipWindows    bool
 	}{
 		"initialization completed; start all containers": {
 			actions: podActions{
@@ -1947,16 +1953,52 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				ContainersToKill:      getKillMapWithInitContainers(basePod, baseStatus, []int{}),
 			},
 		},
+		"resize request exists on a not yet running non-sidecar init container; start it": {
+			mutatePodFn: func(pod *v1.Pod) {
+				pod.Spec.InitContainers[0].Resources.Requests = v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("200m"),
+					v1.ResourceMemory: resource.MustParse("200Mi"),
+				}
+			},
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				status.ContainerStatuses = nil
+			},
+			actions: podActions{
+				KillPod:               false,
+				SandboxID:             baseStatus.SandboxStatuses[0].Id,
+				InitContainersToStart: []int{0},
+				ContainersToStart:     []int{},
+				ContainersToKill:      getKillMapWithInitContainers(basePod, baseStatus, []int{}),
+				UpdatePodResources:    true,
+			},
+		},
 	} {
 		t.Run(desc, func(t *testing.T) {
+			if test.skipWindows && goruntime.GOOS == "windows" {
+				t.Skip("Skipping test since Windows does not support resize")
+			}
+			tCtx := ktesting.Init(t)
+
 			pod, status := makeBasePodAndStatusWithInitContainers()
+
+			// Sync the actuated state with the base values before any resize
+			// Note: we call UpdateActuatedPodLevelResources without logger in 1.35
+			require.NoError(t, m.UpdateActuatedPodLevelResources(pod))
+
+			if test.actions.ContainersToUpdate != nil {
+				for res := range test.actions.ContainersToUpdate {
+					for i := range test.actions.ContainersToUpdate[res] {
+						// Link the expected action to the mutated pod container
+						test.actions.ContainersToUpdate[res][i].container = &pod.Spec.InitContainers[0]
+					}
+				}
+			}
 			if test.mutatePodFn != nil {
 				test.mutatePodFn(pod)
 			}
 			if test.mutateStatusFn != nil {
 				test.mutateStatusFn(status)
 			}
-			tCtx := ktesting.Init(t)
 			actions := m.computePodActions(tCtx, pod, status, false)
 			verifyActions(t, &test.actions, &actions, desc)
 		})
@@ -3577,6 +3619,190 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 			verifyActions(t, expectedActions, &actions, desc)
 		})
 	}
+}
+
+func TestComputePodResizeActionForOOMKilledContainer(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("in-place resize is only supported on Linux")
+	}
+	_, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
+	require.NoError(t, err)
+
+	mem100M := resource.MustParse("100Mi")
+	mem200M := resource.MustParse("200Mi")
+	cpu100m := resource.MustParse("100m")
+
+	pod, status := makeBasePodAndStatus()
+	pod.Spec.Containers = pod.Spec.Containers[:1]
+	status.ContainerStatuses = status.ContainerStatuses[:1]
+
+	pod.Spec.Containers[0].Resources = v1.ResourceRequirements{
+		Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+		Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+	}
+	pod.Spec.Containers[0].ResizePolicy = []v1.ContainerResizePolicy{
+		{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired},
+		{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired},
+	}
+	// record the pre-resize resource limits as what was last actuated.
+	// Note: we call UpdateActuatedPodLevelResources without logger in 1.35
+	require.NoError(t, m.UpdateActuatedPodLevelResources(pod))
+
+	// Pod Resized
+	resize := pod.Spec.Containers[0].Resources.DeepCopy()
+	resize.Requests[v1.ResourceMemory] = mem200M
+	resize.Limits[v1.ResourceMemory] = mem200M
+	pod.Spec.Containers[0].Resources = *resize
+
+	// simulate OOMKilled
+	status.ContainerStatuses[0].State = kubecontainer.ContainerStateExited
+	status.ContainerStatuses[0].Hash = kubecontainer.HashContainer(&pod.Spec.Containers[0])
+
+	actions := m.computePodActions(tCtx, pod, status, false)
+
+	// the container is OOMKilled and must not be added to ContainersToUpdate (no live CRI call).
+	assert.Empty(t, actions.ContainersToUpdate, "OOMKilled container must not be in ContainersToUpdate")
+	// UpdatePodResources must be true so doPodResizeAction updates the pod-level cgroup.
+	assert.True(t, actions.UpdatePodResources, "UpdatePodResources must be true for OOMKilled container with pending resize")
+}
+
+func TestComputePodResizeActionForOOMKilledInitContainer(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("in-place resize is only supported on Linux")
+	}
+	_, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
+	require.NoError(t, err)
+
+	mem100M := resource.MustParse("100Mi")
+	mem200M := resource.MustParse("200Mi")
+	cpu100m := resource.MustParse("100m")
+
+	pod, status := makeBasePodAndStatus()
+	// a single init container.
+	pod.Spec.InitContainers = []v1.Container{
+		{
+			Name:  "init1",
+			Image: "bar-image",
+			Resources: v1.ResourceRequirements{
+				Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+				Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+			},
+			ResizePolicy: []v1.ContainerResizePolicy{
+				{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired},
+				{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired},
+			},
+		},
+	}
+	// no regular containers running so pod is not yet initialized.
+	status.ContainerStatuses = []*kubecontainer.Status{
+		{
+			ID:       kubecontainer.ContainerID{ID: "initid1"},
+			Name:     "init1",
+			State:    kubecontainer.ContainerStateExited,
+			Reason:   "OOMKilled",
+			ExitCode: 137,
+			Hash:     kubecontainer.HashContainer(&pod.Spec.InitContainers[0]),
+		},
+	}
+	pod.Spec.Containers = nil
+	pod.Status.ContainerStatuses = nil
+
+	// record pre-resize resource limits as what was last actuated.
+	// Note: we call UpdateActuatedPodLevelResources without logger in 1.35
+	require.NoError(t, m.UpdateActuatedPodLevelResources(pod))
+
+	// Pod Resized
+	resize := pod.Spec.InitContainers[0].Resources.DeepCopy()
+	resize.Requests[v1.ResourceMemory] = mem200M
+	resize.Limits[v1.ResourceMemory] = mem200M
+	pod.Spec.InitContainers[0].Resources = *resize
+
+	actions := m.computePodActions(tCtx, pod, status, false)
+
+	// the init container is OOMKilled and must not be in ContainersToUpdate.
+	assert.Empty(t, actions.ContainersToUpdate, "OOMKilled init container must not be in ContainersToUpdate")
+	// UpdatePodResources must be true so doPodResizeAction updates the pod-level cgroup.
+	assert.True(t, actions.UpdatePodResources, "UpdatePodResources must be true for OOMKilled init container with pending resize")
+}
+
+func TestComputePodResizeActionForOOMKilledSidecarContainer(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skip("in-place resize is only supported on Linux")
+	}
+	_, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	m.machineInfo.MemoryCapacity = 17179860387 // 16GB
+	require.NoError(t, err)
+
+	mem100M := resource.MustParse("100Mi")
+	mem200M := resource.MustParse("200Mi")
+	cpu100m := resource.MustParse("100m")
+
+	pod, status := makeBasePodAndStatus()
+	pod.Spec.Containers = nil
+	pod.Status.ContainerStatuses = nil
+	status.ContainerStatuses = nil
+
+	// one running regular container so the pod is considered initialized.
+	regularContainer := v1.Container{
+		Name:  "app",
+		Image: "busybox",
+	}
+	pod.Spec.Containers = []v1.Container{regularContainer}
+	status.ContainerStatuses = append(status.ContainerStatuses, &kubecontainer.Status{
+		ID:    kubecontainer.ContainerID{ID: "appid"},
+		Name:  "app",
+		State: kubecontainer.ContainerStateRunning,
+		Hash:  kubecontainer.HashContainer(&pod.Spec.Containers[0]),
+	})
+
+	// one sidecar that has been OOMKilled.
+	sidecar := v1.Container{
+		Name:          "sidecar",
+		Image:         "bar-image",
+		RestartPolicy: &containerRestartPolicyAlways,
+		Resources: v1.ResourceRequirements{
+			Limits:   v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+			Requests: v1.ResourceList{v1.ResourceCPU: cpu100m, v1.ResourceMemory: mem100M},
+		},
+		ResizePolicy: []v1.ContainerResizePolicy{
+			{ResourceName: v1.ResourceCPU, RestartPolicy: v1.NotRequired},
+			{ResourceName: v1.ResourceMemory, RestartPolicy: v1.NotRequired},
+		},
+	}
+	pod.Spec.InitContainers = []v1.Container{sidecar}
+	status.ContainerStatuses = append(status.ContainerStatuses, &kubecontainer.Status{
+		ID:       kubecontainer.ContainerID{ID: "sidecarid"},
+		Name:     "sidecar",
+		State:    kubecontainer.ContainerStateExited,
+		Reason:   "OOMKilled",
+		ExitCode: 137,
+		Hash:     kubecontainer.HashContainer(&pod.Spec.InitContainers[0]),
+	})
+
+	// record pre-resize resource limits as what was last actuated.
+	// Note: we call UpdateActuatedPodLevelResources without logger in 1.35
+	require.NoError(t, m.UpdateActuatedPodLevelResources(pod))
+
+	// Pod Resized
+	resize := pod.Spec.InitContainers[0].Resources.DeepCopy()
+	resize.Requests[v1.ResourceMemory] = mem200M
+	resize.Limits[v1.ResourceMemory] = mem200M
+	pod.Spec.InitContainers[0].Resources = *resize
+
+	actions := m.computePodActions(tCtx, pod, status, false)
+
+	// the sidecar is OOMKilled and must not be in ContainersToUpdate.
+	assert.Empty(t, actions.ContainersToUpdate, "OOMKilled sidecar must not be in ContainersToUpdate")
+	// UpdatePodResources must be true so doPodResizeAction updates the pod-level cgroup.
+	assert.True(t, actions.UpdatePodResources, "UpdatePodResources must be true for OOMKilled sidecar with pending resize")
 }
 
 func TestUpdatePodContainerResources(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #140387 on release-1.35.

#140387: Always set UpdatePodResources when a starting container is resized

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```

/kind bug

Cherry-pick to 1.35 branch was discussed in https://github.com/kubernetes/kubernetes/issues/138760.

I had to modify some of the unit tests as they were testing behavior for a FG that did not yet exist in 1.35.

AI was used to resolve merge conflicts.