### PR TITLE
scheduler: refactor entity key extraction logic

### DIFF
--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package gangscheduling
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1754,10 +1753,10 @@ func TestPlacementFeasible(t *testing.T) {
 			pgName := "test-pg"
 			namespace := "default"
 
-			pgInfo := &testPodGroupInfo{
-				namespace:       namespace,
-				name:            pgName,
-				unscheduledPods: tc.unscheduledPods,
+			pgInfo := &schedulerframework.PodGroupInfo{
+				Namespace:       namespace,
+				Name:            pgName,
+				UnscheduledPods: tc.unscheduledPods,
 			}
 
 			var objs []runtime.Object
@@ -1772,8 +1771,8 @@ func TestPlacementFeasible(t *testing.T) {
 				} else {
 					cpg.Spec.SchedulingPolicy.Basic = &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}
 				}
-				pgInfo.groupType = fwk.CompositePodGroupKeyType
-				pgInfo.cpg = cpg
+				pgInfo.Type = fwk.CompositePodGroupKeyType
+				pgInfo.CompositePodGroup = cpg
 				objs = append(objs, cpg)
 			} else {
 				pg := st.MakePodGroup().Namespace(namespace).Name(pgName).ParentCompositePodGroup("cpg-root").Obj()
@@ -1782,8 +1781,8 @@ func TestPlacementFeasible(t *testing.T) {
 				} else {
 					pg.Spec.SchedulingPolicy.Basic = &schedulingv1beta1.BasicSchedulingPolicy{}
 				}
-				pgInfo.groupType = fwk.PodGroupKeyType
-				pgInfo.podGroup = pg
+				pgInfo.Type = fwk.PodGroupKeyType
+				pgInfo.PodGroup = pg
 				objs = append(objs, pg)
 			}
 
@@ -1836,30 +1835,6 @@ func TestPlacementFeasible(t *testing.T) {
 			}
 		})
 	}
-}
-
-type testPodGroupInfo struct {
-	namespace       string
-	name            string
-	groupType       fwk.EntityKeyType
-	unscheduledPods []*v1.Pod
-	cpg             *schedulingv1alpha3.CompositePodGroup
-	podGroup        *schedulingv1beta1.PodGroup
-}
-
-func (t *testPodGroupInfo) GetNamespace() string                     { return t.namespace }
-func (t *testPodGroupInfo) GetName() string                          { return t.name }
-func (t *testPodGroupInfo) GetUnscheduledPods() []*v1.Pod            { return t.unscheduledPods }
-func (t *testPodGroupInfo) GetPodGroup() *schedulingv1beta1.PodGroup { return t.podGroup }
-func (t *testPodGroupInfo) GetType() fwk.EntityKeyType               { return t.groupType }
-func (t *testPodGroupInfo) GetKey() string {
-	return fmt.Sprintf("%s/%s/%s", t.groupType, t.namespace, t.name)
-}
-func (t *testPodGroupInfo) GetCompositePodGroup() *schedulingv1alpha3.CompositePodGroup {
-	return t.cpg
-}
-func (t *testPodGroupInfo) GetChildren() []fwk.PodGroupInfo {
-	return nil
 }
 
 type mockPodGroupManager struct {

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -1016,10 +1016,10 @@ func TestPlacementFeasible(t *testing.T) {
 					pgName := "test-pg"
 					namespace := "default"
 
-					pgInfo := &testPodGroupInfo{
-						namespace:       namespace,
-						name:            pgName,
-						unscheduledPods: tc.unscheduledPods,
+					pgInfo := &schedulerframework.PodGroupInfo{
+						Namespace:       namespace,
+						Name:            pgName,
+						UnscheduledPods: tc.unscheduledPods,
 					}
 
 					var objs []runtime.Object
@@ -1031,8 +1031,8 @@ func TestPlacementFeasible(t *testing.T) {
 						} else {
 							cpg.Spec.SchedulingPolicy.Basic = &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}
 						}
-						pgInfo.groupType = fwk.CompositePodGroupKeyType
-						pgInfo.cpg = cpg
+						pgInfo.Type = fwk.CompositePodGroupKeyType
+						pgInfo.CompositePodGroup = cpg
 						objs = append(objs, cpg)
 					} else {
 						pg := st.MakePodGroup().Namespace(namespace).Name(pgName).ParentCompositePodGroup("cpg-root").Obj()
@@ -1041,8 +1041,8 @@ func TestPlacementFeasible(t *testing.T) {
 						} else {
 							pg.Spec.SchedulingPolicy.Basic = &schedulingv1beta1.BasicSchedulingPolicy{}
 						}
-						pgInfo.groupType = fwk.PodGroupKeyType
-						pgInfo.podGroup = pg
+						pgInfo.Type = fwk.PodGroupKeyType
+						pgInfo.PodGroup = pg
 						objs = append(objs, pg)
 					}
 
@@ -1097,30 +1097,6 @@ func TestPlacementFeasible(t *testing.T) {
 			}
 		}
 	}
-}
-
-type testPodGroupInfo struct {
-	namespace       string
-	name            string
-	groupType       fwk.EntityKeyType
-	unscheduledPods []*v1.Pod
-	cpg             *schedulingv1alpha3.CompositePodGroup
-	podGroup        *schedulingv1beta1.PodGroup
-}
-
-func (t *testPodGroupInfo) GetNamespace() string                     { return t.namespace }
-func (t *testPodGroupInfo) GetName() string                          { return t.name }
-func (t *testPodGroupInfo) GetUnscheduledPods() []*v1.Pod            { return t.unscheduledPods }
-func (t *testPodGroupInfo) GetPodGroup() *schedulingv1beta1.PodGroup { return t.podGroup }
-func (t *testPodGroupInfo) GetType() fwk.EntityKeyType               { return t.groupType }
-func (t *testPodGroupInfo) GetKey() string {
-	return fmt.Sprintf("%s/%s/%s", t.groupType, t.namespace, t.name)
-}
-func (t *testPodGroupInfo) GetCompositePodGroup() *schedulingv1alpha3.CompositePodGroup {
-	return t.cpg
-}
-func (t *testPodGroupInfo) GetChildren() []fwk.PodGroupInfo {
-	return nil
 }
 
 type mockPodGroupManager struct {

--- a/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count.go
+++ b/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count.go
@@ -93,7 +93,7 @@ func (pl *PodGroupPodsCount) NormalizePlacementScore(ctx context.Context, state 
 func (pl *PodGroupPodsCount) getScheduledPodsCount(podGroup fwk.PodGroupInfo) (int, error) {
 	if pl.fts.EnableCompositePodGroup {
 		count := 0
-		for podGroupState, err := range helper.GetPodGroupStates(pl.handle.SnapshotSharedLister(), fwk.MustParseEntityKey(podGroup.GetKey())) {
+		for podGroupState, err := range helper.GetPodGroupStates(pl.handle.SnapshotSharedLister(), podGroup.GetKey()) {
 			if err != nil {
 				return 0, err
 			}

--- a/pkg/scheduler/framework/plugins/topologyaware/topology_placement.go
+++ b/pkg/scheduler/framework/plugins/topologyaware/topology_placement.go
@@ -137,7 +137,7 @@ func (pl *TopologyPlacement) getTopologyKey(pgi fwk.PodGroupInfo) (string, bool)
 func (pl *TopologyPlacement) getScheduledPods(podGroup fwk.PodGroupInfo) ([]*v1.Pod, error) {
 	if pl.fts.EnableCompositePodGroup {
 		var results []*v1.Pod
-		for podGroupState, err := range helper.GetPodGroupStates(pl.handle.SnapshotSharedLister(), fwk.MustParseEntityKey(podGroup.GetKey())) {
+		for podGroupState, err := range helper.GetPodGroupStates(pl.handle.SnapshotSharedLister(), podGroup.GetKey()) {
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -1603,10 +1603,7 @@ func TestPodGroupEvaluator_Preempt(t *testing.T) {
 				return nil, fwk.NewStatus(fwk.Error)
 			}
 
-			pgInfo := &testPodGroupInfo{
-				pg:   tt.preemptorPodGroup,
-				pods: tt.preemptorPods,
-			}
+			pgInfo := newTestPodGroupInfo(tt.preemptorPodGroup, nil, tt.preemptorPods)
 
 			gotResult, gotStatus := pl.Preempt(ctx, pgInfo, mockSchedulingFunc)
 			if gotStatus.Code() != tt.expectedStatus.Code() || gotStatus.Message() != tt.expectedStatus.Message() {
@@ -1655,10 +1652,7 @@ func TestPodGroupPreemptionEvaluationDurationMetric(t *testing.T) {
 	nodeName := "node1"
 	preemptorPod := st.MakePod().Name("p1").UID("p1").Obj()
 	preemptor := newPodGroupPreemptor(
-		&testPodGroupInfo{
-			pg:   st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
-			pods: []*v1.Pod{preemptorPod},
-		},
+		newTestPodGroupInfo(st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(), nil, []*v1.Pod{preemptorPod}),
 		false,
 	)
 

--- a/pkg/scheduler/framework/preemption/types_test.go
+++ b/pkg/scheduler/framework/preemption/types_test.go
@@ -278,7 +278,7 @@ func TestNewPodGroupPreemptorResolvesPreemptionPolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			preemptor := newPodGroupPreemptor(&testPodGroupInfo{pg: tt.pg, cpg: tt.cpg, pods: tt.pods}, tt.enablePodGroupPreemptionPolicy)
+			preemptor := newPodGroupPreemptor(newTestPodGroupInfo(tt.pg, tt.cpg, tt.pods), tt.enablePodGroupPreemptionPolicy)
 			if preemptor.preemptionPolicy != tt.wantPolicy {
 				t.Errorf("expected preemption policy %q, got %q", tt.wantPolicy, preemptor.preemptionPolicy)
 			}
@@ -1153,61 +1153,26 @@ func TestNewDomainVictim(t *testing.T) {
 	}
 }
 
-type testPodGroupInfo struct {
-	pg   *schedulingv1beta1.PodGroup
-	cpg  *schedulingv1alpha3.CompositePodGroup
-	pods []*v1.Pod
-}
-
-func (t *testPodGroupInfo) GetName() string {
-	if t.cpg != nil {
-		return t.cpg.Name
+func newTestPodGroupInfo(pg *schedulingv1beta1.PodGroup, cpg *schedulingv1alpha3.CompositePodGroup, pods []*v1.Pod) *framework.PodGroupInfo {
+	pgi := &framework.PodGroupInfo{
+		UnscheduledPods:   pods,
+		PodGroup:          pg,
+		CompositePodGroup: cpg,
 	}
-	if t.pg != nil {
-		return t.pg.Name
+	if cpg != nil {
+		pgi.Name = cpg.Name
+		pgi.Namespace = cpg.Namespace
+		pgi.Type = fwk.CompositePodGroupKeyType
+		pgi.Children = []*framework.PodGroupInfo{
+			{
+				PodGroup:        &schedulingv1beta1.PodGroup{},
+				UnscheduledPods: pods,
+			},
+		}
+	} else if pg != nil {
+		pgi.Name = pg.Name
+		pgi.Namespace = pg.Namespace
+		pgi.Type = fwk.PodGroupKeyType
 	}
-	return ""
-}
-
-func (t *testPodGroupInfo) GetNamespace() string {
-	if t.cpg != nil {
-		return t.cpg.Namespace
-	}
-	if t.pg != nil {
-		return t.pg.Namespace
-	}
-	return ""
-}
-
-func (t *testPodGroupInfo) GetType() fwk.EntityKeyType {
-	if t.cpg != nil {
-		return fwk.CompositePodGroupKeyType
-	}
-	return fwk.PodGroupKeyType
-}
-
-func (t *testPodGroupInfo) GetKey() string {
-	if t.cpg != nil {
-		return t.cpg.Name
-	}
-	if t.pg != nil {
-		return t.pg.Name
-	}
-	return ""
-}
-
-func (t *testPodGroupInfo) GetUnscheduledPods() []*v1.Pod {
-	return t.pods
-}
-
-func (t *testPodGroupInfo) GetPodGroup() *schedulingv1beta1.PodGroup {
-	return t.pg
-}
-
-func (t *testPodGroupInfo) GetCompositePodGroup() *schedulingv1alpha3.CompositePodGroup {
-	return t.cpg
-}
-
-func (t *testPodGroupInfo) GetChildren() []fwk.PodGroupInfo {
-	return nil
+	return pgi
 }

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -1223,8 +1223,11 @@ func (pgi *PodGroupInfo) GetType() fwk.EntityKeyType {
 	return pgi.Type
 }
 
-func (pgi *PodGroupInfo) GetKey() string {
-	return fmt.Sprintf("%s/%s/%s", pgi.Type, pgi.Namespace, pgi.Name)
+func (pgi *PodGroupInfo) GetKey() fwk.EntityKey {
+	if pgi.Type == fwk.CompositePodGroupKeyType {
+		return fwk.CompositePodGroupKey(pgi.Namespace, pgi.Name)
+	}
+	return fwk.PodGroupKey(pgi.Namespace, pgi.Name)
 }
 
 // GetUnscheduledPods returns the unscheduled pods for this pod group.

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -372,7 +372,7 @@ func (sched *Scheduler) updateUnscheduledPods(pgi *framework.PodGroupInfo, queue
 		}
 		return
 	}
-	key := pgKey(pgi)
+	key := pgi.GetKey()
 	if podInfos, ok := queuedPodInfosToUpdate[key]; ok {
 		pgi.UnscheduledPods = make([]*v1.Pod, 0, len(podInfos))
 		for _, pInfo := range podInfos {
@@ -427,15 +427,15 @@ func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleSt
 // Cluster state should be snapshotted before calling this method.
 func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, rootPodGroupInfo *framework.QueuedPodGroupInfo, start time.Time) {
 	pgResults := sched.runRootSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo)
-	rootStatus := pgResults[pgKey(rootPodGroupInfo.PodGroupInfo)].status
+	rootStatus := pgResults[rootPodGroupInfo.PodGroupInfo.GetKey()].status
 	var completePGResults map[fwk.EntityKey]*podGroupAlgorithmResult
 	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) && rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
 		completePGResults = completeCompositePodGroupAlgorithmResult(ctx, rootPodGroupInfo, podGroupCycleState, pgResults)
 	} else {
 		// pgResults has exactly 1 element.
-		queuedPodInfos := rootPodGroupInfo.QueuedPodInfos[pgKey(rootPodGroupInfo.PodGroupInfo)]
-		result := completePodGroupAlgorithmResult(ctx, queuedPodInfos, podGroupCycleState, pgResults[pgKey(rootPodGroupInfo.PodGroupInfo)])
-		completePGResults = map[fwk.EntityKey]*podGroupAlgorithmResult{pgKey(rootPodGroupInfo.PodGroupInfo): result}
+		queuedPodInfos := rootPodGroupInfo.QueuedPodInfos[rootPodGroupInfo.PodGroupInfo.GetKey()]
+		result := completePodGroupAlgorithmResult(ctx, queuedPodInfos, podGroupCycleState, pgResults[rootPodGroupInfo.PodGroupInfo.GetKey()])
+		completePGResults = map[fwk.EntityKey]*podGroupAlgorithmResult{rootPodGroupInfo.PodGroupInfo.GetKey(): result}
 	}
 
 	metrics.PodGroupSchedulingAlgorithmLatency.Observe(metrics.SinceInSeconds(start))
@@ -451,7 +451,7 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 			}
 			return &fwk.PodGroupAssignments{
 				ProposedAssignments: proposedAssignments,
-			}, results[pgKey(rootPodGroupInfo.PodGroupInfo)].status
+			}, results[rootPodGroupInfo.PodGroupInfo.GetKey()].status
 		}
 		pgPostFilterResult, status := schedFwk.RunPodGroupPostFilterPlugins(ctx, podGroupCycleState, rootPodGroupInfo.PodGroupInfo, pgSchedulingFunc)
 		applyPodGroupPostFilterResult(completePGResults, pgPostFilterResult, status)
@@ -484,7 +484,7 @@ func (sched *Scheduler) runRootSchedulingAlgorithm(ctx context.Context, schedFwk
 		// The framework requires at least 1 pod to be scheduled in order to return a success status.
 		result.status = fwk.NewStatus(fwk.Unschedulable).WithError(errPodGroupUnschedulable)
 	}
-	return map[fwk.EntityKey]*podGroupAlgorithmResult{pgKey(result.podGroupInfo): result}
+	return map[fwk.EntityKey]*podGroupAlgorithmResult{result.podGroupInfo.GetKey(): result}
 }
 
 // algorithmResult stores the scheduling result and status for a scheduling attempt of a single pod.
@@ -562,7 +562,7 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 	}()
 
 	// Retrieve the queued podinfos for the given pod group from the root queuedPodGroupInfo.
-	queuedPodInfos := queuedPodGroupInfo.QueuedPodInfos[pgKey(podGroupInfo)]
+	queuedPodInfos := queuedPodGroupInfo.QueuedPodInfos[podGroupInfo.GetKey()]
 	result = &podGroupAlgorithmResult{
 		podGroupInfo:        podGroupInfo,
 		podResults:          make([]algorithmResult, 0, len(queuedPodInfos)),
@@ -748,7 +748,7 @@ func completeCompositePodGroupAlgorithmResult(ctx context.Context, rootPodGroupI
 // This is necessary because child pod groups cannot be committed or bound if their parent composite
 // pod group fails to meet its scheduling requirements.
 func completeCompositePodGroupAlgorithmResultMap(ctx context.Context, podGroupInfo *framework.PodGroupInfo, pgResults map[fwk.EntityKey]*podGroupAlgorithmResult, parentResult *podGroupAlgorithmResult) {
-	key := pgKey(podGroupInfo)
+	key := podGroupInfo.GetKey()
 	result, ok := pgResults[key]
 	// When a parent composite pod group fails, any child that previously succeeded during its own evaluation
 	// must be invalidated with the parent's failure status to prevent its pods from proceeding to binding.
@@ -818,7 +818,7 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 			// Composite pod groups do not own any pods directly.
 			continue
 		}
-		queuedPodInfos := rootPodGroupInfo.QueuedPodInfos[pgKey(pgi)]
+		queuedPodInfos := rootPodGroupInfo.QueuedPodInfos[pgi.GetKey()]
 		if len(podGroupResult.podResults) != len(queuedPodInfos) {
 			// This should never happen, but if it does, complete the result with the error status.
 			logger.Error(fmt.Errorf("some pods were not processed"), "scheduling error for pod group", "podGroup", klog.KObj(pgi))
@@ -920,7 +920,7 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		sched.updatePodGroupCondition(ctx, pgi, condition)
 	}
 
-	rootResult := podGroupResults[pgKey(rootPodGroupInfo.PodGroupInfo)]
+	rootResult := podGroupResults[rootPodGroupInfo.PodGroupInfo.GetKey()]
 	switch {
 	case rootResult.status.IsSuccess():
 		metrics.PodGroupScheduled(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
@@ -1052,7 +1052,7 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 	bestResult := successfulResults[bestPlacement]
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) {
-		revertFns, err = sched.assumeSubtreeWithRevert(ctx, schedFwk, podGroupInfo, map[fwk.EntityKey]*podGroupAlgorithmResult{pgKey(podGroupInfo): bestResult})
+		revertFns, err = sched.assumeSubtreeWithRevert(ctx, schedFwk, podGroupInfo, map[fwk.EntityKey]*podGroupAlgorithmResult{podGroupInfo.GetKey(): bestResult})
 		if err != nil {
 			return &podGroupAlgorithmResult{
 				podGroupInfo: podGroupInfo,
@@ -1072,7 +1072,7 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 // Finally, it runs placement scorer plugins to select the best placement.
 func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, root *framework.QueuedPodGroupInfo, podGroupInfo *framework.PodGroupInfo, results map[fwk.EntityKey]*podGroupAlgorithmResult) (finalResult *podGroupAlgorithmResult, revertFns revertFns) {
 	defer func() {
-		results[pgKey(podGroupInfo)] = finalResult
+		results[podGroupInfo.GetKey()] = finalResult
 	}()
 	logger := klog.FromContext(ctx)
 	allNodes, err := sched.nodeInfoSnapshot.ListNodesInPlacement()
@@ -1137,7 +1137,7 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 	if len(successfulResults) == 0 {
 		// We need to send events and set the status for pods in case all simulations were infeasible.
 		// The selection of which simulation we report is arbitrary for now, but may change in the future.
-		anyResultRoot := anyResultSubtree[pgKey(podGroupInfo)]
+		anyResultRoot := anyResultSubtree[podGroupInfo.GetKey()]
 		anyResultRoot.status = fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("0/%d placements are available, first placement status: %v", len(placements), anyResultRoot.status.AsError())).WithError(errPodGroupUnschedulable)
 		// It is critical to copy the entire anyResultSubtree into results.
 		// If omitted, the pod results are reconstructed later using the generic parent error
@@ -1167,7 +1167,7 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 	}
 	maps.Copy(results, bestResult)
 
-	return bestResult[pgKey(podGroupInfo)], revertFns
+	return bestResult[podGroupInfo.GetKey()], revertFns
 }
 
 func (sched *Scheduler) findBestPodGroupPlacement(ctx context.Context, schedFwk framework.Framework, podGroupCycleState fwk.PodGroupCycleState, podGroupInfo *framework.PodGroupInfo, successfulResults map[*fwk.Placement]*podGroupAlgorithmResult) (*fwk.Placement, *fwk.Status) {
@@ -1254,7 +1254,7 @@ func makeCompositePodGroupAssignments(pgi *framework.PodGroupInfo, successfulRes
 			Placement:           placement,
 			ProposedAssignments: combinedProposedAssignments,
 		})
-		placementStates = append(placementStates, subtreeResults[pgKey(pgi)].placementCycleState)
+		placementStates = append(placementStates, subtreeResults[pgi.GetKey()].placementCycleState)
 	}
 	return placementPodGroupAssignments, placementStates
 }
@@ -1299,7 +1299,7 @@ func (sched *Scheduler) podGroupSchedulingRecursiveAlgorithm(ctx context.Context
 	var childRevertFns revertFns
 	if podGroupInfo.Type == fwk.PodGroupKeyType {
 		algorithmResult, childRevertFns = sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, podGroupInfo, root)
-		results[pgKey(podGroupInfo)] = algorithmResult
+		results[podGroupInfo.GetKey()] = algorithmResult
 	} else {
 		algorithmResult, childRevertFns = sched.compositePodGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, root, podGroupInfo, results)
 	}
@@ -1321,7 +1321,7 @@ func (sched *Scheduler) compositePodGroupSchedulingAlgorithm(ctx context.Context
 func (sched *Scheduler) compositePodGroupSchedulingDefaultAlgorithm(ctx context.Context, schedFwk framework.Framework, placementCycleState *framework.CycleState, root *framework.QueuedPodGroupInfo, podGroupInfo *framework.PodGroupInfo, results map[fwk.EntityKey]*podGroupAlgorithmResult) (result *podGroupAlgorithmResult, revertFns revertFns) {
 	logger := klog.FromContext(ctx)
 	defer func() {
-		results[pgKey(podGroupInfo)] = result
+		results[podGroupInfo.GetKey()] = result
 		if result.status.IsSuccess() {
 			logger.V(5).Info("Composite podgroup scheduling algorithm succeeded", "compositePodGroup", klog.KObj(podGroupInfo))
 		} else {
@@ -1378,13 +1378,6 @@ func (sched *Scheduler) compositePodGroupSchedulingDefaultAlgorithm(ctx context.
 	}, revertFns
 }
 
-func pgKey(pgi *framework.PodGroupInfo) fwk.EntityKey {
-	if pgi.Type == fwk.CompositePodGroupKeyType {
-		return fwk.CompositePodGroupKey(pgi.Namespace, pgi.Name)
-	}
-	return fwk.PodGroupKey(pgi.Namespace, pgi.Name)
-}
-
 // assumeSubtreeWithRevert runs assumeAndReserveWithRevert on all pods within the subtree.
 // This is needed for placement-based algorithm, because after evaluating the results for all placements,
 // the chosen result needs to be assumed for the other pods in the hierarchy to see the result.
@@ -1424,7 +1417,7 @@ func successfulLeafResults(root *framework.PodGroupInfo, results map[fwk.EntityK
 	return func(yield func(*podGroupAlgorithmResult) bool) {
 		var walk func(pgi *framework.PodGroupInfo) bool
 		walk = func(pgi *framework.PodGroupInfo) bool {
-			result, ok := results[pgKey(pgi)]
+			result, ok := results[pgi.GetKey()]
 			// Result may be missing because it may have been skipped due to PlacementFeasible status.
 			// If the result for a given subtree is non-success (e.g. actualCount < minGroupCount), we treat all of its descendants as non-success with 0 pods scheduled.
 			if !ok || !result.status.IsSuccess() {

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -336,7 +336,7 @@ func (sched *Scheduler) updateUnscheduledPods(pgi *framework.PodGroupInfo, queue
 		}
 		return
 	}
-	key := pgKey(pgi)
+	key := pgi.GetKey()
 	if podInfos, ok := queuedPodInfosToUpdate[key]; ok {
 		pgi.UnscheduledPods = make([]*v1.Pod, 0, len(podInfos))
 		for _, pInfo := range podInfos {
@@ -382,15 +382,15 @@ func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleSt
 // Cluster state should be snapshotted before calling this method.
 func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, rootPodGroupInfo *framework.QueuedPodGroupInfo, start time.Time) {
 	pgResults := sched.runRootSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo)
-	rootStatus := pgResults[pgKey(rootPodGroupInfo.PodGroupInfo)].status
+	rootStatus := pgResults[rootPodGroupInfo.PodGroupInfo.GetKey()].status
 	var completePGResults map[fwk.EntityKey]*podGroupAlgorithmResult
 	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) && rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
 		completePGResults = completeCompositePodGroupAlgorithmResult(ctx, rootPodGroupInfo, podGroupCycleState, pgResults)
 	} else {
 		// pgResults has exactly 1 element.
-		queuedPodInfos := rootPodGroupInfo.QueuedPodInfos[pgKey(rootPodGroupInfo.PodGroupInfo)]
-		result := completePodGroupAlgorithmResult(ctx, queuedPodInfos, podGroupCycleState, pgResults[pgKey(rootPodGroupInfo.PodGroupInfo)])
-		completePGResults = map[fwk.EntityKey]*podGroupAlgorithmResult{pgKey(rootPodGroupInfo.PodGroupInfo): result}
+		queuedPodInfos := rootPodGroupInfo.QueuedPodInfos[rootPodGroupInfo.PodGroupInfo.GetKey()]
+		result := completePodGroupAlgorithmResult(ctx, queuedPodInfos, podGroupCycleState, pgResults[rootPodGroupInfo.PodGroupInfo.GetKey()])
+		completePGResults = map[fwk.EntityKey]*podGroupAlgorithmResult{rootPodGroupInfo.PodGroupInfo.GetKey(): result}
 	}
 
 	metrics.PodGroupSchedulingAlgorithmLatency.Observe(metrics.SinceInSeconds(start))
@@ -406,7 +406,7 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 			}
 			return &fwk.PodGroupAssignments{
 				ProposedAssignments: proposedAssignments,
-			}, results[pgKey(rootPodGroupInfo.PodGroupInfo)].status
+			}, results[rootPodGroupInfo.PodGroupInfo.GetKey()].status
 		}
 		pgPostFilterResult, status := schedFwk.RunPodGroupPostFilterPlugins(ctx, podGroupCycleState, rootPodGroupInfo.PodGroupInfo, pgSchedulingFunc)
 		applyPodGroupPostFilterResult(completePGResults, pgPostFilterResult, status)
@@ -441,7 +441,7 @@ func (sched *Scheduler) runRootSchedulingAlgorithm(ctx context.Context, schedFwk
 		fitError := newPodGroupFitError(fwk.NewStatus(fwk.Unschedulable, "no pods were schedulable"))
 		result.status = fwk.NewStatus(fwk.Unschedulable).WithError(fitError)
 	}
-	return map[fwk.EntityKey]*podGroupAlgorithmResult{pgKey(result.podGroupInfo): result}
+	return map[fwk.EntityKey]*podGroupAlgorithmResult{result.podGroupInfo.GetKey(): result}
 }
 
 // podGroupSchedulingDefaultAlgorithm runs the default algorithm for scheduling a pod group.
@@ -459,7 +459,7 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 	}()
 
 	// Retrieve the queued podinfos for the given pod group from the root queuedPodGroupInfo.
-	queuedPodInfos := queuedPodGroupInfo.QueuedPodInfos[pgKey(podGroupInfo)]
+	queuedPodInfos := queuedPodGroupInfo.QueuedPodInfos[podGroupInfo.GetKey()]
 	result = &podGroupAlgorithmResult{
 		podGroupInfo:        podGroupInfo,
 		podResults:          make([]algorithmResult, 0, len(queuedPodInfos)),
@@ -650,7 +650,7 @@ func completeCompositePodGroupAlgorithmResult(ctx context.Context, rootPodGroupI
 // This is necessary because child pod groups cannot be committed or bound if their parent composite
 // pod group fails to meet its scheduling requirements.
 func completeCompositePodGroupAlgorithmResultMap(ctx context.Context, podGroupInfo *framework.PodGroupInfo, pgResults map[fwk.EntityKey]*podGroupAlgorithmResult, parentResult *podGroupAlgorithmResult) {
-	key := pgKey(podGroupInfo)
+	key := podGroupInfo.GetKey()
 	result, ok := pgResults[key]
 	if !ok {
 		// In case the pod group wasn't processed, create the result and set its status to parent.
@@ -731,7 +731,7 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 			// Composite pod groups do not own any pods directly.
 			continue
 		}
-		queuedPodInfos := rootPodGroupInfo.QueuedPodInfos[pgKey(pgi)]
+		queuedPodInfos := rootPodGroupInfo.QueuedPodInfos[pgi.GetKey()]
 		if len(podGroupResult.podResults) != len(queuedPodInfos) {
 			// This should never happen, but if it does, complete the result with the error status.
 			logger.Error(fmt.Errorf("some pods were not processed"), "scheduling error for pod group", "podGroup", klog.KObj(pgi))
@@ -832,7 +832,7 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 		sched.updatePodGroupCondition(ctx, pgi, condition)
 	}
 
-	rootResult := podGroupResults[pgKey(rootPodGroupInfo.PodGroupInfo)]
+	rootResult := podGroupResults[rootPodGroupInfo.PodGroupInfo.GetKey()]
 	switch {
 	case rootResult.status.IsSuccess():
 		metrics.PodGroupScheduled(schedFwk.ProfileName(), metrics.SinceInSeconds(start))
@@ -965,7 +965,7 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 	bestResult := successfulResults[bestPlacement]
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) {
-		revertFns, err = sched.assumeSubtreeWithRevert(ctx, schedFwk, podGroupInfo, map[fwk.EntityKey]*podGroupAlgorithmResult{pgKey(podGroupInfo): bestResult})
+		revertFns, err = sched.assumeSubtreeWithRevert(ctx, schedFwk, podGroupInfo, map[fwk.EntityKey]*podGroupAlgorithmResult{podGroupInfo.GetKey(): bestResult})
 		if err != nil {
 			return &podGroupAlgorithmResult{
 				podGroupInfo: podGroupInfo,
@@ -985,7 +985,7 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 // Finally, it runs placement scorer plugins to select the best placement.
 func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, root *framework.QueuedPodGroupInfo, podGroupInfo *framework.PodGroupInfo, results map[fwk.EntityKey]*podGroupAlgorithmResult) (finalResult *podGroupAlgorithmResult, revertFns revertFns) {
 	defer func() {
-		results[pgKey(podGroupInfo)] = finalResult
+		results[podGroupInfo.GetKey()] = finalResult
 	}()
 	logger := klog.FromContext(ctx)
 	allNodes, err := sched.nodeInfoSnapshot.ListNodesInPlacement()
@@ -1054,7 +1054,7 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 	if len(successfulResults) == 0 {
 		// We need to send events and set the status for pods in case all simulations were infeasible.
 		// The selection of which simulation we report is arbitrary for now, but may change in the future.
-		anyResultRoot := anyResultSubtree[pgKey(podGroupInfo)]
+		anyResultRoot := anyResultSubtree[podGroupInfo.GetKey()]
 		fitError := newPodGroupPlacementFitError(anyResultRoot.status, len(placements))
 		anyResultRoot.status = fwk.NewStatus(fwk.Unschedulable).WithError(fitError)
 		// It is critical to copy the entire anyResultSubtree into results.
@@ -1085,7 +1085,7 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 	}
 	maps.Copy(results, bestResult)
 
-	return bestResult[pgKey(podGroupInfo)], revertFns
+	return bestResult[podGroupInfo.GetKey()], revertFns
 }
 
 func (sched *Scheduler) findBestPodGroupPlacement(ctx context.Context, schedFwk framework.Framework, podGroupCycleState fwk.PodGroupCycleState, podGroupInfo *framework.PodGroupInfo, successfulResults map[*fwk.Placement]*podGroupAlgorithmResult) (*fwk.Placement, *fwk.Status) {
@@ -1172,7 +1172,7 @@ func makeCompositePodGroupAssignments(pgi *framework.PodGroupInfo, successfulRes
 			Placement:           placement,
 			ProposedAssignments: combinedProposedAssignments,
 		})
-		placementStates = append(placementStates, subtreeResults[pgKey(pgi)].placementCycleState)
+		placementStates = append(placementStates, subtreeResults[pgi.GetKey()].placementCycleState)
 	}
 	return placementPodGroupAssignments, placementStates
 }
@@ -1217,7 +1217,7 @@ func (sched *Scheduler) podGroupSchedulingRecursiveAlgorithm(ctx context.Context
 	var childRevertFns revertFns
 	if podGroupInfo.Type == fwk.PodGroupKeyType {
 		algorithmResult, childRevertFns = sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, podGroupInfo, root)
-		results[pgKey(podGroupInfo)] = algorithmResult
+		results[podGroupInfo.GetKey()] = algorithmResult
 	} else {
 		algorithmResult, childRevertFns = sched.compositePodGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, root, podGroupInfo, results)
 	}
@@ -1239,7 +1239,7 @@ func (sched *Scheduler) compositePodGroupSchedulingAlgorithm(ctx context.Context
 func (sched *Scheduler) compositePodGroupSchedulingDefaultAlgorithm(ctx context.Context, schedFwk framework.Framework, placementCycleState *framework.CycleState, root *framework.QueuedPodGroupInfo, podGroupInfo *framework.PodGroupInfo, results map[fwk.EntityKey]*podGroupAlgorithmResult) (result *podGroupAlgorithmResult, revertFns revertFns) {
 	logger := klog.FromContext(ctx)
 	defer func() {
-		results[pgKey(podGroupInfo)] = result
+		results[podGroupInfo.GetKey()] = result
 		if result.status.IsSuccess() {
 			logger.V(5).Info("Composite podgroup scheduling algorithm succeeded", "compositePodGroup", klog.KObj(podGroupInfo))
 		} else {
@@ -1299,13 +1299,6 @@ func (sched *Scheduler) compositePodGroupSchedulingDefaultAlgorithm(ctx context.
 	}, revertFns
 }
 
-func pgKey(pgi *framework.PodGroupInfo) fwk.EntityKey {
-	if pgi.Type == fwk.CompositePodGroupKeyType {
-		return fwk.CompositePodGroupKey(pgi.Namespace, pgi.Name)
-	}
-	return fwk.PodGroupKey(pgi.Namespace, pgi.Name)
-}
-
 // assumeSubtreeWithRevert runs assumeAndReserveWithRevert on all pods within the subtree.
 // This is needed for placement-based algorithm, because after evaluating the results for all placements,
 // the chosen result needs to be assumed for the other pods in the hierarchy to see the result.
@@ -1345,7 +1338,7 @@ func successfulLeafResults(root *framework.PodGroupInfo, results map[fwk.EntityK
 	return func(yield func(*podGroupAlgorithmResult) bool) {
 		var walk func(pgi *framework.PodGroupInfo) bool
 		walk = func(pgi *framework.PodGroupInfo) bool {
-			result, ok := results[pgKey(pgi)]
+			result, ok := results[pgi.GetKey()]
 			// Result may be missing because it may have been skipped due to PlacementFeasible status.
 			// If the result for a given subtree is non-success (e.g. actualCount < minGroupCount), we treat all of its descendants as non-success with 0 pods scheduled.
 			if !ok || !result.status.IsSuccess() {

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -634,7 +634,7 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 	}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2, qInfo3}},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2, qInfo3}},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -684,8 +684,8 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 	if podGroupInfo.Size() != 1 {
 		t.Errorf("Expected 1 queued pod left, got %d", podGroupInfo.Size())
 	}
-	if podGroupInfo.QueuedPodInfos[fwk.MustParseEntityKey("podgroup/default/pg")][0].Pod.Name != "p1" {
-		t.Errorf("Expected p1 to be left in queued pods, got %s", podGroupInfo.QueuedPodInfos[fwk.MustParseEntityKey("podgroup/default/pg")][0].Pod.Name)
+	if podGroupInfo.QueuedPodInfos[fwk.PodGroupKey("default", "pg")][0].Pod.Name != "p1" {
+		t.Errorf("Expected p1 to be left in queued pods, got %s", podGroupInfo.QueuedPodInfos[fwk.PodGroupKey("default", "pg")][0].Pod.Name)
 	}
 	if len(podGroupInfo.UnscheduledPods) != 1 {
 		t.Errorf("Expected 1 unscheduled pod left, got %d", len(podGroupInfo.UnscheduledPods))
@@ -789,7 +789,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			if len(requeuedPodGroup.QueuedPodInfos) != 1 {
 				t.Errorf("Expected 1 key in QueuedPodInfos, got %v", requeuedPodGroup.QueuedPodInfos)
 			}
-			infos := requeuedPodGroup.QueuedPodInfos[fwk.MustParseEntityKey("podgroup/default/pg")]
+			infos := requeuedPodGroup.QueuedPodInfos[fwk.PodGroupKey("default", "pg")]
 			if len(infos) != 1 || infos[0].Pod.UID != p2.UID {
 				t.Errorf("Expected queued PodGroup to contain pod %q, got %v", p2.Name, infos)
 			}
@@ -808,7 +808,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 	}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -892,7 +892,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	queuedPodInfos := []*framework.QueuedPodInfo{qInfo1, qInfo2, qInfo3}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -975,7 +975,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	sched.SchedulePod = sched.schedulePod
 
 	resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
-	schedulePodResult := resultsMap[pgKey(podGroupInfo.PodGroupInfo)]
+	schedulePodResult := resultsMap[podGroupInfo.PodGroupInfo.GetKey()]
 	if len(schedulePodResult.podResults) != 2 {
 		t.Errorf("Expected 2 pod results, got %d", len(schedulePodResult.podResults))
 	}
@@ -1054,7 +1054,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 			qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 
 			podGroupInfo := &framework.QueuedPodGroupInfo{
-				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 				PodGroupInfo: &framework.PodGroupInfo{
 					Name:            "pg",
 					Namespace:       "default",
@@ -1182,7 +1182,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 	queuedPodInfos := []*framework.QueuedPodInfo{qInfo1, qInfo2, qInfo3}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -1512,7 +1512,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					}
 
 					resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
-					result := resultsMap[pgKey(podGroupInfo.PodGroupInfo)]
+					result := resultsMap[podGroupInfo.PodGroupInfo.GetKey()]
 
 					if result.status.Code() != tt.expectedGroupStatusCode {
 						t.Errorf("Expected group status code: %v, got: %v", tt.expectedGroupStatusCode, result.status.Code())
@@ -1942,7 +1942,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				algorithmResult.podResults = append(algorithmResult.podResults, result)
 			}
 
-			sched.submitPodGroupAlgorithmResult(ctx, schedFwk, podGroupCycleState, podGroupInfo, map[fwk.EntityKey]*podGroupAlgorithmResult{pgKey(algorithmResult.podGroupInfo): &algorithmResult}, time.Now(), tt.status)
+			sched.submitPodGroupAlgorithmResult(ctx, schedFwk, podGroupCycleState, podGroupInfo, map[fwk.EntityKey]*podGroupAlgorithmResult{algorithmResult.podGroupInfo.GetKey(): &algorithmResult}, time.Now(), tt.status)
 
 			if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 				lock.Lock()
@@ -2361,11 +2361,11 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 // fakePlacementPlugin simulates Filter, PlacementGenerate and PlacementScore behaviors for PodGroup placement scheduling testing.
 type fakePlacementPlugin struct {
 	name                     string
-	filterStatus             map[string]*fwk.Status            // node name to status
-	generatePlacementsResult map[string]map[string][]string    // PodGroupInfo key to placement name to list of node names
-	generatePlacementsStatus map[string]*fwk.Status            // PodGroupInfo key to status
-	scorePlacementsResult    map[string]map[string]int64       // PodGroupInfo key to placement name to score
-	scorePlacementsStatus    map[string]map[string]*fwk.Status // PodGroupInfo key to placement name to status
+	filterStatus             map[string]*fwk.Status                   // node name to status
+	generatePlacementsResult map[fwk.EntityKey]map[string][]string    // PodGroupInfo key to placement name to list of node names
+	generatePlacementsStatus map[fwk.EntityKey]*fwk.Status            // PodGroupInfo key to status
+	scorePlacementsResult    map[fwk.EntityKey]map[string]int64       // PodGroupInfo key to placement name to score
+	scorePlacementsStatus    map[fwk.EntityKey]map[string]*fwk.Status // PodGroupInfo key to placement name to status
 	podPerNode               bool
 	reservedNodes            sets.Set[string]
 }
@@ -2485,9 +2485,10 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 	}
 	podGroupPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
 
+	pgKeyVal := fwk.PodGroupKey("default", "pg")
 	queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: podGroupPod}}}
 	pgInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{pgKeyVal: queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -2509,14 +2510,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedGeneratedPlacements: 2,
 			expectedFeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 2,
 						"placement2": 1,
 					},
@@ -2540,14 +2541,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedGeneratedPlacements: 2,
 			expectedFeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 						"placement2": 2,
 					},
@@ -2569,7 +2570,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 		},
 		"when no placements are generated, returns unschedulable": {
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{},
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{},
 			},
 			expectedResult: podGroupAlgorithmResult{
 				status: fwk.NewStatus(fwk.Unschedulable, "no feasible placements found").WithPlugin("FakePlacementPlugin_Ordered"),
@@ -2579,14 +2580,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedGeneratedPlacements:   2,
 			expectedInfeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 						"placement2": 2,
 					},
@@ -2618,14 +2619,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedGeneratedPlacements:   2,
 			expectedInfeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 						"placement2": 2,
 					},
@@ -2659,14 +2660,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedFeasibleEvaluations:   1,
 			expectedInfeasibleEvaluations: 1,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 					},
 				},
@@ -2697,14 +2698,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedFeasibleEvaluations:   1,
 			expectedInfeasibleEvaluations: 1,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 						"placement2": 2,
 					},
@@ -2733,7 +2734,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 		},
 		"when generate plugin fails, returns error": {
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsStatus: map[string]*fwk.Status{pgInfo.GetKey(): fwk.NewStatus(fwk.Error, "error for test")},
+				generatePlacementsStatus: map[fwk.EntityKey]*fwk.Status{pgKeyVal: fwk.NewStatus(fwk.Error, "error for test")},
 			},
 			expectedResult: podGroupAlgorithmResult{
 				status: fwk.NewStatus(fwk.Error, "error for test").WithPlugin("FakePlacementPlugin"),
@@ -2743,19 +2744,19 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedGeneratedPlacements: 2,
 			expectedFeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 					},
 				},
-				scorePlacementsStatus: map[string]map[string]*fwk.Status{
-					pgInfo.GetKey(): {
+				scorePlacementsStatus: map[fwk.EntityKey]map[string]*fwk.Status{
+					pgKeyVal: {
 						"placement2": fwk.NewStatus(fwk.Error, "error for test"),
 					},
 				},
@@ -2767,13 +2768,13 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 		"when a placement evaluation errors, returns error": {
 			expectedGeneratedPlacements: 1,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 					},
 				},
@@ -2871,7 +2872,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				metrics.PlacementEvaluationDuration.Reset()
 
 				resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo)
-				result := resultsMap[pgKey(pgInfo.PodGroupInfo)]
+				result := resultsMap[pgInfo.PodGroupInfo.GetKey()]
 
 				if result.podGroupInfo != pgInfo.PodGroupInfo {
 					t.Errorf("Unexpected podGroupInfo field (-want,+got):\n- %v\n+ %v", pgInfo, result.podGroupInfo)
@@ -2994,9 +2995,10 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(), 0)
 				queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 
+				pgKeyVal := fwk.PodGroupKey("default", "pg")
 				queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: podGroupPod}}}
 				pgInfo := &framework.QueuedPodGroupInfo{
-					QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
+					QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{pgKeyVal: queuedPodInfos},
 					PodGroupInfo: &framework.PodGroupInfo{
 						Name:            "pg",
 						Namespace:       "default",
@@ -3007,8 +3009,8 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 
 				placementPlugin := fakePlacementPlugin{
 					name: "FakeGeneratorPlugin",
-					generatePlacementsResult: map[string]map[string][]string{
-						pgInfo.GetKey(): placements,
+					generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+						pgKeyVal: placements,
 					},
 				}
 
@@ -3024,11 +3026,11 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				for i, placementScorePluginData := range tt.pluginData {
 					plugin := fakePlacementPlugin{
 						name: fmt.Sprintf("FakeScorePlugin[%d]", i),
-						scorePlacementsResult: map[string]map[string]int64{
-							pgInfo.GetKey(): placementScorePluginData.scorePlacementResult,
+						scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+							pgKeyVal: placementScorePluginData.scorePlacementResult,
 						},
-						scorePlacementsStatus: map[string]map[string]*fwk.Status{
-							pgInfo.GetKey(): placementScorePluginData.scorePlacementStatus,
+						scorePlacementsStatus: map[fwk.EntityKey]map[string]*fwk.Status{
+							pgKeyVal: placementScorePluginData.scorePlacementStatus,
 						},
 					}
 
@@ -3246,7 +3248,7 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 
 			queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: podGroupPod}}}
 			pgInfo := &framework.QueuedPodGroupInfo{
-				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
+				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 				PodGroupInfo: &framework.PodGroupInfo{
 					Name:            "pg",
 					Namespace:       "default",
@@ -3293,7 +3295,7 @@ type multiLevelPlacementStateTracker struct {
 	placementFeasibleTrajectories [][]string
 	placementScoreTrajectories    [][]string
 	filterTrajectories            [][]string
-	generatePlacementsResult      map[string][]string
+	generatePlacementsResult      map[fwk.EntityKey][]string
 }
 
 func (p *multiLevelPlacementStateTracker) Name() string {
@@ -3389,7 +3391,7 @@ func (p *multiLevelPlacementStateTracker) GeneratePlacements(ctx context.Context
 		}
 		p.placementGenerateTrajectories = append(p.placementGenerateTrajectories, trajectory)
 	}
-	state.Write(hierarchyKey, &hierarchyData{id: podGroup.GetKey()})
+	state.Write(hierarchyKey, &hierarchyData{id: podGroup.GetKey().String()})
 	placements := []*fwk.Placement{}
 	for _, placementName := range p.generatePlacementsResult[podGroup.GetKey()] {
 		placements = append(placements, &fwk.Placement{Name: placementName, Nodes: parentPlacement.Nodes})
@@ -3447,7 +3449,7 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 
 	tracker := &multiLevelPlacementStateTracker{
-		generatePlacementsResult: map[string][]string{
+		generatePlacementsResult: map[fwk.EntityKey][]string{
 			rootPGInfo.GetKey(): {
 				"placement1",
 				"placement2",
@@ -3515,13 +3517,13 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 
 	cpgQueuedInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
-			fwk.MustParseEntityKey(leafPGInfo.GetKey()): {queuedPodInfo1},
+			leafPGInfo.GetKey(): {queuedPodInfo1},
 		},
 		PodGroupInfo: rootPGInfo,
 	}
 
 	results := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), cpgQueuedInfo)
-	if result, ok := results[pgKey(rootPGInfo)]; !ok || !result.status.IsSuccess() {
+	if result, ok := results[rootPGInfo.GetKey()]; !ok || !result.status.IsSuccess() {
 		t.Fatalf("Expected success for root pod group, got: %v", result.status)
 	}
 
@@ -3627,7 +3629,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		Children:          []*framework.PodGroupInfo{childPGInfo1, childPGInfo2},
 	}
 
-	defaultPlacementResults := map[string]map[string][]string{
+	defaultPlacementResults := map[fwk.EntityKey]map[string][]string{
 		rootPGInfo.GetKey(): {
 			"placement1": {nodes[0].Name, nodes[1].Name},
 			"placement2": {nodes[2].Name, nodes[3].Name},
@@ -3649,12 +3651,12 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 	tests := map[string]struct {
 		placementPlugin           fakePlacementPlugin
 		placementFeasibleStatuses [][]fwk.Code
-		expectedResults           map[string]podGroupAlgorithmResult
+		expectedResults           map[fwk.EntityKey]podGroupAlgorithmResult
 	}{
 		"respects higher score of parent placement": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: defaultPlacementResults,
-				scorePlacementsResult: map[string]map[string]int64{
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 					rootPGInfo.GetKey(): {
 						"placement1": 1,
 						"placement2": 2,
@@ -3673,7 +3675,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 					},
 				},
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {},
 				childPGInfo1.GetKey(): {
 					podResults: []algorithmResult{
@@ -3704,7 +3706,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		"discards infeasible placements": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: defaultPlacementResults,
-				scorePlacementsResult: map[string]map[string]int64{
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 					rootPGInfo.GetKey(): {
 						"placement1": 2,
 						"placement2": 1,
@@ -3728,7 +3730,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				{fwk.Unschedulable, fwk.Unschedulable, fwk.Unschedulable},
 				// success for the remaining placements
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {},
 				childPGInfo1.GetKey(): {
 					podResults: []algorithmResult{
@@ -3759,7 +3761,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		"returns unschedulable if no pods got scheduled": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: defaultPlacementResults,
-				scorePlacementsResult: map[string]map[string]int64{
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 					rootPGInfo.GetKey(): {
 						"placement1": 2,
 						"placement2": 1,
@@ -3784,7 +3786,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 					nodes[3].Name: fwk.NewStatus(fwk.Unschedulable, "node4 rejected"),
 				},
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {
 					status: fwk.NewStatus(fwk.Unschedulable, "pod group is unschedulable"),
 				},
@@ -3811,7 +3813,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				generatePlacementsResult: defaultPlacementResults,
 				podPerNode:               true,
 				reservedNodes:            sets.New[string](),
-				scorePlacementsResult: map[string]map[string]int64{
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 					rootPGInfo.GetKey(): {
 						"placement1": 1,
 					},
@@ -3827,7 +3829,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				},
 				filterStatus: map[string]*fwk.Status{},
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {},
 				childPGInfo1.GetKey(): {
 					podResults: []algorithmResult{
@@ -3854,11 +3856,11 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		"when generate plugin fails at CPG, returns error": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: defaultPlacementResults,
-				generatePlacementsStatus: map[string]*fwk.Status{
+				generatePlacementsStatus: map[fwk.EntityKey]*fwk.Status{
 					rootPGInfo.GetKey(): fwk.AsStatus(fmt.Errorf("injected error")),
 				},
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {
 					status: fwk.NewStatus(fwk.Error, "injected error"),
 				},
@@ -3867,11 +3869,11 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		"when generate plugin fails at PG, returns error": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: defaultPlacementResults,
-				generatePlacementsStatus: map[string]*fwk.Status{
+				generatePlacementsStatus: map[fwk.EntityKey]*fwk.Status{
 					childPGInfo2.GetKey(): fwk.AsStatus(fmt.Errorf("injected error")),
 				},
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {
 					status: fwk.NewStatus(fwk.Error, "composite pod group evaluation failed due to child error: injected error"),
 				},
@@ -3951,17 +3953,17 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 
 			cpgInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
-					fwk.MustParseEntityKey(childPGInfo1.GetKey()): {queuedPodInfo1},
-					fwk.MustParseEntityKey(childPGInfo2.GetKey()): {queuedPodInfo2},
+					childPGInfo1.GetKey(): {queuedPodInfo1},
+					childPGInfo2.GetKey(): {queuedPodInfo2},
 				},
 				PodGroupInfo: rootPGInfo,
 			}
 
 			results := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), cpgInfo)
-			gotResults := make(map[string]podGroupAlgorithmResult, len(results))
+			gotResults := make(map[fwk.EntityKey]podGroupAlgorithmResult, len(results))
 			for k, v := range results {
 				if v != nil {
-					gotResults[k.String()] = *v
+					gotResults[k] = *v
 				}
 			}
 
@@ -4047,7 +4049,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 		Children:          []*framework.PodGroupInfo{childPGInfo1, childPGInfo2},
 	}
 
-	placements := map[string]map[string][]string{
+	placements := map[fwk.EntityKey]map[string][]string{
 		rootPGInfo.GetKey(): {
 			"placement1": {nodes[0].Name, nodes[1].Name},
 			"placement2": {nodes[2].Name, nodes[3].Name},
@@ -4068,8 +4070,8 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 
 	type pluginData struct {
 		weight                int32
-		scorePlacementsResult map[string]map[string]int64
-		scorePlacementsStatus map[string]map[string]*fwk.Status
+		scorePlacementsResult map[fwk.EntityKey]map[string]int64
+		scorePlacementsStatus map[fwk.EntityKey]map[string]*fwk.Status
 	}
 
 	tests := map[string]struct {
@@ -4080,7 +4082,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 			pluginData: []pluginData{
 				{
 					weight: 1,
-					scorePlacementsResult: map[string]map[string]int64{
+					scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 						rootPGInfo.GetKey(): {
 							"placement1": 50,
 							"placement2": 75,
@@ -4101,7 +4103,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				},
 				{
 					weight: 2,
-					scorePlacementsResult: map[string]map[string]int64{
+					scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 						rootPGInfo.GetKey(): {
 							"placement1": 25,
 							"placement2": 10,
@@ -4130,7 +4132,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 			pluginData: []pluginData{
 				{
 					weight: 1,
-					scorePlacementsResult: map[string]map[string]int64{
+					scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 						rootPGInfo.GetKey(): {
 							"placement1": 75,
 							"placement2": 50,
@@ -4151,7 +4153,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				},
 				{
 					weight: 2,
-					scorePlacementsResult: map[string]map[string]int64{
+					scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 						rootPGInfo.GetKey(): {
 							"placement1": 10,
 							"placement2": 25,
@@ -4258,8 +4260,8 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 
 			cpgInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
-					fwk.MustParseEntityKey(childPGInfo1.GetKey()): {queuedPodInfo1},
-					fwk.MustParseEntityKey(childPGInfo2.GetKey()): {queuedPodInfo2},
+					childPGInfo1.GetKey(): {queuedPodInfo1},
+					childPGInfo2.GetKey(): {queuedPodInfo2},
 				},
 				PodGroupInfo: rootPGInfo,
 			}
@@ -4298,7 +4300,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -4423,7 +4425,7 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -4502,7 +4504,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	testPodGroup := st.MakePodGroup().Name("pg").Namespace("default").Obj()
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:      "pg",
 			Namespace: "default",
@@ -4626,9 +4628,9 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
 	queuedPodInfosMap := map[fwk.EntityKey][]*framework.QueuedPodInfo{
-		fwk.MustParseEntityKey("podgroup/default/pg1"): {qInfo1},
-		fwk.MustParseEntityKey("podgroup/default/pg2"): {qInfo2},
-		fwk.MustParseEntityKey("podgroup/default/pg3"): {qInfo3},
+		fwk.PodGroupKey("default", "pg1"): {qInfo1},
+		fwk.PodGroupKey("default", "pg2"): {qInfo2},
+		fwk.PodGroupKey("default", "pg3"): {qInfo3},
 	}
 
 	cpgRootInfo := &framework.QueuedPodGroupInfo{
@@ -5859,7 +5861,7 @@ func TestScorePlacementPodGroupAssignments(t *testing.T) {
 					pgi.Type = fwk.PodGroupKeyType
 					pgi.PodGroup = st.MakePodGroup().Name(node.name).Namespace("default").Obj()
 				}
-				nameToKey[node.name] = pgKey(pgi)
+				nameToKey[node.name] = pgi.GetKey()
 				return pgi
 			}
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -635,7 +635,7 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 	}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2, qInfo3}},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2, qInfo3}},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -685,8 +685,8 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 	if podGroupInfo.Size() != 1 {
 		t.Errorf("Expected 1 queued pod left, got %d", podGroupInfo.Size())
 	}
-	if podGroupInfo.QueuedPodInfos[fwk.MustParseEntityKey("podgroup/default/pg")][0].Pod.Name != "p1" {
-		t.Errorf("Expected p1 to be left in queued pods, got %s", podGroupInfo.QueuedPodInfos[fwk.MustParseEntityKey("podgroup/default/pg")][0].Pod.Name)
+	if podGroupInfo.QueuedPodInfos[fwk.PodGroupKey("default", "pg")][0].Pod.Name != "p1" {
+		t.Errorf("Expected p1 to be left in queued pods, got %s", podGroupInfo.QueuedPodInfos[fwk.PodGroupKey("default", "pg")][0].Pod.Name)
 	}
 	if len(podGroupInfo.UnscheduledPods) != 1 {
 		t.Errorf("Expected 1 unscheduled pod left, got %d", len(podGroupInfo.UnscheduledPods))
@@ -790,7 +790,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			if len(requeuedPodGroup.QueuedPodInfos) != 1 {
 				t.Errorf("Expected 1 key in QueuedPodInfos, got %v", requeuedPodGroup.QueuedPodInfos)
 			}
-			infos := requeuedPodGroup.QueuedPodInfos[fwk.MustParseEntityKey("podgroup/default/pg")]
+			infos := requeuedPodGroup.QueuedPodInfos[fwk.PodGroupKey("default", "pg")]
 			if len(infos) != 1 || infos[0].Pod.UID != p2.UID {
 				t.Errorf("Expected queued PodGroup to contain pod %q, got %v", p2.Name, infos)
 			}
@@ -809,7 +809,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 	}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -893,7 +893,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	queuedPodInfos := []*framework.QueuedPodInfo{qInfo1, qInfo2, qInfo3}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -976,7 +976,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	sched.SchedulePod = sched.schedulePod
 
 	resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
-	schedulePodResult := resultsMap[pgKey(podGroupInfo.PodGroupInfo)]
+	schedulePodResult := resultsMap[podGroupInfo.PodGroupInfo.GetKey()]
 	if len(schedulePodResult.podResults) != 2 {
 		t.Errorf("Expected 2 pod results, got %d", len(schedulePodResult.podResults))
 	}
@@ -1055,7 +1055,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 			qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 
 			podGroupInfo := &framework.QueuedPodGroupInfo{
-				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 				PodGroupInfo: &framework.PodGroupInfo{
 					Name:            "pg",
 					Namespace:       "default",
@@ -1183,7 +1183,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 	queuedPodInfos := []*framework.QueuedPodInfo{qInfo1, qInfo2, qInfo3}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -1513,7 +1513,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 					}
 
 					resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
-					result := resultsMap[pgKey(podGroupInfo.PodGroupInfo)]
+					result := resultsMap[podGroupInfo.PodGroupInfo.GetKey()]
 
 					if result.status.Code() != tt.expectedGroupStatusCode {
 						t.Errorf("Expected group status code: %v, got: %v", tt.expectedGroupStatusCode, result.status.Code())
@@ -1975,7 +1975,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				algorithmResult.podResults = append(algorithmResult.podResults, result)
 			}
 
-			sched.submitPodGroupAlgorithmResult(ctx, schedFwk, podGroupCycleState, podGroupInfo, map[fwk.EntityKey]*podGroupAlgorithmResult{pgKey(algorithmResult.podGroupInfo): &algorithmResult}, time.Now(), tt.status)
+			sched.submitPodGroupAlgorithmResult(ctx, schedFwk, podGroupCycleState, podGroupInfo, map[fwk.EntityKey]*podGroupAlgorithmResult{algorithmResult.podGroupInfo.GetKey(): &algorithmResult}, time.Now(), tt.status)
 
 			if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*200, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 				lock.Lock()
@@ -2394,11 +2394,11 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 // fakePlacementPlugin simulates Filter, PlacementGenerate and PlacementScore behaviors for PodGroup placement scheduling testing.
 type fakePlacementPlugin struct {
 	name                     string
-	filterStatus             map[string]*fwk.Status            // node name to status
-	generatePlacementsResult map[string]map[string][]string    // PodGroupInfo key to placement name to list of node names
-	generatePlacementsStatus map[string]*fwk.Status            // PodGroupInfo key to status
-	scorePlacementsResult    map[string]map[string]int64       // PodGroupInfo key to placement name to score
-	scorePlacementsStatus    map[string]map[string]*fwk.Status // PodGroupInfo key to placement name to status
+	filterStatus             map[string]*fwk.Status                   // node name to status
+	generatePlacementsResult map[fwk.EntityKey]map[string][]string    // PodGroupInfo key to placement name to list of node names
+	generatePlacementsStatus map[fwk.EntityKey]*fwk.Status            // PodGroupInfo key to status
+	scorePlacementsResult    map[fwk.EntityKey]map[string]int64       // PodGroupInfo key to placement name to score
+	scorePlacementsStatus    map[fwk.EntityKey]map[string]*fwk.Status // PodGroupInfo key to placement name to status
 	podPerNode               bool
 	reservedNodes            sets.Set[string]
 }
@@ -2518,9 +2518,10 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 	}
 	podGroupPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
 
+	pgKeyVal := fwk.PodGroupKey("default", "pg")
 	queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: podGroupPod}}}
 	pgInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{pgKeyVal: queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -2542,14 +2543,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedGeneratedPlacements: 2,
 			expectedFeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 2,
 						"placement2": 1,
 					},
@@ -2573,14 +2574,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedGeneratedPlacements: 2,
 			expectedFeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 						"placement2": 2,
 					},
@@ -2602,7 +2603,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 		},
 		"when no placements are generated, returns unschedulable": {
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{},
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{},
 			},
 			expectedResult: podGroupAlgorithmResult{
 				status: fwk.NewStatus(fwk.Unschedulable, "no feasible placements found").WithPlugin("FakePlacementPlugin_Ordered"),
@@ -2612,14 +2613,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedGeneratedPlacements:   2,
 			expectedInfeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 						"placement2": 2,
 					},
@@ -2651,14 +2652,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedGeneratedPlacements:   2,
 			expectedInfeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 						"placement2": 2,
 					},
@@ -2692,14 +2693,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedFeasibleEvaluations:   1,
 			expectedInfeasibleEvaluations: 1,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 					},
 				},
@@ -2730,14 +2731,14 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedFeasibleEvaluations:   1,
 			expectedInfeasibleEvaluations: 1,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 						"placement2": 2,
 					},
@@ -2766,7 +2767,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 		},
 		"when generate plugin fails, returns error": {
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsStatus: map[string]*fwk.Status{pgInfo.GetKey(): fwk.NewStatus(fwk.Error, "error for test")},
+				generatePlacementsStatus: map[fwk.EntityKey]*fwk.Status{pgKeyVal: fwk.NewStatus(fwk.Error, "error for test")},
 			},
 			expectedResult: podGroupAlgorithmResult{
 				status: fwk.NewStatus(fwk.Error, "error for test").WithPlugin("FakePlacementPlugin"),
@@ -2776,19 +2777,19 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 			expectedGeneratedPlacements: 2,
 			expectedFeasibleEvaluations: 2,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 						"placement2": {nodes[1].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 					},
 				},
-				scorePlacementsStatus: map[string]map[string]*fwk.Status{
-					pgInfo.GetKey(): {
+				scorePlacementsStatus: map[fwk.EntityKey]map[string]*fwk.Status{
+					pgKeyVal: {
 						"placement2": fwk.NewStatus(fwk.Error, "error for test"),
 					},
 				},
@@ -2800,13 +2801,13 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 		"when a placement evaluation errors, returns error": {
 			expectedGeneratedPlacements: 1,
 			placementPlugin: fakePlacementPlugin{
-				generatePlacementsResult: map[string]map[string][]string{
-					pgInfo.GetKey(): {
+				generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+					pgKeyVal: {
 						"placement1": {nodes[0].Name},
 					},
 				},
-				scorePlacementsResult: map[string]map[string]int64{
-					pgInfo.GetKey(): {
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+					pgKeyVal: {
 						"placement1": 1,
 					},
 				},
@@ -2904,7 +2905,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				metrics.PlacementEvaluationDuration.Reset()
 
 				resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo)
-				result := resultsMap[pgKey(pgInfo.PodGroupInfo)]
+				result := resultsMap[pgInfo.PodGroupInfo.GetKey()]
 
 				if result.podGroupInfo != pgInfo.PodGroupInfo {
 					t.Errorf("Unexpected podGroupInfo field (-want,+got):\n- %v\n+ %v", pgInfo, result.podGroupInfo)
@@ -3027,9 +3028,10 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				informerFactory := informers.NewSharedInformerFactory(clientsetfake.NewClientset(), 0)
 				queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 
+				pgKeyVal := fwk.PodGroupKey("default", "pg")
 				queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: podGroupPod}}}
 				pgInfo := &framework.QueuedPodGroupInfo{
-					QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
+					QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{pgKeyVal: queuedPodInfos},
 					PodGroupInfo: &framework.PodGroupInfo{
 						Name:            "pg",
 						Namespace:       "default",
@@ -3040,8 +3042,8 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 
 				placementPlugin := fakePlacementPlugin{
 					name: "FakeGeneratorPlugin",
-					generatePlacementsResult: map[string]map[string][]string{
-						pgInfo.GetKey(): placements,
+					generatePlacementsResult: map[fwk.EntityKey]map[string][]string{
+						pgKeyVal: placements,
 					},
 				}
 
@@ -3057,11 +3059,11 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				for i, placementScorePluginData := range tt.pluginData {
 					plugin := fakePlacementPlugin{
 						name: fmt.Sprintf("FakeScorePlugin[%d]", i),
-						scorePlacementsResult: map[string]map[string]int64{
-							pgInfo.GetKey(): placementScorePluginData.scorePlacementResult,
+						scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
+							pgKeyVal: placementScorePluginData.scorePlacementResult,
 						},
-						scorePlacementsStatus: map[string]map[string]*fwk.Status{
-							pgInfo.GetKey(): placementScorePluginData.scorePlacementStatus,
+						scorePlacementsStatus: map[fwk.EntityKey]map[string]*fwk.Status{
+							pgKeyVal: placementScorePluginData.scorePlacementStatus,
 						},
 					}
 
@@ -3279,7 +3281,7 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 
 			queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: podGroupPod}}}
 			pgInfo := &framework.QueuedPodGroupInfo{
-				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
+				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 				PodGroupInfo: &framework.PodGroupInfo{
 					Name:            "pg",
 					Namespace:       "default",
@@ -3326,7 +3328,7 @@ type multiLevelPlacementStateTracker struct {
 	placementFeasibleTrajectories [][]string
 	placementScoreTrajectories    [][]string
 	filterTrajectories            [][]string
-	generatePlacementsResult      map[string][]string
+	generatePlacementsResult      map[fwk.EntityKey][]string
 }
 
 func (p *multiLevelPlacementStateTracker) Name() string {
@@ -3422,7 +3424,7 @@ func (p *multiLevelPlacementStateTracker) GeneratePlacements(ctx context.Context
 		}
 		p.placementGenerateTrajectories = append(p.placementGenerateTrajectories, trajectory)
 	}
-	state.Write(hierarchyKey, &hierarchyData{id: podGroup.GetKey()})
+	state.Write(hierarchyKey, &hierarchyData{id: podGroup.GetKey().String()})
 	placements := []*fwk.Placement{}
 	for _, placementName := range p.generatePlacementsResult[podGroup.GetKey()] {
 		placements = append(placements, &fwk.Placement{Name: placementName, Nodes: parentPlacement.Nodes})
@@ -3480,7 +3482,7 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 
 	tracker := &multiLevelPlacementStateTracker{
-		generatePlacementsResult: map[string][]string{
+		generatePlacementsResult: map[fwk.EntityKey][]string{
 			rootPGInfo.GetKey(): {
 				"placement1",
 				"placement2",
@@ -3548,13 +3550,13 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 
 	cpgQueuedInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
-			fwk.MustParseEntityKey(leafPGInfo.GetKey()): {queuedPodInfo1},
+			leafPGInfo.GetKey(): {queuedPodInfo1},
 		},
 		PodGroupInfo: rootPGInfo,
 	}
 
 	results := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), cpgQueuedInfo)
-	if result, ok := results[pgKey(rootPGInfo)]; !ok || !result.status.IsSuccess() {
+	if result, ok := results[rootPGInfo.GetKey()]; !ok || !result.status.IsSuccess() {
 		t.Fatalf("Expected success for root pod group, got: %v", result.status)
 	}
 
@@ -3660,7 +3662,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		Children:          []*framework.PodGroupInfo{childPGInfo1, childPGInfo2},
 	}
 
-	defaultPlacementResults := map[string]map[string][]string{
+	defaultPlacementResults := map[fwk.EntityKey]map[string][]string{
 		rootPGInfo.GetKey(): {
 			"placement1": {nodes[0].Name, nodes[1].Name},
 			"placement2": {nodes[2].Name, nodes[3].Name},
@@ -3682,12 +3684,12 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 	tests := map[string]struct {
 		placementPlugin           fakePlacementPlugin
 		placementFeasibleStatuses [][]fwk.Code
-		expectedResults           map[string]podGroupAlgorithmResult
+		expectedResults           map[fwk.EntityKey]podGroupAlgorithmResult
 	}{
 		"respects higher score of parent placement": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: defaultPlacementResults,
-				scorePlacementsResult: map[string]map[string]int64{
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 					rootPGInfo.GetKey(): {
 						"placement1": 1,
 						"placement2": 2,
@@ -3706,7 +3708,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 					},
 				},
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {},
 				childPGInfo1.GetKey(): {
 					podResults: []algorithmResult{
@@ -3737,7 +3739,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		"discards infeasible placements": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: defaultPlacementResults,
-				scorePlacementsResult: map[string]map[string]int64{
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 					rootPGInfo.GetKey(): {
 						"placement1": 2,
 						"placement2": 1,
@@ -3761,7 +3763,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				{fwk.Unschedulable, fwk.Unschedulable, fwk.Unschedulable},
 				// success for the remaining placements
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {},
 				childPGInfo1.GetKey(): {
 					podResults: []algorithmResult{
@@ -3792,7 +3794,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		"returns unschedulable if no pods got scheduled": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: defaultPlacementResults,
-				scorePlacementsResult: map[string]map[string]int64{
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 					rootPGInfo.GetKey(): {
 						"placement1": 2,
 						"placement2": 1,
@@ -3817,7 +3819,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 					nodes[3].Name: fwk.NewStatus(fwk.Unschedulable, "node4 rejected"),
 				},
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {
 					status: fwk.NewStatus(fwk.Unschedulable, "no pods were schedulable"),
 				},
@@ -3842,7 +3844,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		"returns unschedulable if no pods got scheduled and placement feasible rejected pods": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: defaultPlacementResults,
-				scorePlacementsResult: map[string]map[string]int64{
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 					rootPGInfo.GetKey(): {
 						"placement1": 2,
 						"placement2": 1,
@@ -3889,7 +3891,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				// pg2, p4
 				{fwk.Wait, fwk.Unschedulable},
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {
 					status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status"),
 				},
@@ -3918,7 +3920,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				generatePlacementsResult: defaultPlacementResults,
 				podPerNode:               true,
 				reservedNodes:            sets.New[string](),
-				scorePlacementsResult: map[string]map[string]int64{
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 					rootPGInfo.GetKey(): {
 						"placement1": 1,
 					},
@@ -3934,7 +3936,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				},
 				filterStatus: map[string]*fwk.Status{},
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {},
 				childPGInfo1.GetKey(): {
 					podResults: []algorithmResult{
@@ -3961,11 +3963,11 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		"when generate plugin fails at CPG, returns error": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: defaultPlacementResults,
-				generatePlacementsStatus: map[string]*fwk.Status{
+				generatePlacementsStatus: map[fwk.EntityKey]*fwk.Status{
 					rootPGInfo.GetKey(): fwk.AsStatus(fmt.Errorf("injected error")),
 				},
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {
 					status: fwk.NewStatus(fwk.Error, "injected error"),
 				},
@@ -3974,10 +3976,10 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 		"when generate plugin fails at PG, returns error": {
 			placementPlugin: fakePlacementPlugin{
 				generatePlacementsResult: defaultPlacementResults,
-				generatePlacementsStatus: map[string]*fwk.Status{
+				generatePlacementsStatus: map[fwk.EntityKey]*fwk.Status{
 					childPGInfo2.GetKey(): fwk.AsStatus(fmt.Errorf("injected error")),
 				},
-				scorePlacementsResult: map[string]map[string]int64{
+				scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 					rootPGInfo.GetKey(): {
 						"placement1": 1,
 					},
@@ -3991,7 +3993,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 					},
 				},
 			},
-			expectedResults: map[string]podGroupAlgorithmResult{
+			expectedResults: map[fwk.EntityKey]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {
 					status: fwk.NewStatus(fwk.Error, "composite pod group evaluation failed due to child error: injected error"),
 				},
@@ -4086,17 +4088,17 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 
 			cpgInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
-					fwk.MustParseEntityKey(childPGInfo1.GetKey()): {queuedPodInfo1},
-					fwk.MustParseEntityKey(childPGInfo2.GetKey()): {queuedPodInfo2},
+					childPGInfo1.GetKey(): {queuedPodInfo1},
+					childPGInfo2.GetKey(): {queuedPodInfo2},
 				},
 				PodGroupInfo: rootPGInfo,
 			}
 
 			results := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), cpgInfo)
-			gotResults := make(map[string]podGroupAlgorithmResult, len(results))
+			gotResults := make(map[fwk.EntityKey]podGroupAlgorithmResult, len(results))
 			for k, v := range results {
 				if v != nil {
-					gotResults[k.String()] = *v
+					gotResults[k] = *v
 				}
 			}
 
@@ -4173,7 +4175,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 		Children:          []*framework.PodGroupInfo{childPGInfo1, childPGInfo2},
 	}
 
-	placements := map[string]map[string][]string{
+	placements := map[fwk.EntityKey]map[string][]string{
 		rootPGInfo.GetKey(): {
 			"placement1": {nodes[0].Name, nodes[1].Name},
 			"placement2": {nodes[2].Name, nodes[3].Name},
@@ -4194,8 +4196,8 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 
 	type pluginData struct {
 		weight                int32
-		scorePlacementsResult map[string]map[string]int64
-		scorePlacementsStatus map[string]map[string]*fwk.Status
+		scorePlacementsResult map[fwk.EntityKey]map[string]int64
+		scorePlacementsStatus map[fwk.EntityKey]map[string]*fwk.Status
 	}
 
 	tests := map[string]struct {
@@ -4206,7 +4208,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 			pluginData: []pluginData{
 				{
 					weight: 1,
-					scorePlacementsResult: map[string]map[string]int64{
+					scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 						rootPGInfo.GetKey(): {
 							"placement1": 50,
 							"placement2": 75,
@@ -4227,7 +4229,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				},
 				{
 					weight: 2,
-					scorePlacementsResult: map[string]map[string]int64{
+					scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 						rootPGInfo.GetKey(): {
 							"placement1": 25,
 							"placement2": 10,
@@ -4256,7 +4258,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 			pluginData: []pluginData{
 				{
 					weight: 1,
-					scorePlacementsResult: map[string]map[string]int64{
+					scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 						rootPGInfo.GetKey(): {
 							"placement1": 75,
 							"placement2": 50,
@@ -4277,7 +4279,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				},
 				{
 					weight: 2,
-					scorePlacementsResult: map[string]map[string]int64{
+					scorePlacementsResult: map[fwk.EntityKey]map[string]int64{
 						rootPGInfo.GetKey(): {
 							"placement1": 10,
 							"placement2": 25,
@@ -4383,8 +4385,8 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 
 			cpgInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
-					fwk.MustParseEntityKey(childPGInfo1.GetKey()): {queuedPodInfo1},
-					fwk.MustParseEntityKey(childPGInfo2.GetKey()): {queuedPodInfo2},
+					childPGInfo1.GetKey(): {queuedPodInfo1},
+					childPGInfo2.GetKey(): {queuedPodInfo2},
 				},
 				PodGroupInfo: rootPGInfo,
 			}
@@ -4423,7 +4425,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -4548,7 +4550,7 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:            "pg",
 			Namespace:       "default",
@@ -4627,7 +4629,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	testPodGroup := st.MakePodGroup().Name("pg").Namespace("default").Obj()
 	podGroupInfo := &framework.QueuedPodGroupInfo{
-		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
 			Name:      "pg",
 			Namespace: "default",
@@ -4831,7 +4833,7 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 			qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 			testPodGroup := st.MakePodGroup().Name("pg").Namespace("default").MinCount(2).Obj()
 			podGroupInfo := &framework.QueuedPodGroupInfo{
-				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
+				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 				PodGroupInfo: &framework.PodGroupInfo{
 					Name:            "pg",
 					Namespace:       "default",
@@ -4998,9 +5000,9 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
 	queuedPodInfosMap := map[fwk.EntityKey][]*framework.QueuedPodInfo{
-		fwk.MustParseEntityKey("podgroup/default/pg1"): {qInfo1},
-		fwk.MustParseEntityKey("podgroup/default/pg2"): {qInfo2},
-		fwk.MustParseEntityKey("podgroup/default/pg3"): {qInfo3},
+		fwk.PodGroupKey("default", "pg1"): {qInfo1},
+		fwk.PodGroupKey("default", "pg2"): {qInfo2},
+		fwk.PodGroupKey("default", "pg3"): {qInfo3},
 	}
 
 	cpgRootInfo := &framework.QueuedPodGroupInfo{
@@ -6228,7 +6230,7 @@ func TestScorePlacementPodGroupAssignments(t *testing.T) {
 					pgi.Type = fwk.PodGroupKeyType
 					pgi.PodGroup = st.MakePodGroup().Name(node.name).Namespace("default").Obj()
 				}
-				nameToKey[node.name] = pgKey(pgi)
+				nameToKey[node.name] = pgi.GetKey()
 				return pgi
 			}
 

--- a/staging/src/k8s.io/kube-scheduler/framework/types.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/types.go
@@ -18,7 +18,6 @@ package framework
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -698,8 +697,8 @@ type PodGroupInfo interface {
 	GetNamespace() string
 	// GetType returns the type of the pod group.
 	GetType() EntityKeyType
-	// GetKey returns the key uniquely identifying the pod group.
-	GetKey() string
+	// GetKey returns the EntityKey that uniquely identifies the pod group.
+	GetKey() EntityKey
 	// GetPodGroup returns the PodGroup API object or nil if the group is a composite pod group.
 	GetPodGroup() *schedulingv1beta1.PodGroup
 	// GetCompositePodGroup returns the associated composite pod group or nil if the group is not a composite pod group.
@@ -746,37 +745,34 @@ type PodGroupAssignments struct {
 	ProposedAssignments []ProposedAssignment
 }
 
-// EntityKey uniquely identifies a specific instance of an entity (like PodGroup or CompositePodGroup).
+// EntityKey uniquely identifies a specific instance of an entity (Pod, PodGroup or CompositePodGroup).
 type EntityKey struct {
-	Type      EntityKeyType
-	Name      string
+	// Type represents the kind of entity identified by this key (e.g. Pod, PodGroup, CompositePodGroup).
+	Type EntityKeyType
+	// Name represents the name of the entity.
+	Name string
+	// Namespace represents the namespace of the entity.
 	Namespace string
 }
 
+// GetName returns the name of the entity.
 func (ek EntityKey) GetName() string {
 	return ek.Name
 }
 
+// GetNamespace returns the namespace of the entity.
 func (ek EntityKey) GetNamespace() string {
 	return ek.Namespace
 }
 
+// GetType returns the type of the entity.
 func (ek EntityKey) GetType() EntityKeyType {
 	return ek.Type
 }
 
+// String returns a string representation of the EntityKey in the form "Type/Namespace/Name".
 func (ek EntityKey) String() string {
 	return fmt.Sprintf("%s/%s/%s", ek.Type, ek.Namespace, ek.Name)
-}
-
-// MustParseEntityKey returns the entity key for a given key.
-// It should be only used in tests.
-func MustParseEntityKey(key string) EntityKey {
-	parts := strings.Split(key, "/")
-	if len(parts) != 3 {
-		return EntityKey{}
-	}
-	return EntityKey{Type: EntityKeyType(parts[0]), Namespace: parts[1], Name: parts[2]}
 }
 
 // PodKey returns the key for a pod.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/wg workload-aware-scheduling
/sig scheduling

#### What this PR does / why we need it:

This PR standardizes `PodGroup` and `CompositePodGroup` key management across the scheduler framework by returning type-safe `EntityKey` structs directly from `PodGroupInfo.GetKey()`.

Specifically:
- **`PodGroupInfo.GetKey()`**: Updated the interface method and concrete implementations to return `fwk.EntityKey` instead of `string`.
- **Removed `MustParseEntityKey()`**: Eliminated the unnecessary string-to-EntityKey parsing utility from scheduler framework types.
- **Removed `pgKey()` Helper**: Cleaned up internal scheduler logic (`schedule_one_podgroup.go`) and unit tests by removing the package-level `pgKey()` helper function and calling `.GetKey()` directly on `PodGroupInfo` instances.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

- Verified with `make test WHAT=./pkg/scheduler/...` and `make test-integration WHAT=./test/integration/scheduler/podgroup`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```