### PR TITLE
Pin github.com/google/cel-go to v0.29.2 in unwanted-dependencies.json

### DIFF
--- a/hack/unwanted-dependencies.json
+++ b/hack/unwanted-dependencies.json
@@ -4,6 +4,10 @@
       "github.com/fsnotify/fsnotify": {
         "version": "v1.9.0",
         "reason": "pin to v1.9.0 until we figure out what the future of fsnotify library is, see #138812"
+      },
+      "github.com/google/cel-go": {
+        "version": "v0.29.2",
+        "reason": "pin to v0.29.2 until the CEL runtime cost changes in newer releases are handled, see #141056"
       }
     },
     "unwantedModules": {


### PR DESCRIPTION
### What type of PR is this?

/kind failing-test
/sig architecture
/sig api-machinery
/area dependency

### What this PR does / why we need it:

This adds github.com/google/cel-go to spec.pinnedModules in hack/unwanted-dependencies.json, pinned at v0.29.2, the version we use today.

The ci-kubernetes-unit-dependencies job updates every dependency to its latest release before running the unit tests, and it skips the modules listed in spec.pinnedModules. cel-go v0.30.0 changed the observed runtime cost of some CEL expressions (cel-expr/cel-go#1369). The cel-go maintainers confirmed the change is intentional (cel-expr/cel-go#1394). The job picks up v0.30.0 on every run, and TestCelCostStability fails because it pins exact cost values.

With this pin the job stays on v0.29.2 for cel-go and goes green again.

The plan is to land this first, and then land the update to cel-go v0.30.0 (#141058) with adjusted cost values when the 1.38 development window opens. That update will also remove this pin.

Part of #141056.

### Does this PR introduce a user-facing change?

```release-note
NONE
```