### PR TITLE
Fix unit test compile failure under the fieldsv1string build tag

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/validator_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/validator_test.go
@@ -227,7 +227,7 @@ func TestGetObjectMeta(t *testing.T) {
 						APIVersion: "example.com/v1",
 						Time:       &metav1.Time{Time: time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC).Local()},
 						FieldsType: "FieldsV1",
-						FieldsV1:   &metav1.FieldsV1{Raw: []byte(`{"f:metadata":{"f:labels":{".":{},"f:app.kubernetes.io/name":{}}}}`)},
+						FieldsV1:   metav1.NewFieldsV1(`{"f:metadata":{"f:labels":{".":{},"f:app.kubernetes.io/name":{}}}}`),
 					},
 				},
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it:**

The test added in #139505 builds a FieldsV1 value with the `FieldsV1{Raw: ...}` struct literal. The `Raw` field does not exist when the `fieldsv1string` build tag is set, so the package fails to compile. Because of this, the ci-kubernetes-unit-fieldsv1string job has failed every run since 2026-07-09.

This change uses the `NewFieldsV1` constructor instead. The constructor exists for both build tag variants.

Job history: https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-unit-fieldsv1string

cc @aaron-prindle

**Which issue(s) this PR fixes:**

None

**Does this PR introduce a user-facing change?**

```release-note
NONE
```