### PR TITLE
Automated cherry pick of #140882: kubelet: detach probe workers from the pod sync context

### DIFF
--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -187,6 +187,18 @@ func (m *manager) AddPod(ctx context.Context, pod *v1.Pod) {
 	defer m.workerLock.Unlock()
 
 	logger := klog.FromContext(ctx)
+	// Detach the workers' context from the caller's: the pod worker cancels the
+	// sync context when the pod begins terminating, but probe workers must keep
+	// probing until the container stops so a failing readiness probe can mark
+	// the pod NotReady during graceful termination. Workers are stopped
+	// explicitly via their stop channel (RemovePod/CleanupPods).
+	//
+	// TODO(#140977): This also means nothing cancels an in-flight probe. worker.stop()
+	// only signals stopCh, which is checked between probes, so an exec probe that is
+	// already running keeps executing in a container that is being killed until its
+	// own TimeoutSeconds elapses. The fix is a per-worker cancellable context
+	// cancelled by stop(), not the pod sync context, which cancels too early.
+	ctx = context.WithoutCancel(ctx)
 	key := probeKey{podUID: pod.UID}
 	for _, c := range append(pod.Spec.Containers, getRestartableInitContainers(pod)...) {
 		key.containerName = c.Name

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package prober
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
@@ -691,5 +693,60 @@ func cleanup(t *testing.T, m *manager) {
 	}
 	if err := wait.Poll(interval, wait.ForeverTestTimeout, condition); err != nil {
 		t.Fatalf("Error during cleanup: %v", err)
+	}
+}
+
+// ctxAwareRunner implements kubecontainer.CommandRunner and fails once the
+// probe context is canceled, like a real CRI runtime client.
+type ctxAwareRunner struct{}
+
+func (r ctxAwareRunner) RunInContainer(ctx context.Context, id kubecontainer.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return []byte("ok"), nil
+}
+
+// TestProbeWorkersSurviveSyncContextCancellation verifies that probe workers
+// keep probing after the context passed to AddPod is canceled. The pod worker
+// cancels its sync context when a pod begins terminating, and readiness probes
+// must keep executing through termination so a failing probe can mark the pod
+// NotReady. Regression test for https://github.com/kubernetes/kubernetes/issues/140881.
+func TestProbeWorkersSurviveSyncContextCancellation(t *testing.T) {
+	ktesting.Init(t).SyncTest("", testProbeWorkersSurviveSyncContextCancellation)
+}
+
+func testProbeWorkersSurviveSyncContextCancellation(tCtx ktesting.TContext) {
+	t := tCtx.TB()
+	logger := tCtx.Logger()
+	testPod := getTestPod()
+	setTestProbe(testPod, readiness, v1.Probe{})
+	m := newTestManager()
+	defer cleanup(t, m)
+
+	// Probe through the real exec prober backed by a runner that honors
+	// context cancellation, mirroring how CRI ExecSync fails once its
+	// context is canceled.
+	m.prober = newProber(ctxAwareRunner{}, &record.FakeRecorder{})
+
+	m.statusManager.SetPodStatus(logger, testPod, getTestRunningStatus())
+
+	ctx, cancel := context.WithCancel(tCtx)
+	m.AddPod(ctx, testPod)
+	// Simulate the pod worker canceling the sync context at the start of
+	// pod termination.
+	cancel()
+
+	// The readiness worker seeds the result cache with Failure for a new
+	// container, then must record Success from an actual probe execution.
+	for {
+		select {
+		case update := <-m.readinessManager.Updates():
+			if update.Result == results.Success {
+				return
+			}
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Fatal("Probe worker recorded no probe result after the sync context was canceled; probes are likely being canceled by pod termination")
+		}
 	}
 }

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -713,11 +713,7 @@ func (r ctxAwareRunner) RunInContainer(ctx context.Context, id kubecontainer.Con
 // must keep executing through termination so a failing probe can mark the pod
 // NotReady. Regression test for https://github.com/kubernetes/kubernetes/issues/140881.
 func TestProbeWorkersSurviveSyncContextCancellation(t *testing.T) {
-	ktesting.Init(t).SyncTest("", testProbeWorkersSurviveSyncContextCancellation)
-}
-
-func testProbeWorkersSurviveSyncContextCancellation(tCtx ktesting.TContext) {
-	t := tCtx.TB()
+	tCtx := ktesting.Init(t)
 	logger := tCtx.Logger()
 	testPod := getTestPod()
 	setTestProbe(testPod, readiness, v1.Probe{})


### PR DESCRIPTION
Cherry pick of #140882 on release-1.36.

#140882: kubelet: detach probe workers from the pod sync context

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### Not a clean pick

The fix itself (`prober_manager.go`) is unmodified. The regression test needed one adaptation, in its own commit so it is easy to review separately: `cleanup()` takes `*testing.T` on this branch rather than `ktesting.TB`, so the `SyncTest` wrapper does not compile. The test now calls `ktesting.Init(t)` directly, which is how every other test in that file is already written here.

Verified on this branch: `go test ./pkg/kubelet/prober/...` passes with the fix and fails without it (`Probe errored ... err="context canceled"`), so the regression test is meaningful here and not vacuously green.

Affected range on this branch is v1.36.3 and later. v1.36.0 through v1.36.2 happen to be unaffected: they allocated a fresh sync context per sync, so the context the probe worker captured in AddPod was not the one pod_workers.go cancelled at teardown. #140066 (cherry-pick of #139850) restored context reuse and re-armed this bug along with it.

```release-note
Fixed a regression where exec readiness probes stopped executing (failing with "context canceled") once a pod began graceful termination, leaving the pod's Ready condition frozen during shutdown.
```
