### PR TITLE
Add CompositePodGroup garbage collection finalizer protection and int…

### DIFF
--- a/cmd/kube-controller-manager/app/scheduling.go
+++ b/cmd/kube-controller-manager/app/scheduling.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	schedulinginformers "k8s.io/client-go/informers/scheduling/v1alpha3"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
 
@@ -48,11 +49,19 @@ func newPodGroupProtectionController(ctx context.Context, controllerContext Cont
 		return nil, err
 	}
 
+	var compositePodGroupInformer schedulinginformers.CompositePodGroupInformer
+	isCompositePodGroupEnabled := utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup)
+	if isCompositePodGroupEnabled {
+		compositePodGroupInformer = controllerContext.InformerFactory.Scheduling().V1alpha3().CompositePodGroups()
+	}
+
 	pgProtectionController, err := podgroupprotection.NewPodGroupProtectionController(
 		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Scheduling().V1beta1().PodGroups(),
+		compositePodGroupInformer,
 		controllerContext.InformerFactory.Core().V1().Pods(),
 		client,
+		isCompositePodGroupEnabled,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init %s: %w", controllerName, err)

--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -43,6 +43,10 @@ const (
 	// PodGroupProtectionFinalizer is the finalizer added to PodGroups to prevent
 	// premature deletion while pods still reference them.
 	PodGroupProtectionFinalizer = GroupName + "/podgroup-protection"
+
+	// CompositePodGroupProtectionFinalizer is the finalizer added to CompositePodGroups to prevent
+	// premature deletion while child PodGroups or CompositePodGroups still reference them.
+	CompositePodGroupProtectionFinalizer = GroupName + "/compositepodgroup-protection"
 )
 
 // PreemptionPolicy describes a policy for if/when to preempt a pod/podgroup.

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
@@ -23,18 +23,22 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
-	schedulinginformers "k8s.io/client-go/informers/scheduling/v1beta1"
+	schedulinginformersv1alpha3 "k8s.io/client-go/informers/scheduling/v1alpha3"
+	schedulinginformersv1beta1 "k8s.io/client-go/informers/scheduling/v1beta1"
 	clientset "k8s.io/client-go/kubernetes"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1beta1"
+	schedulinglistersv1alpha3 "k8s.io/client-go/listers/scheduling/v1alpha3"
+	schedulinglistersv1beta1 "k8s.io/client-go/listers/scheduling/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/controller/util/protectionutil"
 	"k8s.io/kubernetes/pkg/util/slice"
@@ -44,17 +48,32 @@ const (
 	// The index name for looking up active pods by their
 	// schedulingGroup.podGroupName field.
 	activePodSchedulingGroupIndex = "activePodSchedulingGroup"
+
+	// The index name for looking up child PodGroups by their
+	// parentCompositePodGroupName field.
+	childPodGroupParentCompositeGroupIndex = "childPodGroupParentCompositeGroup"
+
+	// The index name for looking up child CompositePodGroups by their
+	// parentCompositePodGroupName field.
+	childCompositePodGroupParentCompositeGroupIndex = "childCompositePodGroupParentCompositeGroup"
 )
 
-// Controller manages the PodGroupProtectionFinalizer on PodGroup objects.
-// The finalizer is stamped at creation time by the PodGroupProtection admission
-// plugin; this controller removes it when the PodGroup is being deleted and no
-// active (non-terminated) pods still reference it.
+// Controller manages the PodGroupProtectionFinalizer on PodGroup objects and
+// CompositePodGroupProtectionFinalizer on CompositePodGroup objects.
+// Finalizers are stamped at creation time by the PodGroupProtection admission
+// plugin; this controller removes them when objects are being deleted and no
+// child resources still reference them.
 type Controller struct {
 	kubeClient clientset.Interface
 
-	podGroupLister schedulinglisters.PodGroupLister
-	podGroupSynced cache.InformerSynced
+	podGroupLister  schedulinglistersv1beta1.PodGroupLister
+	podGroupSynced  cache.InformerSynced
+	podGroupIndexer cache.Indexer
+
+	isCompositePodGroupEnabled bool
+	compositePodGroupLister    schedulinglistersv1alpha3.CompositePodGroupLister
+	compositePodGroupSynced    cache.InformerSynced
+	compositePodGroupIndexer   cache.Indexer
 
 	podSynced cache.InformerSynced
 
@@ -62,34 +81,68 @@ type Controller struct {
 	// limit iteration over pods to those of interest.
 	podIndexer cache.Indexer
 
-	queue workqueue.TypedRateLimitingInterface[string]
+	queue workqueue.TypedRateLimitingInterface[fwk.EntityKey]
 }
 
 // NewPodGroupProtectionController returns a new instance of the PodGroup protection controller.
 func NewPodGroupProtectionController(
 	logger klog.Logger,
-	podGroupInformer schedulinginformers.PodGroupInformer,
+	podGroupInformer schedulinginformersv1beta1.PodGroupInformer,
+	compositePodGroupInformer schedulinginformersv1alpha3.CompositePodGroupInformer,
 	podInformer coreinformers.PodInformer,
 	kubeClient clientset.Interface,
+	isCompositePodGroupEnabled bool,
 ) (*Controller, error) {
 	c := &Controller{
-		kubeClient:     kubeClient,
-		podGroupLister: podGroupInformer.Lister(),
-		podGroupSynced: podGroupInformer.Informer().HasSynced,
-		podIndexer:     podInformer.Informer().GetIndexer(),
-		podSynced:      podInformer.Informer().HasSynced,
+		kubeClient:                 kubeClient,
+		isCompositePodGroupEnabled: isCompositePodGroupEnabled,
+		podGroupLister:             podGroupInformer.Lister(),
+		podGroupSynced:             podGroupInformer.Informer().HasSynced,
+		podGroupIndexer:            podGroupInformer.Informer().GetIndexer(),
+		podIndexer:                 podInformer.Informer().GetIndexer(),
+		podSynced:                  podInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "podgroupprotection"},
+			workqueue.DefaultTypedControllerRateLimiter[fwk.EntityKey](),
+			workqueue.TypedRateLimitingQueueConfig[fwk.EntityKey]{Name: "podgroupprotection"},
 		),
 	}
 
+	if c.isCompositePodGroupEnabled {
+		c.compositePodGroupLister = compositePodGroupInformer.Lister()
+		c.compositePodGroupSynced = compositePodGroupInformer.Informer().HasSynced
+		c.compositePodGroupIndexer = compositePodGroupInformer.Informer().GetIndexer()
+
+		if err := addChildCompositePodGroupParentCompositeGroupIndexer(c.compositePodGroupIndexer); err != nil {
+			return nil, fmt.Errorf("could not initialize CompositePodGroup parent indexer: %w", err)
+		}
+		if err := addChildPodGroupParentCompositeGroupIndexer(c.podGroupIndexer); err != nil {
+			return nil, fmt.Errorf("could not initialize PodGroup parent indexer: %w", err)
+		}
+
+		if _, err := compositePodGroupInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				c.handleCompositePodGroupUpdate(logger, nil, obj)
+			},
+			UpdateFunc: func(old, new any) {
+				c.handleCompositePodGroupUpdate(logger, old, new)
+			},
+			DeleteFunc: func(obj any) {
+				c.handleCompositePodGroupUpdate(logger, obj, nil)
+			},
+		}, cache.HandlerOptions{Logger: &logger}); err != nil {
+			return nil, err
+		}
+	}
+
 	if _, err := podGroupInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			c.handlePodGroupUpdate(logger, obj)
+		AddFunc: func(obj any) {
+			c.handlePodGroupUpdate(logger, nil, obj)
 		},
-		UpdateFunc: func(old, new interface{}) {
-			c.handlePodGroupUpdate(logger, new)
+		UpdateFunc: func(old, new any) {
+			c.handlePodGroupUpdate(logger, old, new)
+		},
+		DeleteFunc: func(obj any) {
+			c.handlePodGroupUpdate(logger, obj, nil)
 		},
 	}, cache.HandlerOptions{Logger: &logger}); err != nil {
 		return nil, err
@@ -100,13 +153,13 @@ func NewPodGroupProtectionController(
 	}
 
 	if _, err := podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			c.handlePodChange(logger, nil, obj)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			c.handlePodChange(logger, obj, nil)
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new any) {
 			c.handlePodChange(logger, old, new)
 		},
 	}, cache.HandlerOptions{Logger: &logger}); err != nil {
@@ -121,7 +174,7 @@ func NewPodGroupProtectionController(
 // determine whether a PodGroup still has active pods.
 func addActivePodSchedulingGroupIndexer(indexer cache.Indexer) error {
 	return indexer.AddIndexers(cache.Indexers{
-		activePodSchedulingGroupIndex: func(obj interface{}) ([]string, error) {
+		activePodSchedulingGroupIndex: func(obj any) ([]string, error) {
 			pod, ok := obj.(*v1.Pod)
 			if !ok {
 				return nil, nil
@@ -133,6 +186,40 @@ func addActivePodSchedulingGroupIndexer(indexer cache.Indexer) error {
 				return nil, nil
 			}
 			return []string{pod.Namespace + "/" + *pod.Spec.SchedulingGroup.PodGroupName}, nil
+		},
+	})
+}
+
+// addChildPodGroupParentCompositeGroupIndexer adds an indexer to look up child PodGroups by their
+// parentCompositePodGroupName field.
+func addChildPodGroupParentCompositeGroupIndexer(indexer cache.Indexer) error {
+	return indexer.AddIndexers(cache.Indexers{
+		childPodGroupParentCompositeGroupIndex: func(obj any) ([]string, error) {
+			pg, ok := obj.(*schedulingv1beta1.PodGroup)
+			if !ok {
+				return nil, nil
+			}
+			if pg.Spec.ParentCompositePodGroupName == nil {
+				return nil, nil
+			}
+			return []string{pg.Namespace + "/" + *pg.Spec.ParentCompositePodGroupName}, nil
+		},
+	})
+}
+
+// addChildCompositePodGroupParentCompositeGroupIndexer adds an indexer to look up child CompositePodGroups by their
+// parentCompositePodGroupName field.
+func addChildCompositePodGroupParentCompositeGroupIndexer(indexer cache.Indexer) error {
+	return indexer.AddIndexers(cache.Indexers{
+		childCompositePodGroupParentCompositeGroupIndex: func(obj any) ([]string, error) {
+			cpg, ok := obj.(*schedulingv1alpha3.CompositePodGroup)
+			if !ok {
+				return nil, nil
+			}
+			if cpg.Spec.ParentCompositePodGroupName == nil {
+				return nil, nil
+			}
+			return []string{cpg.Namespace + "/" + *cpg.Spec.ParentCompositePodGroupName}, nil
 		},
 	})
 }
@@ -151,7 +238,12 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 		wg.Wait()
 	}()
 
-	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.podGroupSynced, c.podSynced) {
+	synced := []cache.InformerSynced{c.podGroupSynced, c.podSynced}
+	if c.compositePodGroupSynced != nil {
+		synced = append(synced, c.compositePodGroupSynced)
+	}
+
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, synced...) {
 		return
 	}
 
@@ -169,34 +261,39 @@ func (c *Controller) runWorker(ctx context.Context) {
 }
 
 func (c *Controller) processNextWorkItem(ctx context.Context) bool {
-	pgKey, quit := c.queue.Get()
+	itemKey, quit := c.queue.Get()
 	if quit {
 		return false
 	}
-	defer c.queue.Done(pgKey)
+	defer c.queue.Done(itemKey)
 
-	err := c.processPodGroup(ctx, pgKey)
+	var err error
+	switch itemKey.Type {
+	case fwk.CompositePodGroupKeyType:
+		err = c.processCompositePodGroup(ctx, itemKey)
+	case fwk.PodGroupKeyType:
+		err = c.processPodGroup(ctx, itemKey)
+	default:
+		// Fallback for any legacy queued keys (should not happen)
+		err = c.processPodGroup(ctx, itemKey)
+	}
+
 	if err == nil {
-		c.queue.Forget(pgKey)
+		c.queue.Forget(itemKey)
 		return true
 	}
 
-	c.queue.AddRateLimited(pgKey)
-	utilruntime.HandleError(fmt.Errorf("PodGroup %v failed with: %w", pgKey, err))
+	c.queue.AddRateLimited(itemKey)
+	utilruntime.HandleError(fmt.Errorf("work item %v failed with: %w", itemKey, err))
 
 	return true
 }
 
-func (c *Controller) processPodGroup(ctx context.Context, pgKey string) error {
+func (c *Controller) processPodGroup(ctx context.Context, pgKey fwk.EntityKey) error {
 	logger := klog.FromContext(ctx)
 	logger.V(4).Info("Processing PodGroup", "podGroup", pgKey)
 
-	pgNamespace, pgName, err := cache.SplitMetaNamespaceKey(pgKey)
-	if err != nil {
-		return fmt.Errorf("error parsing PodGroup key %q: %w", pgKey, err)
-	}
-
-	pg, err := c.podGroupLister.PodGroups(pgNamespace).Get(pgName)
+	pg, err := c.podGroupLister.PodGroups(pgKey.Namespace).Get(pgKey.Name)
 	if apierrors.IsNotFound(err) {
 		logger.V(4).Info("PodGroup not found, ignoring", "podGroup", pgKey)
 		return nil
@@ -220,6 +317,38 @@ func (c *Controller) processPodGroup(ctx context.Context, pgKey string) error {
 	return nil
 }
 
+func (c *Controller) processCompositePodGroup(ctx context.Context, cpgKey fwk.EntityKey) error {
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("Processing CompositePodGroup", "compositePodGroup", cpgKey)
+
+	if c.compositePodGroupLister == nil {
+		return nil
+	}
+
+	cpg, err := c.compositePodGroupLister.CompositePodGroups(cpgKey.Namespace).Get(cpgKey.Name)
+	if apierrors.IsNotFound(err) {
+		logger.V(4).Info("CompositePodGroup not found, ignoring", "compositePodGroup", cpgKey)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if !protectionutil.IsDeletionCandidate(cpg, scheduling.CompositePodGroupProtectionFinalizer) {
+		return nil
+	}
+
+	hasChildren, err := c.hasChildGroups(ctx, cpg)
+	if err != nil {
+		return err
+	}
+	if !hasChildren {
+		return c.removeCompositePodGroupFinalizer(ctx, cpg)
+	}
+	logger.V(4).Info("Keeping CompositePodGroup finalizer because it still has child pod groups or composite pod groups", "compositePodGroup", klog.KObj(cpg))
+	return nil
+}
+
 func (c *Controller) removeFinalizer(ctx context.Context, pg *schedulingv1beta1.PodGroup) error {
 	logger := klog.FromContext(ctx)
 	pgClone := pg.DeepCopy()
@@ -232,6 +361,21 @@ func (c *Controller) removeFinalizer(ctx context.Context, pg *schedulingv1beta1.
 	}
 
 	logger.V(3).Info("Removed protection finalizer from PodGroup", "podGroup", klog.KObj(pg))
+	return nil
+}
+
+func (c *Controller) removeCompositePodGroupFinalizer(ctx context.Context, cpg *schedulingv1alpha3.CompositePodGroup) error {
+	logger := klog.FromContext(ctx)
+	cpgClone := cpg.DeepCopy()
+
+	cpgClone.Finalizers = slice.RemoveString(cpgClone.Finalizers, scheduling.CompositePodGroupProtectionFinalizer, nil)
+	_, err := c.kubeClient.SchedulingV1alpha3().CompositePodGroups(cpgClone.Namespace).Update(ctx, cpgClone, metav1.UpdateOptions{})
+	if err != nil {
+		logger.Error(err, "Error removing protection finalizer from CompositePodGroup", "compositePodGroup", klog.KObj(cpg))
+		return err
+	}
+
+	logger.V(3).Info("Removed protection finalizer from CompositePodGroup", "compositePodGroup", klog.KObj(cpg))
 	return nil
 }
 
@@ -256,35 +400,87 @@ func (c *Controller) hasActivePods(ctx context.Context, pg *schedulingv1beta1.Po
 	return false, nil
 }
 
+// hasChildGroups returns true if any child PodGroups or child CompositePodGroups
+// reference the parent CompositePodGroup via spec.parentCompositePodGroupName.
+func (c *Controller) hasChildGroups(ctx context.Context, cpg *schedulingv1alpha3.CompositePodGroup) (bool, error) {
+	logger := klog.FromContext(ctx)
+	indexKey := cpg.Namespace + "/" + cpg.Name
+
+	if c.podGroupIndexer != nil {
+		pgObjs, err := c.podGroupIndexer.ByIndex(childPodGroupParentCompositeGroupIndex, indexKey)
+		if err != nil {
+			return false, fmt.Errorf("index-based list of child PodGroups failed for CompositePodGroup %s: %w", indexKey, err)
+		}
+		if len(pgObjs) > 0 {
+			logger.V(4).Info("Child PodGroup is using CompositePodGroup", "childPodGroup", klog.KObj(pgObjs[0].(*schedulingv1beta1.PodGroup)), "compositePodGroup", klog.KObj(cpg))
+			return true, nil
+		}
+	}
+
+	if c.compositePodGroupIndexer != nil {
+		cpgObjs, err := c.compositePodGroupIndexer.ByIndex(childCompositePodGroupParentCompositeGroupIndex, indexKey)
+		if err != nil {
+			return false, fmt.Errorf("index-based list of child CompositePodGroups failed for CompositePodGroup %s: %w", indexKey, err)
+		}
+		if len(cpgObjs) > 0 {
+			logger.V(4).Info("Child CompositePodGroup is using CompositePodGroup", "childCompositePodGroup", klog.KObj(cpgObjs[0].(*schedulingv1alpha3.CompositePodGroup)), "compositePodGroup", klog.KObj(cpg))
+			return true, nil
+		}
+	}
+
+	logger.V(4).Info("No child PodGroups or CompositePodGroups found using CompositePodGroup", "compositePodGroup", klog.KObj(cpg))
+	return false, nil
+}
+
 // isPodTerminated returns true if the pod has completed (Succeeded or Failed).
 func isPodTerminated(pod *v1.Pod) bool {
 	return pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed
 }
 
-// handlePodGroupUpdate handles PodGroup add/update events.
-// Only deletion candidates which are being deleted and have the finalizer need processing.
-func (c *Controller) handlePodGroupUpdate(logger klog.Logger, obj interface{}) {
-	pg, ok := obj.(*schedulingv1beta1.PodGroup)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("PodGroup informer returned non-PodGroup object: %#v", obj))
-		return
+// handlePodGroupUpdate handles PodGroup add/delete/update events.
+func (c *Controller) handlePodGroupUpdate(logger klog.Logger, old, new any) {
+	pg := getPodGroup(new)
+	oldPg := getPodGroup(old)
+
+	if pg != nil && protectionutil.IsDeletionCandidate(pg, scheduling.PodGroupProtectionFinalizer) {
+		logger.V(4).Info("Got event on PodGroup", "podGroup", klog.KObj(pg))
+		c.queue.Add(fwk.PodGroupKey(pg.Namespace, pg.Name))
 	}
-	if !protectionutil.IsDeletionCandidate(pg, scheduling.PodGroupProtectionFinalizer) {
-		return
+
+	// Since ParentCompositePodGroupName is immutable, we can extract it from either the new or old object.
+	cpgToCheck := pg
+	if oldPg != nil {
+		cpgToCheck = oldPg
 	}
-	key, err := cache.MetaNamespaceKeyFunc(pg)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for PodGroup %#v: %w", pg, err))
-		return
+	if cpgToCheck.Spec.ParentCompositePodGroupName != nil {
+		c.queue.Add(fwk.CompositePodGroupKey(cpgToCheck.Namespace, *cpgToCheck.Spec.ParentCompositePodGroupName))
 	}
-	logger.V(4).Info("Got event on PodGroup", "podGroup", klog.KObj(pg))
-	c.queue.Add(key)
+}
+
+// handleCompositePodGroupUpdate handles CompositePodGroup add/delete/update events.
+func (c *Controller) handleCompositePodGroupUpdate(logger klog.Logger, old, new any) {
+	cpg := getCompositePodGroup(new)
+	oldCpg := getCompositePodGroup(old)
+
+	if cpg != nil && protectionutil.IsDeletionCandidate(cpg, scheduling.CompositePodGroupProtectionFinalizer) {
+		logger.V(4).Info("Got event on CompositePodGroup", "compositePodGroup", klog.KObj(cpg))
+		c.queue.Add(fwk.CompositePodGroupKey(cpg.Namespace, cpg.Name))
+	}
+
+	// Since ParentCompositePodGroupName is immutable, we can extract it from either the new or old object.
+	cpgToCheck := cpg
+	if oldCpg != nil {
+		cpgToCheck = oldCpg
+	}
+	if cpgToCheck.Spec.ParentCompositePodGroupName != nil {
+		c.queue.Add(fwk.CompositePodGroupKey(cpgToCheck.Namespace, *cpgToCheck.Spec.ParentCompositePodGroupName))
+	}
 }
 
 // handlePodChange handles Pod add/delete/update events.
 // It enqueues the referenced PodGroup only when the event could affect
 // finalizer decisions where the pod is deleted or transitioned to a terminal phase.
-func (c *Controller) handlePodChange(logger klog.Logger, old, new interface{}) {
+func (c *Controller) handlePodChange(logger klog.Logger, old, new any) {
 	newPod := getPod(new)
 	oldPod := getPod(old)
 
@@ -313,12 +509,52 @@ func (c *Controller) enqueuePodGroupForPod(logger klog.Logger, pod *v1.Pod) {
 		return
 	}
 
-	pgKey := pod.Namespace + "/" + *pod.Spec.SchedulingGroup.PodGroupName
+	pgKey := fwk.PodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
 	logger.V(4).Info("Enqueuing PodGroup for pod event", "pod", klog.KObj(pod), "podGroup", pgKey)
 	c.queue.Add(pgKey)
 }
 
-func getPod(obj interface{}) *v1.Pod {
+func getPodGroup(obj any) *schedulingv1beta1.PodGroup {
+	if obj == nil {
+		return nil
+	}
+	pg, ok := obj.(*schedulingv1beta1.PodGroup)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return nil
+		}
+		pg, ok = tombstone.Obj.(*schedulingv1beta1.PodGroup)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a PodGroup %#v", obj))
+			return nil
+		}
+	}
+	return pg
+}
+
+func getCompositePodGroup(obj any) *schedulingv1alpha3.CompositePodGroup {
+	if obj == nil {
+		return nil
+	}
+	cpg, ok := obj.(*schedulingv1alpha3.CompositePodGroup)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
+			return nil
+		}
+		cpg, ok = tombstone.Obj.(*schedulingv1alpha3.CompositePodGroup)
+		if !ok {
+			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a CompositePodGroup %#v", obj))
+			return nil
+		}
+	}
+	return cpg
+}
+
+func getPod(obj any) *v1.Pod {
 	if obj == nil {
 		return nil
 	}

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
@@ -23,15 +23,18 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	coreinformers "k8s.io/client-go/informers/core/v1"
-	schedulinginformers "k8s.io/client-go/informers/scheduling/v1beta1"
+	schedulinginformersv1alpha3 "k8s.io/client-go/informers/scheduling/v1alpha3"
+	schedulinginformersv1beta1 "k8s.io/client-go/informers/scheduling/v1beta1"
 	clientset "k8s.io/client-go/kubernetes"
-	schedulinglisters "k8s.io/client-go/listers/scheduling/v1beta1"
+	schedulinglistersv1alpha3 "k8s.io/client-go/listers/scheduling/v1alpha3"
+	schedulinglistersv1beta1 "k8s.io/client-go/listers/scheduling/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -44,17 +47,32 @@ const (
 	// The index name for looking up active pods by their
 	// schedulingGroup.podGroupName field.
 	activePodSchedulingGroupIndex = "activePodSchedulingGroup"
+
+	// The index name for looking up child PodGroups by their
+	// parentCompositePodGroupName field.
+	childPodGroupParentCompositeGroupIndex = "childPodGroupParentCompositeGroup"
+
+	// The index name for looking up child CompositePodGroups by their
+	// parentCompositePodGroupName field.
+	childCompositePodGroupParentCompositeGroupIndex = "childCompositePodGroupParentCompositeGroup"
 )
 
-// Controller manages the PodGroupProtectionFinalizer on PodGroup objects.
-// The finalizer is stamped at creation time by the PodGroupProtection admission
-// plugin; this controller removes it when the PodGroup is being deleted and no
-// active (non-terminated) pods still reference it.
+// Controller manages the PodGroupProtectionFinalizer on PodGroup objects and
+// CompositePodGroupProtectionFinalizer on CompositePodGroup objects.
+// Finalizers are stamped at creation time by the PodGroupProtection admission
+// plugin; this controller removes them when objects are being deleted and no
+// child resources still reference them.
 type Controller struct {
 	kubeClient clientset.Interface
 
-	podGroupLister schedulinglisters.PodGroupLister
-	podGroupSynced cache.InformerSynced
+	podGroupLister  schedulinglistersv1beta1.PodGroupLister
+	podGroupSynced  cache.InformerSynced
+	podGroupIndexer cache.Indexer
+
+	isCompositePodGroupEnabled bool
+	compositePodGroupLister    schedulinglistersv1alpha3.CompositePodGroupLister
+	compositePodGroupSynced    cache.InformerSynced
+	compositePodGroupIndexer   cache.Indexer
 
 	podSynced cache.InformerSynced
 
@@ -62,37 +80,71 @@ type Controller struct {
 	// limit iteration over pods to those of interest.
 	podIndexer cache.Indexer
 
-	queue workqueue.TypedRateLimitingInterface[string]
+	queue workqueue.TypedRateLimitingInterface[queueKey]
 }
 
 // NewPodGroupProtectionController returns a new instance of the PodGroup protection controller.
 func NewPodGroupProtectionController(
 	logger klog.Logger,
-	podGroupInformer schedulinginformers.PodGroupInformer,
+	podGroupInformer schedulinginformersv1beta1.PodGroupInformer,
+	compositePodGroupInformer schedulinginformersv1alpha3.CompositePodGroupInformer,
 	podInformer coreinformers.PodInformer,
 	kubeClient clientset.Interface,
+	isCompositePodGroupEnabled bool,
 ) (*Controller, error) {
 	c := &Controller{
-		kubeClient:     kubeClient,
-		podGroupLister: podGroupInformer.Lister(),
-		podGroupSynced: podGroupInformer.Informer().HasSynced,
-		podIndexer:     podInformer.Informer().GetIndexer(),
-		podSynced:      podInformer.Informer().HasSynced,
+		kubeClient:                 kubeClient,
+		isCompositePodGroupEnabled: isCompositePodGroupEnabled,
+		podGroupLister:             podGroupInformer.Lister(),
+		podGroupSynced:             podGroupInformer.Informer().HasSynced,
+		podGroupIndexer:            podGroupInformer.Informer().GetIndexer(),
+		podIndexer:                 podInformer.Informer().GetIndexer(),
+		podSynced:                  podInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{
+			workqueue.DefaultTypedControllerRateLimiter[queueKey](),
+			workqueue.TypedRateLimitingQueueConfig[queueKey]{
 				Logger: &logger,
 				Name:   "podgroupprotection",
 			},
 		),
 	}
 
+	if c.isCompositePodGroupEnabled {
+		c.compositePodGroupLister = compositePodGroupInformer.Lister()
+		c.compositePodGroupSynced = compositePodGroupInformer.Informer().HasSynced
+		c.compositePodGroupIndexer = compositePodGroupInformer.Informer().GetIndexer()
+
+		if err := addChildIndexer(c.compositePodGroupIndexer, childCompositePodGroupParentCompositeGroupIndex, compositePodGroupParent); err != nil {
+			return nil, fmt.Errorf("could not initialize CompositePodGroup parent indexer: %w", err)
+		}
+		if err := addChildIndexer(c.podGroupIndexer, childPodGroupParentCompositeGroupIndex, podGroupParent); err != nil {
+			return nil, fmt.Errorf("could not initialize PodGroup parent indexer: %w", err)
+		}
+
+		if _, err := compositePodGroupInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj any) {
+				c.handleCompositePodGroupUpdate(logger, nil, obj)
+			},
+			UpdateFunc: func(old, new any) {
+				c.handleCompositePodGroupUpdate(logger, old, new)
+			},
+			DeleteFunc: func(obj any) {
+				c.handleCompositePodGroupUpdate(logger, obj, nil)
+			},
+		}, cache.HandlerOptions{Logger: &logger}); err != nil {
+			return nil, err
+		}
+	}
+
 	if _, err := podGroupInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			c.handlePodGroupUpdate(logger, obj)
+		AddFunc: func(obj any) {
+			c.handlePodGroupUpdate(logger, nil, obj)
 		},
-		UpdateFunc: func(old, new interface{}) {
-			c.handlePodGroupUpdate(logger, new)
+		UpdateFunc: func(old, new any) {
+			c.handlePodGroupUpdate(logger, old, new)
+		},
+		DeleteFunc: func(obj any) {
+			c.handlePodGroupUpdate(logger, obj, nil)
 		},
 	}, cache.HandlerOptions{Logger: &logger}); err != nil {
 		return nil, err
@@ -103,13 +155,13 @@ func NewPodGroupProtectionController(
 	}
 
 	if _, err := podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			c.handlePodChange(logger, nil, obj)
 		},
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			c.handlePodChange(logger, obj, nil)
 		},
-		UpdateFunc: func(old, new interface{}) {
+		UpdateFunc: func(old, new any) {
 			c.handlePodChange(logger, old, new)
 		},
 	}, cache.HandlerOptions{Logger: &logger}); err != nil {
@@ -119,12 +171,46 @@ func NewPodGroupProtectionController(
 	return c, nil
 }
 
+func namespacedKey(namespace, name string) string {
+	return namespace + "/" + name
+}
+
+// podGroupParent extracts the namespace and parent CompositePodGroup name from a PodGroup
+// for hierarchical relationship indexing.
+func podGroupParent(pg *schedulingv1beta1.PodGroup) (string, *string) {
+	return pg.Namespace, pg.Spec.ParentCompositePodGroupName
+}
+
+// compositePodGroupParent extracts the namespace and parent CompositePodGroup name from a CompositePodGroup
+// for hierarchical relationship indexing.
+func compositePodGroupParent(cpg *schedulingv1alpha3.CompositePodGroup) (string, *string) {
+	return cpg.Namespace, cpg.Spec.ParentCompositePodGroupName
+}
+
+// addChildIndexer registers an indexer on the given cache to look up child resources
+// by their parent CompositePodGroup reference.
+func addChildIndexer[T any](indexer cache.Indexer, indexName string, parentOf func(T) (namespace string, parent *string)) error {
+	return indexer.AddIndexers(cache.Indexers{
+		indexName: func(obj any) ([]string, error) {
+			t, ok := obj.(T)
+			if !ok {
+				return nil, nil
+			}
+			ns, parent := parentOf(t)
+			if parent == nil {
+				return nil, nil
+			}
+			return []string{namespacedKey(ns, *parent)}, nil
+		},
+	})
+}
+
 // addActivePodSchedulingGroupIndexer adds an indexer to look up active
 // pods by their schedulingGroup.podGroupName field so we can efficiently
 // determine whether a PodGroup still has active pods.
 func addActivePodSchedulingGroupIndexer(indexer cache.Indexer) error {
 	return indexer.AddIndexers(cache.Indexers{
-		activePodSchedulingGroupIndex: func(obj interface{}) ([]string, error) {
+		activePodSchedulingGroupIndex: func(obj any) ([]string, error) {
 			pod, ok := obj.(*v1.Pod)
 			if !ok {
 				return nil, nil
@@ -135,7 +221,7 @@ func addActivePodSchedulingGroupIndexer(indexer cache.Indexer) error {
 			if pod.Spec.SchedulingGroup == nil || pod.Spec.SchedulingGroup.PodGroupName == nil {
 				return nil, nil
 			}
-			return []string{pod.Namespace + "/" + *pod.Spec.SchedulingGroup.PodGroupName}, nil
+			return []string{namespacedKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)}, nil
 		},
 	})
 }
@@ -154,7 +240,12 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 		wg.Wait()
 	}()
 
-	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.podGroupSynced, c.podSynced) {
+	synced := []cache.InformerSynced{c.podGroupSynced, c.podSynced}
+	if c.isCompositePodGroupEnabled {
+		synced = append(synced, c.compositePodGroupSynced)
+	}
+
+	if !cache.WaitForNamedCacheSyncWithContext(ctx, synced...) {
 		return
 	}
 
@@ -172,36 +263,42 @@ func (c *Controller) runWorker(ctx context.Context) {
 }
 
 func (c *Controller) processNextWorkItem(ctx context.Context) bool {
-	pgKey, quit := c.queue.Get()
+	itemKey, quit := c.queue.Get()
 	if quit {
 		return false
 	}
-	defer c.queue.Done(pgKey)
+	defer c.queue.Done(itemKey)
 
-	err := c.processPodGroup(ctx, pgKey)
-	if err == nil {
-		c.queue.Forget(pgKey)
+	var err error
+	switch itemKey.kind {
+	case kindCompositePodGroup:
+		err = c.processCompositePodGroup(ctx, itemKey)
+	case kindPodGroup:
+		err = c.processPodGroup(ctx, itemKey)
+	default:
+		utilruntime.HandleError(fmt.Errorf("unexpected queue item kind %q for %s/%s", itemKey.kind, itemKey.namespace, itemKey.name))
+		c.queue.Forget(itemKey)
 		return true
 	}
 
-	c.queue.AddRateLimited(pgKey)
-	utilruntime.HandleError(fmt.Errorf("PodGroup %v failed with: %w", pgKey, err))
+	if err == nil {
+		c.queue.Forget(itemKey)
+		return true
+	}
+
+	c.queue.AddRateLimited(itemKey)
+	utilruntime.HandleError(fmt.Errorf("work item %v failed with: %w", itemKey, err))
 
 	return true
 }
 
-func (c *Controller) processPodGroup(ctx context.Context, pgKey string) error {
+func (c *Controller) processPodGroup(ctx context.Context, pgKey queueKey) error {
 	logger := klog.FromContext(ctx)
-	logger.V(4).Info("Processing PodGroup", "podGroup", pgKey)
+	logger.V(4).Info("Processing PodGroup", "podGroup", klog.KRef(pgKey.namespace, pgKey.name))
 
-	pgNamespace, pgName, err := cache.SplitMetaNamespaceKey(pgKey)
-	if err != nil {
-		return fmt.Errorf("error parsing PodGroup key %q: %w", pgKey, err)
-	}
-
-	pg, err := c.podGroupLister.PodGroups(pgNamespace).Get(pgName)
+	pg, err := c.podGroupLister.PodGroups(pgKey.namespace).Get(pgKey.name)
 	if apierrors.IsNotFound(err) {
-		logger.V(4).Info("PodGroup not found, ignoring", "podGroup", pgKey)
+		logger.V(4).Info("PodGroup not found, ignoring", "podGroup", klog.KRef(pgKey.namespace, pgKey.name))
 		return nil
 	}
 	if err != nil {
@@ -223,6 +320,38 @@ func (c *Controller) processPodGroup(ctx context.Context, pgKey string) error {
 	return nil
 }
 
+func (c *Controller) processCompositePodGroup(ctx context.Context, cpgKey queueKey) error {
+	logger := klog.FromContext(ctx)
+	logger.V(4).Info("Processing CompositePodGroup", "compositePodGroup", klog.KRef(cpgKey.namespace, cpgKey.name))
+
+	if !c.isCompositePodGroupEnabled {
+		return nil
+	}
+
+	cpg, err := c.compositePodGroupLister.CompositePodGroups(cpgKey.namespace).Get(cpgKey.name)
+	if apierrors.IsNotFound(err) {
+		logger.V(4).Info("CompositePodGroup not found, ignoring", "compositePodGroup", klog.KRef(cpgKey.namespace, cpgKey.name))
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if !protectionutil.IsDeletionCandidate(cpg, scheduling.CompositePodGroupProtectionFinalizer) {
+		return nil
+	}
+
+	hasChildren, err := c.hasChildGroups(ctx, cpg)
+	if err != nil {
+		return err
+	}
+	if !hasChildren {
+		return c.removeCompositePodGroupFinalizer(ctx, cpg)
+	}
+	logger.V(4).Info("Keeping CompositePodGroup finalizer because it still has child pod groups or composite pod groups", "compositePodGroup", klog.KObj(cpg))
+	return nil
+}
+
 func (c *Controller) removeFinalizer(ctx context.Context, pg *schedulingv1beta1.PodGroup) error {
 	logger := klog.FromContext(ctx)
 	pgClone := pg.DeepCopy()
@@ -230,11 +359,24 @@ func (c *Controller) removeFinalizer(ctx context.Context, pg *schedulingv1beta1.
 	pgClone.Finalizers = slice.RemoveString(pgClone.Finalizers, scheduling.PodGroupProtectionFinalizer, nil)
 	_, err := c.kubeClient.SchedulingV1beta1().PodGroups(pgClone.Namespace).Update(ctx, pgClone, metav1.UpdateOptions{})
 	if err != nil {
-		logger.Error(err, "Error removing protection finalizer from PodGroup", "podGroup", klog.KObj(pg))
 		return err
 	}
 
 	logger.V(3).Info("Removed protection finalizer from PodGroup", "podGroup", klog.KObj(pg))
+	return nil
+}
+
+func (c *Controller) removeCompositePodGroupFinalizer(ctx context.Context, cpg *schedulingv1alpha3.CompositePodGroup) error {
+	logger := klog.FromContext(ctx)
+	cpgClone := cpg.DeepCopy()
+
+	cpgClone.Finalizers = slice.RemoveString(cpgClone.Finalizers, scheduling.CompositePodGroupProtectionFinalizer, nil)
+	_, err := c.kubeClient.SchedulingV1alpha3().CompositePodGroups(cpgClone.Namespace).Update(ctx, cpgClone, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	logger.V(3).Info("Removed protection finalizer from CompositePodGroup", "compositePodGroup", klog.KObj(cpg))
 	return nil
 }
 
@@ -243,7 +385,7 @@ func (c *Controller) removeFinalizer(ctx context.Context, pg *schedulingv1beta1.
 // non-terminated pods, so a non-empty result means the PodGroup is still in use.
 func (c *Controller) hasActivePods(ctx context.Context, pg *schedulingv1beta1.PodGroup) (bool, error) {
 	logger := klog.FromContext(ctx)
-	indexKey := pg.Namespace + "/" + pg.Name
+	indexKey := namespacedKey(pg.Namespace, pg.Name)
 
 	objs, err := c.podIndexer.ByIndex(activePodSchedulingGroupIndex, indexKey)
 	if err != nil {
@@ -259,37 +401,88 @@ func (c *Controller) hasActivePods(ctx context.Context, pg *schedulingv1beta1.Po
 	return false, nil
 }
 
+// hasChildGroups returns true if any child PodGroups or child CompositePodGroups
+// reference the parent CompositePodGroup via spec.parentCompositePodGroupName.
+func (c *Controller) hasChildGroups(ctx context.Context, cpg *schedulingv1alpha3.CompositePodGroup) (bool, error) {
+	logger := klog.FromContext(ctx)
+	indexKey := namespacedKey(cpg.Namespace, cpg.Name)
+
+	pgObjs, err := c.podGroupIndexer.ByIndex(childPodGroupParentCompositeGroupIndex, indexKey)
+	if err != nil {
+		return false, fmt.Errorf("index-based list of child PodGroups failed for CompositePodGroup %s: %w", indexKey, err)
+	}
+	if len(pgObjs) > 0 {
+		logger.V(4).Info("Child PodGroup is using CompositePodGroup", "childPodGroup", klog.KObj(pgObjs[0].(*schedulingv1beta1.PodGroup)), "compositePodGroup", klog.KObj(cpg))
+		return true, nil
+	}
+
+	if c.isCompositePodGroupEnabled {
+		cpgObjs, err := c.compositePodGroupIndexer.ByIndex(childCompositePodGroupParentCompositeGroupIndex, indexKey)
+		if err != nil {
+			return false, fmt.Errorf("index-based list of child CompositePodGroups failed for CompositePodGroup %s: %w", indexKey, err)
+		}
+		if len(cpgObjs) > 0 {
+			logger.V(4).Info("Child CompositePodGroup is using CompositePodGroup", "childCompositePodGroup", klog.KObj(cpgObjs[0].(*schedulingv1alpha3.CompositePodGroup)), "compositePodGroup", klog.KObj(cpg))
+			return true, nil
+		}
+	}
+
+	logger.V(4).Info("No child PodGroups or CompositePodGroups found using CompositePodGroup", "compositePodGroup", klog.KObj(cpg))
+	return false, nil
+}
+
 // isPodTerminated returns true if the pod has completed (Succeeded or Failed).
 func isPodTerminated(pod *v1.Pod) bool {
 	return pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed
 }
 
-// handlePodGroupUpdate handles PodGroup add/update events.
-// Only deletion candidates which are being deleted and have the finalizer need processing.
-func (c *Controller) handlePodGroupUpdate(logger klog.Logger, obj interface{}) {
-	pg, ok := obj.(*schedulingv1beta1.PodGroup)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("PodGroup informer returned non-PodGroup object: %#v", obj))
+// handlePodGroupUpdate handles PodGroup add/delete/update events.
+func (c *Controller) handlePodGroupUpdate(logger klog.Logger, old, new any) {
+	pg, _ := objectOf[*schedulingv1beta1.PodGroup](new)
+	oldPg, _ := objectOf[*schedulingv1beta1.PodGroup](old)
+
+	if pg != nil && protectionutil.IsDeletionCandidate(pg, scheduling.PodGroupProtectionFinalizer) {
+		logger.V(4).Info("Got event on PodGroup", "podGroup", klog.KObj(pg))
+		c.queue.Add(podGroupKey(pg.Namespace, pg.Name))
+	}
+
+	if !c.isCompositePodGroupEnabled {
 		return
 	}
-	if !protectionutil.IsDeletionCandidate(pg, scheduling.PodGroupProtectionFinalizer) {
+
+	if oldPg != nil && (pg == nil || oldPg.UID != pg.UID) {
+		if oldPg.Spec.ParentCompositePodGroupName != nil {
+			c.queue.Add(compositePodGroupKey(oldPg.Namespace, *oldPg.Spec.ParentCompositePodGroupName))
+		}
+	}
+}
+
+// handleCompositePodGroupUpdate handles CompositePodGroup add/delete/update events.
+func (c *Controller) handleCompositePodGroupUpdate(logger klog.Logger, old, new any) {
+	if !c.isCompositePodGroupEnabled {
 		return
 	}
-	key, err := cache.MetaNamespaceKeyFunc(pg)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("couldn't get key for PodGroup %#v: %w", pg, err))
-		return
+	cpg, _ := objectOf[*schedulingv1alpha3.CompositePodGroup](new)
+	oldCpg, _ := objectOf[*schedulingv1alpha3.CompositePodGroup](old)
+
+	if cpg != nil && protectionutil.IsDeletionCandidate(cpg, scheduling.CompositePodGroupProtectionFinalizer) {
+		logger.V(4).Info("Got event on CompositePodGroup", "compositePodGroup", klog.KObj(cpg))
+		c.queue.Add(compositePodGroupKey(cpg.Namespace, cpg.Name))
 	}
-	logger.V(4).Info("Got event on PodGroup", "podGroup", klog.KObj(pg))
-	c.queue.Add(key)
+
+	if oldCpg != nil && (cpg == nil || oldCpg.UID != cpg.UID) {
+		if oldCpg.Spec.ParentCompositePodGroupName != nil {
+			c.queue.Add(compositePodGroupKey(oldCpg.Namespace, *oldCpg.Spec.ParentCompositePodGroupName))
+		}
+	}
 }
 
 // handlePodChange handles Pod add/delete/update events.
 // It enqueues the referenced PodGroup only when the event could affect
 // finalizer decisions where the pod is deleted or transitioned to a terminal phase.
-func (c *Controller) handlePodChange(logger klog.Logger, old, new interface{}) {
-	newPod := getPod(new)
-	oldPod := getPod(old)
+func (c *Controller) handlePodChange(logger klog.Logger, old, new any) {
+	newPod, _ := objectOf[*v1.Pod](new)
+	oldPod, _ := objectOf[*v1.Pod](old)
 
 	if newPod != nil && isPodTerminated(newPod) {
 		c.enqueuePodGroupForPod(logger, newPod)
@@ -316,27 +509,57 @@ func (c *Controller) enqueuePodGroupForPod(logger klog.Logger, pod *v1.Pod) {
 		return
 	}
 
-	pgKey := pod.Namespace + "/" + *pod.Spec.SchedulingGroup.PodGroupName
-	logger.V(4).Info("Enqueuing PodGroup for pod event", "pod", klog.KObj(pod), "podGroup", pgKey)
+	pgKey := podGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
+	logger.V(4).Info("Enqueuing PodGroup for pod event", "pod", klog.KObj(pod), "podGroup", klog.KRef(pgKey.namespace, pgKey.name))
 	c.queue.Add(pgKey)
 }
 
-func getPod(obj interface{}) *v1.Pod {
+// objectOf extracts a typed object from an informer event payload or unwraps it
+// from a cache.DeletedFinalStateUnknown tombstone.
+func objectOf[T any](obj any) (T, bool) {
+	var zero T
 	if obj == nil {
-		return nil
+		return zero, false
 	}
-	pod, ok := obj.(*v1.Pod)
+	if t, ok := obj.(T); ok {
+		return t, true
+	}
+	tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 	if !ok {
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("couldn't get object from tombstone %#v", obj))
-			return nil
-		}
-		pod, ok = tombstone.Obj.(*v1.Pod)
-		if !ok {
-			utilruntime.HandleError(fmt.Errorf("tombstone contained object that is not a Pod %#v", obj))
-			return nil
-		}
+		utilruntime.HandleError(fmt.Errorf("expected %T or DeletedFinalStateUnknown, got %T", zero, obj))
+		return zero, false
 	}
-	return pod
+	t, ok := tombstone.Obj.(T)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("tombstone contained unexpected object: expected %T, got %T", zero, tombstone.Obj))
+		return zero, false
+	}
+	return t, true
+}
+
+type resourceKind string
+
+const (
+	kindPodGroup          resourceKind = "PodGroup"
+	kindCompositePodGroup resourceKind = "CompositePodGroup"
+)
+
+type queueKey struct {
+	kind      resourceKind
+	namespace string
+	name      string
+}
+
+func (k queueKey) String() string {
+	return fmt.Sprintf("%s:%s/%s", k.kind, k.namespace, k.name)
+}
+
+// podGroupKey constructs a queueKey for a PodGroup.
+func podGroupKey(namespace, name string) queueKey {
+	return queueKey{kind: kindPodGroup, namespace: namespace, name: name}
+}
+
+// compositePodGroupKey constructs a queueKey for a CompositePodGroup.
+func compositePodGroupKey(namespace, name string) queueKey {
+	return queueKey{kind: kindCompositePodGroup, namespace: namespace, name: name}
 }

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,8 +36,10 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
+	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/controller"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/utils/ptr"
 )
 
@@ -63,6 +66,24 @@ func withFinalizer(pg *schedulingv1beta1.PodGroup) *schedulingv1beta1.PodGroup {
 
 func deletedPodGroup(pg *schedulingv1beta1.PodGroup) *schedulingv1beta1.PodGroup {
 	pg.DeletionTimestamp = &metav1.Time{}
+	return pg
+}
+
+func withCPGFinalizer(cpg *schedulingv1alpha3.CompositePodGroup) *schedulingv1alpha3.CompositePodGroup {
+	cpg.Finalizers = append(cpg.Finalizers, scheduling.CompositePodGroupProtectionFinalizer)
+	return cpg
+}
+
+func deletedCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) *schedulingv1alpha3.CompositePodGroup {
+	cpg.DeletionTimestamp = &metav1.Time{}
+	return cpg
+}
+
+func podGroupWithParent(name string, parentName string) *schedulingv1beta1.PodGroup {
+	pg := podGroup()
+	pg.Name = name
+	pg.UID = types.UID(name + "-uid")
+	pg.Spec.ParentCompositePodGroupName = &parentName
 	return pg
 }
 
@@ -260,7 +281,7 @@ func TestHandlePodChange(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := &Controller{
-				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[fwk.EntityKey]()),
 			}
 			defer c.queue.ShutDown()
 			c.handlePodChange(logger, tc.old, tc.new)
@@ -374,9 +395,10 @@ func TestPodGroupProtectionController(t *testing.T) {
 			client := fake.NewClientset(test.initialObjects...)
 			informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 			pgInformer := informerFactory.Scheduling().V1beta1().PodGroups()
+			cpgInformer := informerFactory.Scheduling().V1alpha3().CompositePodGroups()
 			podInformer := informerFactory.Core().V1().Pods()
 
-			ctrl, err := NewPodGroupProtectionController(klog.FromContext(ctx), pgInformer, podInformer, client)
+			ctrl, err := NewPodGroupProtectionController(klog.FromContext(ctx), pgInformer, cpgInformer, podInformer, client, true)
 			if err != nil {
 				t.Fatalf("unexpected error creating controller: %v", err)
 			}
@@ -419,6 +441,127 @@ func TestPodGroupProtectionController(t *testing.T) {
 				return hasFinalizer == test.expectFinalizer, nil
 			}); err != nil {
 				t.Fatalf("timed out waiting for expected finalizer state (want present=%v): %v", test.expectFinalizer, err)
+			}
+		})
+	}
+}
+
+func TestCompositePodGroupProtectionController(t *testing.T) {
+	cpgRootName := "cpg-root"
+	cpgChildName := "cpg-child"
+	pgChildName := "pg-child"
+
+	tests := []struct {
+		name            string
+		initialObjects  []runtime.Object
+		pgToDelete      string
+		cpgToDelete     string
+		cpgToCheck      string
+		expectFinalizer bool
+	}{
+		{
+			name:            "deleted CompositePodGroup with finalizer, no children, finalizer is removed",
+			initialObjects:  []runtime.Object{deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name(cpgRootName).Namespace(defaultNS).UID(cpgRootName + "-uid").Obj()))},
+			cpgToCheck:      cpgRootName,
+			expectFinalizer: false,
+		},
+		{
+			name:            "deleted CompositePodGroup with finalizer, child PodGroup exists, finalizer is kept",
+			initialObjects:  []runtime.Object{deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name(cpgRootName).Namespace(defaultNS).UID(cpgRootName + "-uid").Obj())), st.MakePodGroup().Name(pgChildName).Namespace(defaultNS).UID(types.UID(pgChildName + "-uid")).ParentCompositePodGroup(cpgRootName).Obj()},
+			cpgToCheck:      cpgRootName,
+			expectFinalizer: true,
+		},
+		{
+			name:            "deleted CompositePodGroup with finalizer, child CompositePodGroup exists, finalizer is kept",
+			initialObjects:  []runtime.Object{deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name(cpgRootName).Namespace(defaultNS).UID(cpgRootName + "-uid").Obj())), st.MakeCompositePodGroup().Name(cpgChildName).Namespace(defaultNS).UID(cpgChildName + "-uid").ParentCompositePodGroup(cpgRootName).Obj()},
+			cpgToCheck:      cpgRootName,
+			expectFinalizer: true,
+		},
+		{
+			name:            "deleted CompositePodGroup with finalizer, child PodGroup is deleted, finalizer is removed",
+			initialObjects:  []runtime.Object{deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name(cpgRootName).Namespace(defaultNS).UID(cpgRootName + "-uid").Obj())), st.MakePodGroup().Name(pgChildName).Namespace(defaultNS).UID(types.UID(pgChildName + "-uid")).ParentCompositePodGroup(cpgRootName).Obj()},
+			pgToDelete:      pgChildName,
+			cpgToCheck:      cpgRootName,
+			expectFinalizer: false,
+		},
+		{
+			name:            "deleted CompositePodGroup with finalizer, child CompositePodGroup is deleted, finalizer is removed",
+			initialObjects:  []runtime.Object{deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name(cpgRootName).Namespace(defaultNS).UID(cpgRootName + "-uid").Obj())), st.MakeCompositePodGroup().Name(cpgChildName).Namespace(defaultNS).UID(cpgChildName + "-uid").ParentCompositePodGroup(cpgRootName).Obj()},
+			cpgToDelete:     cpgChildName,
+			cpgToCheck:      cpgRootName,
+			expectFinalizer: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			client := fake.NewClientset(test.initialObjects...)
+			informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
+			pgInformer := informerFactory.Scheduling().V1beta1().PodGroups()
+			cpgInformer := informerFactory.Scheduling().V1alpha3().CompositePodGroups()
+			podInformer := informerFactory.Core().V1().Pods()
+
+			ctrl, err := NewPodGroupProtectionController(klog.FromContext(ctx), pgInformer, cpgInformer, podInformer, client, true)
+			if err != nil {
+				t.Fatalf("unexpected error creating controller: %v", err)
+			}
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+			go ctrl.Run(ctx, 1)
+
+			// In order to reduce test flakiness, make sure that the object-to-delete is visible in the client set. Create a dummy CPG and PG to "warm up" the watch pipe.
+			// Since they are created after LIST (WaitForCacheSync), the informer must see them via WATCH before any deletions occur.
+			syncCPG := st.MakeCompositePodGroup().Name("sync-cpg").Namespace(defaultNS).Obj()
+			if _, err := client.SchedulingV1alpha3().CompositePodGroups(defaultNS).Create(ctx, syncCPG, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("creating sync cpg: %v", err)
+			}
+			if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				_, err := cpgInformer.Lister().CompositePodGroups(defaultNS).Get(syncCPG.Name)
+				return err == nil, nil
+			}); err != nil {
+				t.Fatalf("timed out waiting for informer to see the sync cpg: %v", err)
+			}
+
+			syncPG := st.MakePodGroup().Name("sync-pg").Namespace(defaultNS).Obj()
+			if _, err := client.SchedulingV1beta1().PodGroups(defaultNS).Create(ctx, syncPG, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("creating sync pg: %v", err)
+			}
+			if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				_, err := pgInformer.Lister().PodGroups(defaultNS).Get(syncPG.Name)
+				return err == nil, nil
+			}); err != nil {
+				t.Fatalf("timed out waiting for informer to see the sync pg: %v", err)
+			}
+
+			if test.pgToDelete != "" {
+				if err := client.SchedulingV1beta1().PodGroups(defaultNS).Delete(ctx, test.pgToDelete, metav1.DeleteOptions{}); err != nil {
+					t.Fatalf("deleting pod group: %v", err)
+				}
+			}
+
+			if test.cpgToDelete != "" {
+				if err := client.SchedulingV1alpha3().CompositePodGroups(defaultNS).Delete(ctx, test.cpgToDelete, metav1.DeleteOptions{}); err != nil {
+					t.Fatalf("deleting composite pod group: %v", err)
+				}
+			}
+
+			if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				cpg, err := client.SchedulingV1alpha3().CompositePodGroups(defaultNS).Get(ctx, test.cpgToCheck, metav1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					return !test.expectFinalizer, nil
+				}
+				if err != nil {
+					return false, err
+				}
+				hasFinalizer := slices.Contains(cpg.Finalizers, scheduling.CompositePodGroupProtectionFinalizer)
+				return hasFinalizer == test.expectFinalizer, nil
+			}); err != nil {
+				t.Fatalf("timed out waiting for expected CPG finalizer state (want present=%v): %v", test.expectFinalizer, err)
 			}
 		})
 	}
@@ -550,15 +693,22 @@ func TestHandlePodGroupUpdate(t *testing.T) {
 			pg:       withFinalizer(podGroup()),
 			wantSize: 0,
 		},
+		"PodGroup with parent CompositePodGroup -> enqueued for parent": {
+			pg:       podGroupWithParent("pg-1", "cpg-parent"),
+			wantSize: 1,
+		},
 	}
 
+	informersFactory := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 0)
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := &Controller{
-				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+				isCompositePodGroupEnabled: true,
+				compositePodGroupLister:    informersFactory.Scheduling().V1alpha3().CompositePodGroups().Lister(),
+				queue:                      workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[fwk.EntityKey]()),
 			}
 			defer c.queue.ShutDown()
-			c.handlePodGroupUpdate(logger, tc.pg)
+			c.handlePodGroupUpdate(logger, nil, tc.pg)
 			if c.queue.Len() != tc.wantSize {
 				t.Errorf("queue size = %d, want %d", c.queue.Len(), tc.wantSize)
 			}

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +38,7 @@ import (
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/controller"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/utils/ptr"
 )
 
@@ -63,6 +65,24 @@ func withFinalizer(pg *schedulingv1beta1.PodGroup) *schedulingv1beta1.PodGroup {
 
 func deletedPodGroup(pg *schedulingv1beta1.PodGroup) *schedulingv1beta1.PodGroup {
 	pg.DeletionTimestamp = &metav1.Time{}
+	return pg
+}
+
+func withCPGFinalizer(cpg *schedulingv1alpha3.CompositePodGroup) *schedulingv1alpha3.CompositePodGroup {
+	cpg.Finalizers = append(cpg.Finalizers, scheduling.CompositePodGroupProtectionFinalizer)
+	return cpg
+}
+
+func deletedCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) *schedulingv1alpha3.CompositePodGroup {
+	cpg.DeletionTimestamp = &metav1.Time{}
+	return cpg
+}
+
+func podGroupWithParent(name string, parentName string) *schedulingv1beta1.PodGroup {
+	pg := podGroup()
+	pg.Name = name
+	pg.UID = types.UID(name + "-uid")
+	pg.Spec.ParentCompositePodGroupName = &parentName
 	return pg
 }
 
@@ -131,7 +151,7 @@ func TestIsPodTerminated(t *testing.T) {
 	}
 }
 
-func TestGetPod(t *testing.T) {
+func TestObjectOf(t *testing.T) {
 	tests := map[string]struct {
 		obj  interface{}
 		want bool
@@ -165,9 +185,9 @@ func TestGetPod(t *testing.T) {
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := getPod(tc.obj)
-			if (got != nil) != tc.want {
-				t.Errorf("parsePod() returned pod=%v, want non-nil=%v", got, tc.want)
+			got, ok := objectOf[*v1.Pod](tc.obj)
+			if (got != nil && ok) != tc.want {
+				t.Errorf("objectOf() returned pod=%v, ok=%v, want non-nil=%v", got, ok, tc.want)
 			}
 		})
 	}
@@ -260,7 +280,7 @@ func TestHandlePodChange(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := &Controller{
-				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()), //nolint:logcheck // Intentionally testing old API here.
+				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[queueKey]()), //nolint:logcheck // Intentionally testing old API here.
 			}
 			defer c.queue.ShutDown()
 			c.handlePodChange(logger, tc.old, tc.new)
@@ -374,9 +394,10 @@ func TestPodGroupProtectionController(t *testing.T) {
 			client := fake.NewClientset(test.initialObjects...)
 			informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 			pgInformer := informerFactory.Scheduling().V1beta1().PodGroups()
+			cpgInformer := informerFactory.Scheduling().V1alpha3().CompositePodGroups()
 			podInformer := informerFactory.Core().V1().Pods()
 
-			ctrl, err := NewPodGroupProtectionController(klog.FromContext(ctx), pgInformer, podInformer, client)
+			ctrl, err := NewPodGroupProtectionController(klog.FromContext(ctx), pgInformer, cpgInformer, podInformer, client, true)
 			if err != nil {
 				t.Fatalf("unexpected error creating controller: %v", err)
 			}
@@ -419,6 +440,127 @@ func TestPodGroupProtectionController(t *testing.T) {
 				return hasFinalizer == test.expectFinalizer, nil
 			}); err != nil {
 				t.Fatalf("timed out waiting for expected finalizer state (want present=%v): %v", test.expectFinalizer, err)
+			}
+		})
+	}
+}
+
+func TestCompositePodGroupProtectionController(t *testing.T) {
+	cpgRootName := "cpg-root"
+	cpgChildName := "cpg-child"
+	pgChildName := "pg-child"
+
+	tests := []struct {
+		name            string
+		initialObjects  []runtime.Object
+		pgToDelete      string
+		cpgToDelete     string
+		cpgToCheck      string
+		expectFinalizer bool
+	}{
+		{
+			name:            "deleted CompositePodGroup with finalizer, no children, finalizer is removed",
+			initialObjects:  []runtime.Object{deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name(cpgRootName).Namespace(defaultNS).UID(cpgRootName + "-uid").Obj()))},
+			cpgToCheck:      cpgRootName,
+			expectFinalizer: false,
+		},
+		{
+			name:            "deleted CompositePodGroup with finalizer, child PodGroup exists, finalizer is kept",
+			initialObjects:  []runtime.Object{deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name(cpgRootName).Namespace(defaultNS).UID(cpgRootName + "-uid").Obj())), st.MakePodGroup().Name(pgChildName).Namespace(defaultNS).UID(types.UID(pgChildName + "-uid")).ParentCompositePodGroup(cpgRootName).Obj()},
+			cpgToCheck:      cpgRootName,
+			expectFinalizer: true,
+		},
+		{
+			name:            "deleted CompositePodGroup with finalizer, child CompositePodGroup exists, finalizer is kept",
+			initialObjects:  []runtime.Object{deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name(cpgRootName).Namespace(defaultNS).UID(cpgRootName + "-uid").Obj())), st.MakeCompositePodGroup().Name(cpgChildName).Namespace(defaultNS).UID(cpgChildName + "-uid").ParentCompositePodGroup(cpgRootName).Obj()},
+			cpgToCheck:      cpgRootName,
+			expectFinalizer: true,
+		},
+		{
+			name:            "deleted CompositePodGroup with finalizer, child PodGroup is deleted, finalizer is removed",
+			initialObjects:  []runtime.Object{deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name(cpgRootName).Namespace(defaultNS).UID(cpgRootName + "-uid").Obj())), st.MakePodGroup().Name(pgChildName).Namespace(defaultNS).UID(types.UID(pgChildName + "-uid")).ParentCompositePodGroup(cpgRootName).Obj()},
+			pgToDelete:      pgChildName,
+			cpgToCheck:      cpgRootName,
+			expectFinalizer: false,
+		},
+		{
+			name:            "deleted CompositePodGroup with finalizer, child CompositePodGroup is deleted, finalizer is removed",
+			initialObjects:  []runtime.Object{deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name(cpgRootName).Namespace(defaultNS).UID(cpgRootName + "-uid").Obj())), st.MakeCompositePodGroup().Name(cpgChildName).Namespace(defaultNS).UID(cpgChildName + "-uid").ParentCompositePodGroup(cpgRootName).Obj()},
+			cpgToDelete:     cpgChildName,
+			cpgToCheck:      cpgRootName,
+			expectFinalizer: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			t.Cleanup(cancel)
+
+			client := fake.NewClientset(test.initialObjects...)
+			informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
+			pgInformer := informerFactory.Scheduling().V1beta1().PodGroups()
+			cpgInformer := informerFactory.Scheduling().V1alpha3().CompositePodGroups()
+			podInformer := informerFactory.Core().V1().Pods()
+
+			ctrl, err := NewPodGroupProtectionController(klog.FromContext(ctx), pgInformer, cpgInformer, podInformer, client, true)
+			if err != nil {
+				t.Fatalf("unexpected error creating controller: %v", err)
+			}
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+			go ctrl.Run(ctx, 1)
+
+			// In order to reduce test flakiness, make sure that the object-to-delete is visible in the client set. Create a dummy CPG and PG to "warm up" the watch pipe.
+			// Since they are created after LIST (WaitForCacheSync), the informer must see them via WATCH before any deletions occur.
+			syncCPG := st.MakeCompositePodGroup().Name("sync-cpg").Namespace(defaultNS).Obj()
+			if _, err := client.SchedulingV1alpha3().CompositePodGroups(defaultNS).Create(ctx, syncCPG, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("creating sync cpg: %v", err)
+			}
+			if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				_, err := cpgInformer.Lister().CompositePodGroups(defaultNS).Get(syncCPG.Name)
+				return err == nil, nil
+			}); err != nil {
+				t.Fatalf("timed out waiting for informer to see the sync cpg: %v", err)
+			}
+
+			syncPG := st.MakePodGroup().Name("sync-pg").Namespace(defaultNS).Obj()
+			if _, err := client.SchedulingV1beta1().PodGroups(defaultNS).Create(ctx, syncPG, metav1.CreateOptions{}); err != nil {
+				t.Fatalf("creating sync pg: %v", err)
+			}
+			if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				_, err := pgInformer.Lister().PodGroups(defaultNS).Get(syncPG.Name)
+				return err == nil, nil
+			}); err != nil {
+				t.Fatalf("timed out waiting for informer to see the sync pg: %v", err)
+			}
+
+			if test.pgToDelete != "" {
+				if err := client.SchedulingV1beta1().PodGroups(defaultNS).Delete(ctx, test.pgToDelete, metav1.DeleteOptions{}); err != nil {
+					t.Fatalf("deleting pod group: %v", err)
+				}
+			}
+
+			if test.cpgToDelete != "" {
+				if err := client.SchedulingV1alpha3().CompositePodGroups(defaultNS).Delete(ctx, test.cpgToDelete, metav1.DeleteOptions{}); err != nil {
+					t.Fatalf("deleting composite pod group: %v", err)
+				}
+			}
+
+			if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+				cpg, err := client.SchedulingV1alpha3().CompositePodGroups(defaultNS).Get(ctx, test.cpgToCheck, metav1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					return !test.expectFinalizer, nil
+				}
+				if err != nil {
+					return false, err
+				}
+				hasFinalizer := slices.Contains(cpg.Finalizers, scheduling.CompositePodGroupProtectionFinalizer)
+				return hasFinalizer == test.expectFinalizer, nil
+			}); err != nil {
+				t.Fatalf("timed out waiting for expected CPG finalizer state (want present=%v): %v", test.expectFinalizer, err)
 			}
 		})
 	}
@@ -469,36 +611,45 @@ func TestActivePodSchedulingGroupIndexer(t *testing.T) {
 	}
 }
 
+func cpg(name string) *schedulingv1alpha3.CompositePodGroup {
+	return st.MakeCompositePodGroup().Name(name).Namespace(defaultNS).UID(name + "-uid").Obj()
+}
+
+func cpgWithParent(name, parentName string) *schedulingv1alpha3.CompositePodGroup {
+	group := cpg(name)
+	group.Spec.ParentCompositePodGroupName = &parentName
+	return group
+}
+
 func TestHasActivePods(t *testing.T) {
 	tests := map[string]struct {
 		pods []runtime.Object
 		want bool
 	}{
 		"no pods": {
-			pods: nil,
 			want: false,
 		},
-		"active pod referencing PodGroup": {
+		"active pod in cache referencing PodGroup": {
 			pods: []runtime.Object{
 				podForPG("pod-1", defaultPGName),
 			},
 			want: true,
 		},
-		"only terminated pods": {
+		"only terminated pods in cache": {
 			pods: []runtime.Object{
 				terminatedPod(podForPG("pod-1", defaultPGName), v1.PodSucceeded),
 				terminatedPod(podForPG("pod-2", defaultPGName), v1.PodFailed),
 			},
 			want: false,
 		},
-		"mix of active and terminated": {
+		"mix of active and terminated in cache": {
 			pods: []runtime.Object{
 				podForPG("pod-active", defaultPGName),
 				terminatedPod(podForPG("pod-done", defaultPGName), v1.PodSucceeded),
 			},
 			want: true,
 		},
-		"pods referencing different PodGroup": {
+		"pods in cache referencing different PodGroup": {
 			pods: []runtime.Object{
 				podForPG("pod-1", "other-pg"),
 			},
@@ -531,37 +682,346 @@ func TestHasActivePods(t *testing.T) {
 	}
 }
 
+func TestHasChildGroups(t *testing.T) {
+	tests := map[string]struct {
+		cachedPGs                  []runtime.Object
+		cachedCPGs                 []runtime.Object
+		isCompositePodGroupEnabled bool
+		want                       bool
+	}{
+		"no children": {
+			isCompositePodGroupEnabled: true,
+			want:                       false,
+		},
+		"child PodGroup in cache, CPG feature enabled": {
+			cachedPGs: []runtime.Object{
+				podGroupWithParent("child-pg", "parent-cpg"),
+			},
+			isCompositePodGroupEnabled: true,
+			want:                       true,
+		},
+		"child PodGroup in cache, CPG feature disabled": {
+			cachedPGs: []runtime.Object{
+				podGroupWithParent("child-pg", "parent-cpg"),
+			},
+			isCompositePodGroupEnabled: false,
+			want:                       true,
+		},
+		"child CompositePodGroup in cache, CPG feature enabled": {
+			cachedCPGs: []runtime.Object{
+				cpgWithParent("child-cpg", "parent-cpg"),
+			},
+			isCompositePodGroupEnabled: true,
+			want:                       true,
+		},
+		"child CompositePodGroup in cache, CPG feature disabled": {
+			cachedCPGs: []runtime.Object{
+				cpgWithParent("child-cpg", "parent-cpg"),
+			},
+			isCompositePodGroupEnabled: false,
+			want:                       false,
+		},
+		"children referencing different parent": {
+			cachedPGs: []runtime.Object{
+				podGroupWithParent("other-child-pg", "different-parent"),
+			},
+			cachedCPGs: []runtime.Object{
+				cpgWithParent("other-child-cpg", "different-parent"),
+			},
+			isCompositePodGroupEnabled: true,
+			want:                       false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			pgIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if err := addChildIndexer(pgIndexer, childPodGroupParentCompositeGroupIndex, podGroupParent); err != nil {
+				t.Fatalf("unexpected error adding PG indexer: %v", err)
+			}
+			for _, obj := range tc.cachedPGs {
+				_ = pgIndexer.Add(obj)
+			}
+
+			var cpgIndexer cache.Indexer
+			if tc.isCompositePodGroupEnabled {
+				cpgIndexer = cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+				if err := addChildIndexer(cpgIndexer, childCompositePodGroupParentCompositeGroupIndex, compositePodGroupParent); err != nil {
+					t.Fatalf("unexpected error adding CPG indexer: %v", err)
+				}
+				for _, obj := range tc.cachedCPGs {
+					_ = cpgIndexer.Add(obj)
+				}
+			}
+
+			ctrl := &Controller{
+				podGroupIndexer:            pgIndexer,
+				compositePodGroupIndexer:   cpgIndexer,
+				isCompositePodGroupEnabled: tc.isCompositePodGroupEnabled,
+			}
+
+			parentCPG := cpg("parent-cpg")
+			got, err := ctrl.hasChildGroups(context.Background(), parentCPG)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("hasChildGroups() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestHandlePodGroupUpdate(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 
 	tests := map[string]struct {
-		pg       *schedulingv1beta1.PodGroup
-		wantSize int
+		old                        any
+		new                        any
+		isCompositePodGroupEnabled bool
+		wantSize                   int
 	}{
-		"PodGroup without finalizer, not deleting/not enqueued": {
-			pg:       podGroup(),
-			wantSize: 0,
+		"both old and new are nil -> not enqueued, no panic": {
+			old:                        nil,
+			new:                        nil,
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
 		},
-		"PodGroup is deletion candidate -> enqueued": {
-			pg:       deletedPodGroup(withFinalizer(podGroup())),
-			wantSize: 1,
+		"non-PodGroup object -> not enqueued, no panic": {
+			old:                        nil,
+			new:                        &v1.ConfigMap{},
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"invalid tombstone -> not enqueued, no panic": {
+			old: cache.DeletedFinalStateUnknown{
+				Key: "default/pg",
+				Obj: &v1.ConfigMap{},
+			},
+			new:                        nil,
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"PodGroup without finalizer, not deleting/not enqueued": {
+			new:                        podGroup(),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"PodGroup is deletion candidate, CPG enabled -> enqueued": {
+			new:                        deletedPodGroup(withFinalizer(podGroup())),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   1,
+		},
+		"PodGroup is deletion candidate, CPG disabled -> enqueued": {
+			new:                        deletedPodGroup(withFinalizer(podGroup())),
+			isCompositePodGroupEnabled: false,
+			wantSize:                   1,
 		},
 		"PodGroup has finalizer, not deleting -> not enqueued": {
-			pg:       withFinalizer(podGroup()),
-			wantSize: 0,
+			new:                        withFinalizer(podGroup()),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"PodGroup with parent CompositePodGroup on add -> parent not enqueued": {
+			new:                        podGroupWithParent("pg-1", "cpg-parent"),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"PodGroup with parent CompositePodGroup on delete, CPG enabled -> enqueued for parent": {
+			old:                        podGroupWithParent("pg-1", "cpg-parent"),
+			new:                        nil,
+			isCompositePodGroupEnabled: true,
+			wantSize:                   1,
+		},
+		"PodGroup with parent CompositePodGroup on delete, CPG disabled -> parent not enqueued": {
+			old:                        podGroupWithParent("pg-1", "cpg-parent"),
+			new:                        nil,
+			isCompositePodGroupEnabled: false,
+			wantSize:                   0,
+		},
+		"PodGroup with parent CompositePodGroup on update (same UID) -> parent not enqueued": {
+			old:                        podGroupWithParent("pg-1", "cpg-parent"),
+			new:                        podGroupWithParent("pg-1", "cpg-parent"),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"PodGroup with parent CompositePodGroup on update (same UID) and deletion candidate, CPG enabled -> only child enqueued": {
+			old:                        podGroupWithParent("pg-1", "cpg-parent"),
+			new:                        deletedPodGroup(withFinalizer(podGroupWithParent("pg-1", "cpg-parent"))),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   1,
+		},
+		"PodGroup with parent CompositePodGroup on update (same UID) and deletion candidate, CPG disabled -> only child enqueued": {
+			old:                        podGroupWithParent("pg-1", "cpg-parent"),
+			new:                        deletedPodGroup(withFinalizer(podGroupWithParent("pg-1", "cpg-parent"))),
+			isCompositePodGroupEnabled: false,
+			wantSize:                   1,
+		},
+		"PodGroup with parent CompositePodGroup on update (UID mismatch), CPG enabled -> parent enqueued": {
+			old:                        podGroupWithParent("pg-1", "cpg-parent-1"),
+			new:                        podGroupWithParent("pg-2", "cpg-parent-2"),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   1,
+		},
+		"PodGroup with parent CompositePodGroup on update (UID mismatch), CPG disabled -> parent not enqueued": {
+			old:                        podGroupWithParent("pg-1", "cpg-parent-1"),
+			new:                        podGroupWithParent("pg-2", "cpg-parent-2"),
+			isCompositePodGroupEnabled: false,
+			wantSize:                   0,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := &Controller{
-				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()), //nolint:logcheck // Intentionally testing old API here.
+				isCompositePodGroupEnabled: tc.isCompositePodGroupEnabled,
+				queue:                      workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[queueKey]()), //nolint:logcheck // Intentionally testing old API here.
 			}
 			defer c.queue.ShutDown()
-			c.handlePodGroupUpdate(logger, tc.pg)
+			c.handlePodGroupUpdate(logger, tc.old, tc.new)
 			if c.queue.Len() != tc.wantSize {
 				t.Errorf("queue size = %d, want %d", c.queue.Len(), tc.wantSize)
 			}
 		})
+	}
+}
+
+func TestHandleCompositePodGroupUpdate(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	cpgWithParent := func(name, parentName string) *schedulingv1alpha3.CompositePodGroup {
+		cpg := st.MakeCompositePodGroup().Name(name).Namespace(defaultNS).UID(name + "-uid").ParentCompositePodGroup(parentName).Obj()
+		return cpg
+	}
+
+	tests := map[string]struct {
+		old                        any
+		new                        any
+		isCompositePodGroupEnabled bool
+		wantSize                   int
+	}{
+		"both old and new are nil -> not enqueued, no panic": {
+			old:                        nil,
+			new:                        nil,
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"non-CPG object -> not enqueued, no panic": {
+			old:                        nil,
+			new:                        &v1.ConfigMap{},
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"invalid tombstone -> not enqueued, no panic": {
+			old: cache.DeletedFinalStateUnknown{
+				Key: "default/cpg",
+				Obj: &v1.ConfigMap{},
+			},
+			new:                        nil,
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"CPG without finalizer, not deleting -> not enqueued": {
+			new:                        st.MakeCompositePodGroup().Name("cpg-1").Namespace(defaultNS).Obj(),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"CPG is deletion candidate, CPG enabled -> enqueued": {
+			new:                        deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name("cpg-1").Namespace(defaultNS).Obj())),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   1,
+		},
+		"CPG is deletion candidate, CPG disabled -> not enqueued": {
+			new:                        deletedCompositePodGroup(withCPGFinalizer(st.MakeCompositePodGroup().Name("cpg-1").Namespace(defaultNS).Obj())),
+			isCompositePodGroupEnabled: false,
+			wantSize:                   0,
+		},
+		"CPG with parent CompositePodGroup on add -> parent not enqueued": {
+			new:                        cpgWithParent("cpg-child", "cpg-parent"),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"CPG with parent CompositePodGroup on delete, CPG enabled -> enqueued for parent": {
+			old:                        cpgWithParent("cpg-child", "cpg-parent"),
+			new:                        nil,
+			isCompositePodGroupEnabled: true,
+			wantSize:                   1,
+		},
+		"CPG with parent CompositePodGroup on delete, CPG disabled -> not enqueued": {
+			old:                        cpgWithParent("cpg-child", "cpg-parent"),
+			new:                        nil,
+			isCompositePodGroupEnabled: false,
+			wantSize:                   0,
+		},
+		"CPG with parent CompositePodGroup on update (same UID) -> parent not enqueued": {
+			old:                        cpgWithParent("cpg-child", "cpg-parent"),
+			new:                        cpgWithParent("cpg-child", "cpg-parent"),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   0,
+		},
+		"CPG with parent CompositePodGroup on update (same UID) and deletion candidate, CPG enabled -> only child enqueued": {
+			old:                        cpgWithParent("cpg-child", "cpg-parent"),
+			new:                        deletedCompositePodGroup(withCPGFinalizer(cpgWithParent("cpg-child", "cpg-parent"))),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   1,
+		},
+		"CPG with parent CompositePodGroup on update (same UID) and deletion candidate, CPG disabled -> not enqueued": {
+			old:                        cpgWithParent("cpg-child", "cpg-parent"),
+			new:                        deletedCompositePodGroup(withCPGFinalizer(cpgWithParent("cpg-child", "cpg-parent"))),
+			isCompositePodGroupEnabled: false,
+			wantSize:                   0,
+		},
+		"CPG with parent CompositePodGroup on update (UID mismatch), CPG enabled -> parent enqueued": {
+			old:                        cpgWithParent("cpg-child-1", "cpg-parent-1"),
+			new:                        cpgWithParent("cpg-child-2", "cpg-parent-2"),
+			isCompositePodGroupEnabled: true,
+			wantSize:                   1,
+		},
+		"CPG with parent CompositePodGroup on update (UID mismatch), CPG disabled -> not enqueued": {
+			old:                        cpgWithParent("cpg-child-1", "cpg-parent-1"),
+			new:                        cpgWithParent("cpg-child-2", "cpg-parent-2"),
+			isCompositePodGroupEnabled: false,
+			wantSize:                   0,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			c := &Controller{
+				isCompositePodGroupEnabled: tc.isCompositePodGroupEnabled,
+				queue:                      workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[queueKey]()), //nolint:logcheck // Intentionally testing old API here.
+			}
+			defer c.queue.ShutDown()
+			c.handleCompositePodGroupUpdate(logger, tc.old, tc.new)
+			if c.queue.Len() != tc.wantSize {
+				t.Errorf("queue size = %d, want %d", c.queue.Len(), tc.wantSize)
+			}
+		})
+	}
+}
+
+func TestProcessNextWorkItem_UnknownKind(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	c := &Controller{
+		queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[queueKey]()), //nolint:logcheck // Intentionally testing old API here.
+	}
+	defer c.queue.ShutDown()
+
+	unknownKey := queueKey{
+		kind:      "UnknownKind",
+		namespace: defaultNS,
+		name:      "unknown-item",
+	}
+	c.queue.Add(unknownKey)
+
+	if !c.processNextWorkItem(ctx) {
+		t.Fatal("processNextWorkItem returned false, expected true")
+	}
+
+	if c.queue.Len() != 0 {
+		t.Errorf("queue size = %d, expected 0 after processing unknown kind", c.queue.Len())
+	}
+	if c.queue.NumRequeues(unknownKey) != 0 {
+		t.Errorf("expected 0 requeues, got %d", c.queue.NumRequeues(unknownKey))
 	}
 }

--- a/plugin/pkg/admission/scheduling/podgroupprotection/admission.go
+++ b/plugin/pkg/admission/scheduling/podgroupprotection/admission.go
@@ -43,8 +43,9 @@ func Register(plugins *admission.Plugins) {
 
 type podGroupProtectionPlugin struct {
 	*admission.Handler
-	enabled               bool
-	inspectedFeatureGates bool
+	enabled                  bool
+	compositePodGroupEnabled bool
+	inspectedFeatureGates    bool
 }
 
 var _ admission.MutationInterface = &podGroupProtectionPlugin{}
@@ -58,6 +59,7 @@ func newPlugin() *podGroupProtectionPlugin {
 
 func (p *podGroupProtectionPlugin) InspectFeatureGates(featureGates featuregate.FeatureGate) {
 	p.enabled = featureGates.Enabled(features.GenericWorkload)
+	p.compositePodGroupEnabled = featureGates.Enabled(features.CompositePodGroup)
 	p.inspectedFeatureGates = true
 }
 
@@ -68,34 +70,54 @@ func (p *podGroupProtectionPlugin) ValidateInitialization() error {
 	return nil
 }
 
-var podGroupResource = schedulingapi.Resource("podgroups")
+var (
+	podGroupResource          = schedulingapi.Resource("podgroups")
+	compositePodGroupResource = schedulingapi.Resource("compositepodgroups")
+)
 
-// Admit stamps the PodGroupProtectionFinalizer on every newly created PodGroup
-// so that it cannot be deleted while pods still reference it.
-// The finalizer is removed by the PodGroupProtection controller when the
-// PodGroup is no longer in use.
+// Admit stamps the PodGroupProtectionFinalizer on every newly created PodGroup,
+// and CompositePodGroupProtectionFinalizer on every newly created CompositePodGroup
+// so that they cannot be deleted while child resources still reference them.
+// The finalizers are removed by the PodGroupProtection controller when the
+// resource is no longer in use.
 func (p *podGroupProtectionPlugin) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
 	if !p.enabled {
 		return nil
 	}
 
-	if a.GetResource().GroupResource() != podGroupResource {
+	gr := a.GetResource().GroupResource()
+	if gr != podGroupResource && gr != compositePodGroupResource {
 		return nil
 	}
 	if len(a.GetSubresource()) != 0 {
 		return nil
 	}
 
-	pg, ok := a.GetObject().(*schedulingapi.PodGroup)
+	if gr == podGroupResource {
+		pg, ok := a.GetObject().(*schedulingapi.PodGroup)
+		if !ok {
+			return nil
+		}
+		if slices.Contains(pg.Finalizers, schedulingapi.PodGroupProtectionFinalizer) {
+			return nil
+		}
+		klog.V(4).InfoS("Adding protection finalizer to PodGroup", "podGroup", klog.KObj(pg))
+		pg.Finalizers = append(pg.Finalizers, schedulingapi.PodGroupProtectionFinalizer)
+		return nil
+	}
+
+	if !p.compositePodGroupEnabled {
+		return nil
+	}
+
+	cpg, ok := a.GetObject().(*schedulingapi.CompositePodGroup)
 	if !ok {
 		return nil
 	}
-
-	if slices.Contains(pg.Finalizers, schedulingapi.PodGroupProtectionFinalizer) {
+	if slices.Contains(cpg.Finalizers, schedulingapi.CompositePodGroupProtectionFinalizer) {
 		return nil
 	}
-
-	klog.V(4).InfoS("Adding protection finalizer to PodGroup", "podGroup", klog.KObj(pg))
-	pg.Finalizers = append(pg.Finalizers, schedulingapi.PodGroupProtectionFinalizer)
+	klog.V(4).InfoS("Adding protection finalizer to CompositePodGroup", "compositePodGroup", klog.KObj(cpg))
+	cpg.Finalizers = append(cpg.Finalizers, schedulingapi.CompositePodGroupProtectionFinalizer)
 	return nil
 }

--- a/plugin/pkg/admission/scheduling/podgroupprotection/admission.go
+++ b/plugin/pkg/admission/scheduling/podgroupprotection/admission.go
@@ -23,7 +23,7 @@ import (
 	"slices"
 
 	"k8s.io/apiserver/pkg/admission"
-	apiserveradmission "k8s.io/apiserver/pkg/admission/initializer"
+	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
 	schedulingapi "k8s.io/kubernetes/pkg/apis/scheduling"
@@ -43,12 +43,13 @@ func Register(plugins *admission.Plugins) {
 
 type podGroupProtectionPlugin struct {
 	*admission.Handler
-	enabled               bool
-	inspectedFeatureGates bool
+	genericWorkloadEnabled   bool
+	compositePodGroupEnabled bool
+	inspectedFeatureGates    bool
 }
 
 var _ admission.MutationInterface = &podGroupProtectionPlugin{}
-var _ apiserveradmission.WantsFeatures = &podGroupProtectionPlugin{}
+var _ genericadmissioninitializer.WantsFeatures = &podGroupProtectionPlugin{}
 
 func newPlugin() *podGroupProtectionPlugin {
 	return &podGroupProtectionPlugin{
@@ -57,7 +58,8 @@ func newPlugin() *podGroupProtectionPlugin {
 }
 
 func (p *podGroupProtectionPlugin) InspectFeatureGates(featureGates featuregate.FeatureGate) {
-	p.enabled = featureGates.Enabled(features.GenericWorkload)
+	p.genericWorkloadEnabled = featureGates.Enabled(features.GenericWorkload)
+	p.compositePodGroupEnabled = featureGates.Enabled(features.CompositePodGroup)
 	p.inspectedFeatureGates = true
 }
 
@@ -68,34 +70,59 @@ func (p *podGroupProtectionPlugin) ValidateInitialization() error {
 	return nil
 }
 
-var podGroupResource = schedulingapi.Resource("podgroups")
+var (
+	podGroupResource          = schedulingapi.Resource("podgroups")
+	compositePodGroupResource = schedulingapi.Resource("compositepodgroups")
+)
 
-// Admit stamps the PodGroupProtectionFinalizer on every newly created PodGroup
-// so that it cannot be deleted while pods still reference it.
-// The finalizer is removed by the PodGroupProtection controller when the
-// PodGroup is no longer in use.
+// Admit stamps the PodGroupProtectionFinalizer on newly created PodGroups
+// and CompositePodGroupProtectionFinalizer on newly created CompositePodGroups
+// so that they cannot be deleted while child resources still reference them.
+// The finalizers are removed by the PodGroupProtection controller when the
+// resource is no longer in use.
 func (p *podGroupProtectionPlugin) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
-	if !p.enabled {
+	if !p.genericWorkloadEnabled {
+		return nil
+	}
+	if a.GetOperation() != admission.Create {
 		return nil
 	}
 
-	if a.GetResource().GroupResource() != podGroupResource {
+	gr := a.GetResource().GroupResource()
+	if gr != podGroupResource && gr != compositePodGroupResource {
 		return nil
 	}
 	if len(a.GetSubresource()) != 0 {
 		return nil
 	}
 
-	pg, ok := a.GetObject().(*schedulingapi.PodGroup)
+	logger := klog.FromContext(ctx)
+
+	if gr == podGroupResource {
+		pg, ok := a.GetObject().(*schedulingapi.PodGroup)
+		if !ok {
+			return nil
+		}
+		if slices.Contains(pg.Finalizers, schedulingapi.PodGroupProtectionFinalizer) {
+			return nil
+		}
+		logger.V(4).Info("Adding protection finalizer to PodGroup", "podGroup", klog.KObj(pg))
+		pg.Finalizers = append(pg.Finalizers, schedulingapi.PodGroupProtectionFinalizer)
+		return nil
+	}
+
+	if !p.compositePodGroupEnabled {
+		return nil
+	}
+
+	cpg, ok := a.GetObject().(*schedulingapi.CompositePodGroup)
 	if !ok {
 		return nil
 	}
-
-	if slices.Contains(pg.Finalizers, schedulingapi.PodGroupProtectionFinalizer) {
+	if slices.Contains(cpg.Finalizers, schedulingapi.CompositePodGroupProtectionFinalizer) {
 		return nil
 	}
-
-	klog.V(4).InfoS("Adding protection finalizer to PodGroup", "podGroup", klog.KObj(pg))
-	pg.Finalizers = append(pg.Finalizers, schedulingapi.PodGroupProtectionFinalizer)
+	logger.V(4).Info("Adding protection finalizer to CompositePodGroup", "compositePodGroup", klog.KObj(cpg))
+	cpg.Finalizers = append(cpg.Finalizers, schedulingapi.CompositePodGroupProtectionFinalizer)
 	return nil
 }

--- a/plugin/pkg/admission/scheduling/podgroupprotection/admission_test.go
+++ b/plugin/pkg/admission/scheduling/podgroupprotection/admission_test.go
@@ -44,13 +44,25 @@ func TestAdmit(t *testing.T) {
 	pgWithFinalizer := pg.DeepCopy()
 	pgWithFinalizer.Finalizers = []string{schedulingapi.PodGroupProtectionFinalizer}
 
+	cpg := &schedulingapi.CompositePodGroup{
+		TypeMeta: metav1.TypeMeta{Kind: "CompositePodGroup"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-compositepodgroup",
+			Namespace: "default",
+		},
+	}
+
+	cpgWithFinalizer := cpg.DeepCopy()
+	cpgWithFinalizer.Finalizers = []string{schedulingapi.CompositePodGroupProtectionFinalizer}
+
 	tests := []struct {
-		name           string
-		enabled        bool
-		resource       schema.GroupVersionResource
-		object         runtime.Object
-		expectedObject runtime.Object
-		namespace      string
+		name                  string
+		enabled               bool
+		compositeGroupEnabled bool
+		resource              schema.GroupVersionResource
+		object                runtime.Object
+		expectedObject        runtime.Object
+		namespace             string
 	}{
 		{
 			name:           "podgroup create with plugin enabled, add finalizer",
@@ -76,11 +88,42 @@ func TestAdmit(t *testing.T) {
 			expectedObject: pg,
 			namespace:      pg.Namespace,
 		},
+		{
+			name:                  "compositepodgroup create with plugin enabled, add finalizer",
+			compositeGroupEnabled: true,
+			resource:              schedulingapi.SchemeGroupVersion.WithResource("compositepodgroups"),
+			object:                cpg,
+			expectedObject:        cpgWithFinalizer,
+			namespace:             cpg.Namespace,
+		},
+		{
+			name:                  "compositepodgroup finalizer already exists, no new finalizer",
+			compositeGroupEnabled: true,
+			resource:              schedulingapi.SchemeGroupVersion.WithResource("compositepodgroups"),
+			object:                cpgWithFinalizer,
+			expectedObject:        cpgWithFinalizer,
+			namespace:             cpgWithFinalizer.Namespace,
+		},
+		{
+			name:                  "compositepodgroup create with plugin disabled, no finalizer added",
+			compositeGroupEnabled: false,
+			resource:              schedulingapi.SchemeGroupVersion.WithResource("compositepodgroups"),
+			object:                cpg,
+			expectedObject:        cpg,
+			namespace:             cpg.Namespace,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, test.enabled)
+			if test.compositeGroupEnabled {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareWorkloadScheduling, true)
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CompositePodGroup, true)
+			} else {
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, test.enabled)
+				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CompositePodGroup, false)
+			}
 
 			ctrl := newPlugin()
 			ctrl.InspectFeatureGates(utilfeature.DefaultFeatureGate)

--- a/plugin/pkg/admission/scheduling/podgroupprotection/admission_test.go
+++ b/plugin/pkg/admission/scheduling/podgroupprotection/admission_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package podgroupprotection
 
 import (
-	"context"
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,58 +28,97 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	schedulingapi "k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/utils/dump"
 )
 
 func TestAdmit(t *testing.T) {
-	pg := &schedulingapi.PodGroup{
-		TypeMeta: metav1.TypeMeta{Kind: "PodGroup"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "my-podgroup",
-			Namespace: "default",
-		},
-	}
+	pg := &schedulingapi.PodGroup{}
+	pg.Name = "my-podgroup"
+	pg.Namespace = "default"
 
 	pgWithFinalizer := pg.DeepCopy()
 	pgWithFinalizer.Finalizers = []string{schedulingapi.PodGroupProtectionFinalizer}
 
+	cpg := &schedulingapi.CompositePodGroup{}
+	cpg.Name = "my-compositepodgroup"
+	cpg.Namespace = "default"
+
+	cpgWithFinalizer := cpg.DeepCopy()
+	cpgWithFinalizer.Finalizers = []string{schedulingapi.CompositePodGroupProtectionFinalizer}
+
 	tests := []struct {
-		name           string
-		enabled        bool
-		resource       schema.GroupVersionResource
-		object         runtime.Object
-		expectedObject runtime.Object
-		namespace      string
+		name                   string
+		genericWorkloadEnabled bool
+		compositeGroupEnabled  bool
+		resource               schema.GroupVersionResource
+		object                 runtime.Object
+		expectedObject         runtime.Object
+		namespace              string
 	}{
 		{
-			name:           "podgroup create with plugin enabled, add finalizer",
-			enabled:        true,
-			resource:       schedulingapi.SchemeGroupVersion.WithResource("podgroups"),
-			object:         pg,
-			expectedObject: pgWithFinalizer,
-			namespace:      pg.Namespace,
+			name:                   "podgroup create with plugin enabled, add finalizer",
+			genericWorkloadEnabled: true,
+			resource:               schedulingapi.SchemeGroupVersion.WithResource("podgroups"),
+			object:                 pg,
+			expectedObject:         pgWithFinalizer,
+			namespace:              pg.Namespace,
 		},
 		{
-			name:           "podgroup finalizer already exists, no new finalizer",
-			enabled:        true,
-			resource:       schedulingapi.SchemeGroupVersion.WithResource("podgroups"),
-			object:         pgWithFinalizer,
-			expectedObject: pgWithFinalizer,
-			namespace:      pgWithFinalizer.Namespace,
+			name:                   "podgroup finalizer already exists, no new finalizer",
+			genericWorkloadEnabled: true,
+			resource:               schedulingapi.SchemeGroupVersion.WithResource("podgroups"),
+			object:                 pgWithFinalizer,
+			expectedObject:         pgWithFinalizer,
+			namespace:              pgWithFinalizer.Namespace,
 		},
 		{
 			name:           "podgroup create with plugin disabled, no finalizer added",
-			enabled:        false,
 			resource:       schedulingapi.SchemeGroupVersion.WithResource("podgroups"),
 			object:         pg,
 			expectedObject: pg,
 			namespace:      pg.Namespace,
 		},
+		{
+			name:                   "compositepodgroup create with plugin enabled, add finalizer",
+			genericWorkloadEnabled: true,
+			compositeGroupEnabled:  true,
+			resource:               schedulingapi.SchemeGroupVersion.WithResource("compositepodgroups"),
+			object:                 cpg,
+			expectedObject:         cpgWithFinalizer,
+			namespace:              cpg.Namespace,
+		},
+		{
+			name:                   "compositepodgroup finalizer already exists, no new finalizer",
+			genericWorkloadEnabled: true,
+			compositeGroupEnabled:  true,
+			resource:               schedulingapi.SchemeGroupVersion.WithResource("compositepodgroups"),
+			object:                 cpgWithFinalizer,
+			expectedObject:         cpgWithFinalizer,
+			namespace:              cpgWithFinalizer.Namespace,
+		},
+		{
+			name:                   "compositepodgroup create with CompositePodGroup feature disabled, no finalizer added",
+			genericWorkloadEnabled: true,
+			resource:               schedulingapi.SchemeGroupVersion.WithResource("compositepodgroups"),
+			object:                 cpg,
+			expectedObject:         cpg,
+			namespace:              cpg.Namespace,
+		},
+		{
+			name:           "compositepodgroup create with GenericWorkload feature disabled, no finalizer added",
+			resource:       schedulingapi.SchemeGroupVersion.WithResource("compositepodgroups"),
+			object:         cpg,
+			expectedObject: cpg,
+			namespace:      cpg.Namespace,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, test.enabled)
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 test.genericWorkloadEnabled,
+				features.TopologyAwareWorkloadScheduling: test.compositeGroupEnabled,
+				features.CompositePodGroup:               test.compositeGroupEnabled,
+			})
 
 			ctrl := newPlugin()
 			ctrl.InspectFeatureGates(utilfeature.DefaultFeatureGate)
@@ -100,12 +138,29 @@ func TestAdmit(t *testing.T) {
 				nil,
 			)
 
-			if err := ctrl.Admit(context.TODO(), attrs, nil); err != nil {
+			if err := ctrl.Admit(t.Context(), attrs, nil); err != nil {
 				t.Errorf("got unexpected error: %v", err)
 			}
-			if !reflect.DeepEqual(test.expectedObject, obj) {
-				t.Errorf("Expected object:\n%s\ngot:\n%s", dump.Pretty(test.expectedObject), dump.Pretty(obj))
+			if diff := cmp.Diff(test.expectedObject, obj); diff != "" {
+				t.Errorf("unexpected object diff (-want +got):\n%s", diff)
 			}
 		})
 	}
+}
+
+func TestValidateInitialization(t *testing.T) {
+	t.Run("uninspected feature gates", func(t *testing.T) {
+		ctrl := newPlugin()
+		if err := ctrl.ValidateInitialization(); err == nil {
+			t.Errorf("expected error for uninspected feature gates")
+		}
+	})
+
+	t.Run("inspected feature gates", func(t *testing.T) {
+		ctrl := newPlugin()
+		ctrl.InspectFeatureGates(utilfeature.DefaultFeatureGate)
+		if err := ctrl.ValidateInitialization(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
 }

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -506,12 +506,18 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
+		rules := []rbacv1.PolicyRule{
+			rbacv1helpers.NewRule("get", "list", "watch", "update").Groups(schedulingGroup).Resources("podgroups").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("pods").RuleOrDie(),
+		}
+		if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) {
+			rules = append(rules,
+				rbacv1helpers.NewRule("get", "list", "watch", "update").Groups(schedulingGroup).Resources("compositepodgroups").RuleOrDie(),
+			)
+		}
 		addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "podgroup-protection-controller"},
-			Rules: []rbacv1.PolicyRule{
-				rbacv1helpers.NewRule("get", "list", "watch", "update").Groups(schedulingGroup).Resources("podgroups").RuleOrDie(),
-				rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("pods").RuleOrDie(),
-			},
+			Rules:      rules,
 		})
 	}
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
@@ -108,25 +108,47 @@ func TestPodGroupProtectionControllerRBAC(t *testing.T) {
 	roleName := saRolePrefix + "podgroup-protection-controller"
 
 	tests := []struct {
-		name              string
-		enableFeatureGate bool
-		expectRole        bool
+		name                    string
+		enableGenericWorkload   bool
+		enableCompositePodGroup bool
+		expectRole              bool
+		wantRules               []rbacv1.PolicyRule
 	}{
 		{
-			name:              "role and binding absent when GenericWorkload is disabled",
-			enableFeatureGate: false,
-			expectRole:        false,
+			name:                  "role and binding absent when GenericWorkload is disabled",
+			enableGenericWorkload: false,
+			expectRole:            false,
 		},
 		{
-			name:              "role and binding present when GenericWorkload is enabled",
-			enableFeatureGate: true,
-			expectRole:        true,
+			name:                    "role and binding present when GenericWorkload is enabled and CompositePodGroup is disabled",
+			enableGenericWorkload:   true,
+			enableCompositePodGroup: false,
+			expectRole:              true,
+			wantRules: []rbacv1.PolicyRule{
+				{Verbs: []string{"get", "list", "update", "watch"}, APIGroups: []string{"scheduling.k8s.io"}, Resources: []string{"podgroups"}},
+				{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+			},
+		},
+		{
+			name:                    "role and binding present with compositepodgroups when GenericWorkload and CompositePodGroup are enabled",
+			enableGenericWorkload:   true,
+			enableCompositePodGroup: true,
+			expectRole:              true,
+			wantRules: []rbacv1.PolicyRule{
+				{Verbs: []string{"get", "list", "update", "watch"}, APIGroups: []string{"scheduling.k8s.io"}, Resources: []string{"podgroups"}},
+				{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{""}, Resources: []string{"pods"}},
+				{Verbs: []string{"get", "list", "update", "watch"}, APIGroups: []string{"scheduling.k8s.io"}, Resources: []string{"compositepodgroups"}},
+			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, test.enableFeatureGate)
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 test.enableGenericWorkload,
+				features.TopologyAwareWorkloadScheduling: test.enableCompositePodGroup,
+				features.CompositePodGroup:               test.enableCompositePodGroup,
+			})
 
 			var foundRole *rbacv1.ClusterRole
 			for i, role := range ControllerRoles() {
@@ -147,12 +169,8 @@ func TestPodGroupProtectionControllerRBAC(t *testing.T) {
 				t.Fatalf("role %q not found when GenericWorkload is enabled", roleName)
 			}
 
-			wantRules := []rbacv1.PolicyRule{
-				{Verbs: []string{"get", "list", "update", "watch"}, APIGroups: []string{"scheduling.k8s.io"}, Resources: []string{"podgroups"}},
-				{Verbs: []string{"get", "list", "watch"}, APIGroups: []string{""}, Resources: []string{"pods"}},
-			}
-			if !reflect.DeepEqual(foundRole.Rules, wantRules) {
-				t.Errorf("unexpected rules:\ngot:  %+v\nwant: %+v", foundRole.Rules, wantRules)
+			if !reflect.DeepEqual(foundRole.Rules, test.wantRules) {
+				t.Errorf("unexpected rules:\ngot:  %+v\nwant: %+v", foundRole.Rules, test.wantRules)
 			}
 
 			var foundBinding *rbacv1.ClusterRoleBinding

--- a/test/integration/podgroupprotection/podgroup_protection_test.go
+++ b/test/integration/podgroupprotection/podgroup_protection_test.go
@@ -1,0 +1,378 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podgroupprotection
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	fwk "k8s.io/kube-scheduler/framework"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/pkg/controller/scheduling/podgroupprotection"
+	"k8s.io/kubernetes/pkg/features"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+const testNamespace = "default"
+
+func cpgKey(name string) fwk.EntityKey {
+	return fwk.CompositePodGroupKey(testNamespace, name)
+}
+
+func pgKey(name string) fwk.EntityKey {
+	return fwk.PodGroupKey(testNamespace, name)
+}
+
+func setup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, clientset.Interface, *podgroupprotection.Controller, informers.SharedInformerFactory) {
+	tCtx := ktesting.Init(t)
+
+	// Enable feature gates for CompositePodGroup
+	featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.GenericWorkload, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.TopologyAwareWorkloadScheduling, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, feature.DefaultFeatureGate, features.CompositePodGroup, true)
+
+	flags := append(framework.DefaultTestServerFlags(),
+		"--enable-admission-plugins=PodGroupProtection",
+		"--feature-gates=GenericWorkload=true,TopologyAwareWorkloadScheduling=true,CompositePodGroup=true",
+		fmt.Sprintf("--runtime-config=%s=true,%s=true", schedulingv1alpha3.SchemeGroupVersion, schedulingv1beta1.SchemeGroupVersion),
+	)
+
+	// Start test server with admission plugin enabled
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, flags, framework.SharedEtcd())
+
+	config := restclient.CopyConfig(server.ClientConfig)
+	clientSet, err := clientset.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Error in create clientset: %v", err)
+	}
+
+	informerFactory := informers.NewSharedInformerFactory(clientSet, 0)
+
+	pgInformer := informerFactory.Scheduling().V1beta1().PodGroups()
+	cpgInformer := informerFactory.Scheduling().V1alpha3().CompositePodGroups()
+	podInformer := informerFactory.Core().V1().Pods()
+
+	ctrl, err := podgroupprotection.NewPodGroupProtectionController(
+		tCtx.Logger(),
+		pgInformer,
+		cpgInformer,
+		podInformer,
+		clientSet,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("Failed to create PodGroupProtectionController: %v", err)
+	}
+
+	tearDown := func() {
+		tCtx.Cancel("tearing down")
+		server.TearDownFn()
+	}
+
+	return tCtx, tearDown, clientSet, ctrl, informerFactory
+}
+
+type testAction string
+
+const (
+	deleteCPG testAction = "delete-cpg"
+	deletePG  testAction = "delete-pg"
+	deletePod testAction = "delete-pod"
+)
+
+type testStep struct {
+	action           testAction
+	targetName       string
+	expectedExisting sets.Set[fwk.EntityKey]
+}
+
+type gcTestCase struct {
+	name        string
+	initialCPGs []*schedulingv1alpha3.CompositePodGroup
+	initialPGs  []*schedulingv1beta1.PodGroup
+	initialPods []*v1.Pod
+	steps       []testStep
+}
+
+func TestCompositePodGroupGarbageCollection(t *testing.T) {
+	tests := []gcTestCase{
+		{
+			name: "CPG with no children gets deleted immediately upon deletion request",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace(testNamespace).Name("standalone-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+			},
+			steps: []testStep{
+				{
+					action:           deleteCPG,
+					targetName:       "standalone-cpg",
+					expectedExisting: sets.New[fwk.EntityKey](),
+				},
+			},
+		},
+		{
+			name: "CPG with child CPG and child PG: deletion blocked until all children are deleted",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace(testNamespace).Name("root-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+				st.MakeCompositePodGroup().Namespace(testNamespace).Name("child-cpg").ParentCompositePodGroup("root-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+			},
+			initialPGs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace(testNamespace).Name("child-pg").ParentCompositePodGroup("root-cpg").WorkloadRef("test-tpl", "test-wl").BasicPolicy().Obj(),
+			},
+			steps: []testStep{
+				{
+					action:           deleteCPG,
+					targetName:       "root-cpg",
+					expectedExisting: sets.New(cpgKey("root-cpg"), cpgKey("child-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deleteCPG,
+					targetName:       "child-cpg",
+					expectedExisting: sets.New(cpgKey("root-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deletePG,
+					targetName:       "child-pg",
+					expectedExisting: sets.New[fwk.EntityKey](),
+				},
+			},
+		},
+		{
+			name: "Multi-level CPG hierarchy: grandparent -> parent -> child PG",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace(testNamespace).Name("grandparent-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+				st.MakeCompositePodGroup().Namespace(testNamespace).Name("parent-cpg").ParentCompositePodGroup("grandparent-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+			},
+			initialPGs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace(testNamespace).Name("child-pg").ParentCompositePodGroup("parent-cpg").WorkloadRef("test-tpl", "test-wl").BasicPolicy().Obj(),
+			},
+			steps: []testStep{
+				{
+					action:           deleteCPG,
+					targetName:       "grandparent-cpg",
+					expectedExisting: sets.New(cpgKey("grandparent-cpg"), cpgKey("parent-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deleteCPG,
+					targetName:       "parent-cpg",
+					expectedExisting: sets.New(cpgKey("grandparent-cpg"), cpgKey("parent-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deletePG,
+					targetName:       "child-pg",
+					expectedExisting: sets.New[fwk.EntityKey](),
+				},
+			},
+		},
+		{
+			name: "CPG with child PG containing active Pod: Pod protects PG, PG protects CPG",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace(testNamespace).Name("root-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+			},
+			initialPGs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace(testNamespace).Name("child-pg").ParentCompositePodGroup("root-cpg").WorkloadRef("test-tpl", "test-wl").BasicPolicy().Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Namespace(testNamespace).Name("active-pod").PodGroupName("child-pg").Obj(),
+			},
+			steps: []testStep{
+				{
+					action:           deleteCPG,
+					targetName:       "root-cpg",
+					expectedExisting: sets.New(cpgKey("root-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deletePG,
+					targetName:       "child-pg",
+					expectedExisting: sets.New(cpgKey("root-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deletePod,
+					targetName:       "active-pod",
+					expectedExisting: sets.New[fwk.EntityKey](),
+				},
+			},
+		},
+		{
+			name: "CPG with multiple sibling child PGs: partial child deletion keeps parent protected",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace(testNamespace).Name("root-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+			},
+			initialPGs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace(testNamespace).Name("child-pg-1").ParentCompositePodGroup("root-cpg").WorkloadRef("test-tpl", "test-wl").BasicPolicy().Obj(),
+				st.MakePodGroup().Namespace(testNamespace).Name("child-pg-2").ParentCompositePodGroup("root-cpg").WorkloadRef("test-tpl", "test-wl").BasicPolicy().Obj(),
+			},
+			steps: []testStep{
+				{
+					action:           deleteCPG,
+					targetName:       "root-cpg",
+					expectedExisting: sets.New(cpgKey("root-cpg"), pgKey("child-pg-1"), pgKey("child-pg-2")),
+				},
+				{
+					action:           deletePG,
+					targetName:       "child-pg-1",
+					expectedExisting: sets.New(cpgKey("root-cpg"), pgKey("child-pg-2")),
+				},
+				{
+					action:           deletePG,
+					targetName:       "child-pg-2",
+					expectedExisting: sets.New[fwk.EntityKey](),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, tearDown, clientSet, ctrl, informerFactory := setup(t)
+			defer tearDown()
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			go ctrl.Run(ctx, 1)
+
+			// Track all initial objects created in this test case
+			allObjects := sets.New[fwk.EntityKey]()
+			for _, cpg := range tc.initialCPGs {
+				allObjects.Insert(cpgKey(cpg.Name))
+			}
+			for _, pg := range tc.initialPGs {
+				allObjects.Insert(pgKey(pg.Name))
+			}
+
+			// Create all initial CPGs
+			for _, cpg := range tc.initialCPGs {
+				if _, err := clientSet.SchedulingV1alpha3().CompositePodGroups(cpg.Namespace).Create(ctx, cpg, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create CPG %s: %v", cpg.Name, err)
+				}
+			}
+
+			// Create all initial PGs
+			for _, pg := range tc.initialPGs {
+				if _, err := clientSet.SchedulingV1beta1().PodGroups(pg.Namespace).Create(ctx, pg, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create PG %s: %v", pg.Name, err)
+				}
+			}
+
+			// Create all initial Pods
+			for _, pod := range tc.initialPods {
+				podCopy := pod.DeepCopy()
+				if len(podCopy.Spec.Containers) == 0 {
+					podCopy.Spec.Containers = []v1.Container{{Name: "c1", Image: "pause"}}
+				}
+				if _, err := clientSet.CoreV1().Pods(podCopy.Namespace).Create(ctx, podCopy, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create Pod %s: %v", podCopy.Name, err)
+				}
+			}
+
+			// Wait for admission plugin to stamp finalizers on CPGs and PGs
+			err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(c context.Context) (bool, error) {
+				for _, cpg := range tc.initialCPGs {
+					obj, err := clientSet.SchedulingV1alpha3().CompositePodGroups(cpg.Namespace).Get(c, cpg.Name, metav1.GetOptions{})
+					if err != nil || len(obj.Finalizers) == 0 {
+						return false, nil
+					}
+				}
+				for _, pg := range tc.initialPGs {
+					obj, err := clientSet.SchedulingV1beta1().PodGroups(pg.Namespace).Get(c, pg.Name, metav1.GetOptions{})
+					if err != nil || len(obj.Finalizers) == 0 {
+						return false, nil
+					}
+				}
+				return true, nil
+			})
+			if err != nil {
+				t.Fatalf("Timeout waiting for admission finalizers to be stamped: %v", err)
+			}
+
+			// Execute steps sequentially
+			for i, step := range tc.steps {
+				t.Logf("Executing step %d (%s on %s)", i, step.action, step.targetName)
+				switch step.action {
+				case deleteCPG:
+					if err := clientSet.SchedulingV1alpha3().CompositePodGroups(testNamespace).Delete(ctx, step.targetName, metav1.DeleteOptions{}); err != nil {
+						t.Fatalf("Step %d: failed to delete CPG %s: %v", i, step.targetName, err)
+					}
+				case deletePG:
+					if err := clientSet.SchedulingV1beta1().PodGroups(testNamespace).Delete(ctx, step.targetName, metav1.DeleteOptions{}); err != nil {
+						t.Fatalf("Step %d: failed to delete PG %s: %v", i, step.targetName, err)
+					}
+				case deletePod:
+					if err := clientSet.CoreV1().Pods(testNamespace).Delete(ctx, step.targetName, metav1.DeleteOptions{}); err != nil {
+						t.Fatalf("Step %d: failed to delete Pod %s: %v", i, step.targetName, err)
+					}
+				default:
+					t.Fatalf("Step %d: unknown action %s", i, step.action)
+				}
+
+				// Check expected state of all tracked objects using EntityKey
+				for key := range allObjects {
+					shouldExist := step.expectedExisting.Has(key)
+					err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(c context.Context) (bool, error) {
+						switch key.Type {
+						case fwk.CompositePodGroupKeyType:
+							cpg, err := clientSet.SchedulingV1alpha3().CompositePodGroups(key.Namespace).Get(c, key.Name, metav1.GetOptions{})
+							if shouldExist {
+								if err == nil && len(cpg.Finalizers) > 0 {
+									return true, nil
+								}
+								return false, nil
+							}
+							if apierrors.IsNotFound(err) {
+								return true, nil
+							}
+							return false, err
+						case fwk.PodGroupKeyType:
+							pg, err := clientSet.SchedulingV1beta1().PodGroups(key.Namespace).Get(c, key.Name, metav1.GetOptions{})
+							if shouldExist {
+								if err == nil && len(pg.Finalizers) > 0 {
+									return true, nil
+								}
+								return false, nil
+							}
+							if apierrors.IsNotFound(err) {
+								return true, nil
+							}
+							return false, err
+						default:
+							return false, fmt.Errorf("unsupported EntityKey type: %s", key.Type)
+						}
+					})
+					if err != nil {
+						t.Fatalf("Step %d: %s %s failed expected existence status (want exist=%v): %v", i, key.Type, key.Name, shouldExist, err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/test/integration/podgroupprotection/podgroup_protection_test.go
+++ b/test/integration/podgroupprotection/podgroup_protection_test.go
@@ -1,0 +1,422 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podgroupprotection
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/pkg/controller/scheduling/podgroupprotection"
+	"k8s.io/kubernetes/pkg/features"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+type objectKind string
+
+const (
+	compositePodGroupKind objectKind = "CompositePodGroup"
+	podGroupKind          objectKind = "PodGroup"
+)
+
+type objectKey struct {
+	kind objectKind
+	name string
+}
+
+func cpgKey(name string) objectKey {
+	return objectKey{kind: compositePodGroupKind, name: name}
+}
+
+func pgKey(name string) objectKey {
+	return objectKey{kind: podGroupKind, name: name}
+}
+
+func setup(t *testing.T) (context.Context, kubeapiservertesting.TearDownFunc, clientset.Interface, *podgroupprotection.Controller, informers.SharedInformerFactory, *sync.WaitGroup) {
+	tCtx := ktesting.Init(t)
+
+	// Enable feature gates for CompositePodGroup
+	featuregatetesting.SetFeatureGatesDuringTest(t, feature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.GenericWorkload:                 true,
+		features.TopologyAwareWorkloadScheduling: true,
+		features.CompositePodGroup:               true,
+	})
+
+	flags := append(framework.DefaultTestServerFlags(),
+		"--enable-admission-plugins=PodGroupProtection",
+		"--feature-gates=GenericWorkload=true,TopologyAwareWorkloadScheduling=true,CompositePodGroup=true",
+		fmt.Sprintf("--runtime-config=%s=true,%s=true", schedulingv1alpha3.SchemeGroupVersion, schedulingv1beta1.SchemeGroupVersion),
+	)
+
+	// Start test server with admission plugin enabled
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, flags, framework.SharedEtcd())
+
+	config := restclient.CopyConfig(server.ClientConfig)
+	clientSet, err := clientset.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Error in create clientset: %v", err)
+	}
+
+	informerFactory := informers.NewSharedInformerFactory(clientSet, 0)
+
+	pgInformer := informerFactory.Scheduling().V1beta1().PodGroups()
+	cpgInformer := informerFactory.Scheduling().V1alpha3().CompositePodGroups()
+	podInformer := informerFactory.Core().V1().Pods()
+
+	ctrl, err := podgroupprotection.NewPodGroupProtectionController(
+		tCtx.Logger(),
+		pgInformer,
+		cpgInformer,
+		podInformer,
+		clientSet,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("Failed to create PodGroupProtectionController: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	tearDown := func() {
+		tCtx.Cancel("tearing down")
+		wg.Wait()
+		server.TearDownFn()
+	}
+
+	return tCtx, tearDown, clientSet, ctrl, informerFactory, &wg
+}
+
+type testAction string
+
+const (
+	deleteCPG testAction = "delete-cpg"
+	deletePG  testAction = "delete-pg"
+	deletePod testAction = "delete-pod"
+)
+
+type testStep struct {
+	action           testAction
+	targetName       string
+	expectedExisting sets.Set[objectKey]
+}
+
+type gcTestCase struct {
+	name        string
+	initialCPGs []*schedulingv1alpha3.CompositePodGroup
+	initialPGs  []*schedulingv1beta1.PodGroup
+	initialPods []*v1.Pod
+	steps       []testStep
+}
+
+func TestCompositePodGroupGarbageCollection(t *testing.T) {
+	tests := []gcTestCase{
+		{
+			name: "CPG with no children gets deleted immediately upon deletion request",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("standalone-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+			},
+			steps: []testStep{
+				{
+					action:           deleteCPG,
+					targetName:       "standalone-cpg",
+					expectedExisting: sets.New[objectKey](),
+				},
+			},
+		},
+		{
+			name: "CPG with child CPG and child PG: deletion blocked until all children are deleted",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+				st.MakeCompositePodGroup().Name("child-cpg").ParentCompositePodGroup("root-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+			},
+			initialPGs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("child-pg").ParentCompositePodGroup("root-cpg").WorkloadRef("test-tpl", "test-wl").BasicPolicy().Obj(),
+			},
+			steps: []testStep{
+				{
+					action:           deleteCPG,
+					targetName:       "root-cpg",
+					expectedExisting: sets.New(cpgKey("root-cpg"), cpgKey("child-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deleteCPG,
+					targetName:       "child-cpg",
+					expectedExisting: sets.New(cpgKey("root-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deletePG,
+					targetName:       "child-pg",
+					expectedExisting: sets.New[objectKey](),
+				},
+			},
+		},
+		{
+			name: "Multi-level CPG hierarchy: grandparent -> parent -> child PG",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("grandparent-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+				st.MakeCompositePodGroup().Name("parent-cpg").ParentCompositePodGroup("grandparent-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+			},
+			initialPGs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("child-pg").ParentCompositePodGroup("parent-cpg").WorkloadRef("test-tpl", "test-wl").BasicPolicy().Obj(),
+			},
+			steps: []testStep{
+				{
+					action:           deleteCPG,
+					targetName:       "grandparent-cpg",
+					expectedExisting: sets.New(cpgKey("grandparent-cpg"), cpgKey("parent-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deleteCPG,
+					targetName:       "parent-cpg",
+					expectedExisting: sets.New(cpgKey("grandparent-cpg"), cpgKey("parent-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deletePG,
+					targetName:       "child-pg",
+					expectedExisting: sets.New[objectKey](),
+				},
+			},
+		},
+		{
+			name: "CPG with child PG containing active Pod: Pod protects PG, PG protects CPG",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+			},
+			initialPGs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("child-pg").ParentCompositePodGroup("root-cpg").WorkloadRef("test-tpl", "test-wl").BasicPolicy().Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("active-pod").PodGroupName("child-pg").Obj(),
+			},
+			steps: []testStep{
+				{
+					action:           deleteCPG,
+					targetName:       "root-cpg",
+					expectedExisting: sets.New(cpgKey("root-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deletePG,
+					targetName:       "child-pg",
+					expectedExisting: sets.New(cpgKey("root-cpg"), pgKey("child-pg")),
+				},
+				{
+					action:           deletePod,
+					targetName:       "active-pod",
+					expectedExisting: sets.New[objectKey](),
+				},
+			},
+		},
+		{
+			name: "CPG with multiple sibling child PGs: partial child deletion keeps parent protected",
+			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("root-cpg").WorkloadRef("test-wl", "test-tpl").BasicPolicy().Obj(),
+			},
+			initialPGs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("child-pg-1").ParentCompositePodGroup("root-cpg").WorkloadRef("test-tpl", "test-wl").BasicPolicy().Obj(),
+				st.MakePodGroup().Name("child-pg-2").ParentCompositePodGroup("root-cpg").WorkloadRef("test-tpl", "test-wl").BasicPolicy().Obj(),
+			},
+			steps: []testStep{
+				{
+					action:           deleteCPG,
+					targetName:       "root-cpg",
+					expectedExisting: sets.New(cpgKey("root-cpg"), pgKey("child-pg-1"), pgKey("child-pg-2")),
+				},
+				{
+					action:           deletePG,
+					targetName:       "child-pg-1",
+					expectedExisting: sets.New(cpgKey("root-cpg"), pgKey("child-pg-2")),
+				},
+				{
+					action:           deletePG,
+					targetName:       "child-pg-2",
+					expectedExisting: sets.New[objectKey](),
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, tearDown, clientSet, ctrl, informerFactory, wg := setup(t)
+			defer tearDown()
+
+			ns := framework.CreateNamespaceOrDie(clientSet, "cpg-gc", t).Name
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			wg.Go(func() {
+				ctrl.Run(ctx, 1)
+			})
+
+			// Track all initial objects created in this test case
+			allObjects := sets.New[objectKey]()
+			for _, cpg := range tc.initialCPGs {
+				allObjects.Insert(cpgKey(cpg.Name))
+			}
+			for _, pg := range tc.initialPGs {
+				allObjects.Insert(pgKey(pg.Name))
+			}
+
+			// Create all initial CPGs
+			for _, cpg := range tc.initialCPGs {
+				cpgCopy := cpg.DeepCopy()
+				cpgCopy.Namespace = ns
+				if _, err := clientSet.SchedulingV1alpha3().CompositePodGroups(ns).Create(ctx, cpgCopy, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create CPG %s: %v", cpgCopy.Name, err)
+				}
+			}
+
+			// Create all initial PGs
+			for _, pg := range tc.initialPGs {
+				pgCopy := pg.DeepCopy()
+				pgCopy.Namespace = ns
+				if _, err := clientSet.SchedulingV1beta1().PodGroups(ns).Create(ctx, pgCopy, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create PG %s: %v", pgCopy.Name, err)
+				}
+			}
+
+			// Create all initial Pods
+			for _, pod := range tc.initialPods {
+				podCopy := pod.DeepCopy()
+				podCopy.Namespace = ns
+				if len(podCopy.Spec.Containers) == 0 {
+					podCopy.Spec.Containers = []v1.Container{{Name: "c1", Image: "pause"}}
+				}
+				if _, err := clientSet.CoreV1().Pods(ns).Create(ctx, podCopy, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Failed to create Pod %s: %v", podCopy.Name, err)
+				}
+			}
+
+			// Wait for admission plugin to stamp finalizers on CPGs and PGs
+			err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(c context.Context) (bool, error) {
+				for key := range allObjects {
+					obj, err := getObject(c, clientSet, ns, key)
+					if err != nil || len(obj.GetFinalizers()) == 0 {
+						return false, nil
+					}
+				}
+				return true, nil
+			})
+			if err != nil {
+				t.Fatalf("Timeout waiting for admission finalizers to be stamped: %v", err)
+			}
+
+			deletedObjects := sets.New[objectKey]()
+
+			// Execute steps sequentially
+			for i, step := range tc.steps {
+				t.Logf("Executing step %d (%s on %s)", i, step.action, step.targetName)
+				switch step.action {
+				case deleteCPG:
+					deletedObjects.Insert(cpgKey(step.targetName))
+					if err := clientSet.SchedulingV1alpha3().CompositePodGroups(ns).Delete(ctx, step.targetName, metav1.DeleteOptions{}); err != nil {
+						t.Fatalf("Step %d: failed to delete CPG %s: %v", i, step.targetName, err)
+					}
+				case deletePG:
+					deletedObjects.Insert(pgKey(step.targetName))
+					if err := clientSet.SchedulingV1beta1().PodGroups(ns).Delete(ctx, step.targetName, metav1.DeleteOptions{}); err != nil {
+						t.Fatalf("Step %d: failed to delete PG %s: %v", i, step.targetName, err)
+					}
+				case deletePod:
+					if err := clientSet.CoreV1().Pods(ns).Delete(ctx, step.targetName, metav1.DeleteOptions{}); err != nil {
+						t.Fatalf("Step %d: failed to delete Pod %s: %v", i, step.targetName, err)
+					}
+				default:
+					t.Fatalf("Step %d: unknown action %s", i, step.action)
+				}
+
+				// First, wait for all objects that should no longer exist to be removed (NotFound).
+				for key := range allObjects {
+					if step.expectedExisting.Has(key) {
+						continue
+					}
+					if err := waitForObjectRemoval(ctx, clientSet, ns, key); err != nil {
+						t.Fatalf("Step %d: %s %s was expected to be deleted, but still exists or failed: %v", i, key.kind, key.name, err)
+					}
+				}
+
+				// Next, verify all objects that should still exist.
+				// If an object has been deleted, it must be terminating (DeletionTimestamp != nil) with finalizer present.
+				for key := range step.expectedExisting {
+					if err := waitForObjectProtection(ctx, clientSet, ns, key, deletedObjects.Has(key)); err != nil {
+						t.Fatalf("Step %d: %s %s failed expected existence status: %v", i, key.kind, key.name, err)
+					}
+				}
+			}
+		})
+	}
+}
+
+func getObject(ctx context.Context, clientSet clientset.Interface, ns string, key objectKey) (metav1.Object, error) {
+	switch key.kind {
+	case compositePodGroupKind:
+		return clientSet.SchedulingV1alpha3().CompositePodGroups(ns).Get(ctx, key.name, metav1.GetOptions{})
+	case podGroupKind:
+		return clientSet.SchedulingV1beta1().PodGroups(ns).Get(ctx, key.name, metav1.GetOptions{})
+	default:
+		return nil, fmt.Errorf("unsupported objectKey kind: %s", key.kind)
+	}
+}
+
+func waitForObjectRemoval(ctx context.Context, clientSet clientset.Interface, ns string, key objectKey) error {
+	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(c context.Context) (bool, error) {
+		_, err := getObject(c, clientSet, ns, key)
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	})
+}
+
+func waitForObjectProtection(ctx context.Context, clientSet clientset.Interface, ns string, key objectKey, isDeleted bool) error {
+	return wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(c context.Context) (bool, error) {
+		obj, err := getObject(c, clientSet, ns, key)
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if len(obj.GetFinalizers()) == 0 {
+			return false, nil
+		}
+		if isDeleted && obj.GetDeletionTimestamp() == nil {
+			return false, nil
+		}
+		return true, nil
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/wg workload-aware-scheduling
/sig scheduling

#### What this PR does / why we need it:

Implements garbage collection finalizer protection for `CompositePodGroup` objects to enforce hierarchical, bottom-up cleanup:

- **Admission**: Extends the `PodGroupProtection` admission plugin (`plugin/pkg/admission/scheduling/podgroupprotection`) to mark newly created `CompositePodGroup` objects with the `scheduling.k8s.io/compositepodgroup-protection` finalizer.
- **Controller**: Extends `PodGroupProtectionController` (`pkg/controller/scheduling/podgroupprotection`) to index `PodGroup` and `CompositePodGroup` objects by `spec.parentCompositePodGroupName`.
- **Lifecycle Invariants**: When a `CompositePodGroup` is marked for deletion, the controller retains its finalizer while any child `PodGroup` or `CompositePodGroup` still references it as a parent. The finalizer is dropped only after all child groups have been removed, ensuring deletion proceeds leaf-to-root (`Pod` -> `PodGroup` -> child `CompositePodGroup` -> root `CompositePodGroup`).
- **Testing**: Adds full integration test coverage in `test/integration/podgroupprotection` verifying multi-level hierarchical deletion and finalizer protection.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/6012-composite-podgroup-api/README.md

#### Special notes for your reviewer:

- Extends the existing `PodGroupProtection` infrastructure without altering standard `PodGroup` protection semantics.
- Uses `spec.parentCompositePodGroupName` indexers in the shared informer cache to evaluate parent-child references without API server queries.

#### Does this PR introduce a user-facing change?

```release-note
Add garbage collection finalizer protection (`scheduling.k8s.io/compositepodgroup-protection`) for CompositePodGroup objects to ensure hierarchical bottom-up cleanup of pod groups.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/6012
```

#### AI was used while crafting the PR