### PR TITLE
kubelet: pass logger to swap utilities

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -214,7 +214,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 		return nil, fmt.Errorf("failed to get mounted cgroup subsystems: %v", err)
 	}
 
-	isSwapOn, err := swap.IsSwapOn()
+	isSwapOn, err := swap.IsSwapOn(logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine if swap is on: %w", err)
 	}
@@ -224,7 +224,7 @@ func NewContainerManager(ctx context.Context, mountUtil mount.Interface, cadviso
 			return nil, fmt.Errorf("running with swap on is not supported, please disable swap or set --fail-swap-on flag to false")
 		}
 
-		if !swap.IsTmpfsNoswapOptionSupported(mountUtil, nodeConfig.KubeletRootDir) {
+		if !swap.IsTmpfsNoswapOptionSupported(logger, mountUtil, nodeConfig.KubeletRootDir) {
 			nodeRef := nodeRefFromNode(string(nodeConfig.NodeName))
 			recorder.Event(nodeRef, v1.EventTypeWarning, events.PossibleMemoryBackedVolumesOnDisk,
 				"The tmpfs noswap option is not supported. Memory-backed volumes (e.g. secrets, emptyDirs, etc.) "+

--- a/pkg/kubelet/util/swap/swap_util.go
+++ b/pkg/kubelet/util/swap/swap_util.go
@@ -18,7 +18,6 @@ package swap
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"os"
 	sysruntime "runtime"
@@ -42,10 +41,7 @@ var (
 
 const TmpfsNoswapOption = "noswap"
 
-func IsTmpfsNoswapOptionSupported(mounter mount.Interface, mountPath string) bool {
-	// TODO: it needs to be replaced by a proper context in the future
-	ctx := context.TODO()
-	logger := klog.FromContext(ctx)
+func IsTmpfsNoswapOptionSupported(logger klog.Logger, mounter mount.Interface, mountPath string) bool {
 	isTmpfsNoswapOptionSupportedHelper := func() bool {
 		if sysruntime.GOOS == "windows" {
 			return false
@@ -125,15 +121,11 @@ func isSwapOnAccordingToProcSwaps(logger klog.Logger, procSwapsContent []byte) b
 // IsSwapOn detects whether swap in enabled on the system by inspecting
 // /proc/swaps. If the file does not exist, an os.NotFound error will be returned.
 // If running on windows, swap is assumed to always be false.
-func IsSwapOn() (bool, error) {
+func IsSwapOn(logger klog.Logger) (bool, error) {
 	isSwapOnHelper := func() (bool, error) {
 		if sysruntime.GOOS == "windows" {
 			return false, nil
 		}
-
-		// TODO: it needs to be replaced by a proper context in the future
-		ctx := context.TODO()
-		logger := klog.FromContext(ctx)
 
 		const swapFilePath = "/proc/swaps"
 		procSwapsContent, err := os.ReadFile(swapFilePath)

--- a/pkg/kubelet/util/swap/swap_util_test.go
+++ b/pkg/kubelet/util/swap/swap_util_test.go
@@ -19,7 +19,6 @@ package swap
 import (
 	"testing"
 
-	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
@@ -59,8 +58,7 @@ Filename				Type		Size		Used		Priority
 			expectedEnabled: false,
 		},
 	}
-	tCtx := ktesting.Init(t)
-	logger := klog.FromContext(tCtx)
+	logger, _ := ktesting.NewTestContext(t)
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -353,7 +353,8 @@ func (ed *emptyDir) setupTmpfs(dir string) error {
 		return nil
 	}
 
-	options := ed.generateTmpfsMountOptions(swap.IsTmpfsNoswapOptionSupported(ed.mounter, ed.plugin.host.GetPluginDir(EmptyDirPluginName)))
+	// The volume.Mounter interface does not provide a logger at this boundary.
+	options := ed.generateTmpfsMountOptions(swap.IsTmpfsNoswapOptionSupported(klog.TODO(), ed.mounter, ed.plugin.host.GetPluginDir(EmptyDirPluginName)))
 
 	klog.V(3).Infof("pod %v: mounting tmpfs for volume %v", ed.pod.UID, ed.volName)
 	return ed.mounter.MountSensitiveWithoutSystemd("tmpfs", dir, "tmpfs", options, nil)

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -353,7 +353,8 @@ func (ed *emptyDir) setupTmpfs(dir string) error {
 		return nil
 	}
 
-	options := ed.generateTmpfsMountOptions(swap.IsTmpfsNoswapOptionSupported(ed.mounter, ed.plugin.host.GetPluginDir(EmptyDirPluginName)))
+	// TODO: pass a real logger once contextual logging reaches the legacy volume.Mounter interface.
+	options := ed.generateTmpfsMountOptions(swap.IsTmpfsNoswapOptionSupported(klog.TODO(), ed.mounter, ed.plugin.host.GetPluginDir(EmptyDirPluginName)))
 
 	klog.V(3).Infof("pod %v: mounting tmpfs for volume %v", ed.pod.UID, ed.volName)
 	return ed.mounter.MountSensitiveWithoutSystemd("tmpfs", dir, "tmpfs", options, nil)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Passes an explicit `klog.Logger` to the swap utilities instead of creating loggers from `context.TODO()` internally. The container manager reuses its contextual logger. The emptyDir call remains at a legacy `volume.Mounter` boundary that does not provide a logger, so it uses `klog.TODO()` at that boundary.

#### Which issue(s) this PR fixes:

Part of #130069

#### Special notes for your reviewer:

Focused tests and checks passed.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```