### PR TITLE
scheduler: move in-memory scheduling onto internal SchedulingAlgorithm type

### DIFF
--- a/pkg/scheduler/algorithm.go
+++ b/pkg/scheduler/algorithm.go
@@ -1,0 +1,219 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/klog/v2"
+	fwk "k8s.io/kube-scheduler/framework"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+type SchedulingAlgorithm struct {
+	nodeInfoSnapshot         *internalcache.Snapshot
+	cache                    internalcache.Cache
+	percentageOfNodesToScore int32
+	cycleProvider            func() int64
+	nextStartNodeIndex       int
+	schedulePodOverride      func(ctx context.Context, f framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error)
+	numNodesToFindOverride   func(numAllNodes int32) int32
+}
+
+func (a *SchedulingAlgorithm) currentCycle() int64 {
+	if a.cycleProvider != nil {
+		return a.cycleProvider()
+	}
+	return 0
+}
+
+type AlgorithmOption func(*SchedulingAlgorithm)
+
+func WithNumNodesToFindOverride(fn func(numAllNodes int32) int32) AlgorithmOption {
+	return func(a *SchedulingAlgorithm) {
+		a.numNodesToFindOverride = fn
+	}
+}
+func WithCycleProvider(fn func() int64) AlgorithmOption {
+	return func(a *SchedulingAlgorithm) {
+		a.cycleProvider = fn
+	}
+}
+
+// WithCache attaches a scheduler cache, enabling AssumeAndReserveInCache and
+// UnreserveAndForgetFromCache. An algorithm built without it can only assume
+// into its snapshot: pods assumed there are dropped by the next UpdateSnapshot,
+// whereas cache-assumed pods survive it until confirmed or forgotten.
+func WithCache(cache internalcache.Cache) AlgorithmOption {
+	return func(a *SchedulingAlgorithm) {
+		a.cache = cache
+	}
+}
+
+// withPercentageOfNodesToScore is unexported because the exported name is taken by
+// the scheduler.Option serving the same purpose, and Go has no
+// overloading. kube-scheduler wiring lives in this package, so unexported is enough.
+func withPercentageOfNodesToScore(percentage int32) AlgorithmOption {
+	return func(a *SchedulingAlgorithm) {
+		a.percentageOfNodesToScore = percentage
+	}
+}
+
+// NewSchedulingAlgorithm creates a standalone in-memory scheduling algorithm
+// operating on the given snapshot. The algorithm assumes pods only where the caller
+// asks it to: pass WithCache to enable the cache methods, otherwise only the snapshot
+// methods are available.
+func NewSchedulingAlgorithm(snapshot *internalcache.Snapshot, opts ...AlgorithmOption) *SchedulingAlgorithm {
+	a := &SchedulingAlgorithm{
+		nodeInfoSnapshot:         snapshot,
+		percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+// runSchedulePod dispatches to the test-only override if one was installed,
+// otherwise to the algorithm's own implementation. Production always falls
+// through to a.schedulePod. Scheduler.SchedulePod must call schedulePod directly
+// rather than runSchedulePod, so an installed override cannot recurse through it.
+func (a *SchedulingAlgorithm) runSchedulePod(ctx context.Context, f framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
+	if a.schedulePodOverride != nil {
+		return a.schedulePodOverride(ctx, f, state, podInfo)
+	}
+	return a.schedulePod(ctx, f, state, podInfo)
+}
+
+// FindAllNodesThatFitPod evaluates all placement nodes without early-exit shortcuts
+// so callers inspecting cluster capacity or running custom batching receive exhaustive results.
+func (a *SchedulingAlgorithm) FindAllNodesThatFitPod(ctx context.Context, state fwk.CycleState, schedFramework framework.Framework, podInfo *framework.QueuedPodInfo) ([]fwk.NodeInfo, framework.Diagnosis, error) {
+	nodes, diagnosis, _, err := a.findNodesThatFitPod(ctx, schedFramework, state, podInfo, true)
+	return nodes, diagnosis, err
+}
+
+// AssumeAndReserveInCache assumes the pod into the scheduler cache and runs Reserve plugins.
+// If Reserve plugins fail, the assumption is rolled back from the cache.
+func (a *SchedulingAlgorithm) AssumeAndReserveInCache(ctx context.Context, state fwk.CycleState,
+	schedFramework framework.Framework, podInfo *framework.QueuedPodInfo,
+	scheduleResult ScheduleResult) (*framework.QueuedPodInfo, *fwk.Status) {
+
+	logger := klog.FromContext(ctx)
+	host := scheduleResult.SuggestedHost
+	if a.cache == nil {
+		return podInfo, fwk.AsStatus(errors.New("SchedulingAlgorithm was built without a cache: " +
+			"use WithCache, or assume into the snapshot instead"))
+	}
+	assumedPodInfo := a.prepareAssumedPod(logger, state, podInfo, host)
+	if err := a.cache.AssumePod(logger, assumedPodInfo.Pod); err != nil {
+		logger.Error(err, "Scheduler cache AssumePod failed")
+		return assumedPodInfo, fwk.AsStatus(err)
+	}
+	schedFramework.DeleteNominatedPodIfExists(assumedPodInfo.Pod)
+
+	if status := a.reserveOrUndo(ctx, state, schedFramework, assumedPodInfo, podInfo.Pod, host,
+		func() error {
+			return a.UnreserveAndForgetFromCache(ctx, state, schedFramework, assumedPodInfo, host)
+		}); status != nil {
+		return assumedPodInfo, status
+	}
+	return assumedPodInfo, nil
+}
+
+// UnreserveAndForgetFromCache runs Unreserve plugins and forgets the pod from the scheduler cache.
+func (a *SchedulingAlgorithm) UnreserveAndForgetFromCache(ctx context.Context, state fwk.CycleState,
+	schedFramework framework.Framework, assumedPodInfo *framework.QueuedPodInfo, nodeName string) error {
+
+	logger := klog.FromContext(ctx)
+	schedFramework.RunReservePluginsUnreserve(ctx, state, assumedPodInfo.Pod, nodeName)
+	// No nomination restore here: a pod that fails after a cache assume goes back
+	// through handleSchedulingFailure, which re-adds the nomination itself.
+	return a.cache.ForgetPod(logger, assumedPodInfo.Pod)
+}
+
+// AssumeAndReserveInSnapshot assumes the pod into the transient node snapshot and runs Reserve plugins.
+// Returns a revert function to roll back the assumption and reservation from the snapshot if needed.
+func (a *SchedulingAlgorithm) AssumeAndReserveInSnapshot(ctx context.Context, state fwk.CycleState,
+	schedFramework framework.Framework, podInfo *framework.QueuedPodInfo,
+	scheduleResult ScheduleResult) (*framework.QueuedPodInfo, *fwk.Status, func()) {
+
+	logger := klog.FromContext(ctx)
+	host := scheduleResult.SuggestedHost
+
+	assumedPodInfo := a.prepareAssumedPod(logger, state, podInfo, host)
+	if err := a.nodeInfoSnapshot.AssumePod(assumedPodInfo.PodInfo); err != nil {
+		logger.Error(err, "Scheduler snapshot AssumePod failed")
+		return assumedPodInfo, fwk.AsStatus(err), nil
+	}
+	schedFramework.DeleteNominatedPodIfExists(assumedPodInfo.Pod)
+
+	revert := func() {
+		if err := a.UnreserveAndForgetFromSnapshot(ctx, state, schedFramework, assumedPodInfo, host); err != nil {
+			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
+		}
+	}
+	if status := a.reserveOrUndo(ctx, state, schedFramework, assumedPodInfo, podInfo.Pod, host,
+		func() error {
+			return a.UnreserveAndForgetFromSnapshot(ctx, state, schedFramework, assumedPodInfo, host)
+		}); status != nil {
+		return nil, status, nil
+	}
+	return assumedPodInfo, nil, revert
+}
+
+// UnreserveAndForgetFromSnapshot runs Unreserve plugins, forgets the pod from the node snapshot,
+// and restores any existing pod nomination.
+func (a *SchedulingAlgorithm) UnreserveAndForgetFromSnapshot(ctx context.Context, state fwk.CycleState,
+	schedFramework framework.Framework, assumedPodInfo *framework.QueuedPodInfo, nodeName string) error {
+
+	logger := klog.FromContext(ctx)
+	schedFramework.RunReservePluginsUnreserve(ctx, state, assumedPodInfo.Pod, nodeName)
+	if err := a.nodeInfoSnapshot.ForgetPod(logger, assumedPodInfo.Pod); err != nil {
+		return err
+	}
+	if assumedPodInfo.Pod.Status.NominatedNodeName != "" {
+		// The assume removed the nomination; reverting a tentative assume restores it.
+		schedFramework.AddNominatedPod(logger, assumedPodInfo.PodInfo, &fwk.NominatingInfo{
+			NominatedNodeName: assumedPodInfo.Pod.Status.NominatedNodeName,
+			NominatingMode:    fwk.ModeOverride,
+		})
+	}
+	return nil
+}
+
+// SchedulePod runs the filter and score phases for one pod and returns the selected
+// host. It assumes nothing and runs no PostFilter: preemption is the caller's policy.
+func (a *SchedulingAlgorithm) SchedulePod(ctx context.Context, schedFramework framework.Framework,
+	state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
+	return a.runSchedulePod(ctx, schedFramework, state, podInfo)
+}
+
+// ScheduleErrorToStatus maps an error from SchedulePod onto the Status
+// kube-scheduler uses for it, so consumers classify failures identically.
+func ScheduleErrorToStatus(err error) *fwk.Status {
+	if err == ErrNoNodesAvailable {
+		return fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(err)
+	}
+	if _, ok := err.(*framework.FitError); !ok {
+		return fwk.AsStatus(err)
+	}
+	return fwk.NewStatus(fwk.Unschedulable).WithError(err)
+}

--- a/pkg/scheduler/algorithm.go
+++ b/pkg/scheduler/algorithm.go
@@ -1,0 +1,572 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/klog/v2"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
+	"k8s.io/kubernetes/pkg/scheduler/metrics"
+	utiltrace "k8s.io/utils/trace"
+)
+
+// SchedulingAlgorithm encapsulates the state and logic required for the in-memory
+// part of a scheduling attempt. It provides methods to select a node for a pod
+// (filter, score, extenders) and assume the resulting placement in the scheduler's
+// cache and snapshot. It does not interact with the scheduling queue, run binding,
+// or handle scheduling failures - those responsibilities remain with the Scheduler.
+//
+// A SchedulingAlgorithm instance is stateful: it advances nextStartNodeIndex
+// between calls and mutates the shared node snapshot when assuming and
+// forgetting pods. It is not safe for concurrent use, so scheduling cycles
+// sharing an instance have to be serialized by the caller.
+type SchedulingAlgorithm struct {
+	// nodeInfoSnapshot is the point-in-time view of cluster nodes used during
+	// filtering and scoring. During pod group scheduling, tentative placements
+	// mutate this snapshot directly so subsequent pods in the group observe them
+	// without modifying the live cache before placement is found for the whole pod group.
+	nodeInfoSnapshot *internalcache.Snapshot
+
+	// cache is the scheduler's live cache. Successful placements are assumed here
+	// immediately so subsequent scheduling cycles account for allocated resources
+	// without waiting for asynchronous binding to complete against the apiserver.
+	cache internalcache.Cache
+
+	// percentageOfNodesToScore is the default percentage of total cluster nodes to
+	// find during filtering before proceeding to scoring. It acts as an algorithm-level
+	// fallback when a scheduling profile does not configure its own threshold,
+	// preventing exhaustive scans in large clusters.
+	percentageOfNodesToScore int32
+
+	// cycleProvider reports the current scheduling cycle counter. It is used by
+	// opportunistic batching to key and reuse scoring state and node hints strictly
+	// across consecutive cycles.
+	cycleProvider func() int64
+
+	// nextStartNodeIndex is the starting index in the node list for the next filter
+	// pass. Advancing this across scheduling cycles distributes evaluations uniformly
+	// across all nodes when percentageOfNodesToScore halts the search early.
+	nextStartNodeIndex int
+}
+
+type AlgorithmOption func(*SchedulingAlgorithm)
+
+// WithAlgorithmPercentageOfNodesToScore sets how many nodes the algorithm should evaluate
+// while filtering, as a percentage of all nodes: once the number of evaluated nodes reaches the set value and
+// at least N feasible nodes are found (where N is calculated by numFeasibleNodesToFind),
+// the search stops, and those are the nodes that go on to scoring.
+// If percentageOfNodesToScore is set on scheduler profile level, the value in profile will be used
+// instead of the global percentageOfNodesToScore value.
+// If percentageOfNodesToScore is set to 0, scheduler will use an adaptive algorithm to calculate a percentage
+// value to use; the larger the cluster, the lower the result value.
+// If the limit of nodes to score is reached but the number of feasible nodes found is lower than the value
+// from numFeasibleNodesToFind, the filtering of subsequent nodes will continue.
+func WithAlgorithmPercentageOfNodesToScore(percentage int32) AlgorithmOption {
+	return func(a *SchedulingAlgorithm) {
+		a.percentageOfNodesToScore = percentage
+	}
+}
+
+// WithCurrentCycleProvider supplies the function reporting the scheduling cycle the
+// algorithm is running in. Only opportunistic batching consumes it: the batch keys
+// its cached scoring state by cycle number and reuses that state only across
+// consecutive cycles. Without this option the algorithm does not batch at all,
+// rather than batching against a synthetic counter that would make unrelated pods
+// look consecutive.
+func WithCurrentCycleProvider(cycleProvider func() int64) AlgorithmOption {
+	return func(a *SchedulingAlgorithm) {
+		a.cycleProvider = cycleProvider
+	}
+}
+
+// NewSchedulingAlgorithm creates a scheduling algorithm operating on the given snapshot and cache.
+func NewSchedulingAlgorithm(snapshot *internalcache.Snapshot, cache internalcache.Cache,
+	opts ...AlgorithmOption) *SchedulingAlgorithm {
+	a := &SchedulingAlgorithm{
+		nodeInfoSnapshot:         snapshot,
+		cache:                    cache,
+		percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+// opportunisticBatchingEnabled reports whether opportunistic batching can run. It needs both the
+// feature gate and a cycle provider: batch state is keyed by scheduling cycle, so
+// without a real counter the batch cannot tell consecutive cycles apart.
+func (a *SchedulingAlgorithm) opportunisticBatchingEnabled() bool {
+	return a.cycleProvider != nil && utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching)
+}
+
+// SchedulePod runs PreFilter, Filter, filter extenders and Score, and returns the
+// selected node. It returns a *framework.FitError when no node fits — running
+// PostFilter (preemption) and requeueing in response is the caller's job:
+// preemption mutates cluster state and stays with Scheduler.
+func (a *SchedulingAlgorithm) SchedulePod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (result ScheduleResult, err error) {
+	pod := podInfo.Pod
+	trace := utiltrace.New("Scheduling", utiltrace.Field{Key: "namespace", Value: pod.Namespace}, utiltrace.Field{Key: "name", Value: pod.Name})
+	defer trace.LogIfLong(100 * time.Millisecond)
+
+	if a.nodeInfoSnapshot.NumNodesInPlacement() == 0 {
+		return result, ErrNoNodesAvailable
+	}
+
+	feasibleNodes, diagnosis, nodeHint, err := a.findNodesThatFitPod(ctx, schedFramework, state, podInfo)
+	if err != nil {
+		return result, err
+	}
+	trace.Step("Computing predicates done")
+
+	if len(feasibleNodes) == 0 {
+		return result, &framework.FitError{
+			Pod:         pod,
+			NumAllNodes: a.nodeInfoSnapshot.NumNodesInPlacement(),
+			Diagnosis:   diagnosis,
+		}
+	}
+
+	// When only one node after predicate, just use it.
+	if len(feasibleNodes) == 1 {
+		node := feasibleNodes[0].Node().Name
+		if a.opportunisticBatchingEnabled() {
+			schedFramework.StoreScheduleResults(ctx, podInfo.PodSignature, nodeHint, node, nil, a.cycleProvider())
+		}
+		return ScheduleResult{
+			SuggestedHost:  node,
+			EvaluatedNodes: 1 + diagnosis.NodeToStatus.Len(),
+			FeasibleNodes:  1,
+		}, nil
+	}
+
+	priorityList, err := prioritizeNodes(ctx, schedFramework, state, pod, feasibleNodes)
+	if err != nil {
+		return result, err
+	}
+
+	sortedPrioritizedNodes := framework.NewSortedScoredNodes(priorityList)
+	node := sortedPrioritizedNodes.Pop().Name
+	trace.Step("Prioritizing done")
+
+	if a.opportunisticBatchingEnabled() {
+		schedFramework.StoreScheduleResults(ctx, podInfo.PodSignature, nodeHint, node, sortedPrioritizedNodes, a.cycleProvider())
+	}
+
+	return ScheduleResult{
+		SuggestedHost:  node,
+		EvaluatedNodes: len(feasibleNodes) + diagnosis.NodeToStatus.Len(),
+		FeasibleNodes:  len(feasibleNodes),
+	}, err
+}
+
+// findNodesThatFitPod filters the nodes to find the ones that fit the pod based on the framework
+// filter plugins and filter extenders.
+func (a *SchedulingAlgorithm) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) ([]fwk.NodeInfo, framework.Diagnosis, string, error) {
+	logger := klog.FromContext(ctx)
+	diagnosis := framework.Diagnosis{
+		NodeToStatus: framework.NewDefaultNodeToStatus(),
+	}
+	allNodes, err := a.nodeInfoSnapshot.ListNodesInPlacement()
+	if err != nil {
+		return nil, diagnosis, "", err
+	}
+	// Run "prefilter" plugins.
+	pod := podInfo.Pod
+	preRes, s, unscheduledPlugins := schedFramework.RunPreFilterPlugins(ctx, state, pod)
+	diagnosis.UnschedulablePlugins = unscheduledPlugins
+	if !s.IsSuccess() {
+		if !s.IsRejected() {
+			return nil, diagnosis, "", s.AsError()
+		}
+		// All nodes in NodeToStatus will have the same status so that they can be handled in the preemption.
+		diagnosis.NodeToStatus.SetAbsentNodesStatus(s)
+
+		// Record the messages from PreFilter in Diagnosis.PreFilterMsg.
+		msg := s.Message()
+		diagnosis.PreFilterMsg = msg
+		logger.V(5).Info("Status after running PreFilter plugins for pod", "pod", klog.KObj(pod), "status", msg)
+		diagnosis.AddPluginStatus(s)
+		return nil, diagnosis, "", nil
+	}
+
+	var nodeHint string
+	if a.opportunisticBatchingEnabled() {
+		// We get the node hint even if we have a nominated name for simplicity, but we could potentially avoid it
+		// in this scenario in the future.
+		nodeHint = schedFramework.GetNodeHint(ctx, pod, podInfo.PodSignature, state, a.cycleProvider())
+	}
+
+	// "NominatedNodeName" can potentially be set in a previous scheduling cycle as a result of preemption.
+	// This node is likely the only candidate that will fit the pod, and hence we try it first before iterating over all nodes.
+	// We take the same tack for hinted nodes from the batch module.
+	if len(pod.Status.NominatedNodeName) > 0 || len(nodeHint) > 0 {
+		feasibleNodes, err := a.evaluateNominatedNode(ctx, pod, schedFramework, state, nodeHint, diagnosis)
+		if err != nil {
+			utilruntime.HandleErrorWithContext(ctx, err, "Evaluation failed on nominated node", "pod", klog.KObj(pod), "node", pod.Status.NominatedNodeName)
+		}
+		// Nominated node passes all the filters, scheduler is good to assign this node to the pod.
+		if len(feasibleNodes) != 0 {
+			return feasibleNodes, diagnosis, nodeHint, nil
+		}
+	}
+
+	nodes := allNodes
+	if !preRes.AllNodes() {
+		nodes = make([]fwk.NodeInfo, 0, len(preRes.NodeNames))
+		for nodeName := range preRes.NodeNames {
+			// PreRes may return nodeName(s) which do not exist; we verify
+			// node exists in the Snapshot within the selected placement.
+			if nodeInfo, err := a.nodeInfoSnapshot.GetNodeInPlacement(nodeName); err == nil {
+				nodes = append(nodes, nodeInfo)
+			}
+		}
+		diagnosis.NodeToStatus.SetAbsentNodesStatus(fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("node(s) didn't satisfy plugin(s) %v", sets.List(unscheduledPlugins))))
+	}
+	feasibleNodes, err := a.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, nodes)
+	// always try to update the a.nextStartNodeIndex regardless of whether an error has occurred
+	// this is helpful to make sure that all the nodes have a chance to be searched
+	processedNodes := len(feasibleNodes) + diagnosis.NodeToStatus.Len()
+	if len(allNodes) > 0 {
+		a.nextStartNodeIndex = (a.nextStartNodeIndex + processedNodes) % len(allNodes)
+	}
+	if err != nil {
+		return nil, diagnosis, nodeHint, err
+	}
+
+	feasibleNodesAfterExtender, err := findNodesThatPassExtenders(ctx, schedFramework.Extenders(), pod, feasibleNodes, diagnosis.NodeToStatus)
+	if err != nil {
+		return nil, diagnosis, nodeHint, err
+	}
+	if len(feasibleNodesAfterExtender) != len(feasibleNodes) {
+		// Extenders filtered out some nodes.
+		//
+		// Extender doesn't support any kind of requeueing feature like EnqueueExtensions in the scheduling framework.
+		// When Extenders reject some Nodes and the pod ends up being unschedulable,
+		// we put fwk.ExtenderName to pInfo.UnschedulablePlugins.
+		// This Pod will be requeued from unschedulable pod pool to activeQ/backoffQ
+		// by any kind of cluster events.
+		// https://github.com/kubernetes/kubernetes/issues/122019
+		if diagnosis.UnschedulablePlugins == nil {
+			diagnosis.UnschedulablePlugins = sets.New[string]()
+		}
+		diagnosis.UnschedulablePlugins.Insert(framework.ExtenderName)
+	}
+
+	return feasibleNodesAfterExtender, diagnosis, nodeHint, nil
+}
+
+func (a *SchedulingAlgorithm) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, schedFramework framework.Framework, state fwk.CycleState, nodeHint string, diagnosis framework.Diagnosis) ([]fwk.NodeInfo, error) {
+	// In the future we could potentially use the hint if the nominated node failed.
+	// https://github.com/kubernetes/kubernetes/issues/135163
+	nnn := pod.Status.NominatedNodeName
+	if len(nnn) == 0 {
+		nnn = nodeHint
+	}
+
+	nodeInfo, err := a.nodeInfoSnapshot.GetNodeInPlacement(nnn)
+	if err != nil {
+		if _, err := a.nodeInfoSnapshot.Get(nnn); err != nil {
+			return nil, err
+		}
+		// It's not an error if NNN is in the cluster but not in the placement.
+		// This can happen during the pod group placement scheduling cycle, where we simulate multiple potential placements.
+		logger := klog.FromContext(ctx)
+		logger.V(4).Info("Pod's nominated node is present in the cluster but not available in the current placement", "pod", klog.KObj(pod), "node", pod.Status.NominatedNodeName)
+		return nil, nil
+	}
+	node := []fwk.NodeInfo{nodeInfo}
+	feasibleNodes, err := a.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, node)
+	if err != nil {
+		return nil, err
+	}
+
+	feasibleNodes, err = findNodesThatPassExtenders(ctx, schedFramework.Extenders(), pod, feasibleNodes, diagnosis.NodeToStatus)
+	if err != nil {
+		return nil, err
+	}
+
+	return feasibleNodes, nil
+}
+
+// findNodesThatPassFilters finds the nodes that fit the filter plugins.
+func (a *SchedulingAlgorithm) findNodesThatPassFilters(
+	ctx context.Context,
+	schedFramework framework.Framework,
+	state fwk.CycleState,
+	pod *v1.Pod,
+	diagnosis *framework.Diagnosis,
+	nodes []fwk.NodeInfo) ([]fwk.NodeInfo, error) {
+	numAllNodes := len(nodes)
+	numNodesToFind := a.numFeasibleNodesToFind(schedFramework.PercentageOfNodesToScore(), int32(numAllNodes))
+	if !hasExtenderFilters(schedFramework) && !hasScoring(schedFramework) {
+		numNodesToFind = 1
+	}
+
+	// Create feasible list with enough space to avoid growing it
+	// and allow assigning.
+	feasibleNodes := make([]fwk.NodeInfo, numNodesToFind)
+
+	if !schedFramework.HasFilterPlugins() {
+		for i := range feasibleNodes {
+			feasibleNodes[i] = nodes[(a.nextStartNodeIndex+i)%numAllNodes]
+		}
+		return feasibleNodes, nil
+	}
+
+	errCh := parallelize.NewResultChannel[error]()
+	var feasibleNodesLen int32
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(errors.New("findNodesThatPassFilters has completed"))
+
+	type nodeStatus struct {
+		node   string
+		status *fwk.Status
+	}
+	result := make([]*nodeStatus, numAllNodes)
+	checkNode := func(i int) {
+		// We check the nodes starting from where we left off in the previous scheduling cycle,
+		// this is to make sure all nodes have the same chance of being examined across pods.
+		nodeInfo := nodes[(a.nextStartNodeIndex+i)%numAllNodes]
+		status := schedFramework.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
+		if status.Code() == fwk.Error {
+			errCh.SendWithCancel(status.AsError(), func() {
+				cancel(errors.New("some other Filter operation failed"))
+			})
+			return
+		}
+		if status.IsSuccess() {
+			length := atomic.AddInt32(&feasibleNodesLen, 1)
+			if length > numNodesToFind {
+				cancel(errors.New("findNodesThatPassFilters has found enough nodes"))
+				atomic.AddInt32(&feasibleNodesLen, -1)
+			} else {
+				feasibleNodes[length-1] = nodeInfo
+			}
+		} else {
+			result[i] = &nodeStatus{node: nodeInfo.Node().Name, status: status}
+		}
+	}
+
+	beginCheckNode := time.Now()
+	statusCode := fwk.Success
+	defer func() {
+		// We record Filter extension point latency here instead of in framework.go because framework.RunFilterPlugins
+		// function is called for each node, whereas we want to have an overall latency for all nodes per scheduling cycle.
+		// Note that this latency also includes latency for `addNominatedPods`, which calls framework.RunPreFilterAddPod.
+		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Filter, statusCode.String(), schedFramework.ProfileName()).Observe(metrics.SinceInSeconds(beginCheckNode))
+	}()
+
+	// Stops searching for more nodes once the configured number of feasible nodes
+	// are found.
+	schedFramework.Parallelizer().Until(ctx, numAllNodes, checkNode, metrics.Filter)
+	feasibleNodes = feasibleNodes[:feasibleNodesLen]
+	for _, item := range result {
+		if item == nil {
+			continue
+		}
+		diagnosis.NodeToStatus.Set(item.node, item.status)
+		diagnosis.AddPluginStatus(item.status)
+	}
+	if err := errCh.Receive(); err != nil {
+		statusCode = fwk.Error
+		return feasibleNodes, err
+	}
+	return feasibleNodes, nil
+}
+
+// numFeasibleNodesToFind returns the number of feasible nodes that once found, the scheduler stops
+// its search for more feasible nodes.
+func (a *SchedulingAlgorithm) numFeasibleNodesToFind(percentageOfNodesToScore *int32, numAllNodes int32) (numNodes int32) {
+	if numAllNodes < minFeasibleNodesToFind {
+		return numAllNodes
+	}
+
+	// Use profile percentageOfNodesToScore if it's set. Otherwise, use global percentageOfNodesToScore.
+	var percentage int32
+	if percentageOfNodesToScore != nil {
+		percentage = *percentageOfNodesToScore
+	} else {
+		percentage = a.percentageOfNodesToScore
+	}
+
+	if percentage == 0 {
+		percentage = max(int32(50)-numAllNodes/125, minFeasibleNodesPercentageToFind)
+	}
+
+	numNodes = numAllNodes * percentage / 100
+	if numNodes < minFeasibleNodesToFind {
+		return minFeasibleNodesToFind
+	}
+
+	return numNodes
+}
+
+// assume signals to the cache that a pod is already in the cache, so that binding can be asynchronous.
+// When called during pod group scheduling cycle, pod is assumed in the snapshot instead.
+func (a *SchedulingAlgorithm) assume(logger klog.Logger, schedFramework framework.Framework, state fwk.CycleState, assumedPodInfo *framework.QueuedPodInfo, host string) error {
+	// Optimistically assume that the binding will succeed and send it to apiserver
+	// in the background.
+	// If the binding fails, scheduler will release resources allocated to assumed pod
+	// immediately.
+	assumedPodInfo.Pod.Spec.NodeName = host
+	if utilfeature.DefaultFeatureGate.Enabled(features.DRANodeAllocatableResources) {
+		// If DRANodeAllocatableResources is enabled, copy the calculated node allocatable resource claim status
+		// from the cycle state to the assumed pod's status. This ensures that the scheduler's
+		// cached version of the pod reflects the node allocatable resources allocated by the DRA plugin
+		// for this scheduling cycle, making this information available for NodeInfo cache update.
+		// Any potential NodeAllocatableResourceClaimStatuses from a previously failed scheduling attempt is overwritten.
+		// This field is not explicitly cleared as the Pod object is reconstructed in handleSchedulingFailure()
+		// before re-queueing.
+		assumedPodInfo.Pod.Status.NodeAllocatableResourceClaimStatuses = dynamicresources.ExtractPodNodeAllocatableResourceClaimStatus(logger, state, host)
+	}
+
+	if state.IsPodGroupSchedulingCycle() {
+		err := a.nodeInfoSnapshot.AssumePod(assumedPodInfo.PodInfo)
+		if err != nil {
+			logger.Error(err, "Scheduler snapshot AssumePod failed")
+			return err
+		}
+	} else {
+		if err := a.cache.AssumePod(logger, assumedPodInfo.Pod); err != nil {
+			logger.Error(err, "Scheduler cache AssumePod failed")
+			return err
+		}
+	}
+	// if "assumed" is a nominated pod, we should remove it from internal cache
+	schedFramework.DeleteNominatedPodIfExists(assumedPodInfo.Pod)
+
+	return nil
+}
+
+// assumeAndReserve assumes and reserves the pod in scheduler's memory.
+func (a *SchedulingAlgorithm) assumeAndReserve(
+	ctx context.Context,
+	state fwk.CycleState,
+	schedFramework framework.Framework,
+	podInfo *framework.QueuedPodInfo,
+	scheduleResult ScheduleResult,
+) (*framework.QueuedPodInfo, *fwk.Status) {
+	logger := klog.FromContext(ctx)
+	// Tell the cache to assume that a pod now is running on a given node, even though it hasn't been bound yet.
+	// This allows us to keep scheduling without waiting on binding to occur.
+	assumedPodInfo := podInfo.DeepCopy()
+	assumedPod := assumedPodInfo.Pod
+	// assume modifies `assumedPod` by setting NodeName=scheduleResult.SuggestedHost
+	err := a.assume(logger, schedFramework, state, assumedPodInfo, scheduleResult.SuggestedHost)
+	if err != nil {
+		// This is most probably result of a BUG in retrying logic.
+		// We report an error here so that pod scheduling can be retried.
+		// This relies on the fact that Error will check if the pod has been bound
+		// to a node and if so will not add it back to the unscheduled pods queue
+		// (otherwise this would cause an infinite loop).
+		return assumedPodInfo, fwk.AsStatus(err)
+	}
+
+	// Run the Reserve method of reserve plugins.
+	if sts := schedFramework.RunReservePluginsReserve(ctx, state, assumedPod, scheduleResult.SuggestedHost); !sts.IsSuccess() {
+		// trigger un-reserve to clean up state associated with the reserved Pod
+		err := a.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
+		if err != nil {
+			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
+		}
+
+		if sts.IsRejected() {
+			fitErr := &framework.FitError{
+				NumAllNodes: 1,
+				Pod:         podInfo.Pod,
+				Diagnosis: framework.Diagnosis{
+					NodeToStatus: framework.NewDefaultNodeToStatus(),
+				},
+			}
+			fitErr.Diagnosis.NodeToStatus.Set(scheduleResult.SuggestedHost, sts)
+			fitErr.Diagnosis.AddPluginStatus(sts)
+			return assumedPodInfo, fwk.NewStatus(sts.Code()).WithError(fitErr)
+		}
+		return assumedPodInfo, sts
+	}
+	return assumedPodInfo, nil
+}
+
+// unreserveAndForget unreserves and forgets the pod from scheduler's memory.
+// This function shouldn't be called during binding cycle with a state, where IsPodGroupSchedulingCycle is set to true,
+// but this shouldn't happen, because such pods with such state cannot reach binding.
+func (a *SchedulingAlgorithm) unreserveAndForget(
+	ctx context.Context,
+	state fwk.CycleState,
+	schedFramework framework.Framework,
+	assumedPodInfo *framework.QueuedPodInfo,
+	nodeName string,
+) error {
+	logger := klog.FromContext(ctx)
+
+	schedFramework.RunReservePluginsUnreserve(ctx, state, assumedPodInfo.Pod, nodeName)
+	if state.IsPodGroupSchedulingCycle() {
+		err := a.nodeInfoSnapshot.ForgetPod(logger, assumedPodInfo.Pod)
+		if err != nil {
+			return err
+		}
+		if assumedPodInfo.Pod.Status.NominatedNodeName != "" {
+			// Assume method removed the nomination, but since we are reverting that stage for pod groups,
+			// we need to revert that operation as well.
+			nominatingInfo := &fwk.NominatingInfo{
+				NominatedNodeName: assumedPodInfo.Pod.Status.NominatedNodeName,
+				NominatingMode:    fwk.ModeOverride,
+			}
+			// AssumedPodInfo can be used here, because the whole pod object is not stored in the nominator.
+			schedFramework.AddNominatedPod(logger, assumedPodInfo.PodInfo, nominatingInfo)
+		}
+		return nil
+	}
+	return a.cache.ForgetPod(logger, assumedPodInfo.Pod)
+}
+
+// assumeAndReserveWithRevert assumes and reserves the pod, returning a function that
+// reverts both steps. It is used by pod group scheduling, where a placement stays
+// tentative until the whole group is submitted.
+func (a *SchedulingAlgorithm) assumeAndReserveWithRevert(ctx context.Context,
+	state fwk.CycleState,
+	schedFramework framework.Framework,
+	podInfo *framework.QueuedPodInfo,
+	scheduleResult ScheduleResult,
+) (*fwk.Status, func()) {
+	assumedPodInfo, assumeStatus := a.assumeAndReserve(ctx, state, schedFramework, podInfo, scheduleResult)
+	if !assumeStatus.IsSuccess() {
+		return assumeStatus, nil
+	}
+	return assumeStatus, func() {
+		err := a.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
+		if err != nil {
+			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
+		}
+	}
+}

--- a/pkg/scheduler/algorithm_test.go
+++ b/pkg/scheduler/algorithm_test.go
@@ -1,0 +1,1175 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
+	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
+)
+
+func TestAssumeAndReserveInCache(t *testing.T) {
+	node1 := st.MakeNode().Name("node1").Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("pod1").Obj()
+
+	tests := []struct {
+		name               string
+		pod                *v1.Pod
+		filterStatus       *fwk.Status
+		reserveStatus      *fwk.Status
+		withCache          bool
+		wantSuccess        bool
+		wantSuggestedHost  string
+		wantAssumedInCache bool
+		wantAssumedInSnap  bool
+		wantErrorMessage   string
+	}{
+		{
+			name:               "success: pod fits on node",
+			pod:                pod1,
+			filterStatus:       fwk.NewStatus(fwk.Success),
+			withCache:          true,
+			wantSuccess:        true,
+			wantSuggestedHost:  "node1",
+			wantAssumedInCache: true,
+			wantAssumedInSnap:  false,
+		},
+		{
+			name:               "reserve failure: algorithm succeeds but Reserve plugin fails",
+			pod:                pod1,
+			filterStatus:       fwk.NewStatus(fwk.Success),
+			reserveStatus:      fwk.NewStatus(fwk.Error, "reserve fake failure"),
+			withCache:          true,
+			wantSuccess:        false,
+			wantAssumedInCache: false,
+			wantAssumedInSnap:  false,
+		},
+		{
+			name:               "failure: standalone algorithm without cache returns non-success status",
+			pod:                pod1,
+			filterStatus:       fwk.NewStatus(fwk.Success),
+			withCache:          false,
+			wantSuccess:        false,
+			wantAssumedInCache: false,
+			wantAssumedInSnap:  false,
+			wantErrorMessage:   "built without a cache",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			client := clientsetfake.NewClientset(node1, tt.pod)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cache := internalcache.New(ctx, nil, true, false)
+			cache.AddNode(logger, node1)
+			snapshot := internalcache.NewEmptySnapshot()
+			queue := internalqueue.NewTestQueueWithObjects(ctx, nil, []runtime.Object{tt.pod})
+
+			podInfo, err := framework.NewPodInfo(tt.pod)
+			if err != nil {
+				t.Fatalf("Failed to create PodInfo: %v", err)
+			}
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			fakePlugin := &assumeReserveTestPlugin{
+				fakePodGroupPlugin: &fakePodGroupPlugin{
+					filterStatus: map[string]*fwk.Status{tt.pod.Name: tt.filterStatus},
+				},
+				reserveStatus: tt.reserveStatus,
+			}
+
+			registry := frameworkruntime.Registry{
+				queuesort.Name:     queuesort.New,
+				defaultbinder.Name: defaultbinder.New,
+				"AssumeReserveTestPlugin": func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+					return fakePlugin, nil
+				},
+			}
+			profileCfg := schedulerapi.KubeSchedulerProfile{
+				SchedulerName: "default-scheduler",
+				Plugins: &schedulerapi.Plugins{
+					QueueSort: schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: queuesort.Name}}},
+					Filter:    schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+					Reserve:   schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+					Bind:      schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: defaultbinder.Name}}},
+				},
+			}
+
+			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(queue),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
+
+			var algo *SchedulingAlgorithm
+			if tt.withCache {
+				algo = NewSchedulingAlgorithm(snapshot, WithCache(cache))
+			} else {
+				algo = NewSchedulingAlgorithm(snapshot)
+			}
+
+			state := framework.NewCycleState()
+
+			scheduleResult, err := algo.SchedulePod(ctx, schedFwk, state, queuedPodInfo)
+			if err != nil {
+				t.Fatalf("SchedulePod failed: %v", err)
+			}
+
+			assumedPodInfo, status := algo.AssumeAndReserveInCache(ctx, state, schedFwk, queuedPodInfo, scheduleResult)
+
+			if status.IsSuccess() != tt.wantSuccess {
+				t.Errorf("status.IsSuccess() = %v, want %v", status.IsSuccess(), tt.wantSuccess)
+			}
+
+			if tt.wantErrorMessage != "" {
+				if status == nil || !strings.Contains(status.Message(), tt.wantErrorMessage) {
+					t.Errorf("status.Message() = %q, want to contain %q", status.Message(), tt.wantErrorMessage)
+				}
+			}
+
+			if tt.wantSuccess {
+				if assumedPodInfo.Pod.Spec.NodeName != scheduleResult.SuggestedHost {
+					t.Errorf("assumedPodInfo.Pod.Spec.NodeName = %q, want %q", assumedPodInfo.Pod.Spec.NodeName, scheduleResult.SuggestedHost)
+				}
+				if tt.pod.Spec.NodeName != "" {
+					t.Errorf("input pod Spec.NodeName mutated = %q, want empty", tt.pod.Spec.NodeName)
+				}
+				if assumedPodInfo.Pod == tt.pod {
+					t.Errorf("expected assumedPodInfo.Pod to be a deep copy of input pod, got same pointer")
+				}
+			}
+
+			isAssumed, err := cache.IsAssumedPod(tt.pod)
+			if err != nil {
+				t.Fatalf("cache.IsAssumedPod() error: %v", err)
+			}
+			if isAssumed != tt.wantAssumedInCache {
+				t.Errorf("cache.IsAssumedPod() = %v, want %v", isAssumed, tt.wantAssumedInCache)
+			}
+
+			inSnap := isPodInSnapshot(snapshot, "node1", tt.pod.Name)
+			if inSnap != tt.wantAssumedInSnap {
+				t.Errorf("pod in snapshot = %v, want %v", inSnap, tt.wantAssumedInSnap)
+			}
+
+			if tt.wantSuccess {
+				if err := algo.UnreserveAndForgetFromCache(ctx, state, schedFwk, assumedPodInfo, scheduleResult.SuggestedHost); err != nil {
+					t.Errorf("UnreserveAndForgetFromCache error: %v", err)
+				}
+				isAssumed, err = cache.IsAssumedPod(tt.pod)
+				if err != nil {
+					t.Fatalf("cache.IsAssumedPod() error after unreserve: %v", err)
+				}
+				if isAssumed {
+					t.Errorf("pod still assumed in cache after UnreserveAndForgetFromCache")
+				}
+			}
+		})
+	}
+}
+
+func TestAssumeAndReserveInSnapshot(t *testing.T) {
+	node1 := st.MakeNode().Name("node1").Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("pod1").Obj()
+	podWithNomination := st.MakePod().Name("pod-nominated").Namespace("default").UID("pod-nominated").NominatedNodeName("node1").Obj()
+
+	tests := []struct {
+		name               string
+		pod                *v1.Pod
+		filterStatus       *fwk.Status
+		reserveStatus      *fwk.Status
+		withCache          bool
+		wantSuccess        bool
+		wantSuggestedHost  string
+		wantAssumedInCache bool
+		wantAssumedInSnap  bool
+	}{
+		{
+			// Why wantAssumedInSnap is true and wantAssumedInCache is false: pod-group scheduling cycles evaluate
+			// candidates against transient snapshot assumptions to prevent incomplete group transactions from polluting shared cache state.
+			name:               "pod group cycle: assumed in snapshot only",
+			pod:                pod1,
+			filterStatus:       fwk.NewStatus(fwk.Success),
+			withCache:          false,
+			wantSuccess:        true,
+			wantSuggestedHost:  "node1",
+			wantAssumedInCache: false,
+			wantAssumedInSnap:  true,
+		},
+		{
+			name:               "pod group cycle with cache: assumed in snapshot only",
+			pod:                pod1,
+			filterStatus:       fwk.NewStatus(fwk.Success),
+			withCache:          true,
+			wantSuccess:        true,
+			wantSuggestedHost:  "node1",
+			wantAssumedInCache: false,
+			wantAssumedInSnap:  true,
+		},
+		{
+			name:               "pod group cycle: pod with nomination is restored on revert",
+			pod:                podWithNomination,
+			filterStatus:       fwk.NewStatus(fwk.Success),
+			withCache:          true,
+			wantSuccess:        true,
+			wantSuggestedHost:  "node1",
+			wantAssumedInCache: false,
+			wantAssumedInSnap:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			client := clientsetfake.NewClientset(node1, tt.pod)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cache := internalcache.New(ctx, nil, true, false)
+			cache.AddNode(logger, node1)
+			snapshot := internalcache.NewEmptySnapshot()
+			queue := internalqueue.NewTestQueueWithObjects(ctx, nil, []runtime.Object{tt.pod})
+
+			podInfo, err := framework.NewPodInfo(tt.pod)
+			if err != nil {
+				t.Fatalf("Failed to create PodInfo: %v", err)
+			}
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			fakePlugin := &assumeReserveTestPlugin{
+				fakePodGroupPlugin: &fakePodGroupPlugin{
+					filterStatus: map[string]*fwk.Status{tt.pod.Name: tt.filterStatus},
+				},
+				reserveStatus: tt.reserveStatus,
+			}
+
+			registry := frameworkruntime.Registry{
+				queuesort.Name:     queuesort.New,
+				defaultbinder.Name: defaultbinder.New,
+				"AssumeReserveTestPlugin": func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+					return fakePlugin, nil
+				},
+			}
+			profileCfg := schedulerapi.KubeSchedulerProfile{
+				SchedulerName: "default-scheduler",
+				Plugins: &schedulerapi.Plugins{
+					QueueSort: schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: queuesort.Name}}},
+					Filter:    schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+					Reserve:   schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+					Bind:      schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: defaultbinder.Name}}},
+				},
+			}
+
+			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(queue),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
+
+			var algo *SchedulingAlgorithm
+			if tt.withCache {
+				algo = NewSchedulingAlgorithm(snapshot, WithCache(cache))
+			} else {
+				algo = NewSchedulingAlgorithm(snapshot)
+			}
+
+			state := framework.NewCycleState()
+			state.SetPodGroupSchedulingCycle(framework.NewCycleState())
+
+			if tt.pod.Status.NominatedNodeName != "" {
+				queue.AddNominatedPod(logger, podInfo, &fwk.NominatingInfo{
+					NominatedNodeName: tt.pod.Status.NominatedNodeName,
+					NominatingMode:    fwk.ModeOverride,
+				})
+			}
+
+			scheduleResult, err := algo.SchedulePod(ctx, schedFwk, state, queuedPodInfo)
+			if err != nil {
+				t.Fatalf("SchedulePod failed: %v", err)
+			}
+
+			assumedPodInfo, status, revertFn := algo.AssumeAndReserveInSnapshot(ctx, state, schedFwk, queuedPodInfo, scheduleResult)
+
+			if status.IsSuccess() != tt.wantSuccess {
+				t.Errorf("status.IsSuccess() = %v, want %v", status.IsSuccess(), tt.wantSuccess)
+			}
+
+			if tt.wantSuccess {
+				if assumedPodInfo.Pod.Spec.NodeName != scheduleResult.SuggestedHost {
+					t.Errorf("assumedPodInfo.Pod.Spec.NodeName = %q, want %q", assumedPodInfo.Pod.Spec.NodeName, scheduleResult.SuggestedHost)
+				}
+				if tt.pod.Spec.NodeName != "" {
+					t.Errorf("input pod Spec.NodeName mutated = %q, want empty", tt.pod.Spec.NodeName)
+				}
+				if assumedPodInfo.Pod == tt.pod {
+					t.Errorf("expected assumedPodInfo.Pod to be a deep copy of input pod, got same pointer")
+				}
+				if tt.pod.Status.NominatedNodeName != "" {
+					if len(queue.NominatedPodsForNode(tt.pod.Status.NominatedNodeName)) != 0 {
+						t.Errorf("expected nomination to be removed after successful AssumeAndReserveInSnapshot, but found: %v", queue.NominatedPodsForNode(tt.pod.Status.NominatedNodeName))
+					}
+				}
+			}
+
+			isAssumed, err := cache.IsAssumedPod(tt.pod)
+			if err != nil {
+				t.Fatalf("cache.IsAssumedPod() error: %v", err)
+			}
+			if isAssumed != tt.wantAssumedInCache {
+				t.Errorf("cache.IsAssumedPod() = %v, want %v", isAssumed, tt.wantAssumedInCache)
+			}
+
+			inSnap := isPodInSnapshot(snapshot, "node1", tt.pod.Name)
+			if inSnap != tt.wantAssumedInSnap {
+				t.Errorf("pod in snapshot = %v, want %v", inSnap, tt.wantAssumedInSnap)
+			}
+
+			if revertFn != nil {
+				revertFn()
+				isAssumed, err = cache.IsAssumedPod(tt.pod)
+				if err != nil {
+					t.Fatalf("cache.IsAssumedPod() error after revert: %v", err)
+				}
+				if isAssumed {
+					t.Errorf("pod still assumed in cache after revert")
+				}
+				if isPodInSnapshot(snapshot, "node1", tt.pod.Name) {
+					t.Errorf("pod still in snapshot after revert")
+				}
+				if tt.reserveStatus == nil && !fakePlugin.unreserved {
+					t.Errorf("expected Unreserve to be called on revert")
+				}
+				if tt.pod.Status.NominatedNodeName != "" {
+					if len(queue.NominatedPodsForNode(tt.pod.Status.NominatedNodeName)) == 0 {
+						t.Errorf("expected nomination to be restored after revert, but none found")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAssumeAndReserveSnapshotSync(t *testing.T) {
+	node1 := st.MakeNode().Name("node1").Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("pod1").Obj()
+	pod2 := st.MakePod().Name("pod2").Namespace("default").UID("pod2").Obj()
+
+	logger, ctx := ktesting.NewTestContext(t)
+	client := clientsetfake.NewClientset(node1, pod1, pod2)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cache := internalcache.New(ctx, nil, true, false)
+	cache.AddNode(logger, node1)
+	snapshot := internalcache.NewEmptySnapshot()
+	queue := internalqueue.NewTestQueueWithObjects(ctx, nil, []runtime.Object{pod1, pod2})
+
+	fakePlugin := &assumeReserveTestPlugin{
+		fakePodGroupPlugin: &fakePodGroupPlugin{
+			filterStatus: map[string]*fwk.Status{
+				pod1.Name: fwk.NewStatus(fwk.Success),
+				pod2.Name: fwk.NewStatus(fwk.Success),
+			},
+		},
+	}
+
+	registry := frameworkruntime.Registry{
+		queuesort.Name:     queuesort.New,
+		defaultbinder.Name: defaultbinder.New,
+		"AssumeReserveTestPlugin": func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+			return fakePlugin, nil
+		},
+	}
+	profileCfg := schedulerapi.KubeSchedulerProfile{
+		SchedulerName: "default-scheduler",
+		Plugins: &schedulerapi.Plugins{
+			QueueSort: schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: queuesort.Name}}},
+			Filter:    schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+			Reserve:   schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+			Bind:      schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: defaultbinder.Name}}},
+		},
+	}
+
+	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
+		frameworkruntime.WithInformerFactory(informerFactory),
+		frameworkruntime.WithSnapshotSharedLister(snapshot),
+		frameworkruntime.WithPodNominator(queue),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+
+	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+		t.Fatalf("Failed to update snapshot: %v", err)
+	}
+
+	algo := NewSchedulingAlgorithm(snapshot, WithCache(cache))
+
+	// 1. Assume pod1 via AssumeAndReserveInCache
+	pod1Info, _ := framework.NewPodInfo(pod1)
+	queuedPod1Info := &framework.QueuedPodInfo{PodInfo: pod1Info}
+	state1 := framework.NewCycleState()
+	res1, err := algo.SchedulePod(ctx, schedFwk, state1, queuedPod1Info)
+	if err != nil {
+		t.Fatalf("SchedulePod failed for pod1: %v", err)
+	}
+	_, status1 := algo.AssumeAndReserveInCache(ctx, state1, schedFwk, queuedPod1Info, res1)
+	if !status1.IsSuccess() {
+		t.Fatalf("AssumeAndReserveInCache failed: %v", status1)
+	}
+
+	// 2. Assume pod2 via AssumeAndReserveInSnapshot
+	pod2Info, _ := framework.NewPodInfo(pod2)
+	queuedPod2Info := &framework.QueuedPodInfo{PodInfo: pod2Info}
+	state2 := framework.NewCycleState()
+	state2.SetPodGroupSchedulingCycle(framework.NewCycleState())
+	res2, err := algo.SchedulePod(ctx, schedFwk, state2, queuedPod2Info)
+	if err != nil {
+		t.Fatalf("SchedulePod failed for pod2: %v", err)
+	}
+	_, status2, _ := algo.AssumeAndReserveInSnapshot(ctx, state2, schedFwk, queuedPod2Info, res2)
+	if !status2.IsSuccess() {
+		t.Fatalf("AssumeAndReserveInSnapshot failed: %v", status2)
+	}
+
+	// Before UpdateSnapshot: pod2 is in snapshot, pod1 is in cache but not yet in snapshot
+	if !isPodInSnapshot(snapshot, "node1", pod2.Name) {
+		t.Errorf("expected pod2 to be in snapshot before UpdateSnapshot")
+	}
+
+	// UpdateSnapshot: syncs cache to snapshot, clearing snapshot-only assumptions
+	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+		t.Fatalf("cache.UpdateSnapshot failed: %v", err)
+	}
+
+	// After UpdateSnapshot: pod1 (assumed in cache) IS visible in snapshot; pod2 (assumed in snapshot only) is GONE
+	if !isPodInSnapshot(snapshot, "node1", pod1.Name) {
+		t.Errorf("expected pod1 (assumed in cache) to be visible in snapshot after UpdateSnapshot")
+	}
+	if isPodInSnapshot(snapshot, "node1", pod2.Name) {
+		t.Errorf("expected pod2 (assumed in snapshot) to be gone from snapshot after UpdateSnapshot")
+	}
+}
+
+func TestSchedulingAlgorithmDriver(t *testing.T) {
+	node1 := st.MakeNode().Name("node1").Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("pod1").Obj()
+
+	tests := []struct {
+		name                 string
+		pod                  *v1.Pod
+		filterStatus         *fwk.Status
+		postFilterStatus     *fwk.Status
+		postFilterResult     *fwk.PostFilterResult
+		podGroupCycle        bool
+		wantSuccess          bool
+		wantNominatingInfo   *fwk.NominatingInfo
+		wantPostFilterCalled bool
+	}{
+		{
+			name:                 "failure: algorithm finds no nodes",
+			pod:                  pod1,
+			filterStatus:         fwk.NewStatus(fwk.Unschedulable, "fake failure"),
+			postFilterStatus:     fwk.NewStatus(fwk.Unschedulable),
+			wantSuccess:          false,
+			wantPostFilterCalled: true,
+		},
+		{
+			name:                 "pod group cycle: per-pod PostFilter is not run (PodGroupPostFilter handles it)",
+			pod:                  pod1,
+			filterStatus:         fwk.NewStatus(fwk.Unschedulable, "no fit"),
+			postFilterStatus:     fwk.NewStatus(fwk.Success),
+			postFilterResult:     &fwk.PostFilterResult{NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
+			podGroupCycle:        true,
+			wantSuccess:          false,
+			wantPostFilterCalled: false,
+		},
+		{
+			name:             "failure: algorithm fails but PostFilter nominates node",
+			pod:              pod1,
+			filterStatus:     fwk.NewStatus(fwk.Unschedulable, "no fit"),
+			postFilterStatus: fwk.NewStatus(fwk.Success),
+			postFilterResult: &fwk.PostFilterResult{
+				NominatingInfo: &fwk.NominatingInfo{
+					NominatedNodeName: "node1",
+					NominatingMode:    fwk.ModeOverride,
+				},
+			},
+			wantSuccess: false,
+			wantNominatingInfo: &fwk.NominatingInfo{
+				NominatedNodeName: "node1",
+				NominatingMode:    fwk.ModeOverride,
+			},
+			wantPostFilterCalled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			client := clientsetfake.NewClientset(node1, tt.pod)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cache := internalcache.New(ctx, nil, true, false)
+			cache.AddNode(logger, node1)
+			snapshot := internalcache.NewEmptySnapshot()
+			queue := internalqueue.NewTestQueueWithObjects(ctx, nil, []runtime.Object{tt.pod})
+
+			podInfo, err := framework.NewPodInfo(tt.pod)
+			if err != nil {
+				t.Fatalf("Failed to create PodInfo: %v", err)
+			}
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			fakePlugin := &assumeReserveTestPlugin{
+				fakePodGroupPlugin: &fakePodGroupPlugin{
+					filterStatus:     map[string]*fwk.Status{tt.pod.Name: tt.filterStatus},
+					postFilterStatus: map[string]*fwk.Status{tt.pod.Name: tt.postFilterStatus},
+					postFilterResult: map[string]*fwk.PostFilterResult{tt.pod.Name: tt.postFilterResult},
+				},
+			}
+
+			registry := frameworkruntime.Registry{
+				queuesort.Name:     queuesort.New,
+				defaultbinder.Name: defaultbinder.New,
+				"AssumeReserveTestPlugin": func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+					return fakePlugin, nil
+				},
+			}
+			profileCfg := schedulerapi.KubeSchedulerProfile{
+				SchedulerName: "default-scheduler",
+				Plugins: &schedulerapi.Plugins{
+					QueueSort:  schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: queuesort.Name}}},
+					Filter:     schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+					PostFilter: schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+					Bind:       schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: defaultbinder.Name}}},
+				},
+			}
+
+			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(queue),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
+
+			sched := &Scheduler{
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
+			}
+
+			state := framework.NewCycleState()
+			if tt.podGroupCycle {
+				state.SetPodGroupSchedulingCycle(framework.NewCycleState())
+			}
+
+			scheduleResult, status := sched.schedulingAlgorithm(ctx, state, schedFwk, queuedPodInfo, time.Now())
+
+			if status.IsSuccess() != tt.wantSuccess {
+				t.Errorf("status.IsSuccess() = %v, want %v", status.IsSuccess(), tt.wantSuccess)
+			}
+
+			if fakePlugin.postFilterCalled != tt.wantPostFilterCalled {
+				t.Errorf("postFilterCalled = %v, want %v", fakePlugin.postFilterCalled, tt.wantPostFilterCalled)
+			}
+
+			if diff := cmp.Diff(tt.wantNominatingInfo, scheduleResult.nominatingInfo); diff != "" {
+				t.Errorf("Unexpected nominatingInfo (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFindAllNodesThatFitPod(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	allNodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+		st.MakeNode().Name("node3").Obj(),
+	}
+
+	tests := []struct {
+		name                    string
+		nodes                   []*v1.Node
+		pod                     *v1.Pod
+		registerPlugins         []tf.RegisterPluginFunc
+		extenders               []fwk.Extender
+		wantNodeNames           []string
+		wantUnschedulablePlugin string
+	}{
+		{
+			name:  "N nodes, Filter plugin admitting a named subset",
+			nodes: allNodes,
+			pod:   st.MakePod().Name("pod1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterFilterPlugin("SubsetFilter", tf.NewFakeFilterPlugin(map[string]fwk.Code{
+					"node2": fwk.Unschedulable,
+				})),
+			},
+			wantNodeNames: []string{"node1", "node3"},
+		},
+		{
+			name:  "Pod with nominated node name does not take shortcut and returns all feasible nodes",
+			nodes: allNodes[:2],
+			pod:   st.MakePod().Name("pod1").NominatedNodeName("node1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+			},
+			wantNodeNames: []string{"node1", "node2"},
+		},
+		{
+			name:  "Profile with no score plugins returns all feasible nodes",
+			nodes: allNodes,
+			pod:   st.MakePod().Name("pod1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+			},
+			wantNodeNames: []string{"node1", "node2", "node3"},
+		},
+		{
+			name:  "PreFilter plugin returning node subset respects narrowing",
+			nodes: allNodes,
+			pod:   st.MakePod().Name("pod1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterPreFilterPlugin("SubsetPreFilter", tf.NewFakePreFilterPlugin("SubsetPreFilter", &fwk.PreFilterResult{
+					NodeNames: sets.New("node2", "node3"),
+				}, nil)),
+				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+			},
+			wantNodeNames: []string{"node2", "node3"},
+		},
+		{
+			name:  "Filter extender rejecting one node excludes node and adds ExtenderName to UnschedulablePlugins",
+			nodes: allNodes[:2],
+			pod:   st.MakePod().Name("pod1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+			},
+			extenders: []fwk.Extender{
+				&tf.FakeExtender{
+					ExtenderName: "FakeExtender",
+					Predicates:   []tf.FitPredicate{tf.Node2PredicateExtender},
+				},
+			},
+			wantNodeNames:           []string{"node2"},
+			wantUnschedulablePlugin: framework.ExtenderName,
+		},
+		{
+			name:  "Empty snapshot with zero nodes returns empty result without error",
+			nodes: nil,
+			pod:   st.MakePod().Name("pod1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+			},
+			wantNodeNames: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot := internalcache.NewSnapshot(nil, tt.nodes)
+			schedFwk, err := tf.NewFramework(ctx, tt.registerPlugins, "default-scheduler",
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+				frameworkruntime.WithExtenders(tt.extenders),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			algo := NewSchedulingAlgorithm(snapshot)
+			podInfo, _ := framework.NewPodInfo(tt.pod)
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			nodes, diagnosis, err := algo.FindAllNodesThatFitPod(ctx, framework.NewCycleState(), schedFwk, queuedPodInfo)
+			if err != nil {
+				t.Fatalf("FindAllNodesThatFitPod returned unexpected error: %v", err)
+			}
+
+			gotNames := nodeNamesFromNodeInfos(nodes)
+			if diff := cmp.Diff(tt.wantNodeNames, gotNames); diff != "" {
+				t.Errorf("FindAllNodesThatFitPod() returned unexpected nodes (-want,+got):\n%s", diff)
+			}
+
+			if tt.wantUnschedulablePlugin != "" {
+				if !diagnosis.UnschedulablePlugins.Has(tt.wantUnschedulablePlugin) {
+					t.Errorf("expected %q in UnschedulablePlugins, got %v", tt.wantUnschedulablePlugin, sets.List(diagnosis.UnschedulablePlugins))
+				}
+			}
+		})
+	}
+}
+
+func TestFindAllNodesThatFitPodIdempotency(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	allNodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+		st.MakeNode().Name("node3").Obj(),
+		st.MakeNode().Name("node4").Obj(),
+		st.MakeNode().Name("node5").Obj(),
+	}
+
+	tests := []struct {
+		name    string
+		podName string
+	}{
+		{
+			name:    "Consecutive calls on same instance return identical results and preserve zero next start node index",
+			podName: "pod-double",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot := internalcache.NewSnapshot(nil, allNodes)
+			registerPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			schedFwk, err := tf.NewFramework(ctx, registerPlugins, "default-scheduler",
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			algo := NewSchedulingAlgorithm(snapshot)
+			pod := st.MakePod().Name(tt.podName).Obj()
+			podInfo, err := framework.NewPodInfo(pod)
+			if err != nil {
+				t.Fatalf("Failed to create PodInfo: %v", err)
+			}
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			nodes1, _, err := algo.FindAllNodesThatFitPod(ctx, framework.NewCycleState(), schedFwk, queuedPodInfo)
+			if err != nil {
+				t.Fatalf("first FindAllNodesThatFitPod call failed: %v", err)
+			}
+			if algo.nextStartNodeIndex != 0 {
+				t.Errorf("after first call nextStartNodeIndex = %d, want 0", algo.nextStartNodeIndex)
+			}
+
+			nodes2, _, err := algo.FindAllNodesThatFitPod(ctx, framework.NewCycleState(), schedFwk, queuedPodInfo)
+			if err != nil {
+				t.Fatalf("second FindAllNodesThatFitPod call failed: %v", err)
+			}
+			if algo.nextStartNodeIndex != 0 {
+				t.Errorf("after second call nextStartNodeIndex = %d, want 0", algo.nextStartNodeIndex)
+			}
+
+			got1 := nodeNamesInOrder(nodes1)
+			got2 := nodeNamesInOrder(nodes2)
+			if diff := cmp.Diff(got1, got2); diff != "" {
+				t.Errorf("consecutive calls returned different results (-first,+second):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNumNodesToFindOverride(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	allNodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+		st.MakeNode().Name("node3").Obj(),
+		st.MakeNode().Name("node4").Obj(),
+		st.MakeNode().Name("node5").Obj(),
+	}
+
+	tests := []struct {
+		name             string
+		pod              *v1.Pod
+		overrideFn       func(int32) int32
+		withFilterPlugin bool
+		wantCount        int
+		wantNames        []string
+		wantNoDuplicates bool
+	}{
+		{
+			name: "Override returning 3 with no score plugins collects exactly 3 nodes",
+			pod:  st.MakePod().Name("pod1").Obj(),
+			overrideFn: func(int32) int32 {
+				return 3
+			},
+			withFilterPlugin: true,
+			wantCount:        3,
+		},
+		{
+			name: "Override returning more than total nodes with no filter plugins collects all nodes without duplicates",
+			pod:  st.MakePod().Name("pod1").Obj(),
+			overrideFn: func(numAllNodes int32) int32 {
+				return numAllNodes + 10
+			},
+			withFilterPlugin: false,
+			wantCount:        len(allNodes),
+			wantNoDuplicates: true,
+		},
+		{
+			name: "Override returning 0 with nominated node name still returns nominated node",
+			pod:  st.MakePod().Name("pod1").NominatedNodeName("node1").Obj(),
+			overrideFn: func(int32) int32 {
+				return 0
+			},
+			withFilterPlugin: true,
+			wantNames:        []string{"node1"},
+		},
+		{
+			name: "Override returning a negative value is clamped and collects 0 nodes",
+			pod:  st.MakePod().Name("pod1").Obj(),
+			overrideFn: func(int32) int32 {
+				return -1
+			},
+			withFilterPlugin: true,
+			wantCount:        0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot := internalcache.NewSnapshot(nil, allNodes)
+			registerPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			if tt.withFilterPlugin {
+				registerPlugins = append(registerPlugins, tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin))
+			}
+			schedFwk, err := tf.NewFramework(ctx, registerPlugins, "default-scheduler",
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			algo := NewSchedulingAlgorithm(snapshot, WithNumNodesToFindOverride(tt.overrideFn))
+
+			podInfo, err := framework.NewPodInfo(tt.pod)
+			if err != nil {
+				t.Fatalf("Failed to create PodInfo: %v", err)
+			}
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			nodes, _, _, err := algo.findNodesThatFitPod(ctx, schedFwk, framework.NewCycleState(), queuedPodInfo, false)
+			if err != nil {
+				t.Fatalf("findNodesThatFitPod returned error: %v", err)
+			}
+			if tt.wantNames != nil {
+				gotNames := nodeNamesFromNodeInfos(nodes)
+				if diff := cmp.Diff(tt.wantNames, gotNames); diff != "" {
+					t.Errorf("findNodesThatFitPod result (-want,+got):\n%s", diff)
+				}
+			} else if len(nodes) != tt.wantCount {
+				t.Errorf("len(nodes) = %d, want %d", len(nodes), tt.wantCount)
+			}
+
+			if tt.wantNoDuplicates {
+				names := make(map[string]bool)
+				for _, node := range nodes {
+					name := node.Node().Name
+					if names[name] {
+						t.Errorf("duplicate node name found in result: %q", name)
+					}
+					names[name] = true
+				}
+			}
+		})
+	}
+}
+
+func TestFindNodesThatPassFiltersEmptyNodes(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	pod := st.MakePod().Name("pod1").Obj()
+
+	snapshot := internalcache.NewSnapshot(nil, nil)
+	algo := NewSchedulingAlgorithm(snapshot)
+
+	tests := []struct {
+		name        string
+		withFilters bool
+	}{
+		{
+			name:        "With filter plugins on empty or nil nodes",
+			withFilters: true,
+		},
+		{
+			name:        "Without filter plugins on empty or nil nodes",
+			withFilters: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registerPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			if tt.withFilters {
+				registerPlugins = append(registerPlugins, tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin))
+			}
+			schedFwk, err := tf.NewFramework(ctx, registerPlugins, "default-scheduler",
+				frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			var diagnosis framework.Diagnosis
+			res, err := algo.findNodesThatPassFilters(ctx, schedFwk, framework.NewCycleState(), pod, &diagnosis, nil, 1)
+			if err != nil {
+				t.Fatalf("findNodesThatPassFilters returned unexpected error: %v", err)
+			}
+			if len(res) != 0 {
+				t.Errorf("expected empty result, got %d nodes", len(res))
+			}
+		})
+	}
+}
+
+func TestCycleProviderDefault(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	allNodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+	}
+	snapshot := internalcache.NewSnapshot(nil, allNodes)
+
+	tests := []struct {
+		name              string
+		enableFeatureGate bool
+		checkFindAllNodes bool
+		wantCycle         int64
+		wantNodeNames     []string
+	}{
+		{
+			name:              "Standalone algorithm without cycle provider initializes current cycle to 0",
+			enableFeatureGate: false,
+			checkFindAllNodes: false,
+			wantCycle:         0,
+		},
+		{
+			name:              "FindAllNodesThatFitPod completes without panic with default opportunistic batching feature gate",
+			enableFeatureGate: true,
+			checkFindAllNodes: true,
+			wantNodeNames:     []string{"node1", "node2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.enableFeatureGate {
+				featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.OpportunisticBatching, true)
+			}
+			algo := NewSchedulingAlgorithm(snapshot)
+
+			if !tt.checkFindAllNodes {
+				if cycle := algo.currentCycle(); cycle != tt.wantCycle {
+					t.Errorf("algo.currentCycle() = %d, want %d", cycle, tt.wantCycle)
+				}
+				return
+			}
+
+			registerPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+			}
+			schedFwk, err := tf.NewFramework(ctx, registerPlugins, "default-scheduler",
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			pod := st.MakePod().Name("pod1").Obj()
+			podInfo, err := framework.NewPodInfo(pod)
+			if err != nil {
+				t.Fatalf("Failed to create PodInfo: %v", err)
+			}
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			nodes, _, err := algo.FindAllNodesThatFitPod(ctx, framework.NewCycleState(), schedFwk, queuedPodInfo)
+			if err != nil {
+				t.Fatalf("FindAllNodesThatFitPod returned unexpected error: %v", err)
+			}
+			gotNames := nodeNamesFromNodeInfos(nodes)
+			if diff := cmp.Diff(tt.wantNodeNames, gotNames); diff != "" {
+				t.Errorf("FindAllNodesThatFitPod() (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCycleProvider(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.OpportunisticBatching, true)
+
+	allNodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+	}
+	snapshot := internalcache.NewSnapshot(nil, allNodes)
+	algo := NewSchedulingAlgorithm(snapshot, WithCycleProvider(func() int64 { return 42 }))
+
+	registerPlugins := []tf.RegisterPluginFunc{
+		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+	}
+	schedFwk, err := tf.NewFramework(ctx, registerPlugins, "default-scheduler",
+		frameworkruntime.WithSnapshotSharedLister(snapshot),
+		frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+
+	recordingFwk := &cycleRecordingFramework{Framework: schedFwk}
+
+	pod := st.MakePod().Name("pod1").Obj()
+	podInfo, err := framework.NewPodInfo(pod)
+	if err != nil {
+		t.Fatalf("Failed to create PodInfo: %v", err)
+	}
+	queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+	_, _, err = algo.FindAllNodesThatFitPod(ctx, framework.NewCycleState(), recordingFwk, queuedPodInfo)
+	if err != nil {
+		t.Fatalf("FindAllNodesThatFitPod returned unexpected error: %v", err)
+	}
+
+	if recordingFwk.recordedCycle != 42 {
+		t.Errorf("GetNodeHint received cycleCount = %d, want 42", recordingFwk.recordedCycle)
+	}
+}
+
+type cycleRecordingFramework struct {
+	framework.Framework
+	recordedCycle int64
+}
+
+func (f *cycleRecordingFramework) GetNodeHint(ctx context.Context, pod *v1.Pod, signature fwk.PodSignature, state fwk.CycleState, cycleCount int64) string {
+	f.recordedCycle = cycleCount
+	return f.Framework.GetNodeHint(ctx, pod, signature, state, cycleCount)
+}
+
+// assumeReserveTestPlugin embeds fakePodGroupPlugin so a single mock instance can test both standard cache assumption
+// and pod-group snapshot assumption paths without duplicating plugin registration logic across subtests.
+type assumeReserveTestPlugin struct {
+	*fakePodGroupPlugin
+	reserveStatus *fwk.Status
+	unreserved    bool
+}
+
+func (p *assumeReserveTestPlugin) Reserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
+	if p.reserveStatus != nil {
+		return p.reserveStatus
+	}
+	return fwk.NewStatus(fwk.Success)
+}
+
+func (p *assumeReserveTestPlugin) Unreserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) {
+	p.unreserved = true
+}
+
+func isPodInSnapshot(snapshot *internalcache.Snapshot, nodeName, podName string) bool {
+	if nodeInfo, err := snapshot.Get(nodeName); err == nil {
+		for _, p := range nodeInfo.GetPods() {
+			if p.GetPod().Name == podName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func nodeNamesInOrder(nodes []fwk.NodeInfo) []string {
+	if len(nodes) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		names = append(names, n.Node().Name)
+	}
+	return names
+}
+
+func nodeNamesFromNodeInfos(nodes []fwk.NodeInfo) []string {
+	if len(nodes) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		names = append(names, n.Node().Name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/scheduler/algorithm_test.go
+++ b/pkg/scheduler/algorithm_test.go
@@ -1,0 +1,741 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/features"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
+	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
+	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	tf "k8s.io/kubernetes/pkg/scheduler/testing/framework"
+)
+
+// assumeReserveFixture wires up the pieces every assume/reserve test needs: a cache
+// and snapshot holding one node, a framework whose Filter and Reserve verdicts the
+// test controls, and the algorithm under test.
+type assumeReserveFixture struct {
+	algorithm *SchedulingAlgorithm
+
+	fwk framework.Framework
+}
+
+func newAssumeReserveFixture(t *testing.T, ctx context.Context, node *v1.Node,
+	plugin *assumeReserveTestPlugin, pods ...*v1.Pod) *assumeReserveFixture {
+	t.Helper()
+
+	logger := klog.FromContext(ctx)
+
+	objects := []runtime.Object{node}
+	queued := make([]runtime.Object, 0, len(pods))
+	for _, p := range pods {
+		objects = append(objects, p)
+		queued = append(queued, p)
+	}
+	client := clientsetfake.NewClientset(objects...)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	cache := internalcache.New(ctx, nil, true, false)
+	cache.AddNode(logger, node)
+	snapshot := internalcache.NewEmptySnapshot()
+	queue := internalqueue.NewTestQueueWithObjects(ctx, nil, queued)
+
+	registry := frameworkruntime.Registry{
+		queuesort.Name:     queuesort.New,
+		defaultbinder.Name: defaultbinder.New,
+		"AssumeReserveTestPlugin": func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+			return plugin, nil
+		},
+	}
+	profileCfg := schedulerapi.KubeSchedulerProfile{
+		SchedulerName: "default-scheduler",
+		Plugins: &schedulerapi.Plugins{
+			QueueSort: schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: queuesort.Name}}},
+			Filter:    schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+			Reserve:   schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+			Bind:      schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: defaultbinder.Name}}},
+		},
+	}
+
+	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
+		frameworkruntime.WithInformerFactory(informerFactory),
+		frameworkruntime.WithSnapshotSharedLister(snapshot),
+		frameworkruntime.WithPodNominator(queue),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+		t.Fatalf("Failed to update snapshot: %v", err)
+	}
+
+	return &assumeReserveFixture{
+		algorithm: NewSchedulingAlgorithm(snapshot, cache),
+		fwk:       schedFwk,
+	}
+}
+
+// TestAssumeAndReserve covers the ordinary scheduling cycle, where the placement is
+// recorded in the scheduler cache and survives the next snapshot refresh.
+func TestAssumeAndReserve(t *testing.T) {
+	node1 := st.MakeNode().Name("node1").Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("pod1").Obj()
+
+	tests := []struct {
+		name               string
+		reserveStatus      *fwk.Status
+		wantStatusCode     fwk.Code
+		wantAssumedInCache bool
+	}{
+		{
+			name:               "success: pod fits on node and is assumed in the cache",
+			wantStatusCode:     fwk.Success,
+			wantAssumedInCache: true,
+		},
+		{
+			name:               "reserve failure: assumption is rolled back",
+			reserveStatus:      fwk.NewStatus(fwk.Error, "reserve fake failure"),
+			wantStatusCode:     fwk.Error,
+			wantAssumedInCache: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+
+			plugin := &assumeReserveTestPlugin{
+				fakePodGroupPlugin: &fakePodGroupPlugin{
+					filterStatus: map[string]*fwk.Status{pod1.Name: fwk.NewStatus(fwk.Success)},
+				},
+				reserveStatus: tt.reserveStatus,
+			}
+			f := newAssumeReserveFixture(t, ctx, node1, plugin, pod1)
+
+			podInfo, err := framework.NewPodInfo(pod1)
+			if err != nil {
+				t.Fatalf("Failed to create PodInfo: %v", err)
+			}
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			state := framework.NewCycleState()
+			scheduleResult, err := f.algorithm.SchedulePod(ctx, f.fwk, state, queuedPodInfo)
+			if err != nil {
+				t.Fatalf("schedulePod failed: %v", err)
+			}
+			if scheduleResult.SuggestedHost != node1.Name {
+				t.Fatalf("SuggestedHost = %q, want %q", scheduleResult.SuggestedHost, node1.Name)
+			}
+
+			assumedPodInfo, status := f.algorithm.assumeAndReserve(ctx, state, f.fwk, queuedPodInfo, scheduleResult)
+			if status.Code() != tt.wantStatusCode {
+				t.Errorf("status.Code() = %v, want %v", status.Code(), tt.wantStatusCode)
+			}
+
+			if tt.wantStatusCode == fwk.Success {
+				if assumedPodInfo.Pod.Spec.NodeName != scheduleResult.SuggestedHost {
+					t.Errorf("assumedPodInfo.Pod.Spec.NodeName = %q, want %q", assumedPodInfo.Pod.Spec.NodeName, scheduleResult.SuggestedHost)
+				}
+				// The queued pod belongs to the caller: assume must work on a copy.
+				if pod1.Spec.NodeName != "" {
+					t.Errorf("input pod Spec.NodeName mutated = %q, want empty", pod1.Spec.NodeName)
+				}
+				if assumedPodInfo.Pod == pod1 {
+					t.Error("expected assumedPodInfo.Pod to be a deep copy of the input pod, got the same pointer")
+				}
+			}
+
+			isAssumed, err := f.algorithm.cache.IsAssumedPod(pod1)
+			if err != nil {
+				t.Fatalf("cache.IsAssumedPod() error: %v", err)
+			}
+			if isAssumed != tt.wantAssumedInCache {
+				t.Errorf("cache.IsAssumedPod() = %v, want %v", isAssumed, tt.wantAssumedInCache)
+			}
+			// A cache assumption is not visible in the snapshot until it is refreshed.
+			if isPodInSnapshot(f.algorithm.nodeInfoSnapshot, node1.Name, pod1.Name) {
+				t.Error("pod assumed in the cache should not be in the snapshot yet")
+			}
+
+			if tt.wantStatusCode == fwk.Success {
+				if plugin.unreserved {
+					t.Error("expected Unreserve not to be called yet")
+				}
+				if err := f.algorithm.unreserveAndForget(ctx, state, f.fwk, assumedPodInfo, scheduleResult.SuggestedHost); err != nil {
+					t.Errorf("unreserveAndForget error: %v", err)
+				}
+				isAssumed, err = f.algorithm.cache.IsAssumedPod(pod1)
+				if err != nil {
+					t.Fatalf("cache.IsAssumedPod() error after unreserve: %v", err)
+				}
+				if isAssumed {
+					t.Error("pod still assumed in the cache after unreserveAndForget")
+				}
+				if !plugin.unreserved {
+					t.Error("expected Unreserve to be called")
+				}
+			} else if !plugin.unreserved {
+				t.Error("expected Unreserve to be called on reserve failure")
+			}
+		})
+	}
+}
+
+// TestAssumeAndReserveWithRevert covers the pod group scheduling cycle, where the
+// placement is only tentative: it goes into the snapshot rather than the cache, and
+// the returned revert function has to undo every part of it.
+func TestAssumeAndReserveWithRevert(t *testing.T) {
+	node1 := st.MakeNode().Name("node1").Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("pod1").Obj()
+	podWithNomination := st.MakePod().Name("pod-nominated").Namespace("default").UID("pod-nominated").NominatedNodeName("node1").Obj()
+
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+	}{
+		{
+			name: "pod group cycle: assumed in the snapshot only",
+			pod:  pod1,
+		},
+		{
+			name: "pod group cycle: nomination is dropped on assume and restored on revert",
+			pod:  podWithNomination,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+
+			plugin := &assumeReserveTestPlugin{
+				fakePodGroupPlugin: &fakePodGroupPlugin{
+					filterStatus: map[string]*fwk.Status{tt.pod.Name: fwk.NewStatus(fwk.Success)},
+				},
+			}
+			f := newAssumeReserveFixture(t, ctx, node1, plugin, tt.pod)
+
+			podInfo, err := framework.NewPodInfo(tt.pod)
+			if err != nil {
+				t.Fatalf("Failed to create PodInfo: %v", err)
+			}
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			state := newPodGroupCycleState()
+
+			nominated := tt.pod.Status.NominatedNodeName
+			if nominated != "" {
+				f.fwk.AddNominatedPod(logger, podInfo, &fwk.NominatingInfo{
+					NominatedNodeName: nominated,
+					NominatingMode:    fwk.ModeOverride,
+				})
+			}
+
+			scheduleResult, err := f.algorithm.SchedulePod(ctx, f.fwk, state, queuedPodInfo)
+			if err != nil {
+				t.Fatalf("schedulePod failed: %v", err)
+			}
+
+			status, revertFn := f.algorithm.assumeAndReserveWithRevert(ctx, state, f.fwk, queuedPodInfo, scheduleResult)
+			if !status.IsSuccess() {
+				t.Fatalf("assumeAndReserveWithRevert status = %v, want success", status)
+			}
+			if revertFn == nil {
+				t.Fatal("assumeAndReserveWithRevert returned no revert function on success")
+			}
+
+			// The pod group cycle keeps its tentative placement out of the shared cache.
+			isAssumed, err := f.algorithm.cache.IsAssumedPod(tt.pod)
+			if err != nil {
+				t.Fatalf("cache.IsAssumedPod() error: %v", err)
+			}
+			if isAssumed {
+				t.Error("pod assumed in the cache during a pod group cycle, want snapshot only")
+			}
+			if !isPodInSnapshot(f.algorithm.nodeInfoSnapshot, node1.Name, tt.pod.Name) {
+				t.Error("pod not assumed in the snapshot during a pod group cycle")
+			}
+			if tt.pod.Spec.NodeName != "" {
+				t.Errorf("input pod Spec.NodeName mutated = %q, want empty", tt.pod.Spec.NodeName)
+			}
+			if nominated != "" && len(f.fwk.NominatedPodsForNode(nominated)) != 0 {
+				t.Error("expected the nomination to be dropped once the pod was assumed")
+			}
+
+			revertFn()
+
+			if isPodInSnapshot(f.algorithm.nodeInfoSnapshot, node1.Name, tt.pod.Name) {
+				t.Error("pod still in the snapshot after revert")
+			}
+			if !plugin.unreserved {
+				t.Error("expected Unreserve to be called on revert")
+			}
+			if nominated != "" && len(f.fwk.NominatedPodsForNode(nominated)) == 0 {
+				t.Error("expected the nomination to be restored on revert")
+			}
+		})
+	}
+}
+
+// TestAssumeAndReserveSnapshotSync pins down the difference that makes the two
+// assume paths worth keeping apart: a cache assumption survives the next snapshot
+// refresh, a snapshot-only one does not.
+func TestAssumeAndReserveSnapshotSync(t *testing.T) {
+	node1 := st.MakeNode().Name("node1").Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("pod1").Obj()
+
+	tests := []struct {
+		name                       string
+		state                      *framework.CycleState
+		wantInSnapshotBeforeUpdate bool
+		wantInSnapshotAfterUpdate  bool
+	}{
+		{
+			name:                       "ordinary cycle: cache assumption is synced to snapshot on refresh",
+			state:                      framework.NewCycleState(),
+			wantInSnapshotBeforeUpdate: false,
+			wantInSnapshotAfterUpdate:  true,
+		},
+		{
+			name:                       "pod group cycle: snapshot-only assumption is overwritten on refresh",
+			state:                      newPodGroupCycleState(),
+			wantInSnapshotBeforeUpdate: true,
+			wantInSnapshotAfterUpdate:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+
+			plugin := &assumeReserveTestPlugin{
+				fakePodGroupPlugin: &fakePodGroupPlugin{
+					filterStatus: map[string]*fwk.Status{
+						pod1.Name: fwk.NewStatus(fwk.Success),
+					},
+				},
+			}
+			f := newAssumeReserveFixture(t, ctx, node1, plugin, pod1)
+
+			podInfo, err := framework.NewPodInfo(pod1)
+			if err != nil {
+				t.Fatalf("Failed to create PodInfo for pod1: %v", err)
+			}
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			state := tt.state
+
+			scheduleResult, err := f.algorithm.SchedulePod(ctx, f.fwk, state, queuedPodInfo)
+			if err != nil {
+				t.Fatalf("schedulePod failed for pod1: %v", err)
+			}
+
+			if _, status := f.algorithm.assumeAndReserve(ctx, state, f.fwk, queuedPodInfo, scheduleResult); !status.IsSuccess() {
+				t.Fatalf("assumeAndReserve failed for pod1: %v", status)
+			}
+
+			if got := isPodInSnapshot(f.algorithm.nodeInfoSnapshot, node1.Name, pod1.Name); got != tt.wantInSnapshotBeforeUpdate {
+				t.Errorf("isPodInSnapshot before UpdateSnapshot = %v, want %v", got, tt.wantInSnapshotBeforeUpdate)
+			}
+
+			if err := f.algorithm.cache.UpdateSnapshot(logger, f.algorithm.nodeInfoSnapshot); err != nil {
+				t.Fatalf("cache.UpdateSnapshot failed: %v", err)
+			}
+
+			if got := isPodInSnapshot(f.algorithm.nodeInfoSnapshot, node1.Name, pod1.Name); got != tt.wantInSnapshotAfterUpdate {
+				t.Errorf("isPodInSnapshot after UpdateSnapshot = %v, want %v", got, tt.wantInSnapshotAfterUpdate)
+			}
+		})
+	}
+}
+
+// TestSchedulingAlgorithmDriver covers the Scheduler-level wrapper around the
+// algorithm: it owns preemption (PostFilter) and the nominating info, which the
+// algorithm itself deliberately knows nothing about.
+func TestSchedulingAlgorithmDriver(t *testing.T) {
+	node1 := st.MakeNode().Name("node1").Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("pod1").Obj()
+
+	tests := []struct {
+		name                 string
+		filterStatus         *fwk.Status
+		postFilterStatus     *fwk.Status
+		postFilterResult     *fwk.PostFilterResult
+		podGroupCycle        bool
+		wantStatusCode       fwk.Code
+		wantNominatingInfo   *fwk.NominatingInfo
+		wantPostFilterCalled bool
+	}{
+		{
+			name:                 "failure: algorithm finds no nodes",
+			filterStatus:         fwk.NewStatus(fwk.Unschedulable, "fake failure"),
+			postFilterStatus:     fwk.NewStatus(fwk.Unschedulable),
+			wantStatusCode:       fwk.Unschedulable,
+			wantPostFilterCalled: true,
+		},
+		{
+			name:                 "pod group cycle: per-pod PostFilter is not run (PodGroupPostFilter handles it)",
+			filterStatus:         fwk.NewStatus(fwk.Unschedulable, "no fit"),
+			postFilterStatus:     fwk.NewStatus(fwk.Success),
+			postFilterResult:     &fwk.PostFilterResult{NominatingInfo: &fwk.NominatingInfo{NominatedNodeName: "node1", NominatingMode: fwk.ModeOverride}},
+			podGroupCycle:        true,
+			wantStatusCode:       fwk.Unschedulable,
+			wantPostFilterCalled: false,
+		},
+		{
+			name:             "failure: algorithm fails but PostFilter nominates a node",
+			filterStatus:     fwk.NewStatus(fwk.Unschedulable, "no fit"),
+			postFilterStatus: fwk.NewStatus(fwk.Success),
+			postFilterResult: &fwk.PostFilterResult{
+				NominatingInfo: &fwk.NominatingInfo{
+					NominatedNodeName: "node1",
+					NominatingMode:    fwk.ModeOverride,
+				},
+			},
+			wantStatusCode: fwk.Unschedulable,
+			wantNominatingInfo: &fwk.NominatingInfo{
+				NominatedNodeName: "node1",
+				NominatingMode:    fwk.ModeOverride,
+			},
+			wantPostFilterCalled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			client := clientsetfake.NewClientset(node1, pod1)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			cache := internalcache.New(ctx, nil, true, false)
+			cache.AddNode(logger, node1)
+			snapshot := internalcache.NewEmptySnapshot()
+			queue := internalqueue.NewTestQueueWithObjects(ctx, nil, []runtime.Object{pod1})
+
+			podInfo, err := framework.NewPodInfo(pod1)
+			if err != nil {
+				t.Fatalf("Failed to create PodInfo: %v", err)
+			}
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			fakePlugin := &assumeReserveTestPlugin{
+				fakePodGroupPlugin: &fakePodGroupPlugin{
+					filterStatus:     map[string]*fwk.Status{pod1.Name: tt.filterStatus},
+					postFilterStatus: map[string]*fwk.Status{pod1.Name: tt.postFilterStatus},
+					postFilterResult: map[string]*fwk.PostFilterResult{pod1.Name: tt.postFilterResult},
+				},
+			}
+
+			registry := frameworkruntime.Registry{
+				queuesort.Name:     queuesort.New,
+				defaultbinder.Name: defaultbinder.New,
+				"AssumeReserveTestPlugin": func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+					return fakePlugin, nil
+				},
+			}
+			profileCfg := schedulerapi.KubeSchedulerProfile{
+				SchedulerName: "default-scheduler",
+				Plugins: &schedulerapi.Plugins{
+					QueueSort:  schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: queuesort.Name}}},
+					Filter:     schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+					PostFilter: schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: "AssumeReserveTestPlugin"}}},
+					Bind:       schedulerapi.PluginSet{Enabled: []schedulerapi.Plugin{{Name: defaultbinder.Name}}},
+				},
+			}
+
+			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(queue),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
+
+			sched := &Scheduler{
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
+			}
+			sched.initAlgorithm()
+			sched.applyDefaultHandlers()
+
+			state := framework.NewCycleState()
+			if tt.podGroupCycle {
+				state.SetPodGroupSchedulingCycle(framework.NewCycleState())
+			}
+
+			scheduleResult, status := sched.schedulingAlgorithm(ctx, state, schedFwk, queuedPodInfo, time.Now())
+
+			if status.Code() != tt.wantStatusCode {
+				t.Errorf("status.Code() = %v, want %v", status.Code(), tt.wantStatusCode)
+			}
+			if fakePlugin.postFilterCalled != tt.wantPostFilterCalled {
+				t.Errorf("postFilterCalled = %v, want %v", fakePlugin.postFilterCalled, tt.wantPostFilterCalled)
+			}
+			if diff := cmp.Diff(tt.wantNominatingInfo, scheduleResult.nominatingInfo); diff != "" {
+				t.Errorf("Unexpected nominatingInfo (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestFindNodesThatPassFiltersBudget covers the early exit: the search stops once it
+// has enough feasible nodes, and "enough" collapses to a single node for profiles
+// that neither score nor run extender filters, since there is nothing left to choose
+// between the candidates.
+func TestFindNodesThatPassFiltersBudget(t *testing.T) {
+	pod := st.MakePod().Name("pod1").Obj()
+	allNodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+		st.MakeNode().Name("node3").Obj(),
+		st.MakeNode().Name("node4").Obj(),
+		st.MakeNode().Name("node5").Obj(),
+	}
+
+	tests := []struct {
+		name             string
+		withScoring      bool
+		withFilterPlugin bool
+		wantCount        int
+	}{
+		{
+			name:             "no scoring and no extenders stops at the first feasible node",
+			withFilterPlugin: true,
+			wantCount:        1,
+		},
+		{
+			name:             "scoring profile keeps every feasible node to choose from",
+			withScoring:      true,
+			withFilterPlugin: true,
+			wantCount:        len(allNodes),
+		},
+		{
+			name:        "profile without filter plugins still honours the budget",
+			withScoring: true,
+			wantCount:   len(allNodes),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			snapshot := internalcache.NewSnapshot(nil, allNodes)
+
+			registerPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			if tt.withFilterPlugin {
+				registerPlugins = append(registerPlugins, tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin))
+			}
+			if tt.withScoring {
+				registerPlugins = append(registerPlugins,
+					tf.RegisterScorePlugin("FakeScore", tf.NewFakePreScoreAndScorePlugin("FakeScore", 1, nil, nil), 1))
+			}
+			schedFwk, err := tf.NewFramework(ctx, registerPlugins, "default-scheduler",
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			algo := NewSchedulingAlgorithm(snapshot, nil)
+
+			nodes, err := snapshot.ListNodesInPlacement()
+			if err != nil {
+				t.Fatalf("ListNodesInPlacement returned error: %v", err)
+			}
+			diagnosis := framework.Diagnosis{
+				NodeToStatus: framework.NewDefaultNodeToStatus(),
+			}
+
+			got, err := algo.findNodesThatPassFilters(ctx, schedFwk, framework.NewCycleState(), pod, &diagnosis, nodes)
+			if err != nil {
+				t.Fatalf("findNodesThatPassFilters returned error: %v", err)
+			}
+			if len(got) != tt.wantCount {
+				t.Errorf("len(nodes) = %d, want %d", len(got), tt.wantCount)
+			}
+
+			seen := make(sets.Set[string], len(got))
+			for _, n := range got {
+				name := n.Node().Name
+				if seen.Has(name) {
+					t.Errorf("duplicate node name in result: %q", name)
+				}
+				seen.Insert(name)
+			}
+		})
+	}
+}
+
+// TestFindNodesThatPassFiltersEmptyNodes covers an empty candidate list, which
+// PreFilter can produce by narrowing to nodes that are not in the placement.
+//
+// Only the filter-plugin path is exercised: a profile with no filter plugins takes
+// the shortcut loop, which indexes nodes[(nextStartNodeIndex+i)%len(nodes)] against
+// a budget that the n = 1 rule raises above the empty candidate list, and divides by
+// zero. That is pre-existing behaviour, unchanged by this commit, so it is not
+// covered here.
+func TestFindNodesThatPassFiltersEmptyNodes(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	pod := st.MakePod().Name("pod1").Obj()
+
+	snapshot := internalcache.NewSnapshot(nil, nil)
+	algo := NewSchedulingAlgorithm(snapshot, nil)
+
+	schedFwk, err := tf.NewFramework(ctx, []tf.RegisterPluginFunc{
+		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+	}, "default-scheduler",
+		frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+
+	diagnosis := framework.Diagnosis{
+		NodeToStatus: framework.NewDefaultNodeToStatus(),
+	}
+	res, err := algo.findNodesThatPassFilters(ctx, schedFwk, framework.NewCycleState(), pod, &diagnosis, nil)
+	if err != nil {
+		t.Fatalf("findNodesThatPassFilters returned unexpected error: %v", err)
+	}
+	if len(res) != 0 {
+		t.Errorf("expected empty result, got %d nodes", len(res))
+	}
+}
+
+// TestCycleProvider checks that the cycle the algorithm was built with is the one the
+// batch module sees: it keys its cached scoring state by cycle, so a wrong or
+// synthetic counter would silently make unrelated pods look consecutive.
+func TestCycleProvider(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.OpportunisticBatching, true)
+
+	allNodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+	}
+	snapshot := internalcache.NewSnapshot(nil, allNodes)
+	algo := NewSchedulingAlgorithm(snapshot, nil, WithCurrentCycleProvider(func() int64 { return 42 }))
+
+	registerPlugins := []tf.RegisterPluginFunc{
+		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+	}
+	schedFwk, err := tf.NewFramework(ctx, registerPlugins, "default-scheduler",
+		frameworkruntime.WithSnapshotSharedLister(snapshot),
+		frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+
+	recordingFwk := &cycleRecordingFramework{Framework: schedFwk}
+
+	pod := st.MakePod().Name("pod1").Obj()
+	podInfo, err := framework.NewPodInfo(pod)
+	if err != nil {
+		t.Fatalf("Failed to create PodInfo: %v", err)
+	}
+	queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+	if _, _, _, err := algo.findNodesThatFitPod(ctx, recordingFwk, framework.NewCycleState(), queuedPodInfo); err != nil {
+		t.Fatalf("findNodesThatFitPod returned unexpected error: %v", err)
+	}
+	if !recordingFwk.hintRequested {
+		t.Fatal("findNodesThatFitPod did not ask the batch for a node hint")
+	}
+	if recordingFwk.recordedCycle != 42 {
+		t.Errorf("GetNodeHint received cycleCount = %d, want 42", recordingFwk.recordedCycle)
+	}
+}
+
+type cycleRecordingFramework struct {
+	framework.Framework
+	recordedCycle int64
+	hintRequested bool
+}
+
+func (f *cycleRecordingFramework) GetNodeHint(ctx context.Context, pod *v1.Pod, signature fwk.PodSignature, state fwk.CycleState, cycleCount int64) string {
+	f.recordedCycle = cycleCount
+	f.hintRequested = true
+	return f.Framework.GetNodeHint(ctx, pod, signature, state, cycleCount)
+}
+
+var _ fwk.ReservePlugin = &assumeReserveTestPlugin{}
+
+// assumeReserveTestPlugin embeds fakePodGroupPlugin so a single mock instance can test both standard cache assumption
+// and pod-group snapshot assumption paths without duplicating plugin registration logic across subtests.
+type assumeReserveTestPlugin struct {
+	*fakePodGroupPlugin
+	reserveStatus *fwk.Status
+	unreserved    bool
+}
+
+func (p *assumeReserveTestPlugin) Reserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) *fwk.Status {
+	if p.reserveStatus != nil {
+		return p.reserveStatus
+	}
+	return fwk.NewStatus(fwk.Success)
+}
+
+func (p *assumeReserveTestPlugin) Unreserve(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) {
+	p.unreserved = true
+}
+
+func isPodInSnapshot(snapshot *internalcache.Snapshot, nodeName, podName string) bool {
+	if nodeInfo, err := snapshot.Get(nodeName); err == nil {
+		for _, p := range nodeInfo.GetPods() {
+			if p.GetPod().Name == podName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func newPodGroupCycleState() *framework.CycleState {
+	state := framework.NewCycleState()
+	state.SetPodGroupSchedulingCycle(framework.NewCycleState())
+	return state
+}

--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/klog/v2/ktesting"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
-	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -344,17 +343,17 @@ func TestSchedulerWithExtenders(t *testing.T) {
 				runtime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
 				runtime.WithLogger(logger),
 				runtime.WithSnapshotSharedLister(emptySnapshot),
+				runtime.WithExtenders(extenders),
 			)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			sched := &Scheduler{
-				Cache:                    cache,
-				nodeInfoSnapshot:         emptySnapshot,
-				percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
-				Extenders:                extenders,
-				logger:                   logger,
+				Cache:            cache,
+				nodeInfoSnapshot: emptySnapshot,
+				Extenders:        extenders,
+				logger:           logger,
 			}
 			sched.applyDefaultHandlers()
 

--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/klog/v2/ktesting"
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
-	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -344,18 +343,18 @@ func TestSchedulerWithExtenders(t *testing.T) {
 				runtime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
 				runtime.WithLogger(logger),
 				runtime.WithSnapshotSharedLister(emptySnapshot),
+				runtime.WithExtenders(extenders),
 			)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			sched := &Scheduler{
-				Cache:                    cache,
-				nodeInfoSnapshot:         emptySnapshot,
-				percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
-				Extenders:                extenders,
-				logger:                   logger,
+				Cache:            cache,
+				nodeInfoSnapshot: emptySnapshot,
+				logger:           logger,
 			}
+			sched.initAlgorithm()
 			sched.applyDefaultHandlers()
 
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -201,7 +201,7 @@ func (sched *Scheduler) prepareForBindingCycle(
 	podsToActivate *framework.PodsToActivate,
 	scheduleResult ScheduleResult,
 ) (*framework.QueuedPodInfo, *fwk.Status) {
-	assumedPodInfo, status := sched.assumeAndReserve(ctx, state, schedFramework, podInfo, scheduleResult)
+	assumedPodInfo, status := sched.alg().AssumeAndReserveInCache(ctx, state, schedFramework, podInfo, scheduleResult)
 	if !status.IsSuccess() {
 		return assumedPodInfo, status
 	}
@@ -213,7 +213,7 @@ func (sched *Scheduler) prepareForBindingCycle(
 		schedFramework.AddWaitingPod(assumedPod, pluginsWaitTime)
 	} else if !runPermitStatus.IsSuccess() {
 		// trigger un-reserve plugins to clean up state associated with the reserved Pod
-		err := sched.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
+		err := sched.alg().UnreserveAndForgetFromCache(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
 		if err != nil {
 			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
 		}
@@ -261,7 +261,7 @@ func (sched *Scheduler) schedulingAlgorithm(
 	pod := podInfo.Pod
 
 	logger := klog.FromContext(ctx)
-	scheduleResult, err := sched.SchedulePod(ctx, schedFramework, state, podInfo)
+	scheduleResult, err := sched.alg().runSchedulePod(ctx, schedFramework, state, podInfo)
 	if err != nil {
 		if err == ErrNoNodesAvailable {
 			status := fwk.NewStatus(fwk.UnschedulableAndUnresolvable).WithError(err)
@@ -309,90 +309,6 @@ func (sched *Scheduler) schedulingAlgorithm(
 		return ScheduleResult{nominatingInfo: nominatingInfo}, fwk.NewStatus(fwk.Unschedulable).WithError(err)
 	}
 	return scheduleResult, nil
-}
-
-// assumeAndReserve assumes and reserves the pod in scheduler's memory.
-func (sched *Scheduler) assumeAndReserve(
-	ctx context.Context,
-	state fwk.CycleState,
-	schedFramework framework.Framework,
-	podInfo *framework.QueuedPodInfo,
-	scheduleResult ScheduleResult,
-) (*framework.QueuedPodInfo, *fwk.Status) {
-	logger := klog.FromContext(ctx)
-	// Tell the cache to assume that a pod now is running on a given node, even though it hasn't been bound yet.
-	// This allows us to keep scheduling without waiting on binding to occur.
-	assumedPodInfo := podInfo.DeepCopy()
-	assumedPod := assumedPodInfo.Pod
-	// assume modifies `assumedPod` by setting NodeName=scheduleResult.SuggestedHost
-	err := sched.assume(logger, state, assumedPodInfo, scheduleResult.SuggestedHost)
-	if err != nil {
-		// This is most probably result of a BUG in retrying logic.
-		// We report an error here so that pod scheduling can be retried.
-		// This relies on the fact that Error will check if the pod has been bound
-		// to a node and if so will not add it back to the unscheduled pods queue
-		// (otherwise this would cause an infinite loop).
-		return assumedPodInfo, fwk.AsStatus(err)
-	}
-
-	// Run the Reserve method of reserve plugins.
-	if sts := schedFramework.RunReservePluginsReserve(ctx, state, assumedPod, scheduleResult.SuggestedHost); !sts.IsSuccess() {
-		// trigger un-reserve to clean up state associated with the reserved Pod
-		err := sched.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
-		if err != nil {
-			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
-		}
-
-		if sts.IsRejected() {
-			fitErr := &framework.FitError{
-				NumAllNodes: 1,
-				Pod:         podInfo.Pod,
-				Diagnosis: framework.Diagnosis{
-					NodeToStatus: framework.NewDefaultNodeToStatus(),
-				},
-			}
-			fitErr.Diagnosis.NodeToStatus.Set(scheduleResult.SuggestedHost, sts)
-			fitErr.Diagnosis.AddPluginStatus(sts)
-			return assumedPodInfo, fwk.NewStatus(sts.Code()).WithError(fitErr)
-		}
-		return assumedPodInfo, sts
-	}
-	return assumedPodInfo, nil
-}
-
-// unreserveAndForget unreserves and forgets the pod from scheduler's memory.
-// This function shouldn't be called during binding cycle with a state, where IsPodGroupSchedulingCycle is set to true,
-// but this shouldn't happen, because such pods with such state cannot reach binding.
-func (sched *Scheduler) unreserveAndForget(
-	ctx context.Context,
-	state fwk.CycleState,
-	schedFramework framework.Framework,
-	assumedPodInfo *framework.QueuedPodInfo,
-	nodeName string,
-) error {
-	logger := klog.FromContext(ctx)
-
-	schedFramework.RunReservePluginsUnreserve(ctx, state, assumedPodInfo.Pod, nodeName)
-	if state.IsPodGroupSchedulingCycle() {
-		err := sched.nodeInfoSnapshot.ForgetPod(logger, assumedPodInfo.Pod)
-		if err != nil {
-			return err
-		}
-		if assumedPodInfo.Pod.Status.NominatedNodeName != "" {
-			// Assume method removed the nomination, but since we are reverting that stage for pod groups,
-			// we need to revert that operation as well.
-			if sched.SchedulingQueue != nil {
-				nominatingInfo := &fwk.NominatingInfo{
-					NominatedNodeName: assumedPodInfo.Pod.Status.NominatedNodeName,
-					NominatingMode:    fwk.ModeOverride,
-				}
-				// AssumedPodInfo can be used here, because the whole pod object is not stored in the nominator.
-				sched.SchedulingQueue.AddNominatedPod(logger, assumedPodInfo.PodInfo, nominatingInfo)
-			}
-		}
-		return nil
-	}
-	return sched.Cache.ForgetPod(logger, assumedPodInfo.Pod)
 }
 
 // bindingCycle tries to bind an assumed Pod.
@@ -516,7 +432,7 @@ func (sched *Scheduler) handleBindingCycleError(
 
 	assumedPod := podInfo.Pod
 	// trigger un-reserve plugins to clean up state associated with the reserved Pod
-	if forgetErr := sched.unreserveAndForget(ctx, state, fwk, podInfo, scheduleResult.SuggestedHost); forgetErr != nil {
+	if forgetErr := sched.alg().UnreserveAndForgetFromCache(ctx, state, fwk, podInfo, scheduleResult.SuggestedHost); forgetErr != nil {
 		utilruntime.HandleErrorWithContext(ctx, forgetErr, "ForgetPod failed")
 	} else {
 		// "Forget"ing an assumed Pod in binding cycle should be treated as a PodDelete event,
@@ -569,16 +485,16 @@ func (sched *Scheduler) skipPodSchedule(ctx context.Context, fwk framework.Frame
 // schedulePod tries to schedule the given pod to one of the nodes in the node list.
 // If it succeeds, it will return the name of the node.
 // If it fails, it will return a FitError with reasons.
-func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (result ScheduleResult, err error) {
+func (a *SchedulingAlgorithm) schedulePod(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (result ScheduleResult, err error) {
 	pod := podInfo.Pod
 	trace := utiltrace.New("Scheduling", utiltrace.Field{Key: "namespace", Value: pod.Namespace}, utiltrace.Field{Key: "name", Value: pod.Name})
 	defer trace.LogIfLong(100 * time.Millisecond)
 
-	if sched.nodeInfoSnapshot.NumNodesInPlacement() == 0 {
+	if a.nodeInfoSnapshot.NumNodesInPlacement() == 0 {
 		return result, ErrNoNodesAvailable
 	}
 
-	feasibleNodes, diagnosis, nodeHint, err := sched.findNodesThatFitPod(ctx, fwk, state, podInfo)
+	feasibleNodes, diagnosis, nodeHint, err := a.findNodesThatFitPod(ctx, fwk, state, podInfo, false)
 	if err != nil {
 		return result, err
 	}
@@ -587,7 +503,7 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 	if len(feasibleNodes) == 0 {
 		return result, &framework.FitError{
 			Pod:         pod,
-			NumAllNodes: sched.nodeInfoSnapshot.NumNodesInPlacement(),
+			NumAllNodes: a.nodeInfoSnapshot.NumNodesInPlacement(),
 			Diagnosis:   diagnosis,
 		}
 	}
@@ -596,7 +512,7 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 	if len(feasibleNodes) == 1 {
 		node := feasibleNodes[0].Node().Name
 		if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
-			fwk.StoreScheduleResults(ctx, podInfo.PodSignature, nodeHint, node, nil, sched.CurrentCycle())
+			fwk.StoreScheduleResults(ctx, podInfo.PodSignature, nodeHint, node, nil, a.currentCycle())
 		}
 		return ScheduleResult{
 			SuggestedHost:  node,
@@ -605,7 +521,7 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 		}, nil
 	}
 
-	priorityList, err := prioritizeNodes(ctx, sched.Extenders, fwk, state, pod, feasibleNodes)
+	priorityList, err := prioritizeNodes(ctx, fwk, state, pod, feasibleNodes)
 	if err != nil {
 		return result, err
 	}
@@ -615,7 +531,7 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 	trace.Step("Prioritizing done")
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
-		fwk.StoreScheduleResults(ctx, podInfo.PodSignature, nodeHint, node, sortedPrioritizedNodes, sched.CurrentCycle())
+		fwk.StoreScheduleResults(ctx, podInfo.PodSignature, nodeHint, node, sortedPrioritizedNodes, a.currentCycle())
 	}
 
 	return ScheduleResult{
@@ -627,12 +543,12 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 
 // Filters the nodes to find the ones that fit the pod based on the framework
 // filter plugins and filter extenders.
-func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) ([]fwk.NodeInfo, framework.Diagnosis, string, error) {
+func (a *SchedulingAlgorithm) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo, findAll bool) ([]fwk.NodeInfo, framework.Diagnosis, string, error) {
 	logger := klog.FromContext(ctx)
 	diagnosis := framework.Diagnosis{
 		NodeToStatus: framework.NewDefaultNodeToStatus(),
 	}
-	allNodes, err := sched.nodeInfoSnapshot.ListNodesInPlacement()
+	allNodes, err := a.nodeInfoSnapshot.ListNodesInPlacement()
 	if err != nil {
 		return nil, diagnosis, "", err
 	}
@@ -659,14 +575,14 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 	if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
 		// We get the node hint even if we have a nominated name for simplicity, but we could potentially avoid it
 		// in this scenario in the future.
-		nodeHint = schedFramework.GetNodeHint(ctx, pod, podInfo.PodSignature, state, sched.CurrentCycle())
+		nodeHint = schedFramework.GetNodeHint(ctx, pod, podInfo.PodSignature, state, a.currentCycle())
 	}
 
 	// "NominatedNodeName" can potentially be set in a previous scheduling cycle as a result of preemption.
 	// This node is likely the only candidate that will fit the pod, and hence we try it first before iterating over all nodes.
 	// We take the same tack for hinted nodes from the batch module.
-	if len(pod.Status.NominatedNodeName) > 0 || len(nodeHint) > 0 {
-		feasibleNodes, err := sched.evaluateNominatedNode(ctx, pod, schedFramework, state, nodeHint, diagnosis)
+	if !findAll && (len(pod.Status.NominatedNodeName) > 0 || len(nodeHint) > 0) {
+		feasibleNodes, err := a.evaluateNominatedNode(ctx, pod, schedFramework, state, nodeHint, diagnosis)
 		if err != nil {
 			utilruntime.HandleErrorWithContext(ctx, err, "Evaluation failed on nominated node", "pod", klog.KObj(pod), "node", pod.Status.NominatedNodeName)
 		}
@@ -682,22 +598,31 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 		for nodeName := range preRes.NodeNames {
 			// PreRes may return nodeName(s) which do not exist; we verify
 			// node exists in the Snapshot within the selected placement.
-			if nodeInfo, err := sched.nodeInfoSnapshot.GetNodeInPlacement(nodeName); err == nil {
+			if nodeInfo, err := a.nodeInfoSnapshot.GetNodeInPlacement(nodeName); err == nil {
 				nodes = append(nodes, nodeInfo)
 			}
 		}
 		diagnosis.NodeToStatus.SetAbsentNodesStatus(fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("node(s) didn't satisfy plugin(s) %v", sets.List(unscheduledPlugins))))
 	}
-	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, nodes)
+
+	// The budget is computed from the candidate list, which PreFilter may have narrowed —
+	// not from allNodes. findAll mode takes every candidate and skips the budget entirely.
+	numNodesToFind := int32(len(nodes))
+	if !findAll {
+		numNodesToFind = a.numNodesToFind(schedFramework, int32(len(nodes)))
+	}
+	feasibleNodes, err := a.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, nodes, numNodesToFind)
 	// always try to update the sched.nextStartNodeIndex regardless of whether an error has occurred
 	// this is helpful to make sure that all the nodes have a chance to be searched
 	processedNodes := len(feasibleNodes) + diagnosis.NodeToStatus.Len()
-	sched.nextStartNodeIndex = (sched.nextStartNodeIndex + processedNodes) % len(allNodes)
+	if !findAll {
+		a.nextStartNodeIndex = (a.nextStartNodeIndex + processedNodes) % len(allNodes)
+	}
 	if err != nil {
 		return nil, diagnosis, nodeHint, err
 	}
 
-	feasibleNodesAfterExtender, err := findNodesThatPassExtenders(ctx, sched.Extenders, pod, feasibleNodes, diagnosis.NodeToStatus)
+	feasibleNodesAfterExtender, err := findNodesThatPassExtenders(ctx, schedFramework.Extenders(), pod, feasibleNodes, diagnosis.NodeToStatus)
 	if err != nil {
 		return nil, diagnosis, nodeHint, err
 	}
@@ -719,7 +644,7 @@ func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework 
 	return feasibleNodesAfterExtender, diagnosis, nodeHint, nil
 }
 
-func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, schedFramework framework.Framework, state fwk.CycleState, nodeHint string, diagnosis framework.Diagnosis) ([]fwk.NodeInfo, error) {
+func (a *SchedulingAlgorithm) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, schedFramework framework.Framework, state fwk.CycleState, nodeHint string, diagnosis framework.Diagnosis) ([]fwk.NodeInfo, error) {
 	// In the future we could potentially use the hint if the nominated node failed.
 	// https://github.com/kubernetes/kubernetes/issues/135163
 	nnn := pod.Status.NominatedNodeName
@@ -727,9 +652,9 @@ func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, 
 		nnn = nodeHint
 	}
 
-	nodeInfo, err := sched.nodeInfoSnapshot.GetNodeInPlacement(nnn)
+	nodeInfo, err := a.nodeInfoSnapshot.GetNodeInPlacement(nnn)
 	if err != nil {
-		if _, err := sched.nodeInfoSnapshot.Get(nnn); err != nil {
+		if _, err := a.nodeInfoSnapshot.Get(nnn); err != nil {
 			return nil, err
 		}
 		// It's not an error if NNN is in the cluster but not in the placement.
@@ -739,12 +664,12 @@ func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, 
 		return nil, nil
 	}
 	node := []fwk.NodeInfo{nodeInfo}
-	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, node)
+	feasibleNodes, err := a.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, node, int32(len(node)))
 	if err != nil {
 		return nil, err
 	}
 
-	feasibleNodes, err = findNodesThatPassExtenders(ctx, sched.Extenders, pod, feasibleNodes, diagnosis.NodeToStatus)
+	feasibleNodes, err = findNodesThatPassExtenders(ctx, schedFramework.Extenders(), pod, feasibleNodes, diagnosis.NodeToStatus)
 	if err != nil {
 		return nil, err
 	}
@@ -753,11 +678,11 @@ func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, 
 }
 
 // hasScoring checks if scoring nodes is configured.
-func (sched *Scheduler) hasScoring(fwk framework.Framework) bool {
+func hasScoring(fwk framework.Framework) bool {
 	if fwk.HasScorePlugins() {
 		return true
 	}
-	for _, extender := range sched.Extenders {
+	for _, extender := range fwk.Extenders() {
 		if extender.IsPrioritizer() {
 			return true
 		}
@@ -766,8 +691,8 @@ func (sched *Scheduler) hasScoring(fwk framework.Framework) bool {
 }
 
 // hasExtenderFilters checks if any extenders filter nodes.
-func (sched *Scheduler) hasExtenderFilters() bool {
-	for _, extender := range sched.Extenders {
+func hasExtenderFilters(fwk framework.Framework) bool {
+	for _, extender := range fwk.Extenders() {
 		if extender.IsFilter() {
 			return true
 		}
@@ -776,18 +701,19 @@ func (sched *Scheduler) hasExtenderFilters() bool {
 }
 
 // findNodesThatPassFilters finds the nodes that fit the filter plugins.
-func (sched *Scheduler) findNodesThatPassFilters(
+func (a *SchedulingAlgorithm) findNodesThatPassFilters(
 	ctx context.Context,
 	schedFramework framework.Framework,
 	state fwk.CycleState,
 	pod *v1.Pod,
 	diagnosis *framework.Diagnosis,
-	nodes []fwk.NodeInfo) ([]fwk.NodeInfo, error) {
-	numAllNodes := len(nodes)
-	numNodesToFind := sched.numFeasibleNodesToFind(schedFramework.PercentageOfNodesToScore(), int32(numAllNodes))
-	if !sched.hasExtenderFilters() && !sched.hasScoring(schedFramework) {
-		numNodesToFind = 1
+	nodes []fwk.NodeInfo,
+	numNodesToFind int32) ([]fwk.NodeInfo, error) {
+	if len(nodes) == 0 {
+		return nil, nil
 	}
+	numAllNodes := len(nodes)
+	numNodesToFind = min(numNodesToFind, int32(numAllNodes))
 
 	// Create feasible list with enough space to avoid growing it
 	// and allow assigning.
@@ -795,7 +721,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 
 	if !schedFramework.HasFilterPlugins() {
 		for i := range feasibleNodes {
-			feasibleNodes[i] = nodes[(sched.nextStartNodeIndex+i)%numAllNodes]
+			feasibleNodes[i] = nodes[(a.nextStartNodeIndex+i)%numAllNodes]
 		}
 		return feasibleNodes, nil
 	}
@@ -813,7 +739,7 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	checkNode := func(i int) {
 		// We check the nodes starting from where we left off in the previous scheduling cycle,
 		// this is to make sure all nodes have the same chance of being examined across pods.
-		nodeInfo := nodes[(sched.nextStartNodeIndex+i)%numAllNodes]
+		nodeInfo := nodes[(a.nextStartNodeIndex+i)%numAllNodes]
 		status := schedFramework.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
 		if status.Code() == fwk.Error {
 			errCh.SendWithCancel(status.AsError(), func() {
@@ -861,9 +787,23 @@ func (sched *Scheduler) findNodesThatPassFilters(
 	return feasibleNodes, nil
 }
 
+// numNodesToFind decides how many feasible nodes Filter should collect.
+// The override (library/simulation) is clamped to numAllNodes; the default is
+// kube-scheduler's percentageOfNodesToScore policy.
+func (a *SchedulingAlgorithm) numNodesToFind(schedFramework framework.Framework, numAllNodes int32) int32 {
+	if a.numNodesToFindOverride != nil {
+		return max(0, min(a.numNodesToFindOverride(numAllNodes), numAllNodes))
+	}
+	n := a.numFeasibleNodesToFind(schedFramework.PercentageOfNodesToScore(), numAllNodes)
+	if !hasExtenderFilters(schedFramework) && !hasScoring(schedFramework) {
+		n = 1
+	}
+	return n
+}
+
 // numFeasibleNodesToFind returns the number of feasible nodes that once found, the scheduler stops
 // its search for more feasible nodes.
-func (sched *Scheduler) numFeasibleNodesToFind(percentageOfNodesToScore *int32, numAllNodes int32) (numNodes int32) {
+func (a *SchedulingAlgorithm) numFeasibleNodesToFind(percentageOfNodesToScore *int32, numAllNodes int32) (numNodes int32) {
 	if numAllNodes < minFeasibleNodesToFind {
 		return numAllNodes
 	}
@@ -873,7 +813,7 @@ func (sched *Scheduler) numFeasibleNodesToFind(percentageOfNodesToScore *int32, 
 	if percentageOfNodesToScore != nil {
 		percentage = *percentageOfNodesToScore
 	} else {
-		percentage = sched.percentageOfNodesToScore
+		percentage = a.percentageOfNodesToScore
 	}
 
 	if percentage == 0 {
@@ -944,13 +884,13 @@ func findNodesThatPassExtenders(ctx context.Context, extenders []fwk.Extender, p
 // All scores are finally combined (added) to get the total weighted scores of all nodes
 func prioritizeNodes(
 	ctx context.Context,
-	extenders []fwk.Extender,
 	schedFramework framework.Framework,
 	state fwk.CycleState,
 	pod *v1.Pod,
 	nodes []fwk.NodeInfo,
 ) ([]fwk.NodePluginScores, error) {
 	logger := klog.FromContext(ctx)
+	extenders := schedFramework.Extenders()
 	// If no priority configs are provided, then all nodes will have a score of one.
 	// This is required to generate the priority list in the required format
 	if len(extenders) == 0 && !schedFramework.HasScorePlugins() {
@@ -1055,43 +995,51 @@ func prioritizeNodes(
 	return nodesScores, nil
 }
 
-// assume signals to the cache that a pod is already in the cache, so that binding can be asynchronous.
-// When called during pod group scheduling cycle, pod is assumed in the snapshot instead.
-func (sched *Scheduler) assume(logger klog.Logger, state fwk.CycleState, assumedPodInfo *framework.QueuedPodInfo, host string) error {
-	// Optimistically assume that the binding will succeed and send it to apiserver
-	// in the background.
-	// If the binding fails, scheduler will release resources allocated to assumed pod
-	// immediately.
+// prepareAssumedPod returns the copy of podInfo that will be recorded as assumed:
+// bound to host and carrying the DRA allocations computed for this cycle. It
+// touches no store — the caller decides where the result is recorded.
+func (a *SchedulingAlgorithm) prepareAssumedPod(logger klog.Logger, state fwk.CycleState,
+	podInfo *framework.QueuedPodInfo, host string) *framework.QueuedPodInfo {
+
+	assumedPodInfo := podInfo.DeepCopy()
 	assumedPodInfo.Pod.Spec.NodeName = host
 	if utilfeature.DefaultFeatureGate.Enabled(features.DRANodeAllocatableResources) {
-		// If DRANodeAllocatableResources is enabled, copy the calculated node allocatable resource claim status
-		// from the cycle state to the assumed pod's status. This ensures that the scheduler's
-		// cached version of the pod reflects the node allocatable resources allocated by the DRA plugin
-		// for this scheduling cycle, making this information available for NodeInfo cache update.
-		// Any potential NodeAllocatableResourceClaimStatuses from a previously failed scheduling attempt is overwritten.
-		// This field is not explicitly cleared as the Pod object is reconstructed in handleSchedulingFailure()
-		// before re-queueing.
-		assumedPodInfo.Pod.Status.NodeAllocatableResourceClaimStatuses = dynamicresources.ExtractPodNodeAllocatableResourceClaimStatus(logger, state, host)
+		// Same rationale as before: the assumed copy must carry the node allocatable
+		// claim statuses the DRA plugin computed for this cycle.
+		assumedPodInfo.Pod.Status.NodeAllocatableResourceClaimStatuses =
+			dynamicresources.ExtractPodNodeAllocatableResourceClaimStatus(logger, state, host)
 	}
+	return assumedPodInfo
+}
 
-	if state.IsPodGroupSchedulingCycle() {
-		err := sched.nodeInfoSnapshot.AssumePod(assumedPodInfo.PodInfo)
-		if err != nil {
-			logger.Error(err, "Scheduler snapshot AssumePod failed")
-			return err
-		}
-	} else {
-		if err := sched.Cache.AssumePod(logger, assumedPodInfo.Pod); err != nil {
-			logger.Error(err, "Scheduler cache AssumePod failed")
-			return err
-		}
-	}
-	// if "assumed" is a nominated pod, we should remove it from internal cache
-	if sched.SchedulingQueue != nil {
-		sched.SchedulingQueue.DeleteNominatedPodIfExists(assumedPodInfo.Pod)
-	}
+// reserveOrUndo runs the Reserve plugins for an already-assumed pod. If they reject
+// it, undo rolls the assumption back. undo is supplied by the caller, so the
+// rollback always targets the store the pod was actually assumed into.
+func (a *SchedulingAlgorithm) reserveOrUndo(ctx context.Context, state fwk.CycleState,
+	schedFramework framework.Framework, assumedPodInfo *framework.QueuedPodInfo,
+	origPod *v1.Pod, host string, undo func() error) *fwk.Status {
 
-	return nil
+	sts := schedFramework.RunReservePluginsReserve(ctx, state, assumedPodInfo.Pod, host)
+	if sts.IsSuccess() {
+		return nil
+	}
+	// trigger un-reserve to clean up state associated with the reserved Pod
+	if err := undo(); err != nil {
+		utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
+	}
+	if sts.IsRejected() {
+		fitErr := &framework.FitError{
+			NumAllNodes: 1,
+			Pod:         origPod,
+			Diagnosis: framework.Diagnosis{
+				NodeToStatus: framework.NewDefaultNodeToStatus(),
+			},
+		}
+		fitErr.Diagnosis.NodeToStatus.Set(host, sts)
+		fitErr.Diagnosis.AddPluginStatus(sts)
+		return fwk.NewStatus(sts.Code()).WithError(fitErr)
+	}
+	return sts
 }
 
 // bind binds a pod to a given node defined in a binding object.

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -23,7 +23,6 @@ import (
 	"math/rand"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -31,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	compresource "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
@@ -39,14 +37,10 @@ import (
 	fwk "k8s.io/kube-scheduler/framework"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
-	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/scheduler/util"
-	utiltrace "k8s.io/utils/trace"
 )
 
 const (
@@ -203,7 +197,7 @@ func (sched *Scheduler) prepareForBindingCycle(
 	podsToActivate *framework.PodsToActivate,
 	scheduleResult ScheduleResult,
 ) (*framework.QueuedPodInfo, *fwk.Status) {
-	assumedPodInfo, status := sched.assumeAndReserve(ctx, state, schedFramework, podInfo, scheduleResult)
+	assumedPodInfo, status := sched.algorithm.assumeAndReserve(ctx, state, schedFramework, podInfo, scheduleResult)
 	if !status.IsSuccess() {
 		return assumedPodInfo, status
 	}
@@ -215,7 +209,7 @@ func (sched *Scheduler) prepareForBindingCycle(
 		schedFramework.AddWaitingPod(assumedPod, pluginsWaitTime)
 	} else if !runPermitStatus.IsSuccess() {
 		// trigger un-reserve plugins to clean up state associated with the reserved Pod
-		err := sched.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
+		err := sched.algorithm.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
 		if err != nil {
 			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
 		}
@@ -311,90 +305,6 @@ func (sched *Scheduler) schedulingAlgorithm(
 		return ScheduleResult{nominatingInfo: nominatingInfo}, fwk.NewStatus(fwk.Unschedulable).WithError(err)
 	}
 	return scheduleResult, nil
-}
-
-// assumeAndReserve assumes and reserves the pod in scheduler's memory.
-func (sched *Scheduler) assumeAndReserve(
-	ctx context.Context,
-	state fwk.CycleState,
-	schedFramework framework.Framework,
-	podInfo *framework.QueuedPodInfo,
-	scheduleResult ScheduleResult,
-) (*framework.QueuedPodInfo, *fwk.Status) {
-	logger := klog.FromContext(ctx)
-	// Tell the cache to assume that a pod now is running on a given node, even though it hasn't been bound yet.
-	// This allows us to keep scheduling without waiting on binding to occur.
-	assumedPodInfo := podInfo.DeepCopy()
-	assumedPod := assumedPodInfo.Pod
-	// assume modifies `assumedPod` by setting NodeName=scheduleResult.SuggestedHost
-	err := sched.assume(logger, state, assumedPodInfo, scheduleResult.SuggestedHost)
-	if err != nil {
-		// This is most probably result of a BUG in retrying logic.
-		// We report an error here so that pod scheduling can be retried.
-		// This relies on the fact that Error will check if the pod has been bound
-		// to a node and if so will not add it back to the unscheduled pods queue
-		// (otherwise this would cause an infinite loop).
-		return assumedPodInfo, fwk.AsStatus(err)
-	}
-
-	// Run the Reserve method of reserve plugins.
-	if sts := schedFramework.RunReservePluginsReserve(ctx, state, assumedPod, scheduleResult.SuggestedHost); !sts.IsSuccess() {
-		// trigger un-reserve to clean up state associated with the reserved Pod
-		err := sched.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
-		if err != nil {
-			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
-		}
-
-		if sts.IsRejected() {
-			fitErr := &framework.FitError{
-				NumAllNodes: 1,
-				Pod:         podInfo.Pod,
-				Diagnosis: framework.Diagnosis{
-					NodeToStatus: framework.NewDefaultNodeToStatus(),
-				},
-			}
-			fitErr.Diagnosis.NodeToStatus.Set(scheduleResult.SuggestedHost, sts)
-			fitErr.Diagnosis.AddPluginStatus(sts)
-			return assumedPodInfo, fwk.NewStatus(sts.Code()).WithError(fitErr)
-		}
-		return assumedPodInfo, sts
-	}
-	return assumedPodInfo, nil
-}
-
-// unreserveAndForget unreserves and forgets the pod from scheduler's memory.
-// This function shouldn't be called during binding cycle with a state, where IsPodGroupSchedulingCycle is set to true,
-// but this shouldn't happen, because such pods with such state cannot reach binding.
-func (sched *Scheduler) unreserveAndForget(
-	ctx context.Context,
-	state fwk.CycleState,
-	schedFramework framework.Framework,
-	assumedPodInfo *framework.QueuedPodInfo,
-	nodeName string,
-) error {
-	logger := klog.FromContext(ctx)
-
-	schedFramework.RunReservePluginsUnreserve(ctx, state, assumedPodInfo.Pod, nodeName)
-	if state.IsPodGroupSchedulingCycle() {
-		err := sched.nodeInfoSnapshot.ForgetPod(logger, assumedPodInfo.Pod)
-		if err != nil {
-			return err
-		}
-		if assumedPodInfo.Pod.Status.NominatedNodeName != "" {
-			// Assume method removed the nomination, but since we are reverting that stage for pod groups,
-			// we need to revert that operation as well.
-			if sched.SchedulingQueue != nil {
-				nominatingInfo := &fwk.NominatingInfo{
-					NominatedNodeName: assumedPodInfo.Pod.Status.NominatedNodeName,
-					NominatingMode:    fwk.ModeOverride,
-				}
-				// AssumedPodInfo can be used here, because the whole pod object is not stored in the nominator.
-				sched.SchedulingQueue.AddNominatedPod(logger, assumedPodInfo.PodInfo, nominatingInfo)
-			}
-		}
-		return nil
-	}
-	return sched.Cache.ForgetPod(logger, assumedPodInfo.Pod)
 }
 
 // bindingCycle tries to bind an assumed Pod.
@@ -518,7 +428,7 @@ func (sched *Scheduler) handleBindingCycleError(
 
 	assumedPod := podInfo.Pod
 	// trigger un-reserve plugins to clean up state associated with the reserved Pod
-	if forgetErr := sched.unreserveAndForget(ctx, state, fwk, podInfo, scheduleResult.SuggestedHost); forgetErr != nil {
+	if forgetErr := sched.algorithm.unreserveAndForget(ctx, state, fwk, podInfo, scheduleResult.SuggestedHost); forgetErr != nil {
 		utilruntime.HandleErrorWithContext(ctx, forgetErr, "ForgetPod failed")
 	} else {
 		// "Forget"ing an assumed Pod in binding cycle should be treated as a PodDelete event,
@@ -575,198 +485,12 @@ func (sched *Scheduler) skipPodSchedule(ctx context.Context, fwk framework.Frame
 	return isAssumed
 }
 
-// schedulePod tries to schedule the given pod to one of the nodes in the node list.
-// If it succeeds, it will return the name of the node.
-// If it fails, it will return a FitError with reasons.
-func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (result ScheduleResult, err error) {
-	pod := podInfo.Pod
-	trace := utiltrace.New("Scheduling", utiltrace.Field{Key: "namespace", Value: pod.Namespace}, utiltrace.Field{Key: "name", Value: pod.Name})
-	defer trace.LogIfLong(100 * time.Millisecond)
-
-	if sched.nodeInfoSnapshot.NumNodesInPlacement() == 0 {
-		return result, ErrNoNodesAvailable
-	}
-
-	feasibleNodes, diagnosis, nodeHint, err := sched.findNodesThatFitPod(ctx, fwk, state, podInfo)
-	if err != nil {
-		return result, err
-	}
-	trace.Step("Computing predicates done")
-
-	if len(feasibleNodes) == 0 {
-		return result, &framework.FitError{
-			Pod:         pod,
-			NumAllNodes: sched.nodeInfoSnapshot.NumNodesInPlacement(),
-			Diagnosis:   diagnosis,
-		}
-	}
-
-	// When only one node after predicate, just use it.
-	if len(feasibleNodes) == 1 {
-		node := feasibleNodes[0].Node().Name
-		if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
-			fwk.StoreScheduleResults(ctx, podInfo.PodSignature, nodeHint, node, nil, sched.CurrentCycle())
-		}
-		return ScheduleResult{
-			SuggestedHost:  node,
-			EvaluatedNodes: 1 + diagnosis.NodeToStatus.Len(),
-			FeasibleNodes:  1,
-		}, nil
-	}
-
-	priorityList, err := prioritizeNodes(ctx, sched.Extenders, fwk, state, pod, feasibleNodes)
-	if err != nil {
-		return result, err
-	}
-
-	sortedPrioritizedNodes := framework.NewSortedScoredNodes(priorityList)
-	node := sortedPrioritizedNodes.Pop().Name
-	trace.Step("Prioritizing done")
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
-		fwk.StoreScheduleResults(ctx, podInfo.PodSignature, nodeHint, node, sortedPrioritizedNodes, sched.CurrentCycle())
-	}
-
-	return ScheduleResult{
-		SuggestedHost:  node,
-		EvaluatedNodes: len(feasibleNodes) + diagnosis.NodeToStatus.Len(),
-		FeasibleNodes:  len(feasibleNodes),
-	}, err
-}
-
-// Filters the nodes to find the ones that fit the pod based on the framework
-// filter plugins and filter extenders.
-func (sched *Scheduler) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) ([]fwk.NodeInfo, framework.Diagnosis, string, error) {
-	logger := klog.FromContext(ctx)
-	diagnosis := framework.Diagnosis{
-		NodeToStatus: framework.NewDefaultNodeToStatus(),
-	}
-	allNodes, err := sched.nodeInfoSnapshot.ListNodesInPlacement()
-	if err != nil {
-		return nil, diagnosis, "", err
-	}
-	// Run "prefilter" plugins.
-	pod := podInfo.Pod
-	preRes, s, unscheduledPlugins := schedFramework.RunPreFilterPlugins(ctx, state, pod)
-	diagnosis.UnschedulablePlugins = unscheduledPlugins
-	if !s.IsSuccess() {
-		if !s.IsRejected() {
-			return nil, diagnosis, "", s.AsError()
-		}
-		// All nodes in NodeToStatus will have the same status so that they can be handled in the preemption.
-		diagnosis.NodeToStatus.SetAbsentNodesStatus(s)
-
-		// Record the messages from PreFilter in Diagnosis.PreFilterMsg.
-		msg := s.Message()
-		diagnosis.PreFilterMsg = msg
-		logger.V(5).Info("Status after running PreFilter plugins for pod", "pod", klog.KObj(pod), "status", msg)
-		diagnosis.AddPluginStatus(s)
-		return nil, diagnosis, "", nil
-	}
-
-	var nodeHint string
-	if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
-		// We get the node hint even if we have a nominated name for simplicity, but we could potentially avoid it
-		// in this scenario in the future.
-		nodeHint = schedFramework.GetNodeHint(ctx, pod, podInfo.PodSignature, state, sched.CurrentCycle())
-	}
-
-	// "NominatedNodeName" can potentially be set in a previous scheduling cycle as a result of preemption.
-	// This node is likely the only candidate that will fit the pod, and hence we try it first before iterating over all nodes.
-	// We take the same tack for hinted nodes from the batch module.
-	if len(pod.Status.NominatedNodeName) > 0 || len(nodeHint) > 0 {
-		feasibleNodes, err := sched.evaluateNominatedNode(ctx, pod, schedFramework, state, nodeHint, diagnosis)
-		if err != nil {
-			utilruntime.HandleErrorWithContext(ctx, err, "Evaluation failed on nominated node", "pod", klog.KObj(pod), "node", pod.Status.NominatedNodeName)
-		}
-		// Nominated node passes all the filters, scheduler is good to assign this node to the pod.
-		if len(feasibleNodes) != 0 {
-			return feasibleNodes, diagnosis, nodeHint, nil
-		}
-	}
-
-	nodes := allNodes
-	if !preRes.AllNodes() {
-		nodes = make([]fwk.NodeInfo, 0, len(preRes.NodeNames))
-		for nodeName := range preRes.NodeNames {
-			// PreRes may return nodeName(s) which do not exist; we verify
-			// node exists in the Snapshot within the selected placement.
-			if nodeInfo, err := sched.nodeInfoSnapshot.GetNodeInPlacement(nodeName); err == nil {
-				nodes = append(nodes, nodeInfo)
-			}
-		}
-		diagnosis.NodeToStatus.SetAbsentNodesStatus(fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("node(s) didn't satisfy plugin(s) %v", sets.List(unscheduledPlugins))))
-	}
-	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, nodes)
-	// always try to update the sched.nextStartNodeIndex regardless of whether an error has occurred
-	// this is helpful to make sure that all the nodes have a chance to be searched
-	processedNodes := len(feasibleNodes) + diagnosis.NodeToStatus.Len()
-	sched.nextStartNodeIndex = (sched.nextStartNodeIndex + processedNodes) % len(allNodes)
-	if err != nil {
-		return nil, diagnosis, nodeHint, err
-	}
-
-	feasibleNodesAfterExtender, err := findNodesThatPassExtenders(ctx, sched.Extenders, pod, feasibleNodes, diagnosis.NodeToStatus)
-	if err != nil {
-		return nil, diagnosis, nodeHint, err
-	}
-	if len(feasibleNodesAfterExtender) != len(feasibleNodes) {
-		// Extenders filtered out some nodes.
-		//
-		// Extender doesn't support any kind of requeueing feature like EnqueueExtensions in the scheduling framework.
-		// When Extenders reject some Nodes and the pod ends up being unschedulable,
-		// we put fwk.ExtenderName to pInfo.UnschedulablePlugins.
-		// This Pod will be requeued from unschedulable pod pool to activeQ/backoffQ
-		// by any kind of cluster events.
-		// https://github.com/kubernetes/kubernetes/issues/122019
-		if diagnosis.UnschedulablePlugins == nil {
-			diagnosis.UnschedulablePlugins = sets.New[string]()
-		}
-		diagnosis.UnschedulablePlugins.Insert(framework.ExtenderName)
-	}
-
-	return feasibleNodesAfterExtender, diagnosis, nodeHint, nil
-}
-
-func (sched *Scheduler) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, schedFramework framework.Framework, state fwk.CycleState, nodeHint string, diagnosis framework.Diagnosis) ([]fwk.NodeInfo, error) {
-	// In the future we could potentially use the hint if the nominated node failed.
-	// https://github.com/kubernetes/kubernetes/issues/135163
-	nnn := pod.Status.NominatedNodeName
-	if len(nnn) == 0 {
-		nnn = nodeHint
-	}
-
-	nodeInfo, err := sched.nodeInfoSnapshot.GetNodeInPlacement(nnn)
-	if err != nil {
-		if _, err := sched.nodeInfoSnapshot.Get(nnn); err != nil {
-			return nil, err
-		}
-		// It's not an error if NNN is in the cluster but not in the placement.
-		// This can happen during the pod group placement scheduling cycle, where we simulate multiple potential placements.
-		logger := klog.FromContext(ctx)
-		logger.V(4).Info("Pod's nominated node is present in the cluster but not available in the current placement", "pod", klog.KObj(pod), "node", pod.Status.NominatedNodeName)
-		return nil, nil
-	}
-	node := []fwk.NodeInfo{nodeInfo}
-	feasibleNodes, err := sched.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, node)
-	if err != nil {
-		return nil, err
-	}
-
-	feasibleNodes, err = findNodesThatPassExtenders(ctx, sched.Extenders, pod, feasibleNodes, diagnosis.NodeToStatus)
-	if err != nil {
-		return nil, err
-	}
-
-	return feasibleNodes, nil
-}
-
 // hasScoring checks if scoring nodes is configured.
-func (sched *Scheduler) hasScoring(fwk framework.Framework) bool {
+func hasScoring(fwk framework.Framework) bool {
 	if fwk.HasScorePlugins() {
 		return true
 	}
-	for _, extender := range sched.Extenders {
+	for _, extender := range fwk.Extenders() {
 		if extender.IsPrioritizer() {
 			return true
 		}
@@ -775,129 +499,13 @@ func (sched *Scheduler) hasScoring(fwk framework.Framework) bool {
 }
 
 // hasExtenderFilters checks if any extenders filter nodes.
-func (sched *Scheduler) hasExtenderFilters() bool {
-	for _, extender := range sched.Extenders {
+func hasExtenderFilters(fwk framework.Framework) bool {
+	for _, extender := range fwk.Extenders() {
 		if extender.IsFilter() {
 			return true
 		}
 	}
 	return false
-}
-
-// findNodesThatPassFilters finds the nodes that fit the filter plugins.
-func (sched *Scheduler) findNodesThatPassFilters(
-	ctx context.Context,
-	schedFramework framework.Framework,
-	state fwk.CycleState,
-	pod *v1.Pod,
-	diagnosis *framework.Diagnosis,
-	nodes []fwk.NodeInfo) ([]fwk.NodeInfo, error) {
-	numAllNodes := len(nodes)
-	numNodesToFind := sched.numFeasibleNodesToFind(schedFramework.PercentageOfNodesToScore(), int32(numAllNodes))
-	if !sched.hasExtenderFilters() && !sched.hasScoring(schedFramework) {
-		numNodesToFind = 1
-	}
-
-	// Create feasible list with enough space to avoid growing it
-	// and allow assigning.
-	feasibleNodes := make([]fwk.NodeInfo, numNodesToFind)
-
-	if !schedFramework.HasFilterPlugins() {
-		for i := range feasibleNodes {
-			feasibleNodes[i] = nodes[(sched.nextStartNodeIndex+i)%numAllNodes]
-		}
-		return feasibleNodes, nil
-	}
-
-	errCh := parallelize.NewResultChannel[error]()
-	var feasibleNodesLen int32
-	ctx, cancel := context.WithCancelCause(ctx)
-	defer cancel(errors.New("findNodesThatPassFilters has completed"))
-
-	type nodeStatus struct {
-		node   string
-		status *fwk.Status
-	}
-	result := make([]*nodeStatus, numAllNodes)
-	checkNode := func(i int) {
-		// We check the nodes starting from where we left off in the previous scheduling cycle,
-		// this is to make sure all nodes have the same chance of being examined across pods.
-		nodeInfo := nodes[(sched.nextStartNodeIndex+i)%numAllNodes]
-		status := schedFramework.RunFilterPluginsWithNominatedPods(ctx, state, pod, nodeInfo)
-		if status.Code() == fwk.Error {
-			errCh.SendWithCancel(status.AsError(), func() {
-				cancel(errors.New("some other Filter operation failed"))
-			})
-			return
-		}
-		if status.IsSuccess() {
-			length := atomic.AddInt32(&feasibleNodesLen, 1)
-			if length > numNodesToFind {
-				cancel(errors.New("findNodesThatPassFilters has found enough nodes"))
-				atomic.AddInt32(&feasibleNodesLen, -1)
-			} else {
-				feasibleNodes[length-1] = nodeInfo
-			}
-		} else {
-			result[i] = &nodeStatus{node: nodeInfo.Node().Name, status: status}
-		}
-	}
-
-	beginCheckNode := time.Now()
-	statusCode := fwk.Success
-	defer func() {
-		// We record Filter extension point latency here instead of in framework.go because framework.RunFilterPlugins
-		// function is called for each node, whereas we want to have an overall latency for all nodes per scheduling cycle.
-		// Note that this latency also includes latency for `addNominatedPods`, which calls framework.RunPreFilterAddPod.
-		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.Filter, statusCode.String(), schedFramework.ProfileName()).Observe(metrics.SinceInSeconds(beginCheckNode))
-	}()
-
-	// Stops searching for more nodes once the configured number of feasible nodes
-	// are found.
-	schedFramework.Parallelizer().Until(ctx, numAllNodes, checkNode, metrics.Filter)
-	feasibleNodes = feasibleNodes[:feasibleNodesLen]
-	for _, item := range result {
-		if item == nil {
-			continue
-		}
-		diagnosis.NodeToStatus.Set(item.node, item.status)
-		diagnosis.AddPluginStatus(item.status)
-	}
-	if err := errCh.Receive(); err != nil {
-		statusCode = fwk.Error
-		return feasibleNodes, err
-	}
-	return feasibleNodes, nil
-}
-
-// numFeasibleNodesToFind returns the number of feasible nodes that once found, the scheduler stops
-// its search for more feasible nodes.
-func (sched *Scheduler) numFeasibleNodesToFind(percentageOfNodesToScore *int32, numAllNodes int32) (numNodes int32) {
-	if numAllNodes < minFeasibleNodesToFind {
-		return numAllNodes
-	}
-
-	// Use profile percentageOfNodesToScore if it's set. Otherwise, use global percentageOfNodesToScore.
-	var percentage int32
-	if percentageOfNodesToScore != nil {
-		percentage = *percentageOfNodesToScore
-	} else {
-		percentage = sched.percentageOfNodesToScore
-	}
-
-	if percentage == 0 {
-		percentage = int32(50) - numAllNodes/125
-		if percentage < minFeasibleNodesPercentageToFind {
-			percentage = minFeasibleNodesPercentageToFind
-		}
-	}
-
-	numNodes = numAllNodes * percentage / 100
-	if numNodes < minFeasibleNodesToFind {
-		return minFeasibleNodesToFind
-	}
-
-	return numNodes
 }
 
 func findNodesThatPassExtenders(ctx context.Context, extenders []fwk.Extender, pod *v1.Pod, feasibleNodes []fwk.NodeInfo, statuses *framework.NodeToStatus) ([]fwk.NodeInfo, error) {
@@ -953,13 +561,13 @@ func findNodesThatPassExtenders(ctx context.Context, extenders []fwk.Extender, p
 // All scores are finally combined (added) to get the total weighted scores of all nodes
 func prioritizeNodes(
 	ctx context.Context,
-	extenders []fwk.Extender,
 	schedFramework framework.Framework,
 	state fwk.CycleState,
 	pod *v1.Pod,
 	nodes []fwk.NodeInfo,
 ) ([]fwk.NodePluginScores, error) {
 	logger := klog.FromContext(ctx)
+	extenders := schedFramework.Extenders()
 	// If no priority configs are provided, then all nodes will have a score of one.
 	// This is required to generate the priority list in the required format
 	if len(extenders) == 0 && !schedFramework.HasScorePlugins() {
@@ -1064,45 +672,6 @@ func prioritizeNodes(
 	return nodesScores, nil
 }
 
-// assume signals to the cache that a pod is already in the cache, so that binding can be asynchronous.
-// When called during pod group scheduling cycle, pod is assumed in the snapshot instead.
-func (sched *Scheduler) assume(logger klog.Logger, state fwk.CycleState, assumedPodInfo *framework.QueuedPodInfo, host string) error {
-	// Optimistically assume that the binding will succeed and send it to apiserver
-	// in the background.
-	// If the binding fails, scheduler will release resources allocated to assumed pod
-	// immediately.
-	assumedPodInfo.Pod.Spec.NodeName = host
-	if utilfeature.DefaultFeatureGate.Enabled(features.DRANodeAllocatableResources) {
-		// If DRANodeAllocatableResources is enabled, copy the calculated node allocatable resource claim status
-		// from the cycle state to the assumed pod's status. This ensures that the scheduler's
-		// cached version of the pod reflects the node allocatable resources allocated by the DRA plugin
-		// for this scheduling cycle, making this information available for NodeInfo cache update.
-		// Any potential NodeAllocatableResourceClaimStatuses from a previously failed scheduling attempt is overwritten.
-		// This field is not explicitly cleared as the Pod object is reconstructed in handleSchedulingFailure()
-		// before re-queueing.
-		assumedPodInfo.Pod.Status.NodeAllocatableResourceClaimStatuses = dynamicresources.ExtractPodNodeAllocatableResourceClaimStatus(logger, state, host)
-	}
-
-	if state.IsPodGroupSchedulingCycle() {
-		err := sched.nodeInfoSnapshot.AssumePod(assumedPodInfo.PodInfo)
-		if err != nil {
-			logger.Error(err, "Scheduler snapshot AssumePod failed")
-			return err
-		}
-	} else {
-		if err := sched.Cache.AssumePod(logger, assumedPodInfo.Pod); err != nil {
-			logger.Error(err, "Scheduler cache AssumePod failed")
-			return err
-		}
-	}
-	// if "assumed" is a nominated pod, we should remove it from internal cache
-	if sched.SchedulingQueue != nil {
-		sched.SchedulingQueue.DeleteNominatedPodIfExists(assumedPodInfo.Pod)
-	}
-
-	return nil
-}
-
 // bind binds a pod to a given node defined in a binding object.
 // The precedence for binding is: (1) extenders and (2) framework plugins.
 // We expect this to run asynchronously, so we handle binding metrics internally.
@@ -1112,7 +681,7 @@ func (sched *Scheduler) bind(ctx context.Context, schedFramework framework.Frame
 		sched.finishBinding(logger, schedFramework, assumed, targetNode, status)
 	}()
 
-	bound, err := sched.extendersBinding(logger, assumed, targetNode)
+	bound, err := sched.extendersBinding(logger, schedFramework, assumed, targetNode)
 	if bound {
 		return fwk.AsStatus(err)
 	}
@@ -1120,8 +689,8 @@ func (sched *Scheduler) bind(ctx context.Context, schedFramework framework.Frame
 }
 
 // TODO(#87159): Move this to a Plugin.
-func (sched *Scheduler) extendersBinding(logger klog.Logger, pod *v1.Pod, node string) (bool, error) {
-	for _, extender := range sched.Extenders {
+func (sched *Scheduler) extendersBinding(logger klog.Logger, schedFramework framework.Framework, pod *v1.Pod, node string) (bool, error) {
+	for _, extender := range schedFramework.Extenders() {
 		if !extender.IsBinder() || !extender.IsInterested(pod) {
 			continue
 		}

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -651,34 +651,35 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 // It returns the algorithm result together with the revert function.
 // The returned revert function rolls back tentative node reservations for the pod if the overall
 // pod group fails to schedule.
-func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, placementCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, podInfo *framework.QueuedPodInfo) (algorithmResult, func()) {
+//
+// Pods of a pod group are assumed into the snapshot rather than the cache: the group's placement
+// stays tentative until the whole group is submitted, and a snapshot assume is dropped by the
+// next UpdateSnapshot instead of outliving the cycle.
+func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework,
+	placementCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo,
+	podInfo *framework.QueuedPodInfo) (algorithmResult, func()) {
+
 	pod := podInfo.Pod
 	podCtx := initPodSchedulingContext(ctx, pod, placementCycleState)
 	logger := podCtx.logger
 	ctx = klog.NewContext(ctx, logger)
 	start := time.Now()
 
-	logger.V(4).Info("Attempting to schedule a pod belonging to a pod group", "podGroup", klog.KObj(podGroupInfo), "pod", klog.KObj(pod))
+	logger.V(4).Info("Attempting to schedule a pod belonging to a pod group",
+		"podGroup", klog.KObj(podGroupInfo), "pod", klog.KObj(pod))
 
 	scheduleResult, status := sched.schedulingAlgorithm(ctx, podCtx.state, schedFwk, podInfo, start)
-	if !status.IsSuccess() {
-		return algorithmResult{
-			podInfo:            podInfo,
-			scheduleResult:     scheduleResult,
-			podCtx:             podCtx,
-			schedulingDuration: time.Since(start),
-			status:             status,
-		}, nil
-	}
-	assumeStatus, revertFn := sched.assumeAndReserveWithRevert(ctx, podCtx.state, schedFwk, podInfo, scheduleResult)
-	if !assumeStatus.IsSuccess() {
-		return algorithmResult{
-			podInfo:            podInfo,
-			scheduleResult:     ScheduleResult{nominatingInfo: clearNominatedNode},
-			podCtx:             podCtx,
-			schedulingDuration: time.Since(start),
-			status:             assumeStatus,
-		}, nil
+	var revertFn func()
+	if status.IsSuccess() {
+		var assumeStatus *fwk.Status
+		_, assumeStatus, revertFn = sched.alg().AssumeAndReserveInSnapshot(
+			ctx, podCtx.state, schedFwk, podInfo, scheduleResult)
+		if !assumeStatus.IsSuccess() {
+			// The evaluation succeeded but the placement could not be held: drop the
+			// result and clear the nomination, as the single-pod cycle does.
+			scheduleResult = ScheduleResult{nominatingInfo: clearNominatedNode}
+			status = assumeStatus
+		}
 	}
 
 	return algorithmResult{
@@ -688,24 +689,6 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 		schedulingDuration: time.Since(start),
 		status:             status,
 	}, revertFn
-}
-
-func (sched *Scheduler) assumeAndReserveWithRevert(ctx context.Context,
-	state fwk.CycleState,
-	schedFramework framework.Framework,
-	podInfo *framework.QueuedPodInfo,
-	scheduleResult ScheduleResult,
-) (*fwk.Status, func()) {
-	assumedPodInfo, assumeStatus := sched.assumeAndReserve(ctx, state, schedFramework, podInfo, scheduleResult)
-	if !assumeStatus.IsSuccess() {
-		return assumeStatus, nil
-	}
-	return assumeStatus, func() {
-		err := sched.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
-		if err != nil {
-			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
-		}
-	}
 }
 
 // completePodGroupAlgorithmResult ensures that the podGroupAlgorithmResult contains the same number of podResults as there are pods in QueuedPodInfos.
@@ -1404,7 +1387,7 @@ func (sched *Scheduler) assumeSubtreeWithRevert(ctx context.Context, schedFwk fr
 			if !podResult.status.IsSuccess() || podResult.GetNodeName() == "" {
 				continue
 			}
-			status, revert := sched.assumeAndReserveWithRevert(ctx, podResult.podCtx.state, schedFwk, podResult.podInfo, podResult.scheduleResult)
+			_, status, revert := sched.alg().AssumeAndReserveInSnapshot(ctx, podResult.podCtx.state, schedFwk, podResult.podInfo, podResult.scheduleResult)
 			if revert != nil {
 				revertFns = append(revertFns, revert)
 			}

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -564,7 +564,7 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 			status:             status,
 		}, nil
 	}
-	assumeStatus, revertFn := sched.assumeAndReserveWithRevert(ctx, podCtx.state, schedFwk, podInfo, scheduleResult)
+	assumeStatus, revertFn := sched.algorithm.assumeAndReserveWithRevert(ctx, podCtx.state, schedFwk, podInfo, scheduleResult)
 	if !assumeStatus.IsSuccess() {
 		return algorithmResult{
 			podInfo:            podInfo,
@@ -582,24 +582,6 @@ func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, sche
 		schedulingDuration: time.Since(start),
 		status:             status,
 	}, revertFn
-}
-
-func (sched *Scheduler) assumeAndReserveWithRevert(ctx context.Context,
-	state fwk.CycleState,
-	schedFramework framework.Framework,
-	podInfo *framework.QueuedPodInfo,
-	scheduleResult ScheduleResult,
-) (*fwk.Status, func()) {
-	assumedPodInfo, assumeStatus := sched.assumeAndReserve(ctx, state, schedFramework, podInfo, scheduleResult)
-	if !assumeStatus.IsSuccess() {
-		return assumeStatus, nil
-	}
-	return assumeStatus, func() {
-		err := sched.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
-		if err != nil {
-			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
-		}
-	}
 }
 
 // completePodGroupAlgorithmResult ensures that the podGroupAlgorithmResult contains the same number of podResults as there are pods in QueuedPodInfos.
@@ -1314,7 +1296,7 @@ func (sched *Scheduler) assumeSubtreeWithRevert(ctx context.Context, schedFwk fr
 			if !podResult.status.IsSuccess() || podResult.GetNodeName() == "" {
 				continue
 			}
-			status, revert := sched.assumeAndReserveWithRevert(ctx, podResult.podCtx.state, schedFwk, podResult.podInfo, podResult.scheduleResult)
+			status, revert := sched.algorithm.assumeAndReserveWithRevert(ctx, podResult.podCtx.state, schedFwk, podResult.podInfo, podResult.scheduleResult)
 			if revert != nil {
 				revertFns = append(revertFns, revert)
 			}

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -972,7 +972,6 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 		t.Fatalf("Failed to update snapshot: %v", err)
 	}
-	sched.SchedulePod = sched.schedulePod
 
 	resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
 	schedulePodResult := resultsMap[pgKey(podGroupInfo.PodGroupInfo)]
@@ -1152,7 +1151,6 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 				},
 			}
 
-			sched.SchedulePod = sched.schedulePod
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
 			}
@@ -1505,7 +1503,6 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 						SchedulingQueue:  queue,
 						Profiles:         profile.Map{"test-scheduler": schedFwk},
 					}
-					sched.SchedulePod = sched.schedulePod
 
 					if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 						t.Fatalf("Failed to update snapshot: %v", err)
@@ -1885,6 +1882,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 
 			fakeClock := testingclock.NewFakeClock(time.Now())
 			schedulingQueue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc(), internalqueue.WithClock(fakeClock))
+			schedFwk.SetPodNominator(schedulingQueue)
 			sched := &Scheduler{
 				client:          client,
 				Cache:           cache,
@@ -2860,7 +2858,6 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 					SchedulingQueue:  queue,
 					Profiles:         profile.Map{"test-scheduler": schedFwk},
 				}
-				sched.SchedulePod = sched.schedulePod
 
 				if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 					t.Fatalf("Failed to update snapshot: %v", err)
@@ -3068,7 +3065,6 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 					SchedulingQueue:  queue,
 					Profiles:         profile.Map{"test-scheduler": schedFwk},
 				}
-				sched.SchedulePod = sched.schedulePod
 
 				if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 					t.Fatalf("Failed to update snapshot: %v", err)
@@ -3238,7 +3234,6 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 				SchedulingQueue:  queue,
 				Profiles:         profile.Map{"test-scheduler": schedFwk},
 			}
-			sched.SchedulePod = sched.schedulePod
 
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
@@ -3507,7 +3502,6 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 		SchedulingQueue:  queue,
 		Profiles:         profile.Map{"test-scheduler": schedFwk},
 	}
-	sched.SchedulePod = sched.schedulePod
 
 	if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 		t.Fatalf("Failed to update snapshot: %v", err)
@@ -3943,7 +3937,6 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				SchedulingQueue:  queue,
 				Profiles:         profile.Map{"test-scheduler": schedFwk},
 			}
-			sched.SchedulePod = sched.schedulePod
 
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
@@ -4250,7 +4243,6 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				SchedulingQueue:  queue,
 				Profiles:         profile.Map{"test-scheduler": schedFwk},
 			}
-			sched.SchedulePod = sched.schedulePod
 
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
@@ -4373,7 +4365,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 
 	// Mock SchedulePod to return Unschedulable initially, and success on subsequent calls
 	callCount := 0
-	sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
+	sched.alg().schedulePodOverride = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
 		callCount++
 		if callCount <= 2 {
 			return ScheduleResult{}, &framework.FitError{Pod: podInfo.Pod, NumAllNodes: 1}
@@ -4737,9 +4729,10 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 		client:           client,
 		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
 	}
+	schedFwk.SetPodNominator(sched.SchedulingQueue)
 
-	// Mock SchedulePod to return success for all pods
-	sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
+	// Mock schedulePodOverride to return success for all pods
+	sched.alg().schedulePodOverride = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
 		return ScheduleResult{SuggestedHost: "node1"}, nil
 	}
 
@@ -5039,7 +5032,6 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 			handledPods[p.Pod.Name] = status
 		},
 	}
-	sched.SchedulePod = sched.schedulePod
 
 	// Run the scheduling cycle
 	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
@@ -5265,7 +5257,6 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 			handledPods[p.Pod.Name] = status
 		},
 	}
-	sched.SchedulePod = sched.schedulePod
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
@@ -5492,7 +5483,6 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 			handledPods[p.Pod.Name] = status
 		},
 	}
-	sched.SchedulePod = sched.schedulePod
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -767,6 +767,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 				nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
 				SchedulingQueue:  queue,
 			}
+			sched.initAlgorithm()
 			sched.scheduleOnePodGroup(ctx, podGroupInfo)
 
 			if !tt.memberArrivesWhileInFlight {
@@ -861,6 +862,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 			}
 		},
 	}
+	sched.initAlgorithm()
 
 	sched.scheduleOnePodGroup(ctx, podGroupInfo)
 
@@ -959,7 +961,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 		t.Fatalf("Failed to update snapshot: %v", err)
 	}
-	sched.SchedulePod = sched.schedulePod
+	initTestAlgorithm(sched)
 
 	resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
 	schedulePodResult := resultsMap[podGroupInfo.PodGroupInfo.GetKey()]
@@ -1136,7 +1138,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 				},
 			}
 
-			sched.SchedulePod = sched.schedulePod
+			initTestAlgorithm(sched)
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
 			}
@@ -1486,7 +1488,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 						SchedulingQueue:  queue,
 						Profiles:         profile.Map{"test-scheduler": schedFwk},
 					}
-					sched.SchedulePod = sched.schedulePod
+					initTestAlgorithm(sched)
 
 					if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 						t.Fatalf("Failed to update snapshot: %v", err)
@@ -1900,6 +1902,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 
 			fakeClock := testingclock.NewFakeClock(time.Now())
 			schedulingQueue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc(), internalqueue.WithClock(fakeClock))
+			schedFwk.SetPodNominator(schedulingQueue)
 			sched := &Scheduler{
 				client:          client,
 				Cache:           cache,
@@ -1918,6 +1921,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					}
 				},
 			}
+			sched.initAlgorithm()
 
 			// Create the pod group and add the pods to queue and pop the group to set up internal queue state correctly.
 			schedulingQueue.AddGenericPodGroup(logger, apg)
@@ -2872,7 +2876,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 					SchedulingQueue:  queue,
 					Profiles:         profile.Map{"test-scheduler": schedFwk},
 				}
-				sched.SchedulePod = sched.schedulePod
+				initTestAlgorithm(sched)
 
 				if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 					t.Fatalf("Failed to update snapshot: %v", err)
@@ -3077,7 +3081,7 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 					SchedulingQueue:  queue,
 					Profiles:         profile.Map{"test-scheduler": schedFwk},
 				}
-				sched.SchedulePod = sched.schedulePod
+				initTestAlgorithm(sched)
 
 				if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 					t.Fatalf("Failed to update snapshot: %v", err)
@@ -3247,7 +3251,7 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 				SchedulingQueue:  queue,
 				Profiles:         profile.Map{"test-scheduler": schedFwk},
 			}
-			sched.SchedulePod = sched.schedulePod
+			initTestAlgorithm(sched)
 
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
@@ -3495,7 +3499,7 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 		SchedulingQueue:  queue,
 		Profiles:         profile.Map{"test-scheduler": schedFwk},
 	}
-	sched.SchedulePod = sched.schedulePod
+	initTestAlgorithm(sched)
 
 	if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 		t.Fatalf("Failed to update snapshot: %v", err)
@@ -4015,7 +4019,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				SchedulingQueue:  queue,
 				Profiles:         profile.Map{"test-scheduler": schedFwk},
 			}
-			sched.SchedulePod = sched.schedulePod
+			initTestAlgorithm(sched)
 
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
@@ -4294,7 +4298,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				SchedulingQueue:  queue,
 				Profiles:         profile.Map{"test-scheduler": schedFwk},
 			}
-			sched.SchedulePod = sched.schedulePod
+			initTestAlgorithm(sched)
 
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
@@ -4411,6 +4415,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 		client:           client,
 		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
 	}
+	sched.initAlgorithm()
 
 	// Mock SchedulePod to return Unschedulable initially, and success on subsequent calls
 	callCount := 0
@@ -4516,6 +4521,7 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 		client:                 client,
 		genericWorkloadEnabled: true,
 	}
+	sched.initAlgorithm()
 	sched.FailureHandler = sched.handleSchedulingFailure
 
 	sched.scheduleOnePodGroup(ctx, podGroupInfo)
@@ -4604,6 +4610,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
 		},
 	}
+	sched.initAlgorithm()
 
 	sched.scheduleOnePodGroup(ctx, podGroupInfo)
 
@@ -4823,6 +4830,7 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 					failedPodsMu.Unlock()
 				},
 			}
+			sched.initAlgorithm()
 			sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
 				return ScheduleResult{SuggestedHost: "node1"}, nil
 			}
@@ -4994,6 +5002,8 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 		client:           client,
 		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
 	}
+	sched.initAlgorithm()
+	schedFwk.SetPodNominator(sched.SchedulingQueue)
 
 	// Mock SchedulePod to return success for all pods
 	sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
@@ -5274,7 +5284,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 			handledPods[p.Pod.Name] = status
 		},
 	}
-	sched.SchedulePod = sched.schedulePod
+	initTestAlgorithm(sched)
 
 	// Run the scheduling cycle
 	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
@@ -5499,7 +5509,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 			handledPods[p.Pod.Name] = status
 		},
 	}
-	sched.SchedulePod = sched.schedulePod
+	initTestAlgorithm(sched)
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
@@ -5719,7 +5729,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 			handledPods[p.Pod.Name] = status
 		},
 	}
-	sched.SchedulePod = sched.schedulePod
+	initTestAlgorithm(sched)
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
@@ -7338,7 +7348,8 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 						client:           client,
 						nodeInfoSnapshot: snapshot,
 					}
-					sched.SchedulePod = sched.schedulePod
+					sched.initAlgorithm()
+					sched.SchedulePod = sched.algorithm.SchedulePod
 					sched.FailureHandler = sched.handleSchedulingFailure
 
 					bindChan := make(chan string, len(tt.pods))

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1150,6 +1150,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 
 		ar := metrics.NewMetricsAsyncRecorder(10, 1*time.Second, ctx.Done())
 		queue := internalqueue.NewSchedulingQueue(nil, informerFactory, internalqueue.WithMetricsRecorder(ar), internalqueue.WithAPIDispatcher(apiDispatcher))
+		schedFramework.SetPodNominator(queue)
 		if features.asyncAPICallsEnabled {
 			schedFramework.SetAPICacher(apicache.New(queue, cache))
 		}
@@ -1170,8 +1171,9 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			queue.AddPodGroup(logger, podGroup)
 		}
 		queue.Add(ctx, item.sendPod)
+		sched.nodeInfoSnapshot = internalcache.NewEmptySnapshot()
 
-		sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
+		sched.alg().schedulePodOverride = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
 			return item.mockScheduleResult, item.injectSchedulingError
 		}
 		sched.FailureHandler = func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
@@ -1192,7 +1194,6 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		sched.nodeInfoSnapshot = internalcache.NewEmptySnapshot()
 		sched.ScheduleOne(ctx)
 
 		if item.postSchedulingCycle != nil {
@@ -1961,7 +1962,8 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 				}
 				queue.Add(ctx, item.sendPod)
 
-				sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
+				sched.nodeInfoSnapshot = internalcache.NewEmptySnapshot()
+				sched.alg().schedulePodOverride = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
 					return item.mockScheduleResult, item.injectSchedulingError
 				}
 				sched.FailureHandler = func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, _ *fwk.NominatingInfo, _ time.Time) {
@@ -1987,7 +1989,7 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				sched.nodeInfoSnapshot = internalcache.NewEmptySnapshot()
+
 				sched.ScheduleOne(ctx)
 				<-called
 
@@ -2049,6 +2051,9 @@ type FakeFramework struct {
 func NewFakeFramework(ctx context.Context, schedQueue internalqueue.SchedulingQueue, fns []tf.RegisterPluginFunc,
 	profileName string, opts ...frameworkruntime.Option) (*FakeFramework, error) {
 	fwk, err := tf.NewFramework(ctx, fns, profileName, opts...)
+	if fwk != nil {
+		fwk.SetPodNominator(schedQueue)
+	}
 	return &FakeFramework{
 			Framework: fwk,
 			queue:     schedQueue},
@@ -2495,11 +2500,10 @@ func TestSchedulerBinding(t *testing.T) {
 				}
 
 				sched := &Scheduler{
-					Extenders:                test.extenders,
-					Cache:                    cache,
-					nodeInfoSnapshot:         nil,
-					percentageOfNodesToScore: 0,
-					APIDispatcher:            apiDispatcher,
+					Extenders:        test.extenders,
+					Cache:            cache,
+					nodeInfoSnapshot: nil,
+					APIDispatcher:    apiDispatcher,
 				}
 				status := sched.bind(ctx, fwk, pod, "node", state)
 				if !status.IsSuccess() {
@@ -3827,26 +3831,26 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				_, _ = cs.CoreV1().PersistentVolumes().Create(ctx, &pv, metav1.CreateOptions{})
 			}
 			snapshot := internalcache.NewSnapshot(test.pods, nodes)
+			var extenders []fwk.Extender
+			for ii := range test.extenders {
+				extenders = append(extenders, &test.extenders[ii])
+			}
 			schedFramework, err := tf.NewFramework(
 				ctx,
 				test.registerPlugins, "",
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
 				frameworkruntime.WithInformerFactory(informerFactory),
 				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+				frameworkruntime.WithExtenders(extenders),
 			)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			var extenders []fwk.Extender
-			for ii := range test.extenders {
-				extenders = append(extenders, &test.extenders[ii])
-			}
 			sched := &Scheduler{
-				Cache:                    cache,
-				nodeInfoSnapshot:         snapshot,
-				percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
-				Extenders:                extenders,
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
+				Extenders:        extenders,
 			}
 			sched.applyDefaultHandlers()
 
@@ -3908,7 +3912,7 @@ func TestFindFitAllError(t *testing.T) {
 	}
 
 	podInfo := queuedPodInfoForPod(&v1.Pod{})
-	_, diagnosis, _, err := scheduler.findNodesThatFitPod(ctx, schedFramework, framework.NewCycleState(), podInfo)
+	_, diagnosis, _, err := scheduler.alg().findNodesThatFitPod(ctx, schedFramework, framework.NewCycleState(), podInfo, false)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -3955,7 +3959,7 @@ func TestFindFitSomeError(t *testing.T) {
 
 	pod := st.MakePod().Name("1").UID("1").Obj()
 	podInfo := queuedPodInfoForPod(pod)
-	_, diagnosis, _, err := scheduler.findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo)
+	_, diagnosis, _, err := scheduler.alg().findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo, false)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -4051,7 +4055,7 @@ func TestFindFitPredicateCallCounts(t *testing.T) {
 			schedFramework.AddNominatedPod(logger, podinfo, &fwk.NominatingInfo{NominatingMode: fwk.ModeOverride, NominatedNodeName: "1"})
 
 			podInfo := queuedPodInfoForPod(test.pod)
-			_, _, _, err = scheduler.findNodesThatFitPod(ctx, schedFramework, framework.NewCycleState(), podInfo)
+			_, _, _, err = scheduler.alg().findNodesThatFitPod(ctx, schedFramework, framework.NewCycleState(), podInfo, false)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -4516,6 +4520,10 @@ func Test_prioritizeNodes(t *testing.T) {
 			if err := cache.UpdateSnapshot(klog.FromContext(ctx), snapshot); err != nil {
 				t.Fatal(err)
 			}
+			var extenders []fwk.Extender
+			for ii := range test.extenders {
+				extenders = append(extenders, &test.extenders[ii])
+			}
 			schedFramework, err := tf.NewFramework(
 				ctx,
 				test.pluginRegistrations, "",
@@ -4523,21 +4531,18 @@ func Test_prioritizeNodes(t *testing.T) {
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
 				frameworkruntime.WithClientSet(client),
 				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+				frameworkruntime.WithExtenders(extenders),
 			)
 			if err != nil {
 				t.Fatalf("error creating framework: %+v", err)
 			}
 
 			state := framework.NewCycleState()
-			var extenders []fwk.Extender
-			for ii := range test.extenders {
-				extenders = append(extenders, &test.extenders[ii])
-			}
 			nodeInfos, err := snapshot.NodeInfos().List()
 			if err != nil {
 				t.Fatalf("failed to list node from snapshot: %v", err)
 			}
-			nodesscores, err := prioritizeNodes(ctx, extenders, schedFramework, state, test.pod, nodeInfos)
+			nodesscores, err := prioritizeNodes(ctx, schedFramework, state, test.pod, nodeInfos)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -4617,11 +4622,9 @@ func TestNumFeasibleNodesToFind(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sched := &Scheduler{
-				percentageOfNodesToScore: tt.globalPercentage,
-			}
-			if gotNumNodes := sched.numFeasibleNodesToFind(tt.profilePercentage, tt.numAllNodes); gotNumNodes != tt.wantNumNodes {
-				t.Errorf("Scheduler.numFeasibleNodesToFind() = %v, want %v", gotNumNodes, tt.wantNumNodes)
+			alg := &SchedulingAlgorithm{percentageOfNodesToScore: tt.globalPercentage}
+			if gotNumNodes := alg.numFeasibleNodesToFind(tt.profilePercentage, tt.numAllNodes); gotNumNodes != tt.wantNumNodes {
+				t.Errorf("SchedulingAlgorithm.numFeasibleNodesToFind() = %v, want %v", gotNumNodes, tt.wantNumNodes)
 			}
 		})
 	}
@@ -4656,21 +4659,35 @@ func TestFairEvaluationForNodes(t *testing.T) {
 	}
 
 	// To make numAllNodes % nodesToFind != 0
-	sched.percentageOfNodesToScore = 30
-	nodesToFind := int(sched.numFeasibleNodesToFind(fwk.PercentageOfNodesToScore(), int32(numAllNodes)))
+	sched.alg().percentageOfNodesToScore = 30
+	nodesToFind := int(sched.alg().numFeasibleNodesToFind(fwk.PercentageOfNodesToScore(), int32(numAllNodes)))
 
 	// Iterating over all nodes more than twice
 	for i := 0; i < 2*(numAllNodes/nodesToFind+1); i++ {
 		podInfo := queuedPodInfoForPod(&v1.Pod{})
-		nodesThatFit, _, _, err := sched.findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo)
+		nodesThatFit, _, _, err := sched.alg().findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo, false)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if len(nodesThatFit) != nodesToFind {
 			t.Errorf("got %d nodes filtered, want %d", len(nodesThatFit), nodesToFind)
 		}
-		if sched.nextStartNodeIndex != (i+1)*nodesToFind%numAllNodes {
-			t.Errorf("got %d lastProcessedNodeIndex, want %d", sched.nextStartNodeIndex, (i+1)*nodesToFind%numAllNodes)
+		expectedNextStartNodeIndex := (i + 1) * nodesToFind % numAllNodes
+		if sched.alg().nextStartNodeIndex != expectedNextStartNodeIndex {
+			t.Errorf("got %d lastProcessedNodeIndex, want %d", sched.alg().nextStartNodeIndex, expectedNextStartNodeIndex)
+		}
+
+		// Interleave a FindAllNodesThatFitPod call between normal cycles and assert nextStartNodeIndex
+		// advances exactly as if the findAll call never happened.
+		allNodesThatFit, _, err := sched.alg().FindAllNodesThatFitPod(ctx, framework.NewCycleState(), fwk, podInfo)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(allNodesThatFit) != numAllNodes {
+			t.Errorf("got %d nodes filtered, want %d", len(allNodesThatFit), numAllNodes)
+		}
+		if sched.alg().nextStartNodeIndex != expectedNextStartNodeIndex {
+			t.Errorf("got %d lastProcessedNodeIndex, want %d", sched.alg().nextStartNodeIndex, expectedNextStartNodeIndex)
 		}
 	}
 }
@@ -4740,14 +4757,13 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 			}
 
 			sched := &Scheduler{
-				Cache:                    cache,
-				nodeInfoSnapshot:         snapshot,
-				percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
 			}
 			sched.applyDefaultHandlers()
 
 			podInfo := queuedPodInfoForPod(test.pod)
-			_, _, _, err = sched.findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo)
+			_, _, _, err = sched.alg().findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo, false)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -4799,9 +4815,8 @@ func makeScheduler(ctx context.Context, nodes []*v1.Node) *Scheduler {
 	}
 
 	sched := &Scheduler{
-		Cache:                    cache,
-		nodeInfoSnapshot:         emptySnapshot,
-		percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
+		Cache:            cache,
+		nodeInfoSnapshot: emptySnapshot,
 	}
 	sched.applyDefaultHandlers()
 	cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot)
@@ -4910,10 +4925,9 @@ func setupTestScheduler(ctx context.Context, t *testing.T, client clientset.Inte
 
 	errChan := make(chan error, 1)
 	sched := &Scheduler{
-		Cache:                    cache,
-		client:                   client,
-		nodeInfoSnapshot:         snapshot,
-		percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
+		Cache:            cache,
+		client:           client,
+		nodeInfoSnapshot: snapshot,
 		NextEntity: func(logger klog.Logger) (framework.QueuedEntityInfo, error) {
 			return &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(t, pop(queuedPodStore).(*v1.Pod))}, nil
 		},
@@ -4922,7 +4936,6 @@ func setupTestScheduler(ctx context.Context, t *testing.T, client clientset.Inte
 		Profiles:        profile.Map{testSchedulerName: schedFramework},
 	}
 
-	sched.SchedulePod = sched.schedulePod
 	sched.FailureHandler = func(ctx context.Context, _ framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, _ *fwk.NominatingInfo, _ time.Time) {
 		err := status.AsError()
 		errChan <- err
@@ -5086,7 +5099,7 @@ func TestEvaluateNominatedNode(t *testing.T) {
 				nodeInfoSnapshot: snapshot,
 			}
 
-			gotNodes, err := sched.evaluateNominatedNode(ctx, tt.pod, fw, framework.NewCycleState(), "", framework.Diagnosis{})
+			gotNodes, err := sched.alg().evaluateNominatedNode(ctx, tt.pod, fw, framework.NewCycleState(), "", framework.Diagnosis{})
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("Unexpected error, want error: %v, got: %v", tt.wantError, err)
@@ -5174,7 +5187,7 @@ func TestScheduler_DeferredResizePluginSkipping(t *testing.T) {
 	podInfo := queuedPodInfoForPod(pod)
 
 	// Run schedulePod
-	_, _ = sched.schedulePod(ctx, schedFramework, state, podInfo)
+	_, _ = sched.SchedulePod(ctx, schedFramework, state, podInfo)
 
 	// Verify the skipped plugins
 	skipped := state.GetSkipFilterPlugins()

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1150,6 +1150,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 
 		ar := metrics.NewMetricsAsyncRecorder(10, 1*time.Second, ctx.Done())
 		queue := internalqueue.NewSchedulingQueue(nil, informerFactory, internalqueue.WithMetricsRecorder(ar), internalqueue.WithAPIDispatcher(apiDispatcher))
+		schedFramework.SetPodNominator(queue)
 		if features.asyncAPICallsEnabled {
 			schedFramework.SetAPICacher(apicache.New(queue, cache))
 		}
@@ -1161,8 +1162,10 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			SchedulingQueue:                        queue,
 			Profiles:                               profile.Map{testSchedulerName: schedFramework},
 			APIDispatcher:                          apiDispatcher,
+			nodeInfoSnapshot:                       internalcache.NewEmptySnapshot(),
 			nominatedNodeNameForExpectationEnabled: features.nominatedNodeNameForExpectationEnabled,
 		}
+		initTestAlgorithm(sched)
 		informerFactory.Start(ctx.Done())
 		informerFactory.WaitForCacheSync(ctx.Done())
 
@@ -1192,7 +1195,6 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		sched.nodeInfoSnapshot = internalcache.NewEmptySnapshot()
 		sched.ScheduleOne(ctx)
 
 		if item.postSchedulingCycle != nil {
@@ -2072,13 +2074,15 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 				}
 
 				sched := &Scheduler{
-					Cache:           cache,
-					client:          client,
-					NextEntity:      queue.Pop,
-					SchedulingQueue: queue,
-					Profiles:        profile.Map{testSchedulerName: schedFramework},
-					APIDispatcher:   apiDispatcher,
+					Cache:            cache,
+					client:           client,
+					NextEntity:       queue.Pop,
+					SchedulingQueue:  queue,
+					Profiles:         profile.Map{testSchedulerName: schedFramework},
+					APIDispatcher:    apiDispatcher,
+					nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
 				}
+				initTestAlgorithm(sched)
 				queue.Add(ctx, item.sendPod)
 
 				sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
@@ -2169,6 +2173,9 @@ type FakeFramework struct {
 func NewFakeFramework(ctx context.Context, schedQueue internalqueue.SchedulingQueue, fns []tf.RegisterPluginFunc,
 	profileName string, opts ...frameworkruntime.Option) (*FakeFramework, error) {
 	fwk, err := tf.NewFramework(ctx, fns, profileName, opts...)
+	if fwk != nil {
+		fwk.SetPodNominator(schedQueue)
+	}
 	return &FakeFramework{
 			Framework: fwk,
 			queue:     schedQueue},
@@ -2602,7 +2609,7 @@ func TestSchedulerBinding(t *testing.T) {
 					[]tf.RegisterPluginFunc{
 						tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 						tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-					}, "", frameworkruntime.WithClientSet(client), frameworkruntime.WithAPIDispatcher(apiDispatcher), frameworkruntime.WithEventRecorder(&events.FakeRecorder{}))
+					}, "", frameworkruntime.WithClientSet(client), frameworkruntime.WithAPIDispatcher(apiDispatcher), frameworkruntime.WithEventRecorder(&events.FakeRecorder{}), frameworkruntime.WithExtenders(test.extenders))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -2615,11 +2622,9 @@ func TestSchedulerBinding(t *testing.T) {
 				}
 
 				sched := &Scheduler{
-					Extenders:                test.extenders,
-					Cache:                    cache,
-					nodeInfoSnapshot:         nil,
-					percentageOfNodesToScore: 0,
-					APIDispatcher:            apiDispatcher,
+					Cache:            cache,
+					nodeInfoSnapshot: nil,
+					APIDispatcher:    apiDispatcher,
 				}
 				status := sched.bind(ctx, fwk, pod, "node", state)
 				if !status.IsSuccess() {
@@ -3947,27 +3952,27 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				_, _ = cs.CoreV1().PersistentVolumes().Create(ctx, &pv, metav1.CreateOptions{})
 			}
 			snapshot := internalcache.NewSnapshot(test.pods, nodes)
+			var extenders []fwk.Extender
+			for ii := range test.extenders {
+				extenders = append(extenders, &test.extenders[ii])
+			}
 			schedFramework, err := tf.NewFramework(
 				ctx,
 				test.registerPlugins, "",
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
 				frameworkruntime.WithInformerFactory(informerFactory),
 				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+				frameworkruntime.WithExtenders(extenders),
 			)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			var extenders []fwk.Extender
-			for ii := range test.extenders {
-				extenders = append(extenders, &test.extenders[ii])
-			}
 			sched := &Scheduler{
-				Cache:                    cache,
-				nodeInfoSnapshot:         snapshot,
-				percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
-				Extenders:                extenders,
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
 			}
+			initTestAlgorithm(sched)
 			sched.applyDefaultHandlers()
 
 			informerFactory.Start(ctx.Done())
@@ -4028,7 +4033,7 @@ func TestFindFitAllError(t *testing.T) {
 	}
 
 	podInfo := queuedPodInfoForPod(&v1.Pod{})
-	_, diagnosis, _, err := scheduler.findNodesThatFitPod(ctx, schedFramework, framework.NewCycleState(), podInfo)
+	_, diagnosis, _, err := scheduler.algorithm.findNodesThatFitPod(ctx, schedFramework, framework.NewCycleState(), podInfo)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -4075,7 +4080,7 @@ func TestFindFitSomeError(t *testing.T) {
 
 	pod := st.MakePod().Name("1").UID("1").Obj()
 	podInfo := queuedPodInfoForPod(pod)
-	_, diagnosis, _, err := scheduler.findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo)
+	_, diagnosis, _, err := scheduler.algorithm.findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -4171,7 +4176,7 @@ func TestFindFitPredicateCallCounts(t *testing.T) {
 			schedFramework.AddNominatedPod(logger, podinfo, &fwk.NominatingInfo{NominatingMode: fwk.ModeOverride, NominatedNodeName: "1"})
 
 			podInfo := queuedPodInfoForPod(test.pod)
-			_, _, _, err = scheduler.findNodesThatFitPod(ctx, schedFramework, framework.NewCycleState(), podInfo)
+			_, _, _, err = scheduler.algorithm.findNodesThatFitPod(ctx, schedFramework, framework.NewCycleState(), podInfo)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -4636,6 +4641,10 @@ func Test_prioritizeNodes(t *testing.T) {
 			if err := cache.UpdateSnapshot(klog.FromContext(ctx), snapshot); err != nil {
 				t.Fatal(err)
 			}
+			var extenders []fwk.Extender
+			for ii := range test.extenders {
+				extenders = append(extenders, &test.extenders[ii])
+			}
 			schedFramework, err := tf.NewFramework(
 				ctx,
 				test.pluginRegistrations, "",
@@ -4643,21 +4652,18 @@ func Test_prioritizeNodes(t *testing.T) {
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
 				frameworkruntime.WithClientSet(client),
 				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+				frameworkruntime.WithExtenders(extenders),
 			)
 			if err != nil {
 				t.Fatalf("error creating framework: %+v", err)
 			}
 
 			state := framework.NewCycleState()
-			var extenders []fwk.Extender
-			for ii := range test.extenders {
-				extenders = append(extenders, &test.extenders[ii])
-			}
 			nodeInfos, err := snapshot.NodeInfos().List()
 			if err != nil {
 				t.Fatalf("failed to list node from snapshot: %v", err)
 			}
-			nodesscores, err := prioritizeNodes(ctx, extenders, schedFramework, state, test.pod, nodeInfos)
+			nodesscores, err := prioritizeNodes(ctx, schedFramework, state, test.pod, nodeInfos)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -4737,11 +4743,9 @@ func TestNumFeasibleNodesToFind(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sched := &Scheduler{
-				percentageOfNodesToScore: tt.globalPercentage,
-			}
-			if gotNumNodes := sched.numFeasibleNodesToFind(tt.profilePercentage, tt.numAllNodes); gotNumNodes != tt.wantNumNodes {
-				t.Errorf("Scheduler.numFeasibleNodesToFind() = %v, want %v", gotNumNodes, tt.wantNumNodes)
+			alg := &SchedulingAlgorithm{percentageOfNodesToScore: tt.globalPercentage}
+			if gotNumNodes := alg.numFeasibleNodesToFind(tt.profilePercentage, tt.numAllNodes); gotNumNodes != tt.wantNumNodes {
+				t.Errorf("SchedulingAlgorithm.numFeasibleNodesToFind() = %v, want %v", gotNumNodes, tt.wantNumNodes)
 			}
 		})
 	}
@@ -4776,21 +4780,21 @@ func TestFairEvaluationForNodes(t *testing.T) {
 	}
 
 	// To make numAllNodes % nodesToFind != 0
-	sched.percentageOfNodesToScore = 30
-	nodesToFind := int(sched.numFeasibleNodesToFind(fwk.PercentageOfNodesToScore(), int32(numAllNodes)))
+	sched.algorithm.percentageOfNodesToScore = 30
+	nodesToFind := int(sched.algorithm.numFeasibleNodesToFind(fwk.PercentageOfNodesToScore(), int32(numAllNodes)))
 
 	// Iterating over all nodes more than twice
 	for i := 0; i < 2*(numAllNodes/nodesToFind+1); i++ {
 		podInfo := queuedPodInfoForPod(&v1.Pod{})
-		nodesThatFit, _, _, err := sched.findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo)
+		nodesThatFit, _, _, err := sched.algorithm.findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if len(nodesThatFit) != nodesToFind {
 			t.Errorf("got %d nodes filtered, want %d", len(nodesThatFit), nodesToFind)
 		}
-		if sched.nextStartNodeIndex != (i+1)*nodesToFind%numAllNodes {
-			t.Errorf("got %d lastProcessedNodeIndex, want %d", sched.nextStartNodeIndex, (i+1)*nodesToFind%numAllNodes)
+		if sched.algorithm.nextStartNodeIndex != (i+1)*nodesToFind%numAllNodes {
+			t.Errorf("got %d lastProcessedNodeIndex, want %d", sched.algorithm.nextStartNodeIndex, (i+1)*nodesToFind%numAllNodes)
 		}
 	}
 }
@@ -4860,14 +4864,14 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 			}
 
 			sched := &Scheduler{
-				Cache:                    cache,
-				nodeInfoSnapshot:         snapshot,
-				percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
 			}
+			initTestAlgorithm(sched)
 			sched.applyDefaultHandlers()
 
 			podInfo := queuedPodInfoForPod(test.pod)
-			_, _, _, err = sched.findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo)
+			_, _, _, err = sched.algorithm.findNodesThatFitPod(ctx, fwk, framework.NewCycleState(), podInfo)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -4910,6 +4914,15 @@ func makeNodeList(nodeNames []string) []*v1.Node {
 	return result
 }
 
+// initTestAlgorithm initializes a Scheduler built as a struct literal the way New
+// does: it builds the scheduling algorithm from the fields already set and points
+// SchedulePod at it. Unlike applyDefaultHandlers it leaves FailureHandler alone,
+// so it is safe for tests that install their own.
+func initTestAlgorithm(sched *Scheduler) {
+	sched.initAlgorithm()
+	sched.SchedulePod = sched.algorithm.SchedulePod
+}
+
 // makeScheduler makes a simple Scheduler for testing.
 func makeScheduler(ctx context.Context, nodes []*v1.Node) *Scheduler {
 	logger := klog.FromContext(ctx)
@@ -4919,10 +4932,10 @@ func makeScheduler(ctx context.Context, nodes []*v1.Node) *Scheduler {
 	}
 
 	sched := &Scheduler{
-		Cache:                    cache,
-		nodeInfoSnapshot:         emptySnapshot,
-		percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
+		Cache:            cache,
+		nodeInfoSnapshot: emptySnapshot,
 	}
+	initTestAlgorithm(sched)
 	sched.applyDefaultHandlers()
 	cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot)
 	return sched
@@ -5030,10 +5043,9 @@ func setupTestScheduler(ctx context.Context, t *testing.T, client clientset.Inte
 
 	errChan := make(chan error, 1)
 	sched := &Scheduler{
-		Cache:                    cache,
-		client:                   client,
-		nodeInfoSnapshot:         snapshot,
-		percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
+		Cache:            cache,
+		client:           client,
+		nodeInfoSnapshot: snapshot,
 		NextEntity: func(logger klog.Logger) (framework.QueuedEntityInfo, error) {
 			return &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(t, pop(queuedPodStore).(*v1.Pod))}, nil
 		},
@@ -5042,7 +5054,7 @@ func setupTestScheduler(ctx context.Context, t *testing.T, client clientset.Inte
 		Profiles:        profile.Map{testSchedulerName: schedFramework},
 	}
 
-	sched.SchedulePod = sched.schedulePod
+	initTestAlgorithm(sched)
 	sched.FailureHandler = func(ctx context.Context, _ framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, _ *fwk.NominatingInfo, _ time.Time) {
 		err := status.AsError()
 		errChan <- err
@@ -5205,8 +5217,9 @@ func TestEvaluateNominatedNode(t *testing.T) {
 			sched := &Scheduler{
 				nodeInfoSnapshot: snapshot,
 			}
+			initTestAlgorithm(sched)
 
-			gotNodes, err := sched.evaluateNominatedNode(ctx, tt.pod, fw, framework.NewCycleState(), "", framework.Diagnosis{})
+			gotNodes, err := sched.algorithm.evaluateNominatedNode(ctx, tt.pod, fw, framework.NewCycleState(), "", framework.Diagnosis{})
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("Unexpected error, want error: %v, got: %v", tt.wantError, err)
@@ -5286,6 +5299,7 @@ func TestScheduler_DeferredResizePluginSkipping(t *testing.T) {
 		Cache:            cache,
 		nodeInfoSnapshot: snapshot,
 	}
+	initTestAlgorithm(sched)
 
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
@@ -5294,7 +5308,7 @@ func TestScheduler_DeferredResizePluginSkipping(t *testing.T) {
 	podInfo := queuedPodInfoForPod(pod)
 
 	// Run schedulePod
-	_, _ = sched.schedulePod(ctx, schedFramework, state, podInfo)
+	_, _ = sched.algorithm.SchedulePod(ctx, schedFramework, state, podInfo)
 
 	// Verify the skipped plugins
 	skipped := state.GetSkipFilterPlugins()
@@ -5492,11 +5506,11 @@ func TestSchedulePodWithOpportunisticBatching(t *testing.T) {
 			}
 
 			sched := &Scheduler{
-				Cache:                    cache,
-				nodeInfoSnapshot:         snapshot,
-				percentageOfNodesToScore: schedulerapi.DefaultPercentageOfNodesToScore,
-				SchedulingQueue:          internalqueue.NewTestQueue(ctx, nil),
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
+				SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
 			}
+			initTestAlgorithm(sched)
 			sched.applyDefaultHandlers()
 
 			informerFactory.Start(ctx.Done())

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -71,6 +71,9 @@ type Scheduler struct {
 	// by NodeLister and Algorithm.
 	Cache internalcache.Cache
 
+	// Extenders holds the same slice of extenders handed to the framework via WithExtenders.
+	// Algorithm-side code (filtering, scoring) reads Framework.Extenders(), while
+	// extendersBinding uses this field because binding is a Scheduler-level concern.
 	Extenders []fwk.Extender
 
 	// NextEntity should be a function that blocks until the next entity (pod or pod group)
@@ -81,11 +84,6 @@ type Scheduler struct {
 
 	// FailureHandler is called upon a scheduling failure.
 	FailureHandler FailureHandlerFn
-
-	// SchedulePod tries to schedule the given pod to one of the nodes in the node list.
-	// Return a struct of ScheduleResult with the name of suggested host on success,
-	// otherwise will return a FitError with reasons.
-	SchedulePod func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error)
 
 	// Close this to shut down the scheduler.
 	StopEverything <-chan struct{}
@@ -108,10 +106,6 @@ type Scheduler struct {
 
 	nodeInfoSnapshot *internalcache.Snapshot
 
-	percentageOfNodesToScore int32
-
-	nextStartNodeIndex int
-
 	// logger *must* be initialized when creating a Scheduler,
 	// otherwise logging functions will access a nil sink and
 	// panic.
@@ -123,10 +117,11 @@ type Scheduler struct {
 	nominatedNodeNameForExpectationEnabled              bool
 	genericWorkloadEnabled                              bool
 	inPlacePodVerticalScalingSchedulerPreemptionEnabled bool
+
+	algorithm *SchedulingAlgorithm
 }
 
 func (sched *Scheduler) applyDefaultHandlers() {
-	sched.SchedulePod = sched.schedulePod
 	sched.FailureHandler = sched.handleSchedulingFailure
 }
 
@@ -458,7 +453,6 @@ func New(ctx context.Context,
 		Cache:                                  schedulerCache,
 		client:                                 client,
 		nodeInfoSnapshot:                       snapshot,
-		percentageOfNodesToScore:               options.percentageOfNodesToScore,
 		Extenders:                              extenders,
 		StopEverything:                         stopEverything,
 		SchedulingQueue:                        podQueue,
@@ -470,6 +464,7 @@ func New(ctx context.Context,
 		genericWorkloadEnabled:                 feature.DefaultFeatureGate.Enabled(features.GenericWorkload),
 		inPlacePodVerticalScalingSchedulerPreemptionEnabled: feature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingSchedulerPreemption),
 	}
+	sched.initAlgorithm(withPercentageOfNodesToScore(options.percentageOfNodesToScore))
 	sched.NextEntity = podQueue.Pop
 	sched.applyDefaultHandlers()
 
@@ -681,4 +676,27 @@ func (sched *Scheduler) CurrentCycle() int64 {
 		return sched.SchedulingQueue.SchedulingCycle()
 	}
 	return 0
+}
+
+// alg returns the scheduling algorithm, initializing it from the Scheduler's
+// fields on first use (tests construct Scheduler literals directly).
+func (sched *Scheduler) alg() *SchedulingAlgorithm {
+	if sched.algorithm == nil {
+		sched.initAlgorithm()
+	}
+	return sched.algorithm
+}
+
+func (sched *Scheduler) initAlgorithm(opts ...AlgorithmOption) {
+	a := NewSchedulingAlgorithm(sched.nodeInfoSnapshot, opts...)
+	a.cache = sched.Cache
+	a.cycleProvider = sched.CurrentCycle
+	sched.algorithm = a
+}
+
+// SchedulePod tries to schedule the given pod to one of the nodes in the node list.
+// Returns a ScheduleResult with the name of the suggested host on success,
+// otherwise a FitError with reasons.
+func (sched *Scheduler) SchedulePod(ctx context.Context, f framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
+	return sched.alg().schedulePod(ctx, f, state, podInfo)
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -63,8 +63,6 @@ type Scheduler struct {
 	// by NodeLister and Algorithm.
 	Cache internalcache.Cache
 
-	Extenders []fwk.Extender
-
 	// NextEntity should be a function that blocks until the next entity (pod or pod group)
 	// is available. We don't use a channel for this, because scheduling
 	// a pod may take some amount of time and we don't want pods to get
@@ -100,10 +98,6 @@ type Scheduler struct {
 
 	nodeInfoSnapshot *internalcache.Snapshot
 
-	percentageOfNodesToScore int32
-
-	nextStartNodeIndex int
-
 	// logger *must* be initialized when creating a Scheduler,
 	// otherwise logging functions will access a nil sink and
 	// panic.
@@ -115,10 +109,14 @@ type Scheduler struct {
 	nominatedNodeNameForExpectationEnabled              bool
 	genericWorkloadEnabled                              bool
 	inPlacePodVerticalScalingSchedulerPreemptionEnabled bool
+
+	algorithm *SchedulingAlgorithm
 }
 
+// applyDefaultHandlers installs the default handlers. It must run after
+// initAlgorithm, whose result SchedulePod points at.
 func (sched *Scheduler) applyDefaultHandlers() {
-	sched.SchedulePod = sched.schedulePod
+	sched.SchedulePod = sched.algorithm.SchedulePod
 	sched.FailureHandler = sched.handleSchedulingFailure
 }
 
@@ -375,8 +373,6 @@ func New(ctx context.Context,
 		Cache:                                  schedulerCache,
 		client:                                 client,
 		nodeInfoSnapshot:                       snapshot,
-		percentageOfNodesToScore:               options.percentageOfNodesToScore,
-		Extenders:                              comps.extenders,
 		StopEverything:                         stopEverything,
 		SchedulingQueue:                        podQueue,
 		Profiles:                               profiles,
@@ -387,6 +383,7 @@ func New(ctx context.Context,
 		genericWorkloadEnabled:                 feature.DefaultFeatureGate.Enabled(features.GenericWorkload),
 		inPlacePodVerticalScalingSchedulerPreemptionEnabled: feature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingSchedulerPreemption),
 	}
+	sched.initAlgorithm(WithAlgorithmPercentageOfNodesToScore(options.percentageOfNodesToScore))
 	sched.NextEntity = podQueue.Pop
 	sched.applyDefaultHandlers()
 
@@ -598,4 +595,15 @@ func (sched *Scheduler) CurrentCycle() int64 {
 		return sched.SchedulingQueue.SchedulingCycle()
 	}
 	return 0
+}
+
+// initAlgorithm builds the scheduling algorithm from the Scheduler's fields. It
+// has to run before any scheduling method, and before applyDefaultHandlers, which
+// hands SchedulePod the algorithm's method value. New calls it, and so must a
+// Scheduler assembled field by field.
+//
+// CurrentCycle is passed as a bound method value, so a SchedulingQueue installed
+// after this call is still picked up.
+func (sched *Scheduler) initAlgorithm(opts ...AlgorithmOption) {
+	sched.algorithm = NewSchedulingAlgorithm(sched.nodeInfoSnapshot, sched.Cache, append(opts, WithCurrentCycleProvider(sched.CurrentCycle))...)
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -461,8 +461,8 @@ func TestWithPercentageOfNodesToScore(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create scheduler: %v", err)
 			}
-			if sched.percentageOfNodesToScore != tt.wantedPercentageOfNodesToScore {
-				t.Errorf("scheduler.percercentageOfNodesToScore = %v, want %v", sched.percentageOfNodesToScore, tt.wantedPercentageOfNodesToScore)
+			if sched.alg().percentageOfNodesToScore != tt.wantedPercentageOfNodesToScore {
+				t.Errorf("scheduler.percentageOfNodesToScore = %v, want %v", sched.alg().percentageOfNodesToScore, tt.wantedPercentageOfNodesToScore)
 			}
 		})
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -262,16 +262,6 @@ func TestSchedulerCreation(t *testing.T) {
 
 			// Extenders
 			if len(tc.wantExtenders) != 0 {
-				// Scheduler.Extenders
-				extenders := make([]string, 0, len(s.Extenders))
-				for _, e := range s.Extenders {
-					extenders = append(extenders, e.Name())
-				}
-				if diff := cmp.Diff(tc.wantExtenders, extenders); diff != "" {
-					t.Errorf("unexpected extenders (-want, +got):\n%s", diff)
-				}
-
-				// fwk.Handle.Extenders()
 				for _, p := range s.Profiles {
 					extenders := make([]string, 0, len(p.Extenders()))
 					for _, e := range p.Extenders() {
@@ -471,8 +461,8 @@ func TestWithPercentageOfNodesToScore(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create scheduler: %v", err)
 			}
-			if sched.percentageOfNodesToScore != tt.wantedPercentageOfNodesToScore {
-				t.Errorf("scheduler.percercentageOfNodesToScore = %v, want %v", sched.percentageOfNodesToScore, tt.wantedPercentageOfNodesToScore)
+			if sched.algorithm.percentageOfNodesToScore != tt.wantedPercentageOfNodesToScore {
+				t.Errorf("scheduler.percentageOfNodesToScore = %v, want %v", sched.algorithm.percentageOfNodesToScore, tt.wantedPercentageOfNodesToScore)
 			}
 		})
 	}
@@ -539,6 +529,7 @@ func initScheduler(ctx context.Context, cache internalcache.Cache, queue interna
 		Profiles:        profile.Map{testSchedulerName: fwk},
 		logger:          logger,
 	}
+	s.initAlgorithm()
 	s.applyDefaultHandlers()
 
 	return s, fwk, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR extracts core in-memory pod scheduling logic from the `Scheduler` struct into an internal `SchedulingAlgorithm` type

Why we need it:
- **Separation of concerns:** Decouples the high-level scheduler control loop from the core in-memory scheduling and reservation algorithm (`schedulePod`, `assumeAndReserve`, `unreserveAndForget`, `tryScheduling`).
- **Modularity:** Encapsulates cycle state and algorithm execution (`nodeInfoSnapshot`, `cache`, `schedulingQueue`, `percentageOfNodesToScore`) for easier maintenance and future refactoring.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```