### PR TITLE
kubelet/cpumanager: reduce iterations during uncore cache allocation

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -117,10 +117,15 @@ func (n *numaFirst) takeFullSecondLevel() {
 // Sort the UncoreCaches within the NUMA nodes.
 func (a *cpuAccumulator) sortAvailableUncoreCaches() []int {
 	var result []int
+	added := cpuset.New()
+
 	for _, numa := range a.sortAvailableNUMANodes() {
-		uncore := a.details.UncoreInNUMANodes(numa).UnsortedList()
-		a.sort(uncore, a.details.CPUsInUncoreCaches)
-		result = append(result, uncore...)
+		uncore := a.details.UncoreInNUMANodes(numa)
+		// UncoreCache can span NUMA nodes, so skip already added
+		uncoreIDs := uncore.Difference(added).UnsortedList()
+		added = added.Union(uncore)
+		a.sort(uncoreIDs, a.details.CPUsInUncoreCaches)
+		result = append(result, uncoreIDs...)
 	}
 	return result
 }
@@ -367,17 +372,6 @@ func (a *cpuAccumulator) freeSockets() []int {
 	return free
 }
 
-// Returns free UncoreCache IDs as a slice sorted by sortAvailableUnCoreCache().
-func (a *cpuAccumulator) freeUncoreCache() []int {
-	free := []int{}
-	for _, uncore := range a.sortAvailableUncoreCaches() {
-		if a.isUncoreCacheFree(uncore) {
-			free = append(free, uncore)
-		}
-	}
-	return free
-}
-
 // Returns free core IDs as a slice sorted by sortAvailableCores().
 func (a *cpuAccumulator) freeCores() []int {
 	free := []int{}
@@ -551,15 +545,16 @@ func (a *cpuAccumulator) takeFullSockets() {
 	}
 }
 
-func (a *cpuAccumulator) takeFullUncore() {
-	for _, uncore := range a.freeUncoreCache() {
-		cpusInUncore := a.topo.CPUDetails.CPUsInUncoreCaches(uncore)
-		if !a.needsAtLeast(cpusInUncore.Size()) {
-			continue
-		}
-		a.logger.V(4).Info("takeFullUncore: claiming uncore", "uncore", uncore)
-		a.take(cpusInUncore)
+func (a *cpuAccumulator) takeFullUncore(uncoreID int) {
+	if !a.isUncoreCacheFree(uncoreID) {
+		return
 	}
+	cpusInUncore := a.topo.CPUDetails.CPUsInUncoreCaches(uncoreID)
+	if !a.needsAtLeast(cpusInUncore.Size()) {
+		return
+	}
+	a.logger.V(4).Info("takeFullUncore: claiming uncore", "uncore", uncoreID)
+	a.take(cpusInUncore)
 }
 
 func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
@@ -606,18 +601,18 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 // First try to take full UncoreCache, if available and need is at least the size of the UncoreCache group.
 // Second try to take the partial UncoreCache if available and the request size can fit w/in the UncoreCache.
 func (a *cpuAccumulator) takeUncoreCache() {
-	numCPUsInUncore := a.topo.CPUsPerUncore()
-	for _, uncore := range a.sortAvailableUncoreCaches() {
-		// take full UncoreCache if the CPUs needed is greater than free UncoreCache size
-		if a.needsAtLeast(numCPUsInUncore) {
-			a.takeFullUncore()
-		}
+	uncores := a.sortAvailableUncoreCaches()
 
+	// take full UncoreCache if the CPUs needed is greater than free UncoreCache size
+	for _, uncore := range uncores {
+		a.takeFullUncore(uncore)
 		if a.isSatisfied() {
 			return
 		}
+	}
 
-		// take partial UncoreCache if the CPUs needed is less than free UncoreCache size
+	// take partial UncoreCache if the CPUs needed is less than free UncoreCache size
+	for _, uncore := range uncores {
 		a.takePartialUncore(uncore)
 		if a.isSatisfied() {
 			return

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -117,10 +117,15 @@ func (n *numaFirst) takeFullSecondLevel() {
 // Sort the UncoreCaches within the NUMA nodes.
 func (a *cpuAccumulator) sortAvailableUncoreCaches() []int {
 	var result []int
+	added := cpuset.New()
+
 	for _, numa := range a.sortAvailableNUMANodes() {
-		uncore := a.details.UncoreInNUMANodes(numa).UnsortedList()
-		a.sort(uncore, a.details.CPUsInUncoreCaches)
-		result = append(result, uncore...)
+		uncore := a.details.UncoreInNUMANodes(numa)
+		// UncoreCache can span NUMA nodes, so skip already added
+		uncoreIDs := uncore.Difference(added).UnsortedList()
+		added = added.Union(uncore)
+		a.sort(uncoreIDs, a.details.CPUsInUncoreCaches)
+		result = append(result, uncoreIDs...)
 	}
 	return result
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment.go
@@ -372,17 +372,6 @@ func (a *cpuAccumulator) freeSockets() []int {
 	return free
 }
 
-// Returns free UncoreCache IDs as a slice sorted by sortAvailableUnCoreCache().
-func (a *cpuAccumulator) freeUncoreCache() []int {
-	free := []int{}
-	for _, uncore := range a.sortAvailableUncoreCaches() {
-		if a.isUncoreCacheFree(uncore) {
-			free = append(free, uncore)
-		}
-	}
-	return free
-}
-
 // Returns free core IDs as a slice sorted by sortAvailableCores().
 func (a *cpuAccumulator) freeCores() []int {
 	free := []int{}
@@ -556,15 +545,16 @@ func (a *cpuAccumulator) takeFullSockets() {
 	}
 }
 
-func (a *cpuAccumulator) takeFullUncore() {
-	for _, uncore := range a.freeUncoreCache() {
-		cpusInUncore := a.topo.CPUDetails.CPUsInUncoreCaches(uncore)
-		if !a.needsAtLeast(cpusInUncore.Size()) {
-			continue
-		}
-		a.logger.V(4).Info("takeFullUncore: claiming uncore", "uncore", uncore)
-		a.take(cpusInUncore)
+func (a *cpuAccumulator) takeFullUncore(uncoreID int) {
+	if !a.isUncoreCacheFree(uncoreID) {
+		return
 	}
+	cpusInUncore := a.topo.CPUDetails.CPUsInUncoreCaches(uncoreID)
+	if !a.needsAtLeast(cpusInUncore.Size()) {
+		return
+	}
+	a.logger.V(4).Info("takeFullUncore: claiming uncore", "uncore", uncoreID)
+	a.take(cpusInUncore)
 }
 
 func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
@@ -611,18 +601,18 @@ func (a *cpuAccumulator) takePartialUncore(uncoreID int) {
 // First try to take full UncoreCache, if available and need is at least the size of the UncoreCache group.
 // Second try to take the partial UncoreCache if available and the request size can fit w/in the UncoreCache.
 func (a *cpuAccumulator) takeUncoreCache() {
-	for _, uncore := range a.sortAvailableUncoreCaches() {
-		numCPUsInUncore := a.topo.CPUDetails.CPUsInUncoreCaches(uncore).Size()
-		// take full UncoreCache if the CPUs needed is greater than free UncoreCache size
-		if a.needsAtLeast(numCPUsInUncore) {
-			a.takeFullUncore()
-		}
+	uncores := a.sortAvailableUncoreCaches()
 
+	// take full UncoreCache if the CPUs needed is greater than free UncoreCache size
+	for _, uncore := range uncores {
+		a.takeFullUncore(uncore)
 		if a.isSatisfied() {
 			return
 		}
+	}
 
-		// take partial UncoreCache if the CPUs needed is less than free UncoreCache size
+	// take partial UncoreCache if the CPUs needed is less than free UncoreCache size
+	for _, uncore := range uncores {
 		a.takePartialUncore(uncore)
 		if a.isSatisfied() {
 			return

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -406,6 +406,45 @@ func TestCPUAccumulatorFreeCPUs(t *testing.T) {
 	}
 }
 
+func TestSortAvailableUncoreCaches(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	testCases := []struct {
+		description   string
+		topo          *topology.CPUTopology
+		availableCPUs cpuset.CPUSet
+		expect        []int
+	}{
+		{
+			"topology with 1 (default) uncore cache, 0 cpus reserved",
+			topoDualSocketMultiNumaPerSocketHT,
+			mustParseCPUSet(t, "0-79"),
+			[]int{0},
+		},
+		{
+			"topology with 2 uncore caches, multi numa per uncore, 2 cpus reserved",
+			topoDualSocketSubNumaPerSocketHTMonolithicUncore,
+			mustParseCPUSet(t, "1-119,121-239"), // two cpu(s) from uncore0 reserved
+			[]int{0, 1},
+		},
+		{
+			"topology with 24 uncore caches, single numa per uncore, 3 cpus reserved",
+			topoDualSocketSingleNumaPerSocketSMTUncore,
+			mustParseCPUSet(t, "0-90,92-151,153-282,284-383"), // two cpu(s) from uncore11 and one from uncore19 reserved
+			[]int{11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 19, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 23},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			result := acc.sortAvailableUncoreCaches()
+			if !reflect.DeepEqual(result, tc.expect) {
+				t.Errorf("expected %v to equal %v", result, tc.expect)
+			}
+		})
+	}
+}
+
 func TestCPUAccumulatorTake(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {

--- a/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_assignment_test.go
@@ -430,6 +430,45 @@ func TestCPUAccumulatorFreeCPUs(t *testing.T) {
 	}
 }
 
+func TestSortAvailableUncoreCaches(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	testCases := []struct {
+		description   string
+		topo          *topology.CPUTopology
+		availableCPUs cpuset.CPUSet
+		expect        []int
+	}{
+		{
+			description:   "topology with 1 (default) uncore cache, 0 cpus reserved",
+			topo:          topoDualSocketMultiNumaPerSocketHT,
+			availableCPUs: mustParseCPUSet(t, "0-79"),
+			expect:        []int{0},
+		},
+		{
+			description:   "topology with 2 uncore caches, multi numa per uncore, 2 cpus reserved",
+			topo:          topoDualSocketSubNumaPerSocketHTMonolithicUncore,
+			availableCPUs: mustParseCPUSet(t, "1-119,121-239"), // two cpu(s) from uncore0 reserved
+			expect:        []int{0, 1},
+		},
+		{
+			description:   "topology with 24 uncore caches, single numa per uncore, 3 cpus reserved",
+			topo:          topoDualSocketSingleNumaPerSocketSMTUncore,
+			availableCPUs: mustParseCPUSet(t, "0-90,92-151,153-282,284-383"), // two cpu(s) from uncore11 and one from uncore19 reserved
+			expect:        []int{11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 19, 12, 13, 14, 15, 16, 17, 18, 20, 21, 22, 23},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			acc := newCPUAccumulator(logger, tc.topo, tc.availableCPUs, 0, CPUSortingStrategyPacked)
+			result := acc.sortAvailableUncoreCaches()
+			if !reflect.DeepEqual(result, tc.expect) {
+				t.Errorf("expected %v to equal %v", result, tc.expect)
+			}
+		})
+	}
+}
+
 func TestCPUAccumulatorTake(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	testCases := []struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/sig node
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR introduces two things:

1. On topologies where an uncore cache spans multiple NUMA nodes, the same uncore cache ID appears in the result of `sortAvailableUncoreCaches()` more than once . The duplicated IDs then flow into `takeUncoreCache()`, which pointlessly retries allocation on uncore caches it has already processed. Function `sortAvailableUncoreCaches()` now returns each uncore cache ID exactly once.

2. Function `takeUncoreCache()` itself was simplified by adjusting `takeFullUncore()` to operate on a single uncore cache ID instead of re-scanning all free uncore caches on its own. Previously, each call to `takeFullUncore()` went through `freeUncoreCache()`, which rebuilt and re-sorted the same candidate list that the outer loop in `takeUncoreCache()` was already iterating over. Now the sorted list is built once and used for two passes: the first pass claims fully-free uncore caches that fit the request, the second falls back to partial allocation. The no-longer-used `freeUncoreCache()` helper is removed as well.

#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
N/A
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
N/A
```
