### PR TITLE
test: make eviction status update timestamps deterministic on Windows

### DIFF
--- a/pkg/apis/lifecycle/validation/validation_test.go
+++ b/pkg/apis/lifecycle/validation/validation_test.go
@@ -440,7 +440,7 @@ func TestValidateEvictionStatusUpdate(t *testing.T) {
 		},
 		// Full Eviction progression/lifecycle
 		"mark active and started": {
-			oldInput: mkValidEvictionStatus(2),
+			oldInput: mkValidEvictionStatus(2, setRespondersStartTime(clockBefore(time.Second), 0, 1)),
 			input: mkValidEvictionStatus(2,
 				setStateFor(lifecycle.ResponderStateActive, 0),
 				setRespondersStartTime(clock, 0, 1)),

--- a/pkg/apis/lifecycle/validation/validation_test.go
+++ b/pkg/apis/lifecycle/validation/validation_test.go
@@ -440,7 +440,7 @@ func TestValidateEvictionStatusUpdate(t *testing.T) {
 		},
 		// Full Eviction progression/lifecycle
 		"mark active and started": {
-			oldInput: mkValidEvictionStatus(0),
+			oldInput: mkValidEvictionStatus(2, setRespondersStartTime(clockBefore(time.Second), 0, 1)),
 			input: mkValidEvictionStatus(2,
 				setStateFor(lifecycle.ResponderStateActive, 0),
 				setRespondersStartTime(clock, 0, 1)),


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
Makes the "mark active and started" case in TestValidateEvictionStatusUpdate deterministic. The old status now uses a fake-clock start time one second before the update, avoiding equality with the update timestamp on Windows.

#### Which issue(s) this PR fixes:
Fixes #140924

#### Special notes for your reviewer:
The change only affects test data; the existing clockBefore helper is used to make the distinct timestamps explicit.

#### Does this PR introduce a user-facing change?
NONE

```release-note
NONE
```