### PR TITLE
Add tie-breaker to non-extender node scores

### DIFF
--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -959,6 +959,7 @@ func prioritizeNodes(
 			result = append(result, fwk.NodePluginScores{
 				Name:       nodes[i].Node().Name,
 				TotalScore: 1,
+				Randomizer: rand.Int(),
 			})
 		}
 		return result, nil
@@ -1042,9 +1043,12 @@ func prioritizeNodes(
 			if score, ok := allNodeExtendersScores[nodes[i].Node().Name]; ok {
 				nodesScores[i].Scores = append(nodesScores[i].Scores, score.Scores...)
 				nodesScores[i].TotalScore += score.TotalScore
-				nodesScores[i].Randomizer = rand.Int()
 			}
 		}
+	}
+
+	for i := range nodesScores {
+		nodesScores[i].Randomizer = rand.Int()
 	}
 
 	if loggerVTen.Enabled() {

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -4557,6 +4557,169 @@ func Test_prioritizeNodes(t *testing.T) {
 	}
 }
 
+type fakeMapScorePlugin struct {
+	name   string
+	scores map[string]int
+}
+
+func (pl *fakeMapScorePlugin) Name() string {
+	return pl.name
+}
+
+func (pl *fakeMapScorePlugin) Score(_ context.Context, _ fwk.CycleState, _ *v1.Pod, nodeInfo fwk.NodeInfo) (int64, *fwk.Status) {
+	score := pl.scores[nodeInfo.Node().Name]
+	return int64(score), nil
+}
+
+func (pl *fakeMapScorePlugin) ScoreExtensions() fwk.ScoreExtensions {
+	return nil
+}
+
+// Verify that scores with identical TotalScore receive unique Randomizer tiebreaker
+// values across successive scheduling cycles so that node selection is non-deterministic.
+func Test_prioritizeNodes_TieBreaker(t *testing.T) {
+	nodes := []*v1.Node{
+		makeNode("node1", 1000, schedutil.DefaultMemoryRequest*10),
+		makeNode("node2", 1000, schedutil.DefaultMemoryRequest*10),
+		makeNode("node3", 1000, schedutil.DefaultMemoryRequest*10),
+		makeNode("node4", 1000, schedutil.DefaultMemoryRequest*10),
+		makeNode("node5", 1000, schedutil.DefaultMemoryRequest*10),
+	}
+
+	tests := []struct {
+		name           string
+		pluginScores   []map[string]int
+		extenderScores []map[string]int
+	}{
+		{
+			name:           "no score plugins or extenders",
+			pluginScores:   nil,
+			extenderScores: nil,
+		},
+		{
+			name: "score plugins only",
+			pluginScores: []map[string]int{
+				{"node1": 10, "node2": 10, "node3": 10, "node4": 10, "node5": 10},
+			},
+		},
+		{
+			name: "extenders only",
+			extenderScores: []map[string]int{
+				{"node1": 10, "node2": 10, "node3": 10, "node4": 10, "node5": 10},
+			},
+		},
+		{
+			name: "tiebreaker between plugin and extender with complementary scores",
+			pluginScores: []map[string]int{
+				{
+					"node1": int(fwk.MaxScore),
+					"node2": int(fwk.MaxScore) * 4 / 5,
+					"node3": int(fwk.MaxScore) * 3 / 5,
+					"node4": int(fwk.MaxScore) * 1 / 5,
+					"node5": 0,
+				},
+			},
+			extenderScores: []map[string]int{
+				{
+					"node1": 0,
+					"node2": int(extenderv1.MaxExtenderPriority) * 1 / 5,
+					"node3": int(extenderv1.MaxExtenderPriority) * 2 / 5,
+					"node4": int(extenderv1.MaxExtenderPriority) * 4 / 5,
+					"node5": int(extenderv1.MaxExtenderPriority),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := clientsetfake.NewClientset()
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			cache := internalcache.New(ctx, nil, false, false)
+			for _, node := range nodes {
+				cache.AddNode(klog.FromContext(ctx), node)
+			}
+			snapshot := internalcache.NewEmptySnapshot()
+			if err := cache.UpdateSnapshot(klog.FromContext(ctx), snapshot); err != nil {
+				t.Fatal(err)
+			}
+
+			pluginRegistrations := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			for i, scores := range test.pluginScores {
+				pluginName := fmt.Sprintf("FakeScorePlugin%d", i)
+				pluginRegistrations = append(pluginRegistrations, tf.RegisterScorePlugin(
+					pluginName,
+					func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+						return &fakeMapScorePlugin{name: pluginName, scores: scores}, nil
+					},
+					1,
+				))
+			}
+			var extenders []fwk.Extender
+			for i, scores := range test.extenderScores {
+				extName := fmt.Sprintf("FakeExtender%d", i)
+				extender := &tf.FakeExtender{
+					ExtenderName: extName,
+					Weight:       1,
+					Prioritizers: []tf.PriorityConfig{
+						{
+							Weight: 1,
+							Function: func(_ *v1.Pod, nodes []fwk.NodeInfo) (*fwk.NodeScoreList, error) {
+								result := fwk.NodeScoreList{}
+								for _, node := range nodes {
+									result = append(result, fwk.NodeScore{Name: node.Node().Name, Score: int64(scores[node.Node().Name])})
+								}
+								return &result, nil
+							},
+						},
+					},
+				}
+				extenders = append(extenders, extender)
+			}
+
+			schedFramework, err := tf.NewFramework(
+				ctx,
+				pluginRegistrations, "",
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithClientSet(client),
+				frameworkruntime.WithExtenders(extenders),
+				frameworkruntime.WithPodNominator(internalqueue.NewSchedulingQueue(nil, informerFactory)),
+			)
+			if err != nil {
+				t.Fatalf("error creating framework: %+v", err)
+			}
+
+			nodeInfos, err := snapshot.NodeInfos().List()
+			if err != nil {
+				t.Fatalf("failed to list node from snapshot: %v", err)
+			}
+			selectedNodes := sets.New[string]()
+			// Up to 100 iterations reduces the chance of coincidental tiebreaker repetition across 5 nodes to under (1/5)^99.
+			for range 100 {
+				scores, err := prioritizeNodes(ctx, extenders, schedFramework, framework.NewCycleState(), &v1.Pod{}, nodeInfos)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				h := framework.NewSortedScoredNodes(scores)
+				selectedNodes.Insert(h.Pop().Name)
+				if selectedNodes.Len() > 1 {
+					break
+				}
+			}
+			if selectedNodes.Len() <= 1 {
+				t.Errorf("expected randomizer to select different nodes across iterations due to tiebreaking, but only selected: %v", selectedNodes)
+			}
+		})
+	}
+}
+
 var lowPriority, midPriority, highPriority = int32(0), int32(100), int32(1000)
 
 func TestNumFeasibleNodesToFind(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

https://github.com/kubernetes/kubernetes/pull/135231 introduced randomizer to node scores as a tiebreaker, however it was only used for nodes affected by extenders. This looks like an unintentional omission. I've moved the randomizer assignment to cover all node scores.

In practice, this is unlikely to change much, as the scores were already in random order due to the feasibleNodes slice being constructed in non-deterministic order with parallel execution: https://github.com/kubernetes/kubernetes/blob/7c2b6c32644a2cc24029ec77576940b63ecca7e7/pkg/scheduler/schedule_one.go#L830

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
