### PR TITLE
kubelet: wire context to syncpods to allow multiple stops

### DIFF
--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -79,6 +79,10 @@ type FakeRuntime struct {
 	imagePullErrBucket chan error
 	SwapBehavior       map[string]kubetypes.SwapBehavior
 	T                  TB
+	// BlockSyncPod will cause SyncPod to block until context is cancelled
+	BlockSyncPod bool
+	// BlockKillPod will cause KillPod to block until context is cancelled
+	BlockKillPod bool
 }
 
 const FakeHost = "localhost:12345"
@@ -259,7 +263,18 @@ func (f *FakeRuntime) GetPod(_ context.Context, podUID types.UID) (*kubecontaine
 	return nil, kubecontainer.ErrPodNotFound
 }
 
-func (f *FakeRuntime) SyncPod(_ context.Context, pod *v1.Pod, _ *kubecontainer.PodStatus, _ []v1.Secret, backOff *flowcontrol.Backoff, _ bool) (result kubecontainer.PodSyncResult) {
+func (f *FakeRuntime) SyncPod(ctx context.Context, pod *v1.Pod, _ *kubecontainer.PodStatus, _ []v1.Secret, backOff *flowcontrol.Backoff, _ bool) (result kubecontainer.PodSyncResult) {
+	f.Lock()
+	blockSync := f.BlockSyncPod
+	f.Unlock()
+
+	// If BlockSyncPod is set, simulate a long-running operation that respects context
+	if blockSync {
+		<-ctx.Done()
+		result.Fail(ctx.Err())
+		return result
+	}
+
 	f.Lock()
 	defer f.Unlock()
 
@@ -278,7 +293,17 @@ func (f *FakeRuntime) SyncPod(_ context.Context, pod *v1.Pod, _ *kubecontainer.P
 	return
 }
 
-func (f *FakeRuntime) KillPod(_ context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) error {
+func (f *FakeRuntime) KillPod(ctx context.Context, pod *v1.Pod, runningPod kubecontainer.Pod, gracePeriodOverride *int64) error {
+	f.Lock()
+	blockKill := f.BlockKillPod
+	f.Unlock()
+
+	// If BlockKillPod is set, simulate a long-running kill that respects context
+	if blockKill {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
 	f.Lock()
 	defer f.Unlock()
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2249,13 +2249,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 	// Ensure the pod is being probed
 	kl.probeManager.AddPod(ctx, pod)
 
-	// TODO(#113606): use cancellation from the incoming context parameter, which comes from the pod worker.
-	// Currently, using cancellation from that context causes test failures. To remove this WithoutCancel,
-	// any wait.Interrupted errors need to be filtered from result and bypass the reasonCache - cancelling
-	// the context for SyncPod is a known and deliberate error, not a generic error.
-	// Use WithoutCancel instead of a new context.TODO() to propagate trace context
 	// Call the container runtime's SyncPod callback
-	sctx := context.WithoutCancel(ctx)
 	restartingAllContainers := false
 	if utilfeature.DefaultFeatureGate.Enabled(features.RestartAllContainersOnContainerExits) {
 		for _, cond := range apiPodStatus.Conditions {
@@ -2264,8 +2258,16 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 			}
 		}
 	}
-	result := kl.containerRuntime.SyncPod(sctx, pod, podStatus, pullSecrets, kl.crashLoopBackOff, restartingAllContainers)
-	kl.reasonCache.Update(pod.UID, result)
+	result := kl.containerRuntime.SyncPod(ctx, pod, podStatus, pullSecrets, kl.crashLoopBackOff, restartingAllContainers)
+	// Don't update the reason cache if the sync was cancelled - cancellation is a deliberate
+	// action (e.g., pod transitioning to terminating or grace period shortening), not an error
+	// that should be cached and reported.
+	if !wait.Interrupted(result.Error()) {
+		kl.reasonCache.Update(pod.UID, result)
+	} else {
+		// Context was cancelled - return immediately without further processing
+		return false, nil, result.Error()
+	}
 
 	// If we just performed a RestartAllContainers reset, we want to immediately
 	// trigger another sync to start the containers, rather than waiting for PLEG
@@ -2338,10 +2340,7 @@ func (kl *Kubelet) SyncPod(ctx context.Context, updateType kubetypes.SyncPodType
 // configuration and the kubelet is restarted - SyncTerminatingRuntimePod handles those orphaned
 // pods.
 func (kl *Kubelet) SyncTerminatingPod(ctx context.Context, pod *v1.Pod, podStatus *kubecontainer.PodStatus, gracePeriod *int64, podStatusFn func(*v1.PodStatus)) (err error) {
-	// TODO(#113606): connect this with the incoming context parameter, which comes from the pod worker.
-	// Currently, using that context causes test failures.
 	logger := klog.FromContext(ctx)
-	ctx = klog.NewContext(context.TODO(), logger)
 	logger.V(4).Info("SyncTerminatingPod enter", "pod", klog.KObj(pod), "podUID", pod.UID)
 
 	ctx, otelSpan := kl.tracer.Start(ctx, "syncTerminatingPod", trace.WithAttributes(
@@ -2475,10 +2474,7 @@ func preserveDataFromBeforeStopping(stoppedPodStatus, podStatus *kubecontainer.P
 // not update the status of the pod because with the source of configuration removed, we have no
 // place to send that status.
 func (kl *Kubelet) SyncTerminatingRuntimePod(ctx context.Context, runningPod *kubecontainer.Pod) error {
-	// TODO(#113606): connect this with the incoming context parameter, which comes from the pod worker.
-	// Currently, using that context causes test failures.
 	logger := klog.FromContext(ctx)
-	ctx = klog.NewContext(context.TODO(), logger)
 	pod := runningPod.ToAPIPod()
 	logger.V(4).Info("SyncTerminatingRuntimePod enter", "pod", klog.KObj(pod), "podUID", pod.UID)
 	defer logger.V(4).Info("SyncTerminatingRuntimePod exit", "pod", klog.KObj(pod), "podUID", pod.UID)

--- a/pkg/kubelet/kubelet_sync_cancellation_test.go
+++ b/pkg/kubelet/kubelet_sync_cancellation_test.go
@@ -1,0 +1,362 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/pkg/kubelet/volumemanager"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+// contextAwareVolumeManager simulates a volume manager that respects context cancellation
+type contextAwareVolumeManager struct {
+	volumemanager.VolumeManager
+	mu                sync.Mutex
+	attachMountCalled chan struct{}
+	unmountCalled     chan struct{}
+}
+
+func (c *contextAwareVolumeManager) WaitForAttachAndMount(ctx context.Context, pod *v1.Pod) error {
+	c.mu.Lock()
+	ch := c.attachMountCalled
+	c.mu.Unlock()
+
+	if ch != nil {
+		close(ch)
+	}
+	// Block until context is cancelled
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (c *contextAwareVolumeManager) WaitForUnmount(ctx context.Context, pod *v1.Pod) error {
+	c.mu.Lock()
+	ch := c.unmountCalled
+	c.mu.Unlock()
+
+	if ch != nil {
+		close(ch)
+	}
+	// Block until context is cancelled
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// TestSyncPodCancellationDuringVolumeMount verifies that when the context is cancelled
+// while SyncPod is waiting for volumes, the cancellation propagates correctly.
+func TestSyncPodCancellationDuringVolumeMount(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "12345678",
+			Name:      "test-pod",
+			Namespace: "test",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+				},
+			},
+		},
+	}
+
+	pods := []*v1.Pod{pod}
+	kl.podManager.SetPods(pods)
+
+	podStatus := &kubecontainer.PodStatus{
+		ID:        pod.UID,
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+
+	// Create a cancellable context
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+
+	// Replace volume manager with one that blocks on context
+	attachMountCalled := make(chan struct{})
+	kl.volumeManager = &contextAwareVolumeManager{
+		VolumeManager:     kl.volumeManager,
+		attachMountCalled: attachMountCalled,
+	}
+
+	// Start SyncPod in goroutine
+	var err error
+	var isTerminal bool
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		isTerminal, _, err = kl.SyncPod(ctx, kubetypes.SyncPodCreate, pod, nil, podStatus)
+	}()
+
+	// Wait for volume operation to start
+	select {
+	case <-attachMountCalled:
+		t.Log("SyncPod is blocked in WaitForAttachAndMount")
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForAttachAndMount was not called")
+	}
+
+	// Cancel context
+	t.Log("Cancelling context")
+	cancel()
+
+	// Verify SyncPod exits with cancellation error
+	select {
+	case <-done:
+		t.Log("SyncPod exited")
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncPod did not exit after cancellation")
+	}
+
+	require.True(t, wait.Interrupted(err), "expected context cancellation error, got: %v", err)
+	assert.False(t, isTerminal, "pod should not be terminal after cancellation")
+}
+
+// TestSyncPodCancellationDuringContainerSync verifies that when the context is cancelled
+// while the container runtime is syncing, the cancellation propagates correctly through
+// kubelet's SyncPod.
+func TestSyncPodCancellationDuringContainerSync(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	fakeRuntime := testKubelet.fakeRuntime
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "12345678",
+			Name:      "test-pod",
+			Namespace: "test",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+				},
+			},
+		},
+	}
+
+	pods := []*v1.Pod{pod}
+	kl.podManager.SetPods(pods)
+
+	podStatus := &kubecontainer.PodStatus{
+		ID:        pod.UID,
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+
+	// Set FakeRuntime to block on SyncPod until context is cancelled
+	fakeRuntime.Lock()
+	fakeRuntime.BlockSyncPod = true
+	fakeRuntime.Unlock()
+
+	// Create a cancellable context
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+
+	// Start SyncPod in goroutine
+	var err error
+	var isTerminal bool
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		isTerminal, _, err = kl.SyncPod(ctx, kubetypes.SyncPodCreate, pod, nil, podStatus)
+	}()
+
+	// Give SyncPod time to reach the blocking runtime.SyncPod call
+	time.Sleep(100 * time.Millisecond)
+	t.Log("Cancelling context while SyncPod is blocked in runtime.SyncPod")
+
+	// Cancel context
+	cancel()
+
+	// Verify SyncPod exits with cancellation error
+	select {
+	case <-done:
+		t.Log("SyncPod exited")
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncPod did not exit after cancellation")
+	}
+
+	require.True(t, wait.Interrupted(err), "expected context cancellation error, got: %v", err)
+	assert.False(t, isTerminal, "pod should not be terminal after cancellation")
+}
+
+// TestSyncTerminatingPodCancellation verifies that when the context is cancelled
+// while KillPod is running, the cancellation propagates correctly through
+// SyncTerminatingPod.
+func TestSyncTerminatingPodCancellation(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+	fakeRuntime := testKubelet.fakeRuntime
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "12345678",
+			Name:      "terminating-pod",
+			Namespace: "test",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "test-container",
+					Image: "test-image",
+				},
+			},
+		},
+	}
+
+	pods := []*v1.Pod{pod}
+	kl.podManager.SetPods(pods)
+
+	podStatus := &kubecontainer.PodStatus{
+		ID:        pod.UID,
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+		ContainerStatuses: []*kubecontainer.Status{
+			{
+				ID:    kubecontainer.ContainerID{Type: "test", ID: "container1"},
+				Name:  "test-container",
+				State: kubecontainer.ContainerStateRunning,
+			},
+		},
+	}
+
+	// Set FakeRuntime to block on KillPod until context is cancelled
+	fakeRuntime.Lock()
+	fakeRuntime.BlockKillPod = true
+	fakeRuntime.Unlock()
+
+	// Create a cancellable context
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+
+	// Start SyncTerminatingPod in goroutine
+	var err error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		gracePeriod := int64(30)
+		err = kl.SyncTerminatingPod(ctx, pod, podStatus, &gracePeriod, nil)
+	}()
+
+	// Give SyncTerminatingPod time to reach the blocking runtime.KillPod call
+	time.Sleep(100 * time.Millisecond)
+	t.Log("Cancelling context while SyncTerminatingPod is blocked in runtime.KillPod")
+
+	// Cancel context
+	cancel()
+
+	// Verify SyncTerminatingPod exits with cancellation error
+	select {
+	case <-done:
+		t.Log("SyncTerminatingPod exited")
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncTerminatingPod did not exit after cancellation")
+	}
+
+	require.True(t, wait.Interrupted(err), "expected context cancellation error, got: %v", err)
+}
+
+// TestSyncTerminatedPodCancellation verifies that when the context is cancelled
+// while waiting for volumes to unmount, the cancellation propagates correctly.
+func TestSyncTerminatedPodCancellation(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "12345678",
+			Name:      "terminated-pod",
+			Namespace: "test",
+		},
+	}
+
+	pods := []*v1.Pod{pod}
+	kl.podManager.SetPods(pods)
+
+	podStatus := &kubecontainer.PodStatus{
+		ID:        pod.UID,
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+
+	// Create a cancellable context
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+
+	// Replace volume manager with one that blocks on context
+	unmountCalled := make(chan struct{})
+	kl.volumeManager = &contextAwareVolumeManager{
+		VolumeManager: kl.volumeManager,
+		unmountCalled: unmountCalled,
+	}
+
+	// Start SyncTerminatedPod in goroutine
+	var err error
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		err = kl.SyncTerminatedPod(ctx, pod, podStatus)
+	}()
+
+	// Wait for unmount to start
+	select {
+	case <-unmountCalled:
+		t.Log("SyncTerminatedPod is blocked in WaitForUnmount")
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForUnmount was not called")
+	}
+
+	// Cancel context
+	t.Log("Cancelling context")
+	cancel()
+
+	// Verify SyncTerminatedPod exits with cancellation error
+	select {
+	case <-done:
+		t.Log("SyncTerminatedPod exited")
+	case <-time.After(5 * time.Second):
+		t.Fatal("SyncTerminatedPod did not exit after cancellation")
+	}
+
+	require.True(t, wait.Interrupted(err), "expected context cancellation error, got: %v", err)
+}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -754,9 +754,10 @@ func (m *kubeGenericRuntimeManager) toKubeContainerStatus(ctx context.Context, p
 	}
 
 	if status.State != runtimeapi.ContainerState_CONTAINER_CREATED {
-		// If container is not in the created state, we have tried and
-		// started the container. Set the StartedAt time.
 		cStatus.StartedAt = time.Unix(0, status.StartedAt)
+		if cStatus.StartedAt.Equal(time.Unix(0, 0)) {
+			cStatus.StartedAt = time.Time{}
+		}
 	}
 	if status.State == runtimeapi.ContainerState_CONTAINER_EXITED {
 		cStatus.Reason = status.Reason

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -1011,6 +1011,7 @@ func (v *podStartVerifier) Verify(event watch.Event) error {
 		}
 
 		defer func() { v.hasTerminated = true }()
+		contextCanceled := t.ExitCode == 128 && t.Reason == "StartError" && strings.Contains(t.Message, "context canceled")
 		switch {
 		case t.ExitCode == 1:
 			// expected
@@ -1024,6 +1025,12 @@ func (v *podStartVerifier) Verify(event watch.Event) error {
 		case t.ExitCode == 128 && (t.Reason == "StartError" || t.Reason == "ContainerCannotRun") && reBug88766.MatchString(t.Message):
 			// pod volume teardown races with container start in CRI, which reports a failure
 			framework.Logf("pod %s on node %s failed with the symptoms of https://github.com/kubernetes/kubernetes/issues/88766", pod.Name, pod.Spec.NodeName)
+		case contextCanceled:
+			// Pod deletion cancelled the in-flight SyncPod, aborting the container start via CRI.
+			// The container should never have been reported as started.
+			if status.Started != nil && *status.Started {
+				return fmt.Errorf("pod %s on node %s container was reported as started despite context cancellation: %#v", pod.Name, pod.Spec.NodeName, status)
+			}
 		default:
 			data, _ := json.MarshalIndent(pod.Status, "", "  ")
 			framework.Logf("pod %s on node %s had incorrect final status:\n%s", pod.Name, pod.Spec.NodeName, string(data))
@@ -1033,8 +1040,8 @@ func (v *podStartVerifier) Verify(event watch.Event) error {
 		case v.duration > time.Hour:
 			// problem with status reporting
 			return fmt.Errorf("pod %s container %s on node %s had very long duration %s: start=%s end=%s", pod.Name, status.Name, pod.Spec.NodeName, v.duration, t.StartedAt, t.FinishedAt)
-		case hasNoStartTime:
-			// should never happen
+		case hasNoStartTime && !contextCanceled:
+			// should never happen unless the container start was cancelled
 			return fmt.Errorf("pod %s container %s on node %s had finish time but not start time: end=%s", pod.Name, status.Name, pod.Spec.NodeName, t.FinishedAt)
 		}
 	}

--- a/test/e2e_node/shortened_grace_period.go
+++ b/test/e2e_node/shortened_grace_period.go
@@ -1,0 +1,79 @@
+//go:build linux
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2enode
+
+import (
+	"context"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = SIGDescribe("Shortened Grace Period", func() {
+	f := framework.NewDefaultFramework("shortened-grace-period")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelBaseline
+	ginkgo.Context("When repeatedly deleting pods", func() {
+		var podClient *e2epod.PodClient
+		ginkgo.BeforeEach(func() {
+			podClient = e2epod.NewPodClient(f)
+		})
+		ginkgo.It("should be deleted immediately", func() {
+			const (
+				gracePeriod      = 10
+				gracePeriodShort = 1
+			)
+			podName := "test"
+			podClient.CreateSync(context.TODO(), getGracePeriodTestPod(podName, gracePeriod))
+			err := podClient.Delete(context.TODO(), podName, *metav1.NewDeleteOptions(gracePeriod))
+			framework.ExpectNoError(err)
+			start := time.Now()
+			podClient.DeleteSync(context.TODO(), podName, *metav1.NewDeleteOptions(gracePeriodShort), gracePeriod*time.Second)
+			gomega.Expect(time.Since(start)).To(gomega.BeNumerically("<", gracePeriod*time.Second))
+		})
+	})
+})
+
+func getGracePeriodTestPod(name string, gracePeriod int64) *v1.Pod {
+	pod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    name,
+					Image:   busyboxImage,
+					Command: []string{"sh", "-c", "999999"},
+				},
+			},
+			TerminationGracePeriodSeconds: &gracePeriod,
+		},
+	}
+	return pod
+}


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
wire the existing context to stop and kill pod, so we catch cases where the pod had a stop period that preempted the old one 

fixes https://github.com/kubernetes/kubernetes/issues/113717 
fixes https://github.com/kubernetes/kubernetes/issues/127339
fixes https://github.com/kubernetes/kubernetes/issues/123872
replaces https://github.com/kubernetes/kubernetes/pull/113882/

claude 4.5 helped
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a bug where the kubelet could not process multiple stops for the same pod. Now, if a pod is sent a kill signal with a grace period that's lower than the previous one, the grace period will be preempted and the pod will respect the lower period.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
