### PR TITLE
memorymanager: restore pod hints from pod allocation

### DIFF
--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -685,37 +685,37 @@ func (p *staticPolicy) releaseMemory(s state.State, blocks []state.Block) {
 	s.SetMachineState(machineState)
 }
 
-func regenerateHints(logger klog.Logger, pod *v1.Pod, ctn *v1.Container, ctnBlocks []state.Block, reqRsrc map[v1.ResourceName]uint64) map[string][]topologymanager.TopologyHint {
+func regenerateHints(logger klog.Logger, pod *v1.Pod, blocks []state.Block, reqRsrc map[v1.ResourceName]uint64) map[string][]topologymanager.TopologyHint {
 	hints := map[string][]topologymanager.TopologyHint{}
 	for resourceName := range reqRsrc {
 		hints[string(resourceName)] = []topologymanager.TopologyHint{}
 	}
 
-	if len(ctnBlocks) != len(reqRsrc) {
-		logger.Info("The number of requested resources by the container differs from the number of memory blocks", "containerName", ctn.Name)
+	if len(blocks) != len(reqRsrc) {
+		logger.Info("The number of requested resources differs from the number of memory blocks")
 		return nil
 	}
 
-	for _, b := range ctnBlocks {
+	for _, b := range blocks {
 		if _, ok := reqRsrc[b.Type]; !ok {
-			logger.Info("Container requested resources but none available of this type", "containerName", ctn.Name, "type", b.Type)
+			logger.Info("Requested resources do not include the allocated memory block type", "type", b.Type)
 			return nil
 		}
 
 		if b.Size != reqRsrc[b.Type] {
-			logger.Info("Memory already allocated with different numbers than requested", "containerName", ctn.Name, "type", b.Type, "requestedResource", reqRsrc[b.Type], "allocatedSize", b.Size)
+			logger.Info("Memory already allocated with a different size than requested", "type", b.Type, "requestedResource", reqRsrc[b.Type], "allocatedSize", b.Size)
 			return nil
 		}
 
-		containerNUMAAffinity, err := bitmask.NewBitMask(b.NUMAAffinity...)
+		numaAffinity, err := bitmask.NewBitMask(b.NUMAAffinity...)
 		if err != nil {
-			logger.Error(err, "Failed to generate NUMA bitmask", "containerName", ctn.Name, "type", b.Type)
+			logger.Error(err, "Failed to generate NUMA bitmask", "type", b.Type)
 			return nil
 		}
 
-		logger.Info("Regenerating TopologyHints, resource was already allocated to pod", "resourceName", b.Type, "podUID", pod.UID, "containerName", ctn.Name)
+		logger.Info("Regenerating TopologyHints, resource was already allocated to pod", "resourceName", b.Type, "podUID", pod.UID)
 		hints[string(b.Type)] = append(hints[string(b.Type)], topologymanager.TopologyHint{
-			NUMANodeAffinity: containerNUMAAffinity,
+			NUMANodeAffinity: numaAffinity,
 			Preferred:        true,
 		})
 	}
@@ -841,13 +841,20 @@ func (p *staticPolicy) GetPodTopologyHints(logger klog.Logger, s state.State, po
 		return nil
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) && resourcehelper.IsPodLevelResourcesSet(pod) {
+		podBlocks := s.GetPodMemoryBlocks(string(pod.UID))
+		if podBlocks != nil {
+			return regenerateHints(klog.LoggerWithValues(logger, "allocationScope", "pod"), pod, podBlocks, reqRsrcs)
+		}
+	}
+
 	for _, ctn := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 		containerBlocks := s.GetMemoryBlocks(string(pod.UID), ctn.Name)
 		// Short circuit to regenerate the same hints if there are already
 		// memory allocated for the container. This might happen after a
 		// kubelet restart, for example.
 		if containerBlocks != nil {
-			return regenerateHints(logger, pod, &ctn, containerBlocks, reqRsrcs)
+			return regenerateHints(klog.LoggerWithValues(logger, "allocationScope", "container", "containerName", ctn.Name), pod, containerBlocks, reqRsrcs)
 		}
 	}
 
@@ -890,7 +897,7 @@ func (p *staticPolicy) GetTopologyHints(logger klog.Logger, s state.State, pod *
 	// memory allocated for the container. This might happen after a
 	// kubelet restart, for example.
 	if containerBlocks != nil {
-		return regenerateHints(logger, pod, container, containerBlocks, requestedResources)
+		return regenerateHints(klog.LoggerWithValues(logger, "allocationScope", "container", "containerName", container.Name), pod, containerBlocks, requestedResources)
 	}
 
 	return p.calculateHints(s.GetMachineState(), pod, requestedResources)

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -854,7 +854,12 @@ func (p *staticPolicy) GetPodTopologyHints(logger klog.Logger, s state.State, po
 		// memory allocated for the container. This might happen after a
 		// kubelet restart, for example.
 		if containerBlocks != nil {
-			return regenerateHints(klog.LoggerWithValues(logger, "allocationScope", "container", "containerName", ctn.Name), pod, containerBlocks, reqRsrcs)
+			containerRequestedResources, err := getContainerRequestedResources(logger, pod, &ctn)
+			if err != nil {
+				logger.Error(err, "Failed to get container requested resources", "podUID", pod.UID, "containerName", ctn.Name)
+				return nil
+			}
+			return regenerateHints(klog.LoggerWithValues(logger, "allocationScope", "container", "containerName", ctn.Name), pod, containerBlocks, containerRequestedResources)
 		}
 	}
 

--- a/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
@@ -49,7 +49,7 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 		podMemoryRequest                string
 		containers                      []containerSpec
 		expectPodBlocks                 bool
-		expectRestoredPodHint           bool
+		expectedAffinity                []int
 	}{
 		{
 			description:                     "PodLevelResources and PodLevelResourceManagers enabled",
@@ -59,7 +59,8 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 			containers: []containerSpec{
 				{name: "container1", memRequest: "100Mi", memLimit: "100Mi"},
 			},
-			expectPodBlocks: true,
+			expectPodBlocks:  true,
+			expectedAffinity: []int{0},
 		},
 		{
 			description:                     "Pod topology hint is restored from a multi-container pod allocation",
@@ -70,8 +71,8 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 				{name: "container1", memRequest: "50Mi", memLimit: "50Mi"},
 				{name: "container2", memRequest: "50Mi", memLimit: "50Mi"},
 			},
-			expectPodBlocks:       true,
-			expectRestoredPodHint: true,
+			expectPodBlocks:  true,
+			expectedAffinity: []int{0},
 		},
 		{
 			description:                     "PodLevelResources enabled, PodLevelResourceManagers disabled",
@@ -92,7 +93,8 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 				{name: "container1", memRequest: "100Mi", memLimit: "100Mi"},
 				{name: "container2", memRequest: "100Mi", memLimit: "100Mi"},
 			},
-			expectPodBlocks: false,
+			expectPodBlocks:  false,
+			expectedAffinity: []int{0},
 		},
 		{
 			description:                     "Container-level pod, features disabled",
@@ -103,7 +105,8 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 				{name: "container1", memRequest: "100Mi", memLimit: "100Mi"},
 				{name: "container2", memRequest: "100Mi", memLimit: "100Mi"},
 			},
-			expectPodBlocks: false,
+			expectPodBlocks:  false,
+			expectedAffinity: []int{0},
 		},
 	}
 
@@ -199,16 +202,20 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 				t.Errorf("expected no pod memory blocks after restore, but got some")
 			}
 
-			if tc.expectRestoredPodHint {
-				hints := mgr2.GetPodTopologyHints(logger, pod, lifecycle.AddOperation)
-				memoryHints := hints[string(v1.ResourceMemory)]
+			hints := mgr2.GetPodTopologyHints(logger, pod, lifecycle.AddOperation)
+			memoryHints := hints[string(v1.ResourceMemory)]
+			if tc.expectedAffinity == nil {
+				if len(memoryHints) != 0 {
+					t.Fatalf("expected no restored memory hint, got %v", memoryHints)
+				}
+			} else {
 				if len(memoryHints) != 1 {
 					t.Fatalf("expected one restored memory hint, got %v", memoryHints)
 				}
 				if !memoryHints[0].Preferred {
 					t.Error("expected restored memory hint to be preferred")
 				}
-				expectedAffinity := newNUMAAffinity(podBlocksRestored[0].NUMAAffinity...)
+				expectedAffinity := newNUMAAffinity(tc.expectedAffinity...)
 				if !memoryHints[0].NUMANodeAffinity.IsEqual(expectedAffinity) {
 					t.Errorf("expected restored memory hint affinity %v, got %v", expectedAffinity, memoryHints[0].NUMANodeAffinity)
 				}

--- a/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
@@ -49,6 +49,7 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 		podMemoryRequest                string
 		containers                      []containerSpec
 		expectPodBlocks                 bool
+		expectRestoredPodHint           bool
 	}{
 		{
 			description:                     "PodLevelResources and PodLevelResourceManagers enabled",
@@ -59,6 +60,18 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 				{name: "container1", memRequest: "100Mi", memLimit: "100Mi"},
 			},
 			expectPodBlocks: true,
+		},
+		{
+			description:                     "Pod topology hint is restored from a multi-container pod allocation",
+			podLevelResourcesEnabled:        true,
+			podLevelResourceManagersEnabled: true,
+			podMemoryRequest:                "128Mi",
+			containers: []containerSpec{
+				{name: "container1", memRequest: "50Mi", memLimit: "50Mi"},
+				{name: "container2", memRequest: "50Mi", memLimit: "50Mi"},
+			},
+			expectPodBlocks:       true,
+			expectRestoredPodHint: true,
 		},
 		{
 			description:                     "PodLevelResources enabled, PodLevelResourceManagers disabled",
@@ -184,6 +197,21 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 				}
 			} else if len(podBlocksRestored) > 0 {
 				t.Errorf("expected no pod memory blocks after restore, but got some")
+			}
+
+			if tc.expectRestoredPodHint {
+				hints := mgr2.GetPodTopologyHints(logger, pod, lifecycle.AddOperation)
+				memoryHints := hints[string(v1.ResourceMemory)]
+				if len(memoryHints) != 1 {
+					t.Fatalf("expected one restored memory hint, got %v", memoryHints)
+				}
+				if !memoryHints[0].Preferred {
+					t.Error("expected restored memory hint to be preferred")
+				}
+				expectedAffinity := newNUMAAffinity(podBlocksRestored[0].NUMAAffinity...)
+				if !memoryHints[0].NUMANodeAffinity.IsEqual(expectedAffinity) {
+					t.Errorf("expected restored memory hint affinity %v, got %v", expectedAffinity, memoryHints[0].NUMANodeAffinity)
+				}
 			}
 
 			// Verify containers restored


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Restores pod-scope topology hints from the pod-level memory allocation instead of a single container allocation. Adds a restart regression test for a multi-container Pod.

#### Which issue(s) this PR is related to:

Fixes #141069

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
Fixed Memory Manager pod-scope topology hint restoration for multi-container Pods after kubelet restart.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```