### PR TITLE
add CRUD e2e tests for new EvictionRequest endpoints

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -56,6 +56,7 @@ import (
 	_ "k8s.io/kubernetes/test/e2e/invariants"
 	"k8s.io/kubernetes/test/e2e/invariants/logcheck"
 	_ "k8s.io/kubernetes/test/e2e/kubectl"
+	_ "k8s.io/kubernetes/test/e2e/lifecycle"
 	_ "k8s.io/kubernetes/test/e2e/network"
 	_ "k8s.io/kubernetes/test/e2e/node"
 	_ "k8s.io/kubernetes/test/e2e/scheduling"

--- a/test/e2e/lifecycle/OWNERS
+++ b/test/e2e/lifecycle/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - sig-node-approvers
+  - atiratree
+reviewers:
+  - atiratree
+labels:
+  - sig/node
+  - wg/node-lifecycle

--- a/test/e2e/lifecycle/evictionrequest.go
+++ b/test/e2e/lifecycle/evictionrequest.go
@@ -1,0 +1,113 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"context"
+
+	lifecyclev1alpha1 "k8s.io/api/lifecycle/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2econformance "k8s.io/kubernetes/test/e2e/framework/conformance"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = framework.SIGDescribe("node")("EvictionRequest", framework.WithFeatureGate(features.EvictionRequestAPI), func() {
+	f := framework.NewDefaultFramework("evictionrequest-test")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	f.Context("CRUD Tests", func() {
+		/*
+			Testname: CRUD operations for EvictionRequests
+			Description: kube-apiserver must support create/get/list/update/patch/delete
+			operations for lifecycle.k8s.io/v1alpha1 EvictionRequest.
+		*/
+		framework.It("EvictionRequest API availability", func(ctx context.Context) {
+			e2econformance.TestResource(ctx, f,
+				&e2econformance.ResourceTestcase[*lifecyclev1alpha1.EvictionRequest]{
+					GVR:        lifecyclev1alpha1.SchemeGroupVersion.WithResource("evictionrequests"),
+					Namespaced: new(true),
+					InitialSpec: &lifecyclev1alpha1.EvictionRequest{
+						Spec: lifecyclev1alpha1.EvictionRequestSpec{
+							Target: lifecyclev1alpha1.EvictionRequestTarget{
+								Pod: &lifecyclev1alpha1.EvictionRequestPodReference{
+									Name: "foo",
+									UID:  "b37d123b-8637-4b23-a8f3-41523c344fc2",
+								}},
+							Requester: "foo.example.com/bar",
+							Intent:    lifecyclev1alpha1.EvictionRequestIntentEviction,
+						},
+					},
+					UpdateSpec: func(obj *lifecyclev1alpha1.EvictionRequest) *lifecyclev1alpha1.EvictionRequest {
+						obj.Spec.Intent = lifecyclev1alpha1.EvictionRequestIntentWithdrawn
+						return obj
+					},
+					UpdateStatus: func(obj *lifecyclev1alpha1.EvictionRequest) *lifecyclev1alpha1.EvictionRequest {
+						obj.Status.Conditions = append(obj.Status.Conditions, metav1.Condition{
+							Type:               "FooCondition",
+							Status:             metav1.ConditionFalse,
+							Reason:             "FooReason",
+							Message:            "Test status condition message",
+							LastTransitionTime: metav1.Now(),
+						})
+						return obj
+					},
+					StrategicMergePatchSpec: `{"spec": {"intent": "Withdrawn"}}`,
+				},
+			)
+		})
+
+		/*
+			Testname: CRUD operations for Evictions
+			Description: kube-apiserver must support create/get/list/update/patch/delete
+			operations for lifecycle.k8s.io/v1alpha1 Eviction.
+		*/
+		framework.It("Eviction API availability", func(ctx context.Context) {
+			e2econformance.TestResource(ctx, f,
+				&e2econformance.ResourceTestcase[*lifecyclev1alpha1.Eviction]{
+					GVR:        lifecyclev1alpha1.SchemeGroupVersion.WithResource("evictions"),
+					Namespaced: new(true),
+					InitialSpec: &lifecyclev1alpha1.Eviction{
+						Spec: lifecyclev1alpha1.EvictionSpec{
+							Target: lifecyclev1alpha1.EvictionTarget{
+								Pod: &lifecyclev1alpha1.EvictionPodReference{
+									Name: "foo",
+									UID:  "b37d123b-8637-4b23-a8f3-41523c344fc2",
+								}},
+						},
+					},
+					UpdateSpec: func(obj *lifecyclev1alpha1.Eviction) *lifecyclev1alpha1.Eviction {
+						obj.Labels["foo"] = "bar"
+						return obj
+					},
+					UpdateStatus: func(obj *lifecyclev1alpha1.Eviction) *lifecyclev1alpha1.Eviction {
+						obj.Status.Conditions = append(obj.Status.Conditions, metav1.Condition{
+							Type:               "FooCondition",
+							Status:             metav1.ConditionFalse,
+							Reason:             "FooReason",
+							Message:            "Test status condition message",
+							LastTransitionTime: metav1.Now(),
+						})
+						return obj
+					},
+					StrategicMergePatchSpec: `{"metadata": {"labels": {"foo": "bar"}}}`,
+				},
+			)
+		})
+	})
+})


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Every new API should have e2e test coverage for new endpoints

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes partially https://github.com/kubernetes/kubernetes/issues/140523

https://github.com/kubernetes/kubernetes/issues/140923 reported failing apisnoop-conformance-gate job.

#### Special notes for your reviewer:

More details in https://github.com/kubernetes/kubernetes/issues/140923#issuecomment-5077982646

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
