### PR TITLE
Speed up preemtion tests by resuing apiserver

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,11 @@ Run `make help` for all available targets. Common workflows:
 
 ```
 make test WHAT=./pkg/kubelet GOFLAGS=-v     # Unit tests (one package)
+
+# Integration tests require etcd. Run hack/install-etcd.sh and set PATH!
+# Example: ./hack/install-etcd.sh && export PATH="${PWD}/third_party/etcd:${PATH}" && make test-integration WHAT=./test/integration/scheduler
 make test-integration WHAT=./test/integration/scheduler
+
 make verify                                 # All verification checks
 make update                                 # ALL generators and formatters
 ```

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1004,129 +1004,136 @@ func TestPreemption(t *testing.T) {
 		testsByWASFeatureGates[key] = append(testsByWASFeatureGates[key], i)
 	}
 
-	for _, asyncPreemptionEnabled := range []bool{true, false} {
-		for _, asyncAPICallsEnabled := range []bool{true, false} {
-			for _, clearingNominatedNodeNameAfterBinding := range []bool{true, false} {
-				for fgKey, testIndexes := range testsByWASFeatureGates {
-					// One API server per full flag combination. All flags including
-					// GenericWorkload and CompositePodGroup are consistent between API server and scheduler.
-					featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-						features.SchedulerAsyncPreemption:              asyncPreemptionEnabled,
-						features.SchedulerAsyncAPICalls:                asyncAPICallsEnabled,
-						features.ClearingNominatedNodeNameAfterBinding: clearingNominatedNodeNameAfterBinding,
-						features.GenericWorkload:                       fgKey.genericWorkloadEnabled,
-						features.CompositePodGroup:                     fgKey.compositePodGroupEnabled,
-						features.TopologyAwareWorkloadScheduling:       fgKey.compositePodGroupEnabled,
-					})
-					sharedAPICtx := testutils.InitTestAPIServer(t, "preemption", nil)
+	// apiserver feature gates
+	for fgKey, testIndexes := range testsByWASFeatureGates {
+		for _, clearingNominatedNodeNameAfterBinding := range []bool{true, false} {
+			t.Run(fmt.Sprintf("APIServer GW=%v CPG=%v clearNomNode=%v", fgKey.genericWorkloadEnabled, fgKey.compositePodGroupEnabled, clearingNominatedNodeNameAfterBinding), func(t *testing.T) {
+				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+					features.GenericWorkload:                       fgKey.genericWorkloadEnabled,
+					features.CompositePodGroup:                     fgKey.compositePodGroupEnabled,
+					features.TopologyAwareWorkloadScheduling:       fgKey.compositePodGroupEnabled,
+					features.ClearingNominatedNodeNameAfterBinding: clearingNominatedNodeNameAfterBinding,
+				})
+				// APIServer initialization is slow. We put APIServer-related feature gates in the outer loops
+				// to avoid restarting the APIServer for every test. Scheduler-only feature gates go in the
+				// inner loops so they can re-use the same running APIServer, preventing test timeouts.
+				sharedAPICtx := testutils.InitTestAPIServer(t, "preemption", nil)
 
-					for _, i := range testIndexes {
-						test := tests[i]
-						t.Run(fmt.Sprintf("%s (Async preemption enabled: %v, Async API calls enabled: %v, ClearingNominatedNodeNameAfterBinding: %v)", test.name, asyncPreemptionEnabled, asyncAPICallsEnabled, clearingNominatedNodeNameAfterBinding), func(t *testing.T) {
-							testCtx := testutils.InitTestSchedulerWithOptions(t,
-								withNewNamespace(t, sharedAPICtx, "preemption"),
-								0,
-								scheduler.WithProfiles(cfg.Profiles...),
-								scheduler.WithFrameworkOutOfTreeRegistry(registry))
-							testutils.SyncSchedulerInformerFactory(testCtx)
-							go testCtx.Scheduler.Run(testCtx.SchedulerCtx)
-							defer testCtx.SchedulerCloseFn()
+				// scheduler feature gates
+				for _, asyncPreemptionEnabled := range []bool{true, false} {
+					for _, asyncAPICallsEnabled := range []bool{true, false} {
+						for _, i := range testIndexes {
+							test := tests[i]
+							t.Run(fmt.Sprintf("%s asyncPr=%v asyncAPI=%v", test.name, asyncPreemptionEnabled, asyncAPICallsEnabled), func(t *testing.T) {
+								featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+									features.SchedulerAsyncPreemption: asyncPreemptionEnabled,
+									features.SchedulerAsyncAPICalls:   asyncAPICallsEnabled,
+								})
+								testCtx := testutils.InitTestSchedulerWithOptions(t,
+									withNewNamespace(t, sharedAPICtx, "preemption"),
+									0,
+									scheduler.WithProfiles(cfg.Profiles...),
+									scheduler.WithFrameworkOutOfTreeRegistry(registry))
+								testutils.SyncSchedulerInformerFactory(testCtx)
+								go testCtx.Scheduler.Run(testCtx.SchedulerCtx)
+								defer testCtx.SchedulerCloseFn()
 
-							if _, err := createNode(testCtx.ClientSet, nodeObject); err != nil {
-								t.Fatalf("Error creating node: %v", err)
-							}
-							t.Cleanup(func() {
-								if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, nodeObject.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-									t.Errorf("Error deleting node %s: %v", nodeObject.Name, err)
+								if _, err := createNode(testCtx.ClientSet, nodeObject); err != nil {
+									t.Fatalf("Error creating node: %v", err)
 								}
-							})
-							for _, n := range test.extraNodes {
-								if _, err := createNode(testCtx.ClientSet, n); err != nil {
-									t.Fatalf("Error creating extra node %s: %v", n.Name, err)
-								}
-								n := n
 								t.Cleanup(func() {
-									if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, n.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-										t.Errorf("Error deleting node %s: %v", n.Name, err)
+									if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, nodeObject.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+										t.Errorf("Error deleting node %s: %v", nodeObject.Name, err)
 									}
 								})
-							}
-
-							cs := testCtx.ClientSet
-							ns := testCtx.NS.Name
-
-							for _, cpg := range test.compositePodGroups {
-								cpg.Namespace = ns
-								if _, err := cs.SchedulingV1alpha3().CompositePodGroups(ns).Create(testCtx.Ctx, cpg, metav1.CreateOptions{}); err != nil {
-									t.Fatalf("Error creating CompositePodGroup %s: %v", cpg.Name, err)
+								for _, n := range test.extraNodes {
+									if _, err := createNode(testCtx.ClientSet, n); err != nil {
+										t.Fatalf("Error creating extra node %s: %v", n.Name, err)
+									}
+									n := n
+									t.Cleanup(func() {
+										if err := testCtx.ClientSet.CoreV1().Nodes().Delete(testCtx.Ctx, n.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+											t.Errorf("Error deleting node %s: %v", n.Name, err)
+										}
+									})
 								}
-							}
 
-							for _, pg := range test.podGroups {
-								pg.Namespace = ns
-								if _, err := cs.SchedulingV1beta1().PodGroups(ns).Create(testCtx.Ctx, pg, metav1.CreateOptions{}); err != nil {
-									t.Fatalf("Error creating PodGroup %s: %v", pg.Name, err)
+								cs := testCtx.ClientSet
+								ns := testCtx.NS.Name
+
+								for _, cpg := range test.compositePodGroups {
+									cpg.Namespace = ns
+									if _, err := cs.SchedulingV1alpha3().CompositePodGroups(ns).Create(testCtx.Ctx, cpg, metav1.CreateOptions{}); err != nil {
+										t.Fatalf("Error creating CompositePodGroup %s: %v", cpg.Name, err)
+									}
 								}
-							}
 
-							filter.Tokens = test.initTokens
-							filter.EnablePreFilter = test.enablePreFilter
-							filter.Unresolvable = test.unresolvable
-							pods := make([]*v1.Pod, len(test.existingPods))
-							// Create and run existingPods.
-							for i, p := range test.existingPods {
-								p.Namespace = ns
-								pods[i], err = runPausePod(cs, p)
+								for _, pg := range test.podGroups {
+									pg.Namespace = ns
+									if _, err := cs.SchedulingV1beta1().PodGroups(ns).Create(testCtx.Ctx, pg, metav1.CreateOptions{}); err != nil {
+										t.Fatalf("Error creating PodGroup %s: %v", pg.Name, err)
+									}
+								}
+
+								filter.Tokens = test.initTokens
+								filter.EnablePreFilter = test.enablePreFilter
+								filter.Unresolvable = test.unresolvable
+								pods := make([]*v1.Pod, len(test.existingPods))
+								// Create and run existingPods.
+								for i, p := range test.existingPods {
+									p.Namespace = ns
+									pods[i], err = runPausePod(cs, p)
+									if err != nil {
+										t.Fatalf("Error running pause pod: %v", err)
+									}
+								}
+								// Create the "pod".
+								test.pod.Namespace = ns
+								preemptor, err := createPausePod(cs, test.pod)
 								if err != nil {
-									t.Fatalf("Error running pause pod: %v", err)
+									t.Errorf("Error while creating high priority pod: %v", err)
 								}
-							}
-							// Create the "pod".
-							test.pod.Namespace = ns
-							preemptor, err := createPausePod(cs, test.pod)
-							if err != nil {
-								t.Errorf("Error while creating high priority pod: %v", err)
-							}
-							// Wait for preemption of pods and make sure the other ones are not preempted.
-							for i, p := range pods {
-								if _, found := test.preemptedPodIndexes[i]; found {
-									if err = wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false,
-										podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
-										t.Errorf("Pod %v/%v is not getting evicted.", p.Namespace, p.Name)
-									}
-									pod, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
-									if err != nil {
-										t.Errorf("Error %v when getting the updated status for pod %v/%v ", err, p.Namespace, p.Name)
-									}
-									_, cond := podutil.GetPodCondition(&pod.Status, v1.DisruptionTarget)
-									if cond == nil {
-										t.Errorf("Pod %q does not have the expected condition: %q", klog.KObj(pod), v1.DisruptionTarget)
-									}
-								} else {
-									// Re-fetch to get current state; the pod object from runPausePod
-									// always has DeletionTimestamp=nil and cannot detect unexpected eviction.
-									current, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
-									if err != nil {
-										t.Errorf("Error getting pod %v: %v", p.Name, err)
-									} else if current.DeletionTimestamp != nil {
-										t.Errorf("Pod %v was unexpectedly preempted", p.Name)
+								// Wait for preemption of pods and make sure the other ones are not preempted.
+								for i, p := range pods {
+									if _, found := test.preemptedPodIndexes[i]; found {
+										if err = wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false,
+											podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
+											t.Errorf("Pod %v/%v is not getting evicted.", p.Namespace, p.Name)
+										}
+										pod, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
+										if err != nil {
+											t.Errorf("Error %v when getting the updated status for pod %v/%v ", err, p.Namespace, p.Name)
+										}
+										_, cond := podutil.GetPodCondition(&pod.Status, v1.DisruptionTarget)
+										if cond == nil {
+											t.Errorf("Pod %q does not have the expected condition: %q", klog.KObj(pod), v1.DisruptionTarget)
+										}
+									} else {
+										// Re-fetch to get current state; the pod object from runPausePod
+										// always has DeletionTimestamp=nil and cannot detect unexpected eviction.
+										current, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
+										if err != nil {
+											t.Errorf("Error getting pod %v: %v", p.Name, err)
+										} else if current.DeletionTimestamp != nil {
+											t.Errorf("Pod %v was unexpectedly preempted", p.Name)
+										}
 									}
 								}
-							}
-							// Also check that the preemptor pod gets the NominatedNodeName field set.
-							if len(test.preemptedPodIndexes) > 0 && !clearingNominatedNodeNameAfterBinding {
-								if err := testutils.WaitForNominatedNodeName(testCtx.Ctx, cs, preemptor); err != nil {
-									t.Errorf("NominatedNodeName field was not set for pod %v: %v", preemptor.Name, err)
+								// Also check that the preemptor pod gets the NominatedNodeName field set.
+								if len(test.preemptedPodIndexes) > 0 && !clearingNominatedNodeNameAfterBinding {
+									if err := testutils.WaitForNominatedNodeName(testCtx.Ctx, cs, preemptor); err != nil {
+										t.Errorf("NominatedNodeName field was not set for pod %v: %v", preemptor.Name, err)
+									}
 								}
-							}
 
-							// Cleanup
-							pods = append(pods, preemptor)
-							testutils.CleanupPods(testCtx.Ctx, cs, t, pods)
-						})
+								// Cleanup
+								pods = append(pods, preemptor)
+								testutils.CleanupPods(testCtx.Ctx, cs, t, pods)
+							})
+						}
 					}
 				}
-			}
+			}) // close t.Run("APIServer...")
 		}
 	}
 }
@@ -3027,6 +3034,7 @@ func TestInterPodAffinityPreemption(t *testing.T) {
 		},
 	}
 
+	// apiserver feature gates
 	for _, clearingNominatedNodeNameAfterBinding := range []bool{true, false} {
 		for _, genericOpts := range []struct{ genericWorkloadEnabled, cpgEnabled bool }{
 			{genericWorkloadEnabled: true, cpgEnabled: true},
@@ -3035,191 +3043,192 @@ func TestInterPodAffinityPreemption(t *testing.T) {
 		} {
 			genericWorkloadEnabled := genericOpts.genericWorkloadEnabled
 			cpgEnabled := genericOpts.cpgEnabled
-			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-				features.GenericWorkload:                       genericWorkloadEnabled,
-				features.CompositePodGroup:                     cpgEnabled,
-				features.TopologyAwareWorkloadScheduling:       cpgEnabled,
-				features.ClearingNominatedNodeNameAfterBinding: clearingNominatedNodeNameAfterBinding,
-			})
-			sharedAPICtx := testutils.InitTestAPIServer(t, "preemption", nil)
+			t.Run(fmt.Sprintf("APIServer GW=%v CPG=%v clearNomNode=%v", genericWorkloadEnabled, cpgEnabled, clearingNominatedNodeNameAfterBinding), func(t *testing.T) {
+				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+					features.GenericWorkload:                       genericWorkloadEnabled,
+					features.CompositePodGroup:                     cpgEnabled,
+					features.TopologyAwareWorkloadScheduling:       cpgEnabled,
+					features.ClearingNominatedNodeNameAfterBinding: clearingNominatedNodeNameAfterBinding,
+				})
+				// APIServer initialization is slow. We put APIServer-related feature gates in the outer loops
+				// to avoid restarting the APIServer for every test. Scheduler-only feature gates go in the
+				// inner loops so they can re-use the same running APIServer, preventing test timeouts.
+				sharedAPICtx := testutils.InitTestAPIServer(t, "preemption", nil)
 
-			for _, asyncPreemptionEnabled := range []bool{true, false} {
-				for _, fpEnabled := range []bool{true, false} {
-					for _, test := range tests {
-						nameSuffix := fmt.Sprintf("Async preemption enabled: %v, ClearingNominatedNodeNameAfterBinding: %v, fpEnabled: %v, genericWorkloadEnabled: %v, cpgEnabled: %v", asyncPreemptionEnabled, clearingNominatedNodeNameAfterBinding, fpEnabled, genericWorkloadEnabled, cpgEnabled)
-						t.Run(fmt.Sprintf("%s (%s)", test.name, nameSuffix), func(t *testing.T) {
-							// Feature gates map to test combinations.
-							featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-								features.SchedulerAsyncPreemption:              asyncPreemptionEnabled,
-								features.ClearingNominatedNodeNameAfterBinding: clearingNominatedNodeNameAfterBinding,
-								features.InterPodAffinityHostnameFastPath:      fpEnabled,
-								features.GenericWorkload:                       genericWorkloadEnabled,
-								features.CompositePodGroup:                     cpgEnabled,
-								features.TopologyAwareWorkloadScheduling:       cpgEnabled,
-							})
+				// scheduler feature gates
+				for _, asyncPreemptionEnabled := range []bool{true, false} {
+					for _, fpEnabled := range []bool{true, false} {
+						for _, test := range tests {
+							nameSuffix := fmt.Sprintf("Async preemption enabled: %v, ClearingNominatedNodeNameAfterBinding: %v, fpEnabled: %v, genericWorkloadEnabled: %v, cpgEnabled: %v", asyncPreemptionEnabled, clearingNominatedNodeNameAfterBinding, fpEnabled, genericWorkloadEnabled, cpgEnabled)
+							t.Run(fmt.Sprintf("%s (%s)", test.name, nameSuffix), func(t *testing.T) {
+								featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+									features.SchedulerAsyncPreemption:         asyncPreemptionEnabled,
+									features.InterPodAffinityHostnameFastPath: fpEnabled,
+								})
 
-							var filter tokenFilter
-							registry := make(frameworkruntime.Registry)
-							err := registry.Register(filterPluginName, func(_ context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
-								return &filter, nil
-							})
-							if err != nil {
-								t.Fatalf("Error registering a filter: %v", err)
-							}
-
-							cfg := configtesting.V1ToInternalWithDefaults(t, configv1.KubeSchedulerConfiguration{
-								Profiles: []configv1.KubeSchedulerProfile{{
-									SchedulerName: ptr.To(v1.DefaultSchedulerName),
-									Plugins: &configv1.Plugins{
-										Filter: configv1.PluginSet{
-											Enabled: []configv1.Plugin{
-												{Name: filterPluginName},
-											},
-										},
-										PreFilter: configv1.PluginSet{
-											Enabled: []configv1.Plugin{
-												{Name: filterPluginName},
-											},
-										},
-									},
-								}},
-							})
-
-							testCtx := testutils.InitTestSchedulerWithOptions(t,
-								withNewNamespace(t, sharedAPICtx, "preemption"),
-								0,
-								scheduler.WithProfiles(cfg.Profiles...),
-								scheduler.WithFrameworkOutOfTreeRegistry(registry),
-								// disable backoff
-								scheduler.WithPodMaxBackoffSeconds(0),
-								scheduler.WithPodInitialBackoffSeconds(0),
-							)
-							defer testCtx.SchedulerCloseFn()
-							testutils.SyncSchedulerInformerFactory(testCtx)
-
-							cs := testCtx.ClientSet
-
-							logger, _ := ktesting.NewTestContext(t)
-							if testCtx.Scheduler.APIDispatcher != nil {
-								testCtx.Scheduler.APIDispatcher.Run(logger)
-								defer testCtx.Scheduler.APIDispatcher.Close()
-							}
-							testCtx.Scheduler.SchedulingQueue.Run(logger)
-							defer testCtx.Scheduler.SchedulingQueue.Close()
-
-							ctx, cancel := context.WithCancel(context.Background())
-							defer cancel()
-							defer testCtx.SchedulerCloseFn()
-
-							// Create a node with some resources and a label.
-							nodeRes := map[v1.ResourceName]string{
-								v1.ResourcePods:   "32",
-								v1.ResourceCPU:    "500m",
-								v1.ResourceMemory: "500",
-							}
-							nodeObject := st.MakeNode().Name("node1").Capacity(nodeRes).Label("node", "node1").Label(v1.LabelHostname, "node1").Obj()
-
-							if _, err := cs.CoreV1().Nodes().Create(ctx, nodeObject, metav1.CreateOptions{}); err != nil {
-								t.Fatalf("Failed to create an initial Node %q: %v", nodeObject.Name, err)
-							}
-							defer func() {
-								if err := cs.CoreV1().Nodes().Delete(ctx, nodeObject.Name, metav1.DeleteOptions{}); err != nil {
-									t.Fatalf("Failed to delete the Node %q: %v", nodeObject.Name, err)
+								var filter tokenFilter
+								registry := make(frameworkruntime.Registry)
+								err := registry.Register(filterPluginName, func(_ context.Context, _ runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
+									return &filter, nil
+								})
+								if err != nil {
+									t.Fatalf("Error registering a filter: %v", err)
 								}
-							}()
 
-							filter.Tokens = test.initTokens
-							filter.EnablePreFilter = test.enablePreFilter
-							filter.Unresolvable = test.unresolvable
+								cfg := configtesting.V1ToInternalWithDefaults(t, configv1.KubeSchedulerConfiguration{
+									Profiles: []configv1.KubeSchedulerProfile{{
+										SchedulerName: ptr.To(v1.DefaultSchedulerName),
+										Plugins: &configv1.Plugins{
+											Filter: configv1.PluginSet{
+												Enabled: []configv1.Plugin{
+													{Name: filterPluginName},
+												},
+											},
+											PreFilter: configv1.PluginSet{
+												Enabled: []configv1.Plugin{
+													{Name: filterPluginName},
+												},
+											},
+										},
+									}},
+								})
 
-							var createdPods []*v1.Pod
-							defer func() {
-								testutils.CleanupPods(testCtx.Ctx, cs, t, createdPods)
-							}()
+								testCtx := testutils.InitTestSchedulerWithOptions(t,
+									withNewNamespace(t, sharedAPICtx, "preemption"),
+									0,
+									scheduler.WithProfiles(cfg.Profiles...),
+									scheduler.WithFrameworkOutOfTreeRegistry(registry),
+									// disable backoff
+									scheduler.WithPodMaxBackoffSeconds(0),
+									scheduler.WithPodInitialBackoffSeconds(0),
+								)
+								defer testCtx.SchedulerCloseFn()
+								testutils.SyncSchedulerInformerFactory(testCtx)
 
-							for _, scenario := range test.scenarios {
-								t.Logf("Running scenario: %s", scenario.name)
-								switch {
-								case scenario.createNode != "":
-									newNode := st.MakeNode().Name(scenario.createNode).Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj()
-									if _, err := cs.CoreV1().Nodes().Create(ctx, newNode, metav1.CreateOptions{}); err != nil {
-										t.Fatalf("Failed to create an initial Node %q: %v", newNode.Name, err)
+								cs := testCtx.ClientSet
+
+								logger, _ := ktesting.NewTestContext(t)
+								if testCtx.Scheduler.APIDispatcher != nil {
+									testCtx.Scheduler.APIDispatcher.Run(logger)
+									defer testCtx.Scheduler.APIDispatcher.Close()
+								}
+								testCtx.Scheduler.SchedulingQueue.Run(logger)
+								defer testCtx.Scheduler.SchedulingQueue.Close()
+
+								ctx, cancel := context.WithCancel(context.Background())
+								defer cancel()
+								defer testCtx.SchedulerCloseFn()
+
+								// Create a node with some resources and a label.
+								nodeRes := map[v1.ResourceName]string{
+									v1.ResourcePods:   "32",
+									v1.ResourceCPU:    "500m",
+									v1.ResourceMemory: "500",
+								}
+								nodeObject := st.MakeNode().Name("node1").Capacity(nodeRes).Label("node", "node1").Label(v1.LabelHostname, "node1").Obj()
+
+								if _, err := cs.CoreV1().Nodes().Create(ctx, nodeObject, metav1.CreateOptions{}); err != nil {
+									t.Fatalf("Failed to create an initial Node %q: %v", nodeObject.Name, err)
+								}
+								defer func() {
+									if err := cs.CoreV1().Nodes().Delete(ctx, nodeObject.Name, metav1.DeleteOptions{}); err != nil {
+										t.Fatalf("Failed to delete the Node %q: %v", nodeObject.Name, err)
 									}
-									defer func() {
-										if err := cs.CoreV1().Nodes().Delete(ctx, newNode.Name, metav1.DeleteOptions{}); err != nil {
-											t.Fatalf("Failed to delete the Node %q: %v", newNode.Name, err)
-										}
-									}()
-								case scenario.createPod != nil:
-									pod, err := cs.CoreV1().Pods(testCtx.NS.Name).Create(ctx, scenario.createPod.pod, metav1.CreateOptions{})
-									if err != nil {
-										t.Fatalf("Failed to create a Pod %q: %v", pod.Name, err)
-									}
-									createdPods = append(createdPods, pod)
-								case scenario.schedulePod != nil:
-									lastFailure := ""
-									if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
-										if len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()) == 0 {
-											lastFailure = fmt.Sprintf("Expected the pod %s to be scheduled, but no pod arrives at the activeQ", scenario.schedulePod.podName)
-											return false, nil
-										}
+								}()
 
-										if testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()[0].Name != scenario.schedulePod.podName {
-											// need to wait more because maybe the queue will get another Pod that higher priority than the current top pod.
-											lastFailure = fmt.Sprintf("The pod %s is expected to be scheduled, but the top Pod is %s", scenario.schedulePod.podName, testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()[0].Name)
-											return false, nil
-										}
+								filter.Tokens = test.initTokens
+								filter.EnablePreFilter = test.enablePreFilter
+								filter.Unresolvable = test.unresolvable
 
-										return true, nil
-									}); err != nil {
-										t.Fatal(lastFailure)
-									}
+								var createdPods []*v1.Pod
+								defer func() {
+									testutils.CleanupPods(testCtx.Ctx, cs, t, createdPods)
+								}()
 
-									testCtx.Scheduler.ScheduleOne(testCtx.Ctx)
-
-									if scenario.schedulePod.expectSuccess {
-										if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, testCtx.NS.Name, scenario.schedulePod.podName)); err != nil {
-											t.Fatalf("Expected the pod %s to be scheduled", scenario.schedulePod.podName)
+								for _, scenario := range test.scenarios {
+									t.Logf("Running scenario: %s", scenario.name)
+									switch {
+									case scenario.createNode != "":
+										newNode := st.MakeNode().Name(scenario.createNode).Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj()
+										if _, err := cs.CoreV1().Nodes().Create(ctx, newNode, metav1.CreateOptions{}); err != nil {
+											t.Fatalf("Failed to create an initial Node %q: %v", newNode.Name, err)
 										}
-									} else if scenario.schedulePod.expectUnschedulable {
-										if !podInUnschedulablePodPool(t, testCtx.Scheduler.SchedulingQueue, scenario.schedulePod.podName) {
-											t.Fatalf("Expected the pod %s to be in the unschedulable queue after the scheduling attempt", scenario.schedulePod.podName)
-										}
-									}
-								case scenario.verifyPodDeleted != "":
-									if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodDeleted(testCtx.Ctx, cs, testCtx.NS.Name, scenario.verifyPodDeleted)); err != nil {
-										t.Fatalf("Failed to wait for pod %s to be deleted: %v", scenario.verifyPodDeleted, err)
-									}
-								case scenario.verifyPodNotDeleted != "":
-									// Wait a small bit to ensure it doesn't get evicted!
-									time.Sleep(200 * time.Millisecond)
-									p, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, scenario.verifyPodNotDeleted, metav1.GetOptions{})
-									if err != nil {
-										t.Errorf("Error getting pod %v: %v", scenario.verifyPodNotDeleted, err)
-									} else if p.DeletionTimestamp != nil {
-										t.Errorf("Pod %v was unexpectedly preempted", p.Name)
-									} else {
-										_, cond := podutil.GetPodCondition(&p.Status, v1.DisruptionTarget)
-										if cond != nil {
-											t.Errorf("Pod %q was evicted unexpectedly.", klog.KObj(p))
-										}
-									}
-								case scenario.waitForNominated != "":
-									if !clearingNominatedNodeNameAfterBinding {
-										preemptor, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, scenario.waitForNominated, metav1.GetOptions{})
+										defer func() {
+											if err := cs.CoreV1().Nodes().Delete(ctx, newNode.Name, metav1.DeleteOptions{}); err != nil {
+												t.Fatalf("Failed to delete the Node %q: %v", newNode.Name, err)
+											}
+										}()
+									case scenario.createPod != nil:
+										pod, err := cs.CoreV1().Pods(testCtx.NS.Name).Create(ctx, scenario.createPod.pod, metav1.CreateOptions{})
 										if err != nil {
-											t.Fatalf("Failed to get preemptor pod: %v", err)
+											t.Fatalf("Failed to create a Pod %q: %v", pod.Name, err)
 										}
-										if err := testutils.WaitForNominatedNodeName(testCtx.Ctx, cs, preemptor); err != nil {
-											t.Errorf("NominatedNodeName field was not set for pod %v: %v", preemptor.Name, err)
+										createdPods = append(createdPods, pod)
+									case scenario.schedulePod != nil:
+										lastFailure := ""
+										if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+											if len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()) == 0 {
+												lastFailure = fmt.Sprintf("Expected the pod %s to be scheduled, but no pod arrives at the activeQ", scenario.schedulePod.podName)
+												return false, nil
+											}
+
+											if testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()[0].Name != scenario.schedulePod.podName {
+												// need to wait more because maybe the queue will get another Pod that higher priority than the current top pod.
+												lastFailure = fmt.Sprintf("The pod %s is expected to be scheduled, but the top Pod is %s", scenario.schedulePod.podName, testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()[0].Name)
+												return false, nil
+											}
+
+											return true, nil
+										}); err != nil {
+											t.Fatal(lastFailure)
+										}
+
+										testCtx.Scheduler.ScheduleOne(testCtx.Ctx)
+
+										if scenario.schedulePod.expectSuccess {
+											if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, testCtx.NS.Name, scenario.schedulePod.podName)); err != nil {
+												t.Fatalf("Expected the pod %s to be scheduled", scenario.schedulePod.podName)
+											}
+										} else if scenario.schedulePod.expectUnschedulable {
+											if !podInUnschedulablePodPool(t, testCtx.Scheduler.SchedulingQueue, scenario.schedulePod.podName) {
+												t.Fatalf("Expected the pod %s to be in the unschedulable queue after the scheduling attempt", scenario.schedulePod.podName)
+											}
+										}
+									case scenario.verifyPodDeleted != "":
+										if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodDeleted(testCtx.Ctx, cs, testCtx.NS.Name, scenario.verifyPodDeleted)); err != nil {
+											t.Fatalf("Failed to wait for pod %s to be deleted: %v", scenario.verifyPodDeleted, err)
+										}
+									case scenario.verifyPodNotDeleted != "":
+										// Wait a small bit to ensure it doesn't get evicted!
+										time.Sleep(200 * time.Millisecond)
+										p, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, scenario.verifyPodNotDeleted, metav1.GetOptions{})
+										if err != nil {
+											t.Errorf("Error getting pod %v: %v", scenario.verifyPodNotDeleted, err)
+										} else if p.DeletionTimestamp != nil {
+											t.Errorf("Pod %v was unexpectedly preempted", p.Name)
+										} else {
+											_, cond := podutil.GetPodCondition(&p.Status, v1.DisruptionTarget)
+											if cond != nil {
+												t.Errorf("Pod %q was evicted unexpectedly.", klog.KObj(p))
+											}
+										}
+									case scenario.waitForNominated != "":
+										if !clearingNominatedNodeNameAfterBinding {
+											preemptor, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(testCtx.Ctx, scenario.waitForNominated, metav1.GetOptions{})
+											if err != nil {
+												t.Fatalf("Failed to get preemptor pod: %v", err)
+											}
+											if err := testutils.WaitForNominatedNodeName(testCtx.Ctx, cs, preemptor); err != nil {
+												t.Errorf("NominatedNodeName field was not set for pod %v: %v", preemptor.Name, err)
+											}
 										}
 									}
 								}
-							}
-						})
+							})
+						}
 					}
 				}
-			}
+			})
 		}
 	}
 }

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -1075,7 +1075,6 @@ func TestPreemption(t *testing.T) {
 									}
 								}
 
-								filter.Tokens = test.initTokens
 								filter.EnablePreFilter = test.enablePreFilter
 								filter.Unresolvable = test.unresolvable
 								pods := make([]*v1.Pod, len(test.existingPods))
@@ -1096,7 +1095,7 @@ func TestPreemption(t *testing.T) {
 								// Wait for preemption of pods and make sure the other ones are not preempted.
 								for i, p := range pods {
 									if _, found := test.preemptedPodIndexes[i]; found {
-										if err = wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false,
+										if err = wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false,
 											podIsGettingEvicted(cs, p.Namespace, p.Name)); err != nil {
 											t.Errorf("Pod %v/%v is not getting evicted.", p.Namespace, p.Name)
 										}
@@ -2125,7 +2124,7 @@ func TestAsyncPreemption(t *testing.T) {
 						}
 					case scenario.schedulePod != nil:
 						lastFailure := ""
-						if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+						if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 							if len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()) == 0 {
 								lastFailure = fmt.Sprintf("Expected the pod %s to be scheduled, but no pod arrives at the activeQ", scenario.schedulePod.podName)
 								return false, nil
@@ -2148,7 +2147,7 @@ func TestAsyncPreemption(t *testing.T) {
 						testCtx.Scheduler.ScheduleOne(testCtx.Ctx)
 
 						if scenario.schedulePod.expectSuccess {
-							if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, testCtx.NS.Name, scenario.schedulePod.podName)); err != nil {
+							if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, testCtx.NS.Name, scenario.schedulePod.podName)); err != nil {
 								t.Fatalf("Expected the pod %s to be scheduled", scenario.schedulePod.podName)
 							}
 						} else if scenario.schedulePod.expectUnschedulable {
@@ -2188,7 +2187,7 @@ func TestAsyncPreemption(t *testing.T) {
 							t.Fatalf("Expected the pod %s to be gated", scenario.podGatedInQueue)
 						}
 					case scenario.podRunningPreemption != nil:
-						if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+						if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 							return preemptionPlugin.Executor.IsPodRunningPreemption(createdPods[*scenario.podRunningPreemption].GetUID()), nil
 						}); err != nil {
 							t.Fatalf("Expected the pod %s to be running preemption", createdPods[*scenario.podRunningPreemption].Name)
@@ -2510,7 +2509,7 @@ func TestPreemptionRespectsWaitingPod(t *testing.T) {
 	case <-time.After(wait.ForeverTestTimeout):
 		t.Fatalf("Timed out waiting for victim to reach WaitOnPermit")
 	}
-	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		return testCtx.Scheduler.Profiles[v1.DefaultSchedulerName].GetWaitingPod(victim.UID) != nil, nil
 	}); err != nil {
 		t.Fatalf("Timed out waiting for victim to be recorded as a waiting pod: %v", err)
@@ -2538,7 +2537,7 @@ func TestPreemptionRespectsWaitingPod(t *testing.T) {
 	// The victim should NOT be deleted from API server.
 	// Instead the victim  should go to the backoff queue and get rescheduled eventually.
 	t.Logf("Waiting for preemptor to be scheduled")
-	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 15*time.Second, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, 15*time.Second, false, func(ctx context.Context) (bool, error) {
 		// Ensure that victim is not deleted
 		_, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(ctx, victim.Name, metav1.GetOptions{})
 		if err != nil {
@@ -2562,7 +2561,7 @@ func TestPreemptionRespectsWaitingPod(t *testing.T) {
 	}
 
 	t.Logf("waiting for victim to be rescheduled")
-	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 15*time.Second, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, 15*time.Second, false, func(ctx context.Context) (bool, error) {
 		v, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(ctx, victim.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -2749,7 +2748,7 @@ func TestPreemptionRespectsBindingPod(t *testing.T) {
 	// It should call CancelPod() on the victim's BindingPod, causing it to go to backoff queue.
 	// The victim pod should NOT be deleted from API server.
 	// Instead it should be rescheduled onto a smaller node.
-	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 		// Check if victim is deleted
 		v, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(ctx, victim.Name, metav1.GetOptions{})
 		if err != nil {
@@ -2770,7 +2769,7 @@ func TestPreemptionRespectsBindingPod(t *testing.T) {
 	}
 
 	// 5. Wait for preemptor to be scheduled.
-	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
 		p, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(ctx, preemptor.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -3166,7 +3165,7 @@ func TestInterPodAffinityPreemption(t *testing.T) {
 										createdPods = append(createdPods, pod)
 									case scenario.schedulePod != nil:
 										lastFailure := ""
-										if err := wait.PollUntilContextTimeout(testCtx.Ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+										if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 											if len(testCtx.Scheduler.SchedulingQueue.PodsInActiveQ()) == 0 {
 												lastFailure = fmt.Sprintf("Expected the pod %s to be scheduled, but no pod arrives at the activeQ", scenario.schedulePod.podName)
 												return false, nil
@@ -3186,7 +3185,7 @@ func TestInterPodAffinityPreemption(t *testing.T) {
 										testCtx.Scheduler.ScheduleOne(testCtx.Ctx)
 
 										if scenario.schedulePod.expectSuccess {
-											if err := wait.PollUntilContextTimeout(testCtx.Ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, testCtx.NS.Name, scenario.schedulePod.podName)); err != nil {
+											if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, testutils.PodScheduled(cs, testCtx.NS.Name, scenario.schedulePod.podName)); err != nil {
 												t.Fatalf("Expected the pod %s to be scheduled", scenario.schedulePod.podName)
 											}
 										} else if scenario.schedulePod.expectUnschedulable {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

 This first commit puts apiserver-related feature gates in the outer loops, then initializes apiserver, then runs loops over scheduler-only feature gates. Since apiserver initialization is slow, reusing the same apiserver makes the suite faster and prevents timeout. 

The second commit tightens polling intervals from 200ms to 50ms. 
				

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:
This makes the tests ~100s faster on my machine: 
`DONE 313 tests in 474.763s`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
