### PR TITLE
Drop unbounded cardinality labels from apiserver_request_terminations_total

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -1760,12 +1760,8 @@
   labels:
   - code
   - component
-  - group
-  - resource
   - scope
-  - subresource
   - verb
-  - version
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -199,7 +199,7 @@ var (
 			Help:           "Number of requests which apiserver terminated in self-defense.",
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
-		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component", "code"},
+		[]string{"verb", "scope", "component", "code"},
 	)
 
 	apiSelfRequestCounter = compbasemetrics.NewCounterVec(
@@ -527,11 +527,7 @@ func RecordRequestTermination(req *http.Request, requestInfo *request.RequestInf
 	// However, we need to tweak it e.g. to differentiate GET from LIST.
 	reportedVerb := cleanVerb(CanonicalVerb(strings.ToUpper(req.Method), scope), "", req, requestInfo)
 
-	if requestInfo.IsResourceRequest {
-		requestTerminationsTotal.WithContext(req.Context()).WithLabelValues(reportedVerb, requestInfo.APIGroup, requestInfo.APIVersion, requestInfo.Resource, requestInfo.Subresource, scope, component, codeToString(code)).Inc()
-	} else {
-		requestTerminationsTotal.WithContext(req.Context()).WithLabelValues(reportedVerb, "", "", "", requestInfo.Path, scope, component, codeToString(code)).Inc()
-	}
+	requestTerminationsTotal.WithContext(req.Context()).WithLabelValues(reportedVerb, scope, component, codeToString(code)).Inc()
 }
 
 // RecordLongRunning tracks the execution of a long running request against the API server. It provides an accurate count


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This is an alpha metric. We need drop all unbounded cardinality labels from it while we still can. 

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/141007

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Updated the alpha metric `apiserver_request_terminations_total` to drop high-cardinality labels (`group`,
`version`, `resource`, `subresource`) since those labels are built from unvalidated request path data.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

