### PR TITLE
Update gcb-docker-gcloud to v20260729-0b834bafc6

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -257,7 +257,7 @@ dependencies:
 
   # GCB docker gcloud image
   - name: "gcb-docker-gcloud: dependents"
-    version: v20260108-7f313c340e@sha256:4d778a001ae3f4247b2b61d8a870319e71d66c87556969a6399b90972e4d0491
+    version: v20260729-0b834bafc6@sha256:77257657315bf94c1bba8f2471b1e210a75005ba8f589d94a48eeb8da176f007
     refPaths:
     - path: build/pause/cloudbuild.yaml
       match: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud

--- a/build/pause/cloudbuild.yaml
+++ b/build/pause/cloudbuild.yaml
@@ -4,7 +4,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: 'E2_HIGHCPU_8'
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260108-7f313c340e@sha256:4d778a001ae3f4247b2b61d8a870319e71d66c87556969a6399b90972e4d0491'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6@sha256:77257657315bf94c1bba8f2471b1e210a75005ba8f589d94a48eeb8da176f007'
     dir: ./build/pause
     env:
       - REGISTRY=gcr.io/$PROJECT_ID

--- a/test/images/cloudbuild.yaml
+++ b/test/images/cloudbuild.yaml
@@ -8,7 +8,7 @@ timeout: 5400s
 options:
   substitution_option: ALLOW_LOOSE
 steps:
-  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260108-7f313c340e@sha256:4d778a001ae3f4247b2b61d8a870319e71d66c87556969a6399b90972e4d0491'
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260729-0b834bafc6@sha256:77257657315bf94c1bba8f2471b1e210a75005ba8f589d94a48eeb8da176f007'
     dir: ./test/images/
     env:
     - BASE_REF=$_PULL_BASE_REF


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

The tag `v20260108-7f313c340e` is no longer present in `gcr.io/k8s-staging-test-infra/gcb-docker-gcloud`, causing all `post-kubernetes-push-e2e-*-test-images` postsubmit jobs to fail immediately at image pull:

```
manifest for gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:4d778a... not found: manifest unknown
```

Example failure: https://storage.googleapis.com/kubernetes-ci-logs/logs/post-kubernetes-push-e2e-agnhost-test-images/2082475251370823680/build-log.txt

Updates `test/images/cloudbuild.yaml` to the latest available tag `v20260729-0b834bafc6` (built 2026-07-29).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

One-line change, no logic change — just bumping the builder image tag + digest.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```