### PR TITLE
kubelet: account for container rootfs usage on dedicated image filesystems

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -613,9 +613,7 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 
 	for _, containerStat := range podStats.Containers {
 		containerUsed := diskUsage(containerStat.Logs)
-		if !*m.dedicatedImageFs {
-			containerUsed.Add(*diskUsage(containerStat.Rootfs))
-		}
+		containerUsed.Add(*diskUsage(containerStat.Rootfs))
 
 		if ephemeralStorageThreshold, ok := thresholdsMap[containerStat.Name]; ok {
 			if ephemeralStorageThreshold.Cmp(*containerUsed) < 0 {

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -34,6 +34,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	kubeapi "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
@@ -3294,5 +3295,46 @@ func TestContainerEphemeralStorageLimitEvictionForRestartableInitContainers(t *t
 	}
 	if len(evictedPods) != 1 || evictedPods[0].Name != pod.Name {
 		t.Fatalf("Expected evicted pod %q, got %v", pod.Name, evictedPods)
+	}
+}
+
+func TestContainerEphemeralStorageLimitEvictionWithDedicatedImageFs(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	writer := newContainer("writer", newResourceList("", "", ""), newResourceList("", "", "500Mi"))
+	sidecar := newContainer("sidecar", newResourceList("", "", ""), newResourceList("", "", "500Mi"))
+	pod := newPod("container-ephemeral-storage-repro", 0, []v1.Container{writer, sidecar}, nil)
+
+	writerRootfs := resource.MustParse("700Mi")
+	writerRootfsUsed := uint64(writerRootfs.Value())
+	sidecarRootfsUsed := uint64(0)
+	logUsed := uint64(0)
+	podStats := statsapi.PodStats{
+		Containers: []statsapi.ContainerStats{
+			{
+				Name:   "writer",
+				Logs:   &statsapi.FsStats{UsedBytes: &logUsed},
+				Rootfs: &statsapi.FsStats{UsedBytes: &writerRootfsUsed},
+			},
+			{
+				Name:   "sidecar",
+				Logs:   &statsapi.FsStats{UsedBytes: &logUsed},
+				Rootfs: &statsapi.FsStats{UsedBytes: &sidecarRootfsUsed},
+			},
+		},
+	}
+
+	podKiller := &mockPodKiller{}
+	mgr := &managerImpl{
+		killPodFunc:      podKiller.killPodNow,
+		recorder:         &record.FakeRecorder{},
+		dedicatedImageFs: ptr.To(true),
+	}
+
+	if !mgr.containerEphemeralStorageLimitEviction(klog.FromContext(tCtx), podStats, pod) {
+		t.Fatal("Expected pod eviction when a container rootfs exceeds its ephemeral-storage limit")
+	}
+	if podKiller.pod == nil || podKiller.pod.Name != pod.Name {
+		t.Fatalf("Expected pod %q to be evicted, got %v", pod.Name, podKiller.pod)
 	}
 }


### PR DESCRIPTION
## Problem

With `dedicatedImageFs=true`, the container ephemeral-storage limit check omitted writable root filesystem usage. A container could exceed its individual limit without causing Pod eviction.

## Change

Count each container's `Rootfs` usage together with log usage when enforcing its ephemeral-storage limit, regardless of image filesystem layout. The regression test covers a two-container Pod where the writer exceeds its own limit while total usage remains below the combined limits.

## Tests

- `go test ./pkg/kubelet/eviction -count=1` � passed

## Notes

No generated files were changed.

Fixes #139205

```release-note
Fixed kubelet eviction of Pods whose container writable layer exceeds its ephemeral-storage limit when using a dedicated image filesystem.
```