### PR TITLE
storage/ephemeral: reclaim PVCs for rejected Pods

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3369,6 +3369,9 @@ const (
 	PodResizeInProgress PodConditionType = "PodResizeInProgress"
 	// AllContainersRestarting indicates that all containers of the pod is being restarted.
 	AllContainersRestarting PodConditionType = "AllContainersRestarting"
+
+	// PodRejected indicates that the kubelet has rejected the pod during admission.
+	PodRejected PodConditionType = "PodRejected"
 )
 
 // PodCondition represents pod's condition

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -1450,3 +1450,17 @@ func AddOrUpdateLabelsOnNode(kubeClient clientset.Interface, nodeName string, la
 		return nil
 	})
 }
+
+// PodIsRejectedFinished returns true if the kubelet rejected the pod during
+// admission and recorded its terminal status.
+func PodIsRejectedFinished(pod *v1.Pod) bool {
+	if pod.Status.Phase != v1.PodFailed {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == v1.PodRejected && condition.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -1787,3 +1787,39 @@ func TestFilterPodsByOwner(t *testing.T) {
 		})
 	}
 }
+
+func TestPodIsRejectedFinished(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want bool
+	}{
+		{
+			name: "rejected failed pod",
+			pod: &v1.Pod{Status: v1.PodStatus{
+				Phase:      v1.PodFailed,
+				Conditions: []v1.PodCondition{{Type: v1.PodRejected, Status: v1.ConditionTrue}},
+			}},
+			want: true,
+		},
+		{
+			name: "rejected non-terminal pod",
+			pod: &v1.Pod{Status: v1.PodStatus{
+				Phase:      v1.PodPending,
+				Conditions: []v1.PodCondition{{Type: v1.PodRejected, Status: v1.ConditionTrue}},
+			}},
+		},
+		{
+			name: "failed pod without rejection condition",
+			pod:  &v1.Pod{Status: v1.PodStatus{Phase: v1.PodFailed}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := PodIsRejectedFinished(tc.pod); got != tc.want {
+				t.Errorf("PodIsRejectedFinished() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"k8s.io/klog/v2"
+	controllerutil "k8s.io/kubernetes/pkg/controller"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -110,6 +111,7 @@ func NewController(
 		// PVC.
 		// Deletion of the PVC is handled through the owner reference and garbage collection.
 		// Therefore pod deletions also can be ignored.
+		UpdateFunc: ec.updatePod,
 	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, fmt.Errorf("could not add pod event handler: %w", err)
@@ -274,8 +276,16 @@ func (ec *ephemeralController) handleVolume(ctx context.Context, pod *v1.Pod, vo
 		if err := ephemeral.VolumeIsForPod(pod, pvc); err != nil {
 			return err
 		}
+		if controllerutil.PodIsRejectedFinished(pod) {
+			return ec.kubeClient.CoreV1().PersistentVolumeClaims(pod.Namespace).Delete(ctx, pvcName, metav1.DeleteOptions{})
+		}
 		// Already created, nothing more to do.
 		logger.V(5).Info("Ephemeral: PVC already created", "volumeName", vol.Name, "PVC", klog.KObj(pvc))
+		return nil
+	}
+
+	// No need to create PVC
+	if controllerutil.PodIsRejectedFinished(pod) {
 		return nil
 	}
 
@@ -306,4 +316,27 @@ func (ec *ephemeralController) handleVolume(ctx context.Context, pod *v1.Pod, vo
 		return fmt.Errorf("create PVC %s: %v", pvcName, err)
 	}
 	return nil
+}
+
+func (ec *ephemeralController) updatePod(old, new interface{}) {
+	pod, ok := new.(*v1.Pod)
+	if !ok {
+		return
+	}
+	if pod.DeletionTimestamp != nil || !controllerutil.PodIsRejectedFinished(pod) {
+		return
+	}
+
+	for _, vol := range pod.Spec.Volumes {
+		if vol.Ephemeral != nil {
+			// It has at least one ephemeral inline volume, work on it.
+			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(pod)
+			if err != nil {
+				runtime.HandleError(fmt.Errorf("couldn't get key for object %#v: %v", pod, err))
+				return
+			}
+			ec.queue.Add(key)
+			break
+		}
+	}
 }

--- a/pkg/controller/volume/ephemeral/controller_test.go
+++ b/pkg/controller/volume/ephemeral/controller_test.go
@@ -93,6 +93,17 @@ func TestSyncHandler(t *testing.T) {
 			podKey: podKey(testPod),
 		},
 		{
+			name:   "skip rejected pod",
+			pods:   []*v1.Pod{rejectedPod(testPodWithEphemeral)},
+			podKey: podKey(testPodWithEphemeral),
+		},
+		{
+			name:   "delete PVC for rejected pod",
+			pods:   []*v1.Pod{rejectedPod(testPodWithEphemeral)},
+			pvcs:   []*v1.PersistentVolumeClaim{testPodEphemeralClaim},
+			podKey: podKey(testPodWithEphemeral),
+		},
+		{
 			name:            "create-with-other-PVC",
 			pods:            []*v1.Pod{testPodWithEphemeral},
 			podKey:          podKey(testPodWithEphemeral),
@@ -208,6 +219,18 @@ func makePod(name, namespace string, uid types.UID, volumes ...v1.Volume) *v1.Po
 	return pvc
 }
 
+func rejectedPod(pod *v1.Pod) *v1.Pod {
+	pod = pod.DeepCopy()
+	pod.Status = v1.PodStatus{
+		Phase: v1.PodFailed,
+		Conditions: []v1.PodCondition{{
+			Type:   v1.PodRejected,
+			Status: v1.ConditionTrue,
+		}},
+	}
+	return pod
+}
+
 func podKey(pod *v1.Pod) string {
 	key, _ := cache.DeletionHandlingMetaNamespaceKeyFunc(testPodWithEphemeral)
 	return key
@@ -270,4 +293,58 @@ func setupMetrics() {
 	ephemeralvolumemetrics.RegisterMetrics()
 	ephemeralvolumemetrics.EphemeralVolumeCreateAttempts.Reset()
 	ephemeralvolumemetrics.EphemeralVolumeCreateFailures.Reset()
+}
+
+func Test_UpdatePodWithEnableFeature(t *testing.T) {
+	ec := buildController()
+	var pod interface{} = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test_pod",
+			Namespace: "default",
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: "ephemeral_vol",
+					VolumeSource: v1.VolumeSource{
+						Ephemeral: &v1.EphemeralVolumeSource{
+							VolumeClaimTemplate: &v1.PersistentVolumeClaimTemplate{
+								Spec: v1.PersistentVolumeClaimSpec{
+									VolumeName: "ephemeral_vol",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodFailed,
+			Conditions: []v1.PodCondition{
+				{
+					Type:   v1.PodRejected,
+					Status: v1.ConditionTrue,
+				},
+			},
+		},
+	}
+	ec.updatePod(nil, pod)
+	item, _ := ec.queue.Get()
+	if item != "default/test_pod" {
+		t.Errorf("item is incorrect. : %v", item)
+	}
+}
+
+func buildController() *ephemeralController {
+	ctx, cancel := context.WithCancel(context.Background())
+	fakeKubeClient := createTestClient()
+	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
+	defer informerFactory.Shutdown()
+	defer cancel()
+	podInformer := informerFactory.Core().V1().Pods()
+	pvcInformer := informerFactory.Core().V1().PersistentVolumeClaims()
+
+	c, _ := NewController(ctx, fakeKubeClient, podInformer, pvcInformer)
+	ec, _ := c.(*ephemeralController)
+	return ec
 }

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/component-helpers/storage/ephemeral"
 	"k8s.io/klog/v2"
+	controllerutil "k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/util/protectionutil"
 	"k8s.io/kubernetes/pkg/controller/volume/common"
 	"k8s.io/kubernetes/pkg/features"
@@ -512,7 +513,7 @@ func podIsShutDown(pod *v1.Pod) bool {
 	//
 	// Therefore it is better to proceed with PVC removal,
 	// which is safe (case a) and/or desirable (case b).
-	return pod.DeletionTimestamp != nil && pod.DeletionGracePeriodSeconds != nil && *pod.DeletionGracePeriodSeconds == 0
+	return (pod.DeletionTimestamp != nil && pod.DeletionGracePeriodSeconds != nil && *pod.DeletionGracePeriodSeconds == 0) || controllerutil.PodIsRejectedFinished(pod)
 }
 
 // pvcAddedUpdated reacts to pvc added/updated events

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2640,11 +2640,24 @@ func (kl *Kubelet) deletePod(ctx context.Context, pod *v1.Pod) error {
 func (kl *Kubelet) rejectPod(ctx context.Context, pod *v1.Pod, reason, message string) {
 	logger := klog.FromContext(ctx)
 	kl.recorder.WithLogger(logger).Eventf(pod, v1.EventTypeWarning, reason, "%s", message)
-	kl.statusManager.SetPodStatus(logger, pod, v1.PodStatus{
+	podStatus := v1.PodStatus{
 		QOSClass: v1qos.GetPodQOS(pod), // keep it as is
 		Phase:    v1.PodFailed,
 		Reason:   reason,
-		Message:  "Pod was rejected: " + message})
+		Message:  "Pod was rejected: " + message,
+	}
+	addRejectCondition(&podStatus, message)
+	kl.statusManager.SetPodStatus(logger, pod, podStatus)
+}
+
+func addRejectCondition(podStatus *v1.PodStatus, message string) {
+	podStatus.Conditions = []v1.PodCondition{
+		{
+			Type:    v1.PodRejected,
+			Status:  v1.ConditionTrue,
+			Message: "Pod was rejected: " + message,
+		},
+	}
 }
 
 func recordAdmissionRejection(reason string) {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2798,6 +2798,18 @@ func TestHandlePodAdditionsInvokesPodAdmitHandlers(t *testing.T) {
 
 	// Check pod status stored in the status map.
 	checkPodStatus(t, kl, podToReject, v1.PodFailed)
+	status, found := kl.statusManager.GetPodStatus(podToReject.UID)
+	require.True(t, found, "Status of pod %q is not found in the status map", podToReject.UID)
+	var rejectedCondition *v1.PodCondition
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == v1.PodRejected {
+			rejectedCondition = &status.Conditions[i]
+			break
+		}
+	}
+	require.NotNil(t, rejectedCondition)
+	assert.Equal(t, v1.ConditionTrue, rejectedCondition.Status)
+	assert.Equal(t, "Pod was rejected: Pod is rejected", rejectedCondition.Message)
 	checkPodStatus(t, kl, podToAdmit, v1.PodPending)
 }
 

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -969,6 +969,9 @@ func (m *manager) updateStatusInternal(logger klog.Logger, pod *v1.Pod, status v
 	// Set PodScheduledCondition.LastTransitionTime.
 	updateLastTransitionTime(&status, &oldStatus, v1.PodScheduled)
 
+	// Set PodRejectedCondition.LastTransitionTime.
+	updateLastTransitionTime(&status, &oldStatus, v1.PodRejected)
+
 	// Set DisruptionTarget.LastTransitionTime.
 	updateLastTransitionTime(&status, &oldStatus, v1.DisruptionTarget)
 

--- a/pkg/kubelet/types/pod_status.go
+++ b/pkg/kubelet/types/pod_status.go
@@ -30,6 +30,7 @@ var PodConditionsByKubelet = []v1.PodConditionType{
 	v1.ContainersReady,
 	v1.PodResizeInProgress,
 	v1.PodResizePending,
+	v1.PodRejected,
 }
 
 // PodConditionByKubelet returns if the pod condition type is owned by kubelet

--- a/pkg/kubelet/types/pod_status_test.go
+++ b/pkg/kubelet/types/pod_status_test.go
@@ -33,6 +33,7 @@ func TestPodConditionByKubelet(t *testing.T) {
 		v1.PodReady,
 		v1.PodInitialized,
 		v1.ContainersReady,
+		v1.PodRejected,
 		v1.PodReadyToStartContainers,
 	}
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -195,7 +195,7 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 		Rules: []rbacv1.PolicyRule{
 			rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("pods").RuleOrDie(),
 			rbacv1helpers.NewRule("update").Groups(legacyGroup).Resources("pods/finalizers").RuleOrDie(),
-			rbacv1helpers.NewRule("get", "list", "watch", "create").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "watch", "create", "delete").Groups(legacyGroup).Resources("persistentvolumeclaims").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3767,6 +3767,9 @@ const (
 	PodResizeInProgress PodConditionType = "PodResizeInProgress"
 	// AllContainersRestarting indicates that all containers of the pod is being restarted.
 	AllContainersRestarting PodConditionType = "AllContainersRestarting"
+
+	// PodRejected indicates that the kubelet has rejected the pod during admission.
+	PodRejected PodConditionType = "PodRejected"
 )
 
 // These are reasons for a pod's transition to a condition.


### PR DESCRIPTION
Fixes #139915

## Problem

When Kubelet rejects a Pod during admission, the Pod remains Failed while its generated generic ephemeral volume PVC can remain allocated. A workload controller may create a replacement Pod, leaving the rejected Pod's storage allocated.

## Change

Kubelet now records a `PodRejected=True` condition for admission rejections. The ephemeral-volume controller skips PVC creation for rejected Pods and deletes existing generated PVCs; PVC protection allows that cleanup.

## Tests

- `docker run --rm -v "C:\Users\maithi.joshi\Documents\genai\PR_Agent\kubernetes\kubernetes:/workspace" -w /workspace golang:1.26.5 go test ./pkg/controller/volume/ephemeral ./pkg/controller/volume/pvcprotection ./pkg/kubelet/types ./pkg/kubelet -run 'Test(SyncHandler|PodIsRejectedFinished|PodConditionByKubelet|HandlePodAdditionsInvokesPodAdmitHandlers)$' -count=1` — passed

Not run: full integration and end-to-end suites.

```release-note
Generic ephemeral volume PVCs are cleaned up when Kubelet rejects a Pod during admission.
```