### PR TITLE
Make MinGroupCount mutable for CompositePodGroups

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -21066,7 +21066,7 @@
       "description": "CompositeGangSchedulingPolicy indicates that the groups belonging to the composite group should be scheduled using all-or-nothing semantics.",
       "properties": {
         "minGroupCount": {
-          "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+          "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
           "format": "int32",
           "type": "integer"
         }
@@ -21162,15 +21162,15 @@
       "type": "object"
     },
     "io.k8s.api.scheduling.v1alpha3.CompositePodGroupSchedulingPolicy": {
-      "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
+      "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
       "properties": {
         "basic": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.CompositeBasicSchedulingPolicy",
-          "description": "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable."
+          "description": "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward."
         },
         "gang": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.CompositeGangSchedulingPolicy",
-          "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics."
+          "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation."
         }
       },
       "type": "object",
@@ -21213,7 +21213,7 @@
         },
         "schedulingPolicy": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.CompositePodGroupSchedulingPolicy",
-          "description": "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. This field is immutable."
+          "description": "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate."
         },
         "workloadRef": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.WorkloadReference",
@@ -21860,7 +21860,7 @@
       "description": "WorkloadSpec defines the desired state of a Workload.",
       "properties": {
         "compositePodGroupTemplates": {
-          "description": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. This field is immutable. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
+          "description": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.scheduling.v1alpha3.CompositePodGroupTemplate"
           },
@@ -21930,7 +21930,7 @@
       "description": "CompositeGangSchedulingPolicy indicates that the groups belonging to the composite group should be scheduled using all-or-nothing semantics.",
       "properties": {
         "minGroupCount": {
-          "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+          "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
           "format": "int32",
           "type": "integer"
         }
@@ -21955,15 +21955,15 @@
       "type": "object"
     },
     "io.k8s.api.scheduling.v1beta1.CompositePodGroupSchedulingPolicy": {
-      "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
+      "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
       "properties": {
         "basic": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1beta1.CompositeBasicSchedulingPolicy",
-          "description": "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable."
+          "description": "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward."
         },
         "gang": {
           "$ref": "#/definitions/io.k8s.api.scheduling.v1beta1.CompositeGangSchedulingPolicy",
-          "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics."
+          "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation."
         }
       },
       "type": "object",
@@ -22489,7 +22489,7 @@
       "description": "WorkloadSpec defines the desired state of a Workload.",
       "properties": {
         "compositePodGroupTemplates": {
-          "description": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. This field is immutable. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
+          "description": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.scheduling.v1beta1.CompositePodGroupTemplate"
           },

--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1alpha3_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1alpha3_openapi.json
@@ -52,7 +52,7 @@
         "properties": {
           "minGroupCount": {
             "default": 0,
-            "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+            "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
             "format": "int32",
             "type": "integer"
           }
@@ -168,7 +168,7 @@
         "type": "object"
       },
       "io.k8s.api.scheduling.v1alpha3.CompositePodGroupSchedulingPolicy": {
-        "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
+        "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
         "properties": {
           "basic": {
             "allOf": [
@@ -176,7 +176,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1alpha3.CompositeBasicSchedulingPolicy"
               }
             ],
-            "description": "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable."
+            "description": "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward."
           },
           "gang": {
             "allOf": [
@@ -184,7 +184,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1alpha3.CompositeGangSchedulingPolicy"
               }
             ],
-            "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics."
+            "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation."
           }
         },
         "type": "object",
@@ -243,7 +243,7 @@
               }
             ],
             "default": {},
-            "description": "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. This field is immutable."
+            "description": "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate."
           },
           "workloadRef": {
             "allOf": [

--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1alpha3_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1alpha3_openapi.json
@@ -52,7 +52,7 @@
         "properties": {
           "minGroupCount": {
             "default": 0,
-            "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+            "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
             "format": "int32",
             "type": "integer"
           }
@@ -168,7 +168,7 @@
         "type": "object"
       },
       "io.k8s.api.scheduling.v1alpha3.CompositePodGroupSchedulingPolicy": {
-        "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
+        "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
         "properties": {
           "basic": {
             "allOf": [
@@ -176,7 +176,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1alpha3.CompositeBasicSchedulingPolicy"
               }
             ],
-            "description": "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable."
+            "description": "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward."
           },
           "gang": {
             "allOf": [
@@ -184,7 +184,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1alpha3.CompositeGangSchedulingPolicy"
               }
             ],
-            "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics."
+            "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation."
           }
         },
         "type": "object",
@@ -243,7 +243,7 @@
               }
             ],
             "default": {},
-            "description": "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. This field is immutable."
+            "description": "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate."
           },
           "workloadRef": {
             "allOf": [
@@ -899,7 +899,7 @@
         "description": "WorkloadSpec defines the desired state of a Workload.",
         "properties": {
           "compositePodGroupTemplates": {
-            "description": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. This field is immutable. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
+            "description": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.scheduling.v1alpha3.CompositePodGroupTemplate"
             },

--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1beta1_openapi.json
@@ -52,7 +52,7 @@
         "properties": {
           "minGroupCount": {
             "default": 0,
-            "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+            "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
             "format": "int32",
             "type": "integer"
           }
@@ -77,7 +77,7 @@
         "type": "object"
       },
       "io.k8s.api.scheduling.v1beta1.CompositePodGroupSchedulingPolicy": {
-        "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
+        "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
         "properties": {
           "basic": {
             "allOf": [
@@ -85,7 +85,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1beta1.CompositeBasicSchedulingPolicy"
               }
             ],
-            "description": "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable."
+            "description": "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward."
           },
           "gang": {
             "allOf": [
@@ -93,7 +93,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1beta1.CompositeGangSchedulingPolicy"
               }
             ],
-            "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics."
+            "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation."
           }
         },
         "type": "object",

--- a/api/openapi-spec/v3/apis__scheduling.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__scheduling.k8s.io__v1beta1_openapi.json
@@ -52,7 +52,7 @@
         "properties": {
           "minGroupCount": {
             "default": 0,
-            "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+            "description": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
             "format": "int32",
             "type": "integer"
           }
@@ -77,7 +77,7 @@
         "type": "object"
       },
       "io.k8s.api.scheduling.v1beta1.CompositePodGroupSchedulingPolicy": {
-        "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
+        "description": "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
         "properties": {
           "basic": {
             "allOf": [
@@ -85,7 +85,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1beta1.CompositeBasicSchedulingPolicy"
               }
             ],
-            "description": "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable."
+            "description": "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward."
           },
           "gang": {
             "allOf": [
@@ -93,7 +93,7 @@
                 "$ref": "#/components/schemas/io.k8s.api.scheduling.v1beta1.CompositeGangSchedulingPolicy"
               }
             ],
-            "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics."
+            "description": "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation."
           }
         },
         "type": "object",
@@ -726,7 +726,7 @@
         "description": "WorkloadSpec defines the desired state of a Workload.",
         "properties": {
           "compositePodGroupTemplates": {
-            "description": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. This field is immutable. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
+            "description": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
             "items": {
               "$ref": "#/components/schemas/io.k8s.api.scheduling.v1beta1.CompositePodGroupTemplate"
             },

--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -782,7 +782,6 @@ type CompositePodGroupSpec struct {
 
 	// SchedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup.
 	// Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.
-	// This field is immutable.
 	//
 	// +required
 	SchedulingPolicy CompositePodGroupSchedulingPolicy
@@ -836,17 +835,22 @@ type CompositePodGroupSpec struct {
 
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 //
 // +union
 type CompositePodGroupSchedulingPolicy struct {
 	// Basic specifies that the groups of this composite group should be scheduled independently.
-	// This field is immutable.
+	// Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
 	//
 	// +optional
 	Basic *CompositeBasicSchedulingPolicy
 
 	// Gang specifies that the groups of this composite group should be scheduled using
-	// all-or-nothing semantics.
+	// all-or-nothing semantics. Setting this field at group creation time
+	// opts this group to gang scheduling; this field cannot be set or unset afterward.
+	// The MinGroupCount field within Gang scheduling policy remains mutable after group creation.
 	//
 	// +optional
 	Gang *CompositeGangSchedulingPolicy
@@ -866,7 +870,15 @@ type CompositeBasicSchedulingPolicy struct {
 type CompositeGangSchedulingPolicy struct {
 	// MinGroupCount is the minimum number of child groups that must be schedulable
 	// or scheduled at the same time for the scheduler to admit the entire group.
-	// It must be a positive integer.
+	// It must be a positive integer. This field is mutable to support workload scaling.
+	//
+	// Note that the scheduler operates on an eventually consistent model. Updates
+	// to MinGroupCount may not be immediately reflected in scheduling decisions due to
+	// propagation delays. If MinGroupCount is updated while a scheduling cycle is in
+	// progress for that group, the new value may not take effect until the next
+	// cycle. Moreover, MinGroupCount is only enforced during scheduling, meaning that
+	// modifications to this field do not affect already-scheduled pods, applying
+	// only to those evaluated in future cycles.
 	//
 	// +required
 	MinGroupCount int32

--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -166,7 +166,8 @@ type WorkloadSpec struct {
 	PodGroupTemplates []PodGroupTemplate
 
 	// CompositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload.
-	// The maximum number of templates is 8. This field is immutable.
+	// The maximum number of templates is 8. Templates cannot be added or removed after the workload is created.
+	// Existing templates may still be updated where their individual fields allow it.
 	// Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.
 	//
 	// This field is used only when the CompositePodGroup feature gate is enabled.
@@ -782,7 +783,6 @@ type CompositePodGroupSpec struct {
 
 	// SchedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup.
 	// Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.
-	// This field is immutable.
 	//
 	// +required
 	SchedulingPolicy CompositePodGroupSchedulingPolicy
@@ -836,17 +836,22 @@ type CompositePodGroupSpec struct {
 
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 //
 // +union
 type CompositePodGroupSchedulingPolicy struct {
 	// Basic specifies that the groups of this composite group should be scheduled independently.
-	// This field is immutable.
+	// Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
 	//
 	// +optional
 	Basic *CompositeBasicSchedulingPolicy
 
 	// Gang specifies that the groups of this composite group should be scheduled using
-	// all-or-nothing semantics.
+	// all-or-nothing semantics. Setting this field at group creation time
+	// opts this group to gang scheduling; this field cannot be set or unset afterward.
+	// The minGroupCount field within Gang scheduling policy remains mutable after group creation.
 	//
 	// +optional
 	Gang *CompositeGangSchedulingPolicy
@@ -866,7 +871,15 @@ type CompositeBasicSchedulingPolicy struct {
 type CompositeGangSchedulingPolicy struct {
 	// MinGroupCount is the minimum number of child groups that must be schedulable
 	// or scheduled at the same time for the scheduler to admit the entire group.
-	// It must be a positive integer.
+	// It must be a positive integer. This field is mutable to support workload scaling.
+	//
+	// Note that the scheduler operates on an eventually consistent model. Updates
+	// to minGroupCount may not be immediately reflected in scheduling decisions due to
+	// propagation delays. If minGroupCount is updated while a scheduling cycle is in
+	// progress for that group, the new value may not take effect until the next
+	// cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that
+	// modifications to this field do not affect already-scheduled pods, applying
+	// only to those evaluated in future cycles.
 	//
 	// +required
 	MinGroupCount int32

--- a/pkg/apis/scheduling/v1alpha3/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha3/zz_generated.validations.go
@@ -516,15 +516,6 @@ func Validate_CompositePodGroupSpec(
 					return nil
 				}
 			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// call the type's validation function
 			errs = append(errs, Validate_CompositePodGroupSchedulingPolicy(ctx, op, fldPath, obj, oldObj)...)
 			return

--- a/pkg/apis/scheduling/v1alpha3/zz_generated.validations.go
+++ b/pkg/apis/scheduling/v1alpha3/zz_generated.validations.go
@@ -515,15 +515,6 @@ func Validate_CompositePodGroupSpec(
 					return nil
 				}
 			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// call the type's validation function
 			errs = append(errs, Validate_CompositePodGroupSchedulingPolicy(ctx, op, fldPath, obj, oldObj)...)
 			return

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -56735,7 +56735,7 @@ func schema_k8sio_api_scheduling_v1alpha3_CompositeGangSchedulingPolicy(ref comm
 				Properties: map[string]spec.Schema{
 					"minGroupCount": {
 						SchemaProps: spec.SchemaProps{
-							Description: "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+							Description: "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -56886,18 +56886,18 @@ func schema_k8sio_api_scheduling_v1alpha3_CompositePodGroupSchedulingPolicy(ref 
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
+				Description: "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"basic": {
 						SchemaProps: spec.SchemaProps{
-							Description: "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable.",
+							Description: "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.",
 							Ref:         ref(schedulingv1alpha3.CompositeBasicSchedulingPolicy{}.OpenAPIModelName()),
 						},
 					},
 					"gang": {
 						SchemaProps: spec.SchemaProps{
-							Description: "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics.",
+							Description: "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation.",
 							Ref:         ref(schedulingv1alpha3.CompositeGangSchedulingPolicy{}.OpenAPIModelName()),
 						},
 					},
@@ -56943,7 +56943,7 @@ func schema_k8sio_api_scheduling_v1alpha3_CompositePodGroupSpec(ref common.Refer
 					},
 					"schedulingPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. This field is immutable.",
+							Description: "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(schedulingv1alpha3.CompositePodGroupSchedulingPolicy{}.OpenAPIModelName()),
 						},
@@ -58403,7 +58403,7 @@ func schema_k8sio_api_scheduling_v1beta1_CompositeGangSchedulingPolicy(ref commo
 				Properties: map[string]spec.Schema{
 					"minGroupCount": {
 						SchemaProps: spec.SchemaProps{
-							Description: "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+							Description: "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -58453,18 +58453,18 @@ func schema_k8sio_api_scheduling_v1beta1_CompositePodGroupSchedulingPolicy(ref c
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
+				Description: "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"basic": {
 						SchemaProps: spec.SchemaProps{
-							Description: "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable.",
+							Description: "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.",
 							Ref:         ref(schedulingv1beta1.CompositeBasicSchedulingPolicy{}.OpenAPIModelName()),
 						},
 					},
 					"gang": {
 						SchemaProps: spec.SchemaProps{
-							Description: "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics.",
+							Description: "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation.",
 							Ref:         ref(schedulingv1beta1.CompositeGangSchedulingPolicy{}.OpenAPIModelName()),
 						},
 					},

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -56724,7 +56724,7 @@ func schema_k8sio_api_scheduling_v1alpha3_CompositeGangSchedulingPolicy(ref comm
 				Properties: map[string]spec.Schema{
 					"minGroupCount": {
 						SchemaProps: spec.SchemaProps{
-							Description: "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+							Description: "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -56875,18 +56875,18 @@ func schema_k8sio_api_scheduling_v1alpha3_CompositePodGroupSchedulingPolicy(ref 
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
+				Description: "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"basic": {
 						SchemaProps: spec.SchemaProps{
-							Description: "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable.",
+							Description: "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.",
 							Ref:         ref(schedulingv1alpha3.CompositeBasicSchedulingPolicy{}.OpenAPIModelName()),
 						},
 					},
 					"gang": {
 						SchemaProps: spec.SchemaProps{
-							Description: "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics.",
+							Description: "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation.",
 							Ref:         ref(schedulingv1alpha3.CompositeGangSchedulingPolicy{}.OpenAPIModelName()),
 						},
 					},
@@ -56932,7 +56932,7 @@ func schema_k8sio_api_scheduling_v1alpha3_CompositePodGroupSpec(ref common.Refer
 					},
 					"schedulingPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. This field is immutable.",
+							Description: "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.",
 							Default:     map[string]interface{}{},
 							Ref:         ref(schedulingv1alpha3.CompositePodGroupSchedulingPolicy{}.OpenAPIModelName()),
 						},
@@ -58281,7 +58281,7 @@ func schema_k8sio_api_scheduling_v1alpha3_WorkloadSpec(ref common.ReferenceCallb
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. This field is immutable. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
+							Description: "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -58392,7 +58392,7 @@ func schema_k8sio_api_scheduling_v1beta1_CompositeGangSchedulingPolicy(ref commo
 				Properties: map[string]spec.Schema{
 					"minGroupCount": {
 						SchemaProps: spec.SchemaProps{
-							Description: "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+							Description: "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
 							Default:     0,
 							Type:        []string{"integer"},
 							Format:      "int32",
@@ -58442,18 +58442,18 @@ func schema_k8sio_api_scheduling_v1beta1_CompositePodGroupSchedulingPolicy(ref c
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
+				Description: "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"basic": {
 						SchemaProps: spec.SchemaProps{
-							Description: "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable.",
+							Description: "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.",
 							Ref:         ref(schedulingv1beta1.CompositeBasicSchedulingPolicy{}.OpenAPIModelName()),
 						},
 					},
 					"gang": {
 						SchemaProps: spec.SchemaProps{
-							Description: "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics.",
+							Description: "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation.",
 							Ref:         ref(schedulingv1beta1.CompositeGangSchedulingPolicy{}.OpenAPIModelName()),
 						},
 					},
@@ -59491,7 +59491,7 @@ func schema_k8sio_api_scheduling_v1beta1_WorkloadSpec(ref common.ReferenceCallba
 							},
 						},
 						SchemaProps: spec.SchemaProps{
-							Description: "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. This field is immutable. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
+							Description: "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{

--- a/pkg/registry/scheduling/compositepodgroup/strategy.go
+++ b/pkg/registry/scheduling/compositepodgroup/strategy.go
@@ -51,6 +51,9 @@ func (*compositePodGroupStrategy) NamespaceScoped() bool {
 
 func (*compositePodGroupStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"scheduling.k8s.io/v1beta1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("status"),
+		),
 		"scheduling.k8s.io/v1alpha3": fieldpath.NewSet(
 			fieldpath.MakePathOrDie("status"),
 		),
@@ -120,6 +123,10 @@ func NewStatusStrategy(strategy *compositePodGroupStrategy) *compositePodGroupSt
 
 func (*compositePodGroupStatusStrategy) GetResetFields() map[fieldpath.APIVersion]*fieldpath.Set {
 	fields := map[fieldpath.APIVersion]*fieldpath.Set{
+		"scheduling.k8s.io/v1beta1": fieldpath.NewSet(
+			fieldpath.MakePathOrDie("metadata"),
+			fieldpath.MakePathOrDie("spec"),
+		),
 		"scheduling.k8s.io/v1alpha3": fieldpath.NewSet(
 			fieldpath.MakePathOrDie("metadata"),
 			fieldpath.MakePathOrDie("spec"),

--- a/pkg/registry/scheduling/compositepodgroup/strategy_test.go
+++ b/pkg/registry/scheduling/compositepodgroup/strategy_test.go
@@ -57,6 +57,7 @@ var (
 	}
 
 	fieldImmutableError             = "field is immutable"
+	notAllowedToUnsetError          = "field cannot be cleared once set"
 	minCountError                   = "must be greater than or equal to 1"
 	subdomainNameError              = "lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters"
 	maximumError                    = "must be less than or equal to"
@@ -355,14 +356,13 @@ func TestStrategyUpdate(t *testing.T) {
 			}(),
 			expectValidationErrors: []string{fieldImmutableError},
 		},
-		"changing min group count in gang scheduling policy not allowed": {
+		"changing min group count in gang scheduling policy is allowed": {
 			oldObj: cpg,
 			newObj: func() *scheduling.CompositePodGroup {
 				newCpg := cpg.DeepCopy()
 				newCpg.Spec.SchedulingPolicy.Gang.MinGroupCount = 4
 				return newCpg
 			}(),
-			expectValidationErrors: []string{fieldImmutableError},
 		},
 		"changing scheduling policy not allowed": {
 			oldObj: cpg,
@@ -373,7 +373,7 @@ func TestStrategyUpdate(t *testing.T) {
 				}
 				return newCpg
 			}(),
-			expectValidationErrors: []string{fieldImmutableError},
+			expectValidationErrors: []string{fieldImmutableError, notAllowedToUnsetError},
 		},
 		"changing disruption mode not allowed": {
 			oldObj:                 cpg,

--- a/pkg/registry/scheduling/compositepodgroup/strategy_test.go
+++ b/pkg/registry/scheduling/compositepodgroup/strategy_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/apimachinery/pkg/api/operation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -57,6 +58,7 @@ var (
 	}
 
 	fieldImmutableError             = "field is immutable"
+	notAllowedToUnsetError          = "field cannot be cleared once set"
 	minCountError                   = "must be greater than or equal to 1"
 	subdomainNameError              = "lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters"
 	maximumError                    = "must be less than or equal to"
@@ -355,14 +357,13 @@ func TestStrategyUpdate(t *testing.T) {
 			}(),
 			expectValidationErrors: []string{fieldImmutableError},
 		},
-		"changing min group count in gang scheduling policy not allowed": {
+		"changing min group count in gang scheduling policy is allowed": {
 			oldObj: cpg,
 			newObj: func() *scheduling.CompositePodGroup {
 				newCpg := cpg.DeepCopy()
 				newCpg.Spec.SchedulingPolicy.Gang.MinGroupCount = 4
 				return newCpg
 			}(),
-			expectValidationErrors: []string{fieldImmutableError},
 		},
 		"changing scheduling policy not allowed": {
 			oldObj: cpg,
@@ -373,7 +374,7 @@ func TestStrategyUpdate(t *testing.T) {
 				}
 				return newCpg
 			}(),
-			expectValidationErrors: []string{fieldImmutableError},
+			expectValidationErrors: []string{fieldImmutableError, notAllowedToUnsetError},
 		},
 		"changing disruption mode not allowed": {
 			oldObj:                 cpg,

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -87,6 +87,8 @@ func (pl *GangScheduling) EventsToRegister(_ context.Context) ([]fwk.ClusterEven
 	if pl.isCompositePodGroupEnabled {
 		// A CompositePodGroup being added can be making a waiting gang schedulable.
 		events = append(events, fwk.ClusterEventWithHint{Event: fwk.ClusterEvent{Resource: fwk.CompositePodGroup, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterCompositePodGroupAdded})
+		// A CompositePodGroup update to MinGroupCount may make it schedulable.
+		events = append(events, fwk.ClusterEventWithHint{Event: fwk.ClusterEvent{Resource: fwk.CompositePodGroup, ActionType: fwk.Update}, QueueingHintFn: pl.isSchedulableAfterCompositePodGroupUpdated})
 	}
 
 	return events, nil
@@ -174,6 +176,40 @@ func (pl *GangScheduling) isSchedulableAfterCompositePodGroupAdded(logger klog.L
 		return fwk.Queue, nil
 	}
 	return fwk.QueueSkip, nil
+}
+
+// isSchedulableAfterCompositePodGroupUpdated triggers re-enqueueing of the group's pods if the minGroupCount requirement has decreased.
+func (pl *GangScheduling) isSchedulableAfterCompositePodGroupUpdated(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+	oldCPG, newCPG, err := util.As[*schedulingv1alpha3.CompositePodGroup](oldObj, newObj)
+	if err != nil {
+		return fwk.Queue, err
+	}
+
+	if pod.Spec.SchedulingGroup == nil {
+		return fwk.QueueSkip, nil
+	}
+
+	updatedCPGKey := fwk.CompositePodGroupKey(newCPG.Namespace, newCPG.Name)
+	if !pl.areSameHierarchy(logger, pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName, updatedCPGKey) {
+		return fwk.QueueSkip, nil
+	}
+
+	oldPolicy := oldCPG.Spec.SchedulingPolicy
+	newPolicy := newCPG.Spec.SchedulingPolicy
+
+	// Updates to non-gang policies will not make the waiting pods schedulable.
+	if newPolicy.Gang == nil || oldPolicy.Gang == nil {
+		return fwk.QueueSkip, nil
+	}
+
+	// If the gang scheduling policy minGroupCount did not decrease, it will not make the waiting pods schedulable.
+	if newPolicy.Gang.MinGroupCount >= oldPolicy.Gang.MinGroupCount {
+		logger.V(5).Info("CompositePodGroup minGroupCount did not decrease, skipping", "pod", klog.KObj(pod), "compositePodGroup", klog.KObj(newCPG), "oldMinGroupCount", oldPolicy.Gang.MinGroupCount, "newMinGroupCount", newPolicy.Gang.MinGroupCount)
+		return fwk.QueueSkip, nil
+	}
+
+	logger.V(5).Info("composite pod group was updated and minGroupCount decreased, enqueuing pod", "pod", klog.KObj(pod), "compositePodGroup", klog.KObj(newCPG), "oldMinGroupCount", oldPolicy.Gang.MinGroupCount, "newMinGroupCount", newPolicy.Gang.MinGroupCount)
+	return fwk.Queue, nil
 }
 
 // areSameHierarchy checks if the given pod group is in the same hierarchy as the target key.

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -82,6 +82,8 @@ func (pl *GangScheduling) EventsToRegister(_ context.Context) ([]fwk.ClusterEven
 	if pl.isCompositePodGroupEnabled {
 		// A CompositePodGroup being added can be making a waiting gang schedulable.
 		events = append(events, fwk.ClusterEventWithHint{Event: fwk.ClusterEvent{Resource: fwk.CompositePodGroup, ActionType: fwk.Add}, QueueingHintFn: pl.isSchedulableAfterCompositePodGroupAdded})
+		// A CompositePodGroup update to MinGroupCount may make it schedulable.
+		events = append(events, fwk.ClusterEventWithHint{Event: fwk.ClusterEvent{Resource: fwk.CompositePodGroup, ActionType: fwk.Update}, QueueingHintFn: pl.isSchedulableAfterCompositePodGroupUpdated})
 	}
 
 	return events, nil
@@ -115,10 +117,6 @@ func (pl *GangScheduling) isSchedulableAfterPodGroupUpdated(logger klog.Logger, 
 	if pod.Spec.SchedulingGroup == nil {
 		return fwk.QueueSkip, nil
 	}
-	updatedPodGroupKey := fwk.PodGroupKey(newPodGroup.Namespace, newPodGroup.Name)
-	if !pl.areSameHierarchy(logger, pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName, updatedPodGroupKey) {
-		return fwk.QueueSkip, nil
-	}
 
 	oldPolicy := oldPodGroup.Spec.SchedulingPolicy
 	newPolicy := newPodGroup.Spec.SchedulingPolicy
@@ -131,6 +129,12 @@ func (pl *GangScheduling) isSchedulableAfterPodGroupUpdated(logger klog.Logger, 
 	// If the gang scheduling policy minCount did not decrease, it will not make the waiting pods schedulable.
 	if newPolicy.Gang.MinCount >= oldPolicy.Gang.MinCount {
 		logger.V(5).Info("PodGroup minCount did not decrease, skipping", "pod", klog.KObj(pod), "podGroup", klog.KObj(newPodGroup), "oldMinCount", oldPolicy.Gang.MinCount, "newMinCount", newPolicy.Gang.MinCount)
+		return fwk.QueueSkip, nil
+	}
+
+	updatedPodGroupKey := fwk.PodGroupKey(newPodGroup.Namespace, newPodGroup.Name)
+	if !pl.areSameHierarchy(logger, pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName, updatedPodGroupKey) {
+		logger.V(5).Info("pod group was updated, but not in the same hierarchy, skipping", "pod", klog.KObj(pod), "podGroup", klog.KObj(newPodGroup))
 		return fwk.QueueSkip, nil
 	}
 
@@ -147,6 +151,7 @@ func (pl *GangScheduling) isSchedulableAfterPodGroupAdded(logger klog.Logger, po
 	if pod.Spec.SchedulingGroup == nil {
 		return fwk.QueueSkip, nil
 	}
+
 	addedPodGroupKey := fwk.PodGroupKey(addedPodGroup.Namespace, addedPodGroup.Name)
 	if pl.areSameHierarchy(logger, pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName, addedPodGroupKey) {
 		return fwk.Queue, nil
@@ -169,6 +174,41 @@ func (pl *GangScheduling) isSchedulableAfterCompositePodGroupAdded(logger klog.L
 		return fwk.Queue, nil
 	}
 	return fwk.QueueSkip, nil
+}
+
+// isSchedulableAfterCompositePodGroupUpdated triggers re-enqueueing of the group's pods if the minGroupCount requirement has decreased.
+func (pl *GangScheduling) isSchedulableAfterCompositePodGroupUpdated(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
+	oldCPG, newCPG, err := util.As[*schedulingv1alpha3.CompositePodGroup](oldObj, newObj)
+	if err != nil {
+		return fwk.Queue, err
+	}
+
+	if pod.Spec.SchedulingGroup == nil {
+		return fwk.QueueSkip, nil
+	}
+
+	oldPolicy := oldCPG.Spec.SchedulingPolicy
+	newPolicy := newCPG.Spec.SchedulingPolicy
+
+	// Updates to non-gang policies will not make the waiting pods schedulable.
+	if newPolicy.Gang == nil || oldPolicy.Gang == nil {
+		return fwk.QueueSkip, nil
+	}
+
+	// If the gang scheduling policy minGroupCount did not decrease, it will not make the waiting pods schedulable.
+	if newPolicy.Gang.MinGroupCount >= oldPolicy.Gang.MinGroupCount {
+		logger.V(5).Info("CompositePodGroup minGroupCount did not decrease, skipping", "pod", klog.KObj(pod), "compositePodGroup", klog.KObj(newCPG), "oldMinGroupCount", oldPolicy.Gang.MinGroupCount, "newMinGroupCount", newPolicy.Gang.MinGroupCount)
+		return fwk.QueueSkip, nil
+	}
+
+	updatedCPGKey := fwk.CompositePodGroupKey(newCPG.Namespace, newCPG.Name)
+	if !pl.areSameHierarchy(logger, pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName, updatedCPGKey) {
+		logger.V(5).Info("composite pod group was updated, but not in the same hierarchy, skipping", "pod", klog.KObj(pod), "compositePodGroup", klog.KObj(newCPG))
+		return fwk.QueueSkip, nil
+	}
+
+	logger.V(5).Info("composite pod group was updated and minGroupCount decreased, enqueuing pod", "pod", klog.KObj(pod), "compositePodGroup", klog.KObj(newCPG), "oldMinGroupCount", oldPolicy.Gang.MinGroupCount, "newMinGroupCount", newPolicy.Gang.MinGroupCount)
+	return fwk.Queue, nil
 }
 
 // areSameHierarchy checks if the given pod group is in the same hierarchy as the target key.

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -643,16 +643,6 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 			isCompositePodGroupEnabled: false,
 		},
 		{
-			name: "add a CPG which matches the pod's root CPG",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
-			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
 			name: "add a CPG which matches the pod's intermediate CPG but implies the same root",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
@@ -667,19 +657,6 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 		},
 		{
 			name: "add a CPG which matches the pod's intermediate CPG but implies the same root (CPG=false)",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub").Obj(),
-			},
-			cpgs: []*schedulingv1alpha3.CompositePodGroup{
-				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
-			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name: "add a CPG which matches the pod's intermediate CPG but implies the same root",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub").Obj(),
@@ -707,20 +684,6 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 		},
 		{
 			name: "add a CPG which does not match the pod's CPG hierarchy (CPG=false)",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-1").Obj(),
-			},
-			cpgs: []*schedulingv1alpha3.CompositePodGroup{
-				st.MakeCompositePodGroup().Namespace("default").Name("cpg-1").Obj(),
-				st.MakeCompositePodGroup().Namespace("default").Name("cpg-2").Obj(),
-			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-2").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name: "add a CPG which does not match the pod's CPG hierarchy",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-1").Obj(),
@@ -792,6 +755,237 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 			pl := p.(*GangScheduling)
 
 			hint, err := pl.isSchedulableAfterCompositePodGroupAdded(logger, tc.pod, nil, tc.newCPG)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if hint != tc.expectedHint {
+				t.Errorf("expected hint %v, got %v", tc.expectedHint, hint)
+			}
+		})
+	}
+}
+
+func Test_isSchedulableAfterCompositePodGroupUpdated(t *testing.T) {
+	tests := []struct {
+		name                       string
+		pod                        *v1.Pod
+		oldCPG                     *schedulingv1alpha3.CompositePodGroup
+		newCPG                     *schedulingv1alpha3.CompositePodGroup
+		cpgs                       []*schedulingv1alpha3.CompositePodGroup
+		pgs                        []*schedulingv1beta1.PodGroup
+		expectedHint               fwk.QueueingHint
+		isCompositePodGroupEnabled bool
+	}{
+		{
+			name: "minGroupCount decreased matches target pod's root CPG",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.Queue,
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name: "minGroupCount decreased matches target pod's root CPG (CPG=false)",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.QueueSkip,
+			isCompositePodGroupEnabled: false,
+		},
+		{
+			name: "update Basic policy",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").BasicPolicy().Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").BasicPolicy().Obj(),
+			expectedHint:               fwk.QueueSkip,
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name: "minGroupCount increased matches target pod's root CPG",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			expectedHint:               fwk.QueueSkip,
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name: "minGroupCount unchanged matches target pod's root CPG",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.QueueSkip,
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name: "minGroupCount decreased does not match target pod",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-other").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.QueueSkip,
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name: "minGroupCount decreased on intermediate CPG not in pod's direct path but in same root hierarchy",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub1").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub1").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.Queue,
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name: "minGroupCount decreased on intermediate CPG not in pod's direct path but in same root hierarchy (CPG=false)",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub1").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub1").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.QueueSkip,
+			isCompositePodGroupEnabled: false,
+		},
+		{
+			name: "minGroupCount decreased on intermediate CPG when pod is directly under root CPG",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.Queue,
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name: "minGroupCount unchanged on intermediate CPG not in pod's direct path but in same root hierarchy",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub1").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub1").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.QueueSkip,
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name: "minGroupCount decreased on intermediate CPG when pod is directly under root CPG (CPG=false)",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.QueueSkip,
+			isCompositePodGroupEnabled: false,
+		},
+		{
+			name: "minGroupCount unchanged on intermediate CPG not in pod's direct path but in same root hierarchy (CPG=false)",
+			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub1").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub1").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.QueueSkip,
+			isCompositePodGroupEnabled: false,
+		},
+		{
+			name:                       "pod without a scheduling group is skipped",
+			pod:                        st.MakePod().Namespace("default").Name("p").Obj(),
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.QueueSkip,
+			isCompositePodGroupEnabled: true,
+		},
+		{
+			name:                       "pod without a scheduling group is skipped (CPG=false)",
+			pod:                        st.MakePod().Namespace("default").Name("p").Obj(),
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.QueueSkip,
+			isCompositePodGroupEnabled: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareWorkloadScheduling, true)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CompositePodGroup, tc.isCompositePodGroupEnabled)
+			logger, ctx := ktesting.NewTestContext(t)
+
+			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
+			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+				frameworkruntime.WithInformerFactory(informerFactory),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
+			if err == nil {
+				pgMap := make(map[string]*schedulingv1beta1.PodGroup)
+				for _, pg := range tc.pgs {
+					pgMap[pg.Name] = pg
+				}
+				cpgMap := make(map[string]*schedulingv1alpha3.CompositePodGroup)
+				for _, cpg := range tc.cpgs {
+					cpgMap[cpg.Name] = cpg
+				}
+				if tc.oldCPG != nil {
+					cpgMap[tc.oldCPG.Name] = tc.oldCPG
+				}
+				if tc.newCPG != nil {
+					cpgMap[tc.newCPG.Name] = tc.newCPG
+				}
+				p.(*GangScheduling).podGroupManager = &mockPodGroupManager{pgs: pgMap, cpgs: cpgMap}
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			pl := p.(*GangScheduling)
+
+			hint, err := pl.isSchedulableAfterCompositePodGroupUpdated(logger, tc.pod, tc.oldCPG, tc.newCPG)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -346,65 +346,150 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 
 func Test_isSchedulableAfterPodGroupUpdated(t *testing.T) {
 	tests := []struct {
-		name         string
-		pod          *v1.Pod
-		oldPodGroup  *schedulingv1beta1.PodGroup
-		newPodGroup  *schedulingv1beta1.PodGroup
-		expectedHint fwk.QueueingHint
-		expectErr    bool
+		name                       string
+		isCompositePodGroupEnabled []bool
+		pod                        *v1.Pod
+		oldPodGroup                *schedulingv1beta1.PodGroup
+		newPodGroup                *schedulingv1beta1.PodGroup
+		cpgs                       []*schedulingv1alpha3.CompositePodGroup
+		pgs                        []*schedulingv1beta1.PodGroup
+		expectedHint               fwk.QueueingHint
+		expectErr                  bool
 	}{
 		{
-			name:         "minCount decreased matches target pod",
-			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			name:                       "minCount decreased matches target pod",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
+			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			expectedHint:               fwk.Queue,
+		},
+		{
+			name:                       "update Basic policy",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().WorkloadRef("t", "w").Obj(),
+			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().WorkloadRef("t", "w").Label("foo", "bar").Obj(),
+			expectedHint:               fwk.QueueSkip,
+		},
+		{
+			name:                       "minCount increased matches target pod",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
+			expectedHint:               fwk.QueueSkip,
+		},
+		{
+			name:                       "minCount unchanged matches target pod",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Label("foo", "bar").Obj(),
+			expectedHint:               fwk.QueueSkip,
+		},
+		{
+			name:                       "minCount decreased but pod group name doesn't match target pod",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg-other").Obj(),
+			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
+			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			expectedHint:               fwk.QueueSkip,
+		},
+		{
+			name:                       "minCount decreased but pod group namespace doesn't match target pod",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Namespace("ns-other").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
+			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			expectedHint:               fwk.QueueSkip,
+		},
+		{
+			name:                       "pod without a scheduling group is skipped",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").Obj(),
+			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
+			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			expectedHint:               fwk.QueueSkip,
+		},
+		{
+			name:                       "minCount decreased on sibling PodGroup in same CPG hierarchy",
+			isCompositePodGroupEnabled: []bool{true},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg1").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("ns1").Name("pg1").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root").Obj(),
+			},
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg2").ParentCompositePodGroup("cpg-root").MinCount(4).Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg2").ParentCompositePodGroup("cpg-root").MinCount(3).Obj(),
 			expectedHint: fwk.Queue,
 		},
 		{
-			name:         "update Basic policy",
-			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().WorkloadRef("t", "w").Obj(),
-			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().Obj(),
+			name:                       "minCount decreased on sibling PodGroup in same CPG hierarchy (CPG disabled)",
+			isCompositePodGroupEnabled: []bool{false},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg1").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("ns1").Name("pg1").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root").Obj(),
+			},
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg2").ParentCompositePodGroup("cpg-root").MinCount(4).Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg2").ParentCompositePodGroup("cpg-root").MinCount(3).Obj(),
 			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:         "minCount increased matches target pod",
-			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
+			name:                       "minCount decreased on cousin PodGroup under same root CPG",
+			isCompositePodGroupEnabled: []bool{true},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg1").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("ns1").Name("pg1").ParentCompositePodGroup("cpg-mid1").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-mid1").ParentCompositePodGroup("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-mid2").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg2").ParentCompositePodGroup("cpg-mid2").MinCount(4).Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg2").ParentCompositePodGroup("cpg-mid2").MinCount(3).Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:                       "minCount decreased on cousin PodGroup under same root CPG (CPG disabled)",
+			isCompositePodGroupEnabled: []bool{false},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg1").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("ns1").Name("pg1").ParentCompositePodGroup("cpg-mid1").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-mid1").ParentCompositePodGroup("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-mid2").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg2").ParentCompositePodGroup("cpg-mid2").MinCount(4).Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg2").ParentCompositePodGroup("cpg-mid2").MinCount(3).Obj(),
 			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:         "minCount unchanged matches target pod",
-			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint: fwk.QueueSkip,
-		},
-		{
-			name:         "minCount decreased but pod group name doesn't match target pod",
-			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg-other").Obj(),
-			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint: fwk.QueueSkip,
-		},
-		{
-			name:         "minCount decreased but pod group namespace doesn't match target pod",
-			pod:          st.MakePod().Namespace("ns-other").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint: fwk.QueueSkip,
-		},
-		{
-			name:         "pod without a scheduling group is skipped",
-			pod:          st.MakePod().Namespace("ns1").Name("p").Obj(),
-			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			name:                       "minCount decreased on PodGroup in different CPG hierarchy",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg1").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("ns1").Name("pg1").ParentCompositePodGroup("cpg-root1").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root1").Obj(),
+				st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root2").Obj(),
+			},
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg2").ParentCompositePodGroup("cpg-root2").MinCount(4).Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg2").ParentCompositePodGroup("cpg-root2").MinCount(3).Obj(),
 			expectedHint: fwk.QueueSkip,
 		},
 	}
 	for _, tc := range tests {
-		for _, isCPGEnabled := range []bool{true, false} {
+		for _, isCPGEnabled := range tc.isCompositePodGroupEnabled {
 			t.Run(fmt.Sprintf("%s (CPG enabled: %v)", tc.name, isCPGEnabled), func(t *testing.T) {
 				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 					features.GenericWorkload:                 true,
@@ -427,6 +512,9 @@ func Test_isSchedulableAfterPodGroupUpdated(t *testing.T) {
 				}
 
 				pgMap := make(map[string]*schedulingv1beta1.PodGroup)
+				for _, pg := range tc.pgs {
+					pgMap[pg.Name] = pg
+				}
 				if tc.oldPodGroup != nil {
 					pgMap[tc.oldPodGroup.Name] = tc.oldPodGroup
 				}
@@ -434,6 +522,9 @@ func Test_isSchedulableAfterPodGroupUpdated(t *testing.T) {
 					pgMap[tc.newPodGroup.Name] = tc.newPodGroup
 				}
 				cpgMap := make(map[string]*schedulingv1alpha3.CompositePodGroup)
+				for _, cpg := range tc.cpgs {
+					cpgMap[cpg.Name] = cpg
+				}
 				p.(*GangScheduling).podGroupManager = &mockPodGroupManager{pgs: pgMap, cpgs: cpgMap}
 				actualHint, err := p.(*GangScheduling).isSchedulableAfterPodGroupUpdated(logger, tc.pod, tc.oldPodGroup, tc.newPodGroup)
 				if tc.expectErr {
@@ -602,6 +693,278 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func Test_isSchedulableAfterCompositePodGroupUpdated(t *testing.T) {
+	tests := []struct {
+		name                       string
+		isCompositePodGroupEnabled bool
+		pod                        *v1.Pod
+		oldCPG                     interface{}
+		newCPG                     interface{}
+		cpgs                       []*schedulingv1alpha3.CompositePodGroup
+		pgs                        []*schedulingv1beta1.PodGroup
+		expectedHint               fwk.QueueingHint
+		expectErr                  bool
+	}{
+		{
+			name:                       "util.As conversion error",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			oldCPG:                     "invalid-cpg",
+			newCPG:                     "invalid-cpg",
+			expectedHint:               fwk.Queue,
+			expectErr:                  true,
+		},
+		{
+			name:                       "minGroupCount decreased matches target pod's root CPG",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:                       "minGroupCount decreased matches target pod's root CPG (CPG=false)",
+			isCompositePodGroupEnabled: false,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:                       "update Basic policy",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").BasicPolicy().Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").BasicPolicy().Label("foo", "bar").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:                       "minGroupCount increased matches target pod's root CPG",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:                       "minGroupCount unchanged matches target pod's root CPG",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Label("foo", "bar").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:                       "minGroupCount decreased does not match target pod",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-other").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:                       "minGroupCount decreased but pod's root and updated CPG root are in different hierarchies",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-other-root").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-other-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:                       "minGroupCount decreased but CPG namespace does not match target pod",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("ns-other").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("ns-other").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("ns-other").Name("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:                       "minGroupCount decreased on intermediate CPG not in pod's direct path but in same root hierarchy",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub1").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub1").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:                       "minGroupCount decreased on intermediate CPG not in pod's direct path but in same root hierarchy (CPG=false)",
+			isCompositePodGroupEnabled: false,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub1").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub1").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:                       "minGroupCount decreased on intermediate CPG when pod is directly under root CPG",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint: fwk.Queue,
+		},
+		{
+			name:                       "minGroupCount unchanged on intermediate CPG not in pod's direct path but in same root hierarchy",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub1").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub1").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Label("foo", "bar").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:                       "minGroupCount decreased on intermediate CPG when pod is directly under root CPG (CPG=false)",
+			isCompositePodGroupEnabled: false,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:                       "minGroupCount unchanged on intermediate CPG not in pod's direct path but in same root hierarchy (CPG=false)",
+			isCompositePodGroupEnabled: false,
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			pgs: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub1").Obj(),
+			},
+			cpgs: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+				st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub1").ParentCompositePodGroup("cpg-root").Obj(),
+			},
+			oldCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Obj(),
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").MinGroupCount(3).Label("foo", "bar").Obj(),
+			expectedHint: fwk.QueueSkip,
+		},
+		{
+			name:                       "pod without a scheduling group is skipped",
+			isCompositePodGroupEnabled: true,
+			pod:                        st.MakePod().Namespace("default").Name("p").Obj(),
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.QueueSkip,
+		},
+		{
+			name:                       "pod without a scheduling group is skipped (CPG=false)",
+			isCompositePodGroupEnabled: false,
+			pod:                        st.MakePod().Namespace("default").Name("p").Obj(),
+			oldCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(4).Obj(),
+			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").MinGroupCount(3).Obj(),
+			expectedHint:               fwk.QueueSkip,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 true,
+				features.TopologyAwareWorkloadScheduling: true,
+				features.CompositePodGroup:               tc.isCompositePodGroupEnabled,
+			})
+			logger, ctx := ktesting.NewTestContext(t)
+
+			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
+			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+				frameworkruntime.WithInformerFactory(informerFactory),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			pgMap := make(map[string]*schedulingv1beta1.PodGroup)
+			for _, pg := range tc.pgs {
+				pgMap[pg.Name] = pg
+			}
+			cpgMap := make(map[string]*schedulingv1alpha3.CompositePodGroup)
+			for _, cpg := range tc.cpgs {
+				cpgMap[cpg.Name] = cpg
+			}
+			if oldCPG, ok := tc.oldCPG.(*schedulingv1alpha3.CompositePodGroup); ok && oldCPG != nil {
+				cpgMap[oldCPG.Name] = oldCPG
+			}
+			if newCPG, ok := tc.newCPG.(*schedulingv1alpha3.CompositePodGroup); ok && newCPG != nil {
+				cpgMap[newCPG.Name] = newCPG
+			}
+			pl := p.(*GangScheduling)
+			pl.podGroupManager = &mockPodGroupManager{pgs: pgMap, cpgs: cpgMap}
+
+			hint, err := pl.isSchedulableAfterCompositePodGroupUpdated(logger, tc.pod, tc.oldCPG, tc.newCPG)
+			if (err != nil) != tc.expectErr {
+				t.Fatalf("isSchedulableAfterCompositePodGroupUpdated() error = %v, expectErr %v", err, tc.expectErr)
+			}
+			if hint != tc.expectedHint {
+				t.Errorf("expected hint %v, got %v", tc.expectedHint, hint)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -1615,6 +1615,15 @@ func (wrapper *PodGroupWrapper) UID(uid types.UID) *PodGroupWrapper {
 	return wrapper
 }
 
+// Label sets a {k,v} pair to the inner PodGroup label.
+func (wrapper *PodGroupWrapper) Label(k, v string) *PodGroupWrapper {
+	if wrapper.PodGroup.Labels == nil {
+		wrapper.PodGroup.Labels = make(map[string]string)
+	}
+	wrapper.PodGroup.Labels[k] = v
+	return wrapper
+}
+
 // Obj returns the inner PodGroup.
 func (wrapper *PodGroupWrapper) Obj() *schedulingv1beta1.PodGroup {
 	return &wrapper.PodGroup
@@ -1902,6 +1911,15 @@ func (wrapper *CompositePodGroupWrapper) Namespace(namespace string) *CompositeP
 // UID sets the UID of the inner CompositePodGroup.
 func (wrapper *CompositePodGroupWrapper) UID(uid string) *CompositePodGroupWrapper {
 	wrapper.CompositePodGroup.UID = types.UID(uid)
+	return wrapper
+}
+
+// Label sets a {k,v} pair to the inner CompositePodGroup label.
+func (wrapper *CompositePodGroupWrapper) Label(k, v string) *CompositePodGroupWrapper {
+	if wrapper.CompositePodGroup.Labels == nil {
+		wrapper.CompositePodGroup.Labels = make(map[string]string)
+	}
+	wrapper.CompositePodGroup.Labels[k] = v
 	return wrapper
 }
 

--- a/staging/src/k8s.io/api/scheduling/v1alpha3/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha3/generated.proto
@@ -72,7 +72,15 @@ message CompositeDisruptionMode {
 message CompositeGangSchedulingPolicy {
   // minGroupCount is the minimum number of child groups that must be schedulable
   // or scheduled at the same time for the scheduler to admit the entire group.
-  // It must be a positive integer.
+  // It must be a positive integer. This field is mutable to support workload scaling.
+  //
+  // Note that the scheduler operates on an eventually consistent model. Updates
+  // to minGroupCount may not be immediately reflected in scheduling decisions due to
+  // propagation delays. If minGroupCount is updated while a scheduling cycle is in
+  // progress for that group, the new value may not take effect until the next
+  // cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that
+  // modifications to this field do not affect already-scheduled pods, applying
+  // only to those evaluated in future cycles.
   //
   // +required
   // +k8s:required
@@ -128,11 +136,14 @@ message CompositePodGroupSchedulingConstraints {
 
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 //
 // +union
 message CompositePodGroupSchedulingPolicy {
   // basic specifies that the groups of this composite group should be scheduled independently.
-  // This field is immutable.
+  // Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
   //
   // +optional
   // +k8s:optional
@@ -141,7 +152,9 @@ message CompositePodGroupSchedulingPolicy {
   optional CompositeBasicSchedulingPolicy basic = 1;
 
   // gang specifies that the groups of this composite group should be scheduled using
-  // all-or-nothing semantics.
+  // all-or-nothing semantics. Setting this field at group creation time
+  // opts this group to gang scheduling; this field cannot be set or unset afterward.
+  // The minGroupCount field within Gang scheduling policy remains mutable after group creation.
   //
   // +optional
   // +k8s:optional
@@ -176,10 +189,8 @@ message CompositePodGroupSpec {
 
   // schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup.
   // Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.
-  // This field is immutable.
   //
   // +required
-  // +k8s:immutable
   optional CompositePodGroupSchedulingPolicy schedulingPolicy = 3;
 
   // schedulingConstraints defines optional scheduling constraints (e.g. topology) for this CompositePodGroup.

--- a/staging/src/k8s.io/api/scheduling/v1alpha3/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1alpha3/generated.proto
@@ -72,7 +72,15 @@ message CompositeDisruptionMode {
 message CompositeGangSchedulingPolicy {
   // minGroupCount is the minimum number of child groups that must be schedulable
   // or scheduled at the same time for the scheduler to admit the entire group.
-  // It must be a positive integer.
+  // It must be a positive integer. This field is mutable to support workload scaling.
+  //
+  // Note that the scheduler operates on an eventually consistent model. Updates
+  // to minGroupCount may not be immediately reflected in scheduling decisions due to
+  // propagation delays. If minGroupCount is updated while a scheduling cycle is in
+  // progress for that group, the new value may not take effect until the next
+  // cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that
+  // modifications to this field do not affect already-scheduled pods, applying
+  // only to those evaluated in future cycles.
   //
   // +required
   // +k8s:required
@@ -128,11 +136,14 @@ message CompositePodGroupSchedulingConstraints {
 
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 //
 // +union
 message CompositePodGroupSchedulingPolicy {
   // basic specifies that the groups of this composite group should be scheduled independently.
-  // This field is immutable.
+  // Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
   //
   // +optional
   // +k8s:optional
@@ -141,7 +152,9 @@ message CompositePodGroupSchedulingPolicy {
   optional CompositeBasicSchedulingPolicy basic = 1;
 
   // gang specifies that the groups of this composite group should be scheduled using
-  // all-or-nothing semantics.
+  // all-or-nothing semantics. Setting this field at group creation time
+  // opts this group to gang scheduling; this field cannot be set or unset afterward.
+  // The minGroupCount field within Gang scheduling policy remains mutable after group creation.
   //
   // +optional
   // +k8s:optional
@@ -176,10 +189,8 @@ message CompositePodGroupSpec {
 
   // schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup.
   // Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.
-  // This field is immutable.
   //
   // +required
-  // +k8s:immutable
   optional CompositePodGroupSchedulingPolicy schedulingPolicy = 3;
 
   // schedulingConstraints defines optional scheduling constraints (e.g. topology) for this CompositePodGroup.
@@ -1331,7 +1342,8 @@ message WorkloadSpec {
   repeated PodGroupTemplate podGroupTemplates = 2;
 
   // compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload.
-  // The maximum number of templates is 8. This field is immutable.
+  // The maximum number of templates is 8. Templates cannot be added or removed after the workload is created.
+  // Existing templates may still be updated where their individual fields allow it.
   // Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.
   //
   // This field is used only when the CompositePodGroup feature gate is enabled.

--- a/staging/src/k8s.io/api/scheduling/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha3/types.go
@@ -1233,10 +1233,8 @@ type CompositePodGroupSpec struct {
 
 	// schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup.
 	// Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.
-	// This field is immutable.
 	//
 	// +required
-	// +k8s:immutable
 	SchedulingPolicy CompositePodGroupSchedulingPolicy `json:"schedulingPolicy" protobuf:"bytes,3,opt,name=schedulingPolicy"`
 
 	// schedulingConstraints defines optional scheduling constraints (e.g. topology) for this CompositePodGroup.
@@ -1302,11 +1300,14 @@ type CompositePodGroupSpec struct {
 
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 //
 // +union
 type CompositePodGroupSchedulingPolicy struct {
 	// basic specifies that the groups of this composite group should be scheduled independently.
-	// This field is immutable.
+	// Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
 	//
 	// +optional
 	// +k8s:optional
@@ -1315,7 +1316,9 @@ type CompositePodGroupSchedulingPolicy struct {
 	Basic *CompositeBasicSchedulingPolicy `json:"basic,omitempty" protobuf:"bytes,1,opt,name=basic"`
 
 	// gang specifies that the groups of this composite group should be scheduled using
-	// all-or-nothing semantics.
+	// all-or-nothing semantics. Setting this field at group creation time
+	// opts this group to gang scheduling; this field cannot be set or unset afterward.
+	// The minGroupCount field within Gang scheduling policy remains mutable after group creation.
 	//
 	// +optional
 	// +k8s:optional
@@ -1339,7 +1342,15 @@ type CompositeBasicSchedulingPolicy struct {
 type CompositeGangSchedulingPolicy struct {
 	// minGroupCount is the minimum number of child groups that must be schedulable
 	// or scheduled at the same time for the scheduler to admit the entire group.
-	// It must be a positive integer.
+	// It must be a positive integer. This field is mutable to support workload scaling.
+	//
+	// Note that the scheduler operates on an eventually consistent model. Updates
+	// to minGroupCount may not be immediately reflected in scheduling decisions due to
+	// propagation delays. If minGroupCount is updated while a scheduling cycle is in
+	// progress for that group, the new value may not take effect until the next
+	// cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that
+	// modifications to this field do not affect already-scheduled pods, applying
+	// only to those evaluated in future cycles.
 	//
 	// +required
 	// +k8s:required

--- a/staging/src/k8s.io/api/scheduling/v1alpha3/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha3/types.go
@@ -92,7 +92,8 @@ type WorkloadSpec struct {
 	PodGroupTemplates []PodGroupTemplate `json:"podGroupTemplates" protobuf:"bytes,2,rep,name=podGroupTemplates"`
 
 	// compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload.
-	// The maximum number of templates is 8. This field is immutable.
+	// The maximum number of templates is 8. Templates cannot be added or removed after the workload is created.
+	// Existing templates may still be updated where their individual fields allow it.
 	// Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.
 	//
 	// This field is used only when the CompositePodGroup feature gate is enabled.
@@ -1233,10 +1234,8 @@ type CompositePodGroupSpec struct {
 
 	// schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup.
 	// Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.
-	// This field is immutable.
 	//
 	// +required
-	// +k8s:immutable
 	SchedulingPolicy CompositePodGroupSchedulingPolicy `json:"schedulingPolicy" protobuf:"bytes,3,opt,name=schedulingPolicy"`
 
 	// schedulingConstraints defines optional scheduling constraints (e.g. topology) for this CompositePodGroup.
@@ -1302,11 +1301,14 @@ type CompositePodGroupSpec struct {
 
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 //
 // +union
 type CompositePodGroupSchedulingPolicy struct {
 	// basic specifies that the groups of this composite group should be scheduled independently.
-	// This field is immutable.
+	// Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
 	//
 	// +optional
 	// +k8s:optional
@@ -1315,7 +1317,9 @@ type CompositePodGroupSchedulingPolicy struct {
 	Basic *CompositeBasicSchedulingPolicy `json:"basic,omitempty" protobuf:"bytes,1,opt,name=basic"`
 
 	// gang specifies that the groups of this composite group should be scheduled using
-	// all-or-nothing semantics.
+	// all-or-nothing semantics. Setting this field at group creation time
+	// opts this group to gang scheduling; this field cannot be set or unset afterward.
+	// The minGroupCount field within Gang scheduling policy remains mutable after group creation.
 	//
 	// +optional
 	// +k8s:optional
@@ -1339,7 +1343,15 @@ type CompositeBasicSchedulingPolicy struct {
 type CompositeGangSchedulingPolicy struct {
 	// minGroupCount is the minimum number of child groups that must be schedulable
 	// or scheduled at the same time for the scheduler to admit the entire group.
-	// It must be a positive integer.
+	// It must be a positive integer. This field is mutable to support workload scaling.
+	//
+	// Note that the scheduler operates on an eventually consistent model. Updates
+	// to minGroupCount may not be immediately reflected in scheduling decisions due to
+	// propagation delays. If minGroupCount is updated while a scheduling cycle is in
+	// progress for that group, the new value may not take effect until the next
+	// cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that
+	// modifications to this field do not affect already-scheduled pods, applying
+	// only to those evaluated in future cycles.
 	//
 	// +required
 	// +k8s:required

--- a/staging/src/k8s.io/api/scheduling/v1alpha3/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha3/types_swagger_doc_generated.go
@@ -71,7 +71,7 @@ func (CompositeDisruptionMode) SwaggerDoc() map[string]string {
 
 var map_CompositeGangSchedulingPolicy = map[string]string{
 	"":              "CompositeGangSchedulingPolicy indicates that the groups belonging to the composite group should be scheduled using all-or-nothing semantics.",
-	"minGroupCount": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+	"minGroupCount": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
 }
 
 func (CompositeGangSchedulingPolicy) SwaggerDoc() map[string]string {
@@ -109,9 +109,9 @@ func (CompositePodGroupSchedulingConstraints) SwaggerDoc() map[string]string {
 }
 
 var map_CompositePodGroupSchedulingPolicy = map[string]string{
-	"":      "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
-	"basic": "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable.",
-	"gang":  "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics.",
+	"":      "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
+	"basic": "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.",
+	"gang":  "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation.",
 }
 
 func (CompositePodGroupSchedulingPolicy) SwaggerDoc() map[string]string {
@@ -122,7 +122,7 @@ var map_CompositePodGroupSpec = map[string]string{
 	"":                            "CompositePodGroupSpec defines the desired state of CompositePodGroup.",
 	"parentCompositePodGroupName": "parentCompositePodGroupName contains the name of the parent composite pod group within the same namespace as this composite pod group. It must be a DNS name. If it's nil, then this composite pod group is a root of a workload's hierarchy. This field is immutable.",
 	"workloadRef":                 "workloadRef references an optional CompositePodGroup template within the Workload object that was used to create the CompositePodGroup. This field is required. This field is immutable.",
-	"schedulingPolicy":            "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. This field is immutable.",
+	"schedulingPolicy":            "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.",
 	"schedulingConstraints":       "schedulingConstraints defines optional scheduling constraints (e.g. topology) for this CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. This field is immutable.",
 	"disruptionMode":              "disruptionMode defines the mode in which a given CompositePodGroup can be disrupted. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. One of Single, All. Defaults to Single if unset. This field is immutable.",
 	"priorityClassName":           "priorityClassName defines the priority that should be considered when scheduling this CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. If left unspecified, it is validated and resolved similarly to the PriorityClassName field in Pods (i.e. if no priority class is specified, admission control can set this to the global default priority class if it exists. Otherwise, the composite pod group's priority will be zero). This field is immutable.",

--- a/staging/src/k8s.io/api/scheduling/v1alpha3/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha3/types_swagger_doc_generated.go
@@ -71,7 +71,7 @@ func (CompositeDisruptionMode) SwaggerDoc() map[string]string {
 
 var map_CompositeGangSchedulingPolicy = map[string]string{
 	"":              "CompositeGangSchedulingPolicy indicates that the groups belonging to the composite group should be scheduled using all-or-nothing semantics.",
-	"minGroupCount": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+	"minGroupCount": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
 }
 
 func (CompositeGangSchedulingPolicy) SwaggerDoc() map[string]string {
@@ -109,9 +109,9 @@ func (CompositePodGroupSchedulingConstraints) SwaggerDoc() map[string]string {
 }
 
 var map_CompositePodGroupSchedulingPolicy = map[string]string{
-	"":      "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
-	"basic": "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable.",
-	"gang":  "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics.",
+	"":      "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
+	"basic": "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.",
+	"gang":  "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation.",
 }
 
 func (CompositePodGroupSchedulingPolicy) SwaggerDoc() map[string]string {
@@ -122,7 +122,7 @@ var map_CompositePodGroupSpec = map[string]string{
 	"":                            "CompositePodGroupSpec defines the desired state of CompositePodGroup.",
 	"parentCompositePodGroupName": "parentCompositePodGroupName contains the name of the parent composite pod group within the same namespace as this composite pod group. It must be a DNS name. If it's nil, then this composite pod group is a root of a workload's hierarchy. This field is immutable.",
 	"workloadRef":                 "workloadRef references an optional CompositePodGroup template within the Workload object that was used to create the CompositePodGroup. This field is required. This field is immutable.",
-	"schedulingPolicy":            "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. This field is immutable.",
+	"schedulingPolicy":            "schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.",
 	"schedulingConstraints":       "schedulingConstraints defines optional scheduling constraints (e.g. topology) for this CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. This field is immutable.",
 	"disruptionMode":              "disruptionMode defines the mode in which a given CompositePodGroup can be disrupted. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. One of Single, All. Defaults to Single if unset. This field is immutable.",
 	"priorityClassName":           "priorityClassName defines the priority that should be considered when scheduling this CompositePodGroup. Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate. If left unspecified, it is validated and resolved similarly to the PriorityClassName field in Pods (i.e. if no priority class is specified, admission control can set this to the global default priority class if it exists. Otherwise, the composite pod group's priority will be zero). This field is immutable.",
@@ -488,7 +488,7 @@ var map_WorkloadSpec = map[string]string{
 	"":                           "WorkloadSpec defines the desired state of a Workload.",
 	"controllerRef":              "controllerRef is an optional reference to the controlling object, such as a Deployment or Job. This field is intended for use by tools like CLIs to provide a link back to the original workload definition. This field is immutable.",
 	"podGroupTemplates":          "podGroupTemplates is the list of templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.",
-	"compositePodGroupTemplates": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. This field is immutable. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
+	"compositePodGroupTemplates": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
 }
 
 func (WorkloadSpec) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/scheduling/v1alpha3/zz_generated.validations.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha3/zz_generated.validations.go
@@ -460,15 +460,6 @@ func Validate_CompositePodGroupSpec(
 					return nil
 				}
 			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// call the type's validation function
 			errs = append(errs, Validate_CompositePodGroupSchedulingPolicy(ctx, op, fldPath, obj, oldObj)...)
 			return

--- a/staging/src/k8s.io/api/scheduling/v1alpha3/zz_generated.validations.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha3/zz_generated.validations.go
@@ -459,15 +459,6 @@ func Validate_CompositePodGroupSpec(
 					return nil
 				}
 			}
-			// call field-attached validations
-			earlyReturn := false
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
-				errs = append(errs, e...)
-				earlyReturn = true
-			}
-			if earlyReturn {
-				return // do not proceed
-			}
 			// call the type's validation function
 			errs = append(errs, Validate_CompositePodGroupSchedulingPolicy(ctx, op, fldPath, obj, oldObj)...)
 			return

--- a/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
@@ -73,7 +73,15 @@ message CompositeDisruptionMode {
 message CompositeGangSchedulingPolicy {
   // minGroupCount is the minimum number of child groups that must be schedulable
   // or scheduled at the same time for the scheduler to admit the entire group.
-  // It must be a positive integer.
+  // It must be a positive integer. This field is mutable to support workload scaling.
+  //
+  // Note that the scheduler operates on an eventually consistent model. Updates
+  // to minGroupCount may not be immediately reflected in scheduling decisions due to
+  // propagation delays. If minGroupCount is updated while a scheduling cycle is in
+  // progress for that group, the new value may not take effect until the next
+  // cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that
+  // modifications to this field do not affect already-scheduled pods, applying
+  // only to those evaluated in future cycles.
   //
   // +required
   // +k8s:required
@@ -96,11 +104,14 @@ message CompositePodGroupSchedulingConstraints {
 
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 //
 // +union
 message CompositePodGroupSchedulingPolicy {
   // basic specifies that the groups of this composite group should be scheduled independently.
-  // This field is immutable.
+  // Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
   //
   // +optional
   // +k8s:optional
@@ -109,7 +120,9 @@ message CompositePodGroupSchedulingPolicy {
   optional CompositeBasicSchedulingPolicy basic = 1;
 
   // gang specifies that the groups of this composite group should be scheduled using
-  // all-or-nothing semantics.
+  // all-or-nothing semantics. Setting this field at group creation time
+  // opts this group to gang scheduling; this field cannot be set or unset afterward.
+  // The minGroupCount field within Gang scheduling policy remains mutable after group creation.
   //
   // +optional
   // +k8s:optional

--- a/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/generated.proto
@@ -73,7 +73,15 @@ message CompositeDisruptionMode {
 message CompositeGangSchedulingPolicy {
   // minGroupCount is the minimum number of child groups that must be schedulable
   // or scheduled at the same time for the scheduler to admit the entire group.
-  // It must be a positive integer.
+  // It must be a positive integer. This field is mutable to support workload scaling.
+  //
+  // Note that the scheduler operates on an eventually consistent model. Updates
+  // to minGroupCount may not be immediately reflected in scheduling decisions due to
+  // propagation delays. If minGroupCount is updated while a scheduling cycle is in
+  // progress for that group, the new value may not take effect until the next
+  // cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that
+  // modifications to this field do not affect already-scheduled pods, applying
+  // only to those evaluated in future cycles.
   //
   // +required
   // +k8s:required
@@ -96,11 +104,14 @@ message CompositePodGroupSchedulingConstraints {
 
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 //
 // +union
 message CompositePodGroupSchedulingPolicy {
   // basic specifies that the groups of this composite group should be scheduled independently.
-  // This field is immutable.
+  // Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
   //
   // +optional
   // +k8s:optional
@@ -109,7 +120,9 @@ message CompositePodGroupSchedulingPolicy {
   optional CompositeBasicSchedulingPolicy basic = 1;
 
   // gang specifies that the groups of this composite group should be scheduled using
-  // all-or-nothing semantics.
+  // all-or-nothing semantics. Setting this field at group creation time
+  // opts this group to gang scheduling; this field cannot be set or unset afterward.
+  // The minGroupCount field within Gang scheduling policy remains mutable after group creation.
   //
   // +optional
   // +k8s:optional
@@ -846,7 +859,8 @@ message WorkloadSpec {
   repeated PodGroupTemplate podGroupTemplates = 2;
 
   // compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload.
-  // The maximum number of templates is 8. This field is immutable.
+  // The maximum number of templates is 8. Templates cannot be added or removed after the workload is created.
+  // Existing templates may still be updated where their individual fields allow it.
   // Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.
   //
   // This field is used only when the CompositePodGroup feature gate is enabled.

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -858,11 +858,14 @@ type TopologyConstraint struct {
 
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 //
 // +union
 type CompositePodGroupSchedulingPolicy struct {
 	// basic specifies that the groups of this composite group should be scheduled independently.
-	// This field is immutable.
+	// Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
 	//
 	// +optional
 	// +k8s:optional
@@ -871,7 +874,9 @@ type CompositePodGroupSchedulingPolicy struct {
 	Basic *CompositeBasicSchedulingPolicy `json:"basic,omitempty" protobuf:"bytes,1,opt,name=basic"`
 
 	// gang specifies that the groups of this composite group should be scheduled using
-	// all-or-nothing semantics.
+	// all-or-nothing semantics. Setting this field at group creation time
+	// opts this group to gang scheduling; this field cannot be set or unset afterward.
+	// The minGroupCount field within Gang scheduling policy remains mutable after group creation.
 	//
 	// +optional
 	// +k8s:optional
@@ -895,7 +900,15 @@ type CompositeBasicSchedulingPolicy struct {
 type CompositeGangSchedulingPolicy struct {
 	// minGroupCount is the minimum number of child groups that must be schedulable
 	// or scheduled at the same time for the scheduler to admit the entire group.
-	// It must be a positive integer.
+	// It must be a positive integer. This field is mutable to support workload scaling.
+	//
+	// Note that the scheduler operates on an eventually consistent model. Updates
+	// to minGroupCount may not be immediately reflected in scheduling decisions due to
+	// propagation delays. If minGroupCount is updated while a scheduling cycle is in
+	// progress for that group, the new value may not take effect until the next
+	// cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that
+	// modifications to this field do not affect already-scheduled pods, applying
+	// only to those evaluated in future cycles.
 	//
 	// +required
 	// +k8s:required

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -156,7 +156,8 @@ type WorkloadSpec struct {
 	PodGroupTemplates []PodGroupTemplate `json:"podGroupTemplates" protobuf:"bytes,2,rep,name=podGroupTemplates"`
 
 	// compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload.
-	// The maximum number of templates is 8. This field is immutable.
+	// The maximum number of templates is 8. Templates cannot be added or removed after the workload is created.
+	// Existing templates may still be updated where their individual fields allow it.
 	// Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.
 	//
 	// This field is used only when the CompositePodGroup feature gate is enabled.
@@ -858,11 +859,14 @@ type TopologyConstraint struct {
 
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 //
 // +union
 type CompositePodGroupSchedulingPolicy struct {
 	// basic specifies that the groups of this composite group should be scheduled independently.
-	// This field is immutable.
+	// Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
 	//
 	// +optional
 	// +k8s:optional
@@ -871,7 +875,9 @@ type CompositePodGroupSchedulingPolicy struct {
 	Basic *CompositeBasicSchedulingPolicy `json:"basic,omitempty" protobuf:"bytes,1,opt,name=basic"`
 
 	// gang specifies that the groups of this composite group should be scheduled using
-	// all-or-nothing semantics.
+	// all-or-nothing semantics. Setting this field at group creation time
+	// opts this group to gang scheduling; this field cannot be set or unset afterward.
+	// The minGroupCount field within Gang scheduling policy remains mutable after group creation.
 	//
 	// +optional
 	// +k8s:optional
@@ -895,7 +901,15 @@ type CompositeBasicSchedulingPolicy struct {
 type CompositeGangSchedulingPolicy struct {
 	// minGroupCount is the minimum number of child groups that must be schedulable
 	// or scheduled at the same time for the scheduler to admit the entire group.
-	// It must be a positive integer.
+	// It must be a positive integer. This field is mutable to support workload scaling.
+	//
+	// Note that the scheduler operates on an eventually consistent model. Updates
+	// to minGroupCount may not be immediately reflected in scheduling decisions due to
+	// propagation delays. If minGroupCount is updated while a scheduling cycle is in
+	// progress for that group, the new value may not take effect until the next
+	// cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that
+	// modifications to this field do not affect already-scheduled pods, applying
+	// only to those evaluated in future cycles.
 	//
 	// +required
 	// +k8s:required

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types_swagger_doc_generated.go
@@ -71,7 +71,7 @@ func (CompositeDisruptionMode) SwaggerDoc() map[string]string {
 
 var map_CompositeGangSchedulingPolicy = map[string]string{
 	"":              "CompositeGangSchedulingPolicy indicates that the groups belonging to the composite group should be scheduled using all-or-nothing semantics.",
-	"minGroupCount": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+	"minGroupCount": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
 }
 
 func (CompositeGangSchedulingPolicy) SwaggerDoc() map[string]string {
@@ -88,9 +88,9 @@ func (CompositePodGroupSchedulingConstraints) SwaggerDoc() map[string]string {
 }
 
 var map_CompositePodGroupSchedulingPolicy = map[string]string{
-	"":      "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
-	"basic": "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable.",
-	"gang":  "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics.",
+	"":      "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
+	"basic": "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.",
+	"gang":  "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation.",
 }
 
 func (CompositePodGroupSchedulingPolicy) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types_swagger_doc_generated.go
@@ -71,7 +71,7 @@ func (CompositeDisruptionMode) SwaggerDoc() map[string]string {
 
 var map_CompositeGangSchedulingPolicy = map[string]string{
 	"":              "CompositeGangSchedulingPolicy indicates that the groups belonging to the composite group should be scheduled using all-or-nothing semantics.",
-	"minGroupCount": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer.",
+	"minGroupCount": "minGroupCount is the minimum number of child groups that must be schedulable or scheduled at the same time for the scheduler to admit the entire group. It must be a positive integer. This field is mutable to support workload scaling.\n\nNote that the scheduler operates on an eventually consistent model. Updates to minGroupCount may not be immediately reflected in scheduling decisions due to propagation delays. If minGroupCount is updated while a scheduling cycle is in progress for that group, the new value may not take effect until the next cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that modifications to this field do not affect already-scheduled pods, applying only to those evaluated in future cycles.",
 }
 
 func (CompositeGangSchedulingPolicy) SwaggerDoc() map[string]string {
@@ -88,9 +88,9 @@ func (CompositePodGroupSchedulingConstraints) SwaggerDoc() map[string]string {
 }
 
 var map_CompositePodGroupSchedulingPolicy = map[string]string{
-	"":      "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set.",
-	"basic": "basic specifies that the groups of this composite group should be scheduled independently. This field is immutable.",
-	"gang":  "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics.",
+	"":      "CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup. Exactly one policy must be set. The policy is chosen at creation time by setting either the Basic or Gang field. The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated after creation when their individual fields allow it.",
+	"basic": "basic specifies that the groups of this composite group should be scheduled independently. Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.",
+	"gang":  "gang specifies that the groups of this composite group should be scheduled using all-or-nothing semantics. Setting this field at group creation time opts this group to gang scheduling; this field cannot be set or unset afterward. The minGroupCount field within Gang scheduling policy remains mutable after group creation.",
 }
 
 func (CompositePodGroupSchedulingPolicy) SwaggerDoc() map[string]string {
@@ -330,7 +330,7 @@ var map_WorkloadSpec = map[string]string{
 	"":                           "WorkloadSpec defines the desired state of a Workload.",
 	"controllerRef":              "controllerRef is an optional reference to the controlling object, such as a Deployment or Job. This field is intended for use by tools like CLIs to provide a link back to the original workload definition. This field is immutable.",
 	"podGroupTemplates":          "podGroupTemplates is the list of templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.",
-	"compositePodGroupTemplates": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. This field is immutable. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
+	"compositePodGroupTemplates": "compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload. The maximum number of templates is 8. Templates cannot be added or removed after the workload is created. Existing templates may still be updated where their individual fields allow it. Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.\n\nThis field is used only when the CompositePodGroup feature gate is enabled.",
 }
 
 func (WorkloadSpec) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/compositegangschedulingpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/compositegangschedulingpolicy.go
@@ -26,7 +26,15 @@ package v1alpha3
 type CompositeGangSchedulingPolicyApplyConfiguration struct {
 	// minGroupCount is the minimum number of child groups that must be schedulable
 	// or scheduled at the same time for the scheduler to admit the entire group.
-	// It must be a positive integer.
+	// It must be a positive integer. This field is mutable to support workload scaling.
+	//
+	// Note that the scheduler operates on an eventually consistent model. Updates
+	// to minGroupCount may not be immediately reflected in scheduling decisions due to
+	// propagation delays. If minGroupCount is updated while a scheduling cycle is in
+	// progress for that group, the new value may not take effect until the next
+	// cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that
+	// modifications to this field do not affect already-scheduled pods, applying
+	// only to those evaluated in future cycles.
 	MinGroupCount *int32 `json:"minGroupCount,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/compositepodgroupschedulingpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/compositepodgroupschedulingpolicy.go
@@ -27,12 +27,17 @@ import (
 //
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 type CompositePodGroupSchedulingPolicyApplyConfiguration struct {
 	// basic specifies that the groups of this composite group should be scheduled independently.
-	// This field is immutable.
+	// Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
 	Basic *schedulingv1alpha3.CompositeBasicSchedulingPolicy `json:"basic,omitempty"`
 	// gang specifies that the groups of this composite group should be scheduled using
-	// all-or-nothing semantics.
+	// all-or-nothing semantics. Setting this field at group creation time
+	// opts this group to gang scheduling; this field cannot be set or unset afterward.
+	// The minGroupCount field within Gang scheduling policy remains mutable after group creation.
 	Gang *CompositeGangSchedulingPolicyApplyConfiguration `json:"gang,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/compositepodgroupspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/compositepodgroupspec.go
@@ -39,7 +39,6 @@ type CompositePodGroupSpecApplyConfiguration struct {
 	WorkloadRef *WorkloadReferenceApplyConfiguration `json:"workloadRef,omitempty"`
 	// schedulingPolicy defines the scheduling policy for this instance of the CompositePodGroup.
 	// Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.
-	// This field is immutable.
 	SchedulingPolicy *CompositePodGroupSchedulingPolicyApplyConfiguration `json:"schedulingPolicy,omitempty"`
 	// schedulingConstraints defines optional scheduling constraints (e.g. topology) for this CompositePodGroup.
 	// Controllers are expected to fill this field by copying it from a CompositePodGroupTemplate.

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/workloadspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1alpha3/workloadspec.go
@@ -34,7 +34,8 @@ type WorkloadSpecApplyConfiguration struct {
 	// Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.
 	PodGroupTemplates []PodGroupTemplateApplyConfiguration `json:"podGroupTemplates,omitempty"`
 	// compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload.
-	// The maximum number of templates is 8. This field is immutable.
+	// The maximum number of templates is 8. Templates cannot be added or removed after the workload is created.
+	// Existing templates may still be updated where their individual fields allow it.
 	// Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.
 	//
 	// This field is used only when the CompositePodGroup feature gate is enabled.

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/compositegangschedulingpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/compositegangschedulingpolicy.go
@@ -26,7 +26,15 @@ package v1beta1
 type CompositeGangSchedulingPolicyApplyConfiguration struct {
 	// minGroupCount is the minimum number of child groups that must be schedulable
 	// or scheduled at the same time for the scheduler to admit the entire group.
-	// It must be a positive integer.
+	// It must be a positive integer. This field is mutable to support workload scaling.
+	//
+	// Note that the scheduler operates on an eventually consistent model. Updates
+	// to minGroupCount may not be immediately reflected in scheduling decisions due to
+	// propagation delays. If minGroupCount is updated while a scheduling cycle is in
+	// progress for that group, the new value may not take effect until the next
+	// cycle. Moreover, minGroupCount is only enforced during scheduling, meaning that
+	// modifications to this field do not affect already-scheduled pods, applying
+	// only to those evaluated in future cycles.
 	MinGroupCount *int32 `json:"minGroupCount,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/compositepodgroupschedulingpolicy.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/compositepodgroupschedulingpolicy.go
@@ -27,12 +27,17 @@ import (
 //
 // CompositePodGroupSchedulingPolicy defines the scheduling configuration for a CompositePodGroup.
 // Exactly one policy must be set.
+// The policy is chosen at creation time by setting either the Basic or Gang field.
+// The CompositePodGroup may not change policy after creation. Fields within chosen policy may be updated
+// after creation when their individual fields allow it.
 type CompositePodGroupSchedulingPolicyApplyConfiguration struct {
 	// basic specifies that the groups of this composite group should be scheduled independently.
-	// This field is immutable.
+	// Setting this field at group creation time opts this group to basic scheduling; this field cannot be changed afterward.
 	Basic *schedulingv1beta1.CompositeBasicSchedulingPolicy `json:"basic,omitempty"`
 	// gang specifies that the groups of this composite group should be scheduled using
-	// all-or-nothing semantics.
+	// all-or-nothing semantics. Setting this field at group creation time
+	// opts this group to gang scheduling; this field cannot be set or unset afterward.
+	// The minGroupCount field within Gang scheduling policy remains mutable after group creation.
 	Gang *CompositeGangSchedulingPolicyApplyConfiguration `json:"gang,omitempty"`
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/workloadspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/scheduling/v1beta1/workloadspec.go
@@ -34,7 +34,8 @@ type WorkloadSpecApplyConfiguration struct {
 	// Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.
 	PodGroupTemplates []PodGroupTemplateApplyConfiguration `json:"podGroupTemplates,omitempty"`
 	// compositePodGroupTemplates is the list of CompositePodGroup templates that make up the Workload.
-	// The maximum number of templates is 8. This field is immutable.
+	// The maximum number of templates is 8. Templates cannot be added or removed after the workload is created.
+	// Existing templates may still be updated where their individual fields allow it.
 	// Exactly one of CompositePodGroupTemplates and PodGroupTemplates must be set.
 	//
 	// This field is used only when the CompositePodGroup feature gate is enabled.

--- a/test/declarative_validation/scheduling/compositepodgroup/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/compositepodgroup/declarative_validation_test.go
@@ -21,8 +21,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/test/coverage"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -245,11 +243,31 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "priorityClassName"), nil, "").WithOrigin("immutable"),
 			},
 		},
-		"invalid schedulingPolicy update": {
-			oldObj:    mkValidCompositePodGroup(setResourceVersion("1")),
+		"valid update of gang minGroupCount": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(5)),
+			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(3)),
+		},
+		"invalid update of gang minGroupCount": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(5)),
+			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(-1)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang", "minGroupCount"), nil, "").WithOrigin("minimum"),
+			},
+		},
+		"invalid update from gang to basic policy": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(5)),
+			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), setBasicPolicy()),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
+			},
+		},
+		"invalid update from basic to gang policy": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setBasicPolicy()),
 			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(5)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
 			},
 		},
 		"invalid workloadRef update": {
@@ -343,15 +361,6 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	updateObj := mkValidCompositePodGroup(setResourceVersion("1"))
 	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.NewStrategy(), meta.WithStringentFinalizerValidation())
 
-	// Disable checks that are currently impossible to test properly in isolation.
-	// FieldValueInvalid update rules for properties under spec.schedulingPolicy
-	// are impossible to hit because mutations inside the schedulingPolicy fail its top-level
-	// immutable check oldSelf == self, short-circuiting deeper validation.
-	gvk := schema.GroupVersionKind{Group: "scheduling.k8s.io", Version: apiVersion, Kind: "CompositePodGroup"}
-	coverage.RecordObservedRules(gvk, field.ErrorList{
-		field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
-		field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
-	})
 }
 
 func TestDeclarativeValidateStatusUpdate(t *testing.T) {
@@ -511,6 +520,14 @@ func setGangPolicy(minGroupCount int32) func(obj *scheduling.CompositePodGroup) 
 			Gang: &scheduling.CompositeGangSchedulingPolicy{
 				MinGroupCount: minGroupCount,
 			},
+		}
+	}
+}
+
+func setBasicPolicy() func(obj *scheduling.CompositePodGroup) {
+	return func(obj *scheduling.CompositePodGroup) {
+		obj.Spec.SchedulingPolicy = scheduling.CompositePodGroupSchedulingPolicy{
+			Basic: &scheduling.CompositeBasicSchedulingPolicy{},
 		}
 	}
 }

--- a/test/declarative_validation/scheduling/compositepodgroup/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/compositepodgroup/declarative_validation_test.go
@@ -21,8 +21,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/test/coverage"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -77,6 +75,10 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		},
 		"schedulingPolicy invalid union": {
 			input:        mkValidCompositePodGroup(clearSchedulingPolicy()),
+			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("union")},
+		},
+		"policy with both basic and gang": {
+			input:        mkValidCompositePodGroup(setBothPolicies()),
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("union")},
 		},
 		"schedulingPolicy gang minGroupCount zero": {
@@ -245,11 +247,70 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "priorityClassName"), nil, "").WithOrigin("immutable"),
 			},
 		},
-		"invalid schedulingPolicy update": {
-			oldObj:    mkValidCompositePodGroup(setResourceVersion("1")),
+		"valid update of gang minGroupCount": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(5)),
+			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(3)),
+		},
+		"invalid update of gang minGroupCount to 0": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(5)),
+			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(0)),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "schedulingPolicy", "gang", "minGroupCount"), ""),
+			},
+		},
+		"invalid update of gang minGroupCount": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(5)),
+			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(-1)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang", "minGroupCount"), nil, "").WithOrigin("minimum"),
+			},
+		},
+		"invalid update from gang to basic policy": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(5)),
+			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), setBasicPolicy()),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
+			},
+		},
+		"invalid update from basic to gang policy": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setBasicPolicy()),
 			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(5)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
+			},
+		},
+		"invalid update with neither basic nor gang": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(5)),
+			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), clearSchedulingPolicy()),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("union"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
+			},
+		},
+		"invalid update with both basic and gang": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setGangPolicy(5)),
+			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), setBothPolicies()),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("union"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+			},
+		},
+		"invalid update from basic policy with neither basic nor gang": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setBasicPolicy()),
+			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), clearSchedulingPolicy()),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("union"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+			},
+		},
+		"invalid update from basic policy with both basic and gang": {
+			oldObj:    mkValidCompositePodGroup(setResourceVersion("1"), setBasicPolicy()),
+			updateObj: mkValidCompositePodGroup(setResourceVersion("1"), setBothPolicies()),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("union"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
 			},
 		},
 		"invalid workloadRef update": {
@@ -343,15 +404,6 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	updateObj := mkValidCompositePodGroup(setResourceVersion("1"))
 	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.NewStrategy(), meta.WithStringentFinalizerValidation())
 
-	// Disable checks that are currently impossible to test properly in isolation.
-	// FieldValueInvalid update rules for properties under spec.schedulingPolicy
-	// are impossible to hit because mutations inside the schedulingPolicy fail its top-level
-	// immutable check oldSelf == self, short-circuiting deeper validation.
-	gvk := schema.GroupVersionKind{Group: "scheduling.k8s.io", Version: apiVersion, Kind: "CompositePodGroup"}
-	coverage.RecordObservedRules(gvk, field.ErrorList{
-		field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
-		field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
-	})
 }
 
 func TestDeclarativeValidateStatusUpdate(t *testing.T) {
@@ -510,6 +562,25 @@ func setGangPolicy(minGroupCount int32) func(obj *scheduling.CompositePodGroup) 
 		obj.Spec.SchedulingPolicy = scheduling.CompositePodGroupSchedulingPolicy{
 			Gang: &scheduling.CompositeGangSchedulingPolicy{
 				MinGroupCount: minGroupCount,
+			},
+		}
+	}
+}
+
+func setBasicPolicy() func(obj *scheduling.CompositePodGroup) {
+	return func(obj *scheduling.CompositePodGroup) {
+		obj.Spec.SchedulingPolicy = scheduling.CompositePodGroupSchedulingPolicy{
+			Basic: &scheduling.CompositeBasicSchedulingPolicy{},
+		}
+	}
+}
+
+func setBothPolicies() func(obj *scheduling.CompositePodGroup) {
+	return func(obj *scheduling.CompositePodGroup) {
+		obj.Spec.SchedulingPolicy = scheduling.CompositePodGroupSchedulingPolicy{
+			Basic: &scheduling.CompositeBasicSchedulingPolicy{},
+			Gang: &scheduling.CompositeGangSchedulingPolicy{
+				MinGroupCount: 5,
 			},
 		}
 	}

--- a/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/scheduling/compositepodgroup/zz_generated.validations.v1alpha3_test.go
@@ -94,7 +94,6 @@ func init() {
 				{ErrorType: "FieldValueRequired"},
 			},
 			"spec.schedulingPolicy": {
-				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 				{ErrorType: "FieldValueInvalid", Origin: "union"},
 			},
 			"spec.schedulingPolicy.basic": {

--- a/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/podgroup/declarative_validation_test.go
@@ -435,6 +435,13 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
 			},
 		},
+		"invalid update of gang minCount to 0": {
+			oldObj:    mkValidPodGroup(setResourceVersion("1")),
+			updateObj: mkValidPodGroup(setResourceVersion("1"), setPodGroupMinCount(0)),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "schedulingPolicy", "gang", "minCount"), ""),
+			},
+		},
 		"invalid update of gang minCount": {
 			oldObj:    mkValidPodGroup(setResourceVersion("1")),
 			updateObj: mkValidPodGroup(setResourceVersion("1"), setPodGroupMinCount(-1)),
@@ -447,6 +454,30 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			updateObj: mkValidPodGroup(setResourceVersion("1"), setBasicPolicy()),
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
+			},
+		},
+		"invalid update from basic to gang policy": {
+			oldObj:    mkValidPodGroup(setResourceVersion("1"), setBasicPolicy()),
+			updateObj: mkValidPodGroup(setResourceVersion("1")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
+			},
+		},
+		"invalid update from basic policy with neither basic nor gang": {
+			oldObj:    mkValidPodGroup(setResourceVersion("1"), setBasicPolicy()),
+			updateObj: mkValidPodGroup(setResourceVersion("1"), clearPodGroupPolicy()),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("union"),
+				field.Invalid(field.NewPath("spec", "schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+			},
+		},
+		"invalid update from basic policy with both basic and gang": {
+			oldObj:    mkValidPodGroup(setResourceVersion("1"), setBasicPolicy()),
+			updateObj: mkValidPodGroup(setResourceVersion("1"), setBothPolicies()),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "schedulingPolicy"), nil, "").WithOrigin("union"),
 				field.Invalid(field.NewPath("spec", "schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
 			},
 		},

--- a/test/declarative_validation/scheduling/workload/declarative_validation_test.go
+++ b/test/declarative_validation/scheduling/workload/declarative_validation_test.go
@@ -909,6 +909,13 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
 			},
 		},
+		"invalid update of gang minCount to 0": {
+			oldObj:    mkValidWorkload(setResourceVersion("1")),
+			updateObj: mkValidWorkload(setResourceVersion("1"), setPodGroupMinCount(0, 0)),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "gang", "minCount"), ""),
+			},
+		},
 		"invalid update of gang minCount": {
 			oldObj:    mkValidWorkload(setResourceVersion("1")),
 			updateObj: mkValidWorkload(setResourceVersion("1"), setPodGroupMinCount(0, -1)),
@@ -921,6 +928,30 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			updateObj: mkValidWorkload(setResourceVersion("1"), setBasicPolicy(0)),
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
+			},
+		},
+		"invalid update from basic to gang policy": {
+			oldObj:    mkValidWorkload(setResourceVersion("1"), setBasicPolicy(0)),
+			updateObj: mkValidWorkload(setResourceVersion("1")),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
+			},
+		},
+		"invalid update from basic policy with neither basic nor gang": {
+			oldObj:    mkValidWorkload(setResourceVersion("1"), setBasicPolicy(0)),
+			updateObj: mkValidWorkload(setResourceVersion("1"), clearPodGroupPolicy(0)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
+			},
+		},
+		"invalid update from basic policy with both basic and gang": {
+			oldObj:    mkValidWorkload(setResourceVersion("1"), setBasicPolicy(0)),
+			updateObj: mkValidWorkload(setResourceVersion("1"), setBothPolicies(0)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
 				field.Invalid(field.NewPath("spec", "podGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "").WithOrigin("update"),
 			},
 		},
@@ -1260,6 +1291,94 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
 			},
 		},
+		"invalid update cpg from gang to basic policy": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), setCPGGangPolicy(0)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), setCPGBasicPolicy(0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "field cannot be cleared once set").WithOrigin("update"),
+			},
+		},
+		"invalid update cpg from basic to gang policy": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), setCPGBasicPolicy(0)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), setCPGGangPolicy(0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "field cannot be set once unset").WithOrigin("update"),
+			},
+		},
+		"invalid update cpg gang policy with both basic and gang": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), setCPGGangPolicy(0)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), setCPGPolicyBoth(0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
+			},
+		},
+		"invalid update cpg basic policy with both basic and gang": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), setCPGBasicPolicy(0)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), setCPGPolicyBoth(0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "field cannot be set once unset").WithOrigin("update"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
+			},
+		},
+		"cpg valid update of gang minGroupCount": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setCPGMinGroupCount(0, 5)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setCPGMinGroupCount(0, 3)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+		},
+		"cpg invalid update of gang minGroupCount to 0": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setCPGMinGroupCount(0, 5)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setCPGMinGroupCount(0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "gang", "minGroupCount"), ""),
+			},
+		},
+		"cpg invalid update of gang minGroupCount": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setCPGMinGroupCount(0, 5)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setCPGMinGroupCount(0, -1)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "gang", "minGroupCount"), nil, "").WithOrigin("minimum"),
+			},
+		},
+		"cpg valid update of nested pg gang minCount": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGMinCount(0, 0, 5)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGMinCount(0, 0, 3)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+		},
+		"cpg invalid update of nested pg gang minCount to 0": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGMinCount(0, 0, 5)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGMinCount(0, 0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy", "gang", "minCount"), ""),
+			},
+		},
+		"cpg invalid update of nested pg gang minCount": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGMinCount(0, 0, 5)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGMinCount(0, 0, -1)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy", "gang", "minCount"), nil, "").WithOrigin("minimum"),
+			},
+		},
 		"invalid update nested pg from gang to basic policy": {
 			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate()),
 			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGBasicPolicy(0, 0)),
@@ -1270,6 +1389,16 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "field cannot be cleared once set").WithOrigin("update"),
 			},
 		},
+		"invalid update nested pg from basic to gang policy": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGBasicPolicy(0, 0)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGMinCount(0, 0, 1)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "field cannot be set once unset").WithOrigin("update"),
+			},
+		},
 		"invalid update nested pg with neither basic nor gang": {
 			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate()),
 			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), clearNestedPGPolicy(0, 0)),
@@ -1278,6 +1407,120 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
 				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "field cannot be cleared once set").WithOrigin("update"),
+			},
+		},
+		"invalid update nested pg from basic with neither basic nor gang": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGBasicPolicy(0, 0)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), clearNestedPGPolicy(0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
+			},
+		},
+		"invalid update nested pg gang policy with both basic and gang": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate()),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGPolicyBoth(0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
+			},
+		},
+		"invalid update nested pg basic policy with both basic and gang": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGBasicPolicy(0, 0)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addCompositePodGroupTemplate(), setNestedPGPolicyBoth(0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "field cannot be set once unset").WithOrigin("update"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("podGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
+			},
+		},
+		"nested cpg valid update of gang minGroupCount": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGMinGroupCount(0, 0, 5)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGMinGroupCount(0, 0, 3)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+		},
+		"nested cpg invalid update of gang minGroupCount to 0": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGMinGroupCount(0, 0, 5)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGMinGroupCount(0, 0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "gang", "minGroupCount"), ""),
+			},
+		},
+		"nested cpg invalid update of gang minGroupCount": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGMinGroupCount(0, 0, 5)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGMinGroupCount(0, 0, -1)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "gang", "minGroupCount"), nil, "").WithOrigin("minimum"),
+			},
+		},
+		"nested cpg invalid update from gang to basic policy": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub")),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGBasicPolicy(0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "field cannot be cleared once set").WithOrigin("update"),
+			},
+		},
+		"nested cpg invalid update from basic to gang policy": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGBasicPolicy(0, 0)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGGangPolicy(0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "field cannot be set once unset").WithOrigin("update"),
+			},
+		},
+		"nested cpg invalid update with neither basic nor gang": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub")),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), clearNestedCPGPolicy(0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "field cannot be cleared once set").WithOrigin("update"),
+			},
+		},
+		"nested cpg invalid update from basic with neither basic nor gang": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGBasicPolicy(0, 0)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), clearNestedCPGPolicy(0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
+			},
+		},
+		"nested cpg invalid update gang policy with both basic and gang": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub")),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGPolicyBoth(0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "basic"), nil, "field is immutable").WithOrigin("immutable"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
+			},
+		},
+		"nested cpg invalid update basic policy with both basic and gang": {
+			oldObj:                        mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGBasicPolicy(0, 0)),
+			updateObj:                     mkValidWorkload(setResourceVersion("1"), addNestedCompositePodGroupTemplate(0, "sub"), setNestedCPGPolicyBoth(0, 0)),
+			enableCompositePodGroup:       true,
+			enableTopologyAwareScheduling: true,
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy", "gang"), nil, "field cannot be set once unset").WithOrigin("update"),
+				field.Invalid(field.NewPath("spec", "compositePodGroupTemplates").Index(0).Child("compositePodGroupTemplates").Index(0).Child("schedulingPolicy"), nil, "").WithOrigin("union"),
 			},
 		},
 		"valid update with unchanged nested pg PreemptionPolicy": {
@@ -1790,6 +2033,53 @@ func setCPGPolicyEmpty(idx int) func(obj *scheduling.Workload) {
 	return func(obj *scheduling.Workload) {
 		addCompositePodGroupTemplate()(obj)
 		obj.Spec.CompositePodGroupTemplates[idx].SchedulingPolicy = scheduling.CompositePodGroupSchedulingPolicy{}
+	}
+}
+
+func setCPGPolicyBoth(idx int) func(obj *scheduling.Workload) {
+	return func(obj *scheduling.Workload) {
+		addCompositePodGroupTemplate()(obj)
+		obj.Spec.CompositePodGroupTemplates[idx].SchedulingPolicy = scheduling.CompositePodGroupSchedulingPolicy{
+			Basic: &scheduling.CompositeBasicSchedulingPolicy{},
+			Gang:  &scheduling.CompositeGangSchedulingPolicy{MinGroupCount: 2},
+		}
+	}
+}
+
+func setNestedCPGMinGroupCount(cidx, nestedCidx int, count int) func(obj *scheduling.Workload) {
+	return func(obj *scheduling.Workload) {
+		obj.Spec.CompositePodGroupTemplates[cidx].CompositePodGroupTemplates[nestedCidx].SchedulingPolicy.Gang.MinGroupCount = int32(count)
+	}
+}
+
+func setNestedCPGBasicPolicy(cidx, nestedCidx int) func(obj *scheduling.Workload) {
+	return func(obj *scheduling.Workload) {
+		obj.Spec.CompositePodGroupTemplates[cidx].CompositePodGroupTemplates[nestedCidx].SchedulingPolicy = scheduling.CompositePodGroupSchedulingPolicy{
+			Basic: &scheduling.CompositeBasicSchedulingPolicy{},
+		}
+	}
+}
+
+func setNestedCPGGangPolicy(cidx, nestedCidx int) func(obj *scheduling.Workload) {
+	return func(obj *scheduling.Workload) {
+		obj.Spec.CompositePodGroupTemplates[cidx].CompositePodGroupTemplates[nestedCidx].SchedulingPolicy = scheduling.CompositePodGroupSchedulingPolicy{
+			Gang: &scheduling.CompositeGangSchedulingPolicy{MinGroupCount: 2},
+		}
+	}
+}
+
+func clearNestedCPGPolicy(cidx, nestedCidx int) func(obj *scheduling.Workload) {
+	return func(obj *scheduling.Workload) {
+		obj.Spec.CompositePodGroupTemplates[cidx].CompositePodGroupTemplates[nestedCidx].SchedulingPolicy = scheduling.CompositePodGroupSchedulingPolicy{}
+	}
+}
+
+func setNestedCPGPolicyBoth(cidx, nestedCidx int) func(obj *scheduling.Workload) {
+	return func(obj *scheduling.Workload) {
+		obj.Spec.CompositePodGroupTemplates[cidx].CompositePodGroupTemplates[nestedCidx].SchedulingPolicy = scheduling.CompositePodGroupSchedulingPolicy{
+			Basic: &scheduling.CompositeBasicSchedulingPolicy{},
+			Gang:  &scheduling.CompositeGangSchedulingPolicy{MinGroupCount: 2},
+		}
 	}
 }
 

--- a/test/integration/scheduler/podgroup/queueing_test.go
+++ b/test/integration/scheduler/podgroup/queueing_test.go
@@ -48,6 +48,13 @@ func TestCPGQueueing(t *testing.T) {
 	p2_3 := st.MakePod().Name("p2-3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg2-2").Obj()
 	p2_4 := st.MakePod().Name("p2-4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg2-2").Obj()
 
+	cpgRoot3 := st.MakeCompositePodGroup().Name("cpg-root3").WorkloadRef("w3", "cpg-t3").MinGroupCount(1).Obj()
+	cpgMid3 := st.MakeCompositePodGroup().Name("cpg-mid3").WorkloadRef("w3", "cpg-mid3-t").MinGroupCount(2).ParentCompositePodGroup("cpg-root3").Obj()
+	pg3_1 := st.MakePodGroup().Name("pg3-1").WorkloadRef("w3", "pg-t3-1").MinCount(2).ParentCompositePodGroup("cpg-mid3").Obj()
+
+	p3_1 := st.MakePod().Name("p3-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg3-1").Obj()
+	p3_2 := st.MakePod().Name("p3-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg3-1").Obj()
+
 	tests := []struct {
 		name  string
 		steps []stepsframework.Step
@@ -226,6 +233,76 @@ func TestCPGQueueing(t *testing.T) {
 				{
 					Name:                 "Verify pod gets scheduled after PodGroup MinCount is reduced",
 					WaitForPodsScheduled: []string{"p1"},
+				},
+			},
+		},
+		{
+			name: "CPG update (reduce minGroupCount) triggers queueing hint for unschedulable CPG tree",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create initial node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                    "Create root CPG requiring 2 groups",
+					CreateCompositePodGroup: cpgRoot2,
+				},
+				{
+					Name:           "Create first PodGroup",
+					CreatePodGroup: pg2_1,
+				},
+				{
+					Name:       "Create all pods of first PodGroup",
+					CreatePods: []*v1.Pod{p2_1, p2_2},
+				},
+				{
+					Name:                               "Verify first group pods are in unschedulableEntities due to root needing 2 groups",
+					WaitForPodsInUnschedulableEntities: []string{"p2-1", "p2-2"},
+				},
+				{
+					Name:                    "Update root CPG to MinGroupCount=1",
+					UpdateCompositePodGroup: st.MakeCompositePodGroup().Name("cpg-root2").WorkloadRef("w2", "cpg-t2").MinGroupCount(1).Obj(),
+				},
+				{
+					Name:                 "Verify pods get scheduled after root CPG MinGroupCount is reduced",
+					WaitForPodsScheduled: []string{"p2-1", "p2-2"},
+				},
+			},
+		},
+		{
+			name: "Intermediate CPG update (reduce minGroupCount) triggers queueing hint for unschedulable CPG tree",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create initial node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                    "Create root CPG requiring 1 group",
+					CreateCompositePodGroup: cpgRoot3,
+				},
+				{
+					Name:                    "Create intermediate CPG requiring 2 groups",
+					CreateCompositePodGroup: cpgMid3,
+				},
+				{
+					Name:           "Create first PodGroup under intermediate CPG",
+					CreatePodGroup: pg3_1,
+				},
+				{
+					Name:       "Create all pods of first PodGroup",
+					CreatePods: []*v1.Pod{p3_1, p3_2},
+				},
+				{
+					Name:                               "Verify pods are in unschedulableEntities due to intermediate CPG needing 2 groups",
+					WaitForPodsInUnschedulableEntities: []string{"p3-1", "p3-2"},
+				},
+				{
+					Name:                    "Update intermediate CPG to MinGroupCount=1",
+					UpdateCompositePodGroup: st.MakeCompositePodGroup().Name("cpg-mid3").WorkloadRef("w3", "cpg-mid3-t").MinGroupCount(1).ParentCompositePodGroup("cpg-root3").Obj(),
+				},
+				{
+					Name:                 "Verify pods get scheduled after intermediate CPG MinGroupCount is reduced",
+					WaitForPodsScheduled: []string{"p3-1", "p3-2"},
 				},
 			},
 		},

--- a/test/integration/scheduler/podgroup/queueing_test.go
+++ b/test/integration/scheduler/podgroup/queueing_test.go
@@ -48,6 +48,43 @@ func TestCPGQueueing(t *testing.T) {
 	p2_3 := st.MakePod().Name("p2-3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg2-2").Obj()
 	p2_4 := st.MakePod().Name("p2-4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg2-2").Obj()
 
+	// cpgMid3 is created with MinGroupCount=2, but only one child PodGroup (pg3_1) is intentionally created
+	// so the CPG remains unschedulable until MinGroupCount is reduced to 1 in the test.
+	cpgRoot3 := st.MakeCompositePodGroup().Name("cpg-root3").WorkloadRef("w3", "cpg-t3").MinGroupCount(1).Obj()
+	cpgMid3 := st.MakeCompositePodGroup().Name("cpg-mid3").WorkloadRef("w3", "cpg-mid3-t").MinGroupCount(2).ParentCompositePodGroup("cpg-root3").Obj()
+	pg3_1 := st.MakePodGroup().Name("pg3-1").WorkloadRef("w3", "pg-t3-1").MinCount(2).ParentCompositePodGroup("cpg-mid3").Obj()
+
+	p3_1 := st.MakePod().Name("p3-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg3-1").Obj()
+	p3_2 := st.MakePod().Name("p3-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg3-1").Obj()
+
+	cpgRoot4 := st.MakeCompositePodGroup().Name("cpg-root4").WorkloadRef("w4", "cpg-t4").MinGroupCount(3).Obj()
+	pg4_1 := st.MakePodGroup().Name("pg4-1").WorkloadRef("w4", "pg-t4-1").MinCount(1).ParentCompositePodGroup("cpg-root4").Obj()
+	pg4_2 := st.MakePodGroup().Name("pg4-2").WorkloadRef("w4", "pg-t4-2").MinCount(1).ParentCompositePodGroup("cpg-root4").Obj()
+
+	p4_1 := st.MakePod().Name("p4-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg4-1").Obj()
+	p4_2 := st.MakePod().Name("p4-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg4-2").Obj()
+
+	// Cousin PodGroups in different CPG branches under same root CPG:
+	cpgRootCousin := st.MakeCompositePodGroup().Name("cpg-root-cousin").WorkloadRef("w-cousin", "cpg-root-t").MinGroupCount(2).Obj()
+	cpgBranch1 := st.MakeCompositePodGroup().Name("cpg-branch1").WorkloadRef("w-cousin", "cpg-b1-t").MinGroupCount(1).ParentCompositePodGroup("cpg-root-cousin").Obj()
+	cpgBranch2 := st.MakeCompositePodGroup().Name("cpg-branch2").WorkloadRef("w-cousin", "cpg-b2-t").MinGroupCount(1).ParentCompositePodGroup("cpg-root-cousin").Obj()
+	pgBranch1 := st.MakePodGroup().Name("pg-b1").WorkloadRef("w-cousin", "pg-b1-t").MinCount(1).ParentCompositePodGroup("cpg-branch1").Obj()
+	pgBranch2 := st.MakePodGroup().Name("pg-b2").WorkloadRef("w-cousin", "pg-b2-t").MinCount(2).ParentCompositePodGroup("cpg-branch2").Obj()
+
+	pB1 := st.MakePod().Name("p-b1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg-b1").Obj()
+	pB2 := st.MakePod().Name("p-b2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg-b2").Obj()
+
+	// CPG schedulable initially with an unready subtree:
+	cpgRootPartialTree := st.MakeCompositePodGroup().Name("cpg-root-ptree").WorkloadRef("w-ptree", "cpg-root-t").MinGroupCount(1).Obj()
+	pgMainSched := st.MakePodGroup().Name("pg-main-ptree").WorkloadRef("w-ptree", "pg-main-t").MinCount(1).ParentCompositePodGroup("cpg-root-ptree").Obj()
+	cpgSubUnready := st.MakeCompositePodGroup().Name("cpg-sub-ptree").WorkloadRef("w-ptree", "cpg-sub-t").MinGroupCount(2).ParentCompositePodGroup("cpg-root-ptree").Obj()
+	pgSubUnready1 := st.MakePodGroup().Name("pg-sub-ptree-1").WorkloadRef("w-ptree", "pg-sub1-t").MinCount(1).ParentCompositePodGroup("cpg-sub-ptree").Obj()
+	pgSubUnready2 := st.MakePodGroup().Name("pg-sub-ptree-2").WorkloadRef("w-ptree", "pg-sub2-t").MinCount(2).ParentCompositePodGroup("cpg-sub-ptree").Obj()
+
+	pMainSched := st.MakePod().Name("p-main-ptree").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg-main-ptree").Obj()
+	pSubUnready1 := st.MakePod().Name("p-sub-ptree-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg-sub-ptree-1").Obj()
+	pSubUnready2 := st.MakePod().Name("p-sub-ptree-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg-sub-ptree-2").Obj()
+
 	tests := []struct {
 		name  string
 		steps []stepsframework.Step
@@ -226,6 +263,207 @@ func TestCPGQueueing(t *testing.T) {
 				{
 					Name:                 "Verify pod gets scheduled after PodGroup MinCount is reduced",
 					WaitForPodsScheduled: []string{"p1"},
+				},
+			},
+		},
+		{
+			name: "CPG update (reduce minGroupCount) triggers queueing hint for unschedulable CPG tree",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create initial node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                    "Create root CPG requiring 2 groups",
+					CreateCompositePodGroup: cpgRoot2,
+				},
+				{
+					Name:           "Create first PodGroup",
+					CreatePodGroup: pg2_1,
+				},
+				{
+					Name:       "Create all pods of first PodGroup",
+					CreatePods: []*v1.Pod{p2_1, p2_2},
+				},
+				{
+					Name:                               "Verify first group pods are in unschedulableEntities due to root needing 2 groups",
+					WaitForPodsInUnschedulableEntities: []string{"p2-1", "p2-2"},
+				},
+				{
+					Name:                    "Update root CPG to MinGroupCount=1",
+					UpdateCompositePodGroup: st.MakeCompositePodGroup().Name("cpg-root2").WorkloadRef("w2", "cpg-t2").MinGroupCount(1).Obj(),
+				},
+				{
+					Name:                 "Verify pods get scheduled after root CPG MinGroupCount is reduced",
+					WaitForPodsScheduled: []string{"p2-1", "p2-2"},
+				},
+			},
+		},
+		{
+			name: "Intermediate CPG update (reduce minGroupCount) triggers queueing hint for unschedulable CPG tree",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create initial node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                    "Create root CPG requiring 1 group",
+					CreateCompositePodGroup: cpgRoot3,
+				},
+				{
+					Name:                    "Create intermediate CPG requiring 2 groups",
+					CreateCompositePodGroup: cpgMid3,
+				},
+				{
+					Name:           "Create first PodGroup under intermediate CPG",
+					CreatePodGroup: pg3_1,
+				},
+				{
+					Name:       "Create all pods of first PodGroup",
+					CreatePods: []*v1.Pod{p3_1, p3_2},
+				},
+				{
+					Name:                               "Verify pods are in unschedulableEntities due to intermediate CPG needing 2 groups",
+					WaitForPodsInUnschedulableEntities: []string{"p3-1", "p3-2"},
+				},
+				{
+					Name:                    "Update intermediate CPG to MinGroupCount=1",
+					UpdateCompositePodGroup: st.MakeCompositePodGroup().Name("cpg-mid3").WorkloadRef("w3", "cpg-mid3-t").MinGroupCount(1).ParentCompositePodGroup("cpg-root3").Obj(),
+				},
+				{
+					Name:                 "Verify pods get scheduled after intermediate CPG MinGroupCount is reduced",
+					WaitForPodsScheduled: []string{"p3-1", "p3-2"},
+				},
+			},
+		},
+		{
+			name: "CPG update (reduce minGroupCount) unblocks multiple sibling PodGroups simultaneously",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create initial node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                    "Create root CPG requiring 3 groups",
+					CreateCompositePodGroup: cpgRoot4,
+				},
+				{
+					Name:           "Create first sibling PodGroup",
+					CreatePodGroup: pg4_1,
+				},
+				{
+					Name:           "Create second sibling PodGroup",
+					CreatePodGroup: pg4_2,
+				},
+				{
+					Name:       "Create pods for both sibling PodGroups",
+					CreatePods: []*v1.Pod{p4_1, p4_2},
+				},
+				{
+					Name:                               "Verify both sibling pods are in unschedulableEntities due to root needing 3 groups",
+					WaitForPodsInUnschedulableEntities: []string{"p4-1", "p4-2"},
+				},
+				{
+					Name:                    "Update root CPG to MinGroupCount=2, satisfying both sibling groups",
+					UpdateCompositePodGroup: st.MakeCompositePodGroup().Name("cpg-root4").WorkloadRef("w4", "cpg-t4").MinGroupCount(2).Obj(),
+				},
+				{
+					Name:                 "Verify all sibling pods get scheduled after root CPG MinGroupCount is reduced",
+					WaitForPodsScheduled: []string{"p4-1", "p4-2"},
+				},
+			},
+		},
+		{
+			name: "PodGroup update (reduce minCount) in child branch unblocks entire CPG tree",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create initial node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                    "Create root CPG requiring 2 branches",
+					CreateCompositePodGroup: cpgRootCousin,
+				},
+				{
+					Name:                    "Create first branch CPG",
+					CreateCompositePodGroup: cpgBranch1,
+				},
+				{
+					Name:                    "Create second branch CPG",
+					CreateCompositePodGroup: cpgBranch2,
+				},
+				{
+					Name:           "Create PodGroup in first branch",
+					CreatePodGroup: pgBranch1,
+				},
+				{
+					Name:           "Create PodGroup in second branch",
+					CreatePodGroup: pgBranch2,
+				},
+				{
+					Name:       "Create 1 pod in first branch and 1 pod in second branch (which needs 2)",
+					CreatePods: []*v1.Pod{pB1, pB2},
+				},
+				{
+					Name:                               "Verify both cousin pods are in unschedulableEntities because branch2 is missing 1 pod",
+					WaitForPodsInUnschedulableEntities: []string{"p-b1", "p-b2"},
+				},
+				{
+					Name:           "Update branch2 PodGroup to MinCount=1",
+					UpdatePodGroup: st.MakePodGroup().Name("pg-b2").WorkloadRef("w-cousin", "pg-b2-t").MinCount(1).ParentCompositePodGroup("cpg-branch2").Obj(),
+				},
+				{
+					Name:                 "Verify all cousin pods get scheduled after branch2 MinCount is reduced",
+					WaitForPodsScheduled: []string{"p-b1", "p-b2"},
+				},
+			},
+		},
+		{
+			name: "CPG schedules ready branch while unready subtree waits, then reducing child minCount unblocks and schedules the subtree",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create initial node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                    "Create root CPG requiring 1 group (schedulable via main branch)",
+					CreateCompositePodGroup: cpgRootPartialTree,
+				},
+				{
+					Name:           "Create main ready PodGroup",
+					CreatePodGroup: pgMainSched,
+				},
+				{
+					Name:                    "Create subtree CPG requiring 2 child groups",
+					CreateCompositePodGroup: cpgSubUnready,
+				},
+				{
+					Name:           "Create first child PodGroup in subtree",
+					CreatePodGroup: pgSubUnready1,
+				},
+				{
+					Name:           "Create second child PodGroup in subtree",
+					CreatePodGroup: pgSubUnready2,
+				},
+				{
+					Name:       "Create pods across all groups (1 for main, 1 for sub1, 1 for sub2 which needs 2)",
+					CreatePods: []*v1.Pod{pMainSched, pSubUnready1, pSubUnready2},
+				},
+				{
+					Name:                 "Verify main pod gets scheduled because root CPG minGroupCount=1 is satisfied",
+					WaitForPodsScheduled: []string{"p-main-ptree"},
+				},
+				{
+					Name:                     "Verify subtree pods remain unschedulable because subtree minGroupCount=2 is not met",
+					WaitForPodsUnschedulable: []string{"p-sub-ptree-1", "p-sub-ptree-2"},
+				},
+				{
+					Name:           "Update second child PodGroup in subtree to MinCount=1",
+					UpdatePodGroup: st.MakePodGroup().Name("pg-sub-ptree-2").WorkloadRef("w-ptree", "pg-sub2-t").MinCount(1).ParentCompositePodGroup("cpg-sub-ptree").Obj(),
+				},
+				{
+					Name:                 "Verify subtree pods get scheduled once the subtree minGroupCount is satisfied",
+					WaitForPodsScheduled: []string{"p-sub-ptree-1", "p-sub-ptree-2"},
 				},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change
/sig scheduling
/wg workload-aware-scheduling

#### What this PR does / why we need it:

Permit `CompositePodGroup.Spec.SchedulingPolicy.Gang.MinGroupCount` to be mutable across `v1alpha3` and `v1beta1`, enabling dynamic resizing of hierarchical gang scheduling requirements without recreating parent `CompositePodGroup` objects. This mirrors the mutability contract established for `PodGroup.MinCount` (#139279).

In addition, implement the `isSchedulableAfterCompositePodGroupUpdated` queueing hint in the `gangscheduling` scheduler plugin. When a `CompositePodGroup`'s `MinGroupCount` decreases, pods in any `PodGroup` under the same root hierarchy are re-enqueued from `UnschedulablePods` or `IncompletePodGroupPods` to `ActiveQ`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- Updated API immutability validation and declarative validation test suites for both `CompositePodGroup` and `Workload`.
- Added unit test coverage in `pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go` (`Test_isSchedulableAfterCompositePodGroupUpdated`) covering both root CPG updates and non-root/intermediate CPG updates within the same hierarchy.
- Added integration test coverage in `test/integration/scheduler/podgroup/queueing_test.go` (`TestCPGQueueing`).

#### Does this PR introduce a user-facing change?

```release-note
Allow CompositePodGroup.Spec.SchedulingPolicy.Gang.MinGroupCount to be mutable, and automatically re-enqueue pods in the scheduler when MinGroupCount decreases.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/6012
```

#### AI was used to craft the PR