### PR TITLE
kube-api-linter: enable optionalorrequired for storagemigration

### DIFF
--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -232,7 +232,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage/)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -247,7 +247,7 @@ linters:
       # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
       # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
       - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+        path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage/)"
       
       # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
       - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/hack/kube-api-linter/exceptions.yaml
+++ b/hack/kube-api-linter/exceptions.yaml
@@ -108,7 +108,7 @@
 # OptionalOrRequired is being enabled over time. For now, each API group should be added to this list until we comb through each group and fix the missing tags.
 # The nonpointerstructs linter is included here as well as these two should be enabled hand-in-hand on each API group.
 - text: "must be marked as optional or required|is a non-pointer struct with no required fields."
-  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage)"
+  path: "staging/src/k8s.io/api/(admissionregistration|authorization|autoscaling|batch|certificates|core|discovery|events|extensions|networking|storage/)"
 
 # OptionalOrRequired - Existing fields that are marked as both optional and required (based on standard optional vs kubebuilder:validation:Required) and should not be fixed.
 - text: "field (PortStatus|IngressPortStatus)\\.Error must not be marked as both optional and required"

--- a/staging/src/k8s.io/api/storagemigration/v1/generated.proto
+++ b/staging/src/k8s.io/api/storagemigration/v1/generated.proto
@@ -62,6 +62,7 @@ message StorageVersionMigrationSpec {
   // The resource that is being migrated. The migrator sends requests to
   // the endpoint serving the resource.
   // Immutable.
+  // +required
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupResource resource = 1;
 }
 
@@ -81,6 +82,7 @@ message StorageVersionMigrationStatus {
   // ResourceVersion to compare with the GC cache for performing the migration.
   // This is the current resource version of given group, version and resource when
   // kube-controller-manager first observes this StorageVersionMigration resource.
+  // +optional
   optional string resourceVersion = 2;
 }
 

--- a/staging/src/k8s.io/api/storagemigration/v1/types.go
+++ b/staging/src/k8s.io/api/storagemigration/v1/types.go
@@ -47,6 +47,7 @@ type StorageVersionMigrationSpec struct {
 	// The resource that is being migrated. The migrator sends requests to
 	// the endpoint serving the resource.
 	// Immutable.
+	// +required
 	Resource metav1.GroupResource `json:"resource" protobuf:"bytes,1,opt,name=resource"`
 }
 
@@ -76,6 +77,7 @@ type StorageVersionMigrationStatus struct {
 	// ResourceVersion to compare with the GC cache for performing the migration.
 	// This is the current resource version of given group, version and resource when
 	// kube-controller-manager first observes this StorageVersionMigration resource.
+	// +optional
 	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,2,opt,name=resourceVersion"`
 }
 

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/generated.proto
@@ -62,6 +62,7 @@ message StorageVersionMigrationSpec {
   // The resource that is being migrated. The migrator sends requests to
   // the endpoint serving the resource.
   // Immutable.
+  // +required
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.GroupResource resource = 1;
 }
 
@@ -81,6 +82,7 @@ message StorageVersionMigrationStatus {
   // ResourceVersion to compare with the GC cache for performing the migration.
   // This is the current resource version of given group, version and resource when
   // kube-controller-manager first observes this StorageVersionMigration resource.
+  // +optional
   optional string resourceVersion = 2;
 }
 

--- a/staging/src/k8s.io/api/storagemigration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storagemigration/v1beta1/types.go
@@ -49,6 +49,7 @@ type StorageVersionMigrationSpec struct {
 	// The resource that is being migrated. The migrator sends requests to
 	// the endpoint serving the resource.
 	// Immutable.
+	// +required
 	Resource metav1.GroupResource `json:"resource" protobuf:"bytes,1,opt,name=resource"`
 }
 
@@ -78,6 +79,7 @@ type StorageVersionMigrationStatus struct {
 	// ResourceVersion to compare with the GC cache for performing the migration.
 	// This is the current resource version of given group, version and resource when
 	// kube-controller-manager first observes this StorageVersionMigration resource.
+	// +optional
 	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,2,opt,name=resourceVersion"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR enables the `optionalorrequired` kube-api-linter rule for the `storagemigration` API group.

While implementing this, I found that the linter's matching logic was treating `storage` as a prefix match for `storagemigration`, causing the entire `storagemigration` API group to be unintentionally excluded from the linter. This PR corrects the matching behavior and enables the `optionalorrequired` linter for the `storagemigration` API group.

#### Which issue(s) this PR is related to:

Fixes #136875

#### Special notes for your reviewer:

- This change follows the same pattern as #134675 for enabling the `optionalorrequired` linter on an API group.
- Without the matching fix, the `storagemigration` API group would continue to be excluded from the linter, and the `+required`/`+optional` markers would not be validated.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
