### PR TITLE
Fix statefulset parallel scale down

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -537,6 +537,51 @@ func (ssc *defaultStatefulSetControl) processCondemned(ctx context.Context, set 
 	return true, ssc.podControl.DeleteStatefulPod(set, condemned[i])
 }
 
+// processCondemnedPods fixes retention-policy claims and processes Pods
+// whose ordinals are outside the desired replica range.
+func (ssc *defaultStatefulSetControl) processCondemnedPods(
+	ctx context.Context,
+	set *apps.StatefulSet,
+	updateSet *apps.StatefulSet,
+	firstUnavailablePod *v1.Pod,
+	monotonic bool,
+	condemned []*v1.Pod,
+	now time.Time,
+) (bool, error) {
+	fixPodClaim := func(i int) (bool, error) {
+		matchPolicy, err := ssc.podControl.ClaimsMatchRetentionPolicy(ctx, updateSet, condemned[i])
+		if err != nil {
+			return true, err
+		}
+
+		if !matchPolicy {
+			if err := ssc.podControl.UpdatePodClaimForRetentionPolicy(ctx, updateSet, condemned[i]); err != nil {
+				return true, err
+			}
+		}
+
+		return false, nil
+	}
+
+	if shouldExit, err := runForAll(condemned, fixPodClaim, monotonic); shouldExit || err != nil {
+		return shouldExit, err
+	}
+
+	processCondemnedFn := func(i int) (bool, error) {
+		return ssc.processCondemned(
+			ctx,
+			set,
+			firstUnavailablePod,
+			monotonic,
+			condemned,
+			i,
+			now,
+		)
+	}
+
+	return runForAll(condemned, processCondemnedFn, monotonic)
+}
+
 func runForAll(pods []*v1.Pod, fn func(i int) (bool, error), monotonic bool) (bool, error) {
 	if monotonic {
 		for i := range pods {
@@ -683,7 +728,26 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(ctx context.Context, set
 		}
 	}
 
-	// First, process each living replica. Exit if we run into an error or something blocking in monotonic mode.
+	// Parallel Pod management does not require ordered processing. Process
+	// condemned Pods first so scale down can release resources before the
+	// controller attempts to create missing Pods in the desired ordinal range.
+	if !monotonic {
+		if shouldExit, err := ssc.processCondemnedPods(
+			ctx,
+			set,
+			updateSet,
+			firstUnavailablePod,
+			monotonic,
+			condemned,
+			now,
+		); shouldExit || err != nil {
+			updateStatus(&status, set.Spec.MinReadySeconds, currentRevision, updateRevision, now, replicas, condemned)
+			return &status, err
+		}
+	}
+
+	// Process each living replica. Exit if we run into an error or something
+	// blocking in monotonic mode.
 	processReplicaFn := func(i int) (bool, error) {
 		return ssc.processReplica(ctx, set, updateSet, monotonic, replicas, i, now)
 	}
@@ -692,34 +756,20 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(ctx context.Context, set
 		return &status, err
 	}
 
-	// Fix pod claims for condemned pods, if necessary.
-	fixPodClaim := func(i int) (bool, error) {
-		if matchPolicy, err := ssc.podControl.ClaimsMatchRetentionPolicy(ctx, updateSet, condemned[i]); err != nil {
-			return true, err
-		} else if !matchPolicy {
-			if err := ssc.podControl.UpdatePodClaimForRetentionPolicy(ctx, updateSet, condemned[i]); err != nil {
-				return true, err
-			}
+	// Preserve the existing processing order for OrderedReady StatefulSets.
+	if monotonic {
+		if shouldExit, err := ssc.processCondemnedPods(
+			ctx,
+			set,
+			updateSet,
+			firstUnavailablePod,
+			monotonic,
+			condemned,
+			now,
+		); shouldExit || err != nil {
+			updateStatus(&status, set.Spec.MinReadySeconds, currentRevision, updateRevision, now, replicas, condemned)
+			return &status, err
 		}
-		return false, nil
-	}
-	if shouldExit, err := runForAll(condemned, fixPodClaim, monotonic); shouldExit || err != nil {
-		updateStatus(&status, set.Spec.MinReadySeconds, currentRevision, updateRevision, now, replicas, condemned)
-		return &status, err
-	}
-
-	// At this point, in monotonic mode all of the current Replicas are Running, Ready and Available,
-	// and we can consider termination.
-	// We will wait for all predecessors to be Running and Available prior to attempting a deletion.
-	// We will terminate Pods in a monotonically decreasing order.
-	// Note that we do not resurrect Pods in this interval. Also note that scaling will take precedence over
-	// updates.
-	processCondemnedFn := func(i int) (bool, error) {
-		return ssc.processCondemned(ctx, set, firstUnavailablePod, monotonic, condemned, i, now)
-	}
-	if shouldExit, err := runForAll(condemned, processCondemnedFn, monotonic); shouldExit || err != nil {
-		updateStatus(&status, set.Spec.MinReadySeconds, currentRevision, updateRevision, now, replicas, condemned)
-		return &status, err
 	}
 
 	updateStatus(&status, set.Spec.MinReadySeconds, currentRevision, updateRevision, now, replicas, condemned)

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -731,8 +731,9 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(ctx context.Context, set
 	// Parallel Pod management does not require ordered processing. Process
 	// condemned Pods first so scale down can release resources before the
 	// controller attempts to create missing Pods in the desired ordinal range.
-	if !monotonic {
-		if shouldExit, err := ssc.processCondemnedPods(
+
+	processCondemnedPodsFn := func() (bool, error) {
+		return ssc.processCondemnedPods(
 			ctx,
 			set,
 			updateSet,
@@ -740,7 +741,11 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(ctx context.Context, set
 			monotonic,
 			condemned,
 			now,
-		); shouldExit || err != nil {
+		)
+	}
+
+	if !monotonic {
+		if shouldExit, err := processCondemnedPodsFn(); shouldExit || err != nil {
 			updateStatus(&status, set.Spec.MinReadySeconds, currentRevision, updateRevision, now, replicas, condemned)
 			return &status, err
 		}
@@ -758,15 +763,11 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(ctx context.Context, set
 
 	// Preserve the existing processing order for OrderedReady StatefulSets.
 	if monotonic {
-		if shouldExit, err := ssc.processCondemnedPods(
-			ctx,
-			set,
-			updateSet,
-			firstUnavailablePod,
-			monotonic,
-			condemned,
-			now,
-		); shouldExit || err != nil {
+		// We will wait for all predecessors to be Running and Available prior to attempting a deletion.
+		// We will terminate Pods in a monotonically decreasing order.
+		// Note that we do not resurrect Pods in this interval. Also note that scaling will take precedence over
+		// updates.
+		if shouldExit, err := processCondemnedPodsFn(); shouldExit || err != nil {
 			updateStatus(&status, set.Spec.MinReadySeconds, currentRevision, updateRevision, now, replicas, condemned)
 			return &status, err
 		}

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -517,6 +517,80 @@ func RecreatesSucceededPodWithDeleteFailure(t *testing.T, set *apps.StatefulSet,
 	recreatesPod(t, set, invariants, v1.PodSucceeded, true)
 }
 
+func TestParallelScaleDownProcessesCondemnedPodsBeforeMissingReplicas(t *testing.T) {
+	set := burst(newStatefulSet(2))
+	client := fake.NewSimpleClientset(set)
+	om, _, ssc := setupController(client)
+
+	// Pod 0 is inside the desired range. Pod 1 is missing, while Pod 2
+	// is outside the desired range and should therefore be condemned.
+	for _, ordinal := range []int{0, 2} {
+		pod := newStatefulSetPod(set, ordinal)
+		pod.Status.Phase = v1.PodRunning
+		pod.Status.Conditions = []v1.PodCondition{
+			{
+				Type:   v1.PodReady,
+				Status: v1.ConditionTrue,
+			},
+		}
+		fakeResourceVersion(pod)
+
+		if err := om.podsIndexer.Add(pod); err != nil {
+			t.Fatalf("failed to add pod %s to indexer: %v", pod.Name, err)
+		}
+	}
+
+	// Simulate ResourceQuota preventing creation of missing Pod 1.
+	createErr := errors.New("exceeded quota")
+	om.SetCreateStatefulPodError(createErr, 1)
+
+	selector, err := metav1.LabelSelectorAsSelector(set.Spec.Selector)
+	if err != nil {
+		t.Fatalf("failed to create selector: %v", err)
+	}
+
+	pods, err := om.podsLister.Pods(set.Namespace).List(selector)
+	if err != nil {
+		t.Fatalf("failed to list pods: %v", err)
+	}
+
+	_, err = ssc.UpdateStatefulSet(
+		context.TODO(),
+		set,
+		pods,
+		time.Now(),
+	)
+	if err == nil || !strings.Contains(err.Error(), createErr.Error()) {
+		t.Fatalf("expected create error %v, got %v", createErr, err)
+	}
+
+	if got, want := om.deletePodTracker.requests, 1; got != want {
+		t.Fatalf(
+			"expected condemned pod to be deleted before replica creation failed: "+
+				"got %d delete requests, want %d",
+			got,
+			want,
+		)
+	}
+
+	if got, want := om.createPodTracker.requests, 1; got != want {
+		t.Fatalf(
+			"got %d create requests, want %d",
+			got,
+			want,
+		)
+	}
+
+	pods, err = om.podsLister.Pods(set.Namespace).List(selector)
+	if err != nil {
+		t.Fatalf("failed to list pods after update: %v", err)
+	}
+
+	if pod := findPodByOrdinal(pods, 2); pod != nil {
+		t.Fatalf("condemned pod %s was not deleted", pod.Name)
+	}
+}
+
 func CreatePodFailure(t *testing.T, set *apps.StatefulSet, invariants invariantFunc) {
 	client := fake.NewSimpleClientset(set)
 	om, _, ssc := setupController(client)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig apps

#### What this PR does / why we need it:

A StatefulSet using `podManagementPolicy: Parallel` can become stuck while scaling down after a partially successful scale-up.

A failed parallel scale-up can leave:

* missing Pods within the desired ordinal range; and
* existing condemned Pods whose ordinals are outside a subsequently reduced replica range.

The StatefulSet controller currently processes desired-range replicas before condemned Pods. If creation of a missing desired Pod fails because a `ResourceQuota` is exhausted, reconciliation returns before the condemned Pods are deleted.

This creates a deadlock:
* the missing desired Pod cannot be created until quota is released; and
* quota is not released because the out-of-range Pods are not deleted.

This PR changes the reconciliation order for StatefulSets using Parallel Pod management. Condemned Pods are processed before missing desired replicas, allowing scale-down to release resources before the controller attempts to create missing Pods.
The existing processing order for `OrderedReady` StatefulSets is preserved.
A regression test verifies that an out-of-range Pod is deleted before a quota-style Pod creation error is returned.

#### Which issue(s) this PR is related to:
Fixes #140858

#### Special notes for your reviewer:

The behavior change is limited to StatefulSets using:
```yaml
podManagementPolicy: Parallel
```

For `OrderedReady` StatefulSets, the existing replica-first processing order remains unchanged.
The regression test models the following state:

* desired replicas: `2`
* existing Pods: ordinals `0` and `2`
* missing desired Pod: ordinal `1`
* condemned Pod: ordinal `2`
* creation of ordinal `1` fails with a quota-style error

Before this change, the controller returned the creation error without deleting Pod `2`.
After this change, Pod `2` is deleted before the creation error is returned, allowing the deletion to release resources required by the missing desired Pod.

Tests executed:

```text
go test ./pkg/controller/statefulset -count=1

make test WHAT=./pkg/controller/statefulset

go test -race ./pkg/controller/statefulset \
  -run '^TestParallelScaleDownProcessesCondemnedPodsBeforeMissingReplicas$' \
  -count=1

hack/verify-gofmt.sh
git diff --check
```

The complete StatefulSet package test run passed:
```text
DONE 389 tests
```

#### Does this PR introduce a user-facing change?
```release-note
Fixed StatefulSet scale-down becoming blocked with Parallel Pod management when a failed scale-up leaves missing desired Pods and ResourceQuota prevents their creation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
NONE
```
