### PR TITLE
Verify PodGroupCycleState availability discriminates sync from async Unreserve

### DIFF
--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -4587,6 +4587,183 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	}
 }
 
+type unreserveStateTrackerPlugin struct {
+	name                   string
+	failReserveOnSecondPod bool
+	failBind               bool
+
+	mu                     sync.Mutex
+	unreserveCalled        bool
+	podGroupStateAvailable bool
+}
+
+var _ fwk.ReservePlugin = &unreserveStateTrackerPlugin{}
+var _ fwk.BindPlugin = &unreserveStateTrackerPlugin{}
+
+func (u *unreserveStateTrackerPlugin) Name() string { return u.name }
+
+func (u *unreserveStateTrackerPlugin) Reserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
+	if u.failReserveOnSecondPod && p.Name == "p2" {
+		return fwk.NewStatus(fwk.Error, "simulated reserve error for p2")
+	}
+	return nil
+}
+
+func (u *unreserveStateTrackerPlugin) Unreserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.unreserveCalled = true
+	u.podGroupStateAvailable = state.GetPodGroupSchedulingCycle() != nil && state.IsPodGroupSchedulingCycle()
+}
+
+func (u *unreserveStateTrackerPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
+	if u.failBind {
+		return fwk.NewStatus(fwk.Error, "simulated bind error")
+	}
+	return nil
+}
+
+// Verify that PodGroupCycleState is accessible to Reserve plugins during synchronous Unreserve
+// (e.g. gang scheduling rollback), but is stripped prior to asynchronous binding.
+// IMPORTANT: The dynamicresources (DRA / devicemanagement) plugin relies on this contract in Unreserve
+// to distinguish synchronous gang rollbacks from asynchronous binding failures when releasing pending allocations.
+func TestScheduleOnePodGroup_PodGroupStateInUnreserve(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+
+	tests := []struct {
+		name                   string
+		failReserveOnSecondPod bool
+		failBind               bool
+		expectStateAvailable   bool
+	}{
+		{
+			name:                   "sync Unreserve has PodGroupState available",
+			failReserveOnSecondPod: true,
+			failBind:               false,
+			expectStateAvailable:   true,
+		},
+		{
+			name:                   "async Unreserve does not have PodGroupState available",
+			failReserveOnSecondPod: false,
+			failBind:               true,
+			expectStateAvailable:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			p1 := st.MakePod().Name("p1").UID("p1").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+			p2 := st.MakePod().Name("p2").UID("p2").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+			qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
+			qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
+			testPodGroup := st.MakePodGroup().Name("pg").Namespace("default").MinCount(2).Obj()
+			podGroupInfo := &framework.QueuedPodGroupInfo{
+				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+				PodGroupInfo: &framework.PodGroupInfo{
+					Name:            "pg",
+					Namespace:       "default",
+					Type:            fwk.PodGroupKeyType,
+					PodGroup:        testPodGroup,
+					UnscheduledPods: []*v1.Pod{p1, p2},
+				},
+			}
+
+			trackerPlugin := &unreserveStateTrackerPlugin{
+				name:                   "unreserve-state-tracker",
+				failReserveOnSecondPod: tt.failReserveOnSecondPod,
+				failBind:               tt.failBind,
+			}
+
+			gangPluginFactory := func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+				return gangscheduling.New(ctx, obj, handle, feature.Features{})
+			}
+
+			registry := frameworkruntime.Registry{
+				queuesort.Name:      queuesort.New,
+				gangscheduling.Name: gangPluginFactory,
+				trackerPlugin.Name(): func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return trackerPlugin, nil
+				},
+			}
+			profileCfg := config.KubeSchedulerProfile{
+				SchedulerName: "test-scheduler",
+				Plugins: &config.Plugins{
+					QueueSort: config.PluginSet{
+						Enabled: []config.Plugin{{Name: queuesort.Name}},
+					},
+					Reserve: config.PluginSet{
+						Enabled: []config.Plugin{{Name: trackerPlugin.Name()}},
+					},
+					Permit: config.PluginSet{
+						Enabled: []config.Plugin{{Name: gangscheduling.Name}},
+					},
+					Bind: config.PluginSet{
+						Enabled: []config.Plugin{{Name: trackerPlugin.Name()}},
+					},
+				},
+			}
+
+			snapshot := internalcache.NewEmptySnapshot()
+			client := clientsetfake.NewClientset(testPodGroup)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
+				frameworkruntime.WithClientSet(client),
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create new framework: %v", err)
+			}
+
+			cache := internalcache.New(ctx, nil, true, false /* CompositePodGroup */)
+			cache.AddPodGroup(testPodGroup)
+
+			sched := &Scheduler{
+				Profiles:         profile.Map{"test-scheduler": schedFwk},
+				SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
+				Cache:            cache,
+				nodeInfoSnapshot: snapshot,
+				client:           client,
+				FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
+				},
+			}
+			sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
+				return ScheduleResult{SuggestedHost: "node1"}, nil
+			}
+
+			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
+				t.Fatalf("Failed to update snapshot: %v", err)
+			}
+
+			sched.scheduleOnePodGroup(ctx, podGroupInfo)
+
+			if err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+				trackerPlugin.mu.Lock()
+				defer trackerPlugin.mu.Unlock()
+				return trackerPlugin.unreserveCalled, nil
+			}); err != nil {
+				t.Fatalf("Timed out waiting for Unreserve to be called")
+			}
+
+			trackerPlugin.mu.Lock()
+			available := trackerPlugin.podGroupStateAvailable
+			trackerPlugin.mu.Unlock()
+
+			if available != tt.expectStateAvailable {
+				t.Errorf("Expected PodGroupState available to be %v, got %v", tt.expectStateAvailable, available)
+			}
+		})
+	}
+}
+
 func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 		features.CompositePodGroup:               true,

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -4591,17 +4591,12 @@ type unreserveStateTrackerPlugin struct {
 	failReserveOnSecondPod bool
 	failBind               bool
 
-	mu                     sync.Mutex
-	syncReserveCount       int
-	syncReserveHasState    bool
-	asyncReserveCount      int
-	asyncReserveHasState   bool
-	permitCount            int
-	permitHasState         bool
-	syncUnreserveCount     int
-	syncUnreserveHasState  bool
-	asyncUnreserveCount    int
-	asyncUnreserveHasState bool
+	mu                  sync.Mutex
+	syncReserveCount    int
+	asyncReserveCount   int
+	asyncPermitCount    int
+	syncUnreserveCount  int
+	asyncUnreserveCount int
 }
 
 var _ fwk.ReservePlugin = &unreserveStateTrackerPlugin{}
@@ -4614,12 +4609,10 @@ func (u *unreserveStateTrackerPlugin) Reserve(ctx context.Context, state fwk.Cyc
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	if p.Name == "p1" {
-		if state.IsPodGroupSchedulingCycle() {
+		if state.GetPodGroupSchedulingCycle() != nil {
 			u.syncReserveCount++
-			u.syncReserveHasState = state.GetPodGroupSchedulingCycle() != nil
 		} else {
 			u.asyncReserveCount++
-			u.asyncReserveHasState = state.GetPodGroupSchedulingCycle() != nil
 		}
 	}
 	if u.failReserveOnSecondPod && p.Name == "p2" {
@@ -4632,8 +4625,9 @@ func (u *unreserveStateTrackerPlugin) Permit(ctx context.Context, state fwk.Cycl
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	if p.Name == "p1" {
-		u.permitCount++
-		u.permitHasState = state.GetPodGroupSchedulingCycle() != nil || state.IsPodGroupSchedulingCycle()
+		if state.GetPodGroupSchedulingCycle() == nil {
+			u.asyncPermitCount++
+		}
 	}
 	return nil, 0
 }
@@ -4642,12 +4636,10 @@ func (u *unreserveStateTrackerPlugin) Unreserve(ctx context.Context, state fwk.C
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	if p.Name == "p1" {
-		if state.IsPodGroupSchedulingCycle() {
+		if state.GetPodGroupSchedulingCycle() != nil {
 			u.syncUnreserveCount++
-			u.syncUnreserveHasState = state.GetPodGroupSchedulingCycle() != nil
 		} else {
 			u.asyncUnreserveCount++
-			u.asyncUnreserveHasState = state.GetPodGroupSchedulingCycle() != nil
 		}
 	}
 }
@@ -4663,50 +4655,38 @@ func (u *unreserveStateTrackerPlugin) Bind(ctx context.Context, state fwk.CycleS
 // (e.g. gang scheduling rollback), but is stripped prior to Permit, preparation for binding, and asynchronous binding.
 // IMPORTANT: The dynamicresources (DRA / devicemanagement) plugin relies on this contract in Unreserve
 // to distinguish synchronous gang rollbacks from asynchronous binding failures when releasing pending allocations.
-func TestScheduleOnePodGroup_PodGroupStateInUnreserve(t *testing.T) {
+func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
 
 	tests := []struct {
-		name                         string
-		failReserveOnSecondPod       bool
-		failBind                     bool
-		expectSyncReserveCount       int
-		expectSyncReserveHasState    bool
-		expectAsyncReserveCount      int
-		expectAsyncReserveHasState   bool
-		expectPermitCount            int
-		expectPermitHasState         bool
-		expectSyncUnreserveCount     int
-		expectSyncUnreserveHasState  bool
-		expectAsyncUnreserveCount    int
-		expectAsyncUnreserveHasState bool
+		name                   string
+		failReserveOnSecondPod bool
+		failBind               bool
+		expectSyncReserve      int
+		expectAsyncReserve     int
+		expectPermit           int
+		expectSyncUnreserve    int
+		expectAsyncUnreserve   int
 	}{
 		{
-			name:                        "sync Unreserve has PodGroupState available",
-			failReserveOnSecondPod:      true,
-			failBind:                    false,
-			expectSyncReserveCount:      1,
-			expectSyncReserveHasState:   true,
-			expectAsyncReserveCount:     0,
-			expectPermitCount:           0,
-			expectSyncUnreserveCount:    1,
-			expectSyncUnreserveHasState: true,
-			expectAsyncUnreserveCount:   0,
+			name:                   "sync Unreserve has PodGroupState available",
+			failReserveOnSecondPod: true,
+			failBind:               false,
+			expectSyncReserve:      1,
+			expectAsyncReserve:     0,
+			expectPermit:           0,
+			expectSyncUnreserve:    1,
+			expectAsyncUnreserve:   0,
 		},
 		{
-			name:                         "async Unreserve does not have PodGroupState available",
-			failReserveOnSecondPod:       false,
-			failBind:                     true,
-			expectSyncReserveCount:       1,
-			expectSyncReserveHasState:    true,
-			expectAsyncReserveCount:      1,
-			expectAsyncReserveHasState:   false,
-			expectPermitCount:            1,
-			expectPermitHasState:         false,
-			expectSyncUnreserveCount:     1,
-			expectSyncUnreserveHasState:  true,
-			expectAsyncUnreserveCount:    1,
-			expectAsyncUnreserveHasState: false,
+			name:                   "async Unreserve does not have PodGroupState available",
+			failReserveOnSecondPod: false,
+			failBind:               true,
+			expectSyncReserve:      1,
+			expectAsyncReserve:     1,
+			expectPermit:           1,
+			expectSyncUnreserve:    1,
+			expectAsyncUnreserve:   1,
 		},
 	}
 
@@ -4787,6 +4767,11 @@ func TestScheduleOnePodGroup_PodGroupStateInUnreserve(t *testing.T) {
 				t.Fatalf("Failed to create new framework: %v", err)
 			}
 
+			var (
+				failedPodsMu    sync.Mutex
+				failedPodsCount int
+			)
+
 			sched := &Scheduler{
 				Profiles:         profile.Map{"test-scheduler": schedFwk},
 				SchedulingQueue:  queue,
@@ -4794,6 +4779,9 @@ func TestScheduleOnePodGroup_PodGroupStateInUnreserve(t *testing.T) {
 				nodeInfoSnapshot: snapshot,
 				client:           client,
 				FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
+					failedPodsMu.Lock()
+					failedPodsCount++
+					failedPodsMu.Unlock()
 				},
 			}
 			sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
@@ -4806,72 +4794,36 @@ func TestScheduleOnePodGroup_PodGroupStateInUnreserve(t *testing.T) {
 
 			sched.scheduleOnePodGroup(ctx, podGroupInfo)
 
-			if tt.expectSyncUnreserveCount > 0 {
-				if err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-					trackerPlugin.mu.Lock()
-					defer trackerPlugin.mu.Unlock()
-					return trackerPlugin.syncUnreserveCount == tt.expectSyncUnreserveCount, nil
-				}); err != nil {
-					t.Fatalf("Timed out waiting for sync Unreserve to be called %d times", tt.expectSyncUnreserveCount)
-				}
-			}
-
-			if tt.expectAsyncUnreserveCount > 0 {
-				if err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-					trackerPlugin.mu.Lock()
-					defer trackerPlugin.mu.Unlock()
-					return trackerPlugin.asyncUnreserveCount == tt.expectAsyncUnreserveCount, nil
-				}); err != nil {
-					t.Fatalf("Timed out waiting for async Unreserve to be called %d times", tt.expectAsyncUnreserveCount)
-				}
+			if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+				failedPodsMu.Lock()
+				defer failedPodsMu.Unlock()
+				return failedPodsCount == len(podGroupInfo.PodGroupInfo.UnscheduledPods), nil
+			}); err != nil {
+				t.Fatalf("Timed out waiting for pod group scheduling cycle to complete: %v", err)
 			}
 
 			trackerPlugin.mu.Lock()
 			syncReserveCount := trackerPlugin.syncReserveCount
-			syncReserveHasState := trackerPlugin.syncReserveHasState
 			asyncReserveCount := trackerPlugin.asyncReserveCount
-			asyncReserveHasState := trackerPlugin.asyncReserveHasState
-			permitCount := trackerPlugin.permitCount
-			permitHasState := trackerPlugin.permitHasState
+			permitCount := trackerPlugin.asyncPermitCount
 			syncUnreserveCount := trackerPlugin.syncUnreserveCount
-			syncUnreserveHasState := trackerPlugin.syncUnreserveHasState
 			asyncUnreserveCount := trackerPlugin.asyncUnreserveCount
-			asyncUnreserveHasState := trackerPlugin.asyncUnreserveHasState
 			trackerPlugin.mu.Unlock()
 
-			if syncReserveCount != tt.expectSyncReserveCount {
-				t.Errorf("Expected sync Reserve count to be %d, got %d", tt.expectSyncReserveCount, syncReserveCount)
+			if syncReserveCount != tt.expectSyncReserve {
+				t.Errorf("Expected sync Reserve count to be %d, got %d", tt.expectSyncReserve, syncReserveCount)
 			}
-			if tt.expectSyncReserveCount > 0 && syncReserveHasState != tt.expectSyncReserveHasState {
-				t.Errorf("Expected sync Reserve hasState to be %v, got %v", tt.expectSyncReserveHasState, syncReserveHasState)
+			if asyncReserveCount != tt.expectAsyncReserve {
+				t.Errorf("Expected async Reserve count to be %d, got %d", tt.expectAsyncReserve, asyncReserveCount)
 			}
-
-			if asyncReserveCount != tt.expectAsyncReserveCount {
-				t.Errorf("Expected async Reserve count to be %d, got %d", tt.expectAsyncReserveCount, asyncReserveCount)
+			if permitCount != tt.expectPermit {
+				t.Errorf("Expected Permit count to be %d, got %d", tt.expectPermit, permitCount)
 			}
-			if tt.expectAsyncReserveCount > 0 && asyncReserveHasState != tt.expectAsyncReserveHasState {
-				t.Errorf("Expected async Reserve hasState to be %v, got %v", tt.expectAsyncReserveHasState, asyncReserveHasState)
+			if syncUnreserveCount != tt.expectSyncUnreserve {
+				t.Errorf("Expected sync Unreserve count to be %d, got %d", tt.expectSyncUnreserve, syncUnreserveCount)
 			}
-
-			if permitCount != tt.expectPermitCount {
-				t.Errorf("Expected Permit count to be %d, got %d", tt.expectPermitCount, permitCount)
-			}
-			if tt.expectPermitCount > 0 && permitHasState != tt.expectPermitHasState {
-				t.Errorf("Expected Permit hasState to be %v, got %v", tt.expectPermitHasState, permitHasState)
-			}
-
-			if syncUnreserveCount != tt.expectSyncUnreserveCount {
-				t.Errorf("Expected sync Unreserve count to be %d, got %d", tt.expectSyncUnreserveCount, syncUnreserveCount)
-			}
-			if tt.expectSyncUnreserveCount > 0 && syncUnreserveHasState != tt.expectSyncUnreserveHasState {
-				t.Errorf("Expected sync Unreserve hasState to be %v, got %v", tt.expectSyncUnreserveHasState, syncUnreserveHasState)
-			}
-
-			if asyncUnreserveCount != tt.expectAsyncUnreserveCount {
-				t.Errorf("Expected async Unreserve count to be %d, got %d", tt.expectAsyncUnreserveCount, asyncUnreserveCount)
-			}
-			if tt.expectAsyncUnreserveCount > 0 && asyncUnreserveHasState != tt.expectAsyncUnreserveHasState {
-				t.Errorf("Expected async Unreserve hasState to be %v, got %v", tt.expectAsyncUnreserveHasState, asyncUnreserveHasState)
+			if asyncUnreserveCount != tt.expectAsyncUnreserve {
+				t.Errorf("Expected async Unreserve count to be %d, got %d", tt.expectAsyncUnreserve, asyncUnreserveCount)
 			}
 		})
 	}

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -4586,10 +4586,11 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	}
 }
 
-type unreserveStateTrackerPlugin struct {
-	name                   string
-	failReserveOnSecondPod bool
-	failBind               bool
+type podGroupStateTrackerPlugin struct {
+	name             string
+	podToTrack       string
+	failReserveOnPod string
+	failBind         bool
 
 	mu                  sync.Mutex
 	syncReserveCount    int
@@ -4599,32 +4600,32 @@ type unreserveStateTrackerPlugin struct {
 	asyncUnreserveCount int
 }
 
-var _ fwk.ReservePlugin = &unreserveStateTrackerPlugin{}
-var _ fwk.PermitPlugin = &unreserveStateTrackerPlugin{}
-var _ fwk.BindPlugin = &unreserveStateTrackerPlugin{}
+var _ fwk.ReservePlugin = &podGroupStateTrackerPlugin{}
+var _ fwk.PermitPlugin = &podGroupStateTrackerPlugin{}
+var _ fwk.BindPlugin = &podGroupStateTrackerPlugin{}
 
-func (u *unreserveStateTrackerPlugin) Name() string { return u.name }
+func (u *podGroupStateTrackerPlugin) Name() string { return u.name }
 
-func (u *unreserveStateTrackerPlugin) Reserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
+func (u *podGroupStateTrackerPlugin) Reserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	if p.Name == "p1" {
+	if p.Name == u.podToTrack {
 		if state.GetPodGroupSchedulingCycle() != nil {
 			u.syncReserveCount++
 		} else {
 			u.asyncReserveCount++
 		}
 	}
-	if u.failReserveOnSecondPod && p.Name == "p2" {
-		return fwk.NewStatus(fwk.Error, "simulated reserve error for p2")
+	if u.failReserveOnPod != "" && p.Name == u.failReserveOnPod {
+		return fwk.NewStatus(fwk.Error, fmt.Sprintf("simulated reserve error for %s", p.Name))
 	}
 	return nil
 }
 
-func (u *unreserveStateTrackerPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
+func (u *podGroupStateTrackerPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	if p.Name == "p1" {
+	if p.Name == u.podToTrack {
 		if state.GetPodGroupSchedulingCycle() == nil {
 			u.asyncPermitCount++
 		}
@@ -4632,10 +4633,10 @@ func (u *unreserveStateTrackerPlugin) Permit(ctx context.Context, state fwk.Cycl
 	return nil, 0
 }
 
-func (u *unreserveStateTrackerPlugin) Unreserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) {
+func (u *podGroupStateTrackerPlugin) Unreserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	if p.Name == "p1" {
+	if p.Name == u.podToTrack {
 		if state.GetPodGroupSchedulingCycle() != nil {
 			u.syncUnreserveCount++
 		} else {
@@ -4644,7 +4645,7 @@ func (u *unreserveStateTrackerPlugin) Unreserve(ctx context.Context, state fwk.C
 	}
 }
 
-func (u *unreserveStateTrackerPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
+func (u *podGroupStateTrackerPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
 	if u.failBind {
 		return fwk.NewStatus(fwk.Error, "simulated bind error")
 	}
@@ -4659,34 +4660,37 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
 
 	tests := []struct {
-		name                   string
-		failReserveOnSecondPod bool
-		failBind               bool
-		expectSyncReserve      int
-		expectAsyncReserve     int
-		expectPermit           int
-		expectSyncUnreserve    int
-		expectAsyncUnreserve   int
+		name                 string
+		podToTrack           string
+		failReserveOnPod     string
+		failBind             bool
+		expectSyncReserve    int
+		expectAsyncReserve   int
+		expectPermit         int
+		expectSyncUnreserve  int
+		expectAsyncUnreserve int
 	}{
 		{
-			name:                   "sync Unreserve has PodGroupState available",
-			failReserveOnSecondPod: true,
-			failBind:               false,
-			expectSyncReserve:      1,
-			expectAsyncReserve:     0,
-			expectPermit:           0,
-			expectSyncUnreserve:    1,
-			expectAsyncUnreserve:   0,
+			name:                 "sync Unreserve has PodGroupState available",
+			podToTrack:           "p1",
+			failReserveOnPod:     "p2",
+			failBind:             false,
+			expectSyncReserve:    1,
+			expectAsyncReserve:   0,
+			expectPermit:         0,
+			expectSyncUnreserve:  1,
+			expectAsyncUnreserve: 0,
 		},
 		{
-			name:                   "async Unreserve does not have PodGroupState available",
-			failReserveOnSecondPod: false,
-			failBind:               true,
-			expectSyncReserve:      1,
-			expectAsyncReserve:     1,
-			expectPermit:           1,
-			expectSyncUnreserve:    1,
-			expectAsyncUnreserve:   1,
+			name:                 "async Unreserve does not have PodGroupState available",
+			podToTrack:           "p1",
+			failReserveOnPod:     "",
+			failBind:             true,
+			expectSyncReserve:    1,
+			expectAsyncReserve:   1,
+			expectPermit:         1,
+			expectSyncUnreserve:  1,
+			expectAsyncUnreserve: 1,
 		},
 	}
 
@@ -4712,10 +4716,11 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 				},
 			}
 
-			trackerPlugin := &unreserveStateTrackerPlugin{
-				name:                   "unreserve-state-tracker",
-				failReserveOnSecondPod: tt.failReserveOnSecondPod,
-				failBind:               tt.failBind,
+			trackerPlugin := &podGroupStateTrackerPlugin{
+				name:             "podgroup-state-tracker",
+				podToTrack:       tt.podToTrack,
+				failReserveOnPod: tt.failReserveOnPod,
+				failBind:         tt.failBind,
 			}
 
 			registry := frameworkruntime.Registry{

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -4580,7 +4580,6 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 		Reason:  schedulingapi.PodGroupReasonSchedulerError,
 		Message: `all pods in a single pod group should have the same .spec.schedulerName set, got: "sched2" and "sched1"`,
 	}
-
 	matchedCondition := apimeta.FindStatusCondition(pg.Status.Conditions, schedulingapi.PodGroupInitiallyScheduled)
 	if diff := cmp.Diff(&expectedCondition, matchedCondition, cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime", "ObservedGeneration")); diff != "" {
 		t.Errorf("Unexpected condition (-want +got):\n%s", diff)
@@ -4593,27 +4592,64 @@ type unreserveStateTrackerPlugin struct {
 	failBind               bool
 
 	mu                     sync.Mutex
-	unreserveCalled        bool
-	podGroupStateAvailable bool
+	syncReserveCount       int
+	syncReserveHasState    bool
+	asyncReserveCount      int
+	asyncReserveHasState   bool
+	permitCount            int
+	permitHasState         bool
+	syncUnreserveCount     int
+	syncUnreserveHasState  bool
+	asyncUnreserveCount    int
+	asyncUnreserveHasState bool
 }
 
 var _ fwk.ReservePlugin = &unreserveStateTrackerPlugin{}
+var _ fwk.PermitPlugin = &unreserveStateTrackerPlugin{}
 var _ fwk.BindPlugin = &unreserveStateTrackerPlugin{}
 
 func (u *unreserveStateTrackerPlugin) Name() string { return u.name }
 
 func (u *unreserveStateTrackerPlugin) Reserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if p.Name == "p1" {
+		if state.IsPodGroupSchedulingCycle() {
+			u.syncReserveCount++
+			u.syncReserveHasState = state.GetPodGroupSchedulingCycle() != nil
+		} else {
+			u.asyncReserveCount++
+			u.asyncReserveHasState = state.GetPodGroupSchedulingCycle() != nil
+		}
+	}
 	if u.failReserveOnSecondPod && p.Name == "p2" {
 		return fwk.NewStatus(fwk.Error, "simulated reserve error for p2")
 	}
 	return nil
 }
 
+func (u *unreserveStateTrackerPlugin) Permit(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if p.Name == "p1" {
+		u.permitCount++
+		u.permitHasState = state.GetPodGroupSchedulingCycle() != nil || state.IsPodGroupSchedulingCycle()
+	}
+	return nil, 0
+}
+
 func (u *unreserveStateTrackerPlugin) Unreserve(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	u.unreserveCalled = true
-	u.podGroupStateAvailable = state.GetPodGroupSchedulingCycle() != nil && state.IsPodGroupSchedulingCycle()
+	if p.Name == "p1" {
+		if state.IsPodGroupSchedulingCycle() {
+			u.syncUnreserveCount++
+			u.syncUnreserveHasState = state.GetPodGroupSchedulingCycle() != nil
+		} else {
+			u.asyncUnreserveCount++
+			u.asyncUnreserveHasState = state.GetPodGroupSchedulingCycle() != nil
+		}
+	}
 }
 
 func (u *unreserveStateTrackerPlugin) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
@@ -4623,30 +4659,54 @@ func (u *unreserveStateTrackerPlugin) Bind(ctx context.Context, state fwk.CycleS
 	return nil
 }
 
-// Verify that PodGroupCycleState is accessible to Reserve plugins during synchronous Unreserve
-// (e.g. gang scheduling rollback), but is stripped prior to asynchronous binding.
+// Verify that PodGroupCycleState is accessible to Reserve plugins during synchronous Reserve and Unreserve
+// (e.g. gang scheduling rollback), but is stripped prior to Permit, preparation for binding, and asynchronous binding.
 // IMPORTANT: The dynamicresources (DRA / devicemanagement) plugin relies on this contract in Unreserve
 // to distinguish synchronous gang rollbacks from asynchronous binding failures when releasing pending allocations.
 func TestScheduleOnePodGroup_PodGroupStateInUnreserve(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
 
 	tests := []struct {
-		name                   string
-		failReserveOnSecondPod bool
-		failBind               bool
-		expectStateAvailable   bool
+		name                         string
+		failReserveOnSecondPod       bool
+		failBind                     bool
+		expectSyncReserveCount       int
+		expectSyncReserveHasState    bool
+		expectAsyncReserveCount      int
+		expectAsyncReserveHasState   bool
+		expectPermitCount            int
+		expectPermitHasState         bool
+		expectSyncUnreserveCount     int
+		expectSyncUnreserveHasState  bool
+		expectAsyncUnreserveCount    int
+		expectAsyncUnreserveHasState bool
 	}{
 		{
-			name:                   "sync Unreserve has PodGroupState available",
-			failReserveOnSecondPod: true,
-			failBind:               false,
-			expectStateAvailable:   true,
+			name:                        "sync Unreserve has PodGroupState available",
+			failReserveOnSecondPod:      true,
+			failBind:                    false,
+			expectSyncReserveCount:      1,
+			expectSyncReserveHasState:   true,
+			expectAsyncReserveCount:     0,
+			expectPermitCount:           0,
+			expectSyncUnreserveCount:    1,
+			expectSyncUnreserveHasState: true,
+			expectAsyncUnreserveCount:   0,
 		},
 		{
-			name:                   "async Unreserve does not have PodGroupState available",
-			failReserveOnSecondPod: false,
-			failBind:               true,
-			expectStateAvailable:   false,
+			name:                         "async Unreserve does not have PodGroupState available",
+			failReserveOnSecondPod:       false,
+			failBind:                     true,
+			expectSyncReserveCount:       1,
+			expectSyncReserveHasState:    true,
+			expectAsyncReserveCount:      1,
+			expectAsyncReserveHasState:   false,
+			expectPermitCount:            1,
+			expectPermitHasState:         false,
+			expectSyncUnreserveCount:     1,
+			expectSyncUnreserveHasState:  true,
+			expectAsyncUnreserveCount:    1,
+			expectAsyncUnreserveHasState: false,
 		},
 	}
 
@@ -4656,8 +4716,8 @@ func TestScheduleOnePodGroup_PodGroupStateInUnreserve(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			p1 := st.MakePod().Name("p1").UID("p1").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
-			p2 := st.MakePod().Name("p2").UID("p2").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+			p1 := st.MakePod().Name("p1").Namespace("default").UID("p1").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+			p2 := st.MakePod().Name("p2").Namespace("default").UID("p2").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
 			qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
 			qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 			testPodGroup := st.MakePodGroup().Name("pg").Namespace("default").MinCount(2).Obj()
@@ -4678,13 +4738,8 @@ func TestScheduleOnePodGroup_PodGroupStateInUnreserve(t *testing.T) {
 				failBind:               tt.failBind,
 			}
 
-			gangPluginFactory := func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
-				return gangscheduling.New(ctx, obj, handle, feature.Features{})
-			}
-
 			registry := frameworkruntime.Registry{
-				queuesort.Name:      queuesort.New,
-				gangscheduling.Name: gangPluginFactory,
+				queuesort.Name: queuesort.New,
 				trackerPlugin.Name(): func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 					return trackerPlugin, nil
 				},
@@ -4699,7 +4754,7 @@ func TestScheduleOnePodGroup_PodGroupStateInUnreserve(t *testing.T) {
 						Enabled: []config.Plugin{{Name: trackerPlugin.Name()}},
 					},
 					Permit: config.PluginSet{
-						Enabled: []config.Plugin{{Name: gangscheduling.Name}},
+						Enabled: []config.Plugin{{Name: trackerPlugin.Name()}},
 					},
 					Bind: config.PluginSet{
 						Enabled: []config.Plugin{{Name: trackerPlugin.Name()}},
@@ -4713,22 +4768,28 @@ func TestScheduleOnePodGroup_PodGroupStateInUnreserve(t *testing.T) {
 			informerFactory.Start(ctx.Done())
 			informerFactory.WaitForCacheSync(ctx.Done())
 
+			cache := internalcache.New(ctx, nil, true, false /* CompositePodGroup */)
+			cache.AddPodGroup(testPodGroup)
+			queue := internalqueue.NewTestQueue(ctx, nil)
+
 			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
 				frameworkruntime.WithClientSet(client),
 				frameworkruntime.WithInformerFactory(informerFactory),
 				frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodGroupManager(cache),
+				frameworkruntime.WithPodActivator(queue),
+				frameworkruntime.WithPodNominator(queue),
+				frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+				frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
 			)
 			if err != nil {
 				t.Fatalf("Failed to create new framework: %v", err)
 			}
 
-			cache := internalcache.New(ctx, nil, true, false /* CompositePodGroup */)
-			cache.AddPodGroup(testPodGroup)
-
 			sched := &Scheduler{
 				Profiles:         profile.Map{"test-scheduler": schedFwk},
-				SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
+				SchedulingQueue:  queue,
 				Cache:            cache,
 				nodeInfoSnapshot: snapshot,
 				client:           client,
@@ -4745,20 +4806,72 @@ func TestScheduleOnePodGroup_PodGroupStateInUnreserve(t *testing.T) {
 
 			sched.scheduleOnePodGroup(ctx, podGroupInfo)
 
-			if err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-				trackerPlugin.mu.Lock()
-				defer trackerPlugin.mu.Unlock()
-				return trackerPlugin.unreserveCalled, nil
-			}); err != nil {
-				t.Fatalf("Timed out waiting for Unreserve to be called")
+			if tt.expectSyncUnreserveCount > 0 {
+				if err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+					trackerPlugin.mu.Lock()
+					defer trackerPlugin.mu.Unlock()
+					return trackerPlugin.syncUnreserveCount == tt.expectSyncUnreserveCount, nil
+				}); err != nil {
+					t.Fatalf("Timed out waiting for sync Unreserve to be called %d times", tt.expectSyncUnreserveCount)
+				}
+			}
+
+			if tt.expectAsyncUnreserveCount > 0 {
+				if err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+					trackerPlugin.mu.Lock()
+					defer trackerPlugin.mu.Unlock()
+					return trackerPlugin.asyncUnreserveCount == tt.expectAsyncUnreserveCount, nil
+				}); err != nil {
+					t.Fatalf("Timed out waiting for async Unreserve to be called %d times", tt.expectAsyncUnreserveCount)
+				}
 			}
 
 			trackerPlugin.mu.Lock()
-			available := trackerPlugin.podGroupStateAvailable
+			syncReserveCount := trackerPlugin.syncReserveCount
+			syncReserveHasState := trackerPlugin.syncReserveHasState
+			asyncReserveCount := trackerPlugin.asyncReserveCount
+			asyncReserveHasState := trackerPlugin.asyncReserveHasState
+			permitCount := trackerPlugin.permitCount
+			permitHasState := trackerPlugin.permitHasState
+			syncUnreserveCount := trackerPlugin.syncUnreserveCount
+			syncUnreserveHasState := trackerPlugin.syncUnreserveHasState
+			asyncUnreserveCount := trackerPlugin.asyncUnreserveCount
+			asyncUnreserveHasState := trackerPlugin.asyncUnreserveHasState
 			trackerPlugin.mu.Unlock()
 
-			if available != tt.expectStateAvailable {
-				t.Errorf("Expected PodGroupState available to be %v, got %v", tt.expectStateAvailable, available)
+			if syncReserveCount != tt.expectSyncReserveCount {
+				t.Errorf("Expected sync Reserve count to be %d, got %d", tt.expectSyncReserveCount, syncReserveCount)
+			}
+			if tt.expectSyncReserveCount > 0 && syncReserveHasState != tt.expectSyncReserveHasState {
+				t.Errorf("Expected sync Reserve hasState to be %v, got %v", tt.expectSyncReserveHasState, syncReserveHasState)
+			}
+
+			if asyncReserveCount != tt.expectAsyncReserveCount {
+				t.Errorf("Expected async Reserve count to be %d, got %d", tt.expectAsyncReserveCount, asyncReserveCount)
+			}
+			if tt.expectAsyncReserveCount > 0 && asyncReserveHasState != tt.expectAsyncReserveHasState {
+				t.Errorf("Expected async Reserve hasState to be %v, got %v", tt.expectAsyncReserveHasState, asyncReserveHasState)
+			}
+
+			if permitCount != tt.expectPermitCount {
+				t.Errorf("Expected Permit count to be %d, got %d", tt.expectPermitCount, permitCount)
+			}
+			if tt.expectPermitCount > 0 && permitHasState != tt.expectPermitHasState {
+				t.Errorf("Expected Permit hasState to be %v, got %v", tt.expectPermitHasState, permitHasState)
+			}
+
+			if syncUnreserveCount != tt.expectSyncUnreserveCount {
+				t.Errorf("Expected sync Unreserve count to be %d, got %d", tt.expectSyncUnreserveCount, syncUnreserveCount)
+			}
+			if tt.expectSyncUnreserveCount > 0 && syncUnreserveHasState != tt.expectSyncUnreserveHasState {
+				t.Errorf("Expected sync Unreserve hasState to be %v, got %v", tt.expectSyncUnreserveHasState, syncUnreserveHasState)
+			}
+
+			if asyncUnreserveCount != tt.expectAsyncUnreserveCount {
+				t.Errorf("Expected async Unreserve count to be %d, got %d", tt.expectAsyncUnreserveCount, asyncUnreserveCount)
+			}
+			if tt.expectAsyncUnreserveCount > 0 && asyncUnreserveHasState != tt.expectAsyncUnreserveHasState {
+				t.Errorf("Expected async Unreserve hasState to be %v, got %v", tt.expectAsyncUnreserveHasState, asyncUnreserveHasState)
 			}
 		})
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Stripping `PodGroupCycleState` prior to asynchronous binding (`SetPodGroupSchedulingCycle(nil)`) is a core scheduler invariant enforced by `scheduleOnePodGroup` and `bindingCycle`. 

Plugins like `dynamicresources` (DRA / device management) rely on checking `state.GetPodGroupSchedulingCycle() != nil` in `Unreserve` to differentiate synchronous gang rollbacks from asynchronous binding failures when cleaning up shared pending allocations.

This test guards the invariant doesn't change over time, or is replaced with some equivalent mechanism.

#### Which issue(s) this PR is related to:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```

