### PR TITLE
kubelet: report volume stats for pod-scoped (non-PVC) volumes

### DIFF
--- a/pkg/kubelet/metrics/collectors/volume_stats.go
+++ b/pkg/kubelet/metrics/collectors/volume_stats.go
@@ -63,6 +63,47 @@ var (
 		[]string{"namespace", "persistentvolumeclaim"}, nil,
 		metrics.ALPHA, "",
 	)
+
+	// Pod-scoped volume metrics cover volumes that aren't backed by a PVC (e.g. emptyDir,
+	// secret, configMap, downwardAPI, projected), which the metrics above never report since
+	// they're keyed on PVCReference. Labeled by the pod-spec volume name instead of a claim
+	// name, since there is no claim to reference.
+	volumeStatsPodCapacityBytesDesc = metrics.NewDesc(
+		metrics.BuildFQName("", kubeletmetrics.KubeletSubsystem, kubeletmetrics.VolumeStatsPodCapacityBytesKey),
+		"Capacity in bytes of a pod-scoped (non-PVC) volume",
+		[]string{"namespace", "pod", "volume_name"}, nil,
+		metrics.ALPHA, "",
+	)
+	volumeStatsPodAvailableBytesDesc = metrics.NewDesc(
+		metrics.BuildFQName("", kubeletmetrics.KubeletSubsystem, kubeletmetrics.VolumeStatsPodAvailableBytesKey),
+		"Number of available bytes in a pod-scoped (non-PVC) volume",
+		[]string{"namespace", "pod", "volume_name"}, nil,
+		metrics.ALPHA, "",
+	)
+	volumeStatsPodUsedBytesDesc = metrics.NewDesc(
+		metrics.BuildFQName("", kubeletmetrics.KubeletSubsystem, kubeletmetrics.VolumeStatsPodUsedBytesKey),
+		"Number of used bytes in a pod-scoped (non-PVC) volume",
+		[]string{"namespace", "pod", "volume_name"}, nil,
+		metrics.ALPHA, "",
+	)
+	volumeStatsPodInodesDesc = metrics.NewDesc(
+		metrics.BuildFQName("", kubeletmetrics.KubeletSubsystem, kubeletmetrics.VolumeStatsPodInodesKey),
+		"Maximum number of inodes in a pod-scoped (non-PVC) volume",
+		[]string{"namespace", "pod", "volume_name"}, nil,
+		metrics.ALPHA, "",
+	)
+	volumeStatsPodInodesFreeDesc = metrics.NewDesc(
+		metrics.BuildFQName("", kubeletmetrics.KubeletSubsystem, kubeletmetrics.VolumeStatsPodInodesFreeKey),
+		"Number of free inodes in a pod-scoped (non-PVC) volume",
+		[]string{"namespace", "pod", "volume_name"}, nil,
+		metrics.ALPHA, "",
+	)
+	volumeStatsPodInodesUsedDesc = metrics.NewDesc(
+		metrics.BuildFQName("", kubeletmetrics.KubeletSubsystem, kubeletmetrics.VolumeStatsPodInodesUsedKey),
+		"Number of used inodes in a pod-scoped (non-PVC) volume",
+		[]string{"namespace", "pod", "volume_name"}, nil,
+		metrics.ALPHA, "",
+	)
 )
 
 type volumeStatsCollector struct {
@@ -87,6 +128,12 @@ func (collector *volumeStatsCollector) DescribeWithStability(ch chan<- *metrics.
 	ch <- volumeStatsInodesDesc
 	ch <- volumeStatsInodesFreeDesc
 	ch <- volumeStatsInodesUsedDesc
+	ch <- volumeStatsPodCapacityBytesDesc
+	ch <- volumeStatsPodAvailableBytesDesc
+	ch <- volumeStatsPodUsedBytesDesc
+	ch <- volumeStatsPodInodesDesc
+	ch <- volumeStatsPodInodesFreeDesc
+	ch <- volumeStatsPodInodesUsedDesc
 }
 
 // CollectWithStability implements the metrics.StableCollector interface.
@@ -102,6 +149,10 @@ func (collector *volumeStatsCollector) CollectWithStability(ch chan<- metrics.Me
 		lv = append([]string{pvcRef.Namespace, pvcRef.Name}, lv...)
 		ch <- metrics.NewLazyConstMetric(desc, metrics.GaugeValue, v, lv...)
 	}
+	addPodGauge := func(desc *metrics.Desc, podRef stats.PodReference, volumeName string, v float64, lv ...string) {
+		lv = append([]string{podRef.Namespace, podRef.Name, volumeName}, lv...)
+		ch <- metrics.NewLazyConstMetric(desc, metrics.GaugeValue, v, lv...)
+	}
 	allPVCs := sets.Set[stats.PVCReference]{}
 	for _, podStat := range podStats {
 		if podStat.VolumeStats == nil {
@@ -110,7 +161,15 @@ func (collector *volumeStatsCollector) CollectWithStability(ch chan<- metrics.Me
 		for _, volumeStat := range podStat.VolumeStats {
 			pvcRef := volumeStat.PVCRef
 			if pvcRef == nil {
-				// ignore if no PVC reference
+				// No PVC reference: a pod-scoped volume (emptyDir, secret, configMap,
+				// downwardAPI, projected, ...). Report it labeled by pod + volume name
+				// instead of skipping it entirely.
+				addPodGauge(volumeStatsPodCapacityBytesDesc, podStat.PodRef, volumeStat.Name, float64(*volumeStat.CapacityBytes))
+				addPodGauge(volumeStatsPodAvailableBytesDesc, podStat.PodRef, volumeStat.Name, float64(*volumeStat.AvailableBytes))
+				addPodGauge(volumeStatsPodUsedBytesDesc, podStat.PodRef, volumeStat.Name, float64(*volumeStat.UsedBytes))
+				addPodGauge(volumeStatsPodInodesDesc, podStat.PodRef, volumeStat.Name, float64(*volumeStat.Inodes))
+				addPodGauge(volumeStatsPodInodesFreeDesc, podStat.PodRef, volumeStat.Name, float64(*volumeStat.InodesFree))
+				addPodGauge(volumeStatsPodInodesUsedDesc, podStat.PodRef, volumeStat.Name, float64(*volumeStat.InodesUsed))
 				continue
 			}
 			if allPVCs.Has(*pvcRef) {

--- a/pkg/kubelet/metrics/collectors/volume_stats_test.go
+++ b/pkg/kubelet/metrics/collectors/volume_stats_test.go
@@ -43,6 +43,18 @@ func TestVolumeStatsCollector(t *testing.T) {
 		# TYPE kubelet_volume_stats_inodes_free gauge
 		# HELP kubelet_volume_stats_inodes_used [ALPHA] Number of used inodes in the volume
 		# TYPE kubelet_volume_stats_inodes_used gauge
+		# HELP kubelet_volume_stats_pod_available_bytes [ALPHA] Number of available bytes in a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_available_bytes gauge
+		# HELP kubelet_volume_stats_pod_capacity_bytes [ALPHA] Capacity in bytes of a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_capacity_bytes gauge
+		# HELP kubelet_volume_stats_pod_inodes [ALPHA] Maximum number of inodes in a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_inodes gauge
+		# HELP kubelet_volume_stats_pod_inodes_free [ALPHA] Number of free inodes in a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_inodes_free gauge
+		# HELP kubelet_volume_stats_pod_inodes_used [ALPHA] Number of used inodes in a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_inodes_used gauge
+		# HELP kubelet_volume_stats_pod_used_bytes [ALPHA] Number of used bytes in a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_used_bytes gauge
 		# HELP kubelet_volume_stats_used_bytes [ALPHA] Number of used bytes in the volume
 		# TYPE kubelet_volume_stats_used_bytes gauge
 	`
@@ -115,6 +127,12 @@ func TestVolumeStatsCollector(t *testing.T) {
 			kubelet_volume_stats_inodes{namespace="testns",persistentvolumeclaim="testpvc"} 655360
 			kubelet_volume_stats_inodes_free{namespace="testns",persistentvolumeclaim="testpvc"} 655344
 			kubelet_volume_stats_inodes_used{namespace="testns",persistentvolumeclaim="testpvc"} 16
+			kubelet_volume_stats_pod_available_bytes{namespace="test-namespace",pod="test-pod",volume_name="test"} 5.663154176e+09
+			kubelet_volume_stats_pod_capacity_bytes{namespace="test-namespace",pod="test-pod",volume_name="test"} 1.0434699264e+10
+			kubelet_volume_stats_pod_inodes{namespace="test-namespace",pod="test-pod",volume_name="test"} 655360
+			kubelet_volume_stats_pod_inodes_free{namespace="test-namespace",pod="test-pod",volume_name="test"} 655344
+			kubelet_volume_stats_pod_inodes_used{namespace="test-namespace",pod="test-pod",volume_name="test"} 16
+			kubelet_volume_stats_pod_used_bytes{namespace="test-namespace",pod="test-pod",volume_name="test"} 4.21789696e+09
 			kubelet_volume_stats_used_bytes{namespace="testns",persistentvolumeclaim="testpvc"} 4.21789696e+09
 			`
 
@@ -124,6 +142,12 @@ func TestVolumeStatsCollector(t *testing.T) {
 			"kubelet_volume_stats_inodes",
 			"kubelet_volume_stats_inodes_free",
 			"kubelet_volume_stats_inodes_used",
+			"kubelet_volume_stats_pod_available_bytes",
+			"kubelet_volume_stats_pod_capacity_bytes",
+			"kubelet_volume_stats_pod_inodes",
+			"kubelet_volume_stats_pod_inodes_free",
+			"kubelet_volume_stats_pod_inodes_used",
+			"kubelet_volume_stats_pod_used_bytes",
 			"kubelet_volume_stats_used_bytes",
 		}
 	)
@@ -152,6 +176,18 @@ func TestVolumeStatsCollectorWithNullVolumeStatus(t *testing.T) {
 		# TYPE kubelet_volume_stats_inodes_free gauge
 		# HELP kubelet_volume_stats_inodes_used [ALPHA] Number of used inodes in the volume
 		# TYPE kubelet_volume_stats_inodes_used gauge
+		# HELP kubelet_volume_stats_pod_available_bytes [ALPHA] Number of available bytes in a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_available_bytes gauge
+		# HELP kubelet_volume_stats_pod_capacity_bytes [ALPHA] Capacity in bytes of a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_capacity_bytes gauge
+		# HELP kubelet_volume_stats_pod_inodes [ALPHA] Maximum number of inodes in a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_inodes gauge
+		# HELP kubelet_volume_stats_pod_inodes_free [ALPHA] Number of free inodes in a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_inodes_free gauge
+		# HELP kubelet_volume_stats_pod_inodes_used [ALPHA] Number of used inodes in a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_inodes_used gauge
+		# HELP kubelet_volume_stats_pod_used_bytes [ALPHA] Number of used bytes in a pod-scoped (non-PVC) volume
+		# TYPE kubelet_volume_stats_pod_used_bytes gauge
 		# HELP kubelet_volume_stats_used_bytes [ALPHA] Number of used bytes in the volume
 		# TYPE kubelet_volume_stats_used_bytes gauge
 	`
@@ -201,6 +237,12 @@ func TestVolumeStatsCollectorWithNullVolumeStatus(t *testing.T) {
 			kubelet_volume_stats_inodes{namespace="testns",persistentvolumeclaim="testpvc"} 655360
 			kubelet_volume_stats_inodes_free{namespace="testns",persistentvolumeclaim="testpvc"} 655344
 			kubelet_volume_stats_inodes_used{namespace="testns",persistentvolumeclaim="testpvc"} 16
+			kubelet_volume_stats_pod_available_bytes{namespace="test-namespace",pod="test-pod",volume_name="test"} 5.663154176e+09
+			kubelet_volume_stats_pod_capacity_bytes{namespace="test-namespace",pod="test-pod",volume_name="test"} 1.0434699264e+10
+			kubelet_volume_stats_pod_inodes{namespace="test-namespace",pod="test-pod",volume_name="test"} 655360
+			kubelet_volume_stats_pod_inodes_free{namespace="test-namespace",pod="test-pod",volume_name="test"} 655344
+			kubelet_volume_stats_pod_inodes_used{namespace="test-namespace",pod="test-pod",volume_name="test"} 16
+			kubelet_volume_stats_pod_used_bytes{namespace="test-namespace",pod="test-pod",volume_name="test"} 4.21789696e+09
 			kubelet_volume_stats_used_bytes{namespace="testns",persistentvolumeclaim="testpvc"} 4.21789696e+09
 			`
 
@@ -210,6 +252,12 @@ func TestVolumeStatsCollectorWithNullVolumeStatus(t *testing.T) {
 			"kubelet_volume_stats_inodes",
 			"kubelet_volume_stats_inodes_free",
 			"kubelet_volume_stats_inodes_used",
+			"kubelet_volume_stats_pod_available_bytes",
+			"kubelet_volume_stats_pod_capacity_bytes",
+			"kubelet_volume_stats_pod_inodes",
+			"kubelet_volume_stats_pod_inodes_free",
+			"kubelet_volume_stats_pod_inodes_used",
+			"kubelet_volume_stats_pod_used_bytes",
 			"kubelet_volume_stats_used_bytes",
 		}
 	)

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -66,6 +66,12 @@ const (
 	VolumeStatsInodesKey               = "volume_stats_inodes"
 	VolumeStatsInodesFreeKey           = "volume_stats_inodes_free"
 	VolumeStatsInodesUsedKey           = "volume_stats_inodes_used"
+	VolumeStatsPodCapacityBytesKey     = "volume_stats_pod_capacity_bytes"
+	VolumeStatsPodAvailableBytesKey    = "volume_stats_pod_available_bytes"
+	VolumeStatsPodUsedBytesKey         = "volume_stats_pod_used_bytes"
+	VolumeStatsPodInodesKey            = "volume_stats_pod_inodes"
+	VolumeStatsPodInodesFreeKey        = "volume_stats_pod_inodes_free"
+	VolumeStatsPodInodesUsedKey        = "volume_stats_pod_inodes_used"
 
 	RunningPodsKey             = "running_pods"
 	RunningContainersKey       = "running_containers"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

`volumeStatsCollector.CollectWithStability` (`pkg/kubelet/metrics/collectors/volume_stats.go`) iterates every `podStat.VolumeStats` but skips any entry without a `PVCRef`, silently dropping emptyDir, secret, configMap, downwardAPI and projected volumes. The underlying data is already collected by `volumeStatCalculator` - it's just discarded before becoming a metric.

This adds a second metric family, `kubelet_volume_stats_pod_*`, labeled `namespace`, `pod`, `volume_name` instead of `namespace`, `persistentvolumeclaim` (there's no claim to reference for these volumes), covering exactly the volumes the existing PVC-labeled metrics never report. Cardinality is bounded by (pods on this node) x (volumes per pod), the same shape kubelet's own per-container metrics already ship at.

No feature gate: the existing PVC-scoped metrics have never needed one, and consumers who can't afford the extra series can drop them via standard Prometheus relabeling like any other kubelet metric.

#### Which issue(s) this PR is related to:

Fixes #69507

#### Special notes for your reviewer:

Different angle from #121489 (closed for inactivity, added a dedicated emptyDir-only collector): this extends the existing volume_stats collector to cover every non-PVC volume type in one pass instead of just emptyDir. Discussed the approach on the issue first; see https://github.com/kubernetes/kubernetes/issues/69507#issuecomment-5124693906 and the follow-up.

#### Does this PR introduce a user-facing change?

```release-note
Kubelet now exposes `kubelet_volume_stats_pod_capacity_bytes`, `kubelet_volume_stats_pod_available_bytes`, `kubelet_volume_stats_pod_used_bytes`, `kubelet_volume_stats_pod_inodes`, `kubelet_volume_stats_pod_inodes_free` and `kubelet_volume_stats_pod_inodes_used` metrics for volumes that aren't backed by a PVC (emptyDir, secret, configMap, downwardAPI, projected), labeled by namespace/pod/volume_name.
```