### PR TITLE
memorymanager: preserve restored pod allocations

### DIFF
--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -202,6 +202,10 @@ func (p *staticPolicy) AllocatePod(logger klog.Logger, s state.State, pod *v1.Po
 	if qos != v1.PodQOSGuaranteed {
 		return nil
 	}
+	if blocks := s.GetPodMemoryBlocks(podUID); blocks != nil {
+		logger.Info("Pod already present in state, skipping")
+		return nil
+	}
 
 	// 1. Calculate memory resources.
 	podTotalMemory, err := getPodRequestedResources(logger, pod)

--- a/pkg/kubelet/cm/memorymanager/policy_static.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static.go
@@ -203,7 +203,7 @@ func (p *staticPolicy) AllocatePod(logger klog.Logger, s state.State, pod *v1.Po
 		return nil
 	}
 	if blocks := s.GetPodMemoryBlocks(podUID); blocks != nil {
-		logger.Info("Pod already present in state, skipping")
+		logger.V(4).Info("Pod already present in state, skipping")
 		return nil
 	}
 

--- a/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
@@ -51,7 +51,6 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 		podMemoryRequest                string
 		containers                      []containerSpec
 		expectPodBlocks                 bool
-		verifyAllocationIdempotency     bool
 	}{
 		{
 			description:                     "PodLevelResources and PodLevelResourceManagers enabled",
@@ -61,8 +60,7 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 			containers: []containerSpec{
 				{name: "container1", memRequest: "100Mi", memLimit: "100Mi"},
 			},
-			expectPodBlocks:             true,
-			verifyAllocationIdempotency: true,
+			expectPodBlocks: true,
 		},
 		{
 			description:                     "PodLevelResources enabled, PodLevelResourceManagers disabled",
@@ -208,7 +206,7 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 				}
 			}
 
-			if tc.verifyAllocationIdempotency {
+			if tc.podLevelResourceManagersEnabled && resourcehelper.IsPodLevelResourcesSet(pod) {
 				if err := mgr2.AllocatePod(logger, pod, lifecycle.AddOperation); err != nil {
 					t.Fatalf("could not allocate restored pod: %v", err)
 				}

--- a/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_static_restore_test.go
@@ -20,6 +20,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -49,6 +51,7 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 		podMemoryRequest                string
 		containers                      []containerSpec
 		expectPodBlocks                 bool
+		verifyAllocationIdempotency     bool
 	}{
 		{
 			description:                     "PodLevelResources and PodLevelResourceManagers enabled",
@@ -58,7 +61,8 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 			containers: []containerSpec{
 				{name: "container1", memRequest: "100Mi", memLimit: "100Mi"},
 			},
-			expectPodBlocks: true,
+			expectPodBlocks:             true,
+			verifyAllocationIdempotency: true,
 		},
 		{
 			description:                     "PodLevelResources enabled, PodLevelResourceManagers disabled",
@@ -155,6 +159,9 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 			}
 
 			// Verify state before restart
+			podMemoryAssignments := mgr.State().GetPodMemoryAssignments()
+			memoryAssignments := mgr.State().GetMemoryAssignments()
+			machineState := mgr.State().GetMachineState()
 			podBlocks := mgr.State().GetPodMemoryBlocks(string(pod.UID))
 			if tc.expectPodBlocks && len(podBlocks) == 0 {
 				t.Errorf("expected pod memory blocks to be present")
@@ -198,6 +205,22 @@ func TestMemoryManagerRestoreState(t *testing.T) {
 					if len(containerBlocksRestored) == 0 {
 						t.Errorf("expected container memory blocks to be present after restore for %s", container.Name)
 					}
+				}
+			}
+
+			if tc.verifyAllocationIdempotency {
+				if err := mgr2.AllocatePod(logger, pod, lifecycle.AddOperation); err != nil {
+					t.Fatalf("could not allocate restored pod: %v", err)
+				}
+
+				if diff := cmp.Diff(podMemoryAssignments, mgr2.State().GetPodMemoryAssignments()); diff != "" {
+					t.Errorf("pod memory assignments changed after allocating restored pod (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(memoryAssignments, mgr2.State().GetMemoryAssignments()); diff != "" {
+					t.Errorf("container memory assignments changed after allocating restored pod (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(machineState, mgr2.State().GetMachineState()); diff != "" {
+					t.Errorf("machine state changed after allocating restored pod (-want +got):\n%s", diff)
 				}
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

Prevents Memory Manager from reapplying checkpoint-restored pod-level allocations during post-restart admission. Adds regression coverage to ensure restored pod, container, and machine state remains unchanged.

#### Which issue(s) this PR is related to:

Fixes #140906

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```