### PR TITLE
workqueue: make ShutDownWithDrain wait for queued items

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue.go
@@ -285,10 +285,14 @@ func (q *Typed[T]) Get() (item T, shutdown bool) {
 
 // Done marks item as done processing, and if it has been marked as dirty again
 // while it was being processed, it will be re-added to the queue for
-// re-processing.
+// re-processing. Spurious Done calls for items not in processing are ignored.
 func (q *Typed[T]) Done(item T) {
 	q.cond.L.Lock()
 	defer q.cond.L.Unlock()
+
+	if !q.processing.Has(item) {
+		return
+	}
 
 	q.metrics.done(item)
 
@@ -297,7 +301,8 @@ func (q *Typed[T]) Done(item T) {
 		q.queue.Push(item)
 		q.cond.Signal()
 	} else if q.processing.Len() == 0 {
-		q.cond.Signal()
+		// Wake ShutDownWithDrain and any workers waiting on shutdown.
+		q.cond.Broadcast()
 	}
 }
 
@@ -319,11 +324,12 @@ func (q *Typed[T]) ShutDown() {
 }
 
 // ShutDownWithDrain is equivalent to ShutDown but waits until all items
-// in the queue have been processed.
+// in the queue have been processed (both queued and in-flight).
 // ShutDown can be called after ShutDownWithDrain to force
 // ShutDownWithDrain to stop waiting.
-// Workers must call Done on an item after processing it, otherwise
-// ShutDownWithDrain will block indefinitely.
+// Workers must continue to call Get until they receive the shutdown signal and
+// must call Done on each item after processing it, otherwise ShutDownWithDrain
+// will block indefinitely.
 func (q *Typed[T]) ShutDownWithDrain() {
 	defer q.wg.Wait()
 	q.stopOnce.Do(func() {
@@ -336,7 +342,10 @@ func (q *Typed[T]) ShutDownWithDrain() {
 	q.shuttingDown = true
 	q.cond.Broadcast()
 
-	for q.processing.Len() != 0 && q.drain {
+	// Wait until nothing is in-flight and nothing remains queued. Checking only
+	// processing is insufficient: Done on the last in-flight item can leave
+	// other keys sitting in the queue with processing empty.
+	for q.drain && (q.processing.Len() != 0 || q.queue.Len() != 0) {
 		q.cond.Wait()
 	}
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -462,6 +462,157 @@ func mustGarbageCollect(t *testing.T, i interface{}) {
 	})
 }
 
+// TestShutDownWithDrainWaitsForQueuedItems checks that ShutDownWithDrain does not
+// return while items remain in the queue (not only while items are in processing).
+func TestShutDownWithDrainWaitsForQueuedItems(t *testing.T) {
+	q := workqueue.New()
+	q.Add("a")
+	q.Add("b")
+
+	first, _ := q.Get() // processing={a}, queue=[b]
+
+	// Worker takes remaining items but holds "b" in processing until released so
+	// we can assert drain stays blocked without relying on timing.
+	holdB := make(chan struct{})
+	sawB := make(chan struct{})
+	workerDone := make(chan struct{})
+	go func() {
+		defer close(workerDone)
+		for {
+			item, quit := q.Get()
+			if quit {
+				return
+			}
+			if item == "b" {
+				close(sawB)
+				<-holdB
+			}
+			q.Done(item)
+		}
+	}()
+
+	drained := make(chan struct{})
+	go func() {
+		q.ShutDownWithDrain()
+		close(drained)
+	}()
+
+	// Finish "a". Worker should receive queued "b" and block before Done.
+	q.Done(first)
+
+	select {
+	case <-sawB:
+	case <-drained:
+		t.Fatalf("ShutDownWithDrain returned before remaining item was processed (len=%d)", q.Len())
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("timed out waiting for worker to get queued item b")
+	}
+
+	// "b" is in-flight; drain must still be waiting.
+	select {
+	case <-drained:
+		t.Fatal("ShutDownWithDrain returned while item b still processing")
+	default:
+	}
+
+	close(holdB)
+
+	select {
+	case <-drained:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("ShutDownWithDrain did not return after queue drained")
+	}
+
+	select {
+	case <-workerDone:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("worker did not exit after drain")
+	}
+
+	if q.Len() != 0 {
+		t.Fatalf("expected empty queue after drain, len=%d", q.Len())
+	}
+}
+
+// TestShutDownWithDrainManyWorkers stresses ShutDownWithDrain with multiple workers
+// so a single Signal cannot leave drain or workers stuck.
+func TestShutDownWithDrainManyWorkers(t *testing.T) {
+	q := workqueue.New()
+	for i := 0; i < 50; i++ {
+		q.Add(i)
+	}
+
+	const workers = 8
+	var started, wg sync.WaitGroup
+	started.Add(workers)
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			started.Done()
+			for {
+				item, quit := q.Get()
+				if quit {
+					return
+				}
+				q.Done(item)
+			}
+		}()
+	}
+	started.Wait()
+
+	drained := make(chan struct{})
+	go func() {
+		q.ShutDownWithDrain()
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("deadlock: ShutDownWithDrain did not return")
+	}
+
+	workersDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(workersDone)
+	}()
+	select {
+	case <-workersDone:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("deadlock: workers did not exit after drain")
+	}
+}
+
+// TestDoneIdempotent ensures a spurious extra Done does not duplicate queue entries.
+func TestDoneIdempotent(t *testing.T) {
+	q := workqueue.New()
+	q.Add("x")
+	item, _ := q.Get()
+	q.Add(item) // dirty while processing
+	q.Done(item)
+	q.Done(item) // spurious second Done
+
+	if got := q.Len(); got != 1 {
+		t.Fatalf("queue len=%d after requeue + spurious Done, want 1", got)
+	}
+
+	got, quit := q.Get()
+	if quit || got != "x" {
+		t.Fatalf("Get()=(%v, quit=%v), want (x, false)", got, quit)
+	}
+	if q.Len() != 0 {
+		t.Fatalf("queue len=%d after one Get, want 0 (duplicate entries)", q.Len())
+	}
+	q.Done(got)
+
+	q.ShutDown()
+	if _, quit = q.Get(); !quit {
+		t.Fatal("expected shutdown signal with empty queue")
+	}
+}
+
 func BenchmarkQueue(b *testing.B) {
 	keys := make([]string, 100)
 	for idx := range keys {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

`ShutDownWithDrain` only waited until `processing` was empty. After `Done` on the last in-flight item, other keys could still sit in the underlying queue with `processing` empty, so drain returned early and did not match its documented behavior.

`Done` always `Signal`ed when becoming idle, which can fail to wake `ShutDownWithDrain` when multiple waiters exist. Spurious `Done` calls for items not in `processing` could also re-push a dirty item and duplicate queue entries.

This change:
- Waits for both queued and in-flight work in `ShutDownWithDrain`
- Ignores `Done` for items not currently in `processing`
- Uses `Broadcast` when the queue becomes idle
- Adds regression tests (barrier-based, no short sleeps on the success path)

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This PR was written in part with the assistance of generative AI.

Local verification:
```
cd staging/src/k8s.io/client-go
go test -race -count=5 ./util/workqueue/
```

#### Does this PR introduce a user-facing change?

```release-note
Fixed client-go workqueue ShutDownWithDrain so it waits until both queued and in-flight items are finished. Spurious Done calls for items not being processed are now ignored.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```