### PR TITLE
Keep core-type paramKind informers running when an admission policy is unbound

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
@@ -78,7 +78,8 @@ type paramInfo struct {
 	mapping meta.RESTMapping
 
 	// When the param is changed, or the informer is done being used, the cancel
-	// func should be called to stop/cleanup the original informer
+	// func should be called to stop/cleanup the original informer.
+	// No-op for shared informer factory informers, which cannot be stopped.
 	cancelFunc func()
 
 	// The lister for this param
@@ -416,9 +417,9 @@ func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.
 	}
 
 	// We are not watching this param. Start an informer for it.
-	instanceContext, instanceCancel := context.WithCancel(s.ctx)
-
 	var informer informers.GenericInformer
+
+	cancelFunc := func() {}
 
 	// Try to see if our provided informer factory has an informer for this type.
 	// We assume the informer is already started, and starts all types associated
@@ -426,9 +427,9 @@ func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.
 	if genericInformer, err := s.informerFactory.ForResource(mapping.Resource); err == nil {
 		informer = genericInformer
 
-		// Start the informer
-		s.informerFactory.Start(instanceContext.Done())
-
+		// Shared with the other factory consumers, so it outlives this paramKind.
+		// The factory cannot restart an informer it has already started.
+		s.informerFactory.Start(s.ctx.Done())
 	} else {
 		// Dynamic JSON informer fallback.
 		// Cannot use shared dynamic informer since it would be impossible
@@ -444,13 +445,17 @@ func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 			nil,
 		)
+
+		// Owned by this paramKind alone, so it is safe to stop.
+		instanceContext, instanceCancel := context.WithCancel(s.ctx)
+		cancelFunc = instanceCancel
 		go informer.Informer().Run(instanceContext.Done())
 	}
 
 	klog.Infof("informer started for %v", *paramSource)
 	ret := &paramInfo{
 		mapping:    *mapping,
-		cancelFunc: instanceCancel,
+		cancelFunc: cancelFunc,
 		informer:   informer,
 	}
 	s.paramsCRDControllers[*paramSource] = ret

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
@@ -19,6 +19,7 @@ package generic_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -191,6 +192,61 @@ func TestPolicySourceBindsToPolicies(t *testing.T) {
 	require.Len(t, testContext.Source.Hooks()[0].Bindings, 1, "should have one binding")
 	require.Equal(t, "binding1", testContext.Source.Hooks()[0].Bindings[0].GetName(), "binding name should be binding1")
 
+}
+
+// TestPolicySourceCoreParamKindSurvivesUnbind checks that unbinding a policy
+// does not stop the shared informer backing a built-in paramKind. The factory
+// never restarts an informer it has already started, so stopping one freezes
+// its store for the life of the process.
+// Regression test for https://github.com/kubernetes/kubernetes/issues/130887.
+func TestPolicySourceCoreParamKindSurvivesUnbind(t *testing.T) {
+	t.Cleanup(generic.SetPolicyRefreshIntervalForTests(10 * time.Millisecond))
+
+	policy := &FakePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy"},
+		ParamKind: &v1.ParamKind{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+	}
+	binding := &FakeBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-binding"},
+		PolicyName: "test-policy",
+		ParamRef:   &v1.ParamRef{Name: "param-1", Namespace: "default"},
+	}
+
+	testContext, testCancel, err := generic.NewPolicyTestContext(
+		t,
+		func(fp *FakePolicy) generic.PolicyAccessor { return fp },
+		func(fb *FakeBinding) generic.BindingAccessor { return fb },
+		func(fp *FakePolicy) generic.Evaluator { return nil },
+		makeTestDispatcher,
+		[]runtime.Object{policy, binding},
+		nil,
+	)
+	require.NoError(t, err)
+	defer testCancel()
+	require.NoError(t, testContext.Start())
+
+	// While bound, the param informer observes ConfigMaps created after the policy.
+	require.NoError(t, testContext.UpdateAndWait(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "param-1", Namespace: "default"},
+		Data:       map[string]string{"limit": "1"},
+	}), "param created while the policy is bound should become visible")
+
+	// Unbinding drops the paramKind and calls its cancel func.
+	require.NoError(t, testContext.DeleteAndWait(binding))
+	require.Empty(t, testContext.Source.Hooks(), "unbound policy should produce no hooks")
+
+	// Re-bind the policy, pointing at a param created after the unbind.
+	binding.ParamRef = &v1.ParamRef{Name: "param-2", Namespace: "default"}
+	require.NoError(t, testContext.UpdateAndWait(binding))
+
+	// The shared informer is still running, so the new param reaches its store.
+	require.NoError(t, testContext.UpdateAndWait(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "param-2", Namespace: "default"},
+		Data:       map[string]string{"limit": "2"},
+	}), "param created after the policy was re-bound should become visible")
 }
 
 type FakePolicy struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A `ValidatingAdmissionPolicy` (or `MutatingAdmissionPolicy`) whose `paramKind` is a built-in type such as `v1/ConfigMap` permanently loses param resolution the first time the policy has no bindings. Only an apiserver restart recovers it.

Two symptoms, depending on what was in the informer store when it froze:

1. The store lost the param, or the binding points at a param created later. Every matched write is denied with ``no params found for policy binding with `Deny` parameterNotFoundAction``, forever.
2. The store still holds the old param. No error at all. The policy validates against an object that no longer exists in etcd. I measured an apiserver admitting a request validated against `token=v2` while etcd held `token=v3`.

CRD paramKinds are not affected.

Mechanism, on master at 7c2b6c3:

1. [`calculatePolicyData` builds `usedParams` by iterating bindings](https://github.com/kubernetes/kubernetes/blob/7c2b6c32644a2cc24029ec77576940b63ecca7e7/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go#L300-L307), so a policy with no binding contributes [nothing to `usedParams`](https://github.com/kubernetes/kubernetes/blob/7c2b6c32644a2cc24029ec77576940b63ecca7e7/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go#L349-L351).
2. A paramKind missing from `usedParams` gets [its `cancelFunc` called and is dropped from `paramsCRDControllers`](https://github.com/kubernetes/kubernetes/blob/7c2b6c32644a2cc24029ec77576940b63ecca7e7/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go#L381-L387).
3. For a built-in type, [`ensureParamsForPolicyLocked` takes the informer from the shared `informerFactory` and starts that factory with a per-paramKind context](https://github.com/kubernetes/kubernetes/blob/7c2b6c32644a2cc24029ec77576940b63ecca7e7/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go#L419-L430). The [CRD fallback](https://github.com/kubernetes/kubernetes/blob/7c2b6c32644a2cc24029ec77576940b63ecca7e7/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go#L432-L448) allocates a fresh dynamic informer per context, which is why CRDs are fine.
4. [`sharedInformerFactory.StartWithContext` sets `startedInformers[informerType] = true` and never clears it](https://github.com/kubernetes/kubernetes/blob/7c2b6c32644a2cc24029ec77576940b63ecca7e7/staging/src/k8s.io/client-go/informers/factory.go#L167-L183), so a later `Start` is a no-op for that informer.

So the first time a built-in paramKind goes unreferenced, `cancelFunc` stops a shared informer that `Start` will never run again. The store freezes instead of emptying. That is why symptom 2 is silent.

The fix starts the shared factory with the policy source's own long-lived context (`s.ctx`), which is already the parent of the per-instance context. Only the dynamic informer, which the source owns outright, still gets a cancelable context.

Both ValidatingAdmissionPolicy and MutatingAdmissionPolicy construct this same `policySource` ([validating](https://github.com/kubernetes/kubernetes/blob/7c2b6c32644a2cc24029ec77576940b63ecca7e7/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/plugin.go#L121), [mutating](https://github.com/kubernetes/kubernetes/blob/7c2b6c32644a2cc24029ec77576940b63ecca7e7/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin.go#L137)), so the fix covers both.

#### Which issue(s) this PR is related to:

Fixes #130887

#### Special notes for your reviewer:

Trade-off: a built-in paramKind informer now runs for the life of the apiserver, even after the last policy using it goes away. That is already true for every other consumer of that factory, and it is the only lifecycle `SharedInformerFactory` supports. It cannot stop an individual informer, and it cannot restart one it has already started. A per-paramKind lifetime is not expressible against that API.

I also made the shared branch's `cancelFunc` an explicit no-op instead of a `context.CancelFunc` that nothing listens to. Nothing listened to it before either.

Alternative considered: drop the shared-factory fast path and always use the dynamic informer. That is uniform and genuinely stoppable, and the informer would go away when the last policy referencing the paramKind does. The cost is losing informer sharing for the common ConfigMap case, so every policy source runs its own ConfigMap watch instead of reusing the apiserver's.

I went with the smaller change because it backports cleanly, but I have no strong attachment. If you would rather have uniform stoppable informers, say so and I will switch it.

No integration test. The failure is entirely in the policy source's informer lifecycle, and the unit test drives that against a real `informers.NewSharedInformerFactory`, so the `startedInformers` semantics under test are the real ones rather than a fake's. An integration test would pay several seconds of apiserver startup to watch the same store freeze. Happy to add one under `test/integration/apiserver/cel` if you want it.

#### Verification

`TestPolicySourceCoreParamKindSurvivesUnbind` binds a policy with a `v1/ConfigMap` paramKind, confirms a param created after binding is visible, deletes the only binding, lets a refresh tick run, then re-binds against a param created after the unbind.

Against pre-fix `policy_source.go`, it fails on the 5s `UpdateAndWait` timeout:

```
--- FAIL: TestPolicySourceCoreParamKindSurvivesUnbind (5.46s)
    policy_source_test.go:246:
        	Error:      	Received unexpected error:
        	            	error waiting for reconcile of &ConfigMap{ObjectMeta:{param-2  default ...},Data:map[string]string{limit: 2,},...}: context deadline exceeded
        	Messages:   	param created after the policy was re-bound should become visible
FAIL	k8s.io/apiserver/pkg/admission/plugin/policy/generic	6.155s
```

With the fix:

```
$ go test ./pkg/admission/plugin/policy/... -count=1
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/config	0.362s
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/generic	7.230s
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/internal/generic	1.930s
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/manifest/loader	1.207s
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/manifest/source	2.137s
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/matching	1.612s
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/mutating	8.115s
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/mutating/metrics	2.987s
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/mutating/patch	2.417s
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/validating	25.792s
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/validating/metrics	3.805s

$ go test ./pkg/admission/plugin/policy/generic/ -run TestPolicySourceCoreParamKindSurvivesUnbind -count=5 -race
ok  	k8s.io/apiserver/pkg/admission/plugin/policy/generic	4.659s
```

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where a ValidatingAdmissionPolicy or MutatingAdmissionPolicy with a paramKind referencing a built-in type (such as v1/ConfigMap) permanently stopped resolving params once all of its bindings were deleted. Affected policies either denied every matched request (with `parameterNotFoundAction: Deny`) or silently evaluated against a stale param, until the apiserver was restarted.
```
