### PR TITLE
cluster/gce: pick single latest image when the image family matches multiple images

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -59,7 +59,7 @@ fi
 kube_master_image="${KUBE_GCE_MASTER_IMAGE:-}"
 if [[ -z "${kube_master_image}" ]]; then
   # remove architecture:X86_64 once we move on from ubuntu jammy as that image family has both X86_64 and ARM images
-  kube_master_image=$(gcloud compute images list --project="${MASTER_IMAGE_PROJECT}" --no-standard-images --filter="family:${MASTER_IMAGE_FAMILY} architecture:X86_64" --format 'value(name)')
+  kube_master_image=$(gcloud compute images list --project="${MASTER_IMAGE_PROJECT}" --no-standard-images --filter="family:${MASTER_IMAGE_FAMILY} architecture:X86_64" --sort-by=~creationTimestamp --limit=1 --format 'value(name)')
 fi
 
 echo "Using image: ${kube_master_image} from project: ${MASTER_IMAGE_PROJECT} as master image" >&2
@@ -79,7 +79,7 @@ function set-linux-node-image() {
   kube_node_image="${KUBE_GCE_NODE_IMAGE:-}"
   if [[ -z "${kube_node_image}" ]]; then
     # remove architecture:X86_64 once we move on from ubuntu jammy as that image family has both X86_64 and ARM images
-    kube_node_image=$(gcloud compute images list --project="${NODE_IMAGE_PROJECT}" --no-standard-images --filter="family:${NODE_IMAGE_FAMILY} architecture:X86_64" --format 'value(name)')
+    kube_node_image=$(gcloud compute images list --project="${NODE_IMAGE_PROJECT}" --no-standard-images --filter="family:${NODE_IMAGE_FAMILY} architecture:X86_64" --sort-by=~creationTimestamp --limit=1 --format 'value(name)')
   fi
 
   echo "Using image: ${kube_node_image} from project: ${NODE_IMAGE_PROJECT} as node image" >&2


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind flake

**What this PR does / why we need it**:

`cluster/gce/util.sh` resolves `MASTER_IMAGE` / `NODE_IMAGE` from `IMAGE_FAMILY` via:

```sh
gcloud compute images list --project="${MASTER_IMAGE_PROJECT}" \
  --no-standard-images \
  --filter="family:${MASTER_IMAGE_FAMILY} architecture:X86_64" \
  --format 'value(name)'
```

When a rolling image family briefly has more than one matching image (currently observed with `cos-cloud`'s `cos-129-lts` family returning both `cos-129-19506-299-60` and `cos-129-19506-299-61`), the command returns two lines and the shell captures them into `MASTER_IMAGE` / `NODE_IMAGE` as a newline-separated string. Downstream `gcloud compute instances create` then fails with:

```
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - Invalid value for field 'resource.disks[0].initializeParams.sourceImage':
   'https://compute.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-129-19506-299-60
   cos-129-19506-299-61'. The referenced image resource cannot be found.
Failed to create master instance due to non-retryable error
```

Example failure log: pull-sig-storage-local-static-provisioner-e2e ([build 2083011217974104064](https://storage.googleapis.com/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_sig-storage-local-static-provisioner/604/pull-sig-storage-local-static-provisioner-e2e/2083011217974104064/build-log.txt)).

Add `--sort-by=~creationTimestamp --limit=1` so we always pick the single most recently created image in the family, matching what the family alias itself resolves to at the GCE API. Same treatment applied to both master and node image resolution.

**Which issue(s) this PR fixes**:

N/A (fixes a currently-red kubetest gce-provider job; likely helps other gce e2e jobs briefly hitting the same window).

**Special notes for your reviewer**:

/sig cluster-lifecycle
/area provider/gcp
/area e2e-test-framework

**Does this PR introduce a user-facing change?**

```release-note
NONE
```

**Additional documentation**:

```docs
NONE
```