### PR TITLE
Avoid reconcile panic on error

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/auth/reconcile.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
@@ -271,6 +272,9 @@ func (o *ReconcileOptions) RunReconcile() error {
 				result, err = reconcileOptions.Run()
 				return err
 			})
+			if err != nil {
+				return err
+			}
 			o.printResults(result.RoleBinding.GetObject(), result.MissingSubjects, result.ExtraSubjects, nil, nil, result.Operation, result.Protected)
 
 		case *rbacv1.ClusterRoleBinding:
@@ -290,6 +294,9 @@ func (o *ReconcileOptions) RunReconcile() error {
 				result, err = reconcileOptions.Run()
 				return err
 			})
+			if err != nil {
+				return err
+			}
 			o.printResults(result.RoleBinding.GetObject(), result.MissingSubjects, result.ExtraSubjects, nil, nil, result.Operation, result.Protected)
 
 		case *rbacv1beta1.Role,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Avoids a nil panic if `kubectl auth reconcile` errors reconciling bindings

#### Does this PR introduce a user-facing change?
```release-note
Fixes a panic in `kubectl auth reconcile` if an error was encountered reconciling a rolebinding or clusterrolebinding
```

/sig auth
/cc @enj