### PR TITLE
pkg/kubelet/prober: cache HTTP probe request object in worker

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -82,6 +83,12 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 
 // probe probes the container.
 func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+	return pb.probeWithCachedHTTPRequest(ctx, probeType, pod, status, container, containerID, nil)
+}
+
+// probeWithCachedHTTPRequest probes the container using an optionally cached HTTP request for HTTP probes.
+// If cachedReq is nil and the probe is an HTTP probe, a new request will be built from the probe spec.
+func (pb *prober) probeWithCachedHTTPRequest(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, cachedReq *http.Request) (results.Result, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -100,10 +107,9 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 		return results.Success, nil
 	}
 
-	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, maxProbeRetries)
+	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, maxProbeRetries, cachedReq)
 
 	if err != nil {
-		// Handle probe error
 		logger.V(1).Info("Probe errored", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "err", err)
 		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored and resulted in %s state: %s", probeType, result, err)
 		return results.Failure, err
@@ -136,12 +142,12 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 
 // runProbeWithRetries tries to probe the container in a finite loop, it returns the last result
 // if it never succeeds.
-func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, retries int) (probe.Result, string, error) {
+func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, retries int, cachedHTTPRequest *http.Request) (probe.Result, string, error) {
 	var err error
 	var result probe.Result
 	var output string
 	for i := 0; i < retries; i++ {
-		result, output, err = pb.runProbe(ctx, probeType, p, pod, status, container, containerID)
+		result, output, err = pb.runProbe(ctx, probeType, p, pod, status, container, containerID, cachedHTTPRequest)
 		if err == nil {
 			return result, output, nil
 		}
@@ -149,7 +155,7 @@ func (pb *prober) runProbeWithRetries(ctx context.Context, probeType probeType, 
 	return result, output, err
 }
 
-func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (probe.Result, string, error) {
+func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID, cachedHTTPRequest *http.Request) (probe.Result, string, error) {
 	logger := klog.FromContext(ctx)
 	timeout := time.Duration(p.TimeoutSeconds) * time.Second
 	switch {
@@ -159,11 +165,16 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 		return pb.exec.Probe(pb.newExecInContainer(ctx, pod, container, containerID, command, timeout))
 
 	case p.HTTPGet != nil:
-		req, err := httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe")
-		if err != nil {
-			// Log and record event for Unknown result
-			logger.V(4).Info("HTTP-Probe failed to create request", "error", err)
-			return probe.Unknown, "", err
+		var req *http.Request
+		if cachedHTTPRequest != nil {
+			req = cachedHTTPRequest
+		} else {
+			var err error
+			req, err = httpprobe.NewRequestForHTTPGetAction(p.HTTPGet, &container, status.PodIP, "probe")
+			if err != nil {
+				logger.V(4).Info("HTTP-Probe failed to create request", "error", err)
+				return probe.Unknown, "", err
+			}
 		}
 		if loggerV4 := logger.V(4); logger.Enabled() {
 			port := req.URL.Port()

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -392,7 +392,7 @@ func TestRunProbeHTTPGetHTTP2ProtocolFeatureGateDisabled(t *testing.T) {
 	// Gate off: kubelet silently falls back to HTTP/1.1 rather than
 	// failing with a gate error. The probe will fail with a connection
 	// error (no server), but must NOT fail due to the feature gate.
-	res, _, err := pb.runProbe(context.Background(), readiness, p, pod, status, container, containerID)
+	res, _, err := pb.runProbe(context.Background(), readiness, p, pod, status, container, containerID, nil)
 	if res == probe.Unknown {
 		t.Errorf("gate-off probe should fall back to HTTP/1.1, not return Unknown")
 	}

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -19,6 +19,7 @@ package prober
 import (
 	"context"
 	"math/rand"
+	"net/http"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
+	httpprobe "k8s.io/kubernetes/pkg/probe/http"
 )
 
 // worker handles the periodic probing of its assigned container. Each worker has a go-routine
@@ -71,6 +73,10 @@ type worker struct {
 
 	// If set, skip probing.
 	onHold bool
+
+	// Cached HTTP request for HTTP probes, built once from the probe spec.
+	// Reused across probe cycles to avoid creating a new request object each time.
+	httpRequest *http.Request
 
 	// proberResultsMetricLabels holds the labels attached to this worker
 	// for the ProberResults metric by result.
@@ -345,8 +351,18 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 		}
 	}
 
+	// Build and cache the HTTP request for HTTP probes to avoid recreating it on every probe cycle.
+	if w.httpRequest == nil && w.spec.HTTPGet != nil && status.PodIP != "" {
+		req, err := httpprobe.NewRequestForHTTPGetAction(w.spec.HTTPGet, &w.container, status.PodIP, "probe")
+		if err != nil {
+			logger.V(4).Info("HTTP-Probe failed to create cached request", "error", err)
+		} else {
+			w.httpRequest = req
+		}
+	}
+
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
+	result, err := w.probeManager.prober.probeWithCachedHTTPRequest(ctx, w.probeType, w.pod, status, w.container, w.containerID, w.httpRequest)
 	if err != nil {
 		// Prober error, throw away the result.
 		return true

--- a/pkg/probe/http/request_benchmark_test.go
+++ b/pkg/probe/http/request_benchmark_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"net/http"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func BenchmarkNewRequestForHTTPGetAction(b *testing.B) {
+	httpGet := &v1.HTTPGetAction{
+		Port: intstr.FromInt32(8080),
+		Path: "/healthz",
+		Host: "10.0.0.1",
+		HTTPHeaders: []v1.HTTPHeader{
+			{Name: "X-Custom-Header", Value: "test-value"},
+		},
+	}
+	container := &v1.Container{
+		Name: "test-container",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := NewRequestForHTTPGetAction(httpGet, container, "10.0.0.1", "probe")
+		if err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func BenchmarkNewRequestForHTTPGetActionReuse(b *testing.B) {
+	httpGet := &v1.HTTPGetAction{
+		Port: intstr.FromInt32(8080),
+		Path: "/healthz",
+		Host: "10.0.0.1",
+		HTTPHeaders: []v1.HTTPHeader{
+			{Name: "X-Custom-Header", Value: "test-value"},
+		},
+	}
+	container := &v1.Container{
+		Name: "test-container",
+	}
+
+	req, err := NewRequestForHTTPGetAction(httpGet, container, "10.0.0.1", "probe")
+	if err != nil {
+		b.Fatalf("unexpected error creating request: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = req
+	}
+}
+
+func BenchmarkNewRequestForHTTPGetActionWithHeaders(b *testing.B) {
+	httpGet := &v1.HTTPGetAction{
+		Port: intstr.FromInt32(8080),
+		Path: "/healthz",
+		Host: "10.0.0.1",
+		HTTPHeaders: []v1.HTTPHeader{
+			{Name: "X-Custom-Header-1", Value: "value-1"},
+			{Name: "X-Custom-Header-2", Value: "value-2"},
+			{Name: "X-Custom-Header-3", Value: "value-3"},
+			{Name: "Authorization", Value: "Bearer token123"},
+		},
+	}
+	container := &v1.Container{
+		Name: "test-container",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := NewRequestForHTTPGetAction(httpGet, container, "10.0.0.1", "probe")
+		if err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func BenchmarkNewRequestForHTTPGetActionWithHeadersReuse(b *testing.B) {
+	httpGet := &v1.HTTPGetAction{
+		Port: intstr.FromInt32(8080),
+		Path: "/healthz",
+		Host: "10.0.0.1",
+		HTTPHeaders: []v1.HTTPHeader{
+			{Name: "X-Custom-Header-1", Value: "value-1"},
+			{Name: "X-Custom-Header-2", Value: "value-2"},
+			{Name: "X-Custom-Header-3", Value: "value-3"},
+			{Name: "Authorization", Value: "Bearer token123"},
+		},
+	}
+	container := &v1.Container{
+		Name: "test-container",
+	}
+
+	req, err := NewRequestForHTTPGetAction(httpGet, container, "10.0.0.1", "probe")
+	if err != nil {
+		b.Fatalf("unexpected error creating request: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = req
+	}
+}
+
+func BenchmarkNewRequestForHTTPGetActionHTTPS(b *testing.B) {
+	httpsScheme := v1.URISchemeHTTPS
+	httpGet := &v1.HTTPGetAction{
+		Port:   intstr.FromInt32(443),
+		Path:   "/ready",
+		Host:   "10.0.0.1",
+		Scheme: &httpsScheme,
+	}
+	container := &v1.Container{
+		Name: "test-container",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := NewRequestForHTTPGetAction(httpGet, container, "10.0.0.1", "probe")
+		if err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func BenchmarkNewRequestForHTTPGetActionLazyCaching(b *testing.B) {
+	httpGet := &v1.HTTPGetAction{
+		Port: intstr.FromInt32(8080),
+		Path: "/healthz",
+		Host: "10.0.0.1",
+		HTTPHeaders: []v1.HTTPHeader{
+			{Name: "X-Custom-Header", Value: "test-value"},
+		},
+	}
+	container := &v1.Container{
+		Name: "test-container",
+	}
+
+	var cachedReq *http.Request
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if cachedReq == nil {
+			req, err := NewRequestForHTTPGetAction(httpGet, container, "10.0.0.1", "probe")
+			if err != nil {
+				b.Fatalf("unexpected error: %v", err)
+			}
+			cachedReq = req
+		}
+		_ = cachedReq
+	}
+}


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

Reuses the `*http.Request` object across HTTP probe cycles instead of creating a new one on each execution. The probe spec (host, port, path, headers) does not change between probe cycles for a given container, so the request can be built once and cached on the worker.

This optimization reduces CPU and memory allocation overhead. Per @aroradaman's benchmark, a similar approach saved ~32MB RAM and ~2.27s CPU time across 500 probers running for 2 minutes.

## Which issue(s) this PR fixes

Related to #115939

## Special notes for your reviewer

This PR follows the implementation notes from #115939:

1. **Commit 1**: Added `httpRequest *http.Request` field to the `worker` struct and built the request lazily in `doProbe()` when `PodIP` first becomes available
2. **Commit 1** (continued): Added `probeWithCachedHTTPRequest` method that accepts an optional cached `*http.Request`. The existing `probe()` method is now a thin wrapper calling `probeWithCachedHTTPRequest` with `nil` for backward compatibility
3. **Commit 2**: Added benchmark tests comparing `NewRequestForHTTPGetAction` call per probe cycle vs cached request reuse

Key design decisions:
- The request is built lazily (not in `newWorker`) because `PodIP` is not available at worker creation time
- When `cachedHTTPRequest` is `nil`, the code falls back to `NewRequestForHTTPGetAction` (no behavior change)
- The `http.Request` is safe to reuse across sequential probe calls since probes run in a single goroutine per worker and the request body is nil (GET requests)

## Benchmark

Run with: `go test ./pkg/probe/http/ -bench=. -benchmem`

The benchmarks compare:
- `BenchmarkNewRequestForHTTPGetAction`: baseline, creates a new request each time
- `BenchmarkNewRequestForHTTPGetActionReuse`: cached request, no allocation
- `BenchmarkNewRequestForHTTPGetActionWithHeaders`: baseline with multiple custom headers
- `BenchmarkNewRequestForHTTPGetActionWithHeadersReuse`: cached with headers
- `BenchmarkNewRequestForHTTPGetActionHTTPS`: baseline HTTPS probe
- `BenchmarkNewRequestForHTTPGetActionLazyCaching`: simulates the worker lazy caching pattern

## Release Note

```release-note
kubelet: reuse HTTP probe request object across probe cycles to reduce memory and CPU overhead
```