### PR TITLE
test/integration: fix dra optional node operations podgroup flake

### DIFF
--- a/test/integration/dra/optional_node_operations.go
+++ b/test/integration/dra/optional_node_operations.go
@@ -126,9 +126,21 @@ func testOptionalNodeOperations(tCtx ktesting.TContext, enabled bool) {
 			}
 
 			if tt.expectScheduled {
+				// The PodScheduled condition checked by [waitForPodScheduled] could
+				// converge to either a True or False status due to a race
+				// condition, but Pods should still ultimately be scheduled:
+				// https://github.com/kubernetes/kubernetes/issues/139417#issuecomment-4651436886
 				for _, pod := range pods {
-					scheduledPod := waitForPodScheduled(tCtx, namespace, pod.Name)
-					tCtx.Expect(scheduledPod.Spec.NodeName).To(gomega.Equal(tt.expectedNode), "pod should be scheduled to %s", tt.expectedNode)
+					tCtx.Eventually(func(tCtx ktesting.TContext) (string, error) {
+						p, err := tCtx.Client().CoreV1().Pods(namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
+						if err != nil {
+							return "", err
+						}
+						return p.Spec.NodeName, nil
+					}).WithTimeout(schedulingTimeout).Should(
+						gomega.Equal(tt.expectedNode),
+						"pod %s should be scheduled to %s", pod.Name, tt.expectedNode,
+					)
 				}
 			} else {
 				// Verify that the pod with node selector (the last one) is unschedulable.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fixes a flake in `TestDRA/all/OptionalNodeOperations/podgroup-scheduled-on-supported-node`.
In Gang/PodGroup scheduling tests where multiple Pods share a `ResourceClaim`, waiting for the `PodScheduled=True` condition via `waitForPodScheduled` is flaky due to a race condition documented https://github.com/kubernetes/kubernetes/issues/139417#issuecomment-4651436886

#### Which issue(s) this PR is related to:
#141059
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
