### PR TITLE
kubelet: migrate pod resource allocation checkpoint format to store the entire PodSpec

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -25,7 +25,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -425,135 +424,22 @@ func (m *manager) UpdatePodFromAllocation(pod *v1.Pod) (*v1.Pod, bool) {
 		return pod, false
 	}
 
-	allocated, ok := m.allocated.GetPodResourceInfo(pod.UID)
+	allocated, ok := m.allocated.GetPod(pod.UID)
 	if !ok {
 		return pod, false
 	}
 
-	return updatePodFromAllocation(pod, allocated)
-}
-
-func updatePodFromAllocation(pod *v1.Pod, allocated state.PodResourceInfo) (*v1.Pod, bool) {
-	if pod == nil {
-		return pod, false
-	}
-
-	updated := false
-	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
-		pod, updated = updatePodLevelResourcesFromAllocation(pod, allocated)
-	}
-	pod, updated = updateContainerResourcesFromAllocation(pod, allocated, updated)
-	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingMemoryBackedVolumes) {
-		pod, updated = updateEmptyDirVolumeLimitsFromAllocation(pod, allocated, updated)
-	}
-
-	return pod, updated
-}
-
-func updateContainerResourcesFromAllocation(pod *v1.Pod, allocated state.PodResourceInfo, alreadyUpdated bool) (*v1.Pod, bool) {
-	updated := alreadyUpdated
-	containerAlloc := func(c v1.Container) (v1.ResourceRequirements, bool) {
-		if cAlloc, ok := allocated.ContainerResources[c.Name]; ok {
-			if !apiequality.Semantic.DeepEqual(c.Resources, cAlloc) {
-				// Allocation differs from pod spec, retrieve the allocation
-				if !updated {
-					// If this is the first update to be performed, copy the pod
-					pod = pod.DeepCopy()
-					updated = true
-				}
-				return cAlloc, true
-			}
-		}
-		return v1.ResourceRequirements{}, false
-	}
-
-	for i, c := range pod.Spec.Containers {
-		if cAlloc, found := containerAlloc(c); found {
-			// Allocation differs from pod spec, update
-			pod.Spec.Containers[i].Resources = cAlloc
-		}
-	}
-	for i, c := range pod.Spec.InitContainers {
-		if cAlloc, found := containerAlloc(c); found {
-			// Allocation differs from pod spec, update
-			pod.Spec.InitContainers[i].Resources = cAlloc
-		}
-	}
-	return pod, updated
-}
-
-func updatePodLevelResourcesFromAllocation(pod *v1.Pod, allocated state.PodResourceInfo) (*v1.Pod, bool) {
-	pAlloc := allocated.PodLevelResources
-	if !apiequality.Semantic.DeepEqual(pod.Spec.Resources, pAlloc) {
-		// Allocation differs from pod spec, retrieve the allocation
-		pod = pod.DeepCopy()
-		pod.Spec.Resources = pAlloc
-		return pod, true
-	}
-	return pod, false
-}
-
-func updateEmptyDirVolumeLimitsFromAllocation(pod *v1.Pod, allocated state.PodResourceInfo, alreadyUpdated bool) (*v1.Pod, bool) {
-	updated := alreadyUpdated
-	for i, vol := range pod.Spec.Volumes {
-		if !VolHasMemoryBackedEmptyDirSizeLimit(&vol) {
-			continue
-		}
-		if alloc, ok := allocated.EmptyDirVolumeLimits[vol.Name]; ok {
-			if alloc.Cmp(*vol.EmptyDir.SizeLimit) != 0 {
-				if !updated {
-					pod = pod.DeepCopy()
-					updated = true
-				}
-				allocCopy := alloc.DeepCopy()
-				pod.Spec.Volumes[i].EmptyDir.SizeLimit = &allocCopy
-			}
-		}
-	}
-	return pod, updated
+	return state.UpdatePodFromCheckpoint(pod, allocated)
 }
 
 // HasPodAllocatedResources returns whether a pod has been allocated resources.
 func (m *manager) HasPodAllocatedResources(podUID types.UID) bool {
-	_, allocated := m.allocated.GetPodResourceInfo(podUID)
-	return allocated
+	return m.allocated.HasPod(podUID)
 }
 
 // SetAllocatedResources checkpoints the resources allocated to a pod's containers
 func (m *manager) SetAllocatedResources(logger klog.Logger, pod *v1.Pod) error {
-	return m.allocated.SetPodResourceInfo(logger, pod.UID, ResourceInfoForPod(pod))
-}
-
-// ResourceInfoForPod constructs a state.PodResourceInfo containing container resources,
-// memory-backed emptyDir volume limits, and pod-level resources for the given pod.
-func ResourceInfoForPod(pod *v1.Pod) state.PodResourceInfo {
-	var podAlloc state.PodResourceInfo
-	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) && pod.Spec.Resources != nil {
-		podAlloc.PodLevelResources = pod.Spec.Resources.DeepCopy()
-	}
-	podAlloc.ContainerResources = make(map[string]v1.ResourceRequirements)
-	for container, containerType := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
-		if !IsResizableContainer(container, containerType) {
-			continue
-		}
-		alloc := *container.Resources.DeepCopy()
-		podAlloc.ContainerResources[container.Name] = alloc
-	}
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingMemoryBackedVolumes) {
-		for _, vol := range pod.Spec.Volumes {
-			if !VolHasMemoryBackedEmptyDirSizeLimit(&vol) {
-				continue
-			}
-			alloc := vol.EmptyDir.SizeLimit.DeepCopy()
-			if podAlloc.EmptyDirVolumeLimits == nil {
-				podAlloc.EmptyDirVolumeLimits = make(map[string]*resource.Quantity)
-			}
-			podAlloc.EmptyDirVolumeLimits[vol.Name] = &alloc
-		}
-	}
-
-	return podAlloc
+	return m.allocated.SetPod(logger, pod)
 }
 
 func (m *manager) AddPodAdmitHandlers(handlers lifecycle.PodAdmitHandlers) {

--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -430,21 +430,24 @@ func (m *manager) UpdatePodFromAllocation(pod *v1.Pod) (*v1.Pod, bool) {
 		return pod, false
 	}
 
-	return updatePodFromAllocation(pod, allocated)
+	return UpdatePodFromResourceInfo(pod, allocated)
 }
 
-func updatePodFromAllocation(pod *v1.Pod, allocated state.PodResourceInfo) (*v1.Pod, bool) {
-	if pod == nil {
+// UpdatePodFromResourceInfo overwrites the pod's resource requirements (container resources,
+// pod-level resources, and memory-backed emptyDir volume size limits) with the values from resource info.
+// This function does a deep copy of the pod only if updates are needed.
+func UpdatePodFromResourceInfo(pod *v1.Pod, info state.PodResourceInfo) (*v1.Pod, bool) {
+	if pod == nil || info.PodSpec == nil {
 		return pod, false
 	}
 
 	updated := false
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
-		pod, updated = updatePodLevelResourcesFromAllocation(pod, allocated)
+		pod, updated = updatePodLevelResourcesFromAllocation(pod, info)
 	}
-	pod, updated = updateContainerResourcesFromAllocation(pod, allocated, updated)
+	pod, updated = updateContainerResourcesFromAllocation(pod, info, updated)
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingMemoryBackedVolumes) {
-		pod, updated = updateEmptyDirVolumeLimitsFromAllocation(pod, allocated, updated)
+		pod, updated = updateEmptyDirVolumeLimitsFromAllocation(pod, info, updated)
 	}
 
 	return pod, updated
@@ -453,15 +456,20 @@ func updatePodFromAllocation(pod *v1.Pod, allocated state.PodResourceInfo) (*v1.
 func updateContainerResourcesFromAllocation(pod *v1.Pod, allocated state.PodResourceInfo, alreadyUpdated bool) (*v1.Pod, bool) {
 	updated := alreadyUpdated
 	containerAlloc := func(c v1.Container) (v1.ResourceRequirements, bool) {
-		if cAlloc, ok := allocated.ContainerResources[c.Name]; ok {
-			if !apiequality.Semantic.DeepEqual(c.Resources, cAlloc) {
-				// Allocation differs from pod spec, retrieve the allocation
-				if !updated {
-					// If this is the first update to be performed, copy the pod
-					pod = pod.DeepCopy()
-					updated = true
+		if allocated.PodSpec == nil {
+			return v1.ResourceRequirements{}, false
+		}
+		for ac := range podutil.ContainerIter(allocated.PodSpec, podutil.InitContainers|podutil.Containers) {
+			if ac.Name == c.Name {
+				if !apiequality.Semantic.DeepEqual(c.Resources, ac.Resources) {
+					// Allocation differs from pod spec, retrieve the allocation
+					if !updated {
+						// If this is the first update to be performed, copy the pod
+						pod = pod.DeepCopy()
+						updated = true
+					}
+					return ac.Resources, true
 				}
-				return cAlloc, true
 			}
 		}
 		return v1.ResourceRequirements{}, false
@@ -483,11 +491,14 @@ func updateContainerResourcesFromAllocation(pod *v1.Pod, allocated state.PodReso
 }
 
 func updatePodLevelResourcesFromAllocation(pod *v1.Pod, allocated state.PodResourceInfo) (*v1.Pod, bool) {
-	pAlloc := allocated.PodLevelResources
+	pAlloc := allocated.PodSpec.Resources
+	if pAlloc == nil {
+		return pod, false
+	}
 	if !apiequality.Semantic.DeepEqual(pod.Spec.Resources, pAlloc) {
 		// Allocation differs from pod spec, retrieve the allocation
 		pod = pod.DeepCopy()
-		pod.Spec.Resources = pAlloc
+		pod.Spec.Resources = pAlloc.DeepCopy()
 		return pod, true
 	}
 	return pod, false
@@ -499,15 +510,22 @@ func updateEmptyDirVolumeLimitsFromAllocation(pod *v1.Pod, allocated state.PodRe
 		if !VolHasMemoryBackedEmptyDirSizeLimit(&vol) {
 			continue
 		}
-		if alloc, ok := allocated.EmptyDirVolumeLimits[vol.Name]; ok {
-			if alloc.Cmp(*vol.EmptyDir.SizeLimit) != 0 {
-				if !updated {
-					pod = pod.DeepCopy()
-					updated = true
-				}
-				allocCopy := alloc.DeepCopy()
-				pod.Spec.Volumes[i].EmptyDir.SizeLimit = &allocCopy
+
+		var alloc *resource.Quantity
+		for _, av := range allocated.PodSpec.Volumes {
+			if av.Name == vol.Name && av.EmptyDir != nil {
+				alloc = av.EmptyDir.SizeLimit
+				break
 			}
+		}
+
+		if alloc != nil && (vol.EmptyDir.SizeLimit == nil || alloc.Cmp(*vol.EmptyDir.SizeLimit) != 0) {
+			if !updated {
+				pod = pod.DeepCopy()
+				updated = true
+			}
+			allocCopy := alloc.DeepCopy()
+			pod.Spec.Volumes[i].EmptyDir.SizeLimit = &allocCopy
 		}
 	}
 	return pod, updated
@@ -524,36 +542,11 @@ func (m *manager) SetAllocatedResources(logger klog.Logger, pod *v1.Pod) error {
 	return m.allocated.SetPodResourceInfo(logger, pod.UID, ResourceInfoForPod(pod))
 }
 
-// ResourceInfoForPod constructs a state.PodResourceInfo containing container resources,
-// memory-backed emptyDir volume limits, and pod-level resources for the given pod.
+// ResourceInfoForPod constructs a state.PodResourceInfo containing the entire pod spec.
 func ResourceInfoForPod(pod *v1.Pod) state.PodResourceInfo {
-	var podAlloc state.PodResourceInfo
-	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) && pod.Spec.Resources != nil {
-		podAlloc.PodLevelResources = pod.Spec.Resources.DeepCopy()
+	return state.PodResourceInfo{
+		PodSpec: pod.Spec.DeepCopy(),
 	}
-	podAlloc.ContainerResources = make(map[string]v1.ResourceRequirements)
-	for container, containerType := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
-		if !IsResizableContainer(container, containerType) {
-			continue
-		}
-		alloc := *container.Resources.DeepCopy()
-		podAlloc.ContainerResources[container.Name] = alloc
-	}
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingMemoryBackedVolumes) {
-		for _, vol := range pod.Spec.Volumes {
-			if !VolHasMemoryBackedEmptyDirSizeLimit(&vol) {
-				continue
-			}
-			alloc := vol.EmptyDir.SizeLimit.DeepCopy()
-			if podAlloc.EmptyDirVolumeLimits == nil {
-				podAlloc.EmptyDirVolumeLimits = make(map[string]*resource.Quantity)
-			}
-			podAlloc.EmptyDirVolumeLimits[vol.Name] = &alloc
-		}
-	}
-
-	return podAlloc
 }
 
 func (m *manager) AddPodAdmitHandlers(handlers lifecycle.PodAdmitHandlers) {

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -18,7 +18,10 @@ package allocation
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	goruntime "runtime"
 	"strings"
 	"testing"
@@ -41,6 +44,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/allocation/state"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
@@ -167,128 +171,196 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 		v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
 	}
 
+	podWithVolumes := pod.DeepCopy()
+	podWithVolumes.Spec.Volumes = []v1.Volume{
+		{
+			Name: "mem-vol",
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{
+					Medium:    v1.StorageMediumMemory,
+					SizeLimit: resource.NewQuantity(128*1024*1024, resource.BinarySI),
+				},
+			},
+		},
+	}
+
+	resizedPodWithVolumes := podWithVolumes.DeepCopy()
+	resizedPodWithVolumes.Spec.Volumes[0].EmptyDir.SizeLimit = resource.NewQuantity(256*1024*1024, resource.BinarySI)
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeDeclaredFeatures, true)
 
 	tests := []struct {
-		name                         string
-		pod                          *v1.Pod
-		allocated                    state.PodResourceInfo
-		expectPod                    *v1.Pod
-		expectUpdate                 bool
-		inPlacePodLevelResizeEnabled bool
-	}{{
-		name: "steady state",
-		pod:  pod,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *pod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *pod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *pod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *pod.Spec.InitContainers[1].Resources.DeepCopy(),
+		name                                                string
+		pod                                                 *v1.Pod
+		allocated                                           state.PodResourceInfo
+		expectPod                                           *v1.Pod
+		expectUpdate                                        bool
+		inPlacePodLevelResizeEnabled                        bool
+		inPlacePodVerticalScalingMemoryBackedVolumesEnabled bool
+	}{
+		{
+			name: "steady state",
+			pod:  pod,
+			allocated: state.PodResourceInfo{
+				PodSpec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "c1", Resources: *pod.Spec.Containers[0].Resources.DeepCopy()},
+						{Name: "c2", Resources: *pod.Spec.Containers[1].Resources.DeepCopy()},
+					},
+					InitContainers: []v1.Container{
+						{Name: "c1-restartable-init", Resources: *pod.Spec.InitContainers[0].Resources.DeepCopy()},
+						{Name: "c1-init", Resources: *pod.Spec.InitContainers[1].Resources.DeepCopy()},
+					},
+				},
 			},
-		},
-		expectUpdate: false,
-	}, {
-		name:         "no allocations",
-		pod:          pod,
-		allocated:    state.PodResourceInfo{},
-		expectUpdate: false,
-	}, {
-		name: "missing container allocation",
-		pod:  pod,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c2": *pod.Spec.Containers[1].Resources.DeepCopy(),
+			expectUpdate: false,
+		}, {
+			name:         "no allocations",
+			pod:          pod,
+			allocated:    state.PodResourceInfo{},
+			expectUpdate: false,
+		}, {
+			name: "missing container allocation",
+			pod:  pod,
+			allocated: state.PodResourceInfo{
+				PodSpec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "c2", Resources: *pod.Spec.Containers[1].Resources.DeepCopy()},
+					},
+				},
 			},
-		},
-		expectUpdate: false,
-	}, {
-		name: "resized container",
-		pod:  pod,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *resizedPod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *resizedPod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *resizedPod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *resizedPod.Spec.InitContainers[1].Resources.DeepCopy(),
+			expectUpdate: false,
+		}, {
+			name: "resized container",
+			pod:  pod,
+			allocated: state.PodResourceInfo{
+				PodSpec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "c1", Resources: *resizedPod.Spec.Containers[0].Resources.DeepCopy()},
+						{Name: "c2", Resources: *resizedPod.Spec.Containers[1].Resources.DeepCopy()},
+					},
+					InitContainers: []v1.Container{
+						{Name: "c1-restartable-init", Resources: *resizedPod.Spec.InitContainers[0].Resources.DeepCopy()},
+						{Name: "c1-init", Resources: *resizedPod.Spec.InitContainers[1].Resources.DeepCopy()},
+					},
+				},
 			},
-		},
-		expectUpdate: true,
-		expectPod:    resizedPod,
-	}, {
-		name: "resized pod-level allocation",
-		pod:  pod,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *resizedPod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *resizedPod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *resizedPod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *resizedPod.Spec.InitContainers[1].Resources.DeepCopy(),
+			expectUpdate: true,
+			expectPod:    resizedPod,
+		}, {
+			name: "resized pod-level allocation",
+			pod:  pod,
+			allocated: state.PodResourceInfo{
+				PodSpec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "c1", Resources: *resizedPod.Spec.Containers[0].Resources.DeepCopy()},
+						{Name: "c2", Resources: *resizedPod.Spec.Containers[1].Resources.DeepCopy()},
+					},
+					InitContainers: []v1.Container{
+						{Name: "c1-restartable-init", Resources: *resizedPod.Spec.InitContainers[0].Resources.DeepCopy()},
+						{Name: "c1-init", Resources: *resizedPod.Spec.InitContainers[1].Resources.DeepCopy()},
+					},
+					Resources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
+				},
 			},
-			PodLevelResources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
-		},
-		expectUpdate:                 true,
-		expectPod:                    resizedPodWithPodLevelResources,
-		inPlacePodLevelResizeEnabled: true,
-	}, {
-		name: "resized pod-level resources and allocation",
-		pod:  podWithPodLevelResources,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *resizedPod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *resizedPod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *resizedPod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *resizedPod.Spec.InitContainers[1].Resources.DeepCopy(),
+			expectUpdate:                 true,
+			expectPod:                    resizedPodWithPodLevelResources,
+			inPlacePodLevelResizeEnabled: true,
+		}, {
+			name: "resized pod-level resources and allocation",
+			pod:  podWithPodLevelResources,
+			allocated: state.PodResourceInfo{
+				PodSpec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "c1", Resources: *resizedPod.Spec.Containers[0].Resources.DeepCopy()},
+						{Name: "c2", Resources: *resizedPod.Spec.Containers[1].Resources.DeepCopy()},
+					},
+					InitContainers: []v1.Container{
+						{Name: "c1-restartable-init", Resources: *resizedPod.Spec.InitContainers[0].Resources.DeepCopy()},
+						{Name: "c1-init", Resources: *resizedPod.Spec.InitContainers[1].Resources.DeepCopy()},
+					},
+					Resources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
+				},
 			},
-			PodLevelResources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
-		},
-		expectUpdate:                 true,
-		expectPod:                    resizedPodWithPodLevelResources,
-		inPlacePodLevelResizeEnabled: true,
-	}, {
-		name: "resized pod-level resources and no container resources",
-		pod:  podWithoutContainerResources,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *resizedPod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *resizedPod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *resizedPod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *resizedPod.Spec.InitContainers[1].Resources.DeepCopy(),
+			expectUpdate:                 true,
+			expectPod:                    resizedPodWithPodLevelResources,
+			inPlacePodLevelResizeEnabled: true,
+		}, {
+			name: "resized pod-level resources and no container resources",
+			pod:  podWithoutContainerResources,
+			allocated: state.PodResourceInfo{
+				PodSpec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "c1", Resources: *resizedPod.Spec.Containers[0].Resources.DeepCopy()},
+						{Name: "c2", Resources: *resizedPod.Spec.Containers[1].Resources.DeepCopy()},
+					},
+					InitContainers: []v1.Container{
+						{Name: "c1-restartable-init", Resources: *resizedPod.Spec.InitContainers[0].Resources.DeepCopy()},
+						{Name: "c1-init", Resources: *resizedPod.Spec.InitContainers[1].Resources.DeepCopy()},
+					},
+					Resources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
+				},
 			},
-			PodLevelResources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
-		},
-		expectUpdate:                 true,
-		expectPod:                    resizedPodWithPodLevelResources,
-		inPlacePodLevelResizeEnabled: true,
-	}, {
-		name: "pod-level resources with overhead, checkpoint matches spec (no overhead stored)",
-		pod:  podWithPodLevelResourcesAndOverhead,
-		allocated: state.PodResourceInfo{
-			PodLevelResources: podWithPodLevelResourcesAndOverhead.Spec.Resources.DeepCopy(),
-		},
-		expectUpdate:                 false,
-		inPlacePodLevelResizeEnabled: true,
-	}, {
-		name: "resized pod-level resources with feature gate disabled",
-		pod:  podWithPodLevelResources,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *pod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *pod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *pod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *pod.Spec.InitContainers[1].Resources.DeepCopy(),
+			expectUpdate:                 true,
+			expectPod:                    resizedPodWithPodLevelResources,
+			inPlacePodLevelResizeEnabled: true,
+		}, {
+			name: "pod-level resources with overhead, checkpoint matches spec (no overhead stored)",
+			pod:  podWithPodLevelResourcesAndOverhead,
+			allocated: state.PodResourceInfo{
+				PodSpec: &v1.PodSpec{
+					Resources: podWithPodLevelResourcesAndOverhead.Spec.Resources.DeepCopy(),
+				},
 			},
-			PodLevelResources: resizedPod.Spec.Resources.DeepCopy(),
+			expectUpdate:                 false,
+			inPlacePodLevelResizeEnabled: true,
+		}, {
+			name: "resized pod-level resources with feature gate disabled",
+			pod:  podWithPodLevelResources,
+			allocated: state.PodResourceInfo{
+				PodSpec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "c1", Resources: *pod.Spec.Containers[0].Resources.DeepCopy()},
+						{Name: "c2", Resources: *pod.Spec.Containers[1].Resources.DeepCopy()},
+					},
+					InitContainers: []v1.Container{
+						{Name: "c1-restartable-init", Resources: *pod.Spec.InitContainers[0].Resources.DeepCopy()},
+						{Name: "c1-init", Resources: *pod.Spec.InitContainers[1].Resources.DeepCopy()},
+					},
+					Resources: resizedPod.Spec.Resources.DeepCopy(),
+				},
+			},
+			expectUpdate:                 false,
+			expectPod:                    podWithPodLevelResources,
+			inPlacePodLevelResizeEnabled: false,
 		},
-		expectUpdate:                 false,
-		expectPod:                    podWithPodLevelResources,
-		inPlacePodLevelResizeEnabled: false,
-	}}
+		{
+			name: "resized memory-backed volume limit",
+			pod:  podWithVolumes,
+			allocated: state.PodResourceInfo{
+				PodSpec: &resizedPodWithVolumes.Spec,
+			},
+			expectUpdate: true,
+			expectPod:    resizedPodWithVolumes,
+			inPlacePodVerticalScalingMemoryBackedVolumesEnabled: true,
+		},
+		{
+			name: "resized memory-backed volume limit with feature gate disabled",
+			pod:  podWithVolumes,
+			allocated: state.PodResourceInfo{
+				PodSpec: &resizedPodWithVolumes.Spec,
+			},
+			expectUpdate: false,
+			expectPod:    podWithVolumes,
+			inPlacePodVerticalScalingMemoryBackedVolumesEnabled: false,
+		},
+	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodLevelResourcesVerticalScaling, test.inPlacePodLevelResizeEnabled)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingMemoryBackedVolumes, test.inPlacePodVerticalScalingMemoryBackedVolumesEnabled)
 			allocationManager := makeAllocationManager(t, &containertest.FakeRuntime{}, nil, nil)
 			pod := test.pod.DeepCopy()
 			allocationManager.(*manager).allocated.SetPodResourceInfo(logger, pod.UID, test.allocated)
@@ -838,8 +910,9 @@ func TestRetryPendingResizes(t *testing.T) {
 					alloc, found := allocationManager.(*manager).allocated.GetPodResourceInfo(newPod.UID)
 					if tt.expectedAllocatedPodReqs != nil {
 						require.True(t, found, "pod allocation")
-						if alloc.PodLevelResources == nil {
-							assert.Equal(t, tt.expectedAllocatedPodReqs, alloc.PodLevelResources.Requests, "stored pod request allocation")
+						require.NotNil(t, alloc.PodSpec, "allocated pod spec")
+						if alloc.PodSpec.Resources != nil {
+							assert.Equal(t, tt.expectedAllocatedPodReqs, alloc.PodSpec.Resources.Requests, "stored pod request allocation")
 						}
 					} else {
 						require.False(t, found, "pod allocation should not be found")
@@ -2689,7 +2762,8 @@ func TestAllocationManager_EmptyDirVolumeLimits_AddPod(t *testing.T) {
 					},
 				},
 			},
-			expectedAllocated: false,
+			expectedAllocated: true,
+			expectedLimit:     resource.NewQuantity(1024*1024*128, resource.BinarySI),
 		},
 		{
 			name:               "admit volume with medium Default (not Memory) when gate is enabled",
@@ -2725,7 +2799,8 @@ func TestAllocationManager_EmptyDirVolumeLimits_AddPod(t *testing.T) {
 					},
 				},
 			},
-			expectedAllocated: false,
+			expectedAllocated: true,
+			expectedLimit:     resource.NewQuantity(1024*1024*128, resource.BinarySI),
 		},
 		{
 			name:               "admit memory-backed volume with nil size limit when gate is enabled",
@@ -3236,7 +3311,7 @@ func TestAllocationManager_EmptyDirVolumeLimits_RetryPendingResizes(t *testing.T
 				},
 			},
 			expectResizeAllocated:    false,
-			expectedAllocatedLimit:   nil,
+			expectedAllocatedLimit:   resource.NewQuantity(1024*1024*128, resource.BinarySI),
 			expectedResizeConditions: nil,
 		},
 		{
@@ -3691,4 +3766,162 @@ func setupNonAllocatedCapacityTest(t *testing.T) (Manager, *v1.Pod, *v1.Pod, klo
 	})
 
 	return allocationManager, runningPod, pendingPod, logger
+}
+
+func TestAllocationManager_Upgrade_CheckpointMigration(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	testDir := t.TempDir()
+
+	// Enable feature gates
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodLevelResourcesVerticalScaling, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingMemoryBackedVolumes, true)
+
+	// Define the allocated pod (which represents the pod after it has been restored/updated from the checkpoint!)
+	allocatedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "pod1",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "container1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("100m"),
+							v1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("200m"),
+							v1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+			Resources: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("200m"),
+					v1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("400m"),
+					v1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "mem-vol",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							Medium:    v1.StorageMediumMemory,
+							SizeLimit: new(resource.MustParse("128Mi")),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Prepare the legacy V1 checkpoint data using values from allocatedPod
+	v1Entries := state.PodResourceInfoMapV1{
+		allocatedPod.UID: state.PodResourceInfoV1{
+			ContainerResources: map[string]v1.ResourceRequirements{
+				allocatedPod.Spec.Containers[0].Name: allocatedPod.Spec.Containers[0].Resources,
+			},
+			PodLevelResources: allocatedPod.Spec.Resources,
+			EmptyDirVolumeLimits: map[string]*resource.Quantity{
+				allocatedPod.Spec.Volumes[0].Name: allocatedPod.Spec.Volumes[0].EmptyDir.SizeLimit,
+			},
+		},
+	}
+
+	// Serialize and wrap in Checkpoint
+	serializedV1, err := json.Marshal(state.PodResourceCheckpointInfoV1{Entries: v1Entries})
+	require.NoError(t, err)
+
+	cp := &state.Checkpoint{
+		Data: string(serializedV1),
+	}
+	cp.Checksum = checksum.New(cp.Data)
+
+	blob, err := cp.MarshalCheckpoint()
+	require.NoError(t, err)
+
+	// Write to the checkpoint file on disk inside the temp directory
+	err = os.WriteFile(filepath.Join(testDir, "allocated_pods_state"), blob, 0644)
+	require.NoError(t, err)
+
+	// Initialize the real Allocation Manager using NewManager (which triggers the startup migration!)
+	statusManager := status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, kubeletutil.NewPodStartupLatencyTracker())
+	dummySourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	fakeRecorder := &record.FakeRecorder{}
+
+	allocManager := NewManager(
+		testDir,
+		statusManager,
+		func(_ context.Context, _ *v1.Pod) {},
+		func() []*v1.Pod { return nil },
+		func(_ types.UID) (*v1.Pod, bool) { return nil, false },
+		dummySourcesReady,
+		fakeRecorder,
+		logger,
+	)
+
+	// Define the incoming pod by deep copying allocatedPod and modifying its resources to simulate a resize request
+	incomingPod := allocatedPod.DeepCopy()
+	incomingPod.Spec.Containers[0].Resources = v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("500m"),
+			v1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("1000m"),
+			v1.ResourceMemory: resource.MustParse("1024Mi"),
+		},
+	}
+	incomingPod.Spec.Resources = &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("600m"),
+			v1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("1200m"),
+			v1.ResourceMemory: resource.MustParse("1024Mi"),
+		},
+	}
+	incomingPod.Spec.Volumes[0].EmptyDir.SizeLimit = new(resource.MustParse("256Mi"))
+
+	// Call UpdatePodFromAllocation to verify that it correctly overwrites the incoming pod's resources with the previous allocated values from the migrated checkpoint!
+	updatedPod, updated := allocManager.UpdatePodFromAllocation(incomingPod)
+	require.True(t, updated, "pod spec should be updated from the migrated checkpoint")
+
+	// Directly compare the updated pod with our allocated pod!
+	assert.Equal(t, allocatedPod, updatedPod)
+
+	// Call AddPod to trigger writing the fully populated V2 checkpoint to disk!
+	ok, reason, msg := allocManager.AddPod(context.TODO(), nil, incomingPod)
+	require.True(t, ok, "AddPod should succeed, reason: %s, msg: %s", reason, msg)
+
+	// Read the updated checkpoint file from disk!
+	updatedBlob, err := os.ReadFile(filepath.Join(testDir, "allocated_pods_state"))
+	require.NoError(t, err)
+
+	// Deserialise checkpoint
+	var checkpointV2 state.Checkpoint
+	err = json.Unmarshal(updatedBlob, &checkpointV2)
+	require.NoError(t, err)
+
+	// Unmarshal the inner Data string which contains PodResourceCheckpointInfo in V2 format!
+	var praInfoV2 state.PodResourceCheckpointInfo
+	err = json.Unmarshal([]byte(checkpointV2.Data), &praInfoV2)
+	require.NoError(t, err)
+
+	// Assert that the checkpoint now contains the complete PodSpec under PodEntries!
+	require.Len(t, praInfoV2.PodEntries, 1)
+	checkpointPodInfo, found := praInfoV2.PodEntries[allocatedPod.UID]
+	require.True(t, found)
+	require.NotNil(t, checkpointPodInfo.PodSpec)
+
+	// Directly assert that the checkpointed PodSpec matches our updated pod spec!
+	assert.Equal(t, &updatedPod.Spec, checkpointPodInfo.PodSpec)
 }

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -18,7 +18,11 @@ package allocation
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	goruntime "runtime"
 	"strings"
 	"testing"
@@ -41,6 +45,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/allocation/state"
+	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
 	"k8s.io/kubernetes/pkg/kubelet/cm/memorymanager"
@@ -167,50 +172,80 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 		v1.ResourceMemory: *resource.NewQuantity(200, resource.DecimalSI),
 	}
 
+	podWithVolumes := pod.DeepCopy()
+	podWithVolumes.Spec.Volumes = []v1.Volume{
+		{
+			Name: "mem-vol",
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{
+					Medium:    v1.StorageMediumMemory,
+					SizeLimit: resource.NewQuantity(128*1024*1024, resource.BinarySI),
+				},
+			},
+		},
+	}
+
+	resizedPodWithVolumes := podWithVolumes.DeepCopy()
+	resizedPodWithVolumes.Spec.Volumes[0].EmptyDir.SizeLimit = resource.NewQuantity(256*1024*1024, resource.BinarySI)
+
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.NodeDeclaredFeatures, true)
 
 	tests := []struct {
-		name                         string
-		pod                          *v1.Pod
-		allocated                    state.PodResourceInfo
-		expectPod                    *v1.Pod
-		expectUpdate                 bool
-		inPlacePodLevelResizeEnabled bool
+		name                                                string
+		pod                                                 *v1.Pod
+		allocated                                           *v1.Pod
+		expectPod                                           *v1.Pod
+		expectUpdate                                        bool
+		inPlacePodLevelResizeEnabled                        bool
+		inPlacePodVerticalScalingMemoryBackedVolumesEnabled bool
 	}{{
 		name: "steady state",
 		pod:  pod,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *pod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *pod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *pod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *pod.Spec.InitContainers[1].Resources.DeepCopy(),
+		allocated: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: pod.UID},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "c1", Resources: *pod.Spec.Containers[0].Resources.DeepCopy()},
+					{Name: "c2", Resources: *pod.Spec.Containers[1].Resources.DeepCopy()},
+				},
+				InitContainers: []v1.Container{
+					{Name: "c1-restartable-init", Resources: *pod.Spec.InitContainers[0].Resources.DeepCopy()},
+					{Name: "c1-init", Resources: *pod.Spec.InitContainers[1].Resources.DeepCopy()},
+				},
 			},
 		},
 		expectUpdate: false,
 	}, {
 		name:         "no allocations",
 		pod:          pod,
-		allocated:    state.PodResourceInfo{},
+		allocated:    nil,
 		expectUpdate: false,
 	}, {
 		name: "missing container allocation",
 		pod:  pod,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c2": *pod.Spec.Containers[1].Resources.DeepCopy(),
+		allocated: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: pod.UID},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "c2", Resources: *pod.Spec.Containers[1].Resources.DeepCopy()},
+				},
 			},
 		},
 		expectUpdate: false,
 	}, {
 		name: "resized container",
 		pod:  pod,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *resizedPod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *resizedPod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *resizedPod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *resizedPod.Spec.InitContainers[1].Resources.DeepCopy(),
+		allocated: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: pod.UID},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "c1", Resources: *resizedPod.Spec.Containers[0].Resources.DeepCopy()},
+					{Name: "c2", Resources: *resizedPod.Spec.Containers[1].Resources.DeepCopy()},
+				},
+				InitContainers: []v1.Container{
+					{Name: "c1-restartable-init", Resources: *resizedPod.Spec.InitContainers[0].Resources.DeepCopy()},
+					{Name: "c1-init", Resources: *resizedPod.Spec.InitContainers[1].Resources.DeepCopy()},
+				},
 			},
 		},
 		expectUpdate: true,
@@ -218,14 +253,19 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 	}, {
 		name: "resized pod-level allocation",
 		pod:  pod,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *resizedPod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *resizedPod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *resizedPod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *resizedPod.Spec.InitContainers[1].Resources.DeepCopy(),
+		allocated: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: pod.UID},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "c1", Resources: *resizedPod.Spec.Containers[0].Resources.DeepCopy()},
+					{Name: "c2", Resources: *resizedPod.Spec.Containers[1].Resources.DeepCopy()},
+				},
+				InitContainers: []v1.Container{
+					{Name: "c1-restartable-init", Resources: *resizedPod.Spec.InitContainers[0].Resources.DeepCopy()},
+					{Name: "c1-init", Resources: *resizedPod.Spec.InitContainers[1].Resources.DeepCopy()},
+				},
+				Resources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
 			},
-			PodLevelResources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
 		},
 		expectUpdate:                 true,
 		expectPod:                    resizedPodWithPodLevelResources,
@@ -233,14 +273,19 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 	}, {
 		name: "resized pod-level resources and allocation",
 		pod:  podWithPodLevelResources,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *resizedPod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *resizedPod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *resizedPod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *resizedPod.Spec.InitContainers[1].Resources.DeepCopy(),
+		allocated: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: pod.UID},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "c1", Resources: *resizedPod.Spec.Containers[0].Resources.DeepCopy()},
+					{Name: "c2", Resources: *resizedPod.Spec.Containers[1].Resources.DeepCopy()},
+				},
+				InitContainers: []v1.Container{
+					{Name: "c1-restartable-init", Resources: *resizedPod.Spec.InitContainers[0].Resources.DeepCopy()},
+					{Name: "c1-init", Resources: *resizedPod.Spec.InitContainers[1].Resources.DeepCopy()},
+				},
+				Resources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
 			},
-			PodLevelResources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
 		},
 		expectUpdate:                 true,
 		expectPod:                    resizedPodWithPodLevelResources,
@@ -248,14 +293,19 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 	}, {
 		name: "resized pod-level resources and no container resources",
 		pod:  podWithoutContainerResources,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *resizedPod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *resizedPod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *resizedPod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *resizedPod.Spec.InitContainers[1].Resources.DeepCopy(),
+		allocated: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: pod.UID},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "c1", Resources: *resizedPod.Spec.Containers[0].Resources.DeepCopy()},
+					{Name: "c2", Resources: *resizedPod.Spec.Containers[1].Resources.DeepCopy()},
+				},
+				InitContainers: []v1.Container{
+					{Name: "c1-restartable-init", Resources: *resizedPod.Spec.InitContainers[0].Resources.DeepCopy()},
+					{Name: "c1-init", Resources: *resizedPod.Spec.InitContainers[1].Resources.DeepCopy()},
+				},
+				Resources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
 			},
-			PodLevelResources: resizedPodWithPodLevelResources.Spec.Resources.DeepCopy(),
 		},
 		expectUpdate:                 true,
 		expectPod:                    resizedPodWithPodLevelResources,
@@ -263,35 +313,67 @@ func TestUpdatePodFromAllocation(t *testing.T) {
 	}, {
 		name: "pod-level resources with overhead, checkpoint matches spec (no overhead stored)",
 		pod:  podWithPodLevelResourcesAndOverhead,
-		allocated: state.PodResourceInfo{
-			PodLevelResources: podWithPodLevelResourcesAndOverhead.Spec.Resources.DeepCopy(),
+		allocated: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: pod.UID},
+			Spec: v1.PodSpec{
+				Resources: podWithPodLevelResourcesAndOverhead.Spec.Resources.DeepCopy(),
+			},
 		},
 		expectUpdate:                 false,
 		inPlacePodLevelResizeEnabled: true,
 	}, {
 		name: "resized pod-level resources with feature gate disabled",
 		pod:  podWithPodLevelResources,
-		allocated: state.PodResourceInfo{
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"c1":                  *pod.Spec.Containers[0].Resources.DeepCopy(),
-				"c2":                  *pod.Spec.Containers[1].Resources.DeepCopy(),
-				"c1-restartable-init": *pod.Spec.InitContainers[0].Resources.DeepCopy(),
-				"c1-init":             *pod.Spec.InitContainers[1].Resources.DeepCopy(),
+		allocated: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{UID: pod.UID},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{Name: "c1", Resources: *pod.Spec.Containers[0].Resources.DeepCopy()},
+					{Name: "c2", Resources: *pod.Spec.Containers[1].Resources.DeepCopy()},
+				},
+				InitContainers: []v1.Container{
+					{Name: "c1-restartable-init", Resources: *pod.Spec.InitContainers[0].Resources.DeepCopy()},
+					{Name: "c1-init", Resources: *pod.Spec.InitContainers[1].Resources.DeepCopy()},
+				},
+				Resources: resizedPod.Spec.Resources.DeepCopy(),
 			},
-			PodLevelResources: resizedPod.Spec.Resources.DeepCopy(),
 		},
 		expectUpdate:                 false,
 		expectPod:                    podWithPodLevelResources,
 		inPlacePodLevelResizeEnabled: false,
-	}}
+	},
+		{
+			name: "resized memory-backed volume limit",
+			pod:  podWithVolumes,
+			allocated: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{UID: pod.UID},
+				Spec:       resizedPodWithVolumes.Spec,
+			},
+			expectUpdate: true,
+			expectPod:    resizedPodWithVolumes,
+			inPlacePodVerticalScalingMemoryBackedVolumesEnabled: true,
+		},
+		{
+			name: "resized memory-backed volume limit with feature gate disabled",
+			pod:  podWithVolumes,
+			allocated: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{UID: pod.UID},
+				Spec:       resizedPodWithVolumes.Spec,
+			},
+			expectUpdate: false,
+			expectPod:    podWithVolumes,
+			inPlacePodVerticalScalingMemoryBackedVolumesEnabled: false,
+		},
+	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodLevelResourcesVerticalScaling, test.inPlacePodLevelResizeEnabled)
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingMemoryBackedVolumes, test.inPlacePodVerticalScalingMemoryBackedVolumesEnabled)
 			allocationManager := makeAllocationManager(t, &containertest.FakeRuntime{}, nil, nil)
 			pod := test.pod.DeepCopy()
-			allocationManager.(*manager).allocated.SetPodResourceInfo(logger, pod.UID, test.allocated)
+			require.NoError(t, allocationManager.(*manager).allocated.SetPod(logger, test.allocated))
 			allocatedPod, updated := allocationManager.UpdatePodFromAllocation(pod)
 
 			if test.expectUpdate {
@@ -835,11 +917,12 @@ func TestRetryPendingResizes(t *testing.T) {
 						assert.Empty(t, updatedPod.Spec.Resources.Requests, "updated pod spec pod requests should be empty")
 					}
 
-					alloc, found := allocationManager.(*manager).allocated.GetPodResourceInfo(newPod.UID)
+					alloc, found := allocationManager.(*manager).allocated.GetPod(newPod.UID)
 					if tt.expectedAllocatedPodReqs != nil {
 						require.True(t, found, "pod allocation")
-						if alloc.PodLevelResources == nil {
-							assert.Equal(t, tt.expectedAllocatedPodReqs, alloc.PodLevelResources.Requests, "stored pod request allocation")
+						require.NotNil(t, alloc, "allocated pod")
+						if alloc.Spec.Resources != nil {
+							assert.Equal(t, tt.expectedAllocatedPodReqs, alloc.Spec.Resources.Requests, "stored pod request allocation")
 						}
 					} else {
 						require.False(t, found, "pod allocation should not be found")
@@ -2689,7 +2772,8 @@ func TestAllocationManager_EmptyDirVolumeLimits_AddPod(t *testing.T) {
 					},
 				},
 			},
-			expectedAllocated: false,
+			expectedAllocated: true,
+			expectedLimit:     resource.NewQuantity(1024*1024*128, resource.BinarySI),
 		},
 		{
 			name:               "admit volume with medium Default (not Memory) when gate is enabled",
@@ -2725,7 +2809,8 @@ func TestAllocationManager_EmptyDirVolumeLimits_AddPod(t *testing.T) {
 					},
 				},
 			},
-			expectedAllocated: false,
+			expectedAllocated: true,
+			expectedLimit:     resource.NewQuantity(1024*1024*128, resource.BinarySI),
 		},
 		{
 			name:               "admit memory-backed volume with nil size limit when gate is enabled",
@@ -3236,7 +3321,7 @@ func TestAllocationManager_EmptyDirVolumeLimits_RetryPendingResizes(t *testing.T
 				},
 			},
 			expectResizeAllocated:    false,
-			expectedAllocatedLimit:   nil,
+			expectedAllocatedLimit:   resource.NewQuantity(1024*1024*128, resource.BinarySI),
 			expectedResizeConditions: nil,
 		},
 		{
@@ -3691,4 +3776,157 @@ func setupNonAllocatedCapacityTest(t *testing.T) (Manager, *v1.Pod, *v1.Pod, klo
 	})
 
 	return allocationManager, runningPod, pendingPod, logger
+}
+
+func TestAllocationManager_Upgrade_CheckpointMigration(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	testDir := t.TempDir()
+
+	// Enable feature gates
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodLevelResourcesVerticalScaling, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingMemoryBackedVolumes, true)
+
+	// Define the allocated pod (which represents the pod after it has been restored/updated from the checkpoint!)
+	allocatedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "pod1",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "container1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("100m"),
+							v1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("200m"),
+							v1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+			Resources: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("200m"),
+					v1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("400m"),
+					v1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "mem-vol",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							Medium:    v1.StorageMediumMemory,
+							SizeLimit: new(resource.MustParse("128Mi")),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Prepare the legacy V1 checkpoint data using values from allocatedPod
+	v1Entries := map[types.UID]state.PodResourceInfo{
+		allocatedPod.UID: {
+			ContainerResources: map[string]v1.ResourceRequirements{
+				allocatedPod.Spec.Containers[0].Name: allocatedPod.Spec.Containers[0].Resources,
+			},
+			PodLevelResources: allocatedPod.Spec.Resources,
+			EmptyDirVolumeLimits: map[string]*resource.Quantity{
+				allocatedPod.Spec.Volumes[0].Name: allocatedPod.Spec.Volumes[0].EmptyDir.SizeLimit,
+			},
+		},
+	}
+
+	// Serialize V1 entries and write as legacy V1 JSON checkpoint to disk
+	serializedV1, err := json.Marshal(state.PodResourceCheckpointInfo{Entries: v1Entries})
+	require.NoError(t, err)
+
+	v1JSON := fmt.Sprintf(`{"data":%q,"checksum":%d}`, string(serializedV1), checksum.New(string(serializedV1)))
+	err = os.WriteFile(filepath.Join(testDir, "allocated_pods_state"), []byte(v1JSON), 0644)
+	require.NoError(t, err)
+
+	// Initialize the real Allocation Manager using NewManager (which triggers the startup migration!)
+	statusManager := status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, kubeletutil.NewPodStartupLatencyTracker())
+	dummySourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
+	fakeRecorder := &record.FakeRecorder{}
+
+	allocManager := NewManager(
+		testDir,
+		statusManager,
+		func(_ context.Context, _ *v1.Pod) {},
+		func() []*v1.Pod { return nil },
+		func(_ types.UID) (*v1.Pod, bool) { return nil, false },
+		dummySourcesReady,
+		fakeRecorder,
+		logger,
+	)
+
+	// Define the incoming pod by deep copying allocatedPod and modifying its resources to simulate a resize request
+	incomingPod := allocatedPod.DeepCopy()
+	incomingPod.Spec.Containers[0].Resources = v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("500m"),
+			v1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("1000m"),
+			v1.ResourceMemory: resource.MustParse("1024Mi"),
+		},
+	}
+	incomingPod.Spec.Resources = &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("600m"),
+			v1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("1200m"),
+			v1.ResourceMemory: resource.MustParse("1024Mi"),
+		},
+	}
+	incomingPod.Spec.Volumes[0].EmptyDir.SizeLimit = new(resource.MustParse("256Mi"))
+
+	// Call UpdatePodFromAllocation to verify that it correctly overwrites the incoming pod's resources with the previous allocated values from the migrated checkpoint!
+	updatedPod, updated := allocManager.UpdatePodFromAllocation(incomingPod)
+	require.True(t, updated, "pod spec should be updated from the migrated checkpoint")
+
+	// Directly compare the updated pod with our allocated pod!
+	assert.Equal(t, allocatedPod, updatedPod)
+
+	// Call AddPod to trigger writing the fully populated V2 checkpoint to disk!
+	ok, reason, msg := allocManager.AddPod(context.TODO(), nil, incomingPod)
+	require.True(t, ok, "AddPod should succeed, reason: %s, msg: %s", reason, msg)
+
+	// Read the updated checkpoint file from disk!
+	updatedBlob, err := os.ReadFile(filepath.Join(testDir, "allocated_pods_state"))
+	require.NoError(t, err)
+
+	// Deserialise checkpoint envelope
+	var checkpointV2 state.Checkpoint
+	err = checkpointV2.UnmarshalCheckpoint(updatedBlob)
+	require.NoError(t, err)
+	require.NoError(t, checkpointV2.VerifyChecksum(), "checkpoint checksum should be valid")
+
+	// Deserialise the base64-encoded protobuf payload
+	protoBytes, err := base64.StdEncoding.DecodeString(checkpointV2.Data)
+	require.NoError(t, err)
+
+	var podList v1.PodList
+	err = podList.Unmarshal(protoBytes)
+	require.NoError(t, err)
+
+	// Assert that the checkpoint now contains the complete PodList!
+	require.Len(t, podList.Items, 1)
+	checkpointPod := &podList.Items[0]
+	assert.Equal(t, allocatedPod.UID, checkpointPod.UID)
+
+	// Directly assert that the checkpointed PodSpec matches our updated pod spec!
+	assert.Equal(t, updatedPod.Spec, checkpointPod.Spec)
 }

--- a/pkg/kubelet/allocation/state/checkpoint.go
+++ b/pkg/kubelet/allocation/state/checkpoint.go
@@ -27,7 +27,7 @@ import (
 var _ checkpointmanager.Checkpoint = &Checkpoint{}
 
 type PodResourceCheckpointInfo struct {
-	Entries PodResourceInfoMap `json:"entries,omitempty"`
+	PodEntries PodResourceInfoMap `json:"podEntries,omitempty"`
 }
 
 // Checkpoint represents a structure to store pod resource allocation checkpoint data

--- a/pkg/kubelet/allocation/state/checkpoint.go
+++ b/pkg/kubelet/allocation/state/checkpoint.go
@@ -26,10 +26,6 @@ import (
 
 var _ checkpointmanager.Checkpoint = &Checkpoint{}
 
-type PodResourceCheckpointInfo struct {
-	Entries PodResourceInfoMap `json:"entries,omitempty"`
-}
-
 // Checkpoint represents a structure to store pod resource allocation checkpoint data
 type Checkpoint struct {
 	// Data is a serialized PodResourceAllocationInfo

--- a/pkg/kubelet/allocation/state/checkpoint.go
+++ b/pkg/kubelet/allocation/state/checkpoint.go
@@ -17,59 +17,72 @@ limitations under the License.
 package state
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 )
 
+const (
+	// checkpointVersionV2 is the current checkpoint format version storing base64-encoded protobuf PodList.
+	checkpointVersionV2 = "v2"
+)
+
 var _ checkpointmanager.Checkpoint = &Checkpoint{}
 
-// Checkpoint represents a structure to store pod resource allocation checkpoint data
+// Checkpoint represents a structure to store pod resource allocation checkpoint data.
 type Checkpoint struct {
-	// Data is a serialized PodResourceAllocationInfo
+	// Version is the checkpoint format version (e.g. "v2")
+	Version string `json:"version,omitempty"`
+	// Data is a serialized and base64-encoded PodList
 	Data string `json:"data"`
 	// Checksum is a checksum of Data
 	Checksum checksum.Checksum `json:"checksum"`
 }
 
-// NewCheckpoint creates a new checkpoint from a list of claim info states
-func NewCheckpoint(allocations *PodResourceCheckpointInfo) (*Checkpoint, error) {
-
-	serializedAllocations, err := json.Marshal(allocations)
+// NewCheckpoint creates a new checkpoint containing the serialized PodList.
+func NewCheckpoint(podList *v1.PodList) (*Checkpoint, error) {
+	if podList == nil {
+		podList = &v1.PodList{}
+	}
+	protoBytes, err := podList.Marshal()
 	if err != nil {
-		return nil, fmt.Errorf("failed to serialize allocations for checkpointing: %w", err)
+		return nil, fmt.Errorf("failed to marshal PodList to protobuf for checkpointing: %w", err)
 	}
-
+	data := base64.StdEncoding.EncodeToString(protoBytes)
 	cp := &Checkpoint{
-		Data: string(serializedAllocations),
+		Version:  checkpointVersionV2,
+		Data:     data,
+		Checksum: checksum.New(data),
 	}
-	cp.Checksum = checksum.New(cp.Data)
 	return cp, nil
+}
+
+// GetPodList deserializes the base64-encoded protobuf PodList from checkpoint data.
+func (cp *Checkpoint) getPodList() (*v1.PodList, error) {
+	protoBytes, err := base64.StdEncoding.DecodeString(cp.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode base64 protobuf data: %w", err)
+	}
+	var podList v1.PodList
+	if err := podList.Unmarshal(protoBytes); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal protobuf PodList: %w", err)
+	}
+	return &podList, nil
 }
 
 func (cp *Checkpoint) MarshalCheckpoint() ([]byte, error) {
 	return json.Marshal(cp)
 }
 
-// UnmarshalCheckpoint unmarshals checkpoint from JSON
+// UnmarshalCheckpoint unmarshals checkpoint from  JSON
 func (cp *Checkpoint) UnmarshalCheckpoint(blob []byte) error {
 	return json.Unmarshal(blob, cp)
 }
 
-// VerifyChecksum verifies that current checksum
-// of checkpointed Data is valid
 func (cp *Checkpoint) VerifyChecksum() error {
 	return cp.Checksum.Verify(cp.Data)
-}
-
-// GetPodResourceCheckpointInfo returns Pod Resource Allocation info states from checkpoint
-func (cp *Checkpoint) GetPodResourceCheckpointInfo() (*PodResourceCheckpointInfo, error) {
-	var data PodResourceCheckpointInfo
-	if err := json.Unmarshal([]byte(cp.Data), &data); err != nil {
-		return nil, err
-	}
-
-	return &data, nil
 }

--- a/pkg/kubelet/allocation/state/checkpoint_v1.go
+++ b/pkg/kubelet/allocation/state/checkpoint_v1.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// PodResourceInfo stores resource requirements for containers within a pod.
+type PodResourceInfo struct {
+	// ContainerResources maps container names to their respective ResourceRequirements.
+	ContainerResources map[string]v1.ResourceRequirements
+
+	// PodLevelResources represents resource requirements that apply to the entire pod, if any.
+	PodLevelResources *v1.ResourceRequirements
+
+	// EmptyDirVolumeLimits maps emptyDir volume names to their respective resource limits, if any.
+	EmptyDirVolumeLimits map[string]*resource.Quantity
+}
+
+// PodResourceInfoMap maps pod UIDs to their corresponding PodResourceInfo,
+// tracking resource requirements for all containers within each pod.
+type PodResourceInfoMap map[types.UID]PodResourceInfo
+
+type PodResourceCheckpointInfo struct {
+	Entries PodResourceInfoMap `json:"entries,omitempty"`
+}
+
+// Clone returns a copy of PodResourceInfoMap
+func (pr PodResourceInfoMap) Clone() PodResourceInfoMap {
+	prCopy := make(PodResourceInfoMap)
+	for podUID, podInfo := range pr {
+		newPodInfo := PodResourceInfo{
+			ContainerResources: make(map[string]v1.ResourceRequirements),
+			PodLevelResources:  podInfo.PodLevelResources.DeepCopy(),
+		}
+		for containerName, containerInfo := range podInfo.ContainerResources {
+			newPodInfo.ContainerResources[containerName] = *containerInfo.DeepCopy()
+		}
+		if podInfo.EmptyDirVolumeLimits != nil {
+			newPodInfo.EmptyDirVolumeLimits = make(map[string]*resource.Quantity)
+			for volumeName, volumeLimit := range podInfo.EmptyDirVolumeLimits {
+				if volumeLimit == nil {
+					newPodInfo.EmptyDirVolumeLimits[volumeName] = nil
+				} else {
+					vl := volumeLimit.DeepCopy()
+					newPodInfo.EmptyDirVolumeLimits[volumeName] = &vl
+				}
+			}
+		}
+		prCopy[podUID] = newPodInfo
+	}
+	return prCopy
+}

--- a/pkg/kubelet/allocation/state/checkpoint_v1.go
+++ b/pkg/kubelet/allocation/state/checkpoint_v1.go
@@ -1,0 +1,95 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// PodResourceInfoV1 is the legacy checkpoint structure used in v1.37 and earlier.
+type PodResourceInfoV1 struct {
+	ContainerResources   map[string]v1.ResourceRequirements `json:"ContainerResources,omitempty"`
+	PodLevelResources    *v1.ResourceRequirements           `json:"PodLevelResources,omitempty"`
+	EmptyDirVolumeLimits map[string]*resource.Quantity      `json:"EmptyDirVolumeLimits,omitempty"`
+}
+
+type PodResourceInfoMapV1 map[types.UID]PodResourceInfoV1
+
+type PodResourceCheckpointInfoV1 struct {
+	Entries PodResourceInfoMapV1 `json:"entries,omitempty"`
+}
+
+// GetPodResourceCheckpointInfoV1 returns legacy Pod Resource Allocation info states from checkpoint
+func (cp *Checkpoint) GetPodResourceCheckpointInfoV1() (*PodResourceCheckpointInfoV1, error) {
+	var data PodResourceCheckpointInfoV1
+	if err := json.Unmarshal([]byte(cp.Data), &data); err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}
+
+// migrateV1ToV2 converts checkpoints from the v1 format to the v2 format
+func migrateV1ToV2(entries PodResourceInfoMapV1) PodResourceInfoMap {
+	v2Map := make(PodResourceInfoMap)
+	for uid, info := range entries {
+		podSpec := &v1.PodSpec{}
+
+		// Migrate container resources
+		if len(info.ContainerResources) > 0 {
+			podSpec.Containers = make([]v1.Container, 0, len(info.ContainerResources))
+			for name, res := range info.ContainerResources {
+				podSpec.Containers = append(podSpec.Containers, v1.Container{
+					Name:      name,
+					Resources: *res.DeepCopy(),
+				})
+			}
+		}
+
+		// Migrate pod-level resources
+		if info.PodLevelResources != nil {
+			podSpec.Resources = info.PodLevelResources.DeepCopy()
+		}
+
+		// Migrate emptyDir volume limits
+		if len(info.EmptyDirVolumeLimits) > 0 {
+			podSpec.Volumes = make([]v1.Volume, 0, len(info.EmptyDirVolumeLimits))
+			for name, limit := range info.EmptyDirVolumeLimits {
+				if limit != nil {
+					copyLimit := limit.DeepCopy()
+					podSpec.Volumes = append(podSpec.Volumes, v1.Volume{
+						Name: name,
+						VolumeSource: v1.VolumeSource{
+							EmptyDir: &v1.EmptyDirVolumeSource{
+								SizeLimit: &copyLimit,
+							},
+						},
+					})
+				}
+			}
+		}
+
+		v2Map[uid] = PodResourceInfo{
+			PodSpec: podSpec,
+		}
+	}
+	return v2Map
+}

--- a/pkg/kubelet/allocation/state/checkpoint_v1.go
+++ b/pkg/kubelet/allocation/state/checkpoint_v1.go
@@ -17,8 +17,11 @@ limitations under the License.
 package state
 
 import (
+	"encoding/json"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -42,29 +45,68 @@ type PodResourceCheckpointInfo struct {
 	Entries PodResourceInfoMap `json:"entries,omitempty"`
 }
 
-// Clone returns a copy of PodResourceInfoMap
-func (pr PodResourceInfoMap) Clone() PodResourceInfoMap {
-	prCopy := make(PodResourceInfoMap)
-	for podUID, podInfo := range pr {
-		newPodInfo := PodResourceInfo{
-			ContainerResources: make(map[string]v1.ResourceRequirements),
-			PodLevelResources:  podInfo.PodLevelResources.DeepCopy(),
-		}
-		for containerName, containerInfo := range podInfo.ContainerResources {
-			newPodInfo.ContainerResources[containerName] = *containerInfo.DeepCopy()
-		}
-		if podInfo.EmptyDirVolumeLimits != nil {
-			newPodInfo.EmptyDirVolumeLimits = make(map[string]*resource.Quantity)
-			for volumeName, volumeLimit := range podInfo.EmptyDirVolumeLimits {
-				if volumeLimit == nil {
-					newPodInfo.EmptyDirVolumeLimits[volumeName] = nil
-				} else {
-					vl := volumeLimit.DeepCopy()
-					newPodInfo.EmptyDirVolumeLimits[volumeName] = &vl
-				}
-			}
-		}
-		prCopy[podUID] = newPodInfo
+// migrateV1ToV2 migrates the legacy JSON V1 checkpoint data to the V2 PodList format.
+// This results in an incomplete podList as the full podSpec is not available to us
+// in the V1 checkpoint, but will self-heal as the pod is synced:
+//   - When AddPod is called for a particular pod, the checkpoint has sufficient information to
+//     correctly perform UpdatePodFromAllocation to allow the pod to be re-admitted based on its
+//     previously allocated resources. AddPod then calls out to SetAllocatedResources which would
+//     trigger the entire PodSpec to be written to the allocation checkpoint. The test
+//     TestAllocationManager_Upgrade_CheckpointMigration in allocation_manager_test.go
+//     verifies this behavior.
+//   - During the first syncPod for a particular pod, InitializeActuatedPod fills out the remaining
+//     for the actuated checkpoint. The test TestInitializeActuatedPod_HydrateMigratedState in
+//     kuberuntime_manager_test.go verifies this behavior.
+func migrateV1ToV2(data string) (*v1.PodList, error) {
+	var checkpointData PodResourceCheckpointInfo
+	if err := json.Unmarshal([]byte(data), &checkpointData); err != nil {
+		return nil, err
 	}
-	return prCopy
+
+	podList := &v1.PodList{
+		Items: make([]v1.Pod, 0, len(checkpointData.Entries)),
+	}
+	for podUID, entry := range checkpointData.Entries {
+		pod := v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: podUID,
+			},
+		}
+		// The legacy V1 checkpoint format stored all container resource allocations in a single map without
+		// distinguishing between init containers and regular application containers. During migration, we append
+		// all entries to pod.Spec.Containers.
+		// On startup, UpdatePodFromCheckpoint searches across both InitContainers and Containers matching
+		// by container name, ensuring init container allocations are correctly restored. Once the pod is
+		// admitted, AddPod calls SetAllocatedResources which writes the complete, properly partitioned PodSpec
+		// to the checkpoint, self-healing the state.
+		for containerName, resources := range entry.ContainerResources {
+			pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
+				Name:      containerName,
+				Resources: *resources.DeepCopy(),
+			})
+		}
+		if entry.PodLevelResources != nil {
+			pod.Spec.Resources = entry.PodLevelResources.DeepCopy()
+		}
+		for volName, limit := range entry.EmptyDirVolumeLimits {
+			var limitCopy *resource.Quantity
+			if limit != nil {
+				lc := limit.DeepCopy()
+				limitCopy = &lc
+			}
+			pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+				Name: volName,
+				VolumeSource: v1.VolumeSource{
+					EmptyDir: &v1.EmptyDirVolumeSource{
+						// Only memory-backed emptyDir volumes were supported
+						// in the V1 checkpoint format.
+						Medium:    v1.StorageMediumMemory,
+						SizeLimit: limitCopy,
+					},
+				},
+			})
+		}
+		podList.Items = append(podList.Items, pod)
+	}
+	return podList, nil
 }

--- a/pkg/kubelet/allocation/state/state.go
+++ b/pkg/kubelet/allocation/state/state.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
 // PodResourceInfo stores resource requirements for containers within a pod.
@@ -77,7 +78,7 @@ type Reader interface {
 }
 
 type writer interface {
-	SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, resources v1.ResourceRequirements) error
+	SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, containerType podutil.ContainerType, resources v1.ResourceRequirements) error
 	SetPodResourceInfo(logger klog.Logger, podUID types.UID, resourceInfo PodResourceInfo) error
 	SetPodLevelResources(logger klog.Logger, podUID types.UID, alloc *v1.ResourceRequirements) error
 	SetEmptyDirVolumeLimit(podUID types.UID, volumeName string, limit *resource.Quantity) error

--- a/pkg/kubelet/allocation/state/state.go
+++ b/pkg/kubelet/allocation/state/state.go
@@ -24,16 +24,10 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// PodResourceInfo stores resource requirements for containers within a pod.
+// PodResourceInfo stores the entire allocated pod spec.
 type PodResourceInfo struct {
-	// ContainerResources maps container names to their respective ResourceRequirements.
-	ContainerResources map[string]v1.ResourceRequirements
-
-	// PodLevelResources represents resource requirements that apply to the entire pod, if any.
-	PodLevelResources *v1.ResourceRequirements
-
-	// EmptyDirVolumeLimits maps emptyDir volume names to their respective resource limits, if any.
-	EmptyDirVolumeLimits map[string]*resource.Quantity
+	// PodSpec is the entire allocated pod spec.
+	PodSpec *v1.PodSpec `json:"podSpec,omitempty"`
 }
 
 // PodResourceInfoMap maps pod UIDs to their corresponding PodResourceInfo,
@@ -45,22 +39,7 @@ func (pr PodResourceInfoMap) Clone() PodResourceInfoMap {
 	prCopy := make(PodResourceInfoMap)
 	for podUID, podInfo := range pr {
 		newPodInfo := PodResourceInfo{
-			ContainerResources: make(map[string]v1.ResourceRequirements),
-			PodLevelResources:  podInfo.PodLevelResources.DeepCopy(),
-		}
-		for containerName, containerInfo := range podInfo.ContainerResources {
-			newPodInfo.ContainerResources[containerName] = *containerInfo.DeepCopy()
-		}
-		if podInfo.EmptyDirVolumeLimits != nil {
-			newPodInfo.EmptyDirVolumeLimits = make(map[string]*resource.Quantity)
-			for volumeName, volumeLimit := range podInfo.EmptyDirVolumeLimits {
-				if volumeLimit == nil {
-					newPodInfo.EmptyDirVolumeLimits[volumeName] = nil
-				} else {
-					vl := volumeLimit.DeepCopy()
-					newPodInfo.EmptyDirVolumeLimits[volumeName] = &vl
-				}
-			}
+			PodSpec: podInfo.PodSpec.DeepCopy(),
 		}
 		prCopy[podUID] = newPodInfo
 	}

--- a/pkg/kubelet/allocation/state/state.go
+++ b/pkg/kubelet/allocation/state/state.go
@@ -25,18 +25,35 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
+// PodMap maps pod UIDs to their corresponding *v1.Pod,
+// tracking resource requirements for all containers within each pod.
+type PodMap map[types.UID]*v1.Pod
+
+// Clone returns a copy of PodMap
+func (pm PodMap) Clone() PodMap {
+	pmCopy := make(PodMap, len(pm))
+	for podUID, pod := range pm {
+		if pod != nil {
+			pmCopy[podUID] = pod.DeepCopy()
+		}
+	}
+	return pmCopy
+}
+
 // Reader interface used to read current pod resource state
 type Reader interface {
 	GetContainerResources(podUID types.UID, containerName string) (v1.ResourceRequirements, bool)
-	GetPodResourceInfoMap() PodResourceInfoMap
-	GetPodResourceInfo(podUID types.UID) (PodResourceInfo, bool)
+	GetPodMap() PodMap
+	GetPodUIDs() []types.UID
+	GetPod(podUID types.UID) (*v1.Pod, bool)
+	HasPod(podUID types.UID) bool
 	GetPodLevelResources(podUID types.UID) (*v1.ResourceRequirements, bool)
 	GetEmptyDirVolumeLimit(podUID types.UID, volumeName string) (*resource.Quantity, bool)
 }
 
 type writer interface {
 	SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, containerType podutil.ContainerType, resources v1.ResourceRequirements) error
-	SetPodResourceInfo(logger klog.Logger, podUID types.UID, resourceInfo PodResourceInfo) error
+	SetPod(logger klog.Logger, pod *v1.Pod) error
 	SetPodLevelResources(logger klog.Logger, podUID types.UID, alloc *v1.ResourceRequirements) error
 	SetEmptyDirVolumeLimit(podUID types.UID, volumeName string, limit *resource.Quantity) error
 	RemovePod(logger klog.Logger, podUID types.UID) error

--- a/pkg/kubelet/allocation/state/state.go
+++ b/pkg/kubelet/allocation/state/state.go
@@ -25,49 +25,6 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
-// PodResourceInfo stores resource requirements for containers within a pod.
-type PodResourceInfo struct {
-	// ContainerResources maps container names to their respective ResourceRequirements.
-	ContainerResources map[string]v1.ResourceRequirements
-
-	// PodLevelResources represents resource requirements that apply to the entire pod, if any.
-	PodLevelResources *v1.ResourceRequirements
-
-	// EmptyDirVolumeLimits maps emptyDir volume names to their respective resource limits, if any.
-	EmptyDirVolumeLimits map[string]*resource.Quantity
-}
-
-// PodResourceInfoMap maps pod UIDs to their corresponding PodResourceInfo,
-// tracking resource requirements for all containers within each pod.
-type PodResourceInfoMap map[types.UID]PodResourceInfo
-
-// Clone returns a copy of PodResourceInfoMap
-func (pr PodResourceInfoMap) Clone() PodResourceInfoMap {
-	prCopy := make(PodResourceInfoMap)
-	for podUID, podInfo := range pr {
-		newPodInfo := PodResourceInfo{
-			ContainerResources: make(map[string]v1.ResourceRequirements),
-			PodLevelResources:  podInfo.PodLevelResources.DeepCopy(),
-		}
-		for containerName, containerInfo := range podInfo.ContainerResources {
-			newPodInfo.ContainerResources[containerName] = *containerInfo.DeepCopy()
-		}
-		if podInfo.EmptyDirVolumeLimits != nil {
-			newPodInfo.EmptyDirVolumeLimits = make(map[string]*resource.Quantity)
-			for volumeName, volumeLimit := range podInfo.EmptyDirVolumeLimits {
-				if volumeLimit == nil {
-					newPodInfo.EmptyDirVolumeLimits[volumeName] = nil
-				} else {
-					vl := volumeLimit.DeepCopy()
-					newPodInfo.EmptyDirVolumeLimits[volumeName] = &vl
-				}
-			}
-		}
-		prCopy[podUID] = newPodInfo
-	}
-	return prCopy
-}
-
 // Reader interface used to read current pod resource state
 type Reader interface {
 	GetContainerResources(podUID types.UID, containerName string) (v1.ResourceRequirements, bool)

--- a/pkg/kubelet/allocation/state/state_checkpoint.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
@@ -141,11 +142,11 @@ func (sc *stateCheckpoint) GetPodResourceInfo(podUID types.UID) (PodResourceInfo
 	return sc.cache.GetPodResourceInfo(podUID)
 }
 
-// SetContainerResoruces sets resources information for a pod's container
-func (sc *stateCheckpoint) SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, resources v1.ResourceRequirements) error {
+// SetContainerResources sets resources information for a pod's container
+func (sc *stateCheckpoint) SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, containerType podutil.ContainerType, resources v1.ResourceRequirements) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
-	err := sc.cache.SetContainerResources(logger, podUID, containerName, resources)
+	err := sc.cache.SetContainerResources(logger, podUID, containerName, containerType, resources)
 	if err != nil {
 		return err
 	}
@@ -229,7 +230,7 @@ func (sc *noopStateCheckpoint) GetPodResourceInfo(_ types.UID) (PodResourceInfo,
 	return PodResourceInfo{}, false
 }
 
-func (sc *noopStateCheckpoint) SetContainerResources(_ klog.Logger, _ types.UID, _ string, _ v1.ResourceRequirements) error {
+func (sc *noopStateCheckpoint) SetContainerResources(_ klog.Logger, _ types.UID, _ string, _ podutil.ContainerType, _ v1.ResourceRequirements) error {
 	return nil
 }
 

--- a/pkg/kubelet/allocation/state/state_checkpoint.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint.go
@@ -48,7 +48,7 @@ func NewStateCheckpoint(logger klog.Logger, stateDir, checkpointName string) (St
 		return nil, fmt.Errorf("failed to initialize checkpoint manager for pod resource information tracking: %w", err)
 	}
 
-	pra, checksum, err := restoreState(logger, checkpointManager, checkpointName)
+	pra, checksum, migrated, err := restoreState(logger, checkpointManager, checkpointName)
 	if err != nil {
 		//lint:ignore ST1005 user-facing error message
 		return nil, fmt.Errorf("could not restore state from checkpoint: %w, please drain this node and delete pod resource information checkpoint file %q before restarting Kubelet",
@@ -61,26 +61,47 @@ func NewStateCheckpoint(logger klog.Logger, stateDir, checkpointName string) (St
 		checkpointName:    checkpointName,
 		lastChecksum:      checksum,
 	}
+
+	if migrated {
+		logger.Info("Saving migrated V2 checkpoint to disk")
+		if err := stateCheckpoint.storeState(logger); err != nil {
+			logger.Error(err, "Failed to save migrated V2 checkpoint to disk")
+		}
+	}
+
 	return stateCheckpoint, nil
 }
 
 // restores state from a checkpoint and creates it if it doesn't exist
-func restoreState(logger klog.Logger, checkpointManager checkpointmanager.CheckpointManager, checkpointName string) (PodResourceInfoMap, checksum.Checksum, error) {
+func restoreState(logger klog.Logger, checkpointManager checkpointmanager.CheckpointManager, checkpointName string) (PodResourceInfoMap, checksum.Checksum, bool, error) {
 	checkpoint := &Checkpoint{}
 	if err := checkpointManager.GetCheckpoint(checkpointName, checkpoint); err != nil {
 		if err == errors.ErrCheckpointNotFound {
-			return nil, 0, nil
+			return nil, 0, false, nil
 		}
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 
+	// Try to restore as V2 (new format with "podEntries")
 	praInfo, err := checkpoint.GetPodResourceCheckpointInfo()
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get pod resource information: %w", err)
+	if err == nil && len(praInfo.PodEntries) > 0 {
+		logger.V(2).Info("State checkpoint: restored pod resource state from V2 checkpoint")
+		return praInfo.PodEntries, checkpoint.Checksum, false, nil
 	}
 
-	logger.V(2).Info("State checkpoint: restored pod resource state from checkpoint")
-	return praInfo.Entries, checkpoint.Checksum, nil
+	// Fallback to V1 (legacy format with "entries")
+	logger.Info("Could not load V2 checkpoint, trying V1 fallback", "err", err)
+	praInfoV1, err := checkpoint.GetPodResourceCheckpointInfoV1()
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("failed to get pod resource information from V1 checkpoint: %w", err)
+	}
+
+	// Migrate V1 to V2
+	logger.Info("Migrating allocation checkpoint from V1 to V2")
+	migratedEntries := migrateV1ToV2(praInfoV1.Entries)
+
+	logger.V(2).Info("State checkpoint: restored and migrated pod resource state from V1 checkpoint")
+	return migratedEntries, checkpoint.Checksum, true, nil
 }
 
 // saves state to a checkpoint, caller is responsible for locking
@@ -88,7 +109,7 @@ func (sc *stateCheckpoint) storeState(logger klog.Logger) error {
 	resourceInfo := sc.cache.GetPodResourceInfoMap()
 
 	checkpoint, err := NewCheckpoint(&PodResourceCheckpointInfo{
-		Entries: resourceInfo,
+		PodEntries: resourceInfo,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create checkpoint: %w", err)

--- a/pkg/kubelet/allocation/state/state_checkpoint.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint.go
@@ -17,6 +17,7 @@ limitations under the License.
 package state
 
 import (
+	"errors"
 	"fmt"
 	"path"
 	"sync"
@@ -29,14 +30,14 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/checksum"
-	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
+	cperrors "k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
 )
 
 var _ State = &stateCheckpoint{}
 
 type stateCheckpoint struct {
 	mux               sync.RWMutex
-	cache             State
+	cache             *stateMemory
 	checkpointManager checkpointmanager.CheckpointManager
 	checkpointName    string
 	lastChecksum      checksum.Checksum
@@ -49,7 +50,7 @@ func NewStateCheckpoint(logger klog.Logger, stateDir, checkpointName string) (St
 		return nil, fmt.Errorf("failed to initialize checkpoint manager for pod resource information tracking: %w", err)
 	}
 
-	pra, checksum, err := restoreState(logger, checkpointManager, checkpointName)
+	pra, checksum, migrated, err := restoreState(logger, checkpointManager, checkpointName)
 	if err != nil {
 		//lint:ignore ST1005 user-facing error message
 		return nil, fmt.Errorf("could not restore state from checkpoint: %w, please drain this node and delete pod resource information checkpoint file %q before restarting Kubelet",
@@ -57,42 +58,68 @@ func NewStateCheckpoint(logger klog.Logger, stateDir, checkpointName string) (St
 	}
 
 	stateCheckpoint := &stateCheckpoint{
-		cache:             NewStateMemory(logger, pra),
+		cache:             newStateMemory(logger, pra),
 		checkpointManager: checkpointManager,
 		checkpointName:    checkpointName,
 		lastChecksum:      checksum,
 	}
+
+	if migrated {
+		logger.Info("Saving migrated V2 checkpoint to disk")
+		if err := stateCheckpoint.storeState(logger); err != nil {
+			logger.Error(err, "Failed to save migrated V2 checkpoint to disk")
+		}
+	}
+
 	return stateCheckpoint, nil
 }
 
 // restores state from a checkpoint and creates it if it doesn't exist
-func restoreState(logger klog.Logger, checkpointManager checkpointmanager.CheckpointManager, checkpointName string) (PodResourceInfoMap, checksum.Checksum, error) {
+func restoreState(logger klog.Logger, checkpointManager checkpointmanager.CheckpointManager, checkpointName string) (PodMap, checksum.Checksum, bool, error) {
 	checkpoint := &Checkpoint{}
-	if err := checkpointManager.GetCheckpoint(checkpointName, checkpoint); err != nil {
-		if err == errors.ErrCheckpointNotFound {
-			return nil, 0, nil
-		}
-		return nil, 0, err
+	err := checkpointManager.GetCheckpoint(checkpointName, checkpoint)
+	if errors.Is(err, cperrors.ErrCheckpointNotFound) {
+		return nil, 0, false, nil
 	}
-
-	praInfo, err := checkpoint.GetPodResourceCheckpointInfo()
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get pod resource information: %w", err)
+		return nil, 0, false, err
 	}
 
-	logger.V(2).Info("State checkpoint: restored pod resource state from checkpoint")
-	return praInfo.Entries, checkpoint.Checksum, nil
+	if checkpoint.Version == checkpointVersionV2 {
+		podList, errProto := checkpoint.getPodList()
+		if errProto != nil {
+			return nil, 0, false, fmt.Errorf("failed to decode V2 protobuf checkpoint: %w", errProto)
+		}
+		podMap := make(PodMap)
+		for _, pod := range podList.Items {
+			podMap[pod.UID] = pod.DeepCopy()
+		}
+		logger.V(2).Info("State checkpoint: restored pod resource state from V2 checkpoint")
+		return podMap, checkpoint.Checksum, false, nil
+	}
+
+	// Fallback to legacy JSON V1 format (unversioned)
+	logger.Info("Unversioned checkpoint found, migrating legacy JSON V1 format to V2", "checkpoint", checkpointName)
+	podList, errMigrate := migrateV1ToV2(checkpoint.Data)
+	if errMigrate != nil {
+		return nil, 0, false, fmt.Errorf("failed to migrate legacy JSON V1 checkpoint: %w", errMigrate)
+	}
+	podMap := make(PodMap)
+	for _, pod := range podList.Items {
+		podMap[pod.UID] = pod.DeepCopy()
+	}
+	logger.V(2).Info("State checkpoint: restored and migrated pod resource state from legacy JSON V1 checkpoint")
+	return podMap, 0, true, nil
 }
 
 // saves state to a checkpoint, caller is responsible for locking
 func (sc *stateCheckpoint) storeState(logger klog.Logger) error {
-	resourceInfo := sc.cache.GetPodResourceInfoMap()
+	podList := sc.cache.toPodList()
 
-	checkpoint, err := NewCheckpoint(&PodResourceCheckpointInfo{
-		Entries: resourceInfo,
-	})
+	checkpoint, err := NewCheckpoint(podList)
 	if err != nil {
-		return fmt.Errorf("failed to create checkpoint: %w", err)
+		logger.Error(err, "Failed to create pod resource information checkpoint")
+		return err
 	}
 	if checkpoint.Checksum == sc.lastChecksum {
 		// No changes to the checkpoint => no need to re-write it.
@@ -128,18 +155,32 @@ func (sc *stateCheckpoint) GetEmptyDirVolumeLimit(podUID types.UID, volumeName s
 	return sc.cache.GetEmptyDirVolumeLimit(podUID, volumeName)
 }
 
-// GetPodResourceInfoMap returns current pod resource information map
-func (sc *stateCheckpoint) GetPodResourceInfoMap() PodResourceInfoMap {
+// GetPodMap returns current pod map
+func (sc *stateCheckpoint) GetPodMap() PodMap {
 	sc.mux.RLock()
 	defer sc.mux.RUnlock()
-	return sc.cache.GetPodResourceInfoMap()
+	return sc.cache.GetPodMap()
 }
 
-// GetPodResourceInfo returns current pod resource information
-func (sc *stateCheckpoint) GetPodResourceInfo(podUID types.UID) (PodResourceInfo, bool) {
+// GetPodUIDs returns the UIDs of all pods in the state
+func (sc *stateCheckpoint) GetPodUIDs() []types.UID {
 	sc.mux.RLock()
 	defer sc.mux.RUnlock()
-	return sc.cache.GetPodResourceInfo(podUID)
+	return sc.cache.GetPodUIDs()
+}
+
+// GetPod returns current pod
+func (sc *stateCheckpoint) GetPod(podUID types.UID) (*v1.Pod, bool) {
+	sc.mux.RLock()
+	defer sc.mux.RUnlock()
+	return sc.cache.GetPod(podUID)
+}
+
+// HasPod returns whether a pod with the given UID exists in the state
+func (sc *stateCheckpoint) HasPod(podUID types.UID) bool {
+	sc.mux.RLock()
+	defer sc.mux.RUnlock()
+	return sc.cache.HasPod(podUID)
 }
 
 // SetContainerResources sets resources information for a pod's container
@@ -176,18 +217,18 @@ func (sc *stateCheckpoint) SetEmptyDirVolumeLimit(podUID types.UID, volumeName s
 	return sc.storeState(logger)
 }
 
-// SetPodResourceInfo sets pod resource information
-func (sc *stateCheckpoint) SetPodResourceInfo(logger klog.Logger, podUID types.UID, resourceInfo PodResourceInfo) error {
+// SetPod sets pod
+func (sc *stateCheckpoint) SetPod(logger klog.Logger, pod *v1.Pod) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
-	err := sc.cache.SetPodResourceInfo(logger, podUID, resourceInfo)
+	err := sc.cache.SetPod(logger, pod)
 	if err != nil {
 		return err
 	}
 	return sc.storeState(logger)
 }
 
-// Delete deletes resource information for specified pod
+// RemovePod deletes resource information for specified pod
 func (sc *stateCheckpoint) RemovePod(logger klog.Logger, podUID types.UID) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
@@ -222,12 +263,20 @@ func (sc *noopStateCheckpoint) GetEmptyDirVolumeLimit(_ types.UID, _ string) (*r
 	return nil, false
 }
 
-func (sc *noopStateCheckpoint) GetPodResourceInfoMap() PodResourceInfoMap {
+func (sc *noopStateCheckpoint) GetPodMap() PodMap {
 	return nil
 }
 
-func (sc *noopStateCheckpoint) GetPodResourceInfo(_ types.UID) (PodResourceInfo, bool) {
-	return PodResourceInfo{}, false
+func (sc *noopStateCheckpoint) GetPodUIDs() []types.UID {
+	return nil
+}
+
+func (sc *noopStateCheckpoint) GetPod(_ types.UID) (*v1.Pod, bool) {
+	return nil, false
+}
+
+func (sc *noopStateCheckpoint) HasPod(_ types.UID) bool {
+	return false
 }
 
 func (sc *noopStateCheckpoint) SetContainerResources(_ klog.Logger, _ types.UID, _ string, _ podutil.ContainerType, _ v1.ResourceRequirements) error {
@@ -242,7 +291,7 @@ func (sc *noopStateCheckpoint) SetEmptyDirVolumeLimit(_ types.UID, _ string, _ *
 	return nil
 }
 
-func (sc *noopStateCheckpoint) SetPodResourceInfo(_ klog.Logger, _ types.UID, _ PodResourceInfo) error {
+func (sc *noopStateCheckpoint) SetPod(_ klog.Logger, _ *v1.Pod) error {
 	return nil
 }
 

--- a/pkg/kubelet/allocation/state/state_checkpoint_test.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint_test.go
@@ -25,17 +25,18 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 )
 
 const testCheckpoint = "pod_status_manager_state"
 
-func newTestStateCheckpoint(t *testing.T) *stateCheckpoint {
+func newTestStateCheckpoint(t *testing.T, testingDir string) *stateCheckpoint {
 	logger, _ := ktesting.NewTestContext(t)
-	testingDir := getTestDir(t)
-	cache := NewStateMemory(logger, PodResourceInfoMap{})
+	cache := newStateMemory(logger, PodMap{})
 	checkpointManager, err := checkpointmanager.NewCheckpointManager(testingDir)
 	require.NoError(t, err, "failed to create checkpoint manager")
 	checkpointName := "pod_state_checkpoint"
@@ -58,55 +59,21 @@ func getTestDir(t *testing.T) string {
 	return testingDir
 }
 
-func verifyPodResourceAllocation(t *testing.T, expected, actual *PodResourceInfoMap, msgAndArgs string) {
-	for podUID, expectedPodInfo := range *expected {
-		actualPodInfo, exists := (*actual)[podUID]
+func verifyPodResourceAllocation(t *testing.T, expected, actual *PodMap, msgAndArgs string) {
+	for podUID, expectedPod := range *expected {
+		actualPod, exists := (*actual)[podUID]
 		require.True(t, exists, "actual state missing pod %s", podUID)
+		require.NotNil(t, actualPod, msgAndArgs)
+		require.NotNil(t, expectedPod, msgAndArgs)
 
-		// ContainerResources validation
-		require.Len(t, actualPodInfo.ContainerResources, len(expectedPodInfo.ContainerResources), msgAndArgs)
-		for containerName, expectedCtrReq := range expectedPodInfo.ContainerResources {
-			actualCtrReq, exists := actualPodInfo.ContainerResources[containerName]
-			require.True(t, exists, "actual container %s missing", containerName)
-			for name, expectedQty := range expectedCtrReq.Requests {
-				require.True(t, expectedQty.Equal(actualCtrReq.Requests[name]), msgAndArgs)
-			}
-			for name, expectedQty := range expectedCtrReq.Limits {
-				require.True(t, expectedQty.Equal(actualCtrReq.Limits[name]), msgAndArgs)
-			}
-		}
-
-		// PodLevelResources validation
-		if expectedPodInfo.PodLevelResources == nil {
-			require.Nil(t, actualPodInfo.PodLevelResources, msgAndArgs)
-		} else {
-			require.NotNil(t, actualPodInfo.PodLevelResources, msgAndArgs)
-			for name, expectedQty := range expectedPodInfo.PodLevelResources.Requests {
-				require.True(t, expectedQty.Equal(actualPodInfo.PodLevelResources.Requests[name]), msgAndArgs)
-			}
-			for name, expectedQty := range expectedPodInfo.PodLevelResources.Limits {
-				require.True(t, expectedQty.Equal(actualPodInfo.PodLevelResources.Limits[name]), msgAndArgs)
-			}
-		}
-
-		// EmptyDirVolumeLimits validation
-		if expectedPodInfo.EmptyDirVolumeLimits == nil {
-			require.Nil(t, actualPodInfo.EmptyDirVolumeLimits, msgAndArgs)
-		} else {
-			require.NotNil(t, actualPodInfo.EmptyDirVolumeLimits, msgAndArgs)
-			require.Len(t, actualPodInfo.EmptyDirVolumeLimits, len(expectedPodInfo.EmptyDirVolumeLimits), msgAndArgs)
-			for volName, expectedQty := range expectedPodInfo.EmptyDirVolumeLimits {
-				actualQty, exists := actualPodInfo.EmptyDirVolumeLimits[volName]
-				require.True(t, exists, "actual emptyDir volume %s missing", volName)
-				require.True(t, expectedQty.Equal(*actualQty), msgAndArgs)
-			}
-		}
+		// Compare Pod resources
+		require.True(t, apiequality.Semantic.DeepEqual(expectedPod, actualPod), msgAndArgs)
 	}
 }
 
 func Test_stateCheckpoint_storeState(t *testing.T) {
 	type args struct {
-		resInfoMap PodResourceInfoMap
+		podMap PodMap
 	}
 	type testCase struct {
 		name string
@@ -129,27 +96,42 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 			tests = append(tests, testCase{
 				name: fmt.Sprintf("resource - %s - all fields populated", qStr),
 				args: args{
-					resInfoMap: PodResourceInfoMap{
+					podMap: PodMap{
 						"pod1": {
-							ContainerResources: map[string]v1.ResourceRequirements{
-								"container1": {
+							ObjectMeta: metav1.ObjectMeta{
+								UID: "pod1",
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "container1",
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse(qStr),
+												v1.ResourceMemory: resource.MustParse(qStr),
+											},
+										},
+									},
+								},
+								Resources: &v1.ResourceRequirements{
 									Requests: v1.ResourceList{
 										v1.ResourceCPU:    resource.MustParse(qStr),
 										v1.ResourceMemory: resource.MustParse(qStr),
 									},
 								},
-							},
-							PodLevelResources: &v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse(qStr),
-									v1.ResourceMemory: resource.MustParse(qStr),
+								Volumes: []v1.Volume{
+									{
+										Name: "volume1",
+										VolumeSource: v1.VolumeSource{
+											EmptyDir: &v1.EmptyDirVolumeSource{
+												SizeLimit: func() *resource.Quantity {
+													q := resource.MustParse(qStr)
+													return &q
+												}(),
+											},
+										},
+									},
 								},
-							},
-							EmptyDirVolumeLimits: map[string]*resource.Quantity{
-								"volume1": func() *resource.Quantity {
-									q := resource.MustParse(qStr)
-									return &q
-								}(),
 							},
 						},
 					},
@@ -160,18 +142,24 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 			tests = append(tests, testCase{
 				name: fmt.Sprintf("resource - %s - only container", qStr),
 				args: args{
-					resInfoMap: PodResourceInfoMap{
+					podMap: PodMap{
 						"pod1": {
-							ContainerResources: map[string]v1.ResourceRequirements{
-								"container1": {
-									Requests: v1.ResourceList{
-										v1.ResourceCPU:    resource.MustParse(qStr),
-										v1.ResourceMemory: resource.MustParse(qStr),
+							ObjectMeta: metav1.ObjectMeta{
+								UID: "pod1",
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "container1",
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse(qStr),
+												v1.ResourceMemory: resource.MustParse(qStr),
+											},
+										},
 									},
 								},
 							},
-							PodLevelResources:    nil,
-							EmptyDirVolumeLimits: nil,
 						},
 					},
 				},
@@ -181,22 +169,36 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 			tests = append(tests, testCase{
 				name: fmt.Sprintf("resource - %s - container and volume limits", qStr),
 				args: args{
-					resInfoMap: PodResourceInfoMap{
+					podMap: PodMap{
 						"pod1": {
-							ContainerResources: map[string]v1.ResourceRequirements{
-								"container1": {
-									Requests: v1.ResourceList{
-										v1.ResourceCPU:    resource.MustParse(qStr),
-										v1.ResourceMemory: resource.MustParse(qStr),
+							ObjectMeta: metav1.ObjectMeta{
+								UID: "pod1",
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "container1",
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse(qStr),
+												v1.ResourceMemory: resource.MustParse(qStr),
+											},
+										},
 									},
 								},
-							},
-							PodLevelResources: nil,
-							EmptyDirVolumeLimits: map[string]*resource.Quantity{
-								"volume1": func() *resource.Quantity {
-									q := resource.MustParse(qStr)
-									return &q
-								}(),
+								Volumes: []v1.Volume{
+									{
+										Name: "volume1",
+										VolumeSource: v1.VolumeSource{
+											EmptyDir: &v1.EmptyDirVolumeSource{
+												SizeLimit: func() *resource.Quantity {
+													q := resource.MustParse(qStr)
+													return &q
+												}(),
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -207,23 +209,30 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 			tests = append(tests, testCase{
 				name: fmt.Sprintf("resource - %s - container and pod-level", qStr),
 				args: args{
-					resInfoMap: PodResourceInfoMap{
+					podMap: PodMap{
 						"pod1": {
-							ContainerResources: map[string]v1.ResourceRequirements{
-								"container1": {
+							ObjectMeta: metav1.ObjectMeta{
+								UID: "pod1",
+							},
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "container1",
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse(qStr),
+												v1.ResourceMemory: resource.MustParse(qStr),
+											},
+										},
+									},
+								},
+								Resources: &v1.ResourceRequirements{
 									Requests: v1.ResourceList{
 										v1.ResourceCPU:    resource.MustParse(qStr),
 										v1.ResourceMemory: resource.MustParse(qStr),
 									},
 								},
 							},
-							PodLevelResources: &v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse(qStr),
-									v1.ResourceMemory: resource.MustParse(qStr),
-								},
-							},
-							EmptyDirVolumeLimits: nil,
 						},
 					},
 				},
@@ -238,38 +247,53 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 			originalSC, err := NewStateCheckpoint(logger, testDir, testCheckpoint)
 			require.NoError(t, err)
 
-			for podUID, alloc := range tt.args.resInfoMap {
-				err = originalSC.SetPodResourceInfo(logger, podUID, alloc)
+			for _, pod := range tt.args.podMap {
+				err = originalSC.SetPod(logger, pod)
 				require.NoError(t, err)
 			}
 
-			actual := originalSC.GetPodResourceInfoMap()
-			verifyPodResourceAllocation(t, &tt.args.resInfoMap, &actual, "stored pod resource allocation is not equal to original pod resource allocation")
+			actual := originalSC.GetPodMap()
+			verifyPodResourceAllocation(t, &tt.args.podMap, &actual, "stored pod resource allocation is not equal to original pod resource allocation")
 
 			newSC, err := NewStateCheckpoint(logger, testDir, testCheckpoint)
 			require.NoError(t, err)
 
-			actual = newSC.GetPodResourceInfoMap()
-			verifyPodResourceAllocation(t, &tt.args.resInfoMap, &actual, "restored pod resource allocation is not equal to original pod resource allocation")
+			actual = newSC.GetPodMap()
+			verifyPodResourceAllocation(t, &tt.args.podMap, &actual, "restored pod resource allocation is not equal to original pod resource allocation")
 
 			checkpointPath := filepath.Join(testDir, testCheckpoint)
 			require.FileExists(t, checkpointPath)
 			require.NoError(t, os.Remove(checkpointPath)) // Remove the checkpoint file to track whether it's re-written.
 
 			// Setting the pod allocations to the same values should not re-write the checkpoint.
-			for podUID, alloc := range tt.args.resInfoMap {
-				require.NoError(t, originalSC.SetPodResourceInfo(logger, podUID, alloc))
+			for _, pod := range tt.args.podMap {
+				require.NoError(t, originalSC.SetPod(logger, pod))
 				require.NoFileExists(t, checkpointPath, "checkpoint should not be re-written")
 			}
 
 			// Setting a new value should update the checkpoint.
-			require.NoError(t, originalSC.SetPodResourceInfo(logger, "foo-bar", PodResourceInfo{
-				ContainerResources: map[string]v1.ResourceRequirements{
-					"container1": {Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}},
+			require.NoError(t, originalSC.SetPod(logger, &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: "foo-bar",
 				},
-				PodLevelResources: &v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}},
-				EmptyDirVolumeLimits: map[string]*resource.Quantity{
-					"volume1": resource.NewQuantity(1, resource.BinarySI),
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "container1", Resources: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}}},
+					},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}},
+					Volumes: []v1.Volume{
+						{
+							Name: "volume1",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									SizeLimit: func() *resource.Quantity {
+										q := resource.MustParse("1")
+										return &q
+									}(),
+								},
+							},
+						},
+					},
 				},
 			}))
 			require.FileExists(t, checkpointPath, "checkpoint should be re-written")
@@ -277,44 +301,43 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 	}
 }
 
-func Test_stateCheckpoint_formatUpgraded(t *testing.T) {
+func Test_stateCheckpoint_formatUpgraded_FromV1(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
-	// Based on the PodResourceAllocationInfo struct, it's mostly possible that new field will be added
-	// in struct PodResourceAllocationInfo, rather than in struct PodResourceAllocationInfo.AllocationEntries.
-	// Emulate upgrade scenario by pretending that `ResizeStatusEntries` is a new field.
-	// The checkpoint content doesn't have it and that shouldn't prevent the checkpoint from being loaded.
-	sc := newTestStateCheckpoint(t)
+	testDir := getTestDir(t)
+	sc := newTestStateCheckpoint(t, testDir)
 
-	// prepare old checkpoint, ResizeStatusEntries is unset,
-	// pretend that the old checkpoint is unaware for the field ResizeStatusEntries
+	// prepare old checkpoint in V1 format
 	const checkpointContent = `{"data":"{\"entries\":{\"pod1\":{\"ContainerResources\":{\"container1\":{\"requests\":{\"cpu\":\"1Ki\",\"memory\":\"1Ki\"}}}}}}","checksum":1178570812}`
-	expectedPodResourceAllocation := PodResourceInfoMap{
+	expectedPodResourceAllocation := PodMap{
 		"pod1": {
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"container1": {
-					Requests: v1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("1Ki"),
-						v1.ResourceMemory: resource.MustParse("1Ki"),
+			ObjectMeta: metav1.ObjectMeta{
+				UID: "pod1",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "container1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1Ki"),
+								v1.ResourceMemory: resource.MustParse("1Ki"),
+							},
+						},
 					},
 				},
 			},
 		},
 	}
-	checkpoint := &Checkpoint{}
-	err := checkpoint.UnmarshalCheckpoint([]byte(checkpointContent))
-	require.NoError(t, err, "failed to unmarshal checkpoint")
+	err := os.WriteFile(filepath.Join(testDir, sc.checkpointName), []byte(checkpointContent), 0644)
+	require.NoError(t, err, "failed to create old V1 checkpoint")
 
-	err = sc.checkpointManager.CreateCheckpoint(sc.checkpointName, checkpoint)
-	require.NoError(t, err, "failed to create old checkpoint")
-
-	actualPodResourceAllocation, _, err := restoreState(logger, sc.checkpointManager, sc.checkpointName)
+	actualPodResourceAllocation, _, migrated, err := restoreState(logger, sc.checkpointManager, sc.checkpointName)
 	require.NoError(t, err, "failed to restore state")
+	require.True(t, migrated, "checkpoint should be marked as migrated")
 
-	require.Equal(t, expectedPodResourceAllocation, actualPodResourceAllocation, "pod resource allocation info is not equal")
+	verifyPodResourceAllocation(t, &expectedPodResourceAllocation, &actualPodResourceAllocation, "migrated pod resource allocation is not equal")
 
-	sc.cache = NewStateMemory(logger, actualPodResourceAllocation)
-
-	actualPodResourceAllocation = sc.cache.GetPodResourceInfoMap()
-
-	require.Equal(t, expectedPodResourceAllocation, actualPodResourceAllocation, "pod resource allocation info is not equal")
+	sc.cache = newStateMemory(logger, actualPodResourceAllocation)
+	actualPodResourceAllocation = sc.cache.GetPodMap()
+	verifyPodResourceAllocation(t, &expectedPodResourceAllocation, &actualPodResourceAllocation, "cache pod resource allocation is not equal")
 }

--- a/pkg/kubelet/allocation/state/state_checkpoint_test.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
@@ -62,45 +63,11 @@ func verifyPodResourceAllocation(t *testing.T, expected, actual *PodResourceInfo
 	for podUID, expectedPodInfo := range *expected {
 		actualPodInfo, exists := (*actual)[podUID]
 		require.True(t, exists, "actual state missing pod %s", podUID)
+		require.NotNil(t, actualPodInfo.PodSpec, msgAndArgs)
+		require.NotNil(t, expectedPodInfo.PodSpec, msgAndArgs)
 
-		// ContainerResources validation
-		require.Len(t, actualPodInfo.ContainerResources, len(expectedPodInfo.ContainerResources), msgAndArgs)
-		for containerName, expectedCtrReq := range expectedPodInfo.ContainerResources {
-			actualCtrReq, exists := actualPodInfo.ContainerResources[containerName]
-			require.True(t, exists, "actual container %s missing", containerName)
-			for name, expectedQty := range expectedCtrReq.Requests {
-				require.True(t, expectedQty.Equal(actualCtrReq.Requests[name]), msgAndArgs)
-			}
-			for name, expectedQty := range expectedCtrReq.Limits {
-				require.True(t, expectedQty.Equal(actualCtrReq.Limits[name]), msgAndArgs)
-			}
-		}
-
-		// PodLevelResources validation
-		if expectedPodInfo.PodLevelResources == nil {
-			require.Nil(t, actualPodInfo.PodLevelResources, msgAndArgs)
-		} else {
-			require.NotNil(t, actualPodInfo.PodLevelResources, msgAndArgs)
-			for name, expectedQty := range expectedPodInfo.PodLevelResources.Requests {
-				require.True(t, expectedQty.Equal(actualPodInfo.PodLevelResources.Requests[name]), msgAndArgs)
-			}
-			for name, expectedQty := range expectedPodInfo.PodLevelResources.Limits {
-				require.True(t, expectedQty.Equal(actualPodInfo.PodLevelResources.Limits[name]), msgAndArgs)
-			}
-		}
-
-		// EmptyDirVolumeLimits validation
-		if expectedPodInfo.EmptyDirVolumeLimits == nil {
-			require.Nil(t, actualPodInfo.EmptyDirVolumeLimits, msgAndArgs)
-		} else {
-			require.NotNil(t, actualPodInfo.EmptyDirVolumeLimits, msgAndArgs)
-			require.Len(t, actualPodInfo.EmptyDirVolumeLimits, len(expectedPodInfo.EmptyDirVolumeLimits), msgAndArgs)
-			for volName, expectedQty := range expectedPodInfo.EmptyDirVolumeLimits {
-				actualQty, exists := actualPodInfo.EmptyDirVolumeLimits[volName]
-				require.True(t, exists, "actual emptyDir volume %s missing", volName)
-				require.True(t, expectedQty.Equal(*actualQty), msgAndArgs)
-			}
-		}
+		// Compare PodSpec resources
+		require.True(t, apiequality.Semantic.DeepEqual(expectedPodInfo.PodSpec, actualPodInfo.PodSpec), msgAndArgs)
 	}
 }
 
@@ -131,25 +98,37 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 				args: args{
 					resInfoMap: PodResourceInfoMap{
 						"pod1": {
-							ContainerResources: map[string]v1.ResourceRequirements{
-								"container1": {
+							PodSpec: &v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "container1",
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse(qStr),
+												v1.ResourceMemory: resource.MustParse(qStr),
+											},
+										},
+									},
+								},
+								Resources: &v1.ResourceRequirements{
 									Requests: v1.ResourceList{
 										v1.ResourceCPU:    resource.MustParse(qStr),
 										v1.ResourceMemory: resource.MustParse(qStr),
 									},
 								},
-							},
-							PodLevelResources: &v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse(qStr),
-									v1.ResourceMemory: resource.MustParse(qStr),
+								Volumes: []v1.Volume{
+									{
+										Name: "volume1",
+										VolumeSource: v1.VolumeSource{
+											EmptyDir: &v1.EmptyDirVolumeSource{
+												SizeLimit: func() *resource.Quantity {
+													q := resource.MustParse(qStr)
+													return &q
+												}(),
+											},
+										},
+									},
 								},
-							},
-							EmptyDirVolumeLimits: map[string]*resource.Quantity{
-								"volume1": func() *resource.Quantity {
-									q := resource.MustParse(qStr)
-									return &q
-								}(),
 							},
 						},
 					},
@@ -162,16 +141,19 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 				args: args{
 					resInfoMap: PodResourceInfoMap{
 						"pod1": {
-							ContainerResources: map[string]v1.ResourceRequirements{
-								"container1": {
-									Requests: v1.ResourceList{
-										v1.ResourceCPU:    resource.MustParse(qStr),
-										v1.ResourceMemory: resource.MustParse(qStr),
+							PodSpec: &v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "container1",
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse(qStr),
+												v1.ResourceMemory: resource.MustParse(qStr),
+											},
+										},
 									},
 								},
 							},
-							PodLevelResources:    nil,
-							EmptyDirVolumeLimits: nil,
 						},
 					},
 				},
@@ -183,20 +165,31 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 				args: args{
 					resInfoMap: PodResourceInfoMap{
 						"pod1": {
-							ContainerResources: map[string]v1.ResourceRequirements{
-								"container1": {
-									Requests: v1.ResourceList{
-										v1.ResourceCPU:    resource.MustParse(qStr),
-										v1.ResourceMemory: resource.MustParse(qStr),
+							PodSpec: &v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "container1",
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse(qStr),
+												v1.ResourceMemory: resource.MustParse(qStr),
+											},
+										},
 									},
 								},
-							},
-							PodLevelResources: nil,
-							EmptyDirVolumeLimits: map[string]*resource.Quantity{
-								"volume1": func() *resource.Quantity {
-									q := resource.MustParse(qStr)
-									return &q
-								}(),
+								Volumes: []v1.Volume{
+									{
+										Name: "volume1",
+										VolumeSource: v1.VolumeSource{
+											EmptyDir: &v1.EmptyDirVolumeSource{
+												SizeLimit: func() *resource.Quantity {
+													q := resource.MustParse(qStr)
+													return &q
+												}(),
+											},
+										},
+									},
+								},
 							},
 						},
 					},
@@ -209,21 +202,25 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 				args: args{
 					resInfoMap: PodResourceInfoMap{
 						"pod1": {
-							ContainerResources: map[string]v1.ResourceRequirements{
-								"container1": {
+							PodSpec: &v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name: "container1",
+										Resources: v1.ResourceRequirements{
+											Requests: v1.ResourceList{
+												v1.ResourceCPU:    resource.MustParse(qStr),
+												v1.ResourceMemory: resource.MustParse(qStr),
+											},
+										},
+									},
+								},
+								Resources: &v1.ResourceRequirements{
 									Requests: v1.ResourceList{
 										v1.ResourceCPU:    resource.MustParse(qStr),
 										v1.ResourceMemory: resource.MustParse(qStr),
 									},
 								},
 							},
-							PodLevelResources: &v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse(qStr),
-									v1.ResourceMemory: resource.MustParse(qStr),
-								},
-							},
-							EmptyDirVolumeLimits: nil,
 						},
 					},
 				},
@@ -264,12 +261,24 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 
 			// Setting a new value should update the checkpoint.
 			require.NoError(t, originalSC.SetPodResourceInfo(logger, "foo-bar", PodResourceInfo{
-				ContainerResources: map[string]v1.ResourceRequirements{
-					"container1": {Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}},
-				},
-				PodLevelResources: &v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}},
-				EmptyDirVolumeLimits: map[string]*resource.Quantity{
-					"volume1": resource.NewQuantity(1, resource.BinarySI),
+				PodSpec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "container1", Resources: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}}},
+					},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")}},
+					Volumes: []v1.Volume{
+						{
+							Name: "volume1",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									SizeLimit: func() *resource.Quantity {
+										q := resource.MustParse("1")
+										return &q
+									}(),
+								},
+							},
+						},
+					},
 				},
 			}))
 			require.FileExists(t, checkpointPath, "checkpoint should be re-written")
@@ -279,22 +288,22 @@ func Test_stateCheckpoint_storeState(t *testing.T) {
 
 func Test_stateCheckpoint_formatUpgraded(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
-	// Based on the PodResourceAllocationInfo struct, it's mostly possible that new field will be added
-	// in struct PodResourceAllocationInfo, rather than in struct PodResourceAllocationInfo.AllocationEntries.
-	// Emulate upgrade scenario by pretending that `ResizeStatusEntries` is a new field.
-	// The checkpoint content doesn't have it and that shouldn't prevent the checkpoint from being loaded.
 	sc := newTestStateCheckpoint(t)
 
-	// prepare old checkpoint, ResizeStatusEntries is unset,
-	// pretend that the old checkpoint is unaware for the field ResizeStatusEntries
+	// prepare old checkpoint in V1 format
 	const checkpointContent = `{"data":"{\"entries\":{\"pod1\":{\"ContainerResources\":{\"container1\":{\"requests\":{\"cpu\":\"1Ki\",\"memory\":\"1Ki\"}}}}}}","checksum":1178570812}`
 	expectedPodResourceAllocation := PodResourceInfoMap{
 		"pod1": {
-			ContainerResources: map[string]v1.ResourceRequirements{
-				"container1": {
-					Requests: v1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("1Ki"),
-						v1.ResourceMemory: resource.MustParse("1Ki"),
+			PodSpec: &v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name: "container1",
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("1Ki"),
+								v1.ResourceMemory: resource.MustParse("1Ki"),
+							},
+						},
 					},
 				},
 			},
@@ -307,14 +316,15 @@ func Test_stateCheckpoint_formatUpgraded(t *testing.T) {
 	err = sc.checkpointManager.CreateCheckpoint(sc.checkpointName, checkpoint)
 	require.NoError(t, err, "failed to create old checkpoint")
 
-	actualPodResourceAllocation, _, err := restoreState(logger, sc.checkpointManager, sc.checkpointName)
+	actualPodResourceAllocation, _, _, err := restoreState(logger, sc.checkpointManager, sc.checkpointName)
 	require.NoError(t, err, "failed to restore state")
 
-	require.Equal(t, expectedPodResourceAllocation, actualPodResourceAllocation, "pod resource allocation info is not equal")
+	// Compare using verifyPodResourceAllocation to handle semantic equality of resources
+	verifyPodResourceAllocation(t, &expectedPodResourceAllocation, &actualPodResourceAllocation, "migrated pod resource allocation is not equal")
 
 	sc.cache = NewStateMemory(logger, actualPodResourceAllocation)
 
 	actualPodResourceAllocation = sc.cache.GetPodResourceInfoMap()
 
-	require.Equal(t, expectedPodResourceAllocation, actualPodResourceAllocation, "pod resource allocation info is not equal")
+	verifyPodResourceAllocation(t, &expectedPodResourceAllocation, &actualPodResourceAllocation, "cache pod resource allocation is not equal")
 }

--- a/pkg/kubelet/allocation/state/state_helpers.go
+++ b/pkg/kubelet/allocation/state/state_helpers.go
@@ -1,0 +1,143 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/resource"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+// UpdatePodFromCheckpoint overlays mutable fields that are gated on node allocation (e.g.
+// container resources, pod-level resources, and memory-backed emptyDir volume size limits)
+// from the checkpointed pod onto the incoming pod.
+//
+// Fields in PodSpec fall into three categories:
+//  1. Immutable fields (e.g. NodeName, Volumes list, Container names): Identical between pod and storedPod.
+//  2. Allocatable fields (e.g. Container resources, pod-level resources, emptyDir limits): Mutable, but
+//     gated on node allocation admission. These must reflect the node's committed allocation (storedPod)
+//     until newly requested specs are admitted and checkpointed.
+//  3. Allocation-bypass fields (e.g. Container images, tolerations, ActiveDeadlineSeconds): Mutable
+//     without node allocation admission. These reflect the latest incoming spec (pod).
+//
+// Starting from the incoming pod and selectively overlaying Category 2 allocatable fields from
+// storedPod ensures that Category 3 mutations are preserved, forward compatibility is maintained
+// for new PodSpec fields, and legacy V1 checkpoints (which only recorded Category 2 fields) can
+// cleanly hydrate into full PodSpecs without dropping non-resource metadata.
+//
+// This function returns a deep copy of the pod only if updates were applied.
+func UpdatePodFromCheckpoint(pod *v1.Pod, storedPod *v1.Pod) (*v1.Pod, bool) {
+	if pod == nil || storedPod == nil {
+		return pod, false
+	}
+
+	updated := false
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
+		pod, updated = updatePodLevelResourcesFromCheckpoint(pod, storedPod)
+	}
+	pod, updated = updateContainerResourcesFromCheckpoint(pod, storedPod, updated)
+	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingMemoryBackedVolumes) {
+		pod, updated = updateEmptyDirVolumeLimitsFromCheckpoint(pod, storedPod, updated)
+	}
+
+	return pod, updated
+}
+
+func updateContainerResourcesFromCheckpoint(pod *v1.Pod, storedPod *v1.Pod, alreadyUpdated bool) (*v1.Pod, bool) {
+	updated := alreadyUpdated
+	containerAlloc := func(c v1.Container) (v1.ResourceRequirements, bool) {
+		if storedPod == nil {
+			return v1.ResourceRequirements{}, false
+		}
+		for sc := range podutil.ContainerIter(&storedPod.Spec, podutil.InitContainers|podutil.Containers) {
+			if sc.Name == c.Name {
+				if !apiequality.Semantic.DeepEqual(c.Resources, sc.Resources) {
+					// Stored state differs from pod spec, retrieve the stored resources
+					if !updated {
+						// If this is the first update to be performed, copy the pod
+						pod = pod.DeepCopy()
+						updated = true
+					}
+					return sc.Resources, true
+				}
+			}
+		}
+		return v1.ResourceRequirements{}, false
+	}
+
+	for i, c := range pod.Spec.Containers {
+		if cAlloc, updated := containerAlloc(c); updated {
+			// Stored state differs from pod spec, update
+			pod.Spec.Containers[i].Resources = cAlloc
+		}
+	}
+	for i, c := range pod.Spec.InitContainers {
+		if cAlloc, updated := containerAlloc(c); updated {
+			// Stored state differs from pod spec, update
+			pod.Spec.InitContainers[i].Resources = cAlloc
+		}
+	}
+	return pod, updated
+}
+
+func updatePodLevelResourcesFromCheckpoint(pod *v1.Pod, storedPod *v1.Pod) (*v1.Pod, bool) {
+	pAlloc := storedPod.Spec.Resources
+	if pAlloc == nil {
+		return pod, false
+	}
+	if !apiequality.Semantic.DeepEqual(pod.Spec.Resources, pAlloc) {
+		// Stored state differs from pod spec, retrieve the stored resources
+		pod = pod.DeepCopy()
+		pod.Spec.Resources = pAlloc.DeepCopy()
+		return pod, true
+	}
+	return pod, false
+}
+
+func updateEmptyDirVolumeLimitsFromCheckpoint(pod *v1.Pod, storedPod *v1.Pod, alreadyUpdated bool) (*v1.Pod, bool) {
+	updated := alreadyUpdated
+	for i, vol := range pod.Spec.Volumes {
+		if !volHasMemoryBackedEmptyDirSizeLimit(&vol) {
+			continue
+		}
+
+		var alloc *resource.Quantity
+		for _, sv := range storedPod.Spec.Volumes {
+			if sv.Name == vol.Name && sv.EmptyDir != nil {
+				alloc = sv.EmptyDir.SizeLimit
+				break
+			}
+		}
+
+		if alloc != nil && alloc.Cmp(*vol.EmptyDir.SizeLimit) != 0 {
+			if !updated {
+				pod = pod.DeepCopy()
+				updated = true
+			}
+			allocCopy := alloc.DeepCopy()
+			pod.Spec.Volumes[i].EmptyDir.SizeLimit = &allocCopy
+		}
+	}
+	return pod, updated
+}
+
+func volHasMemoryBackedEmptyDirSizeLimit(vol *v1.Volume) bool {
+	return vol != nil && vol.EmptyDir != nil && vol.EmptyDir.Medium == v1.StorageMediumMemory && vol.EmptyDir.SizeLimit != nil
+}

--- a/pkg/kubelet/allocation/state/state_helpers_test.go
+++ b/pkg/kubelet/allocation/state/state_helpers_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+func TestUpdatePodFromCheckpoint(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodLevelResourcesVerticalScaling, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingMemoryBackedVolumes, true)
+
+	res100m100Mi := v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("100m"),
+			v1.ResourceMemory: resource.MustParse("100Mi"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("200m"),
+			v1.ResourceMemory: resource.MustParse("200Mi"),
+		},
+	}
+	res200m200Mi := v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("200m"),
+			v1.ResourceMemory: resource.MustParse("200Mi"),
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("400m"),
+			v1.ResourceMemory: resource.MustParse("400Mi"),
+		},
+	}
+
+	volLimit100Mi := resource.MustParse("100Mi")
+	volLimit200Mi := resource.MustParse("200Mi")
+
+	makePod := func(cRes, icRes, pRes *v1.ResourceRequirements, volLimit *resource.Quantity) *v1.Pod {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-pod",
+				UID:  "test-uid",
+			},
+			Spec: v1.PodSpec{},
+		}
+		if cRes != nil {
+			pod.Spec.Containers = []v1.Container{
+				{
+					Name:      "c1",
+					Resources: *cRes.DeepCopy(),
+				},
+			}
+		}
+		if icRes != nil {
+			pod.Spec.InitContainers = []v1.Container{
+				{
+					Name:      "ic1",
+					Resources: *icRes.DeepCopy(),
+				},
+			}
+		}
+		if pRes != nil {
+			pod.Spec.Resources = pRes.DeepCopy()
+		}
+		if volLimit != nil {
+			lc := volLimit.DeepCopy()
+			pod.Spec.Volumes = []v1.Volume{
+				{
+					Name: "vol1",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							Medium:    v1.StorageMediumMemory,
+							SizeLimit: &lc,
+						},
+					},
+				},
+			}
+		}
+		return pod
+	}
+
+	tests := []struct {
+		name          string
+		pod           *v1.Pod
+		storedPod     *v1.Pod
+		expectUpdated bool
+		expectedPod   *v1.Pod
+	}{
+		{
+			name:          "nil incoming pod",
+			pod:           nil,
+			storedPod:     makePod(&res100m100Mi, nil, nil, nil),
+			expectUpdated: false,
+			expectedPod:   nil,
+		},
+		{
+			name:          "nil stored pod",
+			pod:           makePod(&res100m100Mi, nil, nil, nil),
+			storedPod:     nil,
+			expectUpdated: false,
+			expectedPod:   makePod(&res100m100Mi, nil, nil, nil),
+		},
+		{
+			name:          "identical pod and stored pod - no update",
+			pod:           makePod(&res100m100Mi, &res100m100Mi, &res100m100Mi, &volLimit100Mi),
+			storedPod:     makePod(&res100m100Mi, &res100m100Mi, &res100m100Mi, &volLimit100Mi),
+			expectUpdated: false,
+			expectedPod:   makePod(&res100m100Mi, &res100m100Mi, &res100m100Mi, &volLimit100Mi),
+		},
+		{
+			name:          "container resources updated from stored pod",
+			pod:           makePod(&res100m100Mi, nil, nil, nil),
+			storedPod:     makePod(&res200m200Mi, nil, nil, nil),
+			expectUpdated: true,
+			expectedPod:   makePod(&res200m200Mi, nil, nil, nil),
+		},
+		{
+			name:          "init container resources updated from stored pod",
+			pod:           makePod(nil, &res100m100Mi, nil, nil),
+			storedPod:     makePod(nil, &res200m200Mi, nil, nil),
+			expectUpdated: true,
+			expectedPod:   makePod(nil, &res200m200Mi, nil, nil),
+		},
+		{
+			name:          "pod-level resources updated from stored pod",
+			pod:           makePod(nil, nil, &res100m100Mi, nil),
+			storedPod:     makePod(nil, nil, &res200m200Mi, nil),
+			expectUpdated: true,
+			expectedPod:   makePod(nil, nil, &res200m200Mi, nil),
+		},
+		{
+			name:          "emptyDir volume limit updated from stored pod",
+			pod:           makePod(nil, nil, nil, &volLimit100Mi),
+			storedPod:     makePod(nil, nil, nil, &volLimit200Mi),
+			expectUpdated: true,
+			expectedPod:   makePod(nil, nil, nil, &volLimit200Mi),
+		},
+		{
+			name:          "all resources updated together from stored pod",
+			pod:           makePod(&res100m100Mi, &res100m100Mi, &res100m100Mi, &volLimit100Mi),
+			storedPod:     makePod(&res200m200Mi, &res200m200Mi, &res200m200Mi, &volLimit200Mi),
+			expectUpdated: true,
+			expectedPod:   makePod(&res200m200Mi, &res200m200Mi, &res200m200Mi, &volLimit200Mi),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualPod, updated := UpdatePodFromCheckpoint(tc.pod, tc.storedPod)
+			assert.Equal(t, tc.expectUpdated, updated)
+			if tc.expectedPod == nil {
+				assert.Nil(t, actualPod)
+				return
+			}
+			diff := cmp.Diff(tc.expectedPod, actualPod, cmp.Comparer(func(x, y resource.Quantity) bool {
+				return x.Equal(y)
+			}))
+			if diff != "" {
+				t.Errorf("pod mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/kubelet/allocation/state/state_mem.go
+++ b/pkg/kubelet/allocation/state/state_mem.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
 type stateMemory struct {
@@ -50,14 +51,15 @@ func (s *stateMemory) GetContainerResources(podUID types.UID, containerName stri
 
 	resourceInfo, ok := s.podResources[podUID]
 	if !ok {
-		return v1.ResourceRequirements{}, ok
+		return v1.ResourceRequirements{}, false
 	}
 
-	resources, ok := resourceInfo.ContainerResources[containerName]
-	if !ok {
-		return v1.ResourceRequirements{}, ok
+	for c := range podutil.ContainerIter(resourceInfo.PodSpec, podutil.InitContainers|podutil.Containers) {
+		if c.Name == containerName {
+			return *c.Resources.DeepCopy(), true
+		}
 	}
-	return *resources.DeepCopy(), ok
+	return v1.ResourceRequirements{}, false
 }
 
 // GetPodLevelResources returns current resources information at pod-level
@@ -67,10 +69,13 @@ func (s *stateMemory) GetPodLevelResources(podUID types.UID) (*v1.ResourceRequir
 
 	pr, ok := s.podResources[podUID]
 	if !ok {
-		return nil, ok
+		return nil, false
 	}
 
-	return pr.PodLevelResources.DeepCopy(), ok
+	if pr.PodSpec.Resources == nil {
+		return nil, false
+	}
+	return pr.PodSpec.Resources.DeepCopy(), true
 }
 
 // GetEmptyDirVolumeLimit returns current resources information for emptyDir volume
@@ -80,16 +85,19 @@ func (s *stateMemory) GetEmptyDirVolumeLimit(podUID types.UID, volumeName string
 
 	pr, ok := s.podResources[podUID]
 	if !ok {
-		return nil, ok
+		return nil, false
 	}
 
-	sizeLimit, ok := pr.EmptyDirVolumeLimits[volumeName]
-	if !ok {
-		return nil, ok
+	for _, vol := range pr.PodSpec.Volumes {
+		if vol.Name == volumeName && vol.EmptyDir != nil {
+			if vol.EmptyDir.SizeLimit == nil {
+				return nil, false
+			}
+			sizeLimitCopy := vol.EmptyDir.SizeLimit.DeepCopy()
+			return &sizeLimitCopy, true
+		}
 	}
-
-	sizeLimitCopy := sizeLimit.DeepCopy()
-	return &sizeLimitCopy, ok
+	return nil, false
 }
 
 func (s *stateMemory) GetPodResourceInfoMap() PodResourceInfoMap {
@@ -113,18 +121,27 @@ func (s *stateMemory) SetContainerResources(logger klog.Logger, podUID types.UID
 	podInfo, ok := s.podResources[podUID]
 	if !ok {
 		podInfo = PodResourceInfo{
-			ContainerResources: make(map[string]v1.ResourceRequirements),
+			PodSpec: &v1.PodSpec{},
 		}
 	}
 
-	if podInfo.ContainerResources == nil {
-		podInfo.ContainerResources = make(map[string]v1.ResourceRequirements)
+	found := false
+	for c := range podutil.ContainerIter(podInfo.PodSpec, podutil.InitContainers|podutil.Containers) {
+		if c.Name == containerName {
+			c.Resources = resources
+			found = true
+			break
+		}
+	}
+	if !found {
+		podInfo.PodSpec.Containers = append(podInfo.PodSpec.Containers, v1.Container{
+			Name:      containerName,
+			Resources: resources,
+		})
 	}
 
-	podInfo.ContainerResources[containerName] = resources
 	s.podResources[podUID] = podInfo
-
-	logger.V(3).Info("Updated container resource information", "podUID", podUID, "containerName", containerName, "resources", resources)
+	logger.V(3).Info("Updated container resource information in PodSpec", "podUID", podUID, "containerName", containerName, "resources", resources)
 	return nil
 }
 
@@ -134,14 +151,15 @@ func (s *stateMemory) SetPodLevelResources(logger klog.Logger, podUID types.UID,
 
 	podInfo, ok := s.podResources[podUID]
 	if !ok {
-		podInfo.PodLevelResources = &v1.ResourceRequirements{}
+		podInfo = PodResourceInfo{
+			PodSpec: &v1.PodSpec{},
+		}
 	}
 
-	podInfo.PodLevelResources = resources
-
+	podInfo.PodSpec.Resources = resources
 	s.podResources[podUID] = podInfo
 
-	logger.V(3).Info("Updated pod-level resource info", "podUID", podUID, "resources", resources)
+	logger.V(3).Info("Updated pod-level resource info in PodSpec", "podUID", podUID, "resources", resources)
 	return nil
 }
 
@@ -153,18 +171,31 @@ func (s *stateMemory) SetEmptyDirVolumeLimit(podUID types.UID, volumeName string
 	podInfo, ok := s.podResources[podUID]
 	if !ok {
 		podInfo = PodResourceInfo{
-			ContainerResources: make(map[string]v1.ResourceRequirements),
+			PodSpec: &v1.PodSpec{},
 		}
 	}
 
-	if podInfo.EmptyDirVolumeLimits == nil {
-		podInfo.EmptyDirVolumeLimits = make(map[string]*resource.Quantity)
+	found := false
+	for i, vol := range podInfo.PodSpec.Volumes {
+		if vol.Name == volumeName && vol.EmptyDir != nil {
+			podInfo.PodSpec.Volumes[i].EmptyDir.SizeLimit = limit
+			found = true
+			break
+		}
+	}
+	if !found {
+		podInfo.PodSpec.Volumes = append(podInfo.PodSpec.Volumes, v1.Volume{
+			Name: volumeName,
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{
+					SizeLimit: limit,
+				},
+			},
+		})
 	}
 
-	podInfo.EmptyDirVolumeLimits[volumeName] = limit
 	s.podResources[podUID] = podInfo
-
-	logger.V(3).Info("Updated emptyDir volume limit", "podUID", podUID, "volumeName", volumeName, "limit", limit)
+	logger.V(3).Info("Updated emptyDir volume limit in PodSpec", "podUID", podUID, "volumeName", volumeName, "limit", limit)
 	return nil
 }
 

--- a/pkg/kubelet/allocation/state/state_mem.go
+++ b/pkg/kubelet/allocation/state/state_mem.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
@@ -29,36 +30,41 @@ import (
 
 type stateMemory struct {
 	sync.RWMutex
-	podResources PodResourceInfoMap
+	pods PodMap
 }
 
 var _ State = &stateMemory{}
 
-// NewStateMemory creates new State to track resources resourcesated to pods
-func NewStateMemory(logger klog.Logger, resources PodResourceInfoMap) State {
-	if resources == nil {
-		resources = PodResourceInfoMap{}
+func newStateMemory(logger klog.Logger, pods PodMap) *stateMemory {
+	if pods == nil {
+		pods = PodMap{}
 	}
 	logger.V(2).Info("Initialized new in-memory state store for pod resource information tracking")
 	return &stateMemory{
-		podResources: resources,
+		pods: pods,
 	}
+}
+
+// NewStateMemory creates new State to track resources allocated to pods
+func NewStateMemory(logger klog.Logger, pods PodMap) State {
+	return newStateMemory(logger, pods.Clone())
 }
 
 func (s *stateMemory) GetContainerResources(podUID types.UID, containerName string) (v1.ResourceRequirements, bool) {
 	s.RLock()
 	defer s.RUnlock()
 
-	resourceInfo, ok := s.podResources[podUID]
-	if !ok {
-		return v1.ResourceRequirements{}, ok
+	pod, ok := s.pods[podUID]
+	if !ok || pod == nil {
+		return v1.ResourceRequirements{}, false
 	}
 
-	resources, ok := resourceInfo.ContainerResources[containerName]
-	if !ok {
-		return v1.ResourceRequirements{}, ok
+	for c := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		if c.Name == containerName {
+			return *c.Resources.DeepCopy(), true
+		}
 	}
-	return *resources.DeepCopy(), ok
+	return v1.ResourceRequirements{}, false
 }
 
 // GetPodLevelResources returns current resources information at pod-level
@@ -66,12 +72,12 @@ func (s *stateMemory) GetPodLevelResources(podUID types.UID) (*v1.ResourceRequir
 	s.RLock()
 	defer s.RUnlock()
 
-	pr, ok := s.podResources[podUID]
-	if !ok {
-		return nil, ok
+	pod, ok := s.pods[podUID]
+	if !ok || pod == nil || pod.Spec.Resources == nil {
+		return nil, false
 	}
 
-	return pr.PodLevelResources.DeepCopy(), ok
+	return pod.Spec.Resources.DeepCopy(), true
 }
 
 // GetEmptyDirVolumeLimit returns current resources information for emptyDir volume
@@ -79,53 +85,108 @@ func (s *stateMemory) GetEmptyDirVolumeLimit(podUID types.UID, volumeName string
 	s.RLock()
 	defer s.RUnlock()
 
-	pr, ok := s.podResources[podUID]
-	if !ok {
-		return nil, ok
+	pod, ok := s.pods[podUID]
+	if !ok || pod == nil {
+		return nil, false
 	}
 
-	sizeLimit, ok := pr.EmptyDirVolumeLimits[volumeName]
-	if !ok {
-		return nil, ok
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Name == volumeName && vol.EmptyDir != nil {
+			if vol.EmptyDir.SizeLimit == nil || vol.EmptyDir.SizeLimit.IsZero() {
+				return nil, false
+			}
+			sizeLimitCopy := vol.EmptyDir.SizeLimit.DeepCopy()
+			return &sizeLimitCopy, true
+		}
 	}
-
-	sizeLimitCopy := sizeLimit.DeepCopy()
-	return &sizeLimitCopy, ok
+	return nil, false
 }
 
-func (s *stateMemory) GetPodResourceInfoMap() PodResourceInfoMap {
+func (s *stateMemory) GetPodMap() PodMap {
 	s.RLock()
 	defer s.RUnlock()
-	return s.podResources.Clone()
+	return s.pods.Clone()
 }
 
-func (s *stateMemory) GetPodResourceInfo(podUID types.UID) (PodResourceInfo, bool) {
+func (s *stateMemory) GetPodUIDs() []types.UID {
+	s.RLock()
+	defer s.RUnlock()
+	uids := make([]types.UID, 0, len(s.pods))
+	for uid := range s.pods {
+		uids = append(uids, uid)
+	}
+	return uids
+}
+
+func (s *stateMemory) GetPod(podUID types.UID) (*v1.Pod, bool) {
 	s.RLock()
 	defer s.RUnlock()
 
-	resourceInfo, ok := s.podResources[podUID]
-	return resourceInfo, ok
+	pod, ok := s.pods[podUID]
+	if !ok || pod == nil {
+		return nil, false
+	}
+	return pod.DeepCopy(), true
 }
 
-func (s *stateMemory) SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, _ podutil.ContainerType, resources v1.ResourceRequirements) error {
+func (s *stateMemory) HasPod(podUID types.UID) bool {
+	s.RLock()
+	defer s.RUnlock()
+
+	_, ok := s.pods[podUID]
+	return ok
+}
+
+func (s *stateMemory) toPodList() *v1.PodList {
+	s.RLock()
+	defer s.RUnlock()
+
+	podList := &v1.PodList{Items: make([]v1.Pod, 0, len(s.pods))}
+	for _, pod := range s.pods {
+		if pod != nil {
+			podList.Items = append(podList.Items, *pod.DeepCopy())
+		}
+	}
+	return podList
+}
+
+func (s *stateMemory) SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, containerType podutil.ContainerType, resources v1.ResourceRequirements) error {
 	s.Lock()
 	defer s.Unlock()
 
-	podInfo, ok := s.podResources[podUID]
-	if !ok {
-		podInfo = PodResourceInfo{
-			ContainerResources: make(map[string]v1.ResourceRequirements),
+	pod, ok := s.pods[podUID]
+	if !ok || pod == nil {
+		pod = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: podUID,
+			},
+		}
+	} else {
+		pod = pod.DeepCopy()
+	}
+
+	found := false
+	for c := range podutil.ContainerIter(&pod.Spec, podutil.InitContainers|podutil.Containers) {
+		if c.Name == containerName {
+			c.Resources = *resources.DeepCopy()
+			found = true
+			break
+		}
+	}
+	if !found {
+		newContainer := v1.Container{
+			Name:      containerName,
+			Resources: *resources.DeepCopy(),
+		}
+		if containerType == podutil.InitContainers {
+			pod.Spec.InitContainers = append(pod.Spec.InitContainers, newContainer)
+		} else {
+			pod.Spec.Containers = append(pod.Spec.Containers, newContainer)
 		}
 	}
 
-	if podInfo.ContainerResources == nil {
-		podInfo.ContainerResources = make(map[string]v1.ResourceRequirements)
-	}
-
-	podInfo.ContainerResources[containerName] = resources
-	s.podResources[podUID] = podInfo
-
-	logger.V(3).Info("Updated container resource information", "podUID", podUID, "containerName", containerName, "resources", resources)
+	s.pods[podUID] = pod
+	logger.V(3).Info("Updated container resource information in PodSpec", "podUID", podUID, "containerName", containerName, "resources", resources)
 	return nil
 }
 
@@ -133,16 +194,25 @@ func (s *stateMemory) SetPodLevelResources(logger klog.Logger, podUID types.UID,
 	s.Lock()
 	defer s.Unlock()
 
-	podInfo, ok := s.podResources[podUID]
-	if !ok {
-		podInfo.PodLevelResources = &v1.ResourceRequirements{}
+	podInfo, ok := s.pods[podUID]
+	if !ok || podInfo == nil {
+		podInfo = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: podUID,
+			},
+		}
+	} else {
+		podInfo = podInfo.DeepCopy()
 	}
 
-	podInfo.PodLevelResources = resources
+	if resources == nil {
+		podInfo.Spec.Resources = nil
+	} else {
+		podInfo.Spec.Resources = resources.DeepCopy()
+	}
+	s.pods[podUID] = podInfo
 
-	s.podResources[podUID] = podInfo
-
-	logger.V(3).Info("Updated pod-level resource info", "podUID", podUID, "resources", resources)
+	logger.V(3).Info("Updated pod-level resource info in PodSpec", "podUID", podUID, "resources", resources)
 	return nil
 }
 
@@ -151,37 +221,76 @@ func (s *stateMemory) SetEmptyDirVolumeLimit(podUID types.UID, volumeName string
 	s.Lock()
 	defer s.Unlock()
 
-	podInfo, ok := s.podResources[podUID]
-	if !ok {
-		podInfo = PodResourceInfo{
-			ContainerResources: make(map[string]v1.ResourceRequirements),
+	podInfo, ok := s.pods[podUID]
+	if !ok || podInfo == nil {
+		podInfo = &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: podUID,
+			},
+		}
+	} else {
+		podInfo = podInfo.DeepCopy()
+	}
+
+	found := false
+	for i, vol := range podInfo.Spec.Volumes {
+		if vol.Name == volumeName && vol.EmptyDir != nil {
+			if limit == nil {
+				podInfo.Spec.Volumes[i].EmptyDir.SizeLimit = nil
+			} else {
+				limitCopy := limit.DeepCopy()
+				podInfo.Spec.Volumes[i].EmptyDir.SizeLimit = &limitCopy
+			}
+			podInfo.Spec.Volumes[i].EmptyDir.Medium = v1.StorageMediumMemory
+			found = true
+			break
 		}
 	}
-
-	if podInfo.EmptyDirVolumeLimits == nil {
-		podInfo.EmptyDirVolumeLimits = make(map[string]*resource.Quantity)
+	if !found {
+		var limitCopy *resource.Quantity
+		if limit != nil {
+			lc := limit.DeepCopy()
+			limitCopy = &lc
+		}
+		podInfo.Spec.Volumes = append(podInfo.Spec.Volumes, v1.Volume{
+			Name: volumeName,
+			VolumeSource: v1.VolumeSource{
+				EmptyDir: &v1.EmptyDirVolumeSource{
+					Medium:    v1.StorageMediumMemory,
+					SizeLimit: limitCopy,
+				},
+			},
+		})
 	}
 
-	podInfo.EmptyDirVolumeLimits[volumeName] = limit
-	s.podResources[podUID] = podInfo
-
-	logger.V(3).Info("Updated emptyDir volume limit", "podUID", podUID, "volumeName", volumeName, "limit", limit)
+	s.pods[podUID] = podInfo
+	logger.V(3).Info("Updated emptyDir volume limit in PodSpec", "podUID", podUID, "volumeName", volumeName, "limit", limit)
 	return nil
 }
 
-func (s *stateMemory) SetPodResourceInfo(logger klog.Logger, podUID types.UID, resourceInfo PodResourceInfo) error {
+func (s *stateMemory) SetPod(logger klog.Logger, pod *v1.Pod) error {
 	s.Lock()
 	defer s.Unlock()
 
-	s.podResources[podUID] = resourceInfo
-	logger.V(3).Info("Updated pod resource information", "podUID", podUID, "information", resourceInfo)
+	if pod == nil {
+		return nil
+	}
+	s.pods[pod.UID] = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       pod.UID,
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+		Spec: *pod.Spec.DeepCopy(),
+	}
+	logger.V(3).Info("Updated allocated pod", "podUID", pod.UID)
 	return nil
 }
 
 func (s *stateMemory) RemovePod(logger klog.Logger, podUID types.UID) error {
 	s.Lock()
 	defer s.Unlock()
-	delete(s.podResources, podUID)
+	delete(s.pods, podUID)
 	logger.V(3).Info("Deleted pod resource information", "podUID", podUID)
 	return nil
 }
@@ -190,9 +299,9 @@ func (s *stateMemory) RemoveOrphanedPods(remainingPods sets.Set[types.UID]) {
 	s.Lock()
 	defer s.Unlock()
 
-	for podUID := range s.podResources {
+	for podUID := range s.pods {
 		if _, ok := remainingPods[types.UID(podUID)]; !ok {
-			delete(s.podResources, podUID)
+			delete(s.pods, podUID)
 		}
 	}
 }

--- a/pkg/kubelet/allocation/state/state_mem.go
+++ b/pkg/kubelet/allocation/state/state_mem.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
 type stateMemory struct {
@@ -106,7 +107,7 @@ func (s *stateMemory) GetPodResourceInfo(podUID types.UID) (PodResourceInfo, boo
 	return resourceInfo, ok
 }
 
-func (s *stateMemory) SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, resources v1.ResourceRequirements) error {
+func (s *stateMemory) SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, _ podutil.ContainerType, resources v1.ResourceRequirements) error {
 	s.Lock()
 	defer s.Unlock()
 

--- a/pkg/kubelet/allocation/state/state_mem_test.go
+++ b/pkg/kubelet/allocation/state/state_mem_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
@@ -74,4 +75,97 @@ func TestStateMemory_EmptyDirVolumeLimits(t *testing.T) {
 	qty2, exists2 := state.GetEmptyDirVolumeLimit(podUID, anotherVolName)
 	assert.True(t, exists2)
 	assert.True(t, anotherLimit.Equal(*qty2))
+}
+
+func TestStateMemory_ResourceIsolation(t *testing.T) {
+	logger := klog.TODO()
+	state := NewStateMemory(logger, PodResourceInfoMap{})
+
+	podUID := types.UID("pod-1")
+	containerName := "container-1"
+	volumeName := "volume-1"
+
+	// Set container resources
+	containerResources := v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("250m"),
+		},
+	}
+	err := state.SetContainerResources(logger, podUID, containerName, containerResources)
+	require.NoError(t, err)
+
+	// Verify container resources are set, and others are nil/empty
+	res, found := state.GetContainerResources(podUID, containerName)
+	assert.True(t, found)
+	assert.True(t, containerResources.Requests.Cpu().Equal(*res.Requests.Cpu()))
+
+	podRes, found := state.GetPodLevelResources(podUID)
+	assert.False(t, found)
+	assert.Nil(t, podRes)
+
+	volLimit, found := state.GetEmptyDirVolumeLimit(podUID, volumeName)
+	assert.False(t, found)
+	assert.Nil(t, volLimit)
+
+	// Set pod-level resources
+	podResources := &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+	err = state.SetPodLevelResources(logger, podUID, podResources)
+	require.NoError(t, err)
+
+	// Verify pod-level resources are set, AND container resources are still intact
+	podRes, found = state.GetPodLevelResources(podUID)
+	assert.True(t, found)
+	assert.True(t, podResources.Requests.Memory().Equal(*podRes.Requests.Memory()))
+
+	res, found = state.GetContainerResources(podUID, containerName)
+	assert.True(t, found)
+	assert.True(t, containerResources.Requests.Cpu().Equal(*res.Requests.Cpu()))
+
+	volLimit, found = state.GetEmptyDirVolumeLimit(podUID, volumeName)
+	assert.False(t, found)
+	assert.Nil(t, volLimit)
+
+	// Set emptyDir volume limit
+	targetLimit := resource.MustParse("256Mi")
+	err = state.SetEmptyDirVolumeLimit(podUID, volumeName, &targetLimit)
+	require.NoError(t, err)
+
+	// Verify volume limit is set, AND both container and pod-level resources are still intact
+	volLimit, found = state.GetEmptyDirVolumeLimit(podUID, volumeName)
+	assert.True(t, found)
+	assert.True(t, targetLimit.Equal(*volLimit))
+
+	res, found = state.GetContainerResources(podUID, containerName)
+	assert.True(t, found)
+	assert.True(t, containerResources.Requests.Cpu().Equal(*res.Requests.Cpu()))
+
+	podRes, found = state.GetPodLevelResources(podUID)
+	assert.True(t, found)
+	assert.True(t, podResources.Requests.Memory().Equal(*podRes.Requests.Memory()))
+
+	// Update container resources again
+	updatedContainerResources := v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("500m"),
+		},
+	}
+	err = state.SetContainerResources(logger, podUID, containerName, updatedContainerResources)
+	require.NoError(t, err)
+
+	// Verify container resources are updated, AND both pod-level resources and volume limits are still intact
+	res, found = state.GetContainerResources(podUID, containerName)
+	assert.True(t, found)
+	assert.True(t, updatedContainerResources.Requests.Cpu().Equal(*res.Requests.Cpu()))
+
+	podRes, found = state.GetPodLevelResources(podUID)
+	assert.True(t, found)
+	assert.True(t, podResources.Requests.Memory().Equal(*podRes.Requests.Memory()))
+
+	volLimit, found = state.GetEmptyDirVolumeLimit(podUID, volumeName)
+	assert.True(t, found)
+	assert.True(t, targetLimit.Equal(*volLimit))
 }

--- a/pkg/kubelet/allocation/state/state_mem_test.go
+++ b/pkg/kubelet/allocation/state/state_mem_test.go
@@ -21,14 +21,17 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
 func TestStateMemory_EmptyDirVolumeLimits(t *testing.T) {
 	logger := klog.TODO()
-	state := NewStateMemory(logger, PodResourceInfoMap{})
+	state := NewStateMemory(logger, PodMap{})
 
 	podUID := types.UID("pod-1")
 	volName := "volume-1"
@@ -74,4 +77,147 @@ func TestStateMemory_EmptyDirVolumeLimits(t *testing.T) {
 	qty2, exists2 := state.GetEmptyDirVolumeLimit(podUID, anotherVolName)
 	assert.True(t, exists2)
 	assert.True(t, anotherLimit.Equal(*qty2))
+}
+
+func TestStateMemory_ResourceIsolation(t *testing.T) {
+	logger := klog.TODO()
+	state := NewStateMemory(logger, PodMap{})
+
+	podUID := types.UID("pod-1")
+	containerName := "container-1"
+	volumeName := "volume-1"
+
+	// Set container resources
+	containerResources := v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("250m"),
+		},
+	}
+	err := state.SetContainerResources(logger, podUID, containerName, podutil.Containers, containerResources)
+	require.NoError(t, err)
+
+	// Verify container resources are set, and others are nil/empty
+	res, found := state.GetContainerResources(podUID, containerName)
+	assert.True(t, found)
+	assert.True(t, containerResources.Requests.Cpu().Equal(*res.Requests.Cpu()))
+
+	podRes, found := state.GetPodLevelResources(podUID)
+	assert.False(t, found)
+	assert.Nil(t, podRes)
+
+	volLimit, found := state.GetEmptyDirVolumeLimit(podUID, volumeName)
+	assert.False(t, found)
+	assert.Nil(t, volLimit)
+
+	// Set pod-level resources
+	podResources := &v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+	err = state.SetPodLevelResources(logger, podUID, podResources)
+	require.NoError(t, err)
+
+	// Verify pod-level resources are set, AND container resources are still intact
+	podRes, found = state.GetPodLevelResources(podUID)
+	assert.True(t, found)
+	assert.True(t, podResources.Requests.Memory().Equal(*podRes.Requests.Memory()))
+
+	res, found = state.GetContainerResources(podUID, containerName)
+	assert.True(t, found)
+	assert.True(t, containerResources.Requests.Cpu().Equal(*res.Requests.Cpu()))
+
+	volLimit, found = state.GetEmptyDirVolumeLimit(podUID, volumeName)
+	assert.False(t, found)
+	assert.Nil(t, volLimit)
+
+	// Set emptyDir volume limit
+	targetLimit := resource.MustParse("256Mi")
+	err = state.SetEmptyDirVolumeLimit(podUID, volumeName, &targetLimit)
+	require.NoError(t, err)
+
+	// Verify volume limit is set, AND both container and pod-level resources are still intact
+	volLimit, found = state.GetEmptyDirVolumeLimit(podUID, volumeName)
+	assert.True(t, found)
+	assert.True(t, targetLimit.Equal(*volLimit))
+
+	res, found = state.GetContainerResources(podUID, containerName)
+	assert.True(t, found)
+	assert.True(t, containerResources.Requests.Cpu().Equal(*res.Requests.Cpu()))
+
+	podRes, found = state.GetPodLevelResources(podUID)
+	assert.True(t, found)
+	assert.True(t, podResources.Requests.Memory().Equal(*podRes.Requests.Memory()))
+
+	// Update container resources again
+	updatedContainerResources := v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU: resource.MustParse("500m"),
+		},
+	}
+	err = state.SetContainerResources(logger, podUID, containerName, podutil.Containers, updatedContainerResources)
+	require.NoError(t, err)
+
+	// Verify container resources are updated, AND both pod-level resources and volume limits are still intact
+	res, found = state.GetContainerResources(podUID, containerName)
+	assert.True(t, found)
+	assert.True(t, updatedContainerResources.Requests.Cpu().Equal(*res.Requests.Cpu()))
+
+	podRes, found = state.GetPodLevelResources(podUID)
+	assert.True(t, found)
+	assert.True(t, podResources.Requests.Memory().Equal(*podRes.Requests.Memory()))
+
+	volLimit, found = state.GetEmptyDirVolumeLimit(podUID, volumeName)
+	assert.True(t, found)
+	assert.True(t, targetLimit.Equal(*volLimit))
+}
+
+func TestStateMemory_GetPodUIDs(t *testing.T) {
+	logger := klog.TODO()
+	state := NewStateMemory(logger, PodMap{})
+
+	assert.Empty(t, state.GetPodUIDs())
+
+	pod1 := types.UID("pod-1")
+	pod2 := types.UID("pod-2")
+
+	require.NoError(t, state.SetPod(logger, &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: pod1}}))
+	require.NoError(t, state.SetPod(logger, &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: pod2}}))
+
+	uids := state.GetPodUIDs()
+	assert.ElementsMatch(t, []types.UID{pod1, pod2}, uids)
+
+	require.NoError(t, state.RemovePod(logger, pod1))
+	assert.Equal(t, []types.UID{pod2}, state.GetPodUIDs())
+}
+
+func TestStateMemory_HasPod(t *testing.T) {
+	logger := klog.TODO()
+	state := NewStateMemory(logger, PodMap{})
+
+	podUID := types.UID("pod-1")
+	assert.False(t, state.HasPod(podUID))
+
+	require.NoError(t, state.SetPod(logger, &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: podUID}}))
+	assert.True(t, state.HasPod(podUID))
+
+	require.NoError(t, state.RemovePod(logger, podUID))
+	assert.False(t, state.HasPod(podUID))
+}
+
+func TestStateMemory_ToPodList(t *testing.T) {
+	logger := klog.TODO()
+	sm := newStateMemory(logger, PodMap{})
+
+	podList := sm.toPodList()
+	assert.Empty(t, podList.Items)
+
+	pod1 := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-1"}}
+	pod2 := &v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "pod-2"}}
+
+	require.NoError(t, sm.SetPod(logger, pod1))
+	require.NoError(t, sm.SetPod(logger, pod2))
+
+	podList = sm.toPodList()
+	require.Len(t, podList.Items, 2)
 }

--- a/pkg/kubelet/allocation/state/state_test.go
+++ b/pkg/kubelet/allocation/state/state_test.go
@@ -47,51 +47,75 @@ func TestPodResourceInfoMap_Clone(t *testing.T) {
 			name: "basic cloning with all fields populated",
 			original: PodResourceInfoMap{
 				types.UID("pod"): {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						"container-a": {
+					PodSpec: &v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container-a",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("100m"),
+										v1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									Limits: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("200m"),
+										v1.ResourceMemory: resource.MustParse("512Mi"),
+									},
+								},
+							},
+						},
+						Resources: &v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								v1.ResourceCPU:    resource.MustParse("100m"),
 								v1.ResourceMemory: resource.MustParse("256Mi"),
 							},
-							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("200m"),
-								v1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+						Volumes: []v1.Volume{
+							{
+								Name: "vol-x",
+								VolumeSource: v1.VolumeSource{
+									EmptyDir: &v1.EmptyDirVolumeSource{
+										SizeLimit: resource.NewQuantity(2, resource.BinarySI),
+									},
+								},
 							},
 						},
-					},
-					PodLevelResources: &v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("100m"),
-							v1.ResourceMemory: resource.MustParse("256Mi"),
-						},
-					},
-					EmptyDirVolumeLimits: map[string]*resource.Quantity{
-						"vol-x": resource.NewQuantity(2, resource.BinarySI),
 					},
 				},
 			},
 			expected: PodResourceInfoMap{
 				types.UID("pod"): {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						"container-a": {
+					PodSpec: &v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container-a",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("100m"),
+										v1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									Limits: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("200m"),
+										v1.ResourceMemory: resource.MustParse("512Mi"),
+									},
+								},
+							},
+						},
+						Resources: &v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								v1.ResourceCPU:    resource.MustParse("100m"),
 								v1.ResourceMemory: resource.MustParse("256Mi"),
 							},
-							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("200m"),
-								v1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+						Volumes: []v1.Volume{
+							{
+								Name: "vol-x",
+								VolumeSource: v1.VolumeSource{
+									EmptyDir: &v1.EmptyDirVolumeSource{
+										SizeLimit: resource.NewQuantity(2, resource.BinarySI),
+									},
+								},
 							},
 						},
-					},
-					PodLevelResources: &v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("100m"),
-							v1.ResourceMemory: resource.MustParse("256Mi"),
-						},
-					},
-					EmptyDirVolumeLimits: map[string]*resource.Quantity{
-						"vol-x": resource.NewQuantity(2, resource.BinarySI),
 					},
 				},
 			},
@@ -100,20 +124,24 @@ func TestPodResourceInfoMap_Clone(t *testing.T) {
 			name: "cloning with missing or partially nil fields",
 			original: PodResourceInfoMap{
 				types.UID("pod"): {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						"container-c": {},
+					PodSpec: &v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container-c",
+							},
+						},
 					},
-					PodLevelResources:    nil,
-					EmptyDirVolumeLimits: nil,
 				},
 			},
 			expected: PodResourceInfoMap{
 				types.UID("pod"): {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						"container-c": {},
+					PodSpec: &v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container-c",
+							},
+						},
 					},
-					PodLevelResources:    nil,
-					EmptyDirVolumeLimits: nil,
 				},
 			},
 		},
@@ -142,20 +170,32 @@ func TestPodResourceInfoMap_Clone_DeepCopyIsolation(t *testing.T) {
 	newBaseMap := func() PodResourceInfoMap {
 		return PodResourceInfoMap{
 			types.UID("pod"): {
-				ContainerResources: map[string]v1.ResourceRequirements{
-					"container-a": {
+				PodSpec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "container-a",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
+						},
+					},
+					Resources: &v1.ResourceRequirements{
 						Requests: v1.ResourceList{
 							v1.ResourceMemory: resource.MustParse("256Mi"),
 						},
 					},
-				},
-				PodLevelResources: &v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("256Mi"),
+					Volumes: []v1.Volume{
+						{
+							Name: "vol-y",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									SizeLimit: resource.NewQuantity(1024*1024*100, resource.BinarySI),
+								},
+							},
+						},
 					},
-				},
-				EmptyDirVolumeLimits: map[string]*resource.Quantity{
-					"vol-y": resource.NewQuantity(1024*1024*100, resource.BinarySI),
 				},
 			},
 		}
@@ -169,37 +209,47 @@ func TestPodResourceInfoMap_Clone_DeepCopyIsolation(t *testing.T) {
 			name: "modifying a resource quantity in cloned ContainerResources",
 			mutate: func(cloned PodResourceInfoMap) {
 				pod := cloned[types.UID("pod")]
-				pod.ContainerResources["container-a"].Requests[v1.ResourceMemory] = resource.MustParse("512Mi")
+				pod.PodSpec.Containers[0].Resources.Requests[v1.ResourceMemory] = resource.MustParse("512Mi")
 			},
 		},
 		{
-			name: "adding a new container to cloned ContainerResources",
+			name: "adding a new container to cloned Containers",
 			mutate: func(cloned PodResourceInfoMap) {
 				pod := cloned[types.UID("pod")]
-				pod.ContainerResources["container-new"] = v1.ResourceRequirements{
-					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
-				}
+				pod.PodSpec.Containers = append(pod.PodSpec.Containers, v1.Container{
+					Name: "container-new",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+					},
+				})
 			},
 		},
 		{
-			name: "modifying a resource quantity in cloned PodLevelResources",
+			name: "modifying a resource quantity in cloned Pod Resources",
 			mutate: func(cloned PodResourceInfoMap) {
 				pod := cloned[types.UID("pod")]
-				pod.PodLevelResources.Requests[v1.ResourceMemory] = resource.MustParse("512Mi")
+				pod.PodSpec.Resources.Requests[v1.ResourceMemory] = resource.MustParse("512Mi")
 			},
 		},
 		{
 			name: "modifying a dynamic limit in cloned EmptyDirVolumeLimits",
 			mutate: func(cloned PodResourceInfoMap) {
 				pod := cloned[types.UID("pod")]
-				pod.EmptyDirVolumeLimits["vol-y"].Set(1024 * 1024 * 500)
+				pod.PodSpec.Volumes[0].EmptyDir.SizeLimit.Set(1024 * 1024 * 500)
 			},
 		},
 		{
-			name: "adding a new volume key to cloned EmptyDirVolumeLimits",
+			name: "adding a new volume key to cloned Volumes",
 			mutate: func(cloned PodResourceInfoMap) {
 				pod := cloned[types.UID("pod")]
-				pod.EmptyDirVolumeLimits["vol-new"] = resource.NewQuantity(1024, resource.DecimalSI)
+				pod.PodSpec.Volumes = append(pod.PodSpec.Volumes, v1.Volume{
+					Name: "vol-new",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							SizeLimit: resource.NewQuantity(1024, resource.DecimalSI),
+						},
+					},
+				})
 			},
 		},
 	}

--- a/pkg/kubelet/allocation/state/state_test.go
+++ b/pkg/kubelet/allocation/state/state_test.go
@@ -27,93 +27,121 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestPodResourceInfoMap_Clone(t *testing.T) {
+func TestPodMap_Clone(t *testing.T) {
 	tests := []struct {
 		name     string
-		original PodResourceInfoMap
-		expected PodResourceInfoMap
+		original PodMap
+		expected PodMap
 	}{
 		{
 			name:     "nil map clone returns empty non-nil map",
 			original: nil,
-			expected: make(PodResourceInfoMap),
+			expected: make(PodMap),
 		},
 		{
 			name:     "empty map clone returns empty non-nil map",
-			original: make(PodResourceInfoMap),
-			expected: make(PodResourceInfoMap),
+			original: make(PodMap),
+			expected: make(PodMap),
 		},
 		{
 			name: "basic cloning with all fields populated",
-			original: PodResourceInfoMap{
+			original: PodMap{
 				types.UID("pod"): {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						"container-a": {
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container-a",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("100m"),
+										v1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									Limits: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("200m"),
+										v1.ResourceMemory: resource.MustParse("512Mi"),
+									},
+								},
+							},
+						},
+						Resources: &v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								v1.ResourceCPU:    resource.MustParse("100m"),
 								v1.ResourceMemory: resource.MustParse("256Mi"),
 							},
-							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("200m"),
-								v1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+						Volumes: []v1.Volume{
+							{
+								Name: "vol-x",
+								VolumeSource: v1.VolumeSource{
+									EmptyDir: &v1.EmptyDirVolumeSource{
+										SizeLimit: resource.NewQuantity(2, resource.BinarySI),
+									},
+								},
 							},
 						},
-					},
-					PodLevelResources: &v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("100m"),
-							v1.ResourceMemory: resource.MustParse("256Mi"),
-						},
-					},
-					EmptyDirVolumeLimits: map[string]*resource.Quantity{
-						"vol-x": resource.NewQuantity(2, resource.BinarySI),
 					},
 				},
 			},
-			expected: PodResourceInfoMap{
+			expected: PodMap{
 				types.UID("pod"): {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						"container-a": {
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container-a",
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("100m"),
+										v1.ResourceMemory: resource.MustParse("256Mi"),
+									},
+									Limits: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("200m"),
+										v1.ResourceMemory: resource.MustParse("512Mi"),
+									},
+								},
+							},
+						},
+						Resources: &v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								v1.ResourceCPU:    resource.MustParse("100m"),
 								v1.ResourceMemory: resource.MustParse("256Mi"),
 							},
-							Limits: v1.ResourceList{
-								v1.ResourceCPU:    resource.MustParse("200m"),
-								v1.ResourceMemory: resource.MustParse("512Mi"),
+						},
+						Volumes: []v1.Volume{
+							{
+								Name: "vol-x",
+								VolumeSource: v1.VolumeSource{
+									EmptyDir: &v1.EmptyDirVolumeSource{
+										SizeLimit: resource.NewQuantity(2, resource.BinarySI),
+									},
+								},
 							},
 						},
-					},
-					PodLevelResources: &v1.ResourceRequirements{
-						Requests: v1.ResourceList{
-							v1.ResourceCPU:    resource.MustParse("100m"),
-							v1.ResourceMemory: resource.MustParse("256Mi"),
-						},
-					},
-					EmptyDirVolumeLimits: map[string]*resource.Quantity{
-						"vol-x": resource.NewQuantity(2, resource.BinarySI),
 					},
 				},
 			},
 		},
 		{
 			name: "cloning with missing or partially nil fields",
-			original: PodResourceInfoMap{
+			original: PodMap{
 				types.UID("pod"): {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						"container-c": {},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container-c",
+							},
+						},
 					},
-					PodLevelResources:    nil,
-					EmptyDirVolumeLimits: nil,
 				},
 			},
-			expected: PodResourceInfoMap{
+			expected: PodMap{
 				types.UID("pod"): {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						"container-c": {},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name: "container-c",
+							},
+						},
 					},
-					PodLevelResources:    nil,
-					EmptyDirVolumeLimits: nil,
 				},
 			},
 		},
@@ -121,7 +149,7 @@ func TestPodResourceInfoMap_Clone(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			var cloned PodResourceInfoMap
+			var cloned PodMap
 			require.NotPanics(t, func() {
 				cloned = test.original.Clone()
 			})
@@ -131,31 +159,43 @@ func TestPodResourceInfoMap_Clone(t *testing.T) {
 				return x.Equal(y)
 			}))
 			if diff != "" {
-				t.Errorf("PodResourceInfoMap mismatch (-want +got):\n%s", diff)
+				t.Errorf("PodMap mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 
 }
 
-func TestPodResourceInfoMap_Clone_DeepCopyIsolation(t *testing.T) {
-	newBaseMap := func() PodResourceInfoMap {
-		return PodResourceInfoMap{
+func TestPodMap_Clone_DeepCopyIsolation(t *testing.T) {
+	newBaseMap := func() PodMap {
+		return PodMap{
 			types.UID("pod"): {
-				ContainerResources: map[string]v1.ResourceRequirements{
-					"container-a": {
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "container-a",
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+							},
+						},
+					},
+					Resources: &v1.ResourceRequirements{
 						Requests: v1.ResourceList{
 							v1.ResourceMemory: resource.MustParse("256Mi"),
 						},
 					},
-				},
-				PodLevelResources: &v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceMemory: resource.MustParse("256Mi"),
+					Volumes: []v1.Volume{
+						{
+							Name: "vol-y",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{
+									SizeLimit: resource.NewQuantity(1024*1024*100, resource.BinarySI),
+								},
+							},
+						},
 					},
-				},
-				EmptyDirVolumeLimits: map[string]*resource.Quantity{
-					"vol-y": resource.NewQuantity(1024*1024*100, resource.BinarySI),
 				},
 			},
 		}
@@ -163,43 +203,53 @@ func TestPodResourceInfoMap_Clone_DeepCopyIsolation(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		mutate func(cloned PodResourceInfoMap)
+		mutate func(cloned PodMap)
 	}{
 		{
 			name: "modifying a resource quantity in cloned ContainerResources",
-			mutate: func(cloned PodResourceInfoMap) {
+			mutate: func(cloned PodMap) {
 				pod := cloned[types.UID("pod")]
-				pod.ContainerResources["container-a"].Requests[v1.ResourceMemory] = resource.MustParse("512Mi")
+				pod.Spec.Containers[0].Resources.Requests[v1.ResourceMemory] = resource.MustParse("512Mi")
 			},
 		},
 		{
-			name: "adding a new container to cloned ContainerResources",
-			mutate: func(cloned PodResourceInfoMap) {
+			name: "adding a new container to cloned Containers",
+			mutate: func(cloned PodMap) {
 				pod := cloned[types.UID("pod")]
-				pod.ContainerResources["container-new"] = v1.ResourceRequirements{
-					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
-				}
+				pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
+					Name: "container-new",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1")},
+					},
+				})
 			},
 		},
 		{
-			name: "modifying a resource quantity in cloned PodLevelResources",
-			mutate: func(cloned PodResourceInfoMap) {
+			name: "modifying a resource quantity in cloned Pod Resources",
+			mutate: func(cloned PodMap) {
 				pod := cloned[types.UID("pod")]
-				pod.PodLevelResources.Requests[v1.ResourceMemory] = resource.MustParse("512Mi")
+				pod.Spec.Resources.Requests[v1.ResourceMemory] = resource.MustParse("512Mi")
 			},
 		},
 		{
 			name: "modifying a dynamic limit in cloned EmptyDirVolumeLimits",
-			mutate: func(cloned PodResourceInfoMap) {
+			mutate: func(cloned PodMap) {
 				pod := cloned[types.UID("pod")]
-				pod.EmptyDirVolumeLimits["vol-y"].Set(1024 * 1024 * 500)
+				pod.Spec.Volumes[0].EmptyDir.SizeLimit.Set(1024 * 1024 * 500)
 			},
 		},
 		{
-			name: "adding a new volume key to cloned EmptyDirVolumeLimits",
-			mutate: func(cloned PodResourceInfoMap) {
+			name: "adding a new volume key to cloned Volumes",
+			mutate: func(cloned PodMap) {
 				pod := cloned[types.UID("pod")]
-				pod.EmptyDirVolumeLimits["vol-new"] = resource.NewQuantity(1024, resource.DecimalSI)
+				pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+					Name: "vol-new",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							SizeLimit: resource.NewQuantity(1024, resource.DecimalSI),
+						},
+					},
+				})
 			},
 		},
 	}
@@ -216,7 +266,7 @@ func TestPodResourceInfoMap_Clone_DeepCopyIsolation(t *testing.T) {
 				return x.Equal(y)
 			}))
 			if diff != "" {
-				t.Errorf("original PodResourceInfoMap changed (-want +got):\n%s", diff)
+				t.Errorf("original PodMap changed (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2821,8 +2821,8 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname},
 			Status: v1.NodeStatus{
 				Capacity: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("8"),
-					v1.ResourceMemory: resource.MustParse("8Gi"),
+					v1.ResourceMemory: resource.MustParse("4Gi"),
+					v1.ResourcePods:   *resource.NewQuantity(40, resource.DecimalSI),
 				},
 				Allocatable: v1.ResourceList{
 					v1.ResourceCPU:    resource.MustParse("4"),
@@ -2862,6 +2862,12 @@ func TestPodResourceAllocationReset(t *testing.T) {
 	emptyPodSpec := cpu500mMem500MPodSpec.DeepCopy()
 	emptyPodSpec.Containers[0].Resources.Requests = v1.ResourceList{}
 
+	makeExpectedAlloc := func(spec *v1.PodSpec) state.PodResourceInfo {
+		return state.PodResourceInfo{
+			PodSpec: spec.DeepCopy(),
+		}
+	}
+
 	tests := []struct {
 		name                       string
 		pod                        *v1.Pod
@@ -2872,11 +2878,7 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name: "Having both memory and cpu, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("1", "pod1", "foo", *cpu500mMem500MPodSpec),
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"1": {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu500mMem500MPodSpec.Containers[0].Name: cpu500mMem500MPodSpec.Containers[0].Resources,
-					},
-				},
+				"1": makeExpectedAlloc(cpu500mMem500MPodSpec),
 			},
 		},
 		{
@@ -2884,11 +2886,7 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			pod:                   podWithUIDNameNsSpec("2", "pod2", "foo", *cpu500mMem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("2", "pod2", "foo", *cpu500mMem500MPodSpec),
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"2": {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu500mMem500MPodSpec.Containers[0].Name: cpu500mMem500MPodSpec.Containers[0].Resources,
-					},
-				},
+				"2": makeExpectedAlloc(cpu500mMem500MPodSpec),
 			},
 		},
 		{
@@ -2896,22 +2894,14 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			pod:                   podWithUIDNameNsSpec("3", "pod3", "foo", *cpu500mMem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("3", "pod3", "foo", *cpu800mMem800MPodSpec),
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"3": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu800mMem800MPodSpec.Containers[0].Name: cpu800mMem800MPodSpec.Containers[0].Resources,
-					},
-				},
+				"3": makeExpectedAlloc(cpu800mMem800MPodSpec),
 			},
 		},
 		{
 			name: "Only has cpu, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("4", "pod5", "foo", *cpu500mPodSpec),
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"4": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu500mPodSpec.Containers[0].Name: cpu500mPodSpec.Containers[0].Resources,
-					},
-				},
+				"4": makeExpectedAlloc(cpu500mPodSpec),
 			},
 		},
 		{
@@ -2919,11 +2909,7 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			pod:                   podWithUIDNameNsSpec("5", "pod5", "foo", *cpu500mPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("5", "pod5", "foo", *cpu500mPodSpec),
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"5": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu500mPodSpec.Containers[0].Name: cpu500mPodSpec.Containers[0].Resources,
-					},
-				},
+				"5": makeExpectedAlloc(cpu500mPodSpec),
 			},
 		},
 		{
@@ -2931,22 +2917,14 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			pod:                   podWithUIDNameNsSpec("6", "pod6", "foo", *cpu500mPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("6", "pod6", "foo", *cpu800mPodSpec),
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"6": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu800mPodSpec.Containers[0].Name: cpu800mPodSpec.Containers[0].Resources,
-					},
-				},
+				"6": makeExpectedAlloc(cpu800mPodSpec),
 			},
 		},
 		{
 			name: "Only has memory, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("7", "pod7", "foo", *mem500MPodSpec),
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"7": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						mem500MPodSpec.Containers[0].Name: mem500MPodSpec.Containers[0].Resources,
-					},
-				},
+				"7": makeExpectedAlloc(mem500MPodSpec),
 			},
 		},
 		{
@@ -2954,11 +2932,7 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			pod:                   podWithUIDNameNsSpec("8", "pod8", "foo", *mem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("8", "pod8", "foo", *mem500MPodSpec),
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"8": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						mem500MPodSpec.Containers[0].Name: mem500MPodSpec.Containers[0].Resources,
-					},
-				},
+				"8": makeExpectedAlloc(mem500MPodSpec),
 			},
 		},
 		{
@@ -2966,22 +2940,14 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			pod:                   podWithUIDNameNsSpec("9", "pod9", "foo", *mem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("9", "pod9", "foo", *mem800MPodSpec),
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"9": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						mem800MPodSpec.Containers[0].Name: mem800MPodSpec.Containers[0].Resources,
-					},
-				},
+				"9": makeExpectedAlloc(mem800MPodSpec),
 			},
 		},
 		{
 			name: "No CPU and memory, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("10", "pod10", "foo", *emptyPodSpec),
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"10": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						emptyPodSpec.Containers[0].Name: emptyPodSpec.Containers[0].Resources,
-					},
-				},
+				"10": makeExpectedAlloc(emptyPodSpec),
 			},
 		},
 		{
@@ -2989,11 +2955,7 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			pod:                   podWithUIDNameNsSpec("11", "pod11", "foo", *emptyPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("11", "pod11", "foo", *emptyPodSpec),
 			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"11": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						emptyPodSpec.Containers[0].Name: emptyPodSpec.Containers[0].Resources,
-					},
-				},
+				"11": makeExpectedAlloc(emptyPodSpec),
 			},
 		},
 	}
@@ -3008,11 +2970,13 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			}
 			kubelet.HandlePodAdditions(tCtx, []*v1.Pod{tc.pod})
 
+			// Assert container resources
 			allocatedResources, found := kubelet.allocationManager.GetContainerResourceAllocation(tc.pod.UID, tc.pod.Spec.Containers[0].Name)
 			if !found {
 				t.Fatalf("resource allocation should exist: (pod: %#v, container: %s)", tc.pod, tc.pod.Spec.Containers[0].Name)
 			}
-			assert.Equal(t, tc.expectedPodResourceInfoMap[tc.pod.UID].ContainerResources[tc.pod.Spec.Containers[0].Name], allocatedResources, tc.name)
+			expectedResources := tc.expectedPodResourceInfoMap[tc.pod.UID].PodSpec.Containers[0].Resources
+			assert.Equal(t, expectedResources, allocatedResources, tc.name)
 		})
 	}
 }

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2914,19 +2914,17 @@ func TestPodResourceAllocationReset(t *testing.T) {
 	emptyPodSpec.Containers[0].Resources.Requests = v1.ResourceList{}
 
 	tests := []struct {
-		name                       string
-		pod                        *v1.Pod
-		existingPodAllocation      *v1.Pod
-		expectedPodResourceInfoMap state.PodResourceInfoMap
+		name                  string
+		pod                   *v1.Pod
+		existingPodAllocation *v1.Pod
+		expectedPodMap        state.PodMap
 	}{
 		{
 			name: "Having both memory and cpu, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("1", "pod1", "foo", *cpu500mMem500MPodSpec),
-			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+			expectedPodMap: state.PodMap{
 				"1": {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu500mMem500MPodSpec.Containers[0].Name: cpu500mMem500MPodSpec.Containers[0].Resources,
-					},
+					Spec: *cpu500mMem500MPodSpec,
 				},
 			},
 		},
@@ -2934,11 +2932,9 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Having both memory and cpu, resource allocation exists",
 			pod:                   podWithUIDNameNsSpec("2", "pod2", "foo", *cpu500mMem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("2", "pod2", "foo", *cpu500mMem500MPodSpec),
-			expectedPodResourceInfoMap: state.PodResourceInfoMap{
+			expectedPodMap: state.PodMap{
 				"2": {
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu500mMem500MPodSpec.Containers[0].Name: cpu500mMem500MPodSpec.Containers[0].Resources,
-					},
+					Spec: *cpu500mMem500MPodSpec,
 				},
 			},
 		},
@@ -2946,22 +2942,18 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Having both memory and cpu, resource allocation exists (with different value)",
 			pod:                   podWithUIDNameNsSpec("3", "pod3", "foo", *cpu500mMem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("3", "pod3", "foo", *cpu800mMem800MPodSpec),
-			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"3": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu800mMem800MPodSpec.Containers[0].Name: cpu800mMem800MPodSpec.Containers[0].Resources,
-					},
+			expectedPodMap: state.PodMap{
+				"3": {
+					Spec: *cpu800mMem800MPodSpec,
 				},
 			},
 		},
 		{
 			name: "Only has cpu, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("4", "pod5", "foo", *cpu500mPodSpec),
-			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"4": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu500mPodSpec.Containers[0].Name: cpu500mPodSpec.Containers[0].Resources,
-					},
+			expectedPodMap: state.PodMap{
+				"4": {
+					Spec: *cpu500mPodSpec,
 				},
 			},
 		},
@@ -2969,11 +2961,9 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Only has cpu, resource allocation exists",
 			pod:                   podWithUIDNameNsSpec("5", "pod5", "foo", *cpu500mPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("5", "pod5", "foo", *cpu500mPodSpec),
-			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"5": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu500mPodSpec.Containers[0].Name: cpu500mPodSpec.Containers[0].Resources,
-					},
+			expectedPodMap: state.PodMap{
+				"5": {
+					Spec: *cpu500mPodSpec,
 				},
 			},
 		},
@@ -2981,22 +2971,18 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Only has cpu, resource allocation exists (with different value)",
 			pod:                   podWithUIDNameNsSpec("6", "pod6", "foo", *cpu500mPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("6", "pod6", "foo", *cpu800mPodSpec),
-			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"6": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						cpu800mPodSpec.Containers[0].Name: cpu800mPodSpec.Containers[0].Resources,
-					},
+			expectedPodMap: state.PodMap{
+				"6": {
+					Spec: *cpu800mPodSpec,
 				},
 			},
 		},
 		{
 			name: "Only has memory, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("7", "pod7", "foo", *mem500MPodSpec),
-			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"7": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						mem500MPodSpec.Containers[0].Name: mem500MPodSpec.Containers[0].Resources,
-					},
+			expectedPodMap: state.PodMap{
+				"7": {
+					Spec: *mem500MPodSpec,
 				},
 			},
 		},
@@ -3004,11 +2990,9 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Only has memory, resource allocation exists",
 			pod:                   podWithUIDNameNsSpec("8", "pod8", "foo", *mem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("8", "pod8", "foo", *mem500MPodSpec),
-			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"8": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						mem500MPodSpec.Containers[0].Name: mem500MPodSpec.Containers[0].Resources,
-					},
+			expectedPodMap: state.PodMap{
+				"8": {
+					Spec: *mem500MPodSpec,
 				},
 			},
 		},
@@ -3016,22 +3000,18 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "Only has memory, resource allocation exists (with different value)",
 			pod:                   podWithUIDNameNsSpec("9", "pod9", "foo", *mem500MPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("9", "pod9", "foo", *mem800MPodSpec),
-			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"9": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						mem800MPodSpec.Containers[0].Name: mem800MPodSpec.Containers[0].Resources,
-					},
+			expectedPodMap: state.PodMap{
+				"9": {
+					Spec: *mem800MPodSpec,
 				},
 			},
 		},
 		{
 			name: "No CPU and memory, resource allocation not exists",
 			pod:  podWithUIDNameNsSpec("10", "pod10", "foo", *emptyPodSpec),
-			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"10": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						emptyPodSpec.Containers[0].Name: emptyPodSpec.Containers[0].Resources,
-					},
+			expectedPodMap: state.PodMap{
+				"10": {
+					Spec: *emptyPodSpec,
 				},
 			},
 		},
@@ -3039,11 +3019,9 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			name:                  "No CPU and memory, resource allocation exists",
 			pod:                   podWithUIDNameNsSpec("11", "pod11", "foo", *emptyPodSpec),
 			existingPodAllocation: podWithUIDNameNsSpec("11", "pod11", "foo", *emptyPodSpec),
-			expectedPodResourceInfoMap: state.PodResourceInfoMap{
-				"11": state.PodResourceInfo{
-					ContainerResources: map[string]v1.ResourceRequirements{
-						emptyPodSpec.Containers[0].Name: emptyPodSpec.Containers[0].Resources,
-					},
+			expectedPodMap: state.PodMap{
+				"11": {
+					Spec: *emptyPodSpec,
 				},
 			},
 		},
@@ -3059,11 +3037,13 @@ func TestPodResourceAllocationReset(t *testing.T) {
 			}
 			kubelet.HandlePodAdditions(tCtx, []*v1.Pod{tc.pod})
 
+			// Assert container resources
 			allocatedResources, found := kubelet.allocationManager.GetContainerResourceAllocation(tc.pod.UID, tc.pod.Spec.Containers[0].Name)
 			if !found {
 				t.Fatalf("resource allocation should exist: (pod: %#v, container: %s)", tc.pod, tc.pod.Spec.Containers[0].Name)
 			}
-			assert.Equal(t, tc.expectedPodResourceInfoMap[tc.pod.UID].ContainerResources[tc.pod.Spec.Containers[0].Name], allocatedResources, tc.name)
+			expectedResources := tc.expectedPodMap[tc.pod.UID].Spec.Containers[0].Resources
+			assert.Equal(t, expectedResources, allocatedResources, tc.name)
 		})
 	}
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -107,16 +107,22 @@ func (m *kubeGenericRuntimeManager) recordContainerEvent(ctx context.Context, po
 // containers, plus some additional fields. In both cases startSpec.container will be set.
 type startSpec struct {
 	container          *v1.Container
+	containerType      podutil.ContainerType
 	ephemeralContainer *v1.EphemeralContainer
 }
 
 func containerStartSpec(c *v1.Container) *startSpec {
-	return &startSpec{container: c}
+	return &startSpec{container: c, containerType: podutil.Containers}
+}
+
+func initContainerStartSpec(c *v1.Container) *startSpec {
+	return &startSpec{container: c, containerType: podutil.InitContainers}
 }
 
 func ephemeralContainerStartSpec(ec *v1.EphemeralContainer) *startSpec {
 	return &startSpec{
 		container:          (*v1.Container)(&ec.EphemeralContainerCommon),
+		containerType:      podutil.EphemeralContainers,
 		ephemeralContainer: ec,
 	}
 }
@@ -262,7 +268,7 @@ func (m *kubeGenericRuntimeManager) startContainer(ctx context.Context, podSandb
 	}
 
 	// When creating a container, mark the resources as actuated.
-	if err := m.setActuatedContainerResources(logger, pod, container); err != nil {
+	if err := m.setActuatedContainerResources(logger, pod, container, spec.containerType); err != nil {
 		m.recordContainerEvent(ctx, pod, container, "", v1.EventTypeWarning, events.FailedToCreateContainer, "Error: %v", err)
 		return err.Error(), ErrCreateContainerConfig
 	}
@@ -407,7 +413,7 @@ func (m *kubeGenericRuntimeManager) generateContainerConfig(ctx context.Context,
 	return config, cleanupAction, nil
 }
 
-func (m *kubeGenericRuntimeManager) updateContainerResources(ctx context.Context, pod *v1.Pod, container *v1.Container, containerID kubecontainer.ContainerID) error {
+func (m *kubeGenericRuntimeManager) updateContainerResources(ctx context.Context, pod *v1.Pod, container *v1.Container, containerID kubecontainer.ContainerID, containerType podutil.ContainerType) error {
 	logger := klog.FromContext(ctx)
 	containerResources := m.generateContainerResources(ctx, pod, container)
 	if containerResources == nil {
@@ -415,18 +421,18 @@ func (m *kubeGenericRuntimeManager) updateContainerResources(ctx context.Context
 	}
 	err := m.runtimeService.UpdateContainerResources(ctx, containerID.ID, containerResources)
 	if err == nil {
-		err = m.setActuatedContainerResources(logger, pod, container)
+		err = m.setActuatedContainerResources(logger, pod, container, containerType)
 	}
 	return err
 }
 
-func (m *kubeGenericRuntimeManager) setActuatedContainerResources(logger klog.Logger, pod *v1.Pod, container *v1.Container) error {
+func (m *kubeGenericRuntimeManager) setActuatedContainerResources(logger klog.Logger, pod *v1.Pod, container *v1.Container, containerType podutil.ContainerType) error {
 	containerResources := container.Resources
 	if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodLevelResourcesVerticalScaling) {
 		containerResources = *containerResources.DeepCopy()
 		containerResources.Limits = kubeutil.GetLimits(&kubeutil.ResourceOpts{PodResources: pod.Spec.Resources, ContainerResources: &container.Resources})
 	}
-	return m.actuatedState.SetContainerResources(logger, pod.UID, container.Name, containerResources)
+	return m.actuatedState.SetContainerResources(logger, pod.UID, container.Name, containerType, containerResources)
 }
 
 func (m *kubeGenericRuntimeManager) updatePodSandboxResources(ctx context.Context, sandboxID string, pod *v1.Pod, podResources *cm.ResourceConfig) error {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/test/utils/ktesting"
 
 	kubelettypes "k8s.io/kubelet/pkg/types"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -490,7 +491,7 @@ func TestToKubeContainerStatusWithResources(t *testing.T) {
 			}
 
 			if test.actuatedResources != nil {
-				require.NoError(t, m.actuatedState.SetContainerResources(logger, podUID, meta.Name, *test.actuatedResources))
+				require.NoError(t, m.actuatedState.SetContainerResources(logger, podUID, meta.Name, podutil.Containers, *test.actuatedResources))
 				t.Cleanup(func() { _ = m.actuatedState.RemovePod(logger, podUID) })
 			}
 
@@ -1108,7 +1109,7 @@ func TestUpdateContainerResources(t *testing.T) {
 	require.NoError(t, err)
 	containerID := cStatus[0].ID
 
-	err = m.updateContainerResources(tCtx, pod, &pod.Spec.Containers[0], containerID)
+	err = m.updateContainerResources(tCtx, pod, &pod.Spec.Containers[0], containerID, podutil.Containers)
 	assert.NoError(t, err)
 
 	// Verify container is updated

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -832,7 +832,15 @@ func (m *kubeGenericRuntimeManager) InitializeActuatedPod(logger klog.Logger, al
 	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		return
 	}
-	if _, ok := m.actuatedState.GetPodResourceInfo(allocatedPod.UID); ok {
+	if actuatedInfo, ok := m.actuatedState.GetPodResourceInfo(allocatedPod.UID); ok {
+		// Legacy checkpoints migrated from V1 only populated resource requirements, leaving the
+		// rest of the PodSpec empty. Hydrate non-resource PodSpec metadata while preserving actuated resources.
+		if actuatedInfo.PodSpec != nil && len(actuatedInfo.PodSpec.Containers) > 0 && actuatedInfo.PodSpec.Containers[0].Image == "" {
+			hydratedPod, _ := allocation.UpdatePodFromResourceInfo(allocatedPod, actuatedInfo)
+			if err := m.actuatedState.SetPodResourceInfo(logger, allocatedPod.UID, allocation.ResourceInfoForPod(hydratedPod)); err != nil {
+				logger.Error(err, "Failed to hydrate actuated pod resource info checkpoint", "pod", klog.KObj(allocatedPod))
+			}
+		}
 		return
 	}
 	info := allocation.ResourceInfoForPod(allocatedPod)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -834,12 +834,19 @@ func (m *kubeGenericRuntimeManager) InitializeActuatedPod(logger klog.Logger, al
 	if !utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		return
 	}
-	if _, ok := m.actuatedState.GetPodResourceInfo(allocatedPod.UID); ok {
+	if actuatedPod, ok := m.actuatedState.GetPod(allocatedPod.UID); ok {
+		// Legacy checkpoints migrated from V1 only populated resource requirements, leaving the
+		// rest of the PodSpec empty. Hydrate non-resource PodSpec metadata while preserving actuated resources.
+		if len(actuatedPod.Spec.Containers) == 0 || actuatedPod.Spec.Containers[0].Image == "" {
+			hydratedPod, _ := state.UpdatePodFromCheckpoint(allocatedPod, actuatedPod)
+			if err := m.actuatedState.SetPod(logger, hydratedPod); err != nil {
+				logger.Error(err, "Failed to hydrate actuated pod checkpoint", "pod", klog.KObj(allocatedPod))
+			}
+		}
 		return
 	}
-	info := allocation.ResourceInfoForPod(allocatedPod)
-	if err := m.actuatedState.SetPodResourceInfo(logger, allocatedPod.UID, info); err != nil {
-		logger.Error(err, "Failed to initialize actuated pod resource info checkpoint", "pod", klog.KObj(allocatedPod))
+	if err := m.actuatedState.SetPod(logger, allocatedPod); err != nil {
+		logger.Error(err, "Failed to initialize actuated pod checkpoint", "pod", klog.KObj(allocatedPod))
 	}
 }
 
@@ -2296,7 +2303,7 @@ func (m *kubeGenericRuntimeManager) GetContainerStatus(ctx context.Context, podU
 func (m *kubeGenericRuntimeManager) GarbageCollect(ctx context.Context, gcPolicy kubecontainer.GCPolicy, allSourcesReady bool, evictNonDeletedPods bool) error {
 	logger := klog.FromContext(ctx)
 	// Remove terminated pods from the actuated state.
-	for uid := range m.actuatedState.GetPodResourceInfoMap() {
+	for _, uid := range m.actuatedState.GetPodUIDs() {
 		if m.podStateProvider.ShouldPodContentBeRemoved(uid) {
 			if err := m.actuatedState.RemovePod(logger, uid); err != nil {
 				// No need to act on the error beyond logging it here.

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -587,6 +587,8 @@ type containerToKillInfo struct {
 type containerToUpdateInfo struct {
 	// The spec of the container.
 	container *v1.Container
+	// Type of the container.
+	containerType podutil.ContainerType
 	// ID of the runtime container that needs resource update
 	kubeContainerID kubecontainer.ContainerID
 	// Desired resources for the running container
@@ -726,8 +728,10 @@ func (m *kubeGenericRuntimeManager) computePodResizeAction(ctx context.Context, 
 	}
 
 	var container v1.Container
+	containerType := podutil.Containers
 	if initContainer {
 		container = pod.Spec.InitContainers[containerIdx]
+		containerType = podutil.InitContainers
 	} else {
 		container = pod.Spec.Containers[containerIdx]
 	}
@@ -776,6 +780,7 @@ func (m *kubeGenericRuntimeManager) computePodResizeAction(ctx context.Context, 
 	markContainerForUpdate := func(rName v1.ResourceName, desiredValue, currentValue int64) {
 		cUpdateInfo := containerToUpdateInfo{
 			container:                 &container,
+			containerType:             containerType,
 			kubeContainerID:           kubeContainerStatus.ID,
 			desiredContainerResources: desiredResources,
 			currentContainerResources: &currentResources,
@@ -1249,7 +1254,7 @@ func (m *kubeGenericRuntimeManager) updatePodContainerResources(ctx context.Cont
 				v1.ResourceMemory: *resource.NewQuantity(cInfo.currentContainerResources.memoryRequest, resource.BinarySI),
 			}
 		}
-		if err := m.updateContainerResources(ctx, pod, container, cInfo.kubeContainerID); err != nil {
+		if err := m.updateContainerResources(ctx, pod, container, cInfo.kubeContainerID, cInfo.containerType); err != nil {
 			// Log error and abort as container updates need to succeed in the order determined by computePodResizeAction.
 			// The recovery path is for SyncPod to keep retrying at later times until it succeeds.
 			logger.Error(err, "updateContainerResources failed", "container", container.Name, "cID", cInfo.kubeContainerID,
@@ -1920,7 +1925,7 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 
 		container := &pod.Spec.InitContainers[idx]
 		// Start the next init container.
-		if err := start(ctx, "init container", metrics.InitContainer, containerStartSpec(container)); err != nil {
+		if err := start(ctx, "init container", metrics.InitContainer, initContainerStartSpec(container)); err != nil {
 			if podutil.IsRestartableInitContainer(container) {
 				logger.V(4).Info("Failed to start the restartable init container for the pod, skipping", "initContainerName", container.Name, "pod", klog.KObj(pod))
 				continue

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -55,6 +55,7 @@ import (
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/allocation/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	cmtesting "k8s.io/kubernetes/pkg/kubelet/cm/testing"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -6783,4 +6784,72 @@ func TestSysctlFiltering(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInitializeActuatedPod_HydrateMigratedState(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	require.NoError(t, err)
+
+	// create a pod with full metadata representing a pending unactuated resize
+	allocatedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "pod-123",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "c1",
+					Image: "nginx:latest",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("200m"),
+							v1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("200m"),
+							v1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// simulate a migrated legacy V1 checkpoint entry that has an empty container image and older actuated resources
+	migratedSpec := &v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:  "c1",
+				Image: "", // empty image indicates legacy migrated state
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100m"),
+						v1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+					Limits: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("100m"),
+						v1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
+			},
+		},
+	}
+	err = m.actuatedState.SetPodResourceInfo(logger, allocatedPod.UID, state.PodResourceInfo{PodSpec: migratedSpec})
+	require.NoError(t, err)
+
+	// execute InitializeActuatedPod, which must hydrate non-resource metadata while preserving actuated resources
+	m.InitializeActuatedPod(logger, allocatedPod)
+
+	actuatedInfo, found := m.actuatedState.GetPodResourceInfo(allocatedPod.UID)
+	require.True(t, found)
+	require.NotNil(t, actuatedInfo.PodSpec)
+
+	// assert non-resource metadata was hydrated from allocatedPod
+	assert.Equal(t, "nginx:latest", actuatedInfo.PodSpec.Containers[0].Image)
+
+	// assert actuated resources were preserved, ignoring allocatedPod's desired resources
+	assert.True(t, actuatedInfo.PodSpec.Containers[0].Resources.Requests[v1.ResourceCPU].Equal(resource.MustParse("100m")), "CPU request should remain at actuated value")
+	assert.True(t, actuatedInfo.PodSpec.Containers[0].Resources.Requests[v1.ResourceMemory].Equal(resource.MustParse("128Mi")), "Memory request should remain at actuated value")
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -2159,6 +2159,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 				ContainersToUpdate: map[v1.ResourceName][]containerToUpdateInfo{
 					v1.ResourceMemory: {
 						{
+							containerType:   podutil.InitContainers,
 							kubeContainerID: baseStatus.ContainerStatuses[0].ID,
 							desiredContainerResources: resourceRequirements{
 								memoryRequest: memory800Mi.Value(),
@@ -2172,6 +2173,7 @@ func TestComputePodActionsWithInitContainers(t *testing.T) {
 					},
 					v1.ResourceCPU: {
 						{
+							containerType:   podutil.InitContainers,
 							kubeContainerID: baseStatus.ContainerStatuses[0].ID,
 							desiredContainerResources: resourceRequirements{
 								memoryRequest: memory800Mi.Value(),
@@ -3137,7 +3139,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 	setupActuatedResources := func(pod *v1.Pod, container *v1.Container, actuatedResources v1.ResourceRequirements) {
 		actuatedContainer := container.DeepCopy()
 		actuatedContainer.Resources = actuatedResources
-		require.NoError(t, m.actuatedState.SetContainerResources(logger, pod.UID, actuatedContainer.Name, actuatedContainer.Resources))
+		require.NoError(t, m.actuatedState.SetContainerResources(logger, pod.UID, actuatedContainer.Name, podutil.Containers, actuatedContainer.Resources))
 	}
 
 	setupActuatedPodResources := func(pod *v1.Pod, actuatedPodResources *v1.ResourceRequirements) {
@@ -3248,6 +3250,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceMemory: {
 							{
 								container:       &pod.Spec.Containers[1],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
@@ -3262,6 +3265,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceCPU: {
 							{
 								container:       &pod.Spec.Containers[1],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
@@ -3320,6 +3324,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceMemory: {
 							{
 								container:       &pod.Spec.Containers[1],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem200M.Value(),
@@ -3334,6 +3339,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceCPU: {
 							{
 								container:       &pod.Spec.Containers[1],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem200M.Value(),
@@ -3396,6 +3402,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceMemory: {
 							{
 								container:       &pod.Spec.Containers[1],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem600M.Value(),
@@ -3410,6 +3417,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceCPU: {
 							{
 								container:       &pod.Spec.Containers[1],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem600M.Value(),
@@ -3508,6 +3516,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceMemory: {
 							{
 								container:       &pod.Spec.Containers[1],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
@@ -3522,6 +3531,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceCPU: {
 							{
 								container:       &pod.Spec.Containers[1],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
@@ -3561,6 +3571,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceCPU: {
 							{
 								container:       &pod.Spec.Containers[1],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
@@ -3600,6 +3611,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceMemory: {
 							{
 								container:       &pod.Spec.Containers[2],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem200M.Value(),
@@ -3646,6 +3658,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceCPU: {
 							{
 								container:       &pod.Spec.Containers[0],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs1.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
@@ -3655,6 +3668,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							},
 							{
 								container:       &pod.Spec.Containers[2],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs3.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
@@ -3666,6 +3680,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceMemory: {
 							{
 								container:       &pod.Spec.Containers[0],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs1.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
@@ -3675,6 +3690,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							},
 							{
 								container:       &pod.Spec.Containers[1],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs2.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
@@ -3686,6 +3702,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 							},
 							{
 								container:       &pod.Spec.Containers[2],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs3.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
@@ -3825,6 +3842,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceMemory: {
 							{
 								container:       &pod.Spec.Containers[1],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem200M.Value(),
@@ -3865,6 +3883,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceCPU: {
 							{
 								container:       &pod.Spec.Containers[2],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit: mem100M.Value(),
@@ -3951,6 +3970,7 @@ func TestComputePodActionsForPodResize(t *testing.T) {
 						v1.ResourceMemory: {
 							{
 								container:       &pod.Spec.Containers[2],
+								containerType:   podutil.Containers,
 								kubeContainerID: kcs.ID,
 								desiredContainerResources: resourceRequirements{
 									memoryLimit:   mem200M.Value(),
@@ -4276,9 +4296,10 @@ func TestUpdatePodContainerResources(t *testing.T) {
 	} {
 		for _, allSideCarCtrs := range []bool{false, true} {
 			var containersToUpdate []containerToUpdateInfo
-			containerToUpdateInfo := func(container *v1.Container, idx int) containerToUpdateInfo {
+			containerToUpdateInfo := func(container *v1.Container, idx int, cType podutil.ContainerType) containerToUpdateInfo {
 				return containerToUpdateInfo{
 					container:       container,
+					containerType:   cType,
 					kubeContainerID: kubecontainer.ContainerID{},
 					desiredContainerResources: resourceRequirements{
 						memoryLimit:   tc.apiSpecResources[idx].Limits.Memory().Value(),
@@ -4300,7 +4321,7 @@ func TestUpdatePodContainerResources(t *testing.T) {
 					// default resize policy when pod resize feature is enabled
 					pod.Spec.InitContainers[idx].Resources = tc.apiSpecResources[idx]
 					pod.Status.ContainerStatuses[idx].Resources = &tc.apiStatusResources[idx]
-					cinfo := containerToUpdateInfo(&pod.Spec.InitContainers[idx], idx)
+					cinfo := containerToUpdateInfo(&pod.Spec.InitContainers[idx], idx, podutil.InitContainers)
 					containersToUpdate = append(containersToUpdate, cinfo)
 				}
 			} else {
@@ -4308,7 +4329,7 @@ func TestUpdatePodContainerResources(t *testing.T) {
 					// default resize policy when pod resize feature is enabled
 					pod.Spec.Containers[idx].Resources = tc.apiSpecResources[idx]
 					pod.Status.ContainerStatuses[idx].Resources = &tc.apiStatusResources[idx]
-					cinfo := containerToUpdateInfo(&pod.Spec.Containers[idx], idx)
+					cinfo := containerToUpdateInfo(&pod.Spec.Containers[idx], idx, podutil.Containers)
 					containersToUpdate = append(containersToUpdate, cinfo)
 				}
 			}
@@ -6119,7 +6140,7 @@ func TestIsPodResizeInProgress(t *testing.T) {
 				if c.actuated != nil {
 					actuatedContainer := container.DeepCopy()
 					actuatedContainer.Resources = mkRequirements(*c.actuated)
-					require.NoError(t, m.actuatedState.SetContainerResources(logger, pod.UID, actuatedContainer.Name, actuatedContainer.Resources))
+					require.NoError(t, m.actuatedState.SetContainerResources(logger, pod.UID, actuatedContainer.Name, podutil.Containers, actuatedContainer.Resources))
 
 					fetched, found := m.actuatedState.GetContainerResources(pod.UID, container.Name)
 					require.True(t, found)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -6805,3 +6805,150 @@ func TestSysctlFiltering(t *testing.T) {
 		})
 	}
 }
+
+func TestInitializeActuatedPod_HydrateMigratedState(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	require.NoError(t, err)
+
+	// create a pod with full metadata representing a pending unactuated resize
+	allocatedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "pod-123",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "c1",
+					Image: "nginx:latest",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("200m"),
+							v1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("200m"),
+							v1.ResourceMemory: resource.MustParse("256Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// simulate a migrated legacy V1 checkpoint entry that has an empty container image and older actuated resources
+	migratedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: allocatedPod.UID,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "c1",
+					Image: "", // empty image indicates legacy migrated state
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("100m"),
+							v1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("100m"),
+							v1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	err = m.actuatedState.SetPod(logger, migratedPod)
+	require.NoError(t, err)
+
+	// execute InitializeActuatedPod, which must hydrate non-resource metadata while preserving actuated resources
+	m.InitializeActuatedPod(logger, allocatedPod)
+
+	actuatedPod, found := m.actuatedState.GetPod(allocatedPod.UID)
+	require.True(t, found)
+	require.NotNil(t, actuatedPod)
+
+	// assert non-resource metadata was hydrated from allocatedPod
+	assert.Equal(t, "nginx:latest", actuatedPod.Spec.Containers[0].Image)
+
+	// assert actuated resources were preserved, ignoring allocatedPod's desired resources
+	assert.True(t, actuatedPod.Spec.Containers[0].Resources.Requests[v1.ResourceCPU].Equal(resource.MustParse("100m")), "CPU request should remain at actuated value")
+	assert.True(t, actuatedPod.Spec.Containers[0].Resources.Requests[v1.ResourceMemory].Equal(resource.MustParse("128Mi")), "Memory request should remain at actuated value")
+}
+
+func TestInitializeActuatedPod_HydrateMigratedState_NoContainersInV1(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingMemoryBackedVolumes, true)
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	require.NoError(t, err)
+
+	volLimit := resource.MustParse("256Mi")
+	allocatedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: "pod-no-container-res",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "c1",
+					Image: "nginx:latest",
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "mem-vol",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							Medium:    v1.StorageMediumMemory,
+							SizeLimit: &volLimit,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// simulate a migrated V1 checkpoint that had 0 container requests (only a volume limit)
+	migratedPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: allocatedPod.UID,
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "mem-vol",
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{
+							Medium:    v1.StorageMediumMemory,
+							SizeLimit: &volLimit,
+						},
+					},
+				},
+			},
+		},
+	}
+	err = m.actuatedState.SetPod(logger, migratedPod)
+	require.NoError(t, err)
+
+	// execute InitializeActuatedPod
+	m.InitializeActuatedPod(logger, allocatedPod)
+
+	actuatedPod, found := m.actuatedState.GetPod(allocatedPod.UID)
+	require.True(t, found)
+	require.NotNil(t, actuatedPod)
+
+	// assert containers and non-resource metadata were hydrated
+	require.Len(t, actuatedPod.Spec.Containers, 1)
+	assert.Equal(t, "c1", actuatedPod.Spec.Containers[0].Name)
+	assert.Equal(t, "nginx:latest", actuatedPod.Spec.Containers[0].Image)
+
+	// assert volume limit was preserved
+	require.Len(t, actuatedPod.Spec.Volumes, 1)
+	assert.Equal(t, "mem-vol", actuatedPod.Spec.Volumes[0].Name)
+	require.NotNil(t, actuatedPod.Spec.Volumes[0].EmptyDir)
+	assert.True(t, volLimit.Equal(*actuatedPod.Spec.Volumes[0].EmptyDir.SizeLimit))
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR is intended to be an isolated prefactor. It introduces a new format for the pod resource allocation and actuation checkpoint files to have them store the entire PodSpec, along with startup migration code.

This will be useful for:
- Reliably checking whether a pod sandbox needs to be resized when pod-level resources are not set, which was discussed in https://github.com/kubernetes/kubernetes/pull/138857#pullrequestreview-4557860191.
- Making allocation manager the source of truth for pod allocations: https://github.com/kubernetes/kubernetes/issues/139831.
- Dynamic containers https://github.com/kubernetes/enhancements/pull/6169.
- Dynamic volumes https://github.com/kubernetes/enhancements/issues/6395.
- Any future features that choose to make some aspect of the pod dynamically adjustable at runtime.

This also converts the checkpoint file to be serialized with protobuf, which will result in significant performance improvements over the legacy JSON format.

#### Special notes for your reviewer:

Local testing steps:
1. Created a kind cluster from `master` with all relevant feature gates (`InPlacePodVerticalScaling`, `InPlacePodLevelResourcesVerticalScaling`, and `InPlacePodVerticalScalingMemoryBackedVolumes`) enabled.
1. Created a pod that had container-level resources, pod-level resources, and a memory-backed volume with a size limit.
1. Resized all these values to intentionally put it in a `Deferred` status.
1. Hot-plugged a new build of kubelet based on this branch.
1. Observed the pod get re-admitted based on its pre-resize values, and stay `Deferred`. 
1. Double checked the correctness of the allocated and actuated checkpoint files.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduce a new protobuf-based checkpoint format for kubelet resource allocation & actuation checkpoint files.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

/sig node

Assisted by Antigravity
