### PR TITLE
Treat partially declared cpu and memory limits as unlimited in PodLimits()

### DIFF
--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -31,7 +31,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
-	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
@@ -48,19 +47,9 @@ func ApplyPodLevelMemoryHigh(pod *v1.Pod, rc *ResourceConfig, throttlingFactor f
 		return
 	}
 	reqs := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{})
-	limits := resourcehelper.PodLimits(pod, resourcehelper.PodResourcesOptions{})
-	memoryLimitsDeclared := true
-	for c := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
-		if c.Resources.Limits.Memory().IsZero() {
-			memoryLimitsDeclared = false
-		}
-	}
-	if !pod.Spec.Resources.Limits.Memory().IsZero() {
-		memoryLimitsDeclared = true
-	}
-	if !memoryLimitsDeclared {
-		return
-	}
+	limits := resourcehelper.PodLimits(pod, resourcehelper.PodResourcesOptions{
+		OmitPartialLimits: true,
+	})
 	memoryRequest := int64(0)
 	memoryLimit := int64(0)
 	if req, found := reqs[v1.ResourceMemory]; found {
@@ -187,34 +176,13 @@ func ResourceConfigForPod(allocatedPod *v1.Pod, enforceCPULimits bool, cpuPeriod
 		UseStatusResources:                       false,
 		UseDRANodeAllocatableResourceClaimStatus: draNodeAllocatableEnabled,
 	})
-	// track if limits were applied for each resource.
-	memoryLimitsDeclared := true
-	cpuLimitsDeclared := true
-
 	limits := resourcehelper.PodLimits(allocatedPod, resourcehelper.PodResourcesOptions{
 		// SkipPodLevelResources is set to false when PodLevelResources feature is enabled.
 		SkipPodLevelResources:                    !podLevelResourcesEnabled,
 		UseDRANodeAllocatableResourceClaimStatus: draNodeAllocatableEnabled,
+		OmitPartialLimits:                        true,
 	})
 
-	for c := range podutil.ContainerIter(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers) {
-		if c.Resources.Limits.Cpu().IsZero() {
-			cpuLimitsDeclared = false
-		}
-		if c.Resources.Limits.Memory().IsZero() {
-			memoryLimitsDeclared = false
-		}
-	}
-
-	if podLevelResourcesEnabled && resourcehelper.IsPodLevelResourcesSet(allocatedPod) {
-		if !allocatedPod.Spec.Resources.Limits.Cpu().IsZero() {
-			cpuLimitsDeclared = true
-		}
-
-		if !allocatedPod.Spec.Resources.Limits.Memory().IsZero() {
-			memoryLimitsDeclared = true
-		}
-	}
 	// map hugepage pagesize (bytes) to limits (bytes)
 	hugePageLimits := HugePageLimits(reqs)
 
@@ -224,11 +192,13 @@ func ResourceConfigForPod(allocatedPod *v1.Pod, enforceCPULimits bool, cpuPeriod
 	if request, found := reqs[v1.ResourceCPU]; found {
 		cpuRequests = request.MilliValue()
 	}
-	if limit, found := limits[v1.ResourceCPU]; found {
-		cpuLimits = limit.MilliValue()
+	cpuLimit, cpuLimitsDeclared := limits[v1.ResourceCPU]
+	if cpuLimitsDeclared {
+		cpuLimits = cpuLimit.MilliValue()
 	}
-	if limit, found := limits[v1.ResourceMemory]; found {
-		memoryLimits = limit.Value()
+	memoryLimit, memoryLimitsDeclared := limits[v1.ResourceMemory]
+	if memoryLimitsDeclared {
+		memoryLimits = memoryLimit.Value()
 	}
 
 	// convert to CFS values

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -31,7 +31,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
-	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
@@ -48,19 +47,9 @@ func ApplyPodLevelMemoryHigh(pod *v1.Pod, rc *ResourceConfig, throttlingFactor f
 		return
 	}
 	reqs := resourcehelper.PodRequests(pod, resourcehelper.PodResourcesOptions{})
+	// PodLimits() omits the memory limit unless every container declares it or a pod-level
+	// limit is set, so memoryLimit stays 0 (and memory.high stays unset) otherwise.
 	limits := resourcehelper.PodLimits(pod, resourcehelper.PodResourcesOptions{})
-	memoryLimitsDeclared := true
-	for c := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
-		if c.Resources.Limits.Memory().IsZero() {
-			memoryLimitsDeclared = false
-		}
-	}
-	if !pod.Spec.Resources.Limits.Memory().IsZero() {
-		memoryLimitsDeclared = true
-	}
-	if !memoryLimitsDeclared {
-		return
-	}
 	memoryRequest := int64(0)
 	memoryLimit := int64(0)
 	if req, found := reqs[v1.ResourceMemory]; found {
@@ -187,34 +176,15 @@ func ResourceConfigForPod(allocatedPod *v1.Pod, enforceCPULimits bool, cpuPeriod
 		UseStatusResources:                       false,
 		UseDRANodeAllocatableResourceClaimStatus: draNodeAllocatableEnabled,
 	})
-	// track if limits were applied for each resource.
-	memoryLimitsDeclared := true
-	cpuLimitsDeclared := true
-
+	// PodLimits() omits a cpu or memory limit that is not declared by every container (or
+	// at the pod level), so presence in the map below doubles as the "limits declared"
+	// signal.
 	limits := resourcehelper.PodLimits(allocatedPod, resourcehelper.PodResourcesOptions{
 		// SkipPodLevelResources is set to false when PodLevelResources feature is enabled.
 		SkipPodLevelResources:                    !podLevelResourcesEnabled,
 		UseDRANodeAllocatableResourceClaimStatus: draNodeAllocatableEnabled,
 	})
 
-	for c := range podutil.ContainerIter(&allocatedPod.Spec, podutil.InitContainers|podutil.Containers) {
-		if c.Resources.Limits.Cpu().IsZero() {
-			cpuLimitsDeclared = false
-		}
-		if c.Resources.Limits.Memory().IsZero() {
-			memoryLimitsDeclared = false
-		}
-	}
-
-	if podLevelResourcesEnabled && resourcehelper.IsPodLevelResourcesSet(allocatedPod) {
-		if !allocatedPod.Spec.Resources.Limits.Cpu().IsZero() {
-			cpuLimitsDeclared = true
-		}
-
-		if !allocatedPod.Spec.Resources.Limits.Memory().IsZero() {
-			memoryLimitsDeclared = true
-		}
-	}
 	// map hugepage pagesize (bytes) to limits (bytes)
 	hugePageLimits := HugePageLimits(reqs)
 
@@ -252,11 +222,11 @@ func ResourceConfigForPod(allocatedPod *v1.Pod, enforceCPULimits bool, cpuPeriod
 		result.Memory = &memoryLimits
 	} else if qosClass == v1.PodQOSBurstable {
 		result.CPUShares = &cpuShares
-		if cpuLimitsDeclared {
+		if cpuLimits != 0 {
 			result.CPUQuota = &cpuQuota
 			result.CPUPeriod = &cpuPeriod
 		}
-		if memoryLimitsDeclared {
+		if memoryLimits != 0 {
 			result.Memory = &memoryLimits
 		}
 	} else {

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -5111,6 +5111,176 @@ func Test_generateAPIPodStatus(t *testing.T) {
 			inPlacePodLevelResourcesVerticalScalingEnabled: true,
 		},
 		{
+			name: "InPlacePodLevelResourcesVerticalScaling enabled, partial limits omitted from status",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "containerA",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:              resource.MustParse("100m"),
+									v1.ResourceMemory:           resource.MustParse("100Mi"),
+									v1.ResourceEphemeralStorage: resource.MustParse("500Mi"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:              resource.MustParse("200m"),
+									v1.ResourceMemory:           resource.MustParse("200Mi"),
+									v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+								},
+							},
+						},
+						{
+							Name: "containerB",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("50m"),
+									v1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodPending,
+				},
+			},
+			currentStatus: sandboxReadyStatus,
+			expected: v1.PodStatus{
+				Phase:    v1.PodPending,
+				HostIP:   "127.0.0.1",
+				HostIPs:  []v1.HostIP{{IP: "127.0.0.1"}, {IP: "::1"}},
+				QOSClass: v1.PodQOSBurstable,
+				Conditions: []v1.PodCondition{
+					{Type: v1.PodInitialized, Status: v1.ConditionTrue},
+					{Type: v1.PodReady, Status: v1.ConditionTrue},
+					{Type: v1.ContainersReady, Status: v1.ConditionTrue},
+					{Type: v1.PodScheduled, Status: v1.ConditionTrue},
+				},
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:  "containerA",
+						State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: ContainerCreating}},
+						Ready: true,
+					},
+					{
+						Name:  "containerB",
+						State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: ContainerCreating}},
+						Ready: true,
+					},
+				},
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:              resource.MustParse("150m"),
+						v1.ResourceMemory:           resource.MustParse("150Mi"),
+						v1.ResourceEphemeralStorage: resource.MustParse("500Mi"),
+					},
+					// cpu and memory limits are declared by only some containers, so they are omitted in status
+					Limits: v1.ResourceList{
+						v1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+					},
+				},
+				AllocatedResources: v1.ResourceList{
+					v1.ResourceCPU:              resource.MustParse("150m"),
+					v1.ResourceMemory:           resource.MustParse("150Mi"),
+					v1.ResourceEphemeralStorage: resource.MustParse("500Mi"),
+				},
+				InitContainerStatuses:      []v1.ContainerStatus{},
+				EphemeralContainerStatuses: []v1.ContainerStatus{},
+			},
+			expectedPodReadyToStartContainersCondition: v1.PodCondition{
+				Type:   v1.PodReadyToStartContainers,
+				Status: v1.ConditionTrue,
+			},
+			inPlacePodLevelResourcesVerticalScalingEnabled: true,
+		},
+		{
+			name: "InPlacePodLevelResourcesVerticalScaling enabled, partial container limits not omitted with pod level limits",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Resources: &v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU: resource.MustParse("4"),
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name: "containerA",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("100m"),
+									v1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("200m"),
+									v1.ResourceMemory: resource.MustParse("200Mi"),
+								},
+							},
+						},
+						{
+							Name: "containerB",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("50m"),
+									v1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodPending,
+				},
+			},
+			currentStatus: sandboxReadyStatus,
+			expected: v1.PodStatus{
+				Phase:    v1.PodPending,
+				HostIP:   "127.0.0.1",
+				HostIPs:  []v1.HostIP{{IP: "127.0.0.1"}, {IP: "::1"}},
+				QOSClass: v1.PodQOSBurstable,
+				Conditions: []v1.PodCondition{
+					{Type: v1.PodInitialized, Status: v1.ConditionTrue},
+					{Type: v1.PodReady, Status: v1.ConditionTrue},
+					{Type: v1.ContainersReady, Status: v1.ConditionTrue},
+					{Type: v1.PodScheduled, Status: v1.ConditionTrue},
+				},
+				ContainerStatuses: []v1.ContainerStatus{
+					{
+						Name:  "containerA",
+						State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: ContainerCreating}},
+						Ready: true,
+					},
+					{
+						Name:  "containerB",
+						State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: ContainerCreating}},
+						Ready: true,
+					},
+				},
+				// The pod-level cpu limit covers the container that omits one; the memory
+				// limit is not declared by every container and is not reported.
+				Resources: &v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("150m"),
+						v1.ResourceMemory: resource.MustParse("150Mi"),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("4"),
+					},
+				},
+				AllocatedResources: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("150m"),
+					v1.ResourceMemory: resource.MustParse("150Mi"),
+				},
+				InitContainerStatuses:      []v1.ContainerStatus{},
+				EphemeralContainerStatuses: []v1.ContainerStatus{},
+			},
+			expectedPodReadyToStartContainersCondition: v1.PodCondition{
+				Type:   v1.PodReadyToStartContainers,
+				Status: v1.ConditionTrue,
+			},
+			inPlacePodLevelResourcesVerticalScalingEnabled: true,
+		},
+		{
 			name: "InPlacePodLevelResourcesVerticalScaling enabled, running pod",
 			pod: &v1.Pod{
 				Spec: v1.PodSpec{

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
@@ -53,7 +53,12 @@ func (m *kubeGenericRuntimeManager) calculateSandboxResources(ctx context.Contex
 		UseDRANodeAllocatableResourceClaimStatus: utilfeature.DefaultFeatureGate.Enabled(features.DRANodeAllocatableResources),
 	}
 	req := resourcehelper.PodRequests(pod, opts)
+
+	// PodLimits() omits a cpu or memory limit that any container leaves unset when no
+	// pod-level limit is declared, so the sandbox is unlimited in that case, the same way
+	// ResourceConfigForPod() leaves the pod cgroup unlimited.
 	lim := resourcehelper.PodLimits(pod, opts)
+
 	var cpuRequest *resource.Quantity
 	if _, cpuRequestExists := req[v1.ResourceCPU]; cpuRequestExists {
 		cpuRequest = req.Cpu()

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux.go
@@ -53,7 +53,12 @@ func (m *kubeGenericRuntimeManager) calculateSandboxResources(ctx context.Contex
 		UseDRANodeAllocatableResourceClaimStatus: utilfeature.DefaultFeatureGate.Enabled(features.DRANodeAllocatableResources),
 	}
 	req := resourcehelper.PodRequests(pod, opts)
+
+	// If a limit is omitted in any container spec and not set at the pod level, it should be
+	// unlimited for the sandbox, the same way ResourceConfigForPod() does for the pod cgroup.
+	opts.OmitPartialLimits = true
 	lim := resourcehelper.PodLimits(pod, opts)
+
 	var cpuRequest *resource.Quantity
 	if _, cpuRequestExists := req[v1.ResourceCPU]; cpuRequestExists {
 		cpuRequest = req.Cpu()

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_linux_test.go
@@ -410,6 +410,99 @@ func TestApplySandboxResources(t *testing.T) {
 			expectedOverhead: &runtimeapi.LinuxContainerResources{},
 			cgroupVersion:    cgroupV2,
 		},
+		{
+			description: "pod with limits not set for some containers",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "c1",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse("128Mi"),
+									v1.ResourceCPU:    resource.MustParse("1"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse("256Mi"),
+									v1.ResourceCPU:    resource.MustParse("2"),
+								},
+							},
+						},
+						{
+							Name: "c2",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse("64Mi"),
+									v1.ResourceCPU:    resource.MustParse("500m"),
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResource: &runtimeapi.LinuxContainerResources{
+				MemoryLimitInBytes: 0, // c2 declares no memory limit, so the pod sandbox limit is unlimited
+				CpuPeriod:          100000,
+				CpuQuota:           0, // c2 declares no cpu limit, so the pod sandbox limit is unlimited
+				CpuShares:          1536,
+				Unified:            map[string]string{"memory.oom.group": "1"},
+			},
+			expectedOverhead: &runtimeapi.LinuxContainerResources{},
+			cgroupVersion:    cgroupV2,
+		},
+		{
+			description: "pod with DRA direct claims and limits declared on only some containers",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "c1",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse("128Mi"),
+									v1.ResourceCPU:    resource.MustParse("1"),
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse("256Mi"),
+									v1.ResourceCPU:    resource.MustParse("2"),
+								},
+							},
+						},
+						{
+							Name: "c2",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse("64Mi"),
+									v1.ResourceCPU:    resource.MustParse("500m"),
+								},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					NodeAllocatableResourceClaimStatuses: []v1.NodeAllocatableResourceClaimStatus{
+						{
+							ResourceClaimName: "direct-claim",
+							Containers:        []string{"c1"},
+							Mapping: []v1.NodeAllocatableMappedResources{
+								{Name: v1.ResourceCPU, Quantity: new(resource.MustParse("200m"))},
+								{Name: v1.ResourceMemory, Quantity: new(resource.MustParse("128Mi"))},
+							},
+						},
+					},
+				},
+			},
+			draEnabled: true,
+			expectedResource: &runtimeapi.LinuxContainerResources{
+				MemoryLimitInBytes: 0, // c2 declares no standard memory limit, so the pod sandbox limit is unlimited
+				CpuPeriod:          100000,
+				CpuQuota:           0,
+				CpuShares:          1740,
+				Unified:            map[string]string{"memory.oom.group": "1"},
+			},
+			expectedOverhead: &runtimeapi.LinuxContainerResources{},
+			cgroupVersion:    cgroupV2,
+		},
 	}
 
 	for i, test := range tests {

--- a/pkg/scheduler/metrics/resources/resources_test.go
+++ b/pkg/scheduler/metrics/resources/resources_test.go
@@ -412,6 +412,44 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 						Containers: []v1.Container{
 							{Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{"cpu": resource.MustParse("1")},
+								Limits:   v1.ResourceList{"cpu": resource.MustParse("2"), "memory": resource.MustParse("0.5G")},
+							}},
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{"memory": resource.MustParse("1G")},
+								Limits:   v1.ResourceList{"cpu": resource.MustParse("0.5"), "memory": resource.MustParse("1.5G")},
+							}},
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{"cpu": resource.MustParse("0.5")},
+								Limits:   v1.ResourceList{"cpu": resource.MustParse("0.5"), "memory": resource.MustParse("0.5G")},
+							}},
+							{Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{"cpu": resource.MustParse("0.25"), "memory": resource.MustParse("1.5G")},
+							}},
+						},
+					},
+				},
+			},
+			expected: `
+				# HELP kube_pod_resource_limit [STABLE] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_limit gauge
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 3.25
+				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 4e+09
+				# HELP kube_pod_resource_request [STABLE] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
+				# TYPE kube_pod_resource_request gauge
+				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 1.5
+				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 1e+09
+				`,
+		},
+		{
+			name: "limits declared by only some containers are not reported",
+			pods: []*v1.Pod{
+				{
+					Namespace: "test",
+					Name:      "foo",
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{"cpu": resource.MustParse("1")},
 								Limits:   v1.ResourceList{"cpu": resource.MustParse("2")},
 							}},
 							{Resources: v1.ResourceRequirements{
@@ -429,11 +467,9 @@ func Test_podResourceCollector_CollectWithStability(t *testing.T) {
 					},
 				},
 			},
-			expected: `            
-				# HELP kube_pod_resource_limit [STABLE] Resources limit for workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
-				# TYPE kube_pod_resource_limit gauge
-				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 3.25
-				kube_pod_resource_limit{namespace="test",node="",pod="foo",priority="",resource="memory",scheduler="",unit="bytes"} 4e+09
+			// Neither the cpu nor the memory limit is declared by every container, so no
+			// pod limit is reported, the same as for a pod that declares no limits.
+			expected: `
 				# HELP kube_pod_resource_request [STABLE] Resources requested by workloads on the cluster, broken down by pod. This shows the resource usage the scheduler and kubelet expect per pod for resources along with the unit for the resource if any.
 				# TYPE kube_pod_resource_request gauge
 				kube_pod_resource_request{namespace="test",node="",pod="foo",priority="",resource="cpu",scheduler="",unit="cores"} 1.5

--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -396,6 +396,18 @@ func PodLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 		applyPodLevelResources(limits, effectiveLims)
 	}
 
+	// When any container in a pod does not set a limit for cpu or memory, kubelet treats this
+	// as unlimited (and not zero) while configuring pod and container cgroups.
+	// We must exclude those limits here instead of returning partial limits.
+	for name := range limits {
+		switch name {
+		case v1.ResourceCPU, v1.ResourceMemory:
+			if !isLimitDeclared(pod, name, opts) {
+				delete(limits, name)
+			}
+		}
+	}
+
 	// Add overhead to non-zero limits if requested:
 	if !opts.ExcludeOverhead && pod.Spec.Overhead != nil {
 		for name, quantity := range pod.Spec.Overhead {
@@ -407,6 +419,30 @@ func PodLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 	}
 
 	return limits
+}
+
+// isLimitDeclared reports whether the limit for resourceName is declared for the whole
+// pod: either a pod-level limit is set, or every container in the pod declares it.
+func isLimitDeclared(pod *v1.Pod, resourceName v1.ResourceName, opts PodResourcesOptions) bool {
+	// A pod-level limit bounds the whole pod, so it makes the limit well defined even when
+	// individual containers omit their own.
+	if !opts.SkipPodLevelResources && IsPodLevelResourcesSet(pod) {
+		if limit, found := pod.Spec.Resources.Limits[resourceName]; found && !limit.IsZero() {
+			return true
+		}
+	}
+
+	for i := range pod.Spec.InitContainers {
+		if limit, found := pod.Spec.InitContainers[i].Resources.Limits[resourceName]; !found || limit.IsZero() {
+			return false
+		}
+	}
+	for i := range pod.Spec.Containers {
+		if limit, found := pod.Spec.Containers[i].Resources.Limits[resourceName]; !found || limit.IsZero() {
+			return false
+		}
+	}
+	return true
 }
 
 // AggregateContainerLimits computes the aggregated resource limits of all the containers

--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -62,6 +62,13 @@ type PodResourcesOptions struct {
 	SkipContainerLevelResources bool
 	// Use node allocatable resource claim information from pod status to compute the effective pod resource request.
 	UseDRANodeAllocatableResourceClaimStatus bool
+	// OmitPartialLimits controls whether PodLimits() drops a limit when it is unset for any
+	// container and also not set at the pod level, instead of counting the unset limits as 0.
+	//
+	// This applies to cpu, memory and ephemeral-storage, where the kubelet treats
+	// container and the pod limits as unlimited when unset in the spec. It does not apply
+	// to hugepages or extended resources, where an unset limit means zero.
+	OmitPartialLimits bool
 }
 
 var supportedPodLevelResources = sets.New(v1.ResourceCPU, v1.ResourceMemory)
@@ -396,6 +403,20 @@ func PodLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 		applyPodLevelResources(limits, effectiveLims)
 	}
 
+	// When a container does not set a limit for cpu, memory or ephemeral-storage, it is treated
+	// as unlimited and not as zero, for both the container and the pod. Exclude those here
+	// rather than returning a partial sum.
+	if opts.OmitPartialLimits {
+		for name := range limits {
+			switch name {
+			case v1.ResourceCPU, v1.ResourceMemory, v1.ResourceEphemeralStorage:
+				if !podDeclaresLimit(pod, name, opts) {
+					delete(limits, name)
+				}
+			}
+		}
+	}
+
 	// Add overhead to non-zero limits if requested:
 	if !opts.ExcludeOverhead && pod.Spec.Overhead != nil {
 		for name, quantity := range pod.Spec.Overhead {
@@ -407,6 +428,31 @@ func PodLimits(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 	}
 
 	return limits
+}
+
+// podDeclaresLimit reports whether a limit for resourceName is set at the pod level or by
+// every container in the pod, init containers included.
+func podDeclaresLimit(pod *v1.Pod, resourceName v1.ResourceName, opts PodResourcesOptions) bool {
+	// A pod-level limit bounds the whole pod, so it makes the limit well defined even when
+	// individual containers omit their own.
+	if !opts.SkipPodLevelResources && IsPodLevelResourcesSet(pod) {
+		if limit, found := pod.Spec.Resources.Limits[resourceName]; found && !limit.IsZero() {
+			return true
+		}
+	}
+
+	for i := range pod.Spec.InitContainers {
+		if limit, found := pod.Spec.InitContainers[i].Resources.Limits[resourceName]; !found || limit.IsZero() {
+			return false
+		}
+	}
+	for i := range pod.Spec.Containers {
+		if limit, found := pod.Spec.Containers[i].Resources.Limits[resourceName]; !found || limit.IsZero() {
+			return false
+		}
+	}
+
+	return true
 }
 
 // AggregateContainerLimits computes the aggregated resource limits of all the containers

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -970,6 +970,7 @@ func TestPodResourceLimits(t *testing.T) {
 		description           string
 		options               PodResourcesOptions
 		overhead              v1.ResourceList
+		podLevelResources     *v1.ResourceRequirements
 		initContainers        []v1.Container
 		initContainerStatuses []v1.ContainerStatus
 		containers            []v1.Container
@@ -1115,11 +1116,8 @@ func TestPodResourceLimits(t *testing.T) {
 			},
 		},
 		{
-			description: "one limited and one unlimited container should result in the limited container's limits for the pod",
-			expectedLimits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("2"),
-				v1.ResourceMemory: resource.MustParse("2Gi"),
-			},
+			description:    "one limited and one unlimited container should result in no pod limits",
+			expectedLimits: v1.ResourceList{},
 			initContainers: []v1.Container{},
 			containers: []v1.Container{
 				{
@@ -1136,11 +1134,8 @@ func TestPodResourceLimits(t *testing.T) {
 			},
 		},
 		{
-			description: "one limited and one unlimited init container should result in the limited init container's limits for the pod",
-			expectedLimits: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse("2"),
-				v1.ResourceMemory: resource.MustParse("2Gi"),
-			},
+			description:    "one limited and one unlimited init container should result in no pod limits",
+			expectedLimits: v1.ResourceList{},
 			initContainers: []v1.Container{
 				{
 					Resources: v1.ResourceRequirements{
@@ -1546,6 +1541,100 @@ func TestPodResourceLimits(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "cpu limit missing on one container is omitted by default",
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			description: "only the resource that is missing on a container is omitted",
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				}}},
+			},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Gi")},
+		},
+		{
+			description: "init container missing the limit omits the limit",
+			initContainers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}}},
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			description: "ephemeral-storage partial sums are kept, only cpu and memory limits are omitted",
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceEphemeralStorage: resource.MustParse("1Gi")}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			expectedLimits: v1.ResourceList{v1.ResourceEphemeralStorage: resource.MustParse("1Gi")},
+		},
+		{
+			description: "hugepages are kept, an unset hugepages limit means zero",
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{"hugepages-2Mi": resource.MustParse("2Mi")}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			expectedLimits: v1.ResourceList{"hugepages-2Mi": resource.MustParse("2Mi")},
+		},
+		{
+			description: "extended resources are kept, an unset extended resource limit means zero",
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{"example.com/gpu": resource.MustParse("1")}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			expectedLimits: v1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+		},
+		{
+			description:       "pod-level limit covers the container that omits one",
+			podLevelResources: &v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4")}},
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			expectedLimits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4")},
+		},
+		{
+			description: "overhead is not added to an omitted limit",
+			overhead: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				}}},
+			},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("2112Mi")},
+		},
+		{
+			description: "restartable init container missing the limit omits the limit",
+			initContainers: []v1.Container{
+				{
+					RestartPolicy: &restartAlways,
+					Resources:     v1.ResourceRequirements{Limits: v1.ResourceList{}},
+				},
+			},
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}}},
+			},
+			expectedLimits: v1.ResourceList{},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
@@ -1554,6 +1643,7 @@ func TestPodResourceLimits(t *testing.T) {
 					Containers:     tc.containers,
 					InitContainers: tc.initContainers,
 					Overhead:       tc.overhead,
+					Resources:      tc.podLevelResources,
 				},
 				Status: v1.PodStatus{
 					ContainerStatuses:     tc.containerStatuses,

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -970,6 +970,7 @@ func TestPodResourceLimits(t *testing.T) {
 		description           string
 		options               PodResourcesOptions
 		overhead              v1.ResourceList
+		podLevelResources     *v1.ResourceRequirements
 		initContainers        []v1.Container
 		initContainerStatuses []v1.ContainerStatus
 		containers            []v1.Container
@@ -1546,6 +1547,86 @@ func TestPodResourceLimits(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "OmitPartialLimits unset, cpu limit missing on one container",
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			// partial sum is returned.
+			expectedLimits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+		},
+		{
+			description: "OmitPartialLimits set, cpu limit missing on one container",
+			options:     PodResourcesOptions{OmitPartialLimits: true},
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			description: "OmitPartialLimits drops only the resource that is missing",
+			options:     PodResourcesOptions{OmitPartialLimits: true},
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				}}},
+			},
+			expectedLimits: v1.ResourceList{v1.ResourceMemory: resource.MustParse("2Gi")},
+		},
+		{
+			description: "OmitPartialLimits, init container missing the limit",
+			options:     PodResourcesOptions{OmitPartialLimits: true},
+			initContainers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}}},
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			description: "OmitPartialLimits, ephemeral-storage missing on one container",
+			options:     PodResourcesOptions{OmitPartialLimits: true},
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceEphemeralStorage: resource.MustParse("1Gi")}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			expectedLimits: v1.ResourceList{},
+		},
+		{
+			description: "OmitPartialLimits keeps hugepages, where an unset limit means zero",
+			options:     PodResourcesOptions{OmitPartialLimits: true},
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{"hugepages-2Mi": resource.MustParse("2Mi")}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			expectedLimits: v1.ResourceList{"hugepages-2Mi": resource.MustParse("2Mi")},
+		},
+		{
+			description: "OmitPartialLimits keeps extended resources, where an unset limit means zero",
+			options:     PodResourcesOptions{OmitPartialLimits: true},
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{"example.com/gpu": resource.MustParse("1")}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			expectedLimits: v1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+		},
+		{
+			description:       "OmitPartialLimits, pod-level limit covers the container that omits one",
+			options:           PodResourcesOptions{OmitPartialLimits: true},
+			podLevelResources: &v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4")}},
+			containers: []v1.Container{
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}}},
+				{Resources: v1.ResourceRequirements{Limits: v1.ResourceList{}}},
+			},
+			expectedLimits: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4")},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
@@ -1554,6 +1635,7 @@ func TestPodResourceLimits(t *testing.T) {
 					Containers:     tc.containers,
 					InitContainers: tc.initContainers,
 					Overhead:       tc.overhead,
+					Resources:      tc.podLevelResources,
 				},
 				Status: v1.PodStatus{
 					ContainerStatuses:     tc.containerStatuses,

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -6384,6 +6384,26 @@ func TestDescribeNode(t *testing.T) {
 				Phase: corev1.PodRunning,
 			},
 		},
+		&corev1.Pod{
+			Name:      "pod-with-limits",
+			Namespace: "foo",
+			Kind:      "Pod",
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "cpu-mem-limits",
+						Image: "image:latest",
+						Resources: corev1.ResourceRequirements{
+							Requests: getResourceList("1", "1Gi"),
+							Limits:   getResourceList("2", "2Gi"),
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			},
+		},
 		&corev1.EventList{
 			Items: []corev1.Event{
 				{
@@ -6433,8 +6453,8 @@ func TestDescribeNode(t *testing.T) {
   (Total limits may be over 100 percent, i.e., overcommitted.)
   Resource           Requests     Limits
   --------           --------     ------
-  cpu                1 (25%)      2 (50%)
-  memory             1Gi (8%)     2Gi (16%)
+  cpu                2 (50%)      2 (50%)
+  memory             2Gi (16%)    2Gi (16%)
   ephemeral-storage  0 (0%)       0 (0%)
   hugepages-1Gi      0 (0%)       0 (0%)
   hugepages-2Mi      512Mi (25%)  512Mi (25%)`,
@@ -6585,8 +6605,8 @@ func TestDescribeNodeWithSidecar(t *testing.T) {
   (Total limits may be over 100 percent, i.e., overcommitted.)
   Resource           Requests     Limits
   --------           --------     ------
-  cpu                2 (50%)      2 (50%)
-  memory             2Gi (16%)    2Gi (16%)
+  cpu                2 (50%)      0 (0%)
+  memory             2Gi (16%)    0 (0%)
   ephemeral-storage  0 (0%)       0 (0%)
   hugepages-1Gi      0 (0%)       0 (0%)
   hugepages-2Mi      512Mi (25%)  512Mi (25%)`,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

PodLimits() counts a container that omits a limit as zero, so when only some containers in a pod declare limits, the partial limit is set as sandbox limit. 

`ResourceConfigForPod()` already guards against this by
tracking whether limits are declared by all containers or at the pod level before setting pod cgroup limits. This PR extracts the same logic for calculating sandbox resources.

This bug has likely remained unnoticed because:
1. runc-based runtimes ignore sanbox resources. The kubelet owns the pod cgroup, which is correctly left unlimited.
2. VM-based runtimes like Kata Containers that do act on the field are typically used with Guaranteed pods, where every container declares limits.


#### Which issue(s) this PR is related to:
Fixes #140810
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixes a bug where the kubelet set pod sandbox CPU and memory limits to the partial sum of container limits when only some containers declared them. The sandbox limits are now unlimited when unset, to match pod cgroup behavior.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
