### PR TITLE
pkg/kubelet/cm: add unit tests for PostStopContainer and PreCreateContainer

### DIFF
--- a/pkg/kubelet/cm/internal_container_lifecycle_linux_test.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_linux_test.go
@@ -1,0 +1,189 @@
+//go:build linux
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/utils/cpuset"
+)
+
+type mockCPUManagerWithAffinity struct {
+	cpuAffinity cpuset.CPUSet
+	cpumanager.Manager
+}
+
+func (m *mockCPUManagerWithAffinity) GetCPUAffinity(string, string) cpuset.CPUSet {
+	return m.cpuAffinity
+}
+
+type mockMemoryManagerWithNUMA struct {
+	numaNodes sets.Set[int]
+	memorymanager.Manager
+}
+
+func (m *mockMemoryManagerWithNUMA) GetMemoryNUMANodes(klog.Logger, *v1.Pod, *v1.Container) sets.Set[int] {
+	return m.numaNodes
+}
+
+func TestPreCreateContainer(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "test-pod-uid",
+		},
+	}
+	container := &v1.Container{
+		Name: "test-container",
+	}
+
+	tests := []struct {
+		name                        string
+		lifecycle                   internalContainerLifecycleImpl
+		expectedCpusetCpus          string
+		expectedCpusetMems          string
+		expectCpusetCpusSet         bool
+		expectCpusetMemsSet         bool
+	}{
+		{
+			name: "CPU manager with allocated CPUs sets CpusetCpus",
+			lifecycle: internalContainerLifecycleImpl{
+				cpuManager: &mockCPUManagerWithAffinity{
+					cpuAffinity: cpuset.New(0, 1, 2),
+				},
+				memoryManager:   nil,
+				topologyManager: &mockTopologyManager{},
+			},
+			expectCpusetCpusSet: true,
+			expectedCpusetCpus:  "0-2",
+			expectCpusetMemsSet: false,
+		},
+		{
+			name: "CPU manager with empty CPU affinity does not set CpusetCpus",
+			lifecycle: internalContainerLifecycleImpl{
+				cpuManager: &mockCPUManagerWithAffinity{
+					cpuAffinity: cpuset.New(),
+				},
+				memoryManager:   nil,
+				topologyManager: &mockTopologyManager{},
+			},
+			expectCpusetCpusSet: false,
+			expectedCpusetCpus:  "",
+			expectCpusetMemsSet: false,
+		},
+		{
+			name: "Memory manager with NUMA nodes sets CpusetMems",
+			lifecycle: internalContainerLifecycleImpl{
+				cpuManager: nil,
+				memoryManager: &mockMemoryManagerWithNUMA{
+					numaNodes: sets.New[int](0, 1),
+				},
+				topologyManager: &mockTopologyManager{},
+			},
+			expectCpusetCpusSet: false,
+			expectedCpusetCpus:  "",
+			expectCpusetMemsSet: true,
+			expectedCpusetMems:  "0,1",
+		},
+		{
+			name: "Memory manager with empty NUMA nodes does not set CpusetMems",
+			lifecycle: internalContainerLifecycleImpl{
+				cpuManager: nil,
+				memoryManager: &mockMemoryManagerWithNUMA{
+					numaNodes: nil,
+				},
+				topologyManager: &mockTopologyManager{},
+			},
+			expectCpusetCpusSet: false,
+			expectedCpusetCpus:  "",
+			expectCpusetMemsSet: false,
+		},
+		{
+			name: "Both CPU manager and Memory manager set respective fields",
+			lifecycle: internalContainerLifecycleImpl{
+				cpuManager: &mockCPUManagerWithAffinity{
+					cpuAffinity: cpuset.New(0, 1),
+				},
+				memoryManager: &mockMemoryManagerWithNUMA{
+					numaNodes: sets.New[int](0),
+				},
+				topologyManager: &mockTopologyManager{},
+			},
+			expectCpusetCpusSet: true,
+			expectedCpusetCpus:  "0-1",
+			expectCpusetMemsSet: true,
+			expectedCpusetMems:  "0",
+		},
+		{
+			name: "Neither CPU manager nor Memory manager is set",
+			lifecycle: internalContainerLifecycleImpl{
+				cpuManager:      nil,
+				memoryManager:   nil,
+				topologyManager: &mockTopologyManager{},
+			},
+			expectCpusetCpusSet: false,
+			expectedCpusetCpus:  "",
+			expectCpusetMemsSet: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			containerConfig := &runtimeapi.ContainerConfig{
+				Linux: &runtimeapi.LinuxContainerConfig{
+					Resources: &runtimeapi.LinuxContainerResources{},
+				},
+			}
+
+			err := test.lifecycle.PreCreateContainer(logger, pod, container, containerConfig)
+			if err != nil {
+				t.Errorf("PreCreateContainer should not return an error, got: %v", err)
+			}
+
+			if test.expectCpusetCpusSet {
+				if containerConfig.Linux.Resources.CpusetCpus != test.expectedCpusetCpus {
+					t.Errorf("expected CpusetCpus=%q, got %q", test.expectedCpusetCpus, containerConfig.Linux.Resources.CpusetCpus)
+				}
+			} else {
+				if containerConfig.Linux.Resources.CpusetCpus != "" {
+					t.Errorf("expected CpusetCpus to be empty, got %q", containerConfig.Linux.Resources.CpusetCpus)
+				}
+			}
+
+			if test.expectCpusetMemsSet {
+				if containerConfig.Linux.Resources.CpusetMems != test.expectedCpusetMems {
+					t.Errorf("expected CpusetMems=%q, got %q", test.expectedCpusetMems, containerConfig.Linux.Resources.CpusetMems)
+				}
+			} else {
+				if containerConfig.Linux.Resources.CpusetMems != "" {
+					t.Errorf("expected CpusetMems to be empty, got %q", containerConfig.Linux.Resources.CpusetMems)
+				}
+			}
+		})
+	}
+}

--- a/pkg/kubelet/cm/internal_container_lifecycle_linux_test.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_linux_test.go
@@ -62,12 +62,12 @@ func TestPreCreateContainer(t *testing.T) {
 	}
 
 	tests := []struct {
-		name                        string
-		lifecycle                   internalContainerLifecycleImpl
-		expectedCpusetCpus          string
-		expectedCpusetMems          string
-		expectCpusetCpusSet         bool
-		expectCpusetMemsSet         bool
+		name                string
+		lifecycle           internalContainerLifecycleImpl
+		expectedCpusetCpus  string
+		expectedCpusetMems  string
+		expectCpusetCpusSet bool
+		expectCpusetMemsSet bool
 	}{
 		{
 			name: "CPU manager with allocated CPUs sets CpusetCpus",
@@ -96,6 +96,19 @@ func TestPreCreateContainer(t *testing.T) {
 			expectCpusetMemsSet: false,
 		},
 		{
+			name: "CPU manager with non-contiguous CPUs sets CpusetCpus with comma-separated values",
+			lifecycle: internalContainerLifecycleImpl{
+				cpuManager: &mockCPUManagerWithAffinity{
+					cpuAffinity: cpuset.New(0, 2, 4),
+				},
+				memoryManager:   nil,
+				topologyManager: &mockTopologyManager{},
+			},
+			expectCpusetCpusSet: true,
+			expectedCpusetCpus:  "0,2,4",
+			expectCpusetMemsSet: false,
+		},
+		{
 			name: "Memory manager with NUMA nodes sets CpusetMems",
 			lifecycle: internalContainerLifecycleImpl{
 				cpuManager: nil,
@@ -108,6 +121,20 @@ func TestPreCreateContainer(t *testing.T) {
 			expectedCpusetCpus:  "",
 			expectCpusetMemsSet: true,
 			expectedCpusetMems:  "0,1",
+		},
+		{
+			name: "Memory manager with single NUMA node sets CpusetMems without comma",
+			lifecycle: internalContainerLifecycleImpl{
+				cpuManager: nil,
+				memoryManager: &mockMemoryManagerWithNUMA{
+					numaNodes: sets.New[int](2),
+				},
+				topologyManager: &mockTopologyManager{},
+			},
+			expectCpusetCpusSet: false,
+			expectedCpusetCpus:  "",
+			expectCpusetMemsSet: true,
+			expectedCpusetMems:  "2",
 		},
 		{
 			name: "Memory manager with empty NUMA nodes does not set CpusetMems",
@@ -186,4 +213,146 @@ func TestPreCreateContainer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPreCreateContainerDoesNotOverwriteExistingLinuxConfig(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "test-pod-uid",
+		},
+	}
+	container := &v1.Container{
+		Name: "test-container",
+	}
+
+	containerConfig := &runtimeapi.ContainerConfig{
+		Linux: &runtimeapi.LinuxContainerConfig{
+			Resources: &runtimeapi.LinuxContainerResources{
+				CpusetCpus: "existing-value",
+				CpusetMems: "existing-mems",
+			},
+		},
+	}
+
+	lifecycle := internalContainerLifecycleImpl{
+		cpuManager:      nil,
+		memoryManager:   nil,
+		topologyManager: &mockTopologyManager{},
+	}
+
+	err := lifecycle.PreCreateContainer(logger, pod, container, containerConfig)
+	if err != nil {
+		t.Errorf("PreCreateContainer should not return an error, got: %v", err)
+	}
+
+	if containerConfig.Linux.Resources.CpusetCpus != "existing-value" {
+		t.Errorf("expected existing CpusetCpus to be preserved when no managers set new values, got %q", containerConfig.Linux.Resources.CpusetCpus)
+	}
+	if containerConfig.Linux.Resources.CpusetMems != "existing-mems" {
+		t.Errorf("expected existing CpusetMems to be preserved when no managers set new values, got %q", containerConfig.Linux.Resources.CpusetMems)
+	}
+}
+
+func TestPreCreateContainerOverwritesExistingValuesWhenManagersProvideThem(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "test-pod-uid",
+		},
+	}
+	container := &v1.Container{
+		Name: "test-container",
+	}
+
+	containerConfig := &runtimeapi.ContainerConfig{
+		Linux: &runtimeapi.LinuxContainerConfig{
+			Resources: &runtimeapi.LinuxContainerResources{
+				CpusetCpus: "existing-value",
+				CpusetMems: "existing-mems",
+			},
+		},
+	}
+
+	lifecycle := internalContainerLifecycleImpl{
+		cpuManager: &mockCPUManagerWithAffinity{
+			cpuAffinity: cpuset.New(0),
+		},
+		memoryManager: &mockMemoryManagerWithNUMA{
+			numaNodes: sets.New[int](1),
+		},
+		topologyManager: &mockTopologyManager{},
+	}
+
+	err := lifecycle.PreCreateContainer(logger, pod, container, containerConfig)
+	if err != nil {
+		t.Errorf("PreCreateContainer should not return an error, got: %v", err)
+	}
+
+	if containerConfig.Linux.Resources.CpusetCpus != "0" {
+		t.Errorf("expected CpusetCpus to be overwritten to %q, got %q", "0", containerConfig.Linux.Resources.CpusetCpus)
+	}
+	if containerConfig.Linux.Resources.CpusetMems != "1" {
+		t.Errorf("expected CpusetMems to be overwritten to %q, got %q", "1", containerConfig.Linux.Resources.CpusetMems)
+	}
+}
+
+func TestPreCreateContainerPodUIDPassedCorrectly(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	type trackedCall struct {
+		podUID         string
+		containerName  string
+	}
+	track := &trackedCall{}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "my-pod-uid",
+		},
+	}
+	container := &v1.Container{
+		Name: "my-container",
+	}
+
+	containerConfig := &runtimeapi.ContainerConfig{
+		Linux: &runtimeapi.LinuxContainerConfig{
+			Resources: &runtimeapi.LinuxContainerResources{},
+		},
+	}
+
+	lifecycle := internalContainerLifecycleImpl{
+		cpuManager: &mockCPUManagerTrackingArgs{
+			cpuAffinity: cpuset.New(0),
+			track:       track,
+		},
+		memoryManager:   nil,
+		topologyManager: &mockTopologyManager{},
+	}
+
+	_ = lifecycle.PreCreateContainer(logger, pod, container, containerConfig)
+
+	if track.podUID != "my-pod-uid" {
+		t.Errorf("expected GetCPUAffinity called with podUID=%q, got %q", "my-pod-uid", track.podUID)
+	}
+	if track.containerName != "my-container" {
+		t.Errorf("expected GetCPUAffinity called with containerName=%q, got %q", "my-container", track.containerName)
+	}
+}
+
+type mockCPUManagerTrackingArgs struct {
+	cpuAffinity cpuset.CPUSet
+	track       *struct {
+		podUID        string
+		containerName string
+	}
+	cpumanager.Manager
+}
+
+func (m *mockCPUManagerTrackingArgs) GetCPUAffinity(podUID string, containerName string) cpuset.CPUSet {
+	m.track.podUID = podUID
+	m.track.containerName = containerName
+	return m.cpuAffinity
 }

--- a/pkg/kubelet/cm/internal_container_lifecycle_test.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cm
 
 import (
+	"errors"
 	"testing"
 
 	"k8s.io/klog/v2"
@@ -49,6 +50,8 @@ func (memoryManager *mockMemoryManager) AddContainer(klog.Logger, *v1.Pod, *v1.C
 type mockTopologyManager struct {
 	addContainerCalled    bool
 	removeContainerCalled bool
+	removeContainerErr    error
+	removeContainerID     string
 	topologymanager.Manager
 }
 
@@ -56,9 +59,10 @@ func (topologyManager *mockTopologyManager) AddContainer(klog.Logger, *v1.Pod, *
 	topologyManager.addContainerCalled = true
 }
 
-func (topologyManager *mockTopologyManager) RemoveContainer(klog.Logger, string) error {
+func (topologyManager *mockTopologyManager) RemoveContainer(_ klog.Logger, containerID string) error {
 	topologyManager.removeContainerCalled = true
-	return nil
+	topologyManager.removeContainerID = containerID
+	return topologyManager.removeContainerErr
 }
 
 func TestPreStartContainer(t *testing.T) {
@@ -96,7 +100,10 @@ func TestPreStartContainer(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
-			_ = test.lifecycle.PreStartContainer(logger, pod, container, "42")
+			err := test.lifecycle.PreStartContainer(logger, pod, container, "42")
+			if err != nil {
+				t.Errorf("PreStartContainer should not return an error, got: %v", err)
+			}
 		})
 
 		cManager := test.lifecycle.cpuManager
@@ -116,30 +123,65 @@ func TestPreStartContainer(t *testing.T) {
 
 func TestPostStopContainer(t *testing.T) {
 	tests := []struct {
-		name              string
-		lifecycle         internalContainerLifecycleImpl
-		expectRemoveCalled bool
+		name                string
+		lifecycle           internalContainerLifecycleImpl
+		containerID         string
+		expectRemoveCalled  bool
+		expectErr           bool
+		expectedContainerID string
 	}{
 		{
-			name: "When topology manager RemoveContainer is called",
+			name: "RemoveContainer is called with the correct container ID",
 			lifecycle: internalContainerLifecycleImpl{
 				topologyManager: &mockTopologyManager{},
 			},
-			expectRemoveCalled: true,
+			containerID:         "test-container-id",
+			expectRemoveCalled:  true,
+			expectErr:           false,
+			expectedContainerID: "test-container-id",
+		},
+		{
+			name: "RemoveContainer error is propagated",
+			lifecycle: internalContainerLifecycleImpl{
+				topologyManager: &mockTopologyManager{
+					removeContainerErr: errors.New("RemoveContainer failed"),
+				},
+			},
+			containerID:         "failing-container-id",
+			expectRemoveCalled:  true,
+			expectErr:           true,
+			expectedContainerID: "failing-container-id",
+		},
+		{
+			name: "RemoveContainer called with empty container ID",
+			lifecycle: internalContainerLifecycleImpl{
+				topologyManager: &mockTopologyManager{},
+			},
+			containerID:         "",
+			expectRemoveCalled:  true,
+			expectErr:           false,
+			expectedContainerID: "",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
-			err := test.lifecycle.PostStopContainer(logger, "test-container-id")
-			if err != nil {
+			err := test.lifecycle.PostStopContainer(logger, test.containerID)
+
+			if test.expectErr && err == nil {
+				t.Errorf("expected an error but got nil")
+			}
+			if !test.expectErr && err != nil {
 				t.Errorf("PostStopContainer should not return an error, got: %v", err)
 			}
 
 			tManager := test.lifecycle.topologyManager.(*mockTopologyManager)
 			if test.expectRemoveCalled != tManager.removeContainerCalled {
 				t.Errorf("expected RemoveContainer called=%v, got called=%v", test.expectRemoveCalled, tManager.removeContainerCalled)
+			}
+			if tManager.removeContainerID != test.expectedContainerID {
+				t.Errorf("expected RemoveContainer called with containerID=%q, got %q", test.expectedContainerID, tManager.removeContainerID)
 			}
 		})
 	}

--- a/pkg/kubelet/cm/internal_container_lifecycle_test.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_test.go
@@ -47,12 +47,18 @@ func (memoryManager *mockMemoryManager) AddContainer(klog.Logger, *v1.Pod, *v1.C
 }
 
 type mockTopologyManager struct {
-	called bool
+	addContainerCalled    bool
+	removeContainerCalled bool
 	topologymanager.Manager
 }
 
 func (topologyManager *mockTopologyManager) AddContainer(klog.Logger, *v1.Pod, *v1.Container, string) {
-	topologyManager.called = true
+	topologyManager.addContainerCalled = true
+}
+
+func (topologyManager *mockTopologyManager) RemoveContainer(klog.Logger, string) error {
+	topologyManager.removeContainerCalled = true
+	return nil
 }
 
 func TestPreStartContainer(t *testing.T) {
@@ -102,8 +108,39 @@ func TestPreStartContainer(t *testing.T) {
 		if mManager != nil && !mManager.(*mockMemoryManager).called {
 			t.Errorf("When a Memory manager is provided it must have AddContainer called")
 		}
-		if !tManager.(*mockTopologyManager).called {
+		if !tManager.(*mockTopologyManager).addContainerCalled {
 			t.Errorf("TopologyManager's AddContainer method must be called during container startup")
 		}
+	}
+}
+
+func TestPostStopContainer(t *testing.T) {
+	tests := []struct {
+		name              string
+		lifecycle         internalContainerLifecycleImpl
+		expectRemoveCalled bool
+	}{
+		{
+			name: "When topology manager RemoveContainer is called",
+			lifecycle: internalContainerLifecycleImpl{
+				topologyManager: &mockTopologyManager{},
+			},
+			expectRemoveCalled: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			err := test.lifecycle.PostStopContainer(logger, "test-container-id")
+			if err != nil {
+				t.Errorf("PostStopContainer should not return an error, got: %v", err)
+			}
+
+			tManager := test.lifecycle.topologyManager.(*mockTopologyManager)
+			if test.expectRemoveCalled != tManager.removeContainerCalled {
+				t.Errorf("expected RemoveContainer called=%v, got called=%v", test.expectRemoveCalled, tManager.removeContainerCalled)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

Adds comprehensive unit test coverage for the `internalContainerLifecycleImpl` struct in `pkg/kubelet/cm`:

### `internal_container_lifecycle_test.go` (cross-platform)

**TestPreStartContainer** (existing, enhanced):
- Now verifies `PreStartContainer` returns `nil` (no error)

**TestPostStopContainer** (new):
- Verifies `RemoveContainer` is called with the correct container ID
- Verifies error from `RemoveContainer` is propagated to the caller
- Verifies behavior with empty container ID
- Enhanced `mockTopologyManager` to track the containerID argument and support error injection

### `internal_container_lifecycle_linux_test.go` (Linux-specific)

**TestPreCreateContainer** (new, 8 table-driven cases):
- CPU manager with allocated CPUs sets `CpusetCpus`
- CPU manager with empty affinity does not set `CpusetCpus`
- CPU manager with non-contiguous CPUs (e.g. 0,2,4) produces comma-separated output
- Memory manager with NUMA nodes sets `CpusetMems`
- Memory manager with single NUMA node produces output without comma
- Memory manager with nil/empty NUMA nodes does not set `CpusetMems`
- Both managers active simultaneously
- Neither manager set (nil managers)

**TestPreCreateContainerDoesNotOverwriteExistingLinuxConfig** (new):
- Verifies existing `CpusetCpus`/`CpusetMems` values are preserved when no managers override them

**TestPreCreateContainerOverwritesExistingValuesWhenManagersProvideThem** (new):
- Verifies that when managers provide values, they overwrite pre-existing `CpusetCpus`/`CpusetMems`

**TestPreCreateContainerPodUIDPassedCorrectly** (new):
- Verifies `pod.UID` and `container.Name` are correctly passed to `GetCPUAffinity`

## Which issue(s) this PR fixes

Related to #109717

## Special notes for your reviewer

- The existing `TestPreStartContainer` mock had a single `called` field on `mockTopologyManager`. I renamed it to `addContainerCalled` and added `removeContainerCalled`, `removeContainerID`, and `removeContainerErr` to support the new `TestPostStopContainer` tests.
- The Linux-specific `PreCreateContainer` test uses mock managers that implement `GetCPUAffinity` and `GetMemoryNUMANodes` respectively.
- The `TestPreCreateContainerPodUIDPassedCorrectly` test uses a `mockCPUManagerTrackingArgs` type to verify that the correct `podUID` and `containerName` arguments are passed through.

## Release Note

```release-note
None
```

```release-note
NONE
```