### PR TITLE
Add blank lines around long CSILimits field for stable gofmt output

### DIFF
--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -622,6 +622,8 @@ func NewCSI(_ context.Context, _ runtime.Object, handle fwk.Handle, fts feature.
 	}
 	csiTranslator := csitrans.New()
 
+	// The blank lines around the long field keep gofmt output the same
+	// on all architectures, see issue #141074.
 	return &CSILimits{
 		csiManager:               handle.SharedCSIManager(),
 		pvLister:                 pvLister,
@@ -630,7 +632,9 @@ func NewCSI(_ context.Context, _ runtime.Object, handle fwk.Handle, fts feature.
 		vaLister:                 vaLister,
 		csiDriverLister:          csiDriverLister,
 		enableVolumeLimitScaling: fts.EnableVolumeLimitScaling,
+
 		enableInPlacePodVerticalScalingSchedulerPreemption: fts.EnableInPlacePodVerticalScalingSchedulerPreemption,
+
 		randomVolumeIDPrefix: rand.String(32),
 		translator:           csiTranslator,
 		vaIndexer:            vaInformer.GetIndexer(),


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it:**

gofmt in go1.26.5 formats the CSILimits struct literal in `csi.go` differently on amd64 and arm64, and each build rejects the form the other wants. Because of this, verify-gofmt fails in ci-kubernetes-verify-master-canary, the only verify job that runs on arm64 nodes. See #141074 for the full analysis.

This change assigns the long field after the struct is built, so the literal has no outlier line and gofmt gives the same result everywhere. I verified the file is accepted by gofmt from go1.26.5 on linux amd64, linux arm64, and darwin arm64, and by go1.27rc2. Unit tests in the package pass.

**Which issue(s) this PR fixes:**

Fixes #141074

**Does this PR introduce a user-facing change?**

```release-note
NONE
```

cc @natasha41575 @BenTheElder