### PR TITLE
Unify code for PodGroups and CompositePodGroups in workloadForest

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -1125,30 +1125,42 @@ func (cache *cacheImpl) applyPVCRefCountDelta(snapshot *Snapshot) error {
 	return nil
 }
 
-// AddPodGroup adds a pod group object to the cache.
-func (cache *cacheImpl) AddPodGroup(podGroup *schedulingv1beta1.PodGroup) {
-	if !cache.genericWorkloadEnabled {
-		return
-	}
+// AddAbstractPodGroup adds an abstract pod group object to the cache,
+// and links it to its parent composite pod group if one is specified.
+func (cache *cacheImpl) AddAbstractPodGroup(apg *framework.AbstractPodGroup) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	key := fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)
-	pgs, exists := cache.podGroupStates[key]
-	if !exists {
-		pgs = newPodGroupState()
-		cache.podGroupStates[key] = pgs
-	}
-	pgs.setPodGroup(podGroup)
+	key := apg.GetKey()
 
-	if !cache.compositePodGroupEnabled || podGroup.Spec.ParentCompositePodGroupName == nil {
+	switch apg.GetType() {
+	case fwk.PodGroupKeyType:
+		pgs, exists := cache.podGroupStates[key]
+		if !exists {
+			pgs = newPodGroupState()
+			cache.podGroupStates[key] = pgs
+		}
+		pgs.setPodGroup(apg.PodGroup)
+	case fwk.CompositePodGroupKeyType:
+		cpgState, exists := cache.compositePodGroupStates[key]
+		if !exists {
+			cpgState = newCompositePodGroupState()
+			cache.compositePodGroupStates[key] = cpgState
+		}
+		cpgState.setCompositePodGroup(apg.CompositePodGroup)
+	}
+
+	// Both PodGroups and CompositePodGroups can specify a parent CompositePodGroup.
+	// Even if the parent has not been observed in the cache yet, we create a placeholder entry
+	// so child-parent hierarchy tracking remains consistent.
+	if !cache.compositePodGroupEnabled {
+		return
+	}
+	parentKey, hasParent := apg.GetParentKey()
+	if !hasParent {
 		return
 	}
 
-	parentKey := fwk.CompositePodGroupKey(podGroup.Namespace, *podGroup.Spec.ParentCompositePodGroupName)
-
-	// Even if the parent composite pod group has not been observed in the cache yet, we can assume that it
-	// will be observed eventually, and we should create an entry (placeholder) representing it in the cache.
 	parent, parentExists := cache.compositePodGroupStates[parentKey]
 	if !parentExists {
 		parent = newCompositePodGroupState()
@@ -1157,135 +1169,73 @@ func (cache *cacheImpl) AddPodGroup(podGroup *schedulingv1beta1.PodGroup) {
 	parent.addChild(key)
 }
 
-// UpdatePodGroup updates a pod group object in the cache.
-func (cache *cacheImpl) UpdatePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1beta1.PodGroup) {
-	if !cache.genericWorkloadEnabled {
-		return
-	}
+// UpdateAbstractPodGroup updates an existing abstract pod group object in the cache.
+func (cache *cacheImpl) UpdateAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	key := fwk.PodGroupKey(newPodGroup.Namespace, newPodGroup.Name)
-	pgs, exists := cache.podGroupStates[key]
-	if !exists {
-		// This should not happen: the pod group state should have been already created by a prior pod group add action.
-		utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for update, this indicates a missed add event", "podGroup", klog.KObj(newPodGroup))
-		return
+	key := apg.GetKey()
+
+	switch apg.GetType() {
+	case fwk.PodGroupKeyType:
+		pgs, exists := cache.podGroupStates[key]
+		if !exists {
+			// This should not happen: the pod group state should have been already created by a prior add action.
+			utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for update, this indicates a missed add event", "podGroup", klog.KObj(apg))
+			return
+		}
+		pgs.setPodGroup(apg.PodGroup)
+	case fwk.CompositePodGroupKeyType:
+		cpgState, exists := cache.compositePodGroupStates[key]
+		if !exists {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Composite pod group state not found for update, this indicates a missed add event", "compositePodGroup", klog.KObj(apg))
+			return
+		}
+		cpgState.setCompositePodGroup(apg.CompositePodGroup)
 	}
-	pgs.setPodGroup(newPodGroup)
 }
 
-// RemovePodGroup removes a pod group object from the cache.
-func (cache *cacheImpl) RemovePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
-	if !cache.genericWorkloadEnabled {
-		return
-	}
+// RemoveAbstractPodGroup removes an abstract pod group object from the cache.
+func (cache *cacheImpl) RemoveAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	key := fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)
-	pgs, exists := cache.podGroupStates[key]
-	if !exists {
-		// This should not happen: the pod group state should have been already created by a prior pod group add action.
-		utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for removal", "podGroup", klog.KObj(podGroup))
-		return
-	}
+	key := apg.GetKey()
 
-	if cache.compositePodGroupEnabled && podGroup.Spec.ParentCompositePodGroupName != nil {
-		parentKey := fwk.CompositePodGroupKey(podGroup.Namespace, *podGroup.Spec.ParentCompositePodGroupName)
-		if parent, exists := cache.compositePodGroupStates[parentKey]; exists {
-			parent.removeChild(key)
-			if parent.empty() {
-				// podGroupState can exist without the PodGroup object, but when any of the member pods exists.
-				delete(cache.compositePodGroupStates, parentKey)
+	// Remove this group from its parent's child tracking if composite pod groups are enabled.
+	if cache.compositePodGroupEnabled {
+		if parentKey, hasParent := apg.GetParentKey(); hasParent {
+			if parent, exists := cache.compositePodGroupStates[parentKey]; exists {
+				parent.removeChild(key)
+				if parent.empty() {
+					// A state entry can exist without the API object as long as member pods or children exist.
+					delete(cache.compositePodGroupStates, parentKey)
+				}
 			}
 		}
 	}
 
-	pgs.removePodGroup()
-	if pgs.empty() {
-		delete(cache.podGroupStates, key)
-	}
-}
-
-// AddCompositePodGroup adds a composite pod group to the cache.
-func (cache *cacheImpl) AddCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
-	if !cache.compositePodGroupEnabled {
-		return
-	}
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
-
-	key := fwk.CompositePodGroupKey(cpg.Namespace, cpg.Name)
-	cpgState, exists := cache.compositePodGroupStates[key]
-	if !exists {
-		cpgState = newCompositePodGroupState()
-		cache.compositePodGroupStates[key] = cpgState
-	}
-	cpgState.setCompositePodGroup(cpg)
-
-	if cpg.Spec.ParentCompositePodGroupName == nil {
-		return
-	}
-
-	parentKey := fwk.CompositePodGroupKey(cpg.Namespace, *cpg.Spec.ParentCompositePodGroupName)
-
-	parent, parentExists := cache.compositePodGroupStates[parentKey]
-	if !parentExists {
-		parent = newCompositePodGroupState()
-		cache.compositePodGroupStates[parentKey] = parent
-	}
-	parent.addChild(key)
-}
-
-// UpdateCompositePodGroup updates a composite pod group in the cache.
-func (cache *cacheImpl) UpdateCompositePodGroup(logger klog.Logger, oldCPG, newCPG *schedulingv1alpha3.CompositePodGroup) {
-	if !cache.compositePodGroupEnabled {
-		return
-	}
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
-	key := fwk.CompositePodGroupKey(newCPG.Namespace, newCPG.Name)
-	pgs, exists := cache.compositePodGroupStates[key]
-	if !exists {
-		// This should not happen: the pod group state should have been already created by a prior pod group add action.
-		utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for update, this indicates a missed add event", "podGroup", klog.KObj(newCPG))
-		return
-	}
-	pgs.setCompositePodGroup(newCPG)
-}
-
-// RemoveCompositePodGroup removes a composite pod group from the cache.
-func (cache *cacheImpl) RemoveCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
-	if !cache.compositePodGroupEnabled {
-		return
-	}
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
-
-	key := fwk.CompositePodGroupKey(cpg.Namespace, cpg.Name)
-	cpgs, exists := cache.compositePodGroupStates[key]
-	if !exists {
-		// This should not happen: the pod group state should have been already created by a prior pod group add action.
-		utilruntime.HandleErrorWithLogger(logger, nil, "Composite pod group state not found for removal", "compositePodGroup", klog.KObj(cpg))
-		return
-	}
-
-	if cpgs.compositePodGroup != nil && cpgs.compositePodGroup.Spec.ParentCompositePodGroupName != nil {
-		parentKey := fwk.CompositePodGroupKey(cpg.Namespace, *cpgs.compositePodGroup.Spec.ParentCompositePodGroupName)
-		parent, exists := cache.compositePodGroupStates[parentKey]
+	switch apg.GetType() {
+	case fwk.PodGroupKeyType:
+		pgs, exists := cache.podGroupStates[key]
 		if !exists {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for removal", "podGroup", klog.KObj(apg))
 			return
 		}
-		parent.removeChild(key)
-		if parent.empty() {
-			delete(cache.compositePodGroupStates, parentKey)
+		pgs.removePodGroup()
+		if pgs.empty() {
+			delete(cache.podGroupStates, key)
 		}
-	}
-
-	cpgs.removeCompositePodGroup()
-	if cpgs.empty() {
-		delete(cache.compositePodGroupStates, key)
+	case fwk.CompositePodGroupKeyType:
+		cpgs, exists := cache.compositePodGroupStates[key]
+		if !exists {
+			utilruntime.HandleErrorWithLogger(logger, nil, "Composite pod group state not found for removal", "compositePodGroup", klog.KObj(apg))
+			return
+		}
+		cpgs.removeCompositePodGroup()
+		if cpgs.empty() {
+			delete(cache.compositePodGroupStates, key)
+		}
 	}
 }
 

--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -344,18 +344,18 @@ func (cache *cacheImpl) updatePodGroupStateSnapshot(snapshot *Snapshot) {
 // It removes entries that no longer exist in the live cache
 // and clones entries whose generation has advanced since the last snapshot.
 func (cache *cacheImpl) updateCompositePodGroupStateSnapshot(snapshot *Snapshot) {
-	// Remove pod group states from snapshot that no longer exist in cache.
+	// Remove composite pod group states from snapshot that no longer exist in cache.
 	for key := range snapshot.compositePodGroupStates {
 		if _, exists := cache.compositePodGroupStates[key]; !exists {
 			delete(snapshot.compositePodGroupStates, key)
 		}
 	}
-	// Clone only pod group states that changed since the last snapshot.
-	for key, cpgState := range cache.compositePodGroupStates {
-		if existing, ok := snapshot.compositePodGroupStates[key]; ok && existing.generation == cpgState.generation {
+	// Clone only composite pod group states that changed since the last snapshot.
+	for key, cpgs := range cache.compositePodGroupStates {
+		if existing, ok := snapshot.compositePodGroupStates[key]; ok && existing.generation == cpgs.generation {
 			continue
 		}
-		snapshot.compositePodGroupStates[key] = cpgState.snapshot()
+		snapshot.compositePodGroupStates[key] = cpgs.snapshot()
 	}
 }
 
@@ -1125,30 +1125,42 @@ func (cache *cacheImpl) applyPVCRefCountDelta(snapshot *Snapshot) error {
 	return nil
 }
 
-// AddPodGroup adds a pod group object to the cache.
-func (cache *cacheImpl) AddPodGroup(podGroup *schedulingv1beta1.PodGroup) {
-	if !cache.genericWorkloadEnabled {
-		return
-	}
+// AddGenericPodGroup adds a generic pod group object to the cache,
+// and links it to its parent composite pod group if one is specified.
+func (cache *cacheImpl) AddGenericPodGroup(gpg *framework.GenericPodGroup) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	key := fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)
-	pgs, exists := cache.podGroupStates[key]
-	if !exists {
-		pgs = newPodGroupState()
-		cache.podGroupStates[key] = pgs
-	}
-	pgs.setPodGroup(podGroup)
+	key := gpg.GetKey()
 
-	if !cache.compositePodGroupEnabled || podGroup.Spec.ParentCompositePodGroupName == nil {
+	switch gpg.GetType() {
+	case fwk.PodGroupKeyType:
+		pgs, exists := cache.podGroupStates[key]
+		if !exists {
+			pgs = newPodGroupState()
+			cache.podGroupStates[key] = pgs
+		}
+		pgs.setPodGroup(gpg.PodGroup)
+	case fwk.CompositePodGroupKeyType:
+		cpgs, exists := cache.compositePodGroupStates[key]
+		if !exists {
+			cpgs = newCompositePodGroupState()
+			cache.compositePodGroupStates[key] = cpgs
+		}
+		cpgs.setCompositePodGroup(gpg.CompositePodGroup)
+	}
+
+	// Both PodGroups and CompositePodGroups can specify a parent CompositePodGroup.
+	// Even if the parent has not been observed in the cache yet, we create a placeholder entry
+	// so child-parent hierarchy tracking remains consistent.
+	if !cache.compositePodGroupEnabled {
+		return
+	}
+	parentKey, hasParent := gpg.GetParentKey()
+	if !hasParent {
 		return
 	}
 
-	parentKey := fwk.CompositePodGroupKey(podGroup.Namespace, *podGroup.Spec.ParentCompositePodGroupName)
-
-	// Even if the parent composite pod group has not been observed in the cache yet, we can assume that it
-	// will be observed eventually, and we should create an entry (placeholder) representing it in the cache.
 	parent, parentExists := cache.compositePodGroupStates[parentKey]
 	if !parentExists {
 		parent = newCompositePodGroupState()
@@ -1157,135 +1169,76 @@ func (cache *cacheImpl) AddPodGroup(podGroup *schedulingv1beta1.PodGroup) {
 	parent.addChild(key)
 }
 
-// UpdatePodGroup updates a pod group object in the cache.
-func (cache *cacheImpl) UpdatePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1beta1.PodGroup) {
-	if !cache.genericWorkloadEnabled {
-		return
-	}
+// UpdateGenericPodGroup updates an existing generic pod group object in the cache.
+func (cache *cacheImpl) UpdateGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	key := fwk.PodGroupKey(newPodGroup.Namespace, newPodGroup.Name)
-	pgs, exists := cache.podGroupStates[key]
-	if !exists {
-		// This should not happen: the pod group state should have been already created by a prior pod group add action.
-		utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for update, this indicates a missed add event", "podGroup", klog.KObj(newPodGroup))
-		return
+	key := gpg.GetKey()
+
+	switch gpg.GetType() {
+	case fwk.PodGroupKeyType:
+		pgs, exists := cache.podGroupStates[key]
+		if !exists {
+			// This should not happen: the pod group state should have been already created by a prior add action.
+			utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for update, this indicates a missed add event", "podGroup", klog.KObj(gpg))
+			return
+		}
+		pgs.setPodGroup(gpg.PodGroup)
+	case fwk.CompositePodGroupKeyType:
+		cpgs, exists := cache.compositePodGroupStates[key]
+		if !exists {
+			// This should not happen: the composite pod group state should have been already created by a prior add action.
+			utilruntime.HandleErrorWithLogger(logger, nil, "Composite pod group state not found for update, this indicates a missed add event", "compositePodGroup", klog.KObj(gpg))
+			return
+		}
+		cpgs.setCompositePodGroup(gpg.CompositePodGroup)
 	}
-	pgs.setPodGroup(newPodGroup)
 }
 
-// RemovePodGroup removes a pod group object from the cache.
-func (cache *cacheImpl) RemovePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
-	if !cache.genericWorkloadEnabled {
-		return
-	}
+// RemoveGenericPodGroup removes a generic pod group object from the cache.
+func (cache *cacheImpl) RemoveGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 
-	key := fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)
-	pgs, exists := cache.podGroupStates[key]
-	if !exists {
-		// This should not happen: the pod group state should have been already created by a prior pod group add action.
-		utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for removal", "podGroup", klog.KObj(podGroup))
-		return
-	}
+	key := gpg.GetKey()
 
-	if cache.compositePodGroupEnabled && podGroup.Spec.ParentCompositePodGroupName != nil {
-		parentKey := fwk.CompositePodGroupKey(podGroup.Namespace, *podGroup.Spec.ParentCompositePodGroupName)
-		if parent, exists := cache.compositePodGroupStates[parentKey]; exists {
-			parent.removeChild(key)
-			if parent.empty() {
-				// podGroupState can exist without the PodGroup object, but when any of the member pods exists.
-				delete(cache.compositePodGroupStates, parentKey)
+	// Remove this group from its parent's child tracking if composite pod groups are enabled.
+	if cache.compositePodGroupEnabled {
+		if parentKey, hasParent := gpg.GetParentKey(); hasParent {
+			if parent, exists := cache.compositePodGroupStates[parentKey]; exists {
+				parent.removeChild(key)
+				if parent.empty() {
+					// A state entry can exist without the API object as long as member pods or children exist.
+					delete(cache.compositePodGroupStates, parentKey)
+				}
 			}
 		}
 	}
 
-	pgs.removePodGroup()
-	if pgs.empty() {
-		delete(cache.podGroupStates, key)
-	}
-}
-
-// AddCompositePodGroup adds a composite pod group to the cache.
-func (cache *cacheImpl) AddCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
-	if !cache.compositePodGroupEnabled {
-		return
-	}
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
-
-	key := fwk.CompositePodGroupKey(cpg.Namespace, cpg.Name)
-	cpgState, exists := cache.compositePodGroupStates[key]
-	if !exists {
-		cpgState = newCompositePodGroupState()
-		cache.compositePodGroupStates[key] = cpgState
-	}
-	cpgState.setCompositePodGroup(cpg)
-
-	if cpg.Spec.ParentCompositePodGroupName == nil {
-		return
-	}
-
-	parentKey := fwk.CompositePodGroupKey(cpg.Namespace, *cpg.Spec.ParentCompositePodGroupName)
-
-	parent, parentExists := cache.compositePodGroupStates[parentKey]
-	if !parentExists {
-		parent = newCompositePodGroupState()
-		cache.compositePodGroupStates[parentKey] = parent
-	}
-	parent.addChild(key)
-}
-
-// UpdateCompositePodGroup updates a composite pod group in the cache.
-func (cache *cacheImpl) UpdateCompositePodGroup(logger klog.Logger, oldCPG, newCPG *schedulingv1alpha3.CompositePodGroup) {
-	if !cache.compositePodGroupEnabled {
-		return
-	}
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
-	key := fwk.CompositePodGroupKey(newCPG.Namespace, newCPG.Name)
-	pgs, exists := cache.compositePodGroupStates[key]
-	if !exists {
-		// This should not happen: the pod group state should have been already created by a prior pod group add action.
-		utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for update, this indicates a missed add event", "podGroup", klog.KObj(newCPG))
-		return
-	}
-	pgs.setCompositePodGroup(newCPG)
-}
-
-// RemoveCompositePodGroup removes a composite pod group from the cache.
-func (cache *cacheImpl) RemoveCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
-	if !cache.compositePodGroupEnabled {
-		return
-	}
-	cache.mu.Lock()
-	defer cache.mu.Unlock()
-
-	key := fwk.CompositePodGroupKey(cpg.Namespace, cpg.Name)
-	cpgs, exists := cache.compositePodGroupStates[key]
-	if !exists {
-		// This should not happen: the pod group state should have been already created by a prior pod group add action.
-		utilruntime.HandleErrorWithLogger(logger, nil, "Composite pod group state not found for removal", "compositePodGroup", klog.KObj(cpg))
-		return
-	}
-
-	if cpgs.compositePodGroup != nil && cpgs.compositePodGroup.Spec.ParentCompositePodGroupName != nil {
-		parentKey := fwk.CompositePodGroupKey(cpg.Namespace, *cpgs.compositePodGroup.Spec.ParentCompositePodGroupName)
-		parent, exists := cache.compositePodGroupStates[parentKey]
+	switch gpg.GetType() {
+	case fwk.PodGroupKeyType:
+		pgs, exists := cache.podGroupStates[key]
 		if !exists {
+			// This should not happen: the pod group state should always be present when removal event comes.
+			utilruntime.HandleErrorWithLogger(logger, nil, "Pod group state not found for removal", "podGroup", klog.KObj(gpg))
 			return
 		}
-		parent.removeChild(key)
-		if parent.empty() {
-			delete(cache.compositePodGroupStates, parentKey)
+		pgs.removePodGroup()
+		if pgs.empty() {
+			delete(cache.podGroupStates, key)
 		}
-	}
-
-	cpgs.removeCompositePodGroup()
-	if cpgs.empty() {
-		delete(cache.compositePodGroupStates, key)
+	case fwk.CompositePodGroupKeyType:
+		cpgs, exists := cache.compositePodGroupStates[key]
+		if !exists {
+			// This should not happen: the composite pod group state should always be present when removal event comes.
+			utilruntime.HandleErrorWithLogger(logger, nil, "Composite pod group state not found for removal", "compositePodGroup", klog.KObj(gpg))
+			return
+		}
+		cpgs.removeCompositePodGroup()
+		if cpgs.empty() {
+			delete(cache.compositePodGroupStates, key)
+		}
 	}
 }
 

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -744,7 +744,7 @@ func Test_AddPodGroupMember(t *testing.T) {
 			t.Run(fmt.Sprintf("%v, cpgEnabled=%v", tt.name, cpgEnabled), func(t *testing.T) {
 				cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled, cpgEnabled)
 				if tt.initPodGroup != nil {
-					cache.AddPodGroup(tt.initPodGroup)
+					cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(tt.initPodGroup))
 				}
 
 				cache.AddPodGroupMember(tt.pod)
@@ -937,7 +937,7 @@ func Test_RemovePodGroupMember(t *testing.T) {
 				cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled, cpgEnabled)
 
 				if tt.initPodGroup != nil {
-					cache.AddPodGroup(tt.initPodGroup)
+					cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(tt.initPodGroup))
 				}
 
 				for _, pod := range tt.initPods {
@@ -1098,16 +1098,14 @@ func Test_AddPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, tt.compositePodGroupEnabled)
-			logger := klog.Background()
-
 			if tt.initPod != nil {
 				cache.AddPodGroupMember(tt.initPod)
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.podGroupsToAdd {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 
 			if !tt.genericWorkloadEnabled {
@@ -1174,9 +1172,9 @@ func Test_UpdatePodGroup(t *testing.T) {
 			t.Run(fmt.Sprintf("%v, cpgEnabled=%v", tt.name, cpgEnabled), func(t *testing.T) {
 				logger, ctx := ktesting.NewTestContext(t)
 				cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, cpgEnabled)
-				cache.AddPodGroup(tt.oldPodGroup)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(tt.oldPodGroup))
 
-				cache.UpdatePodGroup(logger, tt.oldPodGroup, tt.newPodGroup)
+				cache.UpdateAbstractPodGroup(logger, framework.NewAbstractPodGroup(tt.newPodGroup))
 
 				gotPodGroup, err := cache.PodGroups().Get(tt.newPodGroup.Namespace, tt.newPodGroup.Name)
 				if tt.expectPodGroup != nil {
@@ -1271,19 +1269,17 @@ func Test_RemovePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, tt.compositePodGroupEnabled)
-			logger := klog.Background()
-
 			if tt.initPod != nil {
 				cache.AddPodGroupMember(tt.initPod)
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 
-			cache.RemovePodGroup(klog.FromContext(ctx), tt.podGroupToDelete)
+			cache.RemoveAbstractPodGroup(klog.FromContext(ctx), framework.NewAbstractPodGroup(tt.podGroupToDelete))
 
 			_, err := cache.PodGroups().Get(tt.podGroupToDelete.Namespace, tt.podGroupToDelete.Name)
 			if err == nil {
@@ -3371,13 +3367,11 @@ func Test_AddCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cache := newCache(ctx, time.Second, nil, true, true)
-			logger := klog.Background()
-
 			for _, pg := range tt.initialPGs {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.cpgsToAdd {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
 			gotCPGs := make(map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup)
@@ -3463,16 +3457,14 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cache := newCache(ctx, time.Second, nil, true, true)
-			logger := klog.Background()
-
 			for _, pg := range tt.initialPGs {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
-			cache.RemoveCompositePodGroup(klog.FromContext(ctx), tt.cpgToDelete)
+			cache.RemoveAbstractPodGroup(klog.FromContext(ctx), framework.NewAbstractCompositePodGroup(tt.cpgToDelete))
 
 			gotCPGs := make(map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup)
 			gotChildren := make(map[fwk.EntityKey]sets.Set[fwk.EntityKey])
@@ -3604,13 +3596,11 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, tt.compositePodGroupEnabled)
-			logger := klog.Background()
-
 			for _, pg := range tt.initialPGs {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
 			snapshot, err := cache.BuildHierarchySnapshotFromPod(tt.pod)

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -744,7 +744,7 @@ func Test_AddPodGroupMember(t *testing.T) {
 			t.Run(fmt.Sprintf("%v, cpgEnabled=%v", tt.name, cpgEnabled), func(t *testing.T) {
 				cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled, cpgEnabled)
 				if tt.initPodGroup != nil {
-					cache.AddPodGroup(tt.initPodGroup)
+					cache.AddGenericPodGroup(framework.NewGenericPodGroup(tt.initPodGroup))
 				}
 
 				cache.AddPodGroupMember(tt.pod)
@@ -937,7 +937,7 @@ func Test_RemovePodGroupMember(t *testing.T) {
 				cache := newCache(context.Background(), time.Second, nil, tt.genericWorkloadEnabled, cpgEnabled)
 
 				if tt.initPodGroup != nil {
-					cache.AddPodGroup(tt.initPodGroup)
+					cache.AddGenericPodGroup(framework.NewGenericPodGroup(tt.initPodGroup))
 				}
 
 				for _, pod := range tt.initPods {
@@ -982,7 +982,6 @@ func Test_AddPodGroup(t *testing.T) {
 
 	tests := []struct {
 		name                     string
-		genericWorkloadEnabled   bool
 		compositePodGroupEnabled bool
 		initPod                  *v1.Pod // From old tests
 		initialCPGs              []*schedulingv1alpha3.CompositePodGroup
@@ -991,15 +990,8 @@ func Test_AddPodGroup(t *testing.T) {
 		wantChildren             map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
-			name:                     "add pod group with GenericWorkload disabled should be no-op",
-			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{podGroup},
-			genericWorkloadEnabled:   false,
-			compositePodGroupEnabled: true,
-		},
-		{
 			name:                     "add pod group",
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{podGroup},
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
 				fwk.PodGroupKey("ns", "pg"): podGroup,
@@ -1010,7 +1002,6 @@ func Test_AddPodGroup(t *testing.T) {
 			name:                     "add pod group when state already exists (from pod group members)",
 			initPod:                  pod,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{podGroup},
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
 				fwk.PodGroupKey("ns", "pg"): podGroup,
@@ -1019,7 +1010,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add single pod group (hierarchical)",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg1},
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
@@ -1029,7 +1019,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add multiple pod groups (hierarchical)",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg1, pg2},
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
@@ -1040,7 +1029,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add pod group with parent",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
@@ -1052,7 +1040,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add pod group with parent, parent already in children",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
@@ -1068,7 +1055,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add pod group with parent, parent already has composite pod group child",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpgChild},
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent},
@@ -1084,7 +1070,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add pod group with parent when CompositePodGroup disabled",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: false,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
@@ -1097,24 +1082,15 @@ func Test_AddPodGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
-			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, tt.compositePodGroupEnabled)
-			logger := klog.Background()
-
+			cache := newCache(ctx, time.Second, nil, true, tt.compositePodGroupEnabled)
 			if tt.initPod != nil {
 				cache.AddPodGroupMember(tt.initPod)
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.podGroupsToAdd {
-				cache.AddPodGroup(pg)
-			}
-
-			if !tt.genericWorkloadEnabled {
-				if len(cache.podGroupStates) > 0 {
-					t.Errorf("Expected pod group state to be empty, got %d", len(cache.podGroupStates))
-				}
-				return
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 
 			gotPodGroups := make(map[fwk.EntityKey]*schedulingv1beta1.PodGroup)
@@ -1146,26 +1122,17 @@ func Test_UpdatePodGroup(t *testing.T) {
 	newPodGroup := st.MakePodGroup().Namespace("ns").Name("pg").MinCount(2).Obj()
 
 	tests := []struct {
-		name                   string
-		initPodGroup           *schedulingv1beta1.PodGroup
-		oldPodGroup            *schedulingv1beta1.PodGroup
-		newPodGroup            *schedulingv1beta1.PodGroup
-		genericWorkloadEnabled bool
-		expectPodGroup         *schedulingv1beta1.PodGroup
+		name           string
+		initPodGroup   *schedulingv1beta1.PodGroup
+		oldPodGroup    *schedulingv1beta1.PodGroup
+		newPodGroup    *schedulingv1beta1.PodGroup
+		expectPodGroup *schedulingv1beta1.PodGroup
 	}{
 		{
-			name:                   "update pod group with GenericWorkload disabled should be no-op",
-			oldPodGroup:            oldPodGroup,
-			newPodGroup:            newPodGroup,
-			genericWorkloadEnabled: false,
-			expectPodGroup:         nil,
-		},
-		{
-			name:                   "update pod group with GenericWorkload enabled",
-			oldPodGroup:            oldPodGroup,
-			newPodGroup:            newPodGroup,
-			genericWorkloadEnabled: true,
-			expectPodGroup:         newPodGroup,
+			name:           "update pod group with GenericWorkload enabled",
+			oldPodGroup:    oldPodGroup,
+			newPodGroup:    newPodGroup,
+			expectPodGroup: newPodGroup,
 		},
 	}
 
@@ -1173,10 +1140,10 @@ func Test_UpdatePodGroup(t *testing.T) {
 		for _, cpgEnabled := range []bool{true, false} {
 			t.Run(fmt.Sprintf("%v, cpgEnabled=%v", tt.name, cpgEnabled), func(t *testing.T) {
 				logger, ctx := ktesting.NewTestContext(t)
-				cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, cpgEnabled)
-				cache.AddPodGroup(tt.oldPodGroup)
+				cache := newCache(ctx, time.Second, nil, true, cpgEnabled)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(tt.oldPodGroup))
 
-				cache.UpdatePodGroup(logger, tt.oldPodGroup, tt.newPodGroup)
+				cache.UpdateGenericPodGroup(logger, framework.NewGenericPodGroup(tt.newPodGroup))
 
 				gotPodGroup, err := cache.PodGroups().Get(tt.newPodGroup.Namespace, tt.newPodGroup.Name)
 				if tt.expectPodGroup != nil {
@@ -1205,7 +1172,6 @@ func Test_RemovePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name                     string
-		genericWorkloadEnabled   bool
 		compositePodGroupEnabled bool
 		initPod                  *v1.Pod // From old tests
 		initialPodGroups         []*schedulingv1beta1.PodGroup
@@ -1217,16 +1183,9 @@ func Test_RemovePodGroup(t *testing.T) {
 		wantChildren             map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
-			name:                     "remove pod group with GenericWorkload disabled should be no-op",
-			podGroupToDelete:         podGroup,
-			genericWorkloadEnabled:   false,
-			compositePodGroupEnabled: true,
-		},
-		{
 			name:                     "remove pod group with GenericWorkload enabled",
 			podGroupToDelete:         podGroup,
 			initialPodGroups:         []*schedulingv1beta1.PodGroup{podGroup},
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			expectStateExists:        "false",
 		},
@@ -1235,14 +1194,12 @@ func Test_RemovePodGroup(t *testing.T) {
 			initPod:                  pod,
 			initialPodGroups:         []*schedulingv1beta1.PodGroup{podGroup},
 			podGroupToDelete:         podGroup,
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			expectStateExists:        "true",
 			expectPodsCount:          1,
 		},
 		{
 			name:                     "delete pod group with parent, parent has other pod group children",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			initialPodGroups:         []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
 			podGroupToDelete:         pg3WithParent,
@@ -1255,7 +1212,6 @@ func Test_RemovePodGroup(t *testing.T) {
 		},
 		{
 			name:                     "delete pod group with parent, parent has other composite pod group children",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			initialPodGroups:         []*schedulingv1beta1.PodGroup{pg3WithParent},
 			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpgChild},
@@ -1270,20 +1226,18 @@ func Test_RemovePodGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
-			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, tt.compositePodGroupEnabled)
-			logger := klog.Background()
-
+			cache := newCache(ctx, time.Second, nil, true, tt.compositePodGroupEnabled)
 			if tt.initPod != nil {
 				cache.AddPodGroupMember(tt.initPod)
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 
-			cache.RemovePodGroup(klog.FromContext(ctx), tt.podGroupToDelete)
+			cache.RemoveGenericPodGroup(klog.FromContext(ctx), framework.NewGenericPodGroup(tt.podGroupToDelete))
 
 			_, err := cache.PodGroups().Get(tt.podGroupToDelete.Namespace, tt.podGroupToDelete.Name)
 			if err == nil {
@@ -3371,13 +3325,11 @@ func Test_AddCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cache := newCache(ctx, time.Second, nil, true, true)
-			logger := klog.Background()
-
 			for _, pg := range tt.initialPGs {
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.cpgsToAdd {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
 			gotCPGs := make(map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup)
@@ -3463,16 +3415,14 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cache := newCache(ctx, time.Second, nil, true, true)
-			logger := klog.Background()
-
 			for _, pg := range tt.initialPGs {
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
-			cache.RemoveCompositePodGroup(klog.FromContext(ctx), tt.cpgToDelete)
+			cache.RemoveGenericPodGroup(klog.FromContext(ctx), framework.NewGenericCompositePodGroup(tt.cpgToDelete))
 
 			gotCPGs := make(map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup)
 			gotChildren := make(map[fwk.EntityKey]sets.Set[fwk.EntityKey])
@@ -3604,13 +3554,11 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, tt.compositePodGroupEnabled)
-			logger := klog.Background()
-
 			for _, pg := range tt.initialPGs {
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
 			snapshot, err := cache.BuildHierarchySnapshotFromPod(tt.pod)

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -982,7 +982,6 @@ func Test_AddPodGroup(t *testing.T) {
 
 	tests := []struct {
 		name                     string
-		genericWorkloadEnabled   bool
 		compositePodGroupEnabled bool
 		initPod                  *v1.Pod // From old tests
 		initialCPGs              []*schedulingv1alpha3.CompositePodGroup
@@ -991,15 +990,8 @@ func Test_AddPodGroup(t *testing.T) {
 		wantChildren             map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
-			name:                     "add pod group with GenericWorkload disabled should be no-op",
-			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{podGroup},
-			genericWorkloadEnabled:   false,
-			compositePodGroupEnabled: true,
-		},
-		{
 			name:                     "add pod group",
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{podGroup},
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
 				fwk.PodGroupKey("ns", "pg"): podGroup,
@@ -1010,7 +1002,6 @@ func Test_AddPodGroup(t *testing.T) {
 			name:                     "add pod group when state already exists (from pod group members)",
 			initPod:                  pod,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{podGroup},
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
 				fwk.PodGroupKey("ns", "pg"): podGroup,
@@ -1019,7 +1010,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add single pod group (hierarchical)",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg1},
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
@@ -1029,7 +1019,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add multiple pod groups (hierarchical)",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg1, pg2},
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
@@ -1040,7 +1029,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add pod group with parent",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
@@ -1052,7 +1040,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add pod group with parent, parent already in children",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
@@ -1068,7 +1055,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add pod group with parent, parent already has composite pod group child",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpgChild},
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent},
@@ -1084,7 +1070,6 @@ func Test_AddPodGroup(t *testing.T) {
 		},
 		{
 			name:                     "add pod group with parent when CompositePodGroup disabled",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: false,
 			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
@@ -1097,7 +1082,7 @@ func Test_AddPodGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
-			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, tt.compositePodGroupEnabled)
+			cache := newCache(ctx, time.Second, nil, true, tt.compositePodGroupEnabled)
 			if tt.initPod != nil {
 				cache.AddPodGroupMember(tt.initPod)
 			}
@@ -1106,13 +1091,6 @@ func Test_AddPodGroup(t *testing.T) {
 			}
 			for _, pg := range tt.podGroupsToAdd {
 				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
-			}
-
-			if !tt.genericWorkloadEnabled {
-				if len(cache.podGroupStates) > 0 {
-					t.Errorf("Expected pod group state to be empty, got %d", len(cache.podGroupStates))
-				}
-				return
 			}
 
 			gotPodGroups := make(map[fwk.EntityKey]*schedulingv1beta1.PodGroup)
@@ -1144,26 +1122,17 @@ func Test_UpdatePodGroup(t *testing.T) {
 	newPodGroup := st.MakePodGroup().Namespace("ns").Name("pg").MinCount(2).Obj()
 
 	tests := []struct {
-		name                   string
-		initPodGroup           *schedulingv1beta1.PodGroup
-		oldPodGroup            *schedulingv1beta1.PodGroup
-		newPodGroup            *schedulingv1beta1.PodGroup
-		genericWorkloadEnabled bool
-		expectPodGroup         *schedulingv1beta1.PodGroup
+		name           string
+		initPodGroup   *schedulingv1beta1.PodGroup
+		oldPodGroup    *schedulingv1beta1.PodGroup
+		newPodGroup    *schedulingv1beta1.PodGroup
+		expectPodGroup *schedulingv1beta1.PodGroup
 	}{
 		{
-			name:                   "update pod group with GenericWorkload disabled should be no-op",
-			oldPodGroup:            oldPodGroup,
-			newPodGroup:            newPodGroup,
-			genericWorkloadEnabled: false,
-			expectPodGroup:         nil,
-		},
-		{
-			name:                   "update pod group with GenericWorkload enabled",
-			oldPodGroup:            oldPodGroup,
-			newPodGroup:            newPodGroup,
-			genericWorkloadEnabled: true,
-			expectPodGroup:         newPodGroup,
+			name:           "update pod group with GenericWorkload enabled",
+			oldPodGroup:    oldPodGroup,
+			newPodGroup:    newPodGroup,
+			expectPodGroup: newPodGroup,
 		},
 	}
 
@@ -1171,7 +1140,7 @@ func Test_UpdatePodGroup(t *testing.T) {
 		for _, cpgEnabled := range []bool{true, false} {
 			t.Run(fmt.Sprintf("%v, cpgEnabled=%v", tt.name, cpgEnabled), func(t *testing.T) {
 				logger, ctx := ktesting.NewTestContext(t)
-				cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, cpgEnabled)
+				cache := newCache(ctx, time.Second, nil, true, cpgEnabled)
 				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(tt.oldPodGroup))
 
 				cache.UpdateAbstractPodGroup(logger, framework.NewAbstractPodGroup(tt.newPodGroup))
@@ -1203,7 +1172,6 @@ func Test_RemovePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name                     string
-		genericWorkloadEnabled   bool
 		compositePodGroupEnabled bool
 		initPod                  *v1.Pod // From old tests
 		initialPodGroups         []*schedulingv1beta1.PodGroup
@@ -1215,16 +1183,9 @@ func Test_RemovePodGroup(t *testing.T) {
 		wantChildren             map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
-			name:                     "remove pod group with GenericWorkload disabled should be no-op",
-			podGroupToDelete:         podGroup,
-			genericWorkloadEnabled:   false,
-			compositePodGroupEnabled: true,
-		},
-		{
 			name:                     "remove pod group with GenericWorkload enabled",
 			podGroupToDelete:         podGroup,
 			initialPodGroups:         []*schedulingv1beta1.PodGroup{podGroup},
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			expectStateExists:        "false",
 		},
@@ -1233,14 +1194,12 @@ func Test_RemovePodGroup(t *testing.T) {
 			initPod:                  pod,
 			initialPodGroups:         []*schedulingv1beta1.PodGroup{podGroup},
 			podGroupToDelete:         podGroup,
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			expectStateExists:        "true",
 			expectPodsCount:          1,
 		},
 		{
 			name:                     "delete pod group with parent, parent has other pod group children",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			initialPodGroups:         []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
 			podGroupToDelete:         pg3WithParent,
@@ -1253,7 +1212,6 @@ func Test_RemovePodGroup(t *testing.T) {
 		},
 		{
 			name:                     "delete pod group with parent, parent has other composite pod group children",
-			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			initialPodGroups:         []*schedulingv1beta1.PodGroup{pg3WithParent},
 			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpgChild},
@@ -1268,7 +1226,7 @@ func Test_RemovePodGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
-			cache := newCache(ctx, time.Second, nil, tt.genericWorkloadEnabled, tt.compositePodGroupEnabled)
+			cache := newCache(ctx, time.Second, nil, true, tt.compositePodGroupEnabled)
 			if tt.initPod != nil {
 				cache.AddPodGroupMember(tt.initPod)
 			}

--- a/pkg/scheduler/backend/cache/interface.go
+++ b/pkg/scheduler/backend/cache/interface.go
@@ -18,8 +18,6 @@ package cache
 
 import (
 	v1 "k8s.io/api/core/v1"
-	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -139,23 +137,14 @@ type Cache interface {
 	// RemovePodGroupMember removes a pod from its pod group state.
 	RemovePodGroupMember(pod *v1.Pod)
 
-	// AddPodGroup adds a pod group object to the cache.
-	AddPodGroup(podGroup *schedulingv1beta1.PodGroup)
+	// AddAbstractPodGroup adds an abstract pod group object to the cache.
+	AddAbstractPodGroup(apg *framework.AbstractPodGroup)
 
-	// UpdatePodGroup updates a pod group object in the cache.
-	UpdatePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1beta1.PodGroup)
+	// UpdateAbstractPodGroup updates an abstract pod group object in the cache.
+	UpdateAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup)
 
-	// RemovePodGroup removes a pod group object from the cache.
-	RemovePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
-
-	// AddCompositePodGroup adds a composite pod group to the cache.
-	AddCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup)
-
-	// UpdateCompositePodGroup updates a composite pod group object in the cache.
-	UpdateCompositePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1alpha3.CompositePodGroup)
-
-	// RemoveCompositePodGroup removes a composite pod group from the cache.
-	RemoveCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup)
+	// RemoveAbstractPodGroup removes an abstract pod group object from the cache.
+	RemoveAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup)
 
 	// BuildHierarchySnapshotFromPod returns a snapshot of the pod group hierarchy for the given pod.
 	BuildHierarchySnapshotFromPod(pod *v1.Pod) (fwk.PodGroupManager, error)

--- a/pkg/scheduler/backend/cache/interface.go
+++ b/pkg/scheduler/backend/cache/interface.go
@@ -18,8 +18,6 @@ package cache
 
 import (
 	v1 "k8s.io/api/core/v1"
-	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -139,23 +137,14 @@ type Cache interface {
 	// RemovePodGroupMember removes a pod from its pod group state.
 	RemovePodGroupMember(pod *v1.Pod)
 
-	// AddPodGroup adds a pod group object to the cache.
-	AddPodGroup(podGroup *schedulingv1beta1.PodGroup)
+	// AddGenericPodGroup adds a generic pod group object to the cache.
+	AddGenericPodGroup(apg *framework.GenericPodGroup)
 
-	// UpdatePodGroup updates a pod group object in the cache.
-	UpdatePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1beta1.PodGroup)
+	// UpdateGenericPodGroup updates a generic pod group object in the cache.
+	UpdateGenericPodGroup(logger klog.Logger, apg *framework.GenericPodGroup)
 
-	// RemovePodGroup removes a pod group object from the cache.
-	RemovePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
-
-	// AddCompositePodGroup adds a composite pod group to the cache.
-	AddCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup)
-
-	// UpdateCompositePodGroup updates a composite pod group object in the cache.
-	UpdateCompositePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1alpha3.CompositePodGroup)
-
-	// RemoveCompositePodGroup removes a composite pod group from the cache.
-	RemoveCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup)
+	// RemoveGenericPodGroup removes a generic pod group object from the cache.
+	RemoveGenericPodGroup(logger klog.Logger, apg *framework.GenericPodGroup)
 
 	// BuildHierarchySnapshotFromPod returns a snapshot of the pod group hierarchy for the given pod.
 	BuildHierarchySnapshotFromPod(pod *v1.Pod) (fwk.PodGroupManager, error)

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -34,6 +34,8 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -1570,7 +1572,7 @@ func (p *PriorityQueue) AddAbstractPodGroup(logger klog.Logger, apg *framework.A
 
 		rootInfo := entity.(*framework.QueuedPodGroupInfo)
 		subtree := p.workloadForest.buildPodGroupInfo(logger, apg, sets.New[fwk.EntityKey]())
-		rootInfo.AddAbstractPodGroup(apg, subtree)
+		rootInfo.AddSubtree(subtree)
 		logger.V(5).Info("New group added to the existing root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "groupType", apg.GetType(), "group", klog.KObj(apg))
 	})
 
@@ -1895,13 +1897,7 @@ func (p *PriorityQueue) GetPodGroup(name, namespace string, entityKeyType fwk.En
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	pgInfo := &framework.QueuedPodGroupInfo{
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:      name,
-			Namespace: namespace,
-			Type:      entityKeyType,
-		},
-	}
+	pgInfo := newPodGroupInfoForLookup(namespace, name)
 	var foundPGInfo *framework.QueuedPodGroupInfo
 	p.activeQ.underRLock(func(unlockedActiveQ unlockedActiveQueueReader) {
 		entity := p.getEntityFromAnyQueue(unlockedActiveQ, pgInfo)
@@ -2190,4 +2186,30 @@ func (p *PriorityQueue) runPreQueueingHintPlugins(logger klog.Logger, event fwk.
 		return nil
 	}
 	return result
+}
+
+func newPodGroupInfoForLookup(namespace, name string) *framework.QueuedPodGroupInfo {
+	return &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			AbstractPodGroup: framework.NewAbstractPodGroup(&schedulingv1beta1.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+			}),
+		},
+	}
+}
+
+func newCompositePodGroupInfoForLookup(namespace, name string) *framework.QueuedPodGroupInfo {
+	return &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			AbstractPodGroup: framework.NewAbstractCompositePodGroup(&schedulingv1alpha3.CompositePodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+			}),
+		},
+	}
 }

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -34,8 +34,6 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
-	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -132,14 +130,13 @@ type SchedulingQueue interface {
 	// Important Note: preCheck shouldn't include anything that depends on the in-tree plugins' logic.
 	// (e.g., filter Pods based on added/updated Node's capacity, etc.)
 	MoveAllToActiveOrBackoffQueue(logger klog.Logger, event fwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck)
-	// AddPodGroup adds a new PodGroup object to the queue,
-	// requeuing all pods associated with the pod group.
-	AddPodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
-	// UpdatePodGroup updates an existing PodGroup object in the queue.
-	UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
-	// DeletePodGroup removes a PodGroup object from the queue,
-	// moving all pods associated with the pod group to the incompletePodGroupPods.
-	DeletePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
+	// AddAbstractPodGroup adds a PodGroup or CompositePodGroup object to the queue,
+	// requeuing all pods associated with the group.
+	AddAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup)
+	// UpdateAbstractPodGroup updates an existing PodGroup or CompositePodGroup object in the queue.
+	UpdateAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup)
+	// DeleteAbstractPodGroup removes a PodGroup or CompositePodGroup object from the queue.
+	DeleteAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup)
 
 	// Close closes the SchedulingQueue so that the goroutine which is
 	// waiting to pop items can exit gracefully.
@@ -166,13 +163,6 @@ type SchedulingQueue interface {
 	// IncompletePodGroupPodsPods returns all the pods belonging to pod groups
 	// waiting for their API objects (PodGroups) to be observed.
 	IncompletePodGroupPodsPods() []*v1.Pod
-
-	// AddCompositePodGroup adds a composite pod group to the queue.
-	AddCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup)
-	// UpdateCompositePodGroup updates a composite pod group in the queue.
-	UpdateCompositePodGroup(logger klog.Logger, newCPG *schedulingv1alpha3.CompositePodGroup)
-	// DeleteCompositePodGroup removes a composite pod group from the queue.
-	DeleteCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup)
 }
 
 // NewSchedulingQueue initializes a priority queue as a new scheduling queue.
@@ -1558,9 +1548,9 @@ func (p *PriorityQueue) deletePod(pod *v1.Pod) {
 	}
 }
 
-// addAbstractPodGroup adds a PodGroup or CompositePodGroup object to the queue,
+// AddAbstractPodGroup adds a PodGroup or CompositePodGroup object to the queue,
 // requeuing all pods associated with the group.
-func (p *PriorityQueue) addAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup) {
+func (p *PriorityQueue) AddAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -1598,8 +1588,8 @@ func (p *PriorityQueue) addAbstractPodGroup(logger klog.Logger, apg *framework.A
 	logger.V(5).Info("New group was added to the root group and its pods were attempted to be moved from incompletePodGroupPods to the queue", "rootType", rootInfoLookup.Type(), "root", klog.KObj(rootInfoLookup), "groupType", apg.GetType(), "group", klog.KObj(apg), "podsLen", len(pInfos))
 }
 
-// updateAbstractPodGroup updates an existing PodGroup or CompositePodGroup object in the queue.
-func (p *PriorityQueue) updateAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup) {
+// UpdateAbstractPodGroup updates an existing PodGroup or CompositePodGroup object in the queue.
+func (p *PriorityQueue) UpdateAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -1620,8 +1610,8 @@ func (p *PriorityQueue) updateAbstractPodGroup(logger klog.Logger, apg *framewor
 	})
 }
 
-// deleteAbstractPodGroup removes a PodGroup or CompositePodGroup object from the queue.
-func (p *PriorityQueue) deleteAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup) {
+// DeleteAbstractPodGroup removes a PodGroup or CompositePodGroup object from the queue.
+func (p *PriorityQueue) DeleteAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -1678,49 +1668,6 @@ func (p *PriorityQueue) deleteAbstractPodGroup(logger klog.Logger, apg *framewor
 		p.activeQ.broadcast()
 	}
 	logger.V(5).Info("Group deleted from root group, decomposed and enqueued pods to incompletePodGroupPods", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "groupType", apg.GetType(), "group", klog.KObj(apg), "pods", len(removedPods))
-}
-
-// AddPodGroup adds a new PodGroup object to the queue,
-// requeuing all pods associated with the pod group.
-func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
-	p.addAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
-}
-
-// UpdatePodGroup updates an existing PodGroup object in the queue.
-func (p *PriorityQueue) UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
-	p.updateAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
-}
-
-// DeletePodGroup removes a PodGroup object from the queue,
-// moving all pods associated with the pod group to the incompletePodGroupPods.
-func (p *PriorityQueue) DeletePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
-	p.deleteAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
-}
-
-// AddCompositePodGroup adds a new CompositePodGroup object to the queue.
-// It requeues all pods associated with the composite pod group.
-func (p *PriorityQueue) AddCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
-	if !p.isCompositePodGroupEnabled {
-		return
-	}
-	p.addAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpg))
-}
-
-// UpdateCompositePodGroup updates an existing CompositePodGroup object in the queue.
-func (p *PriorityQueue) UpdateCompositePodGroup(logger klog.Logger, newCPG *schedulingv1alpha3.CompositePodGroup) {
-	if !p.isCompositePodGroupEnabled {
-		return
-	}
-	p.updateAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(newCPG))
-}
-
-// DeleteCompositePodGroup removes a CompositePodGroup object from the queue.
-// It moves all pods in the hierarchy of the composite pod group to the incompletePodGroupPods.
-func (p *PriorityQueue) DeleteCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
-	if !p.isCompositePodGroupEnabled {
-		return
-	}
-	p.deleteAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpg))
 }
 
 // NOTE: this function assumes a lock has been acquired in the caller.

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -1558,15 +1558,15 @@ func (p *PriorityQueue) deletePod(pod *v1.Pod) {
 	}
 }
 
-// AddPodGroup adds a new PodGroup object to the queue,
-// requeuing all pods associated with the pod group.
-func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+// addAbstractPodGroup adds a PodGroup or CompositePodGroup object to the queue,
+// requeuing all pods associated with the group.
+func (p *PriorityQueue) addAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	p.workloadForest.addPodGroup(podGroup)
+	p.workloadForest.addAbstractPodGroup(apg)
 
-	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfoForPodGroup(podGroup)
+	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfo(apg)
 	if !hasRoot {
 		// If the root does not exist, then pods should stay in the incompletePodGroupPods.
 		return
@@ -1579,8 +1579,9 @@ func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1be
 		}
 
 		rootInfo := entity.(*framework.QueuedPodGroupInfo)
-		rootInfo.AddPodGroup(podGroup)
-		logger.V(5).Info("Pod Group added to the existing root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "podGroup", klog.KObj(podGroup))
+		subtree := p.workloadForest.buildPodGroupInfo(logger, apg, sets.New[fwk.EntityKey]())
+		rootInfo.AddAbstractPodGroup(apg, subtree)
+		logger.V(5).Info("New group added to the existing root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "groupType", apg.GetType(), "group", klog.KObj(apg))
 	})
 
 	pgs := p.workloadForest.getLeafPodGroups(logger, rootInfoLookup)
@@ -1594,16 +1595,16 @@ func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1be
 		// through the addPodGroupMember method.
 		p.addPodGroupMember(logger, pInfo)
 	}
-	logger.V(5).Info("Pod Group was added to the root group and its pods were attempted to be moved from incompletePodGroupPods to the queue", "rootType", rootInfoLookup.Type(), "root", klog.KObj(rootInfoLookup), "podGroup", klog.KObj(podGroup), "podsLen", len(pInfos))
+	logger.V(5).Info("New group was added to the root group and its pods were attempted to be moved from incompletePodGroupPods to the queue", "rootType", rootInfoLookup.Type(), "root", klog.KObj(rootInfoLookup), "groupType", apg.GetType(), "group", klog.KObj(apg), "podsLen", len(pInfos))
 }
 
-// UpdatePodGroup updates an existing PodGroup object in the queue.
-func (p *PriorityQueue) UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+// updateAbstractPodGroup updates an existing PodGroup or CompositePodGroup object in the queue.
+func (p *PriorityQueue) updateAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	p.workloadForest.updatePodGroup(podGroup)
-	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfoForPodGroup(podGroup)
+	p.workloadForest.updateAbstractPodGroup(apg)
+	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfo(apg)
 	if !hasRoot {
 		return
 	}
@@ -1614,145 +1615,23 @@ func (p *PriorityQueue) UpdatePodGroup(logger klog.Logger, podGroup *schedulingv
 			return
 		}
 		rootInfo := entity.(*framework.QueuedPodGroupInfo)
-		rootInfo.UpdatePodGroup(podGroup)
-		logger.V(5).Info("Pod Group in the scheduling queue was updated for the root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "podGroup", klog.KObj(podGroup))
+		rootInfo.UpdateAbstractPodGroup(apg)
+		logger.V(5).Info("Group in the scheduling queue was updated for the root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "groupType", apg.GetType(), "group", klog.KObj(apg))
 	})
 }
 
-// DeletePodGroup removes a PodGroup object from the queue,
-// moving all pods associated with the pod group to the incompletePodGroupPods.
-func (p *PriorityQueue) DeletePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+// deleteAbstractPodGroup removes a PodGroup or CompositePodGroup object from the queue.
+func (p *PriorityQueue) deleteAbstractPodGroup(logger klog.Logger, apg *framework.AbstractPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	rootInfoLookup, hadRoot := p.workloadForest.getRootLookupInfoForPodGroup(podGroup)
-	p.workloadForest.deletePodGroup(podGroup)
+	rootInfoLookup, hadRoot := p.workloadForest.getRootLookupInfo(apg)
 	if !hadRoot {
-		return
-	}
-
-	entity, strategy := p.deleteFromAnyQueue(rootInfoLookup)
-	if entity == nil {
-		if !p.activeQ.isLastPoppedEntity(rootInfoLookup) {
-			// Root PodGroup/CompositePodGroup isn't pending or enqueued.
-			// No pods are tracked for that group in the queue,
-			// because in such case they are either scheduled or the group has no pods left.
-			return
-		}
-		// Get the pending pods and move them to incompletePodGroupPods.
-		pendingPods := p.pendingPodGroupPods.clear(podGroup.Namespace, podGroup.Name)
-		if len(pendingPods) == 0 {
-			// No pending pods, nothing to move.
-			return
-		}
-		for _, pInfo := range pendingPods {
-			p.incompletePodGroupPods.add(pInfo)
-		}
-		logger.V(5).Info("Pod group deleted, decomposed and enqueued pending pods for the pod group to incompletePodGroupPods", "podGroup", klog.KObj(podGroup), "pods", len(pendingPods))
-		return
-	}
-
-	rootInfo := entity.(*framework.QueuedPodGroupInfo)
-	removedPods := rootInfo.RemovePodGroup(podGroup)
-	for _, pInfo := range removedPods {
-		p.incompletePodGroupPods.add(pInfo)
-	}
-
-	if !rootInfo.HasQueuedPodInfos() {
-		logger.V(5).Info("Pod group deleted from root group, decomposed and enqueued pods to incompletePodGroupPods", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "podGroup", klog.KObj(podGroup), "pods", len(removedPods))
-		return
-	}
-
-	queue := p.requeueEntityWithQueueingStrategy(logger, rootInfo, strategy, framework.EventUnscheduledPodUpdate.Label())
-	if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
-		p.activeQ.broadcast()
-	}
-	logger.V(5).Info("Pod group deleted from root group, decomposed and enqueued pods to incompletePodGroupPods", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "podGroup", klog.KObj(podGroup), "pods", len(removedPods))
-}
-
-// AddCompositePodGroup adds a new CompositePodGroup object to the queue.
-// It requeues all pods associated with the composite pod group.
-func (p *PriorityQueue) AddCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
-	if !p.isCompositePodGroupEnabled {
-		return
-	}
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	p.workloadForest.addCompositePodGroup(cpg)
-	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfoForCPG(cpg)
-	if !hasRoot {
-		// If the root does not exist, then pods should stay in the incompletePodGroupPods.
-		return
-	}
-
-	p.activeQ.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
-		entity := p.getEntityFromAnyQueue(unlockedActiveQ, rootInfoLookup)
-		if entity == nil {
-			return
-		}
-
-		rootInfo := entity.(*framework.QueuedPodGroupInfo)
-		subtree := p.workloadForest.buildPodGroupInfoForCPG(logger, cpg, sets.New[fwk.EntityKey]())
-		rootInfo.AddCompositePodGroup(cpg, subtree)
-		logger.V(5).Info("Composite Pod Group added to the existing root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "podGroup", klog.KObj(cpg))
-	})
-
-	pgs := p.workloadForest.getLeafPodGroups(logger, rootInfoLookup)
-	var pInfos []*framework.QueuedPodInfo
-	for _, pg := range pgs {
-		pInfos = append(pInfos, p.incompletePodGroupPods.clear(pg.Namespace, pg.Name)...)
-	}
-
-	for _, pInfo := range pInfos {
-		// To handle all cases reliably, pods removed from incompletePodGroupPods are added to the queue
-		// through the addPodGroupMember method.
-		p.addPodGroupMember(logger, pInfo)
-	}
-	logger.V(5).Info("Composite Pod Group was added to the root group and its pods were attempted to be moved from incompletePodGroupPods to the queue", "rootType", rootInfoLookup.Type(), "root", klog.KObj(rootInfoLookup), "compositePodGroup", klog.KObj(cpg), "podsLen", len(pInfos))
-}
-
-// UpdateCompositePodGroup updates an existing CompositePodGroup object in the queue.
-func (p *PriorityQueue) UpdateCompositePodGroup(logger klog.Logger, newCPG *schedulingv1alpha3.CompositePodGroup) {
-	if !p.isCompositePodGroupEnabled {
-		return
-	}
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	p.workloadForest.updateCompositePodGroup(newCPG)
-	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfoForCPG(newCPG)
-	if !hasRoot {
-		return
-	}
-
-	p.activeQ.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
-		entity := p.getEntityFromAnyQueue(unlockedActiveQ, rootInfoLookup)
-		if entity == nil {
-			return
-		}
-		rootInfo := entity.(*framework.QueuedPodGroupInfo)
-		rootInfo.UpdateCompositePodGroup(newCPG)
-		logger.V(5).Info("Composite Pod Group in the scheduling queue was updated for the root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "compositePodGroup", klog.KObj(newCPG))
-	})
-}
-
-// DeleteCompositePodGroup removes a CompositePodGroup object from the queue.
-// It moves all pods in the hierarchy of the composite pod group to the incompletePodGroupPods.
-func (p *PriorityQueue) DeleteCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
-	if !p.isCompositePodGroupEnabled {
-		return
-	}
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	rootInfoLookup, hadRoot := p.workloadForest.getRootLookupInfoForCPG(cpg)
-	if !hadRoot {
-		p.workloadForest.deleteCompositePodGroup(cpg)
+		p.workloadForest.deleteAbstractPodGroup(apg)
 		return
 	}
 	leafPGs := p.workloadForest.getLeafPodGroups(logger, rootInfoLookup)
-	p.workloadForest.deleteCompositePodGroup(cpg)
+	p.workloadForest.deleteAbstractPodGroup(apg)
 
 	entity, strategy := p.deleteFromAnyQueue(rootInfoLookup)
 	if entity == nil {
@@ -1762,7 +1641,7 @@ func (p *PriorityQueue) DeleteCompositePodGroup(logger klog.Logger, cpg *schedul
 			// because in such case they are either scheduled or the group has no pods left.
 			return
 		}
-		// Get the pending pods and move them to incompletePodGroupPods.
+		// Get the pending pods and move them to incompletePodGroupPods, if no root exists.
 		var pendingPods []*framework.QueuedPodInfo
 		for _, pg := range leafPGs {
 			pendingPods = append(pendingPods, p.pendingPodGroupPods.clear(pg.Namespace, pg.Name)...)
@@ -1779,18 +1658,18 @@ func (p *PriorityQueue) DeleteCompositePodGroup(logger klog.Logger, cpg *schedul
 				p.incompletePodGroupPods.add(pInfo)
 			}
 		}
-		logger.V(5).Info("Composite pod group deleted from the root group, enqueued pending pods in the composite pod group subtree to incompletePodGroupPods", "rootType", rootInfoLookup.Type(), "root", klog.KObj(rootInfoLookup), "compositePodGroup", klog.KObj(cpg), "pods", len(pendingPods))
+		logger.V(5).Info("Group deleted from the root group, enqueued pending pods to incompletePodGroupPods", "rootType", rootInfoLookup.Type(), "root", klog.KObj(rootInfoLookup), "groupType", apg.GetType(), "group", klog.KObj(apg), "pods", len(pendingPods))
 		return
 	}
 
 	rootInfo := entity.(*framework.QueuedPodGroupInfo)
-	removedPods := rootInfo.RemoveCompositePodGroup(cpg)
+	removedPods := rootInfo.RemoveAbstractPodGroup(apg)
 	for _, pInfo := range removedPods {
 		p.incompletePodGroupPods.add(pInfo)
 	}
 
-	logger.V(5).Info("Composite pod group deleted from the root group, decomposed and enqueued pods in the composite pod group subtree to incompletePodGroupPods", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "compositePodGroup", klog.KObj(cpg), "pods", len(removedPods))
 	if !rootInfo.HasQueuedPodInfos() {
+		logger.V(5).Info("Group deleted from root group, decomposed and enqueued pods to incompletePodGroupPods", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "groupType", apg.GetType(), "group", klog.KObj(apg), "pods", len(removedPods))
 		return
 	}
 
@@ -1798,6 +1677,50 @@ func (p *PriorityQueue) DeleteCompositePodGroup(logger klog.Logger, cpg *schedul
 	if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
 		p.activeQ.broadcast()
 	}
+	logger.V(5).Info("Group deleted from root group, decomposed and enqueued pods to incompletePodGroupPods", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "groupType", apg.GetType(), "group", klog.KObj(apg), "pods", len(removedPods))
+}
+
+// AddPodGroup adds a new PodGroup object to the queue,
+// requeuing all pods associated with the pod group.
+func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+	p.addAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
+}
+
+// UpdatePodGroup updates an existing PodGroup object in the queue.
+func (p *PriorityQueue) UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+	p.updateAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
+}
+
+// DeletePodGroup removes a PodGroup object from the queue,
+// moving all pods associated with the pod group to the incompletePodGroupPods.
+func (p *PriorityQueue) DeletePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+	p.deleteAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
+}
+
+// AddCompositePodGroup adds a new CompositePodGroup object to the queue.
+// It requeues all pods associated with the composite pod group.
+func (p *PriorityQueue) AddCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
+	if !p.isCompositePodGroupEnabled {
+		return
+	}
+	p.addAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpg))
+}
+
+// UpdateCompositePodGroup updates an existing CompositePodGroup object in the queue.
+func (p *PriorityQueue) UpdateCompositePodGroup(logger klog.Logger, newCPG *schedulingv1alpha3.CompositePodGroup) {
+	if !p.isCompositePodGroupEnabled {
+		return
+	}
+	p.updateAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(newCPG))
+}
+
+// DeleteCompositePodGroup removes a CompositePodGroup object from the queue.
+// It moves all pods in the hierarchy of the composite pod group to the incompletePodGroupPods.
+func (p *PriorityQueue) DeleteCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
+	if !p.isCompositePodGroupEnabled {
+		return
+	}
+	p.deleteAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpg))
 }
 
 // NOTE: this function assumes a lock has been acquired in the caller.
@@ -2256,14 +2179,6 @@ func podKey(pod *v1.Pod) fwk.EntityKey {
 
 func podGroupKeyForPod(pod *v1.Pod) fwk.EntityKey {
 	return fwk.PodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
-}
-
-func podGroupKey(podGroup *schedulingv1beta1.PodGroup) fwk.EntityKey {
-	return fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)
-}
-
-func compositePodGroupKey(cpg *schedulingv1alpha3.CompositePodGroup) fwk.EntityKey {
-	return fwk.CompositePodGroupKey(cpg.Namespace, cpg.Name)
 }
 
 // preQueueingHintPodKeys holds the result of running PreQueueingHintFns for an event.

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -132,14 +132,13 @@ type SchedulingQueue interface {
 	// Important Note: preCheck shouldn't include anything that depends on the in-tree plugins' logic.
 	// (e.g., filter Pods based on added/updated Node's capacity, etc.)
 	MoveAllToActiveOrBackoffQueue(logger klog.Logger, event fwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck)
-	// AddPodGroup adds a new PodGroup object to the queue,
-	// requeuing all pods associated with the pod group.
-	AddPodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
-	// UpdatePodGroup updates an existing PodGroup object in the queue.
-	UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
-	// DeletePodGroup removes a PodGroup object from the queue,
-	// moving all pods associated with the pod group to the incompletePodGroupPods.
-	DeletePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
+	// AddGenericPodGroup adds a PodGroup or CompositePodGroup object to the queue,
+	// requeuing all pods associated with the group.
+	AddGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup)
+	// UpdateGenericPodGroup updates an existing PodGroup or CompositePodGroup object in the queue.
+	UpdateGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup)
+	// DeleteGenericPodGroup removes a PodGroup or CompositePodGroup object from the queue.
+	DeleteGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup)
 
 	// Close closes the SchedulingQueue so that the goroutine which is
 	// waiting to pop items can exit gracefully.
@@ -152,7 +151,7 @@ type SchedulingQueue interface {
 	PatchPodStatus(pod *v1.Pod, conditions []*v1.PodCondition, nominatingInfo *fwk.NominatingInfo) (<-chan error, error)
 
 	// The following functions are supposed to be used only for testing or debugging.
-	GetPodGroup(name, namespace string, entityKeyType fwk.EntityKeyType) (*framework.QueuedPodGroupInfo, bool)
+	GetPodGroup(name, namespace string) (*framework.QueuedPodGroupInfo, bool)
 	GetPod(name, namespace string, schedulingGroup *v1.PodSchedulingGroup) (*framework.QueuedPodInfo, bool)
 	PendingPods() ([]*v1.Pod, string)
 	InFlightPods() []*v1.Pod
@@ -166,13 +165,6 @@ type SchedulingQueue interface {
 	// IncompletePodGroupPodsPods returns all the pods belonging to pod groups
 	// waiting for their API objects (PodGroups) to be observed.
 	IncompletePodGroupPodsPods() []*v1.Pod
-
-	// AddCompositePodGroup adds a composite pod group to the queue.
-	AddCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup)
-	// UpdateCompositePodGroup updates a composite pod group in the queue.
-	UpdateCompositePodGroup(logger klog.Logger, newCPG *schedulingv1alpha3.CompositePodGroup)
-	// DeleteCompositePodGroup removes a composite pod group from the queue.
-	DeleteCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup)
 }
 
 // NewSchedulingQueue initializes a priority queue as a new scheduling queue.
@@ -194,9 +186,9 @@ func NewSchedulingQueue(
 //     are currently determined to be unschedulable.
 //
 // For handling PodGroups, the PriorityQueue is extended with following structures:
-//   - incompletePodGroupPods: stores pod infos that wait for their corresponding PodGroup object to be observed.
+//   - incompletePodGroupPods: stores pod infos that wait for their corresponding PodGroup or the parent CompositePodGroup object to be observed.
 //   - pendingPodGroupPods: stores all pending pods that wait for their corresponding in-flight pod group to be requeued.
-//   - workloadForest: workloadForest maintains a consistent view of observed PodGroup objects.
+//   - workloadForest: workloadForest maintains a consistent view of observed GenericPodGroup objects (either PodGroup or CompositePodGroup).
 //
 // These additional structures ensure the following lifecycle invariants for a Pod and its corresponding PodGroup are met:
 //  1. Incomplete: A Pod is placed in `incompletePodGroupPods` iff its root PodGroup is NOT present in the `workloadForest`.
@@ -225,11 +217,11 @@ type PriorityQueue struct {
 	// pendingPodGroupPods stores all pending pods that wait for their corresponding pod group to be requeued.
 	// It should be only used when GenericWorkload feature is enabled.
 	pendingPodGroupPods *podGroupMemberPods
-	// incompletePodGroupPods stores pod infos that wait for their corresponding PodGroup object to be observed.
+	// incompletePodGroupPods stores pod infos that wait for their corresponding PodGroup or the parent CompositePodGroup object to be observed.
 	// It should be only used when GenericWorkload feature is enabled.
 	incompletePodGroupPods *podGroupMemberPods
 
-	// workloadForest maintains a consistent view of observed PodGroup objects.
+	// workloadForest maintains a consistent view of observed GenericPodGroup objects (either PodGroup or CompositePodGroup).
 	// It ensures that scheduling queue invariants are preserved, independent of
 	// asynchronous updates happening in the scheduler cache.
 	// Outside of the scheduling queue, cache should be used as the source of truth.
@@ -924,10 +916,12 @@ func (p *PriorityQueue) addPodGroupMember(logger klog.Logger, pInfo *framework.Q
 
 	// Create a new group as it's the first member pod in the queue.
 	rootInfo := p.newQueuedPodGroupInfoFromRootLookup(logger, pInfo, rootInfoLookup)
+	// Get the log values before moving to activeQ, because accessing these values later can race with scheduling cycle.
+	rootType, rootRef := rootInfo.Type(), klog.KObj(rootInfo)
 	if added := p.moveToActiveQ(logger, rootInfo, framework.EventUnscheduledPodAdd.Label(), false, nil); added {
 		p.activeQ.broadcast()
 	}
-	logger.V(5).Info("Pod was added to root group as the first member pod", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "pod", klog.KObj(pInfo))
+	logger.V(5).Info("Pod was added to root group as the first member pod", "rootType", rootType, "root", rootRef, "pod", klog.KObj(pInfo))
 }
 
 // deleteFromAnyQueue deletes an entity from any queue it may be in and returns
@@ -1252,6 +1246,8 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 
 	// Try to requeue this pod group to activeQ or backoffQ.
 	// If the PreEnqueue fails for this pod group, it will be moved to the unschedulableEntities.
+	// Get the log values before moving to activeQ, because accessing these values later can race with scheduling cycle.
+	rootType, rootRef := rootInfo.Type(), klog.KObj(rootInfo)
 	queue := unschedulableQ
 	if !requeueWithoutBackoff && p.backoffQ.isEntityBackingoff(pgInfo) {
 		if added := p.moveToBackoffQ(logger, pgInfo, framework.ScheduleAttemptFailure, nil); added {
@@ -1262,7 +1258,7 @@ func (p *PriorityQueue) AddAttemptedPodGroupIfNeeded(logger klog.Logger, pgInfo 
 			queue = activeQ
 		}
 	}
-	logger.V(3).Info("Pod group moved to an internal scheduling queue", "podGroup", klog.KObj(pgInfo), "event", framework.ScheduleAttemptFailure, "queue", queue, "schedulingCycle", schedulingCycle, "unschedulable plugins", rejectorPlugins)
+	logger.V(3).Info("Pod group moved to an internal scheduling queue", "rootType", rootType, "root", rootRef, "event", framework.ScheduleAttemptFailure, "queue", queue, "schedulingCycle", schedulingCycle, "unschedulable plugins", rejectorPlugins)
 	if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
 		// When the Pod group is moved to activeQ, need to let p.cond know so that the Pod will be pop()ed out.
 		p.activeQ.broadcast()
@@ -1561,15 +1557,15 @@ func (p *PriorityQueue) deletePod(pod *v1.Pod) {
 	}
 }
 
-// AddPodGroup adds a new PodGroup object to the queue,
-// requeuing all pods associated with the pod group.
-func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+// AddGenericPodGroup adds a PodGroup or CompositePodGroup object to the queue,
+// requeuing all pods associated with the group.
+func (p *PriorityQueue) AddGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	p.workloadForest.addPodGroup(podGroup)
+	p.workloadForest.addGenericPodGroup(gpg)
 
-	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfoForPodGroup(podGroup)
+	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfo(gpg)
 	if !hasRoot {
 		// If the root does not exist, then pods should stay in the incompletePodGroupPods.
 		return
@@ -1580,10 +1576,12 @@ func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1be
 		if entity == nil {
 			return
 		}
-
+		// This can only happen when the root is a CompositePodGroup.
+		// It's not possible for regular PodGroup to be present in the queue as a root, when the Add event comes.
 		rootInfo := entity.(*framework.QueuedPodGroupInfo)
-		rootInfo.AddPodGroup(podGroup)
-		logger.V(5).Info("Pod Group added to the existing root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "podGroup", klog.KObj(podGroup))
+		subtree := p.workloadForest.buildPodGroupInfo(logger, gpg, sets.New[fwk.EntityKey]())
+		rootInfo.AddSubtree(subtree)
+		logger.V(5).Info("New group added to the existing root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "groupType", gpg.GetType(), "group", klog.KObj(gpg))
 	})
 
 	pgs := p.workloadForest.getLeafPodGroups(logger, rootInfoLookup)
@@ -1597,16 +1595,16 @@ func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1be
 		// through the addPodGroupMember method.
 		p.addPodGroupMember(logger, pInfo)
 	}
-	logger.V(5).Info("Pod Group was added to the root group and its pods were attempted to be moved from incompletePodGroupPods to the queue", "rootType", rootInfoLookup.Type(), "root", klog.KObj(rootInfoLookup), "podGroup", klog.KObj(podGroup), "podsLen", len(pInfos))
+	logger.V(5).Info("New group was added to the root group and its pods were attempted to be moved from incompletePodGroupPods to the queue", "rootType", rootInfoLookup.Type(), "root", klog.KObj(rootInfoLookup), "groupType", gpg.GetType(), "group", klog.KObj(gpg), "podsLen", len(pInfos))
 }
 
-// UpdatePodGroup updates an existing PodGroup object in the queue.
-func (p *PriorityQueue) UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+// UpdateGenericPodGroup updates an existing PodGroup or CompositePodGroup object in the queue.
+func (p *PriorityQueue) UpdateGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	p.workloadForest.updatePodGroup(podGroup)
-	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfoForPodGroup(podGroup)
+	p.workloadForest.updateGenericPodGroup(gpg)
+	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfo(gpg)
 	if !hasRoot {
 		return
 	}
@@ -1617,145 +1615,23 @@ func (p *PriorityQueue) UpdatePodGroup(logger klog.Logger, podGroup *schedulingv
 			return
 		}
 		rootInfo := entity.(*framework.QueuedPodGroupInfo)
-		rootInfo.UpdatePodGroup(podGroup)
-		logger.V(5).Info("Pod Group in the scheduling queue was updated for the root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "podGroup", klog.KObj(podGroup))
+		rootInfo.UpdateGenericPodGroup(gpg)
+		logger.V(5).Info("Group in the scheduling queue was updated for the root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "groupType", gpg.GetType(), "group", klog.KObj(gpg))
 	})
 }
 
-// DeletePodGroup removes a PodGroup object from the queue,
-// moving all pods associated with the pod group to the incompletePodGroupPods.
-func (p *PriorityQueue) DeletePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+// DeleteGenericPodGroup removes a PodGroup or CompositePodGroup object from the queue.
+func (p *PriorityQueue) DeleteGenericPodGroup(logger klog.Logger, gpg *framework.GenericPodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	rootInfoLookup, hadRoot := p.workloadForest.getRootLookupInfoForPodGroup(podGroup)
-	p.workloadForest.deletePodGroup(podGroup)
+	rootInfoLookup, hadRoot := p.workloadForest.getRootLookupInfo(gpg)
 	if !hadRoot {
-		return
-	}
-
-	entity, strategy := p.deleteFromAnyQueue(rootInfoLookup)
-	if entity == nil {
-		if !p.activeQ.isLastPoppedEntity(rootInfoLookup) {
-			// Root PodGroup/CompositePodGroup isn't pending or enqueued.
-			// No pods are tracked for that group in the queue,
-			// because in such case they are either scheduled or the group has no pods left.
-			return
-		}
-		// Get the pending pods and move them to incompletePodGroupPods.
-		pendingPods := p.pendingPodGroupPods.clear(podGroup.Namespace, podGroup.Name)
-		if len(pendingPods) == 0 {
-			// No pending pods, nothing to move.
-			return
-		}
-		for _, pInfo := range pendingPods {
-			p.incompletePodGroupPods.add(pInfo)
-		}
-		logger.V(5).Info("Pod group deleted, decomposed and enqueued pending pods for the pod group to incompletePodGroupPods", "podGroup", klog.KObj(podGroup), "pods", len(pendingPods))
-		return
-	}
-
-	rootInfo := entity.(*framework.QueuedPodGroupInfo)
-	removedPods := rootInfo.RemovePodGroup(podGroup)
-	for _, pInfo := range removedPods {
-		p.incompletePodGroupPods.add(pInfo)
-	}
-
-	if !rootInfo.HasQueuedPodInfos() {
-		logger.V(5).Info("Pod group deleted from root group, decomposed and enqueued pods to incompletePodGroupPods", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "podGroup", klog.KObj(podGroup), "pods", len(removedPods))
-		return
-	}
-
-	queue := p.requeueEntityWithQueueingStrategy(logger, rootInfo, strategy, framework.EventUnscheduledPodUpdate.Label())
-	if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
-		p.activeQ.broadcast()
-	}
-	logger.V(5).Info("Pod group deleted from root group, decomposed and enqueued pods to incompletePodGroupPods", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "podGroup", klog.KObj(podGroup), "pods", len(removedPods))
-}
-
-// AddCompositePodGroup adds a new CompositePodGroup object to the queue.
-// It requeues all pods associated with the composite pod group.
-func (p *PriorityQueue) AddCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
-	if !p.isCompositePodGroupEnabled {
-		return
-	}
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	p.workloadForest.addCompositePodGroup(cpg)
-	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfoForCPG(cpg)
-	if !hasRoot {
-		// If the root does not exist, then pods should stay in the incompletePodGroupPods.
-		return
-	}
-
-	p.activeQ.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
-		entity := p.getEntityFromAnyQueue(unlockedActiveQ, rootInfoLookup)
-		if entity == nil {
-			return
-		}
-
-		rootInfo := entity.(*framework.QueuedPodGroupInfo)
-		subtree := p.workloadForest.buildPodGroupInfoForCPG(logger, cpg, sets.New[fwk.EntityKey]())
-		rootInfo.AddCompositePodGroup(cpg, subtree)
-		logger.V(5).Info("Composite Pod Group added to the existing root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "podGroup", klog.KObj(cpg))
-	})
-
-	pgs := p.workloadForest.getLeafPodGroups(logger, rootInfoLookup)
-	var pInfos []*framework.QueuedPodInfo
-	for _, pg := range pgs {
-		pInfos = append(pInfos, p.incompletePodGroupPods.clear(pg.Namespace, pg.Name)...)
-	}
-
-	for _, pInfo := range pInfos {
-		// To handle all cases reliably, pods removed from incompletePodGroupPods are added to the queue
-		// through the addPodGroupMember method.
-		p.addPodGroupMember(logger, pInfo)
-	}
-	logger.V(5).Info("Composite Pod Group was added to the root group and its pods were attempted to be moved from incompletePodGroupPods to the queue", "rootType", rootInfoLookup.Type(), "root", klog.KObj(rootInfoLookup), "compositePodGroup", klog.KObj(cpg), "podsLen", len(pInfos))
-}
-
-// UpdateCompositePodGroup updates an existing CompositePodGroup object in the queue.
-func (p *PriorityQueue) UpdateCompositePodGroup(logger klog.Logger, newCPG *schedulingv1alpha3.CompositePodGroup) {
-	if !p.isCompositePodGroupEnabled {
-		return
-	}
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	p.workloadForest.updateCompositePodGroup(newCPG)
-	rootInfoLookup, hasRoot := p.workloadForest.getRootLookupInfoForCPG(newCPG)
-	if !hasRoot {
-		return
-	}
-
-	p.activeQ.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
-		entity := p.getEntityFromAnyQueue(unlockedActiveQ, rootInfoLookup)
-		if entity == nil {
-			return
-		}
-		rootInfo := entity.(*framework.QueuedPodGroupInfo)
-		rootInfo.UpdateCompositePodGroup(newCPG)
-		logger.V(5).Info("Composite Pod Group in the scheduling queue was updated for the root group", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "compositePodGroup", klog.KObj(newCPG))
-	})
-}
-
-// DeleteCompositePodGroup removes a CompositePodGroup object from the queue.
-// It moves all pods in the hierarchy of the composite pod group to the incompletePodGroupPods.
-func (p *PriorityQueue) DeleteCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup) {
-	if !p.isCompositePodGroupEnabled {
-		return
-	}
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	rootInfoLookup, hadRoot := p.workloadForest.getRootLookupInfoForCPG(cpg)
-	if !hadRoot {
-		p.workloadForest.deleteCompositePodGroup(cpg)
+		p.workloadForest.deleteGenericPodGroup(gpg)
 		return
 	}
 	leafPGs := p.workloadForest.getLeafPodGroups(logger, rootInfoLookup)
-	p.workloadForest.deleteCompositePodGroup(cpg)
+	p.workloadForest.deleteGenericPodGroup(gpg)
 
 	entity, strategy := p.deleteFromAnyQueue(rootInfoLookup)
 	if entity == nil {
@@ -1765,7 +1641,7 @@ func (p *PriorityQueue) DeleteCompositePodGroup(logger klog.Logger, cpg *schedul
 			// because in such case they are either scheduled or the group has no pods left.
 			return
 		}
-		// Get the pending pods and move them to incompletePodGroupPods.
+		// Get the pending pods and move them to incompletePodGroupPods, if no root exists.
 		var pendingPods []*framework.QueuedPodInfo
 		for _, pg := range leafPGs {
 			pendingPods = append(pendingPods, p.pendingPodGroupPods.clear(pg.Namespace, pg.Name)...)
@@ -1782,17 +1658,17 @@ func (p *PriorityQueue) DeleteCompositePodGroup(logger klog.Logger, cpg *schedul
 				p.incompletePodGroupPods.add(pInfo)
 			}
 		}
-		logger.V(5).Info("Composite pod group deleted from the root group, enqueued pending pods in the composite pod group subtree to incompletePodGroupPods", "rootType", rootInfoLookup.Type(), "root", klog.KObj(rootInfoLookup), "compositePodGroup", klog.KObj(cpg), "pods", len(pendingPods))
+		logger.V(5).Info("Group deleted from the root group, enqueued pending pods to incompletePodGroupPods", "rootType", rootInfoLookup.Type(), "root", klog.KObj(rootInfoLookup), "groupType", gpg.GetType(), "group", klog.KObj(gpg), "pods", len(pendingPods))
 		return
 	}
 
 	rootInfo := entity.(*framework.QueuedPodGroupInfo)
-	removedPods := rootInfo.RemoveCompositePodGroup(cpg)
+	removedPods := rootInfo.RemoveGenericPodGroup(gpg)
 	for _, pInfo := range removedPods {
 		p.incompletePodGroupPods.add(pInfo)
 	}
 
-	logger.V(5).Info("Composite pod group deleted from the root group, decomposed and enqueued pods in the composite pod group subtree to incompletePodGroupPods", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "compositePodGroup", klog.KObj(cpg), "pods", len(removedPods))
+	logger.V(5).Info("Group deleted from root group, decomposed and enqueued pods to incompletePodGroupPods", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "groupType", gpg.GetType(), "group", klog.KObj(gpg), "pods", len(removedPods))
 	if !rootInfo.HasQueuedPodInfos() {
 		return
 	}
@@ -2024,17 +1900,11 @@ func (p *PriorityQueue) GetPod(name, namespace string, schedulingGroup *v1.PodSc
 
 // GetPodGroup searches for a pod group in the activeQ, backoffQ, and unschedulableEntities.
 // This function is only used for testing.
-func (p *PriorityQueue) GetPodGroup(name, namespace string, entityKeyType fwk.EntityKeyType) (*framework.QueuedPodGroupInfo, bool) {
+func (p *PriorityQueue) GetPodGroup(name, namespace string) (*framework.QueuedPodGroupInfo, bool) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	pgInfo := &framework.QueuedPodGroupInfo{
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:      name,
-			Namespace: namespace,
-			Type:      entityKeyType,
-		},
-	}
+	pgInfo := newPodGroupInfoForLookup(namespace, name)
 	var foundPGInfo *framework.QueuedPodGroupInfo
 	p.activeQ.underRLock(func(unlockedActiveQ unlockedActiveQueueReader) {
 		entity := p.getEntityFromAnyQueue(unlockedActiveQ, pgInfo)
@@ -2261,14 +2131,6 @@ func podGroupKeyForPod(pod *v1.Pod) fwk.EntityKey {
 	return fwk.PodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
 }
 
-func podGroupKey(podGroup *schedulingv1beta1.PodGroup) fwk.EntityKey {
-	return fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)
-}
-
-func compositePodGroupKey(cpg *schedulingv1alpha3.CompositePodGroup) fwk.EntityKey {
-	return fwk.CompositePodGroupKey(cpg.Namespace, cpg.Name)
-}
-
 // preQueueingHintPodKeys holds the result of running PreQueueingHintFns for an event.
 // candidatePods is the union of all pods that any plugin wants to re-evaluate.
 type preQueueingHintPodKeys struct {
@@ -2331,4 +2193,30 @@ func (p *PriorityQueue) runPreQueueingHintPlugins(logger klog.Logger, event fwk.
 		return nil
 	}
 	return result
+}
+
+func newPodGroupInfoForLookup(namespace, name string) *framework.QueuedPodGroupInfo {
+	return &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			GenericPodGroup: framework.NewGenericPodGroup(&schedulingv1beta1.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+			}),
+		},
+	}
+}
+
+func newCompositePodGroupInfoForLookup(namespace, name string) *framework.QueuedPodGroupInfo {
+	return &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			GenericPodGroup: framework.NewGenericCompositePodGroup(&schedulingv1alpha3.CompositePodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+				},
+			}),
+		},
+	}
 }

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -7992,11 +7992,11 @@ func TestAddPodGroup(t *testing.T) {
 					Type:      fwk.PodGroupKeyType,
 				},
 			}
-			gotPodGroup, ok := q.workloadForest.getPodGroup(podGroup)
+			gotAPG, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
 			if !ok {
 				t.Fatalf("Expected pod group to be in workloadForest")
 			}
-			if diff := cmp.Diff(podGroup, gotPodGroup); diff != "" {
+			if diff := cmp.Diff(podGroup, gotAPG.PodGroup); diff != "" {
 				t.Errorf("Unexpected pod group object (-want +got):\n%s", diff)
 			}
 
@@ -8115,11 +8115,11 @@ func TestUpdatePodGroup(t *testing.T) {
 
 			q.UpdatePodGroup(logger, updatedPodGroup)
 
-			gotPodGroup, ok := q.workloadForest.getPodGroup(podGroup)
+			gotAPG, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
 			if !ok {
 				t.Fatalf("Expected pod group to be in workloadForest")
 			}
-			if diff := cmp.Diff(updatedPodGroup, gotPodGroup); diff != "" {
+			if diff := cmp.Diff(updatedPodGroup, gotAPG.PodGroup); diff != "" {
 				t.Errorf("Unexpected pod group object (-want +got):\n%s", diff)
 			}
 
@@ -8249,7 +8249,7 @@ func TestDeletePodGroup(t *testing.T) {
 
 			q.DeletePodGroup(logger, podGroup)
 
-			_, ok := q.workloadForest.getPodGroup(podGroup)
+			_, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
 			if ok {
 				t.Errorf("Expected pod group not to be present in workloadForest")
 			}

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -221,7 +221,7 @@ func TestPriorityQueue_Add(t *testing.T) {
 					st.MakePodGroup().Name("pg-high").Namespace(highPod.Namespace).Priority(highPriority).Obj(),
 				}
 				for _, podGroup := range podGroups {
-					q.AddPodGroup(logger, podGroup)
+					q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
 				}
 			}
 			q.Add(ctx, medPod)
@@ -1104,7 +1104,7 @@ func Test_InFlightPods(t *testing.T) {
 				sortOpt := cmpopts.SortSlices(func(a, b string) bool { return a < b })
 				if genericWorkloadEnabled {
 					for _, pg := range podGroupsToAdd {
-						q.AddPodGroup(logger, pg)
+						q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 					}
 				}
 
@@ -1140,7 +1140,7 @@ func Test_InFlightPods(t *testing.T) {
 							t.Fatalf("unexpected error from AddAttemptedPodGroupIfNeeded: %v", err)
 						}
 					case action.podGroupAdded != nil:
-						q.AddPodGroup(logger, action.podGroupAdded)
+						q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(action.podGroupAdded))
 					case action.callback != nil:
 						action.callback(t, q)
 					}
@@ -3699,7 +3699,15 @@ func TestGatedPodFlushFrequency(t *testing.T) {
 		{
 			name: "queued pod group",
 			entityInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: gatedPod.GetNamespace(), Name: "pg", UnscheduledPods: []*v1.Pod{gatedPod.Pod}},
+				PodGroupInfo: &framework.PodGroupInfo{
+					GenericPodGroup: framework.NewGenericPodGroup(&schedulingv1beta1.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: gatedPod.GetNamespace(),
+							Name:      "pg",
+						},
+					}),
+					UnscheduledPods: []*v1.Pod{gatedPod.Pod},
+				},
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
 					fwk.PodGroupKey("test", "pg"): {{PodInfo: gatedPod, QueueingParams: framework.QueueingParams{UnschedulablePlugins: sets.New("foo")}}},
 				},
@@ -3939,7 +3947,7 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			q := NewTestQueue(tCtx, newDefaultQueueSort(), opts...)
 			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
 			if !test.skipAddPodGroup {
-				q.AddPodGroup(tCtx.Logger(), podGroup)
+				q.AddGenericPodGroup(tCtx.Logger(), framework.NewGenericPodGroup(podGroup))
 			}
 
 			pgInfo := newSingleLevelPodGroupInfo(q.newQueuedPodInfo(tCtx, pod1), podGroup)
@@ -3953,7 +3961,7 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 				tCtx.Fatalf("Unexpected error from AddAttemptedPodGroupIfNeeded: %v", err)
 			}
 			if !test.skipAddPodGroup {
-				if queuedInfo, ok := q.GetPodGroup(podGroup.Name, podGroup.Namespace, fwk.PodGroupKeyType); ok {
+				if queuedInfo, ok := q.GetPodGroup(podGroup.Name, podGroup.Namespace); ok {
 					pgInfo = queuedInfo
 				}
 			}
@@ -4193,7 +4201,7 @@ var (
 	addPodGroupForPod = func(tCtx ktesting.TContext, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		pgName := *pInfo.Pod.Spec.SchedulingGroup.PodGroupName
 		pg := st.MakePodGroup().Name(pgName).Namespace(pInfo.Pod.Namespace).Obj()
-		queue.AddPodGroup(klog.FromContext(tCtx), pg)
+		queue.AddGenericPodGroup(klog.FromContext(tCtx), framework.NewGenericPodGroup(pg))
 	}
 )
 
@@ -5128,7 +5136,7 @@ func TestIncomingEntitiesMetrics(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			metrics.SchedulerQueueIncomingEntities.Reset()
 			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
-			queue.AddPodGroup(logger, st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj())
+			queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
 			test.run(tCtx, queue)
 			if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingEntities, strings.NewReader(queueIncomingEntitiesMetricMetadata+test.want), metricName); err != nil {
 				t.Errorf("unexpected collecting result:\n%s", err)
@@ -5293,8 +5301,7 @@ func TestQueuedEntitiesMetrics(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			metrics.QueuedEntities.Reset()
 			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
-			queue.AddPodGroup(logger, st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj())
-
+			queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
 			test.run(tCtx, queue)
 
 			if err := testutil.CollectAndCompare(metrics.QueuedEntities, strings.NewReader(queuedEntitiesMetricMetadata+test.want), metricName); err != nil {
@@ -6419,7 +6426,7 @@ func setupInitialPodGroupState(t *testing.T, ctx context.Context, q *PriorityQue
 
 	if initialState != stateIncomplete {
 		logger := klog.FromContext(ctx)
-		q.AddPodGroup(logger, initialPodGroup)
+		q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(initialPodGroup))
 	}
 
 	if len(initialPods) == 0 {
@@ -7865,7 +7872,7 @@ func TestAddUnschedulablePodIfNotPresentPodGroupMember(t *testing.T) {
 			}
 
 			if tt.deletePodGroup {
-				q.DeletePodGroup(logger, podGroup)
+				q.DeleteGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
 			}
 
 			// Add unschedulable pods
@@ -7986,20 +7993,14 @@ func TestAddPodGroup(t *testing.T) {
 
 			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 
-			q.AddPodGroup(logger, podGroup)
+			q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
 
-			pgLookup := &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: podGroup.Namespace,
-					Name:      podGroup.Name,
-					Type:      fwk.PodGroupKeyType,
-				},
-			}
-			gotPodGroup, ok := q.workloadForest.getPodGroup(podGroup)
+			pgLookup := newPodGroupInfoForLookup(podGroup.Namespace, podGroup.Name)
+			gotGPG, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
 			if !ok {
 				t.Fatalf("Expected pod group to be in workloadForest")
 			}
-			if diff := cmp.Diff(podGroup, gotPodGroup); diff != "" {
+			if diff := cmp.Diff(podGroup, gotGPG.PodGroup); diff != "" {
 				t.Errorf("Unexpected pod group object (-want +got):\n%s", diff)
 			}
 
@@ -8116,23 +8117,17 @@ func TestUpdatePodGroup(t *testing.T) {
 
 			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 
-			q.UpdatePodGroup(logger, updatedPodGroup)
+			q.UpdateGenericPodGroup(logger, framework.NewGenericPodGroup(updatedPodGroup))
 
-			gotPodGroup, ok := q.workloadForest.getPodGroup(podGroup)
+			gotGPG, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
 			if !ok {
 				t.Fatalf("Expected pod group to be in workloadForest")
 			}
-			if diff := cmp.Diff(updatedPodGroup, gotPodGroup); diff != "" {
+			if diff := cmp.Diff(updatedPodGroup, gotGPG.PodGroup); diff != "" {
 				t.Errorf("Unexpected pod group object (-want +got):\n%s", diff)
 			}
 
-			pgLookup := &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: podGroup.Namespace,
-					Name:      podGroup.Name,
-					Type:      fwk.PodGroupKeyType,
-				},
-			}
+			pgLookup := newPodGroupInfoForLookup(podGroup.Namespace, podGroup.Name)
 			if inActive := q.activeQ.has(pgLookup); inActive != tt.expectedInActiveQ {
 				t.Errorf("Expected target pod group in activeQ: %v, got %v", tt.expectedInActiveQ, inActive)
 			}
@@ -8250,9 +8245,9 @@ func TestDeletePodGroup(t *testing.T) {
 				q.Add(ctx, pod)
 			}
 
-			q.DeletePodGroup(logger, podGroup)
+			q.DeleteGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
 
-			_, ok := q.workloadForest.getPodGroup(podGroup)
+			_, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
 			if ok {
 				t.Errorf("Expected pod group not to be present in workloadForest")
 			}
@@ -8458,10 +8453,10 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 			defer q.Close()
 
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -8470,7 +8465,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 				tt.beforeAdd(ctx, q)
 			}
 
-			q.AddCompositePodGroup(logger, tt.cpgToAdd)
+			q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(tt.cpgToAdd))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -8557,16 +8552,16 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
 			}
 
-			q.UpdateCompositePodGroup(logger, tt.cpgToUpdate)
+			q.UpdateGenericPodGroup(logger, framework.NewGenericCompositePodGroup(tt.cpgToUpdate))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -8785,10 +8780,10 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -8797,7 +8792,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 				tt.beforeDelete(ctx, q)
 			}
 
-			q.DeleteCompositePodGroup(logger, tt.cpgToDelete)
+			q.DeleteGenericPodGroup(logger, framework.NewGenericCompositePodGroup(tt.cpgToDelete))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9011,10 +9006,10 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -9023,7 +9018,7 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 				tt.beforeAdd(ctx, q)
 			}
 
-			q.AddPodGroup(logger, tt.pgToAdd)
+			q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(tt.pgToAdd))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9121,16 +9116,16 @@ func TestPriorityQueue_UpdatePodGroup_Hierarchical(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
 			}
 
-			q.UpdatePodGroup(logger, tt.pgToUpdate)
+			q.UpdateGenericPodGroup(logger, framework.NewGenericPodGroup(tt.pgToUpdate))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9326,10 +9321,10 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -9338,7 +9333,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 				tt.beforeDelete(ctx, q)
 			}
 
-			q.DeletePodGroup(logger, tt.pgToDelete)
+			q.DeleteGenericPodGroup(logger, framework.NewGenericPodGroup(tt.pgToDelete))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9405,7 +9400,7 @@ func findPodGroupInfoInActiveQ(q *PriorityQueue, namespace, name string, entityT
 		if pgi == nil {
 			return nil
 		}
-		if pgi.Namespace == namespace && pgi.Name == name && pgi.GetType() == entityType {
+		if pgi.GetNamespace() == namespace && pgi.GetName() == name && pgi.GetType() == entityType {
 			return pgi
 		}
 		for _, child := range pgi.Children {
@@ -9427,27 +9422,30 @@ func findPodGroupInfoInActiveQ(q *PriorityQueue, namespace, name string, entityT
 
 // newQueuedPodGroupInfoForLookup builds a QueuedPodGroupInfo object for a lookup in the queue.
 func newQueuedPodGroupInfoForLookup(namespace, name string, entityType fwk.EntityKeyType) *framework.QueuedPodGroupInfo {
-	// Since this is only used for a lookup in the queue, we only need to set the PodGroupInfo namespace and name,
-	// and so we avoid creating a full QueuedPodGroupInfo, which is expensive to instantiate frequently.
-	return &framework.QueuedPodGroupInfo{
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace: namespace,
-			Name:      name,
-			Type:      entityType,
-		},
+	if entityType == fwk.CompositePodGroupKeyType {
+		return newCompositePodGroupInfoForLookup(namespace, name)
 	}
+	return newPodGroupInfoForLookup(namespace, name)
 }
 
 func newSingleLevelPodGroupInfo(podInfo *framework.QueuedPodInfo, podGroup *schedulingv1beta1.PodGroup) *framework.QueuedPodGroupInfo {
 	pgName := *podInfo.Pod.Spec.SchedulingGroup.PodGroupName
 	key := fwk.PodGroupKey(podInfo.Pod.Namespace, pgName)
+	var pgObj *schedulingv1beta1.PodGroup
+	if podGroup != nil {
+		pgObj = podGroup
+	} else {
+		pgObj = &schedulingv1beta1.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: podInfo.Pod.Namespace,
+				Name:      pgName,
+			},
+		}
+	}
 	return &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:       podInfo.Pod.Namespace,
-			Name:            pgName,
-			Type:            fwk.PodGroupKeyType,
+			GenericPodGroup: framework.NewGenericPodGroup(pgObj),
 			UnscheduledPods: []*v1.Pod{podInfo.Pod},
-			PodGroup:        podGroup,
 		},
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{key: {podInfo}},
 		QueueingParams: framework.QueueingParams{
@@ -9490,7 +9488,7 @@ func TestPriorityQueue_DeferredPodGroupCompatibility(t *testing.T) {
 
 			if tt.pod.Spec.SchedulingGroup != nil && tt.pod.Spec.SchedulingGroup.PodGroupName != nil {
 				pg := st.MakePodGroup().Name(*tt.pod.Spec.SchedulingGroup.PodGroupName).Namespace(tt.pod.Namespace).Obj()
-				q.AddPodGroup(logger, pg)
+				q.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 			}
 
 			q.Add(ctx, tt.pod)

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -3699,7 +3699,15 @@ func TestGatedPodFlushFrequency(t *testing.T) {
 		{
 			name: "queued pod group",
 			entityInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: gatedPod.GetNamespace(), Name: "pg", UnscheduledPods: []*v1.Pod{gatedPod.Pod}},
+				PodGroupInfo: &framework.PodGroupInfo{
+					AbstractPodGroup: framework.NewAbstractPodGroup(&schedulingv1beta1.PodGroup{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: gatedPod.GetNamespace(),
+							Name:      "pg",
+						},
+					}),
+					UnscheduledPods: []*v1.Pod{gatedPod.Pod},
+				},
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
 					fwk.PodGroupKey("test", "pg"): {{PodInfo: gatedPod, QueueingParams: framework.QueueingParams{UnschedulablePlugins: sets.New("foo")}}},
 				},
@@ -7984,13 +7992,7 @@ func TestAddPodGroup(t *testing.T) {
 
 			q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
 
-			pgLookup := &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: podGroup.Namespace,
-					Name:      podGroup.Name,
-					Type:      fwk.PodGroupKeyType,
-				},
-			}
+			pgLookup := newPodGroupInfoForLookup(podGroup.Namespace, podGroup.Name)
 			gotAPG, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
 			if !ok {
 				t.Fatalf("Expected pod group to be in workloadForest")
@@ -8122,13 +8124,7 @@ func TestUpdatePodGroup(t *testing.T) {
 				t.Errorf("Unexpected pod group object (-want +got):\n%s", diff)
 			}
 
-			pgLookup := &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: podGroup.Namespace,
-					Name:      podGroup.Name,
-					Type:      fwk.PodGroupKeyType,
-				},
-			}
+			pgLookup := newPodGroupInfoForLookup(podGroup.Namespace, podGroup.Name)
 			if inActive := q.activeQ.has(pgLookup); inActive != tt.expectedInActiveQ {
 				t.Errorf("Expected target pod group in activeQ: %v, got %v", tt.expectedInActiveQ, inActive)
 			}
@@ -9401,7 +9397,7 @@ func findPodGroupInfoInActiveQ(q *PriorityQueue, namespace, name string, entityT
 		if pgi == nil {
 			return nil
 		}
-		if pgi.Namespace == namespace && pgi.Name == name && pgi.GetType() == entityType {
+		if pgi.GetNamespace() == namespace && pgi.GetName() == name && pgi.GetType() == entityType {
 			return pgi
 		}
 		for _, child := range pgi.Children {
@@ -9423,27 +9419,30 @@ func findPodGroupInfoInActiveQ(q *PriorityQueue, namespace, name string, entityT
 
 // newQueuedPodGroupInfoForLookup builds a QueuedPodGroupInfo object for a lookup in the queue.
 func newQueuedPodGroupInfoForLookup(namespace, name string, entityType fwk.EntityKeyType) *framework.QueuedPodGroupInfo {
-	// Since this is only used for a lookup in the queue, we only need to set the PodGroupInfo namespace and name,
-	// and so we avoid creating a full QueuedPodGroupInfo, which is expensive to instantiate frequently.
-	return &framework.QueuedPodGroupInfo{
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace: namespace,
-			Name:      name,
-			Type:      entityType,
-		},
+	if entityType == fwk.CompositePodGroupKeyType {
+		return newCompositePodGroupInfoForLookup(namespace, name)
 	}
+	return newPodGroupInfoForLookup(namespace, name)
 }
 
 func newSingleLevelPodGroupInfo(podInfo *framework.QueuedPodInfo, podGroup *schedulingv1beta1.PodGroup) *framework.QueuedPodGroupInfo {
 	pgName := *podInfo.Pod.Spec.SchedulingGroup.PodGroupName
 	key := fwk.PodGroupKey(podInfo.Pod.Namespace, pgName)
+	var pgObj *schedulingv1beta1.PodGroup
+	if podGroup != nil {
+		pgObj = podGroup
+	} else {
+		pgObj = &schedulingv1beta1.PodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: podInfo.Pod.Namespace,
+				Name:      pgName,
+			},
+		}
+	}
 	return &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:       podInfo.Pod.Namespace,
-			Name:            pgName,
-			Type:            fwk.PodGroupKeyType,
-			UnscheduledPods: []*v1.Pod{podInfo.Pod},
-			PodGroup:        podGroup,
+			AbstractPodGroup: framework.NewAbstractPodGroup(pgObj),
+			UnscheduledPods:  []*v1.Pod{podInfo.Pod},
 		},
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{key: {podInfo}},
 		QueueingParams: framework.QueueingParams{

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -221,7 +221,7 @@ func TestPriorityQueue_Add(t *testing.T) {
 					st.MakePodGroup().Name("pg-high").Namespace(highPod.Namespace).Priority(highPriority).Obj(),
 				}
 				for _, podGroup := range podGroups {
-					q.AddPodGroup(logger, podGroup)
+					q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
 				}
 			}
 			q.Add(ctx, medPod)
@@ -1104,7 +1104,7 @@ func Test_InFlightPods(t *testing.T) {
 				sortOpt := cmpopts.SortSlices(func(a, b string) bool { return a < b })
 				if genericWorkloadEnabled {
 					for _, pg := range podGroupsToAdd {
-						q.AddPodGroup(logger, pg)
+						q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 					}
 				}
 
@@ -1140,7 +1140,7 @@ func Test_InFlightPods(t *testing.T) {
 							t.Fatalf("unexpected error from AddAttemptedPodGroupIfNeeded: %v", err)
 						}
 					case action.podGroupAdded != nil:
-						q.AddPodGroup(logger, action.podGroupAdded)
+						q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(action.podGroupAdded))
 					case action.callback != nil:
 						action.callback(t, q)
 					}
@@ -3939,7 +3939,7 @@ func TestAddAttemptedPodGroupIfNeeded(t *testing.T) {
 			q := NewTestQueue(tCtx, newDefaultQueueSort(), opts...)
 			podGroup := st.MakePodGroup().Name(pgName).Namespace("ns1").Obj()
 			if !test.skipAddPodGroup {
-				q.AddPodGroup(tCtx.Logger(), podGroup)
+				q.AddAbstractPodGroup(tCtx.Logger(), framework.NewAbstractPodGroup(podGroup))
 			}
 
 			pgInfo := newSingleLevelPodGroupInfo(q.newQueuedPodInfo(tCtx, pod1), podGroup)
@@ -4193,7 +4193,7 @@ var (
 	addPodGroupForPod = func(tCtx ktesting.TContext, queue *PriorityQueue, pInfo *framework.QueuedPodInfo) {
 		pgName := *pInfo.Pod.Spec.SchedulingGroup.PodGroupName
 		pg := st.MakePodGroup().Name(pgName).Namespace(pInfo.Pod.Namespace).Obj()
-		queue.AddPodGroup(klog.FromContext(tCtx), pg)
+		queue.AddAbstractPodGroup(klog.FromContext(tCtx), framework.NewAbstractPodGroup(pg))
 	}
 )
 
@@ -5125,7 +5125,7 @@ func TestIncomingEntitiesMetrics(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			metrics.SchedulerQueueIncomingEntities.Reset()
 			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
-			queue.AddPodGroup(logger, st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj())
+			queue.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
 			test.run(tCtx, queue)
 			if err := testutil.CollectAndCompare(metrics.SchedulerQueueIncomingEntities, strings.NewReader(queueIncomingEntitiesMetricMetadata+test.want), metricName); err != nil {
 				t.Errorf("unexpected collecting result:\n%s", err)
@@ -5290,8 +5290,7 @@ func TestQueuedEntitiesMetrics(t *testing.T) {
 			tCtx := ktesting.Init(t)
 			metrics.QueuedEntities.Reset()
 			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)))
-			queue.AddPodGroup(logger, st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj())
-
+			queue.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(st.MakePodGroup().Name("pg-1").Namespace("ns-pg").Obj()))
 			test.run(tCtx, queue)
 
 			if err := testutil.CollectAndCompare(metrics.QueuedEntities, strings.NewReader(queuedEntitiesMetricMetadata+test.want), metricName); err != nil {
@@ -6416,7 +6415,7 @@ func setupInitialPodGroupState(t *testing.T, ctx context.Context, q *PriorityQue
 
 	if initialState != stateIncomplete {
 		logger := klog.FromContext(ctx)
-		q.AddPodGroup(logger, initialPodGroup)
+		q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(initialPodGroup))
 	}
 
 	if len(initialPods) == 0 {
@@ -7862,7 +7861,7 @@ func TestAddUnschedulablePodIfNotPresentPodGroupMember(t *testing.T) {
 			}
 
 			if tt.deletePodGroup {
-				q.DeletePodGroup(logger, podGroup)
+				q.DeleteAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
 			}
 
 			// Add unschedulable pods
@@ -7983,7 +7982,7 @@ func TestAddPodGroup(t *testing.T) {
 
 			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 
-			q.AddPodGroup(logger, podGroup)
+			q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
 
 			pgLookup := &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
@@ -8113,7 +8112,7 @@ func TestUpdatePodGroup(t *testing.T) {
 
 			setupInitialPodGroupState(t, ctx, q, tt.initialPods, tt.initialState, podGroup)
 
-			q.UpdatePodGroup(logger, updatedPodGroup)
+			q.UpdateAbstractPodGroup(logger, framework.NewAbstractPodGroup(updatedPodGroup))
 
 			gotAPG, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
 			if !ok {
@@ -8247,7 +8246,7 @@ func TestDeletePodGroup(t *testing.T) {
 				q.Add(ctx, pod)
 			}
 
-			q.DeletePodGroup(logger, podGroup)
+			q.DeleteAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
 
 			_, ok := q.workloadForest.podGroups[fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)]
 			if ok {
@@ -8455,10 +8454,10 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 			defer q.Close()
 
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -8467,7 +8466,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 				tt.beforeAdd(ctx, q)
 			}
 
-			q.AddCompositePodGroup(logger, tt.cpgToAdd)
+			q.AddAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(tt.cpgToAdd))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -8554,16 +8553,16 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
 			}
 
-			q.UpdateCompositePodGroup(logger, tt.cpgToUpdate)
+			q.UpdateAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(tt.cpgToUpdate))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -8782,10 +8781,10 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -8794,7 +8793,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 				tt.beforeDelete(ctx, q)
 			}
 
-			q.DeleteCompositePodGroup(logger, tt.cpgToDelete)
+			q.DeleteAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(tt.cpgToDelete))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9008,10 +9007,10 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -9020,7 +9019,7 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 				tt.beforeAdd(ctx, q)
 			}
 
-			q.AddPodGroup(logger, tt.pgToAdd)
+			q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(tt.pgToAdd))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9118,16 +9117,16 @@ func TestPriorityQueue_UpdatePodGroup_Hierarchical(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
 			}
 
-			q.UpdatePodGroup(logger, tt.pgToUpdate)
+			q.UpdateAbstractPodGroup(logger, framework.NewAbstractPodGroup(tt.pgToUpdate))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9323,10 +9322,10 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 			defer q.Close()
 
 			for _, cpg := range tt.initialCPGs {
-				q.AddCompositePodGroup(logger, cpg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.initialPodGroups {
-				q.AddPodGroup(logger, pg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 			}
 			for _, pod := range tt.initialPods {
 				q.Add(ctx, pod)
@@ -9335,7 +9334,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 				tt.beforeDelete(ctx, q)
 			}
 
-			q.DeletePodGroup(logger, tt.pgToDelete)
+			q.DeleteAbstractPodGroup(logger, framework.NewAbstractPodGroup(tt.pgToDelete))
 
 			cmpOpts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.SortSlices(func(a, b string) bool { return a < b })}
 			if diff := cmp.Diff(tt.expectedActiveQ, getActivePodGroups(q), cmpOpts...); diff != "" {
@@ -9487,7 +9486,7 @@ func TestPriorityQueue_DeferredPodGroupCompatibility(t *testing.T) {
 
 			if tt.pod.Spec.SchedulingGroup != nil && tt.pod.Spec.SchedulingGroup.PodGroupName != nil {
 				pg := st.MakePodGroup().Name(*tt.pod.Spec.SchedulingGroup.PodGroupName).Namespace(tt.pod.Namespace).Obj()
-				q.AddPodGroup(logger, pg)
+				q.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 			}
 
 			q.Add(ctx, tt.pod)

--- a/pkg/scheduler/backend/queue/unschedulable_entities_test.go
+++ b/pkg/scheduler/backend/queue/unschedulable_entities_test.go
@@ -246,8 +246,7 @@ func TestUnschedulablePodGroups_Unified(t *testing.T) {
 
 	pgInfo := &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace: "ns1",
-			Name:      "pg1",
+			GenericPodGroup: framework.NewGenericPodGroup(st.MakePodGroup().Name("pg1").Namespace("ns1").Obj()),
 		},
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
 			fwk.PodGroupKey("ns1", "pg1"): {

--- a/pkg/scheduler/backend/queue/unschedulable_entities_test.go
+++ b/pkg/scheduler/backend/queue/unschedulable_entities_test.go
@@ -246,8 +246,7 @@ func TestUnschedulablePodGroups_Unified(t *testing.T) {
 
 	pgInfo := &framework.QueuedPodGroupInfo{
 		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace: "ns1",
-			Name:      "pg1",
+			AbstractPodGroup: framework.NewAbstractPodGroup(st.MakePodGroup().Name("pg1").Namespace("ns1").Obj()),
 		},
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
 			fwk.PodGroupKey("ns1", "pg1"): {

--- a/pkg/scheduler/backend/queue/workload_forest.go
+++ b/pkg/scheduler/backend/queue/workload_forest.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -29,14 +28,13 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 )
 
-// workloadForest maintains a consistent view of observed PodGroup objects.
+// workloadForest maintains a consistent view of observed GenericPodGroup objects (either PodGroup or CompositePodGroup).
 // It ensures that scheduling queue invariants are preserved, independent of
 // asynchronous updates happening in the scheduler cache.
 // Outside of the scheduling queue, cache should be used as the source of truth.
 // This structure is not thread-safe and should be accessed only under the lock of the PriorityQueue.
 type workloadForest struct {
-	podGroups          map[fwk.EntityKey]*schedulingv1beta1.PodGroup
-	compositePodGroups map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
+	podGroups map[fwk.EntityKey]*framework.GenericPodGroup
 	// children maps a parent CompositePodGroup key to its direct children keys (PodGroups or CompositePodGroups).
 	// As an invariant of this structure, a child-to-parent relationship is populated here regardless of whether
 	// the parent object has been explicitly observed yet. This prevents the need to iterate over all existing
@@ -47,93 +45,55 @@ type workloadForest struct {
 
 func newWorkloadForest(isCompositePodGroupEnabled bool) *workloadForest {
 	return &workloadForest{
-		podGroups:                  make(map[fwk.EntityKey]*schedulingv1beta1.PodGroup),
-		compositePodGroups:         make(map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup),
+		podGroups:                  make(map[fwk.EntityKey]*framework.GenericPodGroup),
 		children:                   make(map[fwk.EntityKey]sets.Set[fwk.EntityKey]),
 		isCompositePodGroupEnabled: isCompositePodGroupEnabled,
 	}
 }
 
-// addPodGroup adds a PodGroup to the forest.
-func (wf *workloadForest) addPodGroup(podGroup *schedulingv1beta1.PodGroup) {
-	pgKey := podGroupKey(podGroup)
-	wf.podGroups[pgKey] = podGroup
+// addGenericPodGroup adds a GenericPodGroup to the forest.
+func (wf *workloadForest) addGenericPodGroup(gpg *framework.GenericPodGroup) {
+	key := gpg.GetKey()
+	wf.podGroups[key] = gpg
 
-	if !wf.podGroupHasParent(podGroup) {
+	if !wf.isCompositePodGroupEnabled {
+		return
+	}
+	parentKey, hasParent := gpg.GetParentKey()
+	if !hasParent {
 		return
 	}
 
-	parentKey := fwk.CompositePodGroupKey(podGroup.Namespace, *podGroup.Spec.ParentCompositePodGroupName)
 	_, exists := wf.children[parentKey]
 	if !exists {
 		wf.children[parentKey] = sets.New[fwk.EntityKey]()
 	}
-	wf.children[parentKey].Insert(pgKey)
+	wf.children[parentKey].Insert(key)
 }
 
-// updatePodGroup updates a PodGroup in the forest.
-func (wf *workloadForest) updatePodGroup(podGroup *schedulingv1beta1.PodGroup) {
-	wf.podGroups[podGroupKey(podGroup)] = podGroup
+// updateGenericPodGroup updates a GenericPodGroup in the forest.
+func (wf *workloadForest) updateGenericPodGroup(gpg *framework.GenericPodGroup) {
+	wf.podGroups[gpg.GetKey()] = gpg
 }
 
-// deletePodGroup removes a PodGroup from the forest.
-func (wf *workloadForest) deletePodGroup(podGroup *schedulingv1beta1.PodGroup) {
-	pgKey := podGroupKey(podGroup)
-	delete(wf.podGroups, pgKey)
+// deleteGenericPodGroup removes a GenericPodGroup from the forest.
+func (wf *workloadForest) deleteGenericPodGroup(gpg *framework.GenericPodGroup) {
+	key := gpg.GetKey()
+	delete(wf.podGroups, key)
 
-	if !wf.podGroupHasParent(podGroup) {
+	if !wf.isCompositePodGroupEnabled {
+		return
+	}
+	parentKey, hasParent := gpg.GetParentKey()
+	if !hasParent {
 		return
 	}
 
-	parentKey := fwk.CompositePodGroupKey(podGroup.Namespace, *podGroup.Spec.ParentCompositePodGroupName)
 	parentChildren, exists := wf.children[parentKey]
 	if !exists {
 		return
 	}
-	parentChildren.Delete(pgKey)
-	if parentChildren.Len() == 0 {
-		delete(wf.children, parentKey)
-	}
-}
-
-// addCompositePodGroup adds a CompositePodGroup to the forest.
-func (wf *workloadForest) addCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) {
-	cpgKey := compositePodGroupKey(cpg)
-	wf.compositePodGroups[cpgKey] = cpg
-
-	if cpg.Spec.ParentCompositePodGroupName == nil {
-		return
-	}
-
-	parentKey := fwk.CompositePodGroupKey(cpg.Namespace, *cpg.Spec.ParentCompositePodGroupName)
-	_, exists := wf.children[parentKey]
-	if !exists {
-		wf.children[parentKey] = sets.New[fwk.EntityKey]()
-	}
-	wf.children[parentKey].Insert(cpgKey)
-}
-
-// updateCompositePodGroup updates a CompositePodGroup in the forest.
-func (wf *workloadForest) updateCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) {
-	wf.compositePodGroups[compositePodGroupKey(cpg)] = cpg
-}
-
-// deleteCompositePodGroup removes a CompositePodGroup from the forest.
-func (wf *workloadForest) deleteCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) {
-	cpgKey := compositePodGroupKey(cpg)
-	delete(wf.compositePodGroups, cpgKey)
-
-	if cpg.Spec.ParentCompositePodGroupName == nil {
-		return
-	}
-
-	parentKey := fwk.CompositePodGroupKey(cpg.Namespace, *cpg.Spec.ParentCompositePodGroupName)
-	parentChildren, exists := wf.children[parentKey]
-	if !exists {
-		return
-	}
-
-	parentChildren.Delete(cpgKey)
+	parentChildren.Delete(key)
 	if parentChildren.Len() == 0 {
 		delete(wf.children, parentKey)
 	}
@@ -145,34 +105,28 @@ func (wf *workloadForest) getRootLookupInfoForPod(pod *v1.Pod) (*framework.Queue
 	if !exists {
 		return nil, false
 	}
-	return wf.getRootLookupInfoForPodGroup(podGroup)
+	return wf.getRootLookupInfo(podGroup)
 }
 
-// getRootLookupInfoForPodGroup returns the lookup info of the current root PodGroup or CompositePodGroup for a given PodGroup.
-func (wf *workloadForest) getRootLookupInfoForPodGroup(podGroup *schedulingv1beta1.PodGroup) (*framework.QueuedPodGroupInfo, bool) {
-	podGroup, exists := wf.podGroups[podGroupKey(podGroup)]
+// getRootLookupInfo returns the lookup info of the current root PodGroup or CompositePodGroup for a given GenericPodGroup.
+func (wf *workloadForest) getRootLookupInfo(gpg *framework.GenericPodGroup) (*framework.QueuedPodGroupInfo, bool) {
+	storedGPG, exists := wf.podGroups[gpg.GetKey()]
 	if !exists {
 		return nil, false
 	}
 
-	if !wf.podGroupHasParent(podGroup) {
+	if !wf.isCompositePodGroupEnabled || !storedGPG.HasParent() {
 		return &framework.QueuedPodGroupInfo{
 			PodGroupInfo: &framework.PodGroupInfo{
-				Namespace: podGroup.Namespace,
-				Name:      podGroup.Name,
-				Type:      fwk.PodGroupKeyType,
+				GenericPodGroup: storedGPG,
 			},
 		}, true
 	}
-	return wf.getRootLookupInfoForParentCPG(*podGroup.Spec.ParentCompositePodGroupName, podGroup.Namespace)
-}
-
-// getRootLookupInfoForCPG returns the lookup info of the current root CompositePodGroup for a given CompositePodGroup.
-func (wf *workloadForest) getRootLookupInfoForCPG(cpg *schedulingv1alpha3.CompositePodGroup) (*framework.QueuedPodGroupInfo, bool) {
-	return wf.getRootLookupInfoForParentCPG(cpg.Name, cpg.Namespace)
+	return wf.getRootLookupInfoForParentCPG(*storedGPG.GetParentCompositePodGroupName(), storedGPG.GetNamespace())
 }
 
 // getRootLookupInfoForParentCPG is a helper to traverse up the parent chain and return the lookup info of the root CompositePodGroup.
+// It should be called only when the CompositePodGroup feature gate is enabled.
 func (wf *workloadForest) getRootLookupInfoForParentCPG(parentName, namespace string) (*framework.QueuedPodGroupInfo, bool) {
 	currParentName := parentName
 	visited := sets.New[fwk.EntityKey]()
@@ -180,44 +134,35 @@ func (wf *workloadForest) getRootLookupInfoForParentCPG(parentName, namespace st
 		cpgKey := fwk.CompositePodGroupKey(namespace, currParentName)
 		if visited.Has(cpgKey) {
 			// TODO(jdzikowski): propagate logger to the getPod method in the scheduling queue.
-			utilruntime.HandleError(fmt.Errorf("cycle detected in composite pod group hierarchy: %s/%s", parentName, namespace))
+			utilruntime.HandleError(fmt.Errorf("cycle detected in composite pod group hierarchy when getting root info: %s/%s", parentName, namespace))
 			return nil, false
 		}
 		visited.Insert(cpgKey)
 
-		cpg, exists := wf.compositePodGroups[cpgKey]
+		cpg, exists := wf.podGroups[cpgKey]
 		if !exists {
 			return nil, false
 		}
 
-		if cpg.Spec.ParentCompositePodGroupName == nil {
-			return &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: cpg.Namespace,
-					Name:      cpg.Name,
-					Type:      fwk.CompositePodGroupKeyType,
-				},
-			}, true
+		if !cpg.HasParent() {
+			return newCompositePodGroupInfoForLookup(cpg.GetNamespace(), cpg.GetName()), true
 		}
-		currParentName = *cpg.Spec.ParentCompositePodGroupName
+		currParentName = *cpg.GetParentCompositePodGroupName()
 	}
 }
 
-// getLeafPodGroups returns all PodGroups that are leaf nodes in the subtree rooted at the given CompositePodGroup.
+// getLeafPodGroups returns all PodGroups that are leaf nodes in the subtree rooted at the given rootLookupInfo.
 func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *framework.QueuedPodGroupInfo) []*schedulingv1beta1.PodGroup {
-	var pgs []*schedulingv1beta1.PodGroup
-	var key fwk.EntityKey
+	key := rootLookupInfo.GetKey()
 	if rootLookupInfo.GetType() == fwk.PodGroupKeyType {
-		key = fwk.PodGroupKey(rootLookupInfo.GetNamespace(), rootLookupInfo.GetName())
-		pg, exists := wf.podGroups[key]
+		gpg, exists := wf.podGroups[key]
 		if !exists {
-			return pgs
+			return nil
 		}
-		pgs = append(pgs, pg)
-		return pgs
+		return []*schedulingv1beta1.PodGroup{gpg.PodGroup}
 	}
 
-	key = fwk.CompositePodGroupKey(rootLookupInfo.GetNamespace(), rootLookupInfo.GetName())
+	var pgs []*schedulingv1beta1.PodGroup
 	queue := []fwk.EntityKey{key}
 	visited := sets.New[fwk.EntityKey]()
 
@@ -226,7 +171,7 @@ func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *f
 		queue = queue[1:]
 
 		if visited.Has(currKey) {
-			utilruntime.HandleErrorWithLogger(logger, nil, "cycle detected in composite pod group hierarchy", "cpg-name", rootLookupInfo.GetName(), "namespace", rootLookupInfo.GetNamespace())
+			utilruntime.HandleErrorWithLogger(logger, nil, "Cycle detected in composite pod group hierarchy when getting leaf PodGroups", "compositePodGroup", klog.KObj(rootLookupInfo))
 			return pgs
 		}
 		visited.Insert(currKey)
@@ -237,10 +182,13 @@ func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *f
 		}
 
 		for childKey := range children {
-			if pg, isPG := wf.podGroups[childKey]; isPG {
-				pgs = append(pgs, pg)
+			gpg, ok := wf.podGroups[childKey]
+			if !ok {
+				continue
 			}
-			if _, isCPG := wf.compositePodGroups[childKey]; isCPG {
+			if gpg.PodGroup != nil {
+				pgs = append(pgs, gpg.PodGroup)
+			} else if gpg.CompositePodGroup != nil {
 				queue = append(queue, childKey)
 			}
 		}
@@ -249,53 +197,19 @@ func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *f
 	return pgs
 }
 
-// getPodGroup returns the current PodGroup object for a given lookup.
-func (wf *workloadForest) getPodGroup(pgLookup *schedulingv1beta1.PodGroup) (*schedulingv1beta1.PodGroup, bool) {
-	podGroup, ok := wf.podGroups[podGroupKey(pgLookup)]
-	return podGroup, ok
-}
-
-// getCompositePodGroup returns the current CompositePodGroup object for a given lookup.
-func (wf *workloadForest) getCompositePodGroup(cpgLookup *schedulingv1alpha3.CompositePodGroup) (*schedulingv1alpha3.CompositePodGroup, bool) {
-	podGroup, ok := wf.compositePodGroups[compositePodGroupKey(cpgLookup)]
-	return podGroup, ok
-}
-
-// buildPodGroupInfoForPG constructs a PodGroupInfo representation for a given PodGroup,
-// using the provided visited set to detect cycles in the hierarchy.
-func (wf *workloadForest) buildPodGroupInfoForPG(logger klog.Logger, pg *schedulingv1beta1.PodGroup, visited sets.Set[fwk.EntityKey]) *framework.PodGroupInfo {
-	key := podGroupKey(pg)
-	if visited.Has(key) {
-		utilruntime.HandleErrorWithLogger(logger, nil, "cycle detected in composite pod group hierarchy", "pg-name", pg.Name, "namespace", pg.Namespace)
-		return nil
-	}
-	visited.Insert(key)
-
-	return &framework.PodGroupInfo{
-		Namespace: pg.Namespace,
-		Name:      pg.Name,
-		Type:      fwk.PodGroupKeyType,
-		PodGroup:  pg,
-		Children:  make([]*framework.PodGroupInfo, 0),
-	}
-}
-
-// buildPodGroupInfoForCPG recursively constructs a PodGroupInfo representation for a given CompositePodGroup
+// buildPodGroupInfo recursively constructs a PodGroupInfo representation for a given GenericPodGroup
 // and all its children, using the provided visited set to detect cycles in the hierarchy.
-func (wf *workloadForest) buildPodGroupInfoForCPG(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup, visited sets.Set[fwk.EntityKey]) *framework.PodGroupInfo {
-	key := compositePodGroupKey(cpg)
+func (wf *workloadForest) buildPodGroupInfo(logger klog.Logger, gpg *framework.GenericPodGroup, visited sets.Set[fwk.EntityKey]) *framework.PodGroupInfo {
+	key := gpg.GetKey()
 	if visited.Has(key) {
-		utilruntime.HandleErrorWithLogger(logger, nil, "cycle detected in composite pod group hierarchy", "cpg-name", cpg.Name, "namespace", cpg.Namespace)
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cycle detected in composite pod group hierarchy when building PodGroupInfo", "groupType", gpg.GetType(), "group", klog.KObj(gpg))
 		return nil
 	}
 	visited.Insert(key)
 
 	pgi := &framework.PodGroupInfo{
-		Namespace:         cpg.Namespace,
-		Name:              cpg.Name,
-		Type:              fwk.CompositePodGroupKeyType,
-		CompositePodGroup: cpg,
-		Children:          make([]*framework.PodGroupInfo, 0),
+		GenericPodGroup: gpg,
+		Children:        make([]*framework.PodGroupInfo, 0),
 	}
 
 	childrenSet, ok := wf.children[key]
@@ -303,13 +217,8 @@ func (wf *workloadForest) buildPodGroupInfoForCPG(logger klog.Logger, cpg *sched
 		return pgi
 	}
 	for childKey := range childrenSet {
-		if childPG, ok := wf.podGroups[childKey]; ok {
-			if childInfo := wf.buildPodGroupInfoForPG(logger, childPG, visited); childInfo != nil {
-				pgi.Children = append(pgi.Children, childInfo)
-			}
-		}
-		if childCPG, ok := wf.compositePodGroups[childKey]; ok {
-			if childInfo := wf.buildPodGroupInfoForCPG(logger, childCPG, visited); childInfo != nil {
+		if childGPG, ok := wf.podGroups[childKey]; ok {
+			if childInfo := wf.buildPodGroupInfo(logger, childGPG, visited); childInfo != nil {
 				pgi.Children = append(pgi.Children, childInfo)
 			}
 		}
@@ -320,29 +229,13 @@ func (wf *workloadForest) buildPodGroupInfoForCPG(logger klog.Logger, cpg *sched
 // buildQueuedPodGroupInfo constructs a QueuedPodGroupInfo starting from the provided root lookup info,
 // building out the full hierarchy of PodGroupInfo nodes and initializing the QueuedPodInfos map.
 func (wf *workloadForest) buildQueuedPodGroupInfo(logger klog.Logger, rootLookup *framework.QueuedPodGroupInfo) *framework.QueuedPodGroupInfo {
-	var pgi *framework.PodGroupInfo
-	switch rootLookup.GetType() {
-	case fwk.PodGroupKeyType:
-		if pg, ok := wf.podGroups[fwk.PodGroupKey(rootLookup.GetNamespace(), rootLookup.GetName())]; ok && pg != nil {
-			pgi = wf.buildPodGroupInfoForPG(logger, pg, sets.New[fwk.EntityKey]())
-		}
-	case fwk.CompositePodGroupKeyType:
-		if cpg, ok := wf.compositePodGroups[fwk.CompositePodGroupKey(rootLookup.GetNamespace(), rootLookup.GetName())]; ok && cpg != nil {
-			pgi = wf.buildPodGroupInfoForCPG(logger, cpg, sets.New[fwk.EntityKey]())
-		}
-	}
-
-	if pgi == nil {
+	key := rootLookup.GetKey()
+	gpg, ok := wf.podGroups[key]
+	if !ok {
 		return nil
 	}
 	return &framework.QueuedPodGroupInfo{
-		PodGroupInfo:   pgi,
+		PodGroupInfo:   wf.buildPodGroupInfo(logger, gpg, sets.New[fwk.EntityKey]()),
 		QueuedPodInfos: make(map[fwk.EntityKey][]*framework.QueuedPodInfo),
 	}
-}
-
-// podGroupHasParent checks whether the given PodGroup has a parent CompositePodGroup configured
-// and the CompositePodGroup feature is enabled.
-func (wf *workloadForest) podGroupHasParent(pg *schedulingv1beta1.PodGroup) bool {
-	return wf.isCompositePodGroupEnabled && pg.Spec.ParentCompositePodGroupName != nil
 }

--- a/pkg/scheduler/backend/queue/workload_forest.go
+++ b/pkg/scheduler/backend/queue/workload_forest.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -35,8 +34,7 @@ import (
 // Outside of the scheduling queue, cache should be used as the source of truth.
 // This structure is not thread-safe and should be accessed only under the lock of the PriorityQueue.
 type workloadForest struct {
-	podGroups          map[fwk.EntityKey]*schedulingv1beta1.PodGroup
-	compositePodGroups map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
+	podGroups map[fwk.EntityKey]*framework.AbstractPodGroup
 	// children maps a parent CompositePodGroup key to its direct children keys (PodGroups or CompositePodGroups).
 	// As an invariant of this structure, a child-to-parent relationship is populated here regardless of whether
 	// the parent object has been explicitly observed yet. This prevents the need to iterate over all existing
@@ -47,93 +45,55 @@ type workloadForest struct {
 
 func newWorkloadForest(isCompositePodGroupEnabled bool) *workloadForest {
 	return &workloadForest{
-		podGroups:                  make(map[fwk.EntityKey]*schedulingv1beta1.PodGroup),
-		compositePodGroups:         make(map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup),
+		podGroups:                  make(map[fwk.EntityKey]*framework.AbstractPodGroup),
 		children:                   make(map[fwk.EntityKey]sets.Set[fwk.EntityKey]),
 		isCompositePodGroupEnabled: isCompositePodGroupEnabled,
 	}
 }
 
-// addPodGroup adds a PodGroup to the forest.
-func (wf *workloadForest) addPodGroup(podGroup *schedulingv1beta1.PodGroup) {
-	pgKey := podGroupKey(podGroup)
-	wf.podGroups[pgKey] = podGroup
+// addAbstractPodGroup adds an AbstractPodGroup to the forest.
+func (wf *workloadForest) addAbstractPodGroup(apg *framework.AbstractPodGroup) {
+	key := apg.GetKey()
+	wf.podGroups[key] = apg
 
-	if !wf.podGroupHasParent(podGroup) {
+	if !wf.isCompositePodGroupEnabled {
+		return
+	}
+	parentKey, hasParent := apg.GetParentKey()
+	if !hasParent {
 		return
 	}
 
-	parentKey := fwk.CompositePodGroupKey(podGroup.Namespace, *podGroup.Spec.ParentCompositePodGroupName)
 	_, exists := wf.children[parentKey]
 	if !exists {
 		wf.children[parentKey] = sets.New[fwk.EntityKey]()
 	}
-	wf.children[parentKey].Insert(pgKey)
+	wf.children[parentKey].Insert(key)
 }
 
-// updatePodGroup updates a PodGroup in the forest.
-func (wf *workloadForest) updatePodGroup(podGroup *schedulingv1beta1.PodGroup) {
-	wf.podGroups[podGroupKey(podGroup)] = podGroup
+// updateAbstractPodGroup updates an AbstractPodGroup in the forest.
+func (wf *workloadForest) updateAbstractPodGroup(apg *framework.AbstractPodGroup) {
+	wf.podGroups[apg.GetKey()] = apg
 }
 
-// deletePodGroup removes a PodGroup from the forest.
-func (wf *workloadForest) deletePodGroup(podGroup *schedulingv1beta1.PodGroup) {
-	pgKey := podGroupKey(podGroup)
-	delete(wf.podGroups, pgKey)
+// deleteAbstractPodGroup removes an AbstractPodGroup from the forest.
+func (wf *workloadForest) deleteAbstractPodGroup(apg *framework.AbstractPodGroup) {
+	key := apg.GetKey()
+	delete(wf.podGroups, key)
 
-	if !wf.podGroupHasParent(podGroup) {
+	if !wf.isCompositePodGroupEnabled {
+		return
+	}
+	parentKey, hasParent := apg.GetParentKey()
+	if !hasParent {
 		return
 	}
 
-	parentKey := fwk.CompositePodGroupKey(podGroup.Namespace, *podGroup.Spec.ParentCompositePodGroupName)
 	parentChildren, exists := wf.children[parentKey]
 	if !exists {
 		return
 	}
-	parentChildren.Delete(pgKey)
-	if parentChildren.Len() == 0 {
-		delete(wf.children, parentKey)
-	}
-}
-
-// addCompositePodGroup adds a CompositePodGroup to the forest.
-func (wf *workloadForest) addCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) {
-	cpgKey := compositePodGroupKey(cpg)
-	wf.compositePodGroups[cpgKey] = cpg
-
-	if cpg.Spec.ParentCompositePodGroupName == nil {
-		return
-	}
-
-	parentKey := fwk.CompositePodGroupKey(cpg.Namespace, *cpg.Spec.ParentCompositePodGroupName)
-	_, exists := wf.children[parentKey]
-	if !exists {
-		wf.children[parentKey] = sets.New[fwk.EntityKey]()
-	}
-	wf.children[parentKey].Insert(cpgKey)
-}
-
-// updateCompositePodGroup updates a CompositePodGroup in the forest.
-func (wf *workloadForest) updateCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) {
-	wf.compositePodGroups[compositePodGroupKey(cpg)] = cpg
-}
-
-// deleteCompositePodGroup removes a CompositePodGroup from the forest.
-func (wf *workloadForest) deleteCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) {
-	cpgKey := compositePodGroupKey(cpg)
-	delete(wf.compositePodGroups, cpgKey)
-
-	if cpg.Spec.ParentCompositePodGroupName == nil {
-		return
-	}
-
-	parentKey := fwk.CompositePodGroupKey(cpg.Namespace, *cpg.Spec.ParentCompositePodGroupName)
-	parentChildren, exists := wf.children[parentKey]
-	if !exists {
-		return
-	}
-
-	parentChildren.Delete(cpgKey)
+	parentChildren.Delete(key)
 	if parentChildren.Len() == 0 {
 		delete(wf.children, parentKey)
 	}
@@ -145,31 +105,26 @@ func (wf *workloadForest) getRootLookupInfoForPod(pod *v1.Pod) (*framework.Queue
 	if !exists {
 		return nil, false
 	}
-	return wf.getRootLookupInfoForPodGroup(podGroup)
+	return wf.getRootLookupInfo(podGroup)
 }
 
-// getRootLookupInfoForPodGroup returns the lookup info of the current root PodGroup or CompositePodGroup for a given PodGroup.
-func (wf *workloadForest) getRootLookupInfoForPodGroup(podGroup *schedulingv1beta1.PodGroup) (*framework.QueuedPodGroupInfo, bool) {
-	podGroup, exists := wf.podGroups[podGroupKey(podGroup)]
+// getRootLookupInfo returns the lookup info of the current root PodGroup or CompositePodGroup for a given AbstractPodGroup.
+func (wf *workloadForest) getRootLookupInfo(apg *framework.AbstractPodGroup) (*framework.QueuedPodGroupInfo, bool) {
+	storedAPG, exists := wf.podGroups[apg.GetKey()]
 	if !exists {
 		return nil, false
 	}
 
-	if !wf.podGroupHasParent(podGroup) {
+	if !wf.isCompositePodGroupEnabled || !storedAPG.HasParent() {
 		return &framework.QueuedPodGroupInfo{
 			PodGroupInfo: &framework.PodGroupInfo{
-				Namespace: podGroup.Namespace,
-				Name:      podGroup.Name,
-				Type:      fwk.PodGroupKeyType,
+				Namespace: storedAPG.GetNamespace(),
+				Name:      storedAPG.GetName(),
+				Type:      storedAPG.GetType(),
 			},
 		}, true
 	}
-	return wf.getRootLookupInfoForParentCPG(*podGroup.Spec.ParentCompositePodGroupName, podGroup.Namespace)
-}
-
-// getRootLookupInfoForCPG returns the lookup info of the current root CompositePodGroup for a given CompositePodGroup.
-func (wf *workloadForest) getRootLookupInfoForCPG(cpg *schedulingv1alpha3.CompositePodGroup) (*framework.QueuedPodGroupInfo, bool) {
-	return wf.getRootLookupInfoForParentCPG(cpg.Name, cpg.Namespace)
+	return wf.getRootLookupInfoForParentCPG(*storedAPG.GetParentCompositePodGroupName(), storedAPG.GetNamespace())
 }
 
 // getRootLookupInfoForParentCPG is a helper to traverse up the parent chain and return the lookup info of the root CompositePodGroup.
@@ -180,43 +135,42 @@ func (wf *workloadForest) getRootLookupInfoForParentCPG(parentName, namespace st
 		cpgKey := fwk.CompositePodGroupKey(namespace, currParentName)
 		if visited.Has(cpgKey) {
 			// TODO(jdzikowski): propagate logger to the getPod method in the scheduling queue.
-			utilruntime.HandleError(fmt.Errorf("cycle detected in composite pod group hierarchy: %s/%s", parentName, namespace))
+			utilruntime.HandleError(fmt.Errorf("cycle detected in composite pod group hierarchy when getting root info: %s/%s", parentName, namespace))
 			return nil, false
 		}
 		visited.Insert(cpgKey)
 
-		cpg, exists := wf.compositePodGroups[cpgKey]
+		cpg, exists := wf.podGroups[cpgKey]
 		if !exists {
 			return nil, false
 		}
 
-		if cpg.Spec.ParentCompositePodGroupName == nil {
+		if !cpg.HasParent() {
 			return &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: cpg.Namespace,
-					Name:      cpg.Name,
+					Namespace: cpg.GetNamespace(),
+					Name:      cpg.GetName(),
 					Type:      fwk.CompositePodGroupKeyType,
 				},
 			}, true
 		}
-		currParentName = *cpg.Spec.ParentCompositePodGroupName
+		currParentName = *cpg.GetParentCompositePodGroupName()
 	}
 }
 
 // getLeafPodGroups returns all PodGroups that are leaf nodes in the subtree rooted at the given CompositePodGroup.
 func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *framework.QueuedPodGroupInfo) []*schedulingv1beta1.PodGroup {
-	var pgs []*schedulingv1beta1.PodGroup
 	var key fwk.EntityKey
 	if rootLookupInfo.GetType() == fwk.PodGroupKeyType {
 		key = fwk.PodGroupKey(rootLookupInfo.GetNamespace(), rootLookupInfo.GetName())
-		pg, exists := wf.podGroups[key]
+		apg, exists := wf.podGroups[key]
 		if !exists {
-			return pgs
+			return nil
 		}
-		pgs = append(pgs, pg)
-		return pgs
+		return []*schedulingv1beta1.PodGroup{apg.PodGroup}
 	}
 
+	var pgs []*schedulingv1beta1.PodGroup
 	key = fwk.CompositePodGroupKey(rootLookupInfo.GetNamespace(), rootLookupInfo.GetName())
 	queue := []fwk.EntityKey{key}
 	visited := sets.New[fwk.EntityKey]()
@@ -226,7 +180,7 @@ func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *f
 		queue = queue[1:]
 
 		if visited.Has(currKey) {
-			utilruntime.HandleErrorWithLogger(logger, nil, "cycle detected in composite pod group hierarchy", "cpg-name", rootLookupInfo.GetName(), "namespace", rootLookupInfo.GetNamespace())
+			utilruntime.HandleErrorWithLogger(logger, nil, "Cycle detected in composite pod group hierarchy when getting leaf PodGroups", "compositePodGroup", klog.KObj(rootLookupInfo))
 			return pgs
 		}
 		visited.Insert(currKey)
@@ -237,10 +191,13 @@ func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *f
 		}
 
 		for childKey := range children {
-			if pg, isPG := wf.podGroups[childKey]; isPG {
-				pgs = append(pgs, pg)
+			apg, ok := wf.podGroups[childKey]
+			if !ok {
+				continue
 			}
-			if _, isCPG := wf.compositePodGroups[childKey]; isCPG {
+			if apg.PodGroup != nil {
+				pgs = append(pgs, apg.PodGroup)
+			} else if apg.CompositePodGroup != nil {
 				queue = append(queue, childKey)
 			}
 		}
@@ -249,52 +206,22 @@ func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *f
 	return pgs
 }
 
-// getPodGroup returns the current PodGroup object for a given lookup.
-func (wf *workloadForest) getPodGroup(pgLookup *schedulingv1beta1.PodGroup) (*schedulingv1beta1.PodGroup, bool) {
-	podGroup, ok := wf.podGroups[podGroupKey(pgLookup)]
-	return podGroup, ok
-}
-
-// getCompositePodGroup returns the current CompositePodGroup object for a given lookup.
-func (wf *workloadForest) getCompositePodGroup(cpgLookup *schedulingv1alpha3.CompositePodGroup) (*schedulingv1alpha3.CompositePodGroup, bool) {
-	podGroup, ok := wf.compositePodGroups[compositePodGroupKey(cpgLookup)]
-	return podGroup, ok
-}
-
-// buildPodGroupInfoForPG constructs a PodGroupInfo representation for a given PodGroup,
-// using the provided visited set to detect cycles in the hierarchy.
-func (wf *workloadForest) buildPodGroupInfoForPG(logger klog.Logger, pg *schedulingv1beta1.PodGroup, visited sets.Set[fwk.EntityKey]) *framework.PodGroupInfo {
-	key := podGroupKey(pg)
-	if visited.Has(key) {
-		utilruntime.HandleErrorWithLogger(logger, nil, "cycle detected in composite pod group hierarchy", "pg-name", pg.Name, "namespace", pg.Namespace)
-		return nil
-	}
-	visited.Insert(key)
-
-	return &framework.PodGroupInfo{
-		Namespace: pg.Namespace,
-		Name:      pg.Name,
-		Type:      fwk.PodGroupKeyType,
-		PodGroup:  pg,
-		Children:  make([]*framework.PodGroupInfo, 0),
-	}
-}
-
-// buildPodGroupInfoForCPG recursively constructs a PodGroupInfo representation for a given CompositePodGroup
+// buildPodGroupInfo recursively constructs a PodGroupInfo representation for a given AbstractPodGroup
 // and all its children, using the provided visited set to detect cycles in the hierarchy.
-func (wf *workloadForest) buildPodGroupInfoForCPG(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup, visited sets.Set[fwk.EntityKey]) *framework.PodGroupInfo {
-	key := compositePodGroupKey(cpg)
+func (wf *workloadForest) buildPodGroupInfo(logger klog.Logger, apg *framework.AbstractPodGroup, visited sets.Set[fwk.EntityKey]) *framework.PodGroupInfo {
+	key := apg.GetKey()
 	if visited.Has(key) {
-		utilruntime.HandleErrorWithLogger(logger, nil, "cycle detected in composite pod group hierarchy", "cpg-name", cpg.Name, "namespace", cpg.Namespace)
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cycle detected in composite pod group hierarchy when building PodGroupInfo", "groupType", apg.GetType(), "group", klog.KObj(apg))
 		return nil
 	}
 	visited.Insert(key)
 
 	pgi := &framework.PodGroupInfo{
-		Namespace:         cpg.Namespace,
-		Name:              cpg.Name,
-		Type:              fwk.CompositePodGroupKeyType,
-		CompositePodGroup: cpg,
+		Namespace:         apg.GetNamespace(),
+		Name:              apg.GetName(),
+		Type:              apg.GetType(),
+		PodGroup:          apg.PodGroup,
+		CompositePodGroup: apg.CompositePodGroup,
 		Children:          make([]*framework.PodGroupInfo, 0),
 	}
 
@@ -303,13 +230,8 @@ func (wf *workloadForest) buildPodGroupInfoForCPG(logger klog.Logger, cpg *sched
 		return pgi
 	}
 	for childKey := range childrenSet {
-		if childPG, ok := wf.podGroups[childKey]; ok {
-			if childInfo := wf.buildPodGroupInfoForPG(logger, childPG, visited); childInfo != nil {
-				pgi.Children = append(pgi.Children, childInfo)
-			}
-		}
-		if childCPG, ok := wf.compositePodGroups[childKey]; ok {
-			if childInfo := wf.buildPodGroupInfoForCPG(logger, childCPG, visited); childInfo != nil {
+		if childAPG, ok := wf.podGroups[childKey]; ok {
+			if childInfo := wf.buildPodGroupInfo(logger, childAPG, visited); childInfo != nil {
 				pgi.Children = append(pgi.Children, childInfo)
 			}
 		}
@@ -320,29 +242,20 @@ func (wf *workloadForest) buildPodGroupInfoForCPG(logger klog.Logger, cpg *sched
 // buildQueuedPodGroupInfo constructs a QueuedPodGroupInfo starting from the provided root lookup info,
 // building out the full hierarchy of PodGroupInfo nodes and initializing the QueuedPodInfos map.
 func (wf *workloadForest) buildQueuedPodGroupInfo(logger klog.Logger, rootLookup *framework.QueuedPodGroupInfo) *framework.QueuedPodGroupInfo {
-	var pgi *framework.PodGroupInfo
+	var key fwk.EntityKey
 	switch rootLookup.GetType() {
 	case fwk.PodGroupKeyType:
-		if pg, ok := wf.podGroups[fwk.PodGroupKey(rootLookup.GetNamespace(), rootLookup.GetName())]; ok && pg != nil {
-			pgi = wf.buildPodGroupInfoForPG(logger, pg, sets.New[fwk.EntityKey]())
-		}
+		key = fwk.PodGroupKey(rootLookup.GetNamespace(), rootLookup.GetName())
 	case fwk.CompositePodGroupKeyType:
-		if cpg, ok := wf.compositePodGroups[fwk.CompositePodGroupKey(rootLookup.GetNamespace(), rootLookup.GetName())]; ok && cpg != nil {
-			pgi = wf.buildPodGroupInfoForCPG(logger, cpg, sets.New[fwk.EntityKey]())
-		}
+		key = fwk.CompositePodGroupKey(rootLookup.GetNamespace(), rootLookup.GetName())
 	}
 
-	if pgi == nil {
+	apg, ok := wf.podGroups[key]
+	if !ok {
 		return nil
 	}
 	return &framework.QueuedPodGroupInfo{
-		PodGroupInfo:   pgi,
+		PodGroupInfo:   wf.buildPodGroupInfo(logger, apg, sets.New[fwk.EntityKey]()),
 		QueuedPodInfos: make(map[fwk.EntityKey][]*framework.QueuedPodInfo),
 	}
-}
-
-// podGroupHasParent checks whether the given PodGroup has a parent CompositePodGroup configured
-// and the CompositePodGroup feature is enabled.
-func (wf *workloadForest) podGroupHasParent(pg *schedulingv1beta1.PodGroup) bool {
-	return wf.isCompositePodGroupEnabled && pg.Spec.ParentCompositePodGroupName != nil
 }

--- a/pkg/scheduler/backend/queue/workload_forest.go
+++ b/pkg/scheduler/backend/queue/workload_forest.go
@@ -118,9 +118,7 @@ func (wf *workloadForest) getRootLookupInfo(apg *framework.AbstractPodGroup) (*f
 	if !wf.isCompositePodGroupEnabled || !storedAPG.HasParent() {
 		return &framework.QueuedPodGroupInfo{
 			PodGroupInfo: &framework.PodGroupInfo{
-				Namespace: storedAPG.GetNamespace(),
-				Name:      storedAPG.GetName(),
-				Type:      storedAPG.GetType(),
+				AbstractPodGroup: storedAPG,
 			},
 		}, true
 	}
@@ -146,13 +144,7 @@ func (wf *workloadForest) getRootLookupInfoForParentCPG(parentName, namespace st
 		}
 
 		if !cpg.HasParent() {
-			return &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: cpg.GetNamespace(),
-					Name:      cpg.GetName(),
-					Type:      fwk.CompositePodGroupKeyType,
-				},
-			}, true
+			return newCompositePodGroupInfoForLookup(cpg.GetNamespace(), cpg.GetName()), true
 		}
 		currParentName = *cpg.GetParentCompositePodGroupName()
 	}
@@ -217,12 +209,8 @@ func (wf *workloadForest) buildPodGroupInfo(logger klog.Logger, apg *framework.A
 	visited.Insert(key)
 
 	pgi := &framework.PodGroupInfo{
-		Namespace:         apg.GetNamespace(),
-		Name:              apg.GetName(),
-		Type:              apg.GetType(),
-		PodGroup:          apg.PodGroup,
-		CompositePodGroup: apg.CompositePodGroup,
-		Children:          make([]*framework.PodGroupInfo, 0),
+		AbstractPodGroup: apg,
+		Children:         make([]*framework.PodGroupInfo, 0),
 	}
 
 	childrenSet, ok := wf.children[key]

--- a/pkg/scheduler/backend/queue/workload_forest_test.go
+++ b/pkg/scheduler/backend/queue/workload_forest_test.go
@@ -730,9 +730,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg1",
-					Type:      fwk.PodGroupKeyType,
+					AbstractPodGroup: framework.NewAbstractPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -744,9 +742,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG2,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "cpg1",
-					Type:      fwk.CompositePodGroupKeyType,
+					AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -764,9 +760,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg1",
-					Type:      fwk.PodGroupKeyType,
+					AbstractPodGroup: framework.NewAbstractPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -778,9 +772,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG2,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg2",
-					Type:      fwk.PodGroupKeyType,
+					AbstractPodGroup: framework.NewAbstractPodGroup(pg2WithParent),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -836,9 +828,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg1",
-					Type:      fwk.PodGroupKeyType,
+					AbstractPodGroup: framework.NewAbstractPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -850,9 +840,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg2WithParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "cpg1",
-					Type:      fwk.CompositePodGroupKeyType,
+					AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -877,9 +865,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg1",
-					Type:      fwk.PodGroupKeyType,
+					AbstractPodGroup: framework.NewAbstractPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -891,9 +877,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg2WithParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg2",
-					Type:      fwk.PodGroupKeyType,
+					AbstractPodGroup: framework.NewAbstractPodGroup(pg2WithParent),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -904,9 +888,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg3WithNonExistentParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg3",
-					Type:      fwk.PodGroupKeyType,
+					AbstractPodGroup: framework.NewAbstractPodGroup(pg3WithNonExistentParent),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -959,9 +941,7 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 			cpg:         cpg1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "cpg1",
-					Type:      fwk.CompositePodGroupKeyType,
+					AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg1),
 				},
 			},
 		},
@@ -971,9 +951,7 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 			cpg:         cpg2WithParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "cpg1",
-					Type:      fwk.CompositePodGroupKeyType,
+					AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg1),
 				},
 			},
 		},
@@ -1026,68 +1004,54 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 		isCompositePodGroupEnabled bool
 	}{
 		{
-			name:             "single pod group lookup",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "pg1", Type: fwk.PodGroupKeyType},
-			},
+			name:                       "single pod group lookup",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "pg1", fwk.PodGroupKeyType),
 			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg1},
 			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:             "cpg with direct pod group child",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent},
-			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "cpg1", Type: fwk.CompositePodGroupKeyType},
-			},
+			name:                       "cpg with direct pod group child",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg2WithParent},
+			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpg1},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "cpg1", fwk.CompositePodGroupKeyType),
 			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg2WithParent},
 			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:             "cpg with nested pod group child",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent, pg3WithParent},
-			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1, cpg2WithParent},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "cpg1", Type: fwk.CompositePodGroupKeyType},
-			},
+			name:                       "cpg with nested pod group child",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg2WithParent, pg3WithParent},
+			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpg1, cpg2WithParent},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "cpg1", fwk.CompositePodGroupKeyType),
 			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg2WithParent, pg3WithParent},
 			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:             "missing root",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "missing", Type: fwk.CompositePodGroupKeyType},
-			},
+			name:                       "missing root",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "missing", fwk.CompositePodGroupKeyType),
 			wantLeaves:                 nil,
 			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:             "single pod group lookup (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "pg1", Type: fwk.PodGroupKeyType},
-			},
+			name:                       "single pod group lookup (CPG=false)",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "pg1", fwk.PodGroupKeyType),
 			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg1},
 			isCompositePodGroupEnabled: false,
 		},
 		{
-			name:             "pg with direct pod group child lookup (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent},
-			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "pg2", Type: fwk.PodGroupKeyType},
-			},
+			name:                       "pg with direct pod group child lookup (CPG=false)",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg2WithParent},
+			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpg1},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "pg2", fwk.PodGroupKeyType),
 			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg2WithParent},
 			isCompositePodGroupEnabled: false,
 		},
 		{
-			name:             "missing root (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "missing", Type: fwk.CompositePodGroupKeyType},
-			},
+			name:                       "missing root (CPG=false)",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "missing", fwk.CompositePodGroupKeyType),
 			wantLeaves:                 nil,
 			isCompositePodGroupEnabled: false,
 		},
@@ -1137,11 +1101,8 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			pg:               pg1,
 			wantInfo: &framework.PodGroupInfo{
-				Namespace: "ns1",
-				Name:      "pg1",
-				Type:      fwk.PodGroupKeyType,
-				PodGroup:  pg1,
-				Children:  []*framework.PodGroupInfo{},
+				AbstractPodGroup: framework.NewAbstractPodGroup(pg1),
+				Children:         []*framework.PodGroupInfo{},
 			},
 			isCompositePodGroupEnabled: true,
 		},
@@ -1150,11 +1111,8 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			pg:               pg1,
 			wantInfo: &framework.PodGroupInfo{
-				Namespace: "ns1",
-				Name:      "pg1",
-				Type:      fwk.PodGroupKeyType,
-				PodGroup:  pg1,
-				Children:  []*framework.PodGroupInfo{},
+				AbstractPodGroup: framework.NewAbstractPodGroup(pg1),
+				Children:         []*framework.PodGroupInfo{},
 			},
 			isCompositePodGroupEnabled: false,
 		},
@@ -1196,17 +1154,11 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpg:              cpg1,
 			wantInfo: &framework.PodGroupInfo{
-				Namespace:         "ns1",
-				Name:              "cpg1",
-				Type:              fwk.CompositePodGroupKeyType,
-				CompositePodGroup: cpg1,
+				AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg1),
 				Children: []*framework.PodGroupInfo{
 					{
-						Namespace: "ns1",
-						Name:      "pg1",
-						Type:      fwk.PodGroupKeyType,
-						PodGroup:  pg1WithParent,
-						Children:  []*framework.PodGroupInfo{},
+						AbstractPodGroup: framework.NewAbstractPodGroup(pg1WithParent),
+						Children:         []*framework.PodGroupInfo{},
 					},
 				},
 			},
@@ -1218,11 +1170,8 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpg:              cpg1,
 			wantInfo: &framework.PodGroupInfo{
-				Namespace:         "ns1",
-				Name:              "cpg1",
-				Type:              fwk.CompositePodGroupKeyType,
-				CompositePodGroup: cpg1,
-				Children:          []*framework.PodGroupInfo{},
+				AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg1),
+				Children:         []*framework.PodGroupInfo{},
 			},
 			isCompositePodGroupEnabled: false,
 		},

--- a/pkg/scheduler/backend/queue/workload_forest_test.go
+++ b/pkg/scheduler/backend/queue/workload_forest_test.go
@@ -42,15 +42,15 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		isCompositePodGroupEnabled bool
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
 		podGroupsToAdd             []*schedulingv1beta1.PodGroup
-		wantPodGroups              map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+		want                       map[fwk.EntityKey]*framework.AbstractPodGroup
 		wantChildren               map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
 			name:                       "add single pod group",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewAbstractPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -58,9 +58,9 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add multiple pod groups",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg2},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
-				fwk.PodGroupKey("ns1", "pg2"): pg2,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewAbstractPodGroup(pg1),
+				fwk.PodGroupKey("ns1", "pg2"): framework.NewAbstractPodGroup(pg2),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -68,8 +68,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add pod group with parent, parent not in children",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): framework.NewAbstractPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg3")),
@@ -79,9 +79,9 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add pod group with parent, parent already in children",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
-				fwk.PodGroupKey("ns1", "pg4"): pg4WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): framework.NewAbstractPodGroup(pg3WithParent),
+				fwk.PodGroupKey("ns1", "pg4"): framework.NewAbstractPodGroup(pg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg3"), fwk.PodGroupKey("ns1", "pg4")),
@@ -92,8 +92,9 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpgChild},
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpgChild"): framework.NewAbstractCompositePodGroup(cpgChild),
+				fwk.PodGroupKey("ns1", "pg3"):               framework.NewAbstractPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpgChild"), fwk.PodGroupKey("ns1", "pg3")),
@@ -103,8 +104,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add pod group with parent, feature disabled",
 			isCompositePodGroupEnabled: false,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): framework.NewAbstractPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -112,8 +113,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group again, feature enabled",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg1},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewAbstractPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -121,8 +122,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group again, feature disabled",
 			isCompositePodGroupEnabled: false,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg1},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewAbstractPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -130,8 +131,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group with parent again, feature enabled",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): framework.NewAbstractPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg3")),
@@ -141,8 +142,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group with parent again, feature disabled",
 			isCompositePodGroupEnabled: false,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): framework.NewAbstractPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -152,13 +153,13 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.podGroupsToAdd {
-				wf.addPodGroup(pg)
+				wf.addAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 
-			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
+			if diff := cmp.Diff(tt.want, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
 			}
 			if diff := cmp.Diff(tt.wantChildren, wf.children); diff != "" {
@@ -177,23 +178,23 @@ func TestWorkloadForest_UpdatePodGroup(t *testing.T) {
 		name             string
 		initialPodGroups []*schedulingv1beta1.PodGroup
 		podGroupToUpdate *schedulingv1beta1.PodGroup
-		want             map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+		want             map[fwk.EntityKey]*framework.AbstractPodGroup
 	}{
 		{
 			name:             "update existing pod group",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			podGroupToUpdate: updatedPG1,
-			want: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): updatedPG1,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewAbstractPodGroup(updatedPG1),
 			},
 		},
 		{
 			name:             "update non-existent pod group adds it",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			podGroupToUpdate: pg2,
-			want: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
-				fwk.PodGroupKey("ns1", "pg2"): pg2,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewAbstractPodGroup(pg1),
+				fwk.PodGroupKey("ns1", "pg2"): framework.NewAbstractPodGroup(pg2),
 			},
 		},
 	}
@@ -202,10 +203,10 @@ func TestWorkloadForest_UpdatePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 
-			wf.updatePodGroup(tt.podGroupToUpdate)
+			wf.updateAbstractPodGroup(framework.NewAbstractPodGroup(tt.podGroupToUpdate))
 
 			if diff := cmp.Diff(tt.want, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
@@ -221,13 +222,15 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 	pg4WithParent := st.MakePodGroup().Name("pg4").Namespace("ns1").UID("uid4").ParentCompositePodGroup("cpg1").Obj()
 	cpgChild := st.MakeCompositePodGroup().Name("cpgChild").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
 
+	cpg1 := st.MakeCompositePodGroup().Name("cpg1").Namespace("ns1").Obj()
+
 	tests := []struct {
 		name                       string
 		isCompositePodGroupEnabled bool
 		initialPodGroups           []*schedulingv1beta1.PodGroup
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
 		podGroupToDelete           *schedulingv1beta1.PodGroup
-		wantPodGroups              map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+		want                       map[fwk.EntityKey]*framework.AbstractPodGroup
 		wantChildren               map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
@@ -235,8 +238,8 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2},
 			podGroupToDelete:           pg1,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg2"): pg2,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg2"): framework.NewAbstractPodGroup(pg2),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -245,8 +248,8 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
 			podGroupToDelete:           pg2,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewAbstractPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -255,25 +258,27 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			want:                       map[fwk.EntityKey]*framework.AbstractPodGroup{},
 			wantChildren:               map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:                       "delete pod group with parent, where parent CPG exists in compositePodGroups",
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
-			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{st.MakeCompositePodGroup().Name("cpg1").Namespace("ns1").Obj()},
+			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
-			wantChildren:               map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewAbstractCompositePodGroup(cpg1),
+			},
+			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:                       "delete pod group with parent, parent has other pod group children",
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg4"): pg4WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pg4"): framework.NewAbstractPodGroup(pg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg4")),
@@ -285,7 +290,9 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpgChild},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpgChild"): framework.NewAbstractCompositePodGroup(cpgChild),
+			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpgChild")),
 			},
@@ -295,7 +302,7 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: false,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			want:                       map[fwk.EntityKey]*framework.AbstractPodGroup{},
 			wantChildren:               map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 	}
@@ -304,15 +311,15 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
-			wf.deletePodGroup(tt.podGroupToDelete)
+			wf.deleteAbstractPodGroup(framework.NewAbstractPodGroup(tt.podGroupToDelete))
 
-			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
+			if diff := cmp.Diff(tt.want, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
 			}
 			if diff := cmp.Diff(tt.wantChildren, wf.children); diff != "" {
@@ -366,10 +373,16 @@ func TestWorkloadForest_GetPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 
-			gotPG, gotFound := wf.getPodGroup(tt.podGroupLookup)
+			gotAPG, gotFound := wf.podGroups[framework.NewAbstractPodGroup(tt.podGroupLookup).GetKey()]
+			var gotPG *schedulingv1beta1.PodGroup
+			if gotFound && gotAPG.PodGroup != nil {
+				gotPG = gotAPG.PodGroup
+			} else {
+				gotFound = false
+			}
 			if wantFound := tt.wantPodGroup != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
@@ -407,10 +420,16 @@ func TestWorkloadForest_GetCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, cpg := range tt.initialCompositePodGroups {
-				wf.addCompositePodGroup(cpg)
+				wf.addAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
-			gotCPG, gotFound := wf.getCompositePodGroup(tt.cpgLookup)
+			gotAPG, gotFound := wf.podGroups[framework.NewAbstractCompositePodGroup(tt.cpgLookup).GetKey()]
+			var gotCPG *schedulingv1alpha3.CompositePodGroup
+			if gotFound && gotAPG.CompositePodGroup != nil {
+				gotCPG = gotAPG.CompositePodGroup
+			} else {
+				gotFound = false
+			}
 			if wantFound := tt.wantCompositePodGroup != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
@@ -433,31 +452,31 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		name         string
 		initialPGs   []*schedulingv1beta1.PodGroup
 		cpgsToAdd    []*schedulingv1alpha3.CompositePodGroup
-		wantCPGs     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
+		want         map[fwk.EntityKey]*framework.AbstractPodGroup
 		wantChildren map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
 			name:      "add single composite pod group",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg1},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): cpg1,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewAbstractCompositePodGroup(cpg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:      "add multiple composite pod groups",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpg2},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): cpg1,
-				fwk.CompositePodGroupKey("ns1", "cpg2"): cpg2,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewAbstractCompositePodGroup(cpg1),
+				fwk.CompositePodGroupKey("ns1", "cpg2"): framework.NewAbstractCompositePodGroup(cpg2),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:      "add composite pod group with parent, parent not in children",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewAbstractCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -466,9 +485,9 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		{
 			name:      "add composite pod group with parent, parent already has other composite pod group child",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
-				fwk.CompositePodGroupKey("ns1", "cpg4"): cpg4WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewAbstractCompositePodGroup(cpg3WithParent),
+				fwk.CompositePodGroupKey("ns1", "cpg4"): framework.NewAbstractCompositePodGroup(cpg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3"), fwk.CompositePodGroupKey("ns1", "cpg4")),
@@ -478,8 +497,9 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 			name:       "add composite pod group with parent, parent already has pod group child",
 			initialPGs: []*schedulingv1beta1.PodGroup{pgChild},
 			cpgsToAdd:  []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pgChild"):       framework.NewAbstractPodGroup(pgChild),
+				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewAbstractCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pgChild"), fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -488,16 +508,16 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		{
 			name:      "add same composite pod group again",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpg1},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): cpg1,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewAbstractCompositePodGroup(cpg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:      "add same composite pod group with parent again",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg3WithParent},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewAbstractCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -509,13 +529,13 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, pg := range tt.initialPGs {
-				wf.addPodGroup(pg)
+				wf.addAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.cpgsToAdd {
-				wf.addCompositePodGroup(cpg)
+				wf.addAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
-			if diff := cmp.Diff(tt.wantCPGs, wf.compositePodGroups); diff != "" {
+			if diff := cmp.Diff(tt.want, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected compositePodGroups (-want,+got)\n%s", diff)
 			}
 			if diff := cmp.Diff(tt.wantChildren, wf.children); diff != "" {
@@ -534,23 +554,23 @@ func TestWorkloadForest_UpdateCompositePodGroup(t *testing.T) {
 		name        string
 		initialCPGs []*schedulingv1alpha3.CompositePodGroup
 		cpgToUpdate *schedulingv1alpha3.CompositePodGroup
-		want        map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
+		want        map[fwk.EntityKey]*framework.AbstractPodGroup
 	}{
 		{
 			name:        "update existing composite pod group",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpgToUpdate: updatedCPG1,
-			want: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): updatedCPG1,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewAbstractCompositePodGroup(updatedCPG1),
 			},
 		},
 		{
 			name:        "update non-existent composite pod group adds it",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpgToUpdate: cpg2,
-			want: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): cpg1,
-				fwk.CompositePodGroupKey("ns1", "cpg2"): cpg2,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewAbstractCompositePodGroup(cpg1),
+				fwk.CompositePodGroupKey("ns1", "cpg2"): framework.NewAbstractCompositePodGroup(cpg2),
 			},
 		},
 	}
@@ -559,12 +579,12 @@ func TestWorkloadForest_UpdateCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
-			wf.updateCompositePodGroup(tt.cpgToUpdate)
+			wf.updateAbstractPodGroup(framework.NewAbstractCompositePodGroup(tt.cpgToUpdate))
 
-			if diff := cmp.Diff(tt.want, wf.compositePodGroups); diff != "" {
+			if diff := cmp.Diff(tt.want, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected compositePodGroups (-want,+got)\n%s", diff)
 			}
 		})
@@ -586,21 +606,21 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 		initialPGs   []*schedulingv1beta1.PodGroup
 		initialCPGs  []*schedulingv1alpha3.CompositePodGroup
 		cpgToDelete  *schedulingv1alpha3.CompositePodGroup
-		wantCPGs     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
+		want         map[fwk.EntityKey]*framework.AbstractPodGroup
 		wantChildren map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
 			name:         "delete existing composite pod group without parent",
 			initialCPGs:  []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpgToDelete:  cpg1,
-			wantCPGs:     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
+			want:         map[fwk.EntityKey]*framework.AbstractPodGroup{},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:         "delete composite pod group with parent, cleans up children map",
 			initialCPGs:  []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
 			cpgToDelete:  cpg3WithParent,
-			wantCPGs:     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
+			want:         map[fwk.EntityKey]*framework.AbstractPodGroup{},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
@@ -608,7 +628,9 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			initialPGs:  []*schedulingv1beta1.PodGroup{pgChild},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
 			cpgToDelete: cpg3WithParent,
-			wantCPGs:    map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pgChild"): framework.NewAbstractPodGroup(pgChild),
+			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pgChild")),
 			},
@@ -617,8 +639,8 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			name:        "delete composite pod group with parent, parent has other composite pod group child",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
 			cpgToDelete: cpg3WithParent,
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg4"): cpg4WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg4"): framework.NewAbstractCompositePodGroup(cpg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg4")),
@@ -629,8 +651,9 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			initialPGs:  []*schedulingv1beta1.PodGroup{pgChild},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
 			cpgToDelete: cpg3WithParent,
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg4"): cpg4WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.PodGroupKey("ns1", "pgChild"):       framework.NewAbstractPodGroup(pgChild),
+				fwk.CompositePodGroupKey("ns1", "cpg4"): framework.NewAbstractCompositePodGroup(cpg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pgChild"), fwk.CompositePodGroupKey("ns1", "cpg4")),
@@ -641,8 +664,9 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			initialPGs:  []*schedulingv1beta1.PodGroup{pgLeaf},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpgMid},
 			cpgToDelete: cpgMid,
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): cpg1,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewAbstractCompositePodGroup(cpg1),
+				fwk.PodGroupKey("ns1", "pgLeaf"):        framework.NewAbstractPodGroup(pgLeaf),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpgMid"): sets.New(fwk.PodGroupKey("ns1", "pgLeaf")),
@@ -652,8 +676,8 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			name:        "delete non-existent composite pod group",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
 			cpgToDelete: cpg1,
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
+			want: map[fwk.EntityKey]*framework.AbstractPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewAbstractCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -665,15 +689,15 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, pg := range tt.initialPGs {
-				wf.addPodGroup(pg)
+				wf.addAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
-			wf.deleteCompositePodGroup(tt.cpgToDelete)
+			wf.deleteAbstractPodGroup(framework.NewAbstractCompositePodGroup(tt.cpgToDelete))
 
-			if diff := cmp.Diff(tt.wantCPGs, wf.compositePodGroups); diff != "" {
+			if diff := cmp.Diff(tt.want, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected compositePodGroups (-want,+got)\n%s", diff)
 			}
 			if diff := cmp.Diff(tt.wantChildren, wf.children); diff != "" {
@@ -774,10 +798,10 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
 			gotInfo, gotFound := wf.getRootLookupInfoForPod(tt.pod)
@@ -900,13 +924,13 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
-			gotInfo, gotFound := wf.getRootLookupInfoForPodGroup(tt.podGroup)
+			gotInfo, gotFound := wf.getRootLookupInfo(framework.NewAbstractPodGroup(tt.podGroup))
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
@@ -971,10 +995,10 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
-			gotInfo, gotFound := wf.getRootLookupInfoForCPG(tt.cpg)
+			gotInfo, gotFound := wf.getRootLookupInfo(framework.NewAbstractCompositePodGroup(tt.cpg))
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
@@ -1073,10 +1097,10 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
@@ -1140,12 +1164,12 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
 			visited := sets.New[fwk.EntityKey]()
-			gotInfo := wf.buildPodGroupInfoForPG(logger, tt.pg, visited)
+			gotInfo := wf.buildPodGroupInfo(logger, framework.NewAbstractPodGroup(tt.pg), visited)
 
 			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
 				t.Errorf("Unexpected PodGroupInfo (-want,+got)\n%s", diff)
@@ -1208,15 +1232,15 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
 			visited := sets.New[fwk.EntityKey]()
-			gotInfo := wf.buildPodGroupInfoForCPG(logger, tt.cpg, visited)
+			gotInfo := wf.buildPodGroupInfo(logger, framework.NewAbstractCompositePodGroup(tt.cpg), visited)
 
 			// Note: Children are sorted by name in buildPodGroupInfoForCPG, so it is deterministic.
 			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {

--- a/pkg/scheduler/backend/queue/workload_forest_test.go
+++ b/pkg/scheduler/backend/queue/workload_forest_test.go
@@ -42,15 +42,15 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		isCompositePodGroupEnabled bool
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
 		podGroupsToAdd             []*schedulingv1beta1.PodGroup
-		wantPodGroups              map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+		wantPodGroups              map[fwk.EntityKey]*framework.GenericPodGroup
 		wantChildren               map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
 			name:                       "add single pod group",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -58,9 +58,9 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add multiple pod groups",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg2},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
-				fwk.PodGroupKey("ns1", "pg2"): pg2,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
+				fwk.PodGroupKey("ns1", "pg2"): framework.NewGenericPodGroup(pg2),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -68,8 +68,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add pod group with parent, parent not in children",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): framework.NewGenericPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg3")),
@@ -79,9 +79,9 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add pod group with parent, parent already in children",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
-				fwk.PodGroupKey("ns1", "pg4"): pg4WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): framework.NewGenericPodGroup(pg3WithParent),
+				fwk.PodGroupKey("ns1", "pg4"): framework.NewGenericPodGroup(pg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg3"), fwk.PodGroupKey("ns1", "pg4")),
@@ -92,8 +92,9 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpgChild},
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpgChild"): framework.NewGenericCompositePodGroup(cpgChild),
+				fwk.PodGroupKey("ns1", "pg3"):               framework.NewGenericPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpgChild"), fwk.PodGroupKey("ns1", "pg3")),
@@ -103,8 +104,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add pod group with parent, feature disabled",
 			isCompositePodGroupEnabled: false,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): framework.NewGenericPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -112,8 +113,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group again, feature enabled",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg1},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -121,8 +122,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group again, feature disabled",
 			isCompositePodGroupEnabled: false,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg1},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -130,8 +131,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group with parent again, feature enabled",
 			isCompositePodGroupEnabled: true,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): framework.NewGenericPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg3")),
@@ -141,8 +142,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add same pod group with parent again, feature disabled",
 			isCompositePodGroupEnabled: false,
 			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg3"): framework.NewGenericPodGroup(pg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -152,10 +153,10 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 			for _, pg := range tt.podGroupsToAdd {
-				wf.addPodGroup(pg)
+				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 
 			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
@@ -177,23 +178,23 @@ func TestWorkloadForest_UpdatePodGroup(t *testing.T) {
 		name             string
 		initialPodGroups []*schedulingv1beta1.PodGroup
 		podGroupToUpdate *schedulingv1beta1.PodGroup
-		want             map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+		wantPodGroups    map[fwk.EntityKey]*framework.GenericPodGroup
 	}{
 		{
 			name:             "update existing pod group",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			podGroupToUpdate: updatedPG1,
-			want: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): updatedPG1,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(updatedPG1),
 			},
 		},
 		{
 			name:             "update non-existent pod group adds it",
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			podGroupToUpdate: pg2,
-			want: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
-				fwk.PodGroupKey("ns1", "pg2"): pg2,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
+				fwk.PodGroupKey("ns1", "pg2"): framework.NewGenericPodGroup(pg2),
 			},
 		},
 	}
@@ -202,12 +203,12 @@ func TestWorkloadForest_UpdatePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 
-			wf.updatePodGroup(tt.podGroupToUpdate)
+			wf.updateGenericPodGroup(framework.NewGenericPodGroup(tt.podGroupToUpdate))
 
-			if diff := cmp.Diff(tt.want, wf.podGroups); diff != "" {
+			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
 			}
 		})
@@ -221,13 +222,15 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 	pg4WithParent := st.MakePodGroup().Name("pg4").Namespace("ns1").UID("uid4").ParentCompositePodGroup("cpg1").Obj()
 	cpgChild := st.MakeCompositePodGroup().Name("cpgChild").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
 
+	cpg1 := st.MakeCompositePodGroup().Name("cpg1").Namespace("ns1").Obj()
+
 	tests := []struct {
 		name                       string
 		isCompositePodGroupEnabled bool
 		initialPodGroups           []*schedulingv1beta1.PodGroup
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
 		podGroupToDelete           *schedulingv1beta1.PodGroup
-		wantPodGroups              map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+		wantPodGroups              map[fwk.EntityKey]*framework.GenericPodGroup
 		wantChildren               map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
@@ -235,8 +238,8 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2},
 			podGroupToDelete:           pg1,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg2"): pg2,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg2"): framework.NewGenericPodGroup(pg2),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -245,8 +248,8 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
 			podGroupToDelete:           pg2,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg1"): pg1,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg1"): framework.NewGenericPodGroup(pg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
@@ -255,25 +258,27 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			wantPodGroups:              map[fwk.EntityKey]*framework.GenericPodGroup{},
 			wantChildren:               map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:                       "delete pod group with parent, where parent CPG exists in compositePodGroups",
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
-			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{st.MakeCompositePodGroup().Name("cpg1").Namespace("ns1").Obj()},
+			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
-			wantChildren:               map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
+			},
+			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:                       "delete pod group with parent, parent has other pod group children",
 			isCompositePodGroupEnabled: true,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
-				fwk.PodGroupKey("ns1", "pg4"): pg4WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pg4"): framework.NewGenericPodGroup(pg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pg4")),
@@ -285,7 +290,9 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpgChild},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpgChild"): framework.NewGenericCompositePodGroup(cpgChild),
+			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpgChild")),
 			},
@@ -295,7 +302,7 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 			isCompositePodGroupEnabled: false,
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			wantPodGroups:              map[fwk.EntityKey]*framework.GenericPodGroup{},
 			wantChildren:               map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 	}
@@ -304,13 +311,13 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
-			wf.deletePodGroup(tt.podGroupToDelete)
+			wf.deleteGenericPodGroup(framework.NewGenericPodGroup(tt.podGroupToDelete))
 
 			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
 				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
@@ -366,10 +373,16 @@ func TestWorkloadForest_GetPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 
-			gotPG, gotFound := wf.getPodGroup(tt.podGroupLookup)
+			gotGPG, gotFound := wf.podGroups[framework.NewGenericPodGroup(tt.podGroupLookup).GetKey()]
+			var gotPG *schedulingv1beta1.PodGroup
+			if gotFound && gotGPG.PodGroup != nil {
+				gotPG = gotGPG.PodGroup
+			} else {
+				gotFound = false
+			}
 			if wantFound := tt.wantPodGroup != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
@@ -407,10 +420,16 @@ func TestWorkloadForest_GetCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, cpg := range tt.initialCompositePodGroups {
-				wf.addCompositePodGroup(cpg)
+				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
-			gotCPG, gotFound := wf.getCompositePodGroup(tt.cpgLookup)
+			gotGPG, gotFound := wf.podGroups[framework.NewGenericCompositePodGroup(tt.cpgLookup).GetKey()]
+			var gotCPG *schedulingv1alpha3.CompositePodGroup
+			if gotFound && gotGPG.CompositePodGroup != nil {
+				gotCPG = gotGPG.CompositePodGroup
+			} else {
+				gotFound = false
+			}
 			if wantFound := tt.wantCompositePodGroup != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
@@ -430,34 +449,34 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 	pgChild := st.MakePodGroup().Name("pgChild").Namespace("ns1").UID("uid1").ParentCompositePodGroup("cpg1").Obj()
 
 	tests := []struct {
-		name         string
-		initialPGs   []*schedulingv1beta1.PodGroup
-		cpgsToAdd    []*schedulingv1alpha3.CompositePodGroup
-		wantCPGs     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
-		wantChildren map[fwk.EntityKey]sets.Set[fwk.EntityKey]
+		name          string
+		initialPGs    []*schedulingv1beta1.PodGroup
+		cpgsToAdd     []*schedulingv1alpha3.CompositePodGroup
+		wantPodGroups map[fwk.EntityKey]*framework.GenericPodGroup
+		wantChildren  map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
 			name:      "add single composite pod group",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg1},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): cpg1,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:      "add multiple composite pod groups",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpg2},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): cpg1,
-				fwk.CompositePodGroupKey("ns1", "cpg2"): cpg2,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
+				fwk.CompositePodGroupKey("ns1", "cpg2"): framework.NewGenericCompositePodGroup(cpg2),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:      "add composite pod group with parent, parent not in children",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewGenericCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -466,9 +485,9 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		{
 			name:      "add composite pod group with parent, parent already has other composite pod group child",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
-				fwk.CompositePodGroupKey("ns1", "cpg4"): cpg4WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewGenericCompositePodGroup(cpg3WithParent),
+				fwk.CompositePodGroupKey("ns1", "cpg4"): framework.NewGenericCompositePodGroup(cpg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3"), fwk.CompositePodGroupKey("ns1", "cpg4")),
@@ -478,8 +497,9 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 			name:       "add composite pod group with parent, parent already has pod group child",
 			initialPGs: []*schedulingv1beta1.PodGroup{pgChild},
 			cpgsToAdd:  []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pgChild"):       framework.NewGenericPodGroup(pgChild),
+				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewGenericCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pgChild"), fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -488,16 +508,16 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		{
 			name:      "add same composite pod group again",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpg1},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): cpg1,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:      "add same composite pod group with parent again",
 			cpgsToAdd: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg3WithParent},
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewGenericCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -509,14 +529,14 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, pg := range tt.initialPGs {
-				wf.addPodGroup(pg)
+				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.cpgsToAdd {
-				wf.addCompositePodGroup(cpg)
+				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
-			if diff := cmp.Diff(tt.wantCPGs, wf.compositePodGroups); diff != "" {
-				t.Errorf("Unexpected compositePodGroups (-want,+got)\n%s", diff)
+			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
+				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
 			}
 			if diff := cmp.Diff(tt.wantChildren, wf.children); diff != "" {
 				t.Errorf("Unexpected children (-want,+got)\n%s", diff)
@@ -531,26 +551,26 @@ func TestWorkloadForest_UpdateCompositePodGroup(t *testing.T) {
 	cpg2 := st.MakeCompositePodGroup().Name("cpg2").Namespace("ns1").MinGroupCount(1).Obj()
 
 	tests := []struct {
-		name        string
-		initialCPGs []*schedulingv1alpha3.CompositePodGroup
-		cpgToUpdate *schedulingv1alpha3.CompositePodGroup
-		want        map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
+		name          string
+		initialCPGs   []*schedulingv1alpha3.CompositePodGroup
+		cpgToUpdate   *schedulingv1alpha3.CompositePodGroup
+		wantPodGroups map[fwk.EntityKey]*framework.GenericPodGroup
 	}{
 		{
 			name:        "update existing composite pod group",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpgToUpdate: updatedCPG1,
-			want: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): updatedCPG1,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(updatedCPG1),
 			},
 		},
 		{
 			name:        "update non-existent composite pod group adds it",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpgToUpdate: cpg2,
-			want: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): cpg1,
-				fwk.CompositePodGroupKey("ns1", "cpg2"): cpg2,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
+				fwk.CompositePodGroupKey("ns1", "cpg2"): framework.NewGenericCompositePodGroup(cpg2),
 			},
 		},
 	}
@@ -559,13 +579,13 @@ func TestWorkloadForest_UpdateCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
-			wf.updateCompositePodGroup(tt.cpgToUpdate)
+			wf.updateGenericPodGroup(framework.NewGenericCompositePodGroup(tt.cpgToUpdate))
 
-			if diff := cmp.Diff(tt.want, wf.compositePodGroups); diff != "" {
-				t.Errorf("Unexpected compositePodGroups (-want,+got)\n%s", diff)
+			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
+				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
 			}
 		})
 	}
@@ -582,33 +602,35 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 	pgLeaf := st.MakePodGroup().Name("pgLeaf").Namespace("ns1").UID("uidLeaf").ParentCompositePodGroup("cpgMid").Obj()
 
 	tests := []struct {
-		name         string
-		initialPGs   []*schedulingv1beta1.PodGroup
-		initialCPGs  []*schedulingv1alpha3.CompositePodGroup
-		cpgToDelete  *schedulingv1alpha3.CompositePodGroup
-		wantCPGs     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
-		wantChildren map[fwk.EntityKey]sets.Set[fwk.EntityKey]
+		name          string
+		initialPGs    []*schedulingv1beta1.PodGroup
+		initialCPGs   []*schedulingv1alpha3.CompositePodGroup
+		cpgToDelete   *schedulingv1alpha3.CompositePodGroup
+		wantPodGroups map[fwk.EntityKey]*framework.GenericPodGroup
+		wantChildren  map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
-			name:         "delete existing composite pod group without parent",
-			initialCPGs:  []*schedulingv1alpha3.CompositePodGroup{cpg1},
-			cpgToDelete:  cpg1,
-			wantCPGs:     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
-			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
+			name:          "delete existing composite pod group without parent",
+			initialCPGs:   []*schedulingv1alpha3.CompositePodGroup{cpg1},
+			cpgToDelete:   cpg1,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{},
+			wantChildren:  map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
-			name:         "delete composite pod group with parent, cleans up children map",
-			initialCPGs:  []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
-			cpgToDelete:  cpg3WithParent,
-			wantCPGs:     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
-			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
+			name:          "delete composite pod group with parent, cleans up children map",
+			initialCPGs:   []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
+			cpgToDelete:   cpg3WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{},
+			wantChildren:  map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:        "delete composite pod group with parent, parent has other pod group child",
 			initialPGs:  []*schedulingv1beta1.PodGroup{pgChild},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
 			cpgToDelete: cpg3WithParent,
-			wantCPGs:    map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pgChild"): framework.NewGenericPodGroup(pgChild),
+			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pgChild")),
 			},
@@ -617,8 +639,8 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			name:        "delete composite pod group with parent, parent has other composite pod group child",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
 			cpgToDelete: cpg3WithParent,
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg4"): cpg4WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg4"): framework.NewGenericCompositePodGroup(cpg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg4")),
@@ -629,8 +651,9 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			initialPGs:  []*schedulingv1beta1.PodGroup{pgChild},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
 			cpgToDelete: cpg3WithParent,
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg4"): cpg4WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.PodGroupKey("ns1", "pgChild"):       framework.NewGenericPodGroup(pgChild),
+				fwk.CompositePodGroupKey("ns1", "cpg4"): framework.NewGenericCompositePodGroup(cpg4WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.PodGroupKey("ns1", "pgChild"), fwk.CompositePodGroupKey("ns1", "cpg4")),
@@ -641,8 +664,9 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			initialPGs:  []*schedulingv1beta1.PodGroup{pgLeaf},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpgMid},
 			cpgToDelete: cpgMid,
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg1"): cpg1,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg1"): framework.NewGenericCompositePodGroup(cpg1),
+				fwk.PodGroupKey("ns1", "pgLeaf"):        framework.NewGenericPodGroup(pgLeaf),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpgMid"): sets.New(fwk.PodGroupKey("ns1", "pgLeaf")),
@@ -652,8 +676,8 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 			name:        "delete non-existent composite pod group",
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
 			cpgToDelete: cpg1,
-			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
-				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
+			wantPodGroups: map[fwk.EntityKey]*framework.GenericPodGroup{
+				fwk.CompositePodGroupKey("ns1", "cpg3"): framework.NewGenericCompositePodGroup(cpg3WithParent),
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpg3")),
@@ -665,16 +689,16 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, pg := range tt.initialPGs {
-				wf.addPodGroup(pg)
+				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
-			wf.deleteCompositePodGroup(tt.cpgToDelete)
+			wf.deleteGenericPodGroup(framework.NewGenericCompositePodGroup(tt.cpgToDelete))
 
-			if diff := cmp.Diff(tt.wantCPGs, wf.compositePodGroups); diff != "" {
-				t.Errorf("Unexpected compositePodGroups (-want,+got)\n%s", diff)
+			if diff := cmp.Diff(tt.wantPodGroups, wf.podGroups); diff != "" {
+				t.Errorf("Unexpected podGroups (-want,+got)\n%s", diff)
 			}
 			if diff := cmp.Diff(tt.wantChildren, wf.children); diff != "" {
 				t.Errorf("Unexpected children (-want,+got)\n%s", diff)
@@ -706,9 +730,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg1",
-					Type:      fwk.PodGroupKeyType,
+					GenericPodGroup: framework.NewGenericPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -720,9 +742,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG2,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "cpg1",
-					Type:      fwk.CompositePodGroupKeyType,
+					GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -740,9 +760,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg1",
-					Type:      fwk.PodGroupKeyType,
+					GenericPodGroup: framework.NewGenericPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -754,9 +772,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			pod:              podWithPG2,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg2",
-					Type:      fwk.PodGroupKeyType,
+					GenericPodGroup: framework.NewGenericPodGroup(pg2WithParent),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -774,10 +790,10 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
 			gotInfo, gotFound := wf.getRootLookupInfoForPod(tt.pod)
@@ -812,9 +828,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg1",
-					Type:      fwk.PodGroupKeyType,
+					GenericPodGroup: framework.NewGenericPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -826,9 +840,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg2WithParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "cpg1",
-					Type:      fwk.CompositePodGroupKeyType,
+					GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
 				},
 			},
 			isCompositePodGroupEnabled: true,
@@ -853,9 +865,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg1",
-					Type:      fwk.PodGroupKeyType,
+					GenericPodGroup: framework.NewGenericPodGroup(pg1),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -867,9 +877,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg2WithParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg2",
-					Type:      fwk.PodGroupKeyType,
+					GenericPodGroup: framework.NewGenericPodGroup(pg2WithParent),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -880,9 +888,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			podGroup:         pg3WithNonExistentParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "pg3",
-					Type:      fwk.PodGroupKeyType,
+					GenericPodGroup: framework.NewGenericPodGroup(pg3WithNonExistentParent),
 				},
 			},
 			isCompositePodGroupEnabled: false,
@@ -900,13 +906,13 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
-			gotInfo, gotFound := wf.getRootLookupInfoForPodGroup(tt.podGroup)
+			gotInfo, gotFound := wf.getRootLookupInfo(framework.NewGenericPodGroup(tt.podGroup))
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
@@ -935,9 +941,7 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 			cpg:         cpg1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "cpg1",
-					Type:      fwk.CompositePodGroupKeyType,
+					GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
 				},
 			},
 		},
@@ -947,9 +951,7 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 			cpg:         cpg2WithParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: "ns1",
-					Name:      "cpg1",
-					Type:      fwk.CompositePodGroupKeyType,
+					GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
 				},
 			},
 		},
@@ -971,10 +973,10 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(true)
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
-			gotInfo, gotFound := wf.getRootLookupInfoForCPG(tt.cpg)
+			gotInfo, gotFound := wf.getRootLookupInfo(framework.NewGenericCompositePodGroup(tt.cpg))
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
@@ -1002,68 +1004,54 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 		isCompositePodGroupEnabled bool
 	}{
 		{
-			name:             "single pod group lookup",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "pg1", Type: fwk.PodGroupKeyType},
-			},
+			name:                       "single pod group lookup",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "pg1", fwk.PodGroupKeyType),
 			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg1},
 			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:             "cpg with direct pod group child",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent},
-			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "cpg1", Type: fwk.CompositePodGroupKeyType},
-			},
+			name:                       "cpg with direct pod group child",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg2WithParent},
+			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpg1},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "cpg1", fwk.CompositePodGroupKeyType),
 			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg2WithParent},
 			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:             "cpg with nested pod group child",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent, pg3WithParent},
-			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1, cpg2WithParent},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "cpg1", Type: fwk.CompositePodGroupKeyType},
-			},
+			name:                       "cpg with nested pod group child",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg2WithParent, pg3WithParent},
+			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpg1, cpg2WithParent},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "cpg1", fwk.CompositePodGroupKeyType),
 			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg2WithParent, pg3WithParent},
 			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:             "missing root",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "missing", Type: fwk.CompositePodGroupKeyType},
-			},
+			name:                       "missing root",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "missing", fwk.CompositePodGroupKeyType),
 			wantLeaves:                 nil,
 			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:             "single pod group lookup (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "pg1", Type: fwk.PodGroupKeyType},
-			},
+			name:                       "single pod group lookup (CPG=false)",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "pg1", fwk.PodGroupKeyType),
 			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg1},
 			isCompositePodGroupEnabled: false,
 		},
 		{
-			name:             "pg with direct pod group child lookup (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent},
-			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "pg2", Type: fwk.PodGroupKeyType},
-			},
+			name:                       "pg with direct pod group child lookup (CPG=false)",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg2WithParent},
+			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpg1},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "pg2", fwk.PodGroupKeyType),
 			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg2WithParent},
 			isCompositePodGroupEnabled: false,
 		},
 		{
-			name:             "missing root (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{},
-			rootLookupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "missing", Type: fwk.CompositePodGroupKeyType},
-			},
+			name:                       "missing root (CPG=false)",
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
+			rootLookupInfo:             newQueuedPodGroupInfoForLookup("ns1", "missing", fwk.CompositePodGroupKeyType),
 			wantLeaves:                 nil,
 			isCompositePodGroupEnabled: false,
 		},
@@ -1073,10 +1061,10 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
@@ -1113,11 +1101,8 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			pg:               pg1,
 			wantInfo: &framework.PodGroupInfo{
-				Namespace: "ns1",
-				Name:      "pg1",
-				Type:      fwk.PodGroupKeyType,
-				PodGroup:  pg1,
-				Children:  []*framework.PodGroupInfo{},
+				GenericPodGroup: framework.NewGenericPodGroup(pg1),
+				Children:        []*framework.PodGroupInfo{},
 			},
 			isCompositePodGroupEnabled: true,
 		},
@@ -1126,11 +1111,8 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
 			pg:               pg1,
 			wantInfo: &framework.PodGroupInfo{
-				Namespace: "ns1",
-				Name:      "pg1",
-				Type:      fwk.PodGroupKeyType,
-				PodGroup:  pg1,
-				Children:  []*framework.PodGroupInfo{},
+				GenericPodGroup: framework.NewGenericPodGroup(pg1),
+				Children:        []*framework.PodGroupInfo{},
 			},
 			isCompositePodGroupEnabled: false,
 		},
@@ -1140,12 +1122,12 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
 			visited := sets.New[fwk.EntityKey]()
-			gotInfo := wf.buildPodGroupInfoForPG(logger, tt.pg, visited)
+			gotInfo := wf.buildPodGroupInfo(logger, framework.NewGenericPodGroup(tt.pg), visited)
 
 			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
 				t.Errorf("Unexpected PodGroupInfo (-want,+got)\n%s", diff)
@@ -1172,17 +1154,11 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpg:              cpg1,
 			wantInfo: &framework.PodGroupInfo{
-				Namespace:         "ns1",
-				Name:              "cpg1",
-				Type:              fwk.CompositePodGroupKeyType,
-				CompositePodGroup: cpg1,
+				GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
 				Children: []*framework.PodGroupInfo{
 					{
-						Namespace: "ns1",
-						Name:      "pg1",
-						Type:      fwk.PodGroupKeyType,
-						PodGroup:  pg1WithParent,
-						Children:  []*framework.PodGroupInfo{},
+						GenericPodGroup: framework.NewGenericPodGroup(pg1WithParent),
+						Children:        []*framework.PodGroupInfo{},
 					},
 				},
 			},
@@ -1194,11 +1170,8 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpg:              cpg1,
 			wantInfo: &framework.PodGroupInfo{
-				Namespace:         "ns1",
-				Name:              "cpg1",
-				Type:              fwk.CompositePodGroupKeyType,
-				CompositePodGroup: cpg1,
-				Children:          []*framework.PodGroupInfo{},
+				GenericPodGroup: framework.NewGenericCompositePodGroup(cpg1),
+				Children:        []*framework.PodGroupInfo{},
 			},
 			isCompositePodGroupEnabled: false,
 		},
@@ -1208,15 +1181,15 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wf := newWorkloadForest(tt.isCompositePodGroupEnabled)
 			for _, pg := range tt.initialPodGroups {
-				wf.addPodGroup(pg)
+				wf.addGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.initialCPGs {
-				wf.addCompositePodGroup(cpg)
+				wf.addGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
 			logger, _ := ktesting.NewTestContext(t)
 			visited := sets.New[fwk.EntityKey]()
-			gotInfo := wf.buildPodGroupInfoForCPG(logger, tt.cpg, visited)
+			gotInfo := wf.buildPodGroupInfo(logger, framework.NewGenericCompositePodGroup(tt.cpg), visited)
 
 			// Note: Children are sorted by name in buildPodGroupInfoForCPG, so it is deterministic.
 			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -476,8 +476,9 @@ func (sched *Scheduler) addPodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Add event for pod group", "podGroup", klog.KObj(pg))
-	sched.Cache.AddPodGroup(pg)
-	sched.SchedulingQueue.AddPodGroup(logger, pg)
+	apg := framework.NewGenericPodGroup(pg)
+	sched.Cache.AddGenericPodGroup(apg)
+	sched.SchedulingQueue.AddGenericPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, nil, pg, nil)
 }
 
@@ -501,8 +502,9 @@ func (sched *Scheduler) updatePodGroup(oldObj, newObj any) {
 	}
 
 	logger.V(4).Info("Update event for pod group", "podGroup", klog.KObj(newPG))
-	sched.Cache.UpdatePodGroup(logger, oldPG, newPG)
-	sched.SchedulingQueue.UpdatePodGroup(logger, newPG)
+	apg := framework.NewGenericPodGroup(newPG)
+	sched.Cache.UpdateGenericPodGroup(logger, apg)
+	sched.SchedulingQueue.UpdateGenericPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, oldPG, newPG, nil)
 }
 
@@ -528,8 +530,9 @@ func (sched *Scheduler) deletePodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Delete event for pod group", "podGroup", klog.KObj(pg))
-	sched.Cache.RemovePodGroup(logger, pg)
-	sched.SchedulingQueue.DeletePodGroup(logger, pg)
+	apg := framework.NewGenericPodGroup(pg)
+	sched.Cache.RemoveGenericPodGroup(logger, apg)
+	sched.SchedulingQueue.DeleteGenericPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, pg, nil, nil)
 }
 
@@ -544,8 +547,9 @@ func (sched *Scheduler) addCompositePodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Add event for composite pod group", "compositePodGroup", klog.KObj(cpg))
-	sched.Cache.AddCompositePodGroup(logger, cpg)
-	sched.SchedulingQueue.AddCompositePodGroup(logger, cpg)
+	apg := framework.NewGenericCompositePodGroup(cpg)
+	sched.Cache.AddGenericPodGroup(apg)
+	sched.SchedulingQueue.AddGenericPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, nil, cpg, nil)
 }
 
@@ -569,8 +573,9 @@ func (sched *Scheduler) updateCompositePodGroup(oldObj, newObj any) {
 	}
 
 	logger.V(4).Info("Update event for composite pod group", "compositePodGroup", klog.KObj(newCPG))
-	sched.Cache.UpdateCompositePodGroup(logger, oldCPG, newCPG)
-	sched.SchedulingQueue.UpdateCompositePodGroup(logger, newCPG)
+	apg := framework.NewGenericCompositePodGroup(newCPG)
+	sched.Cache.UpdateGenericPodGroup(logger, apg)
+	sched.SchedulingQueue.UpdateGenericPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, oldCPG, newCPG, nil)
 }
 
@@ -596,8 +601,9 @@ func (sched *Scheduler) deleteCompositePodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Delete event for composite pod group", "compositePodGroup", klog.KObj(cpg))
-	sched.Cache.RemoveCompositePodGroup(logger, cpg)
-	sched.SchedulingQueue.DeleteCompositePodGroup(logger, cpg)
+	apg := framework.NewGenericCompositePodGroup(cpg)
+	sched.Cache.RemoveGenericPodGroup(logger, apg)
+	sched.SchedulingQueue.DeleteGenericPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, cpg, nil, nil)
 }
 

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -476,8 +476,9 @@ func (sched *Scheduler) addPodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Add event for pod group", "podGroup", klog.KObj(pg))
-	sched.Cache.AddPodGroup(pg)
-	sched.SchedulingQueue.AddPodGroup(logger, pg)
+	apg := framework.NewAbstractPodGroup(pg)
+	sched.Cache.AddAbstractPodGroup(apg)
+	sched.SchedulingQueue.AddAbstractPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, nil, pg, nil)
 }
 
@@ -501,8 +502,9 @@ func (sched *Scheduler) updatePodGroup(oldObj, newObj any) {
 	}
 
 	logger.V(4).Info("Update event for pod group", "podGroup", klog.KObj(newPG))
-	sched.Cache.UpdatePodGroup(logger, oldPG, newPG)
-	sched.SchedulingQueue.UpdatePodGroup(logger, newPG)
+	apg := framework.NewAbstractPodGroup(newPG)
+	sched.Cache.UpdateAbstractPodGroup(logger, apg)
+	sched.SchedulingQueue.UpdateAbstractPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, oldPG, newPG, nil)
 }
 
@@ -528,8 +530,9 @@ func (sched *Scheduler) deletePodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Delete event for pod group", "podGroup", klog.KObj(pg))
-	sched.Cache.RemovePodGroup(logger, pg)
-	sched.SchedulingQueue.DeletePodGroup(logger, pg)
+	apg := framework.NewAbstractPodGroup(pg)
+	sched.Cache.RemoveAbstractPodGroup(logger, apg)
+	sched.SchedulingQueue.DeleteAbstractPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, pg, nil, nil)
 }
 
@@ -544,8 +547,9 @@ func (sched *Scheduler) addCompositePodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Add event for composite pod group", "compositePodGroup", klog.KObj(cpg))
-	sched.Cache.AddCompositePodGroup(logger, cpg)
-	sched.SchedulingQueue.AddCompositePodGroup(logger, cpg)
+	apg := framework.NewAbstractCompositePodGroup(cpg)
+	sched.Cache.AddAbstractPodGroup(apg)
+	sched.SchedulingQueue.AddAbstractPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, nil, cpg, nil)
 }
 
@@ -569,8 +573,9 @@ func (sched *Scheduler) updateCompositePodGroup(oldObj, newObj any) {
 	}
 
 	logger.V(4).Info("Update event for composite pod group", "compositePodGroup", klog.KObj(newCPG))
-	sched.Cache.UpdateCompositePodGroup(logger, oldCPG, newCPG)
-	sched.SchedulingQueue.UpdateCompositePodGroup(logger, newCPG)
+	apg := framework.NewAbstractCompositePodGroup(newCPG)
+	sched.Cache.UpdateAbstractPodGroup(logger, apg)
+	sched.SchedulingQueue.UpdateAbstractPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, oldCPG, newCPG, nil)
 }
 
@@ -596,8 +601,9 @@ func (sched *Scheduler) deleteCompositePodGroup(obj any) {
 	}
 
 	logger.V(3).Info("Delete event for composite pod group", "compositePodGroup", klog.KObj(cpg))
-	sched.Cache.RemoveCompositePodGroup(logger, cpg)
-	sched.SchedulingQueue.DeleteCompositePodGroup(logger, cpg)
+	apg := framework.NewAbstractCompositePodGroup(cpg)
+	sched.Cache.RemoveAbstractPodGroup(logger, apg)
+	sched.SchedulingQueue.DeleteAbstractPodGroup(logger, apg)
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, evt, cpg, nil, nil)
 }
 

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -1480,7 +1480,7 @@ func TestUpdatePodGroup(t *testing.T) {
 				logger:          logger,
 			}
 
-			sched.Cache.AddPodGroup(tt.oldPodGroup)
+			sched.Cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(tt.oldPodGroup))
 
 			sched.updatePodGroup(tt.oldPodGroup, tt.newPodGroup)
 
@@ -1528,7 +1528,7 @@ func TestDeletePodGroup(t *testing.T) {
 			}
 
 			if tt.initPodGroup != nil {
-				sched.Cache.AddPodGroup(tt.initPodGroup)
+				sched.Cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(tt.initPodGroup))
 			}
 
 			sched.deletePodGroup(tt.podGroupToDelete)
@@ -1626,9 +1626,9 @@ func TestAddCompositePodGroup(t *testing.T) {
 
 			if tt.triggerQueueingHint {
 				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
-				queue.AddCompositePodGroup(logger, cpgObj)
+				queue.AddAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpgObj))
 				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
-				queue.AddPodGroup(logger, pg)
+				queue.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 
 				queue.Add(ctx, pod)
 				poppedEntity, _ := queue.Pop(logger)
@@ -1782,14 +1782,14 @@ func TestUpdateCompositePodGroup(t *testing.T) {
 			}
 
 			if tt.cpgEnabled {
-				sched.Cache.AddCompositePodGroup(logger, oldCPG)
+				sched.Cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(oldCPG))
 			}
 
 			if tt.triggerQueueingHint {
 				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
-				queue.AddCompositePodGroup(logger, cpgObj)
+				queue.AddAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpgObj))
 				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
-				queue.AddPodGroup(logger, pg)
+				queue.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 
 				queue.Add(ctx, pod)
 				poppedEntity, _ := queue.Pop(logger)
@@ -1921,9 +1921,9 @@ func TestDeleteCompositePodGroup(t *testing.T) {
 
 			if tt.triggerQueueingHint {
 				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
-				queue.AddCompositePodGroup(logger, cpgObj)
+				queue.AddAbstractPodGroup(logger, framework.NewAbstractCompositePodGroup(cpgObj))
 				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
-				queue.AddPodGroup(logger, pg)
+				queue.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 
 				queue.Add(ctx, pod)
 				poppedEntity, _ := queue.Pop(logger)
@@ -1936,7 +1936,7 @@ func TestDeleteCompositePodGroup(t *testing.T) {
 			}
 
 			if tt.initCPG != nil && tt.cpgEnabled {
-				sched.Cache.AddCompositePodGroup(logger, tt.initCPG)
+				sched.Cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(tt.initCPG))
 			}
 
 			sched.deleteCompositePodGroup(tt.cpgToDelete)

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -1580,7 +1580,7 @@ func TestUpdatePodGroup(t *testing.T) {
 				logger:          logger,
 			}
 
-			sched.Cache.AddPodGroup(tt.oldPodGroup)
+			sched.Cache.AddGenericPodGroup(framework.NewGenericPodGroup(tt.oldPodGroup))
 
 			sched.updatePodGroup(tt.oldPodGroup, tt.newPodGroup)
 
@@ -1628,7 +1628,7 @@ func TestDeletePodGroup(t *testing.T) {
 			}
 
 			if tt.initPodGroup != nil {
-				sched.Cache.AddPodGroup(tt.initPodGroup)
+				sched.Cache.AddGenericPodGroup(framework.NewGenericPodGroup(tt.initPodGroup))
 			}
 
 			sched.deletePodGroup(tt.podGroupToDelete)
@@ -1726,9 +1726,9 @@ func TestAddCompositePodGroup(t *testing.T) {
 
 			if tt.triggerQueueingHint {
 				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
-				queue.AddCompositePodGroup(logger, cpgObj)
+				queue.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpgObj))
 				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
-				queue.AddPodGroup(logger, pg)
+				queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 
 				queue.Add(ctx, pod)
 				poppedEntity, _ := queue.Pop(logger)
@@ -1882,14 +1882,14 @@ func TestUpdateCompositePodGroup(t *testing.T) {
 			}
 
 			if tt.cpgEnabled {
-				sched.Cache.AddCompositePodGroup(logger, oldCPG)
+				sched.Cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(oldCPG))
 			}
 
 			if tt.triggerQueueingHint {
 				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
-				queue.AddCompositePodGroup(logger, cpgObj)
+				queue.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpgObj))
 				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
-				queue.AddPodGroup(logger, pg)
+				queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 
 				queue.Add(ctx, pod)
 				poppedEntity, _ := queue.Pop(logger)
@@ -2021,9 +2021,9 @@ func TestDeleteCompositePodGroup(t *testing.T) {
 
 			if tt.triggerQueueingHint {
 				cpgObj := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg1").Obj()
-				queue.AddCompositePodGroup(logger, cpgObj)
+				queue.AddGenericPodGroup(logger, framework.NewGenericCompositePodGroup(cpgObj))
 				pg := st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("cpg1").Obj()
-				queue.AddPodGroup(logger, pg)
+				queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 
 				queue.Add(ctx, pod)
 				poppedEntity, _ := queue.Pop(logger)
@@ -2036,7 +2036,7 @@ func TestDeleteCompositePodGroup(t *testing.T) {
 			}
 
 			if tt.initCPG != nil && tt.cpgEnabled {
-				sched.Cache.AddCompositePodGroup(logger, tt.initCPG)
+				sched.Cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(tt.initCPG))
 			}
 
 			sched.deleteCompositePodGroup(tt.cpgToDelete)

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -612,7 +612,7 @@ func TestPostFilter(t *testing.T) {
 
 				cache := internalcache.New(ctx, apiDispatcher, tt.features.EnableGenericWorkload, false)
 				for _, podGroup := range tt.podGroups {
-					cache.AddPodGroup(podGroup)
+					cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(podGroup))
 				}
 				snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.pods, tt.nodes, tt.podGroups)
 
@@ -2028,10 +2028,10 @@ func TestCustomSelection(t *testing.T) {
 			informerFactory.WaitForCacheSync(ctx.Done())
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
 			for _, pg := range tt.podGroups {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.compositePodGroups {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(tt.pods, nodes, tt.podGroups, tt.compositePodGroups)
 			fwk, err := tf.NewFramework(
@@ -2351,10 +2351,10 @@ func TestCustomOrdering(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
 			for _, pg := range tt.podGroups {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.compositePodGroups {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
 			fwk, err := tf.NewFramework(
@@ -2581,10 +2581,10 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 			}
 			cache := internalcache.New(ctx, nil, test.features.EnableGenericWorkload, test.features.EnableCompositePodGroup)
 			for _, pg := range test.podGroups {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range test.compositePodGroups {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(test.pods, nodes, test.podGroups, test.compositePodGroups)
 			f, err := tf.NewFramework(ctx, registeredPlugins, "",
@@ -3447,7 +3447,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, false /* CompositePodGroup */)
 			for _, pg := range tt.podGroups {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.initPods, nodes, tt.podGroups)
 
@@ -3753,10 +3753,10 @@ func TestPreEnqueue(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
 			for _, podGroup := range allPgs {
-				cache.AddPodGroup(podGroup)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(podGroup))
 			}
 			for _, cpg := range allCpgs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(pods, []*v1.Node{st.MakeNode().Name("node1").Capacity(onePodRes).Obj()}, allPgs, allCpgs)
@@ -3894,10 +3894,10 @@ func TestDefaultPreemption_PodGroupPostFilter_ErrorWrapping(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, true, tt.enableCompositePodGroup)
 			for _, pg := range pgs {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range cpgs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(testPods, nodes, pgs, cpgs)
@@ -4007,7 +4007,7 @@ func TestDefaultPreemption_PodGroupPostFilter_InvalidSnapshot(t *testing.T) {
 				pg = st.MakePodGroup().Name("preemptor-pg-ok").Priority(highPriority).Obj()
 				client = clientsetfake.NewClientset(pod, pg)
 				cache = internalcache.New(ctx, nil, true, false)
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 				snapshot = internalcache.NewTestSnapshotWithPodGroups(testPods, nodes, []*v1beta1.PodGroup{pg})
 			} else {
 				priorityVal := highPriority
@@ -4101,7 +4101,7 @@ func TestDefaultPreemption_PodGroupPostFilter_CompositePodGroup(t *testing.T) {
 	}
 
 	cache := internalcache.New(ctx, nil, true, true /* compositePodGroupEnabled */)
-	cache.AddPodGroup(pgOk)
+	cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pgOk))
 
 	snapshot := internalcache.NewEmptySnapshot()
 	f, err := tf.NewFramework(ctx, registeredPlugins, "",

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -612,7 +612,7 @@ func TestPostFilter(t *testing.T) {
 
 				cache := internalcache.New(ctx, apiDispatcher, tt.features.EnableGenericWorkload, false)
 				for _, podGroup := range tt.podGroups {
-					cache.AddPodGroup(podGroup)
+					cache.AddGenericPodGroup(framework.NewGenericPodGroup(podGroup))
 				}
 				snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.pods, tt.nodes, tt.podGroups)
 
@@ -2028,10 +2028,10 @@ func TestCustomSelection(t *testing.T) {
 			informerFactory.WaitForCacheSync(ctx.Done())
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
 			for _, pg := range tt.podGroups {
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.compositePodGroups {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(tt.pods, nodes, tt.podGroups, tt.compositePodGroups)
 			fwk, err := tf.NewFramework(
@@ -2351,10 +2351,10 @@ func TestCustomOrdering(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
 			for _, pg := range tt.podGroups {
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.compositePodGroups {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
 			fwk, err := tf.NewFramework(
@@ -2581,10 +2581,10 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 			}
 			cache := internalcache.New(ctx, nil, test.features.EnableGenericWorkload, test.features.EnableCompositePodGroup)
 			for _, pg := range test.podGroups {
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range test.compositePodGroups {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(test.pods, nodes, test.podGroups, test.compositePodGroups)
 			f, err := tf.NewFramework(ctx, registeredPlugins, "",
@@ -3447,7 +3447,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, false /* CompositePodGroup */)
 			for _, pg := range tt.podGroups {
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithPodGroups(tt.initPods, nodes, tt.podGroups)
 
@@ -3753,10 +3753,10 @@ func TestPreEnqueue(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
 			for _, podGroup := range allPgs {
-				cache.AddPodGroup(podGroup)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(podGroup))
 			}
 			for _, cpg := range allCpgs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(pods, []*v1.Node{st.MakeNode().Name("node1").Capacity(onePodRes).Obj()}, allPgs, allCpgs)
@@ -3894,10 +3894,10 @@ func TestDefaultPreemption_PodGroupPostFilter_ErrorWrapping(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, true, tt.enableCompositePodGroup)
 			for _, pg := range pgs {
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range cpgs {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(testPods, nodes, pgs, cpgs)
@@ -4007,7 +4007,7 @@ func TestDefaultPreemption_PodGroupPostFilter_InvalidSnapshot(t *testing.T) {
 				pg = st.MakePodGroup().Name("preemptor-pg-ok").Priority(highPriority).Obj()
 				client = clientsetfake.NewClientset(pod, pg)
 				cache = internalcache.New(ctx, nil, true, false)
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 				snapshot = internalcache.NewTestSnapshotWithPodGroups(testPods, nodes, []*v1beta1.PodGroup{pg})
 			} else {
 				priorityVal := highPriority
@@ -4061,18 +4061,13 @@ func TestDefaultPreemption_PodGroupPostFilter_InvalidSnapshot(t *testing.T) {
 			var pgInfo *framework.PodGroupInfo
 			if !tt.isCPG {
 				pgInfo = &framework.PodGroupInfo{
-					Name:            pg.Name,
-					Namespace:       pg.Namespace,
+					GenericPodGroup: framework.NewGenericPodGroup(pg),
 					UnscheduledPods: preemptorPods,
-					PodGroup:        pg,
 				}
 			} else {
 				pgInfo = &framework.PodGroupInfo{
-					Name:              cpg.Name,
-					Namespace:         cpg.Namespace,
-					Type:              fwk.CompositePodGroupKeyType,
-					UnscheduledPods:   preemptorPods,
-					CompositePodGroup: cpg,
+					GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+					UnscheduledPods: preemptorPods,
 				}
 			}
 			state := framework.NewCycleState()
@@ -4101,7 +4096,7 @@ func TestDefaultPreemption_PodGroupPostFilter_CompositePodGroup(t *testing.T) {
 	}
 
 	cache := internalcache.New(ctx, nil, true, true /* compositePodGroupEnabled */)
-	cache.AddPodGroup(pgOk)
+	cache.AddGenericPodGroup(framework.NewGenericPodGroup(pgOk))
 
 	snapshot := internalcache.NewEmptySnapshot()
 	f, err := tf.NewFramework(ctx, registeredPlugins, "",
@@ -4138,11 +4133,8 @@ func TestDefaultPreemption_PodGroupPostFilter_CompositePodGroup(t *testing.T) {
 		},
 	}
 	pgInfo := &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		UnscheduledPods:   preemptorPods,
-		CompositePodGroup: cpg,
+		GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+		UnscheduledPods: preemptorPods,
 	}
 
 	_, gotStatus := pl.PodGroupPostFilter(ctx, framework.NewCycleState(), pgInfo, mockSchedulingFunc)
@@ -4226,7 +4218,7 @@ func TestDefaultPreemption_PodGroupPostFilter_WorkloadPreemptionAttempts(t *test
 			expectedStatus := tt.status.Code().String()
 			stateBefore := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus)
 
-			pgInfo := &framework.PodGroupInfo{PodGroup: st.MakePodGroup().Obj()}
+			pgInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(st.MakePodGroup().Obj())}
 			pl.PodGroupPostFilter(ctx, nil, pgInfo, nil)
 
 			stateAfter := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus)
@@ -4259,26 +4251,19 @@ func getCounterFromGatherer(g componentmetrics.Gatherer, name string, resultLabe
 	return uint64(vals[resultLabelValue]), nil
 }
 
-// newPGInfo creates a PodGroupInfo representing a standalone PodGroup.
 func newPGInfo(pg *v1beta1.PodGroup, pods ...*v1.Pod) *framework.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:            pg.Name,
-		Namespace:       pg.Namespace,
-		Type:            fwk.PodGroupKeyType,
+		GenericPodGroup: framework.NewGenericPodGroup(pg),
 		UnscheduledPods: pods,
-		PodGroup:        pg,
 	}
 }
 
 // newCPGInfo creates a PodGroupInfo representing a CompositePodGroup hierarchy.
 func newCPGInfo(cpg *v1alpha3.CompositePodGroup, children []*framework.PodGroupInfo, pods ...*v1.Pod) *framework.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		UnscheduledPods:   pods,
-		CompositePodGroup: cpg,
-		Children:          children,
+		GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+		UnscheduledPods: pods,
+		Children:        children,
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -4061,18 +4061,13 @@ func TestDefaultPreemption_PodGroupPostFilter_InvalidSnapshot(t *testing.T) {
 			var pgInfo *framework.PodGroupInfo
 			if !tt.isCPG {
 				pgInfo = &framework.PodGroupInfo{
-					Name:            pg.Name,
-					Namespace:       pg.Namespace,
-					UnscheduledPods: preemptorPods,
-					PodGroup:        pg,
+					AbstractPodGroup: framework.NewAbstractPodGroup(pg),
+					UnscheduledPods:  preemptorPods,
 				}
 			} else {
 				pgInfo = &framework.PodGroupInfo{
-					Name:              cpg.Name,
-					Namespace:         cpg.Namespace,
-					Type:              fwk.CompositePodGroupKeyType,
-					UnscheduledPods:   preemptorPods,
-					CompositePodGroup: cpg,
+					AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg),
+					UnscheduledPods:  preemptorPods,
 				}
 			}
 			state := framework.NewCycleState()
@@ -4138,11 +4133,8 @@ func TestDefaultPreemption_PodGroupPostFilter_CompositePodGroup(t *testing.T) {
 		},
 	}
 	pgInfo := &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		UnscheduledPods:   preemptorPods,
-		CompositePodGroup: cpg,
+		AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg),
+		UnscheduledPods:  preemptorPods,
 	}
 
 	_, gotStatus := pl.PodGroupPostFilter(ctx, framework.NewCycleState(), pgInfo, mockSchedulingFunc)
@@ -4226,7 +4218,7 @@ func TestDefaultPreemption_PodGroupPostFilter_WorkloadPreemptionAttempts(t *test
 			expectedStatus := tt.status.Code().String()
 			stateBefore := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus)
 
-			pgInfo := &framework.PodGroupInfo{PodGroup: st.MakePodGroup().Obj()}
+			pgInfo := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(st.MakePodGroup().Obj())}
 			pl.PodGroupPostFilter(ctx, nil, pgInfo, nil)
 
 			stateAfter := captureWorkloadPreemptionAttempts(testRegistry, expectedStatus)
@@ -4259,26 +4251,19 @@ func getCounterFromGatherer(g componentmetrics.Gatherer, name string, resultLabe
 	return uint64(vals[resultLabelValue]), nil
 }
 
-// newPGInfo creates a PodGroupInfo representing a standalone PodGroup.
 func newPGInfo(pg *v1beta1.PodGroup, pods ...*v1.Pod) *framework.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:            pg.Name,
-		Namespace:       pg.Namespace,
-		Type:            fwk.PodGroupKeyType,
-		UnscheduledPods: pods,
-		PodGroup:        pg,
+		AbstractPodGroup: framework.NewAbstractPodGroup(pg),
+		UnscheduledPods:  pods,
 	}
 }
 
 // newCPGInfo creates a PodGroupInfo representing a CompositePodGroup hierarchy.
 func newCPGInfo(cpg *v1alpha3.CompositePodGroup, children []*framework.PodGroupInfo, pods ...*v1.Pod) *framework.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		UnscheduledPods:   pods,
-		CompositePodGroup: cpg,
-		Children:          children,
+		AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg),
+		UnscheduledPods:  pods,
+		Children:         children,
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4644,7 +4644,7 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 		}
 	}
 	for _, podGroup := range podGroups {
-		tc.podGroupManager.AddPodGroup(podGroup)
+		tc.podGroupManager.AddAbstractPodGroup(framework.NewAbstractPodGroup(podGroup))
 	}
 	snapshot := internalcache.NewTestSnapshotWithPodGroups(nil, nil, podGroups)
 

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4302,10 +4302,8 @@ func testPlugin(tCtx ktesting.TContext) {
 				initialObjects = testCtx.updateAPIServer(tCtx, initialObjects, tc.prepare.postfilter)
 				if len(tc.podGroups) > 0 {
 					pgInfo := &framework.PodGroupInfo{
-						Name:            tc.podGroups[0].Name,
-						Namespace:       tc.podGroups[0].Namespace,
-						UnscheduledPods: []*v1.Pod{tc.pod},
-						PodGroup:        tc.podGroups[0],
+						AbstractPodGroup: framework.NewAbstractPodGroup(tc.podGroups[0]),
+						UnscheduledPods:  []*v1.Pod{tc.pod},
 					}
 					mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 						return nil, fwk.NewStatus(fwk.Unschedulable)
@@ -6171,10 +6169,8 @@ func TestPodGroupPostFilter(t *testing.T) {
 			}
 
 			pgInfo := &framework.PodGroupInfo{
-				Name:            tc.podGroups[0].Name,
-				Namespace:       tc.podGroups[0].Namespace,
-				UnscheduledPods: tc.unscheduledPods,
-				PodGroup:        tc.podGroups[0],
+				AbstractPodGroup: framework.NewAbstractPodGroup(tc.podGroups[0]),
+				UnscheduledPods:  tc.unscheduledPods,
 			}
 
 			mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4302,10 +4302,8 @@ func testPlugin(tCtx ktesting.TContext) {
 				initialObjects = testCtx.updateAPIServer(tCtx, initialObjects, tc.prepare.postfilter)
 				if len(tc.podGroups) > 0 {
 					pgInfo := &framework.PodGroupInfo{
-						Name:            tc.podGroups[0].Name,
-						Namespace:       tc.podGroups[0].Namespace,
+						GenericPodGroup: framework.NewGenericPodGroup(tc.podGroups[0]),
 						UnscheduledPods: []*v1.Pod{tc.pod},
-						PodGroup:        tc.podGroups[0],
 					}
 					mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 						return nil, fwk.NewStatus(fwk.Unschedulable)
@@ -4644,7 +4642,7 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 		}
 	}
 	for _, podGroup := range podGroups {
-		tc.podGroupManager.AddPodGroup(podGroup)
+		tc.podGroupManager.AddGenericPodGroup(framework.NewGenericPodGroup(podGroup))
 	}
 	snapshot := internalcache.NewTestSnapshotWithPodGroups(nil, nil, podGroups)
 
@@ -6171,10 +6169,8 @@ func TestPodGroupPostFilter(t *testing.T) {
 			}
 
 			pgInfo := &framework.PodGroupInfo{
-				Name:            tc.podGroups[0].Name,
-				Namespace:       tc.podGroups[0].Namespace,
+				GenericPodGroup: framework.NewGenericPodGroup(tc.podGroups[0]),
 				UnscheduledPods: tc.unscheduledPods,
-				PodGroup:        tc.podGroups[0],
 			}
 
 			mockSchedulingFunc := func(ctx context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -1152,7 +1152,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 				if err != nil {
 					t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
 				}
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(schedulerframework.NewAbstractPodGroup(pg))
 			}
 			if tt.isCompositePodGroupEnabled {
 				for _, cpg := range tt.initialCompositePodGroups {
@@ -1160,7 +1160,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 					if err != nil {
 						t.Fatalf("Failed to add cpg %s to store: %v", cpg.Name, err)
 					}
-					cache.AddCompositePodGroup(logger, cpg)
+					cache.AddAbstractPodGroup(schedulerframework.NewAbstractCompositePodGroup(cpg))
 				}
 			}
 

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -810,7 +810,7 @@ func TestPreEnqueue(t *testing.T) {
 					features.TopologyAwareWorkloadScheduling: isCPGEnabled,
 					features.CompositePodGroup:               isCPGEnabled,
 				})
-				logger, ctx := ktesting.NewTestContext(t)
+				_, ctx := ktesting.NewTestContext(t)
 				cache := internalcache.New(ctx, nil, true, isCPGEnabled)
 
 				informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
@@ -837,15 +837,15 @@ func TestPreEnqueue(t *testing.T) {
 					if err != nil {
 						t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
 					}
-					cache.AddPodGroup(pg)
+					cache.AddGenericPodGroup(schedulerframework.NewGenericPodGroup(pg))
 				}
 				if isCPGEnabled {
 					for _, cpg := range tt.initialCompositePodGroups {
 						err := informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer().GetStore().Add(cpg)
 						if err != nil {
-							t.Fatalf("Failed to add cpg %s to store: %v", cpg.Name, err)
+							t.Fatalf("Failed to add podGroup %s to store: %v", cpg.Name, err)
 						}
-						cache.AddCompositePodGroup(logger, cpg)
+						cache.AddGenericPodGroup(schedulerframework.NewGenericCompositePodGroup(cpg))
 					}
 				}
 
@@ -1017,8 +1017,6 @@ func TestPlacementFeasible(t *testing.T) {
 					namespace := "default"
 
 					pgInfo := &schedulerframework.PodGroupInfo{
-						Namespace:       namespace,
-						Name:            pgName,
 						UnscheduledPods: tc.unscheduledPods,
 					}
 
@@ -1031,8 +1029,7 @@ func TestPlacementFeasible(t *testing.T) {
 						} else {
 							cpg.Spec.SchedulingPolicy.Basic = &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}
 						}
-						pgInfo.Type = fwk.CompositePodGroupKeyType
-						pgInfo.CompositePodGroup = cpg
+						pgInfo.GenericPodGroup = schedulerframework.NewGenericCompositePodGroup(cpg)
 						objs = append(objs, cpg)
 					} else {
 						pg := st.MakePodGroup().Namespace(namespace).Name(pgName).ParentCompositePodGroup("cpg-root").Obj()
@@ -1041,8 +1038,7 @@ func TestPlacementFeasible(t *testing.T) {
 						} else {
 							pg.Spec.SchedulingPolicy.Basic = &schedulingv1beta1.BasicSchedulingPolicy{}
 						}
-						pgInfo.Type = fwk.PodGroupKeyType
-						pgInfo.PodGroup = pg
+						pgInfo.GenericPodGroup = schedulerframework.NewGenericPodGroup(pg)
 						objs = append(objs, pg)
 					}
 

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
@@ -2717,8 +2718,8 @@ func TestScorePlacement_Resources(t *testing.T) {
 				}
 			}
 			podGroupInfo := &framework.PodGroupInfo{
-				Type:            fwk.PodGroupKeyType,
-				UnscheduledPods: tc.podGroupPods,
+				AbstractPodGroup: framework.NewAbstractPodGroup(&schedulingv1beta1.PodGroup{}),
+				UnscheduledPods:  tc.podGroupPods,
 			}
 			podGroupAssignments := &fwk.PodGroupAssignments{
 				Placement: &fwk.Placement{

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiruntime "k8s.io/apimachinery/pkg/runtime"
@@ -2717,7 +2718,7 @@ func TestScorePlacement_Resources(t *testing.T) {
 				}
 			}
 			podGroupInfo := &framework.PodGroupInfo{
-				Type:            fwk.PodGroupKeyType,
+				GenericPodGroup: framework.NewGenericPodGroup(&schedulingv1beta1.PodGroup{}),
 				UnscheduledPods: tc.podGroupPods,
 			}
 			podGroupAssignments := &fwk.PodGroupAssignments{

--- a/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count_test.go
+++ b/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count_test.go
@@ -381,7 +381,13 @@ func TestNormalizePlacementScore(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pl := &PodGroupPodsCount{}
-			pgInfo := &framework.PodGroupInfo{Name: "pg1", Type: fwk.PodGroupKeyType}
+			pgInfo := &framework.PodGroupInfo{
+				GenericPodGroup: framework.NewGenericPodGroup(&schedulingapi.PodGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pg1",
+					},
+				}),
+			}
 			status := pl.NormalizePlacementScore(context.Background(), nil, pgInfo, tt.scores)
 			if tt.expectedError != "" {
 				if status.IsSuccess() {
@@ -406,19 +412,13 @@ func TestNormalizePlacementScore(t *testing.T) {
 
 func makePodGroupInfoFromPG(pg *schedulingapi.PodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:      pg.Name,
-		Namespace: pg.Namespace,
-		PodGroup:  pg,
-		Type:      fwk.PodGroupKeyType,
+		GenericPodGroup: framework.NewGenericPodGroup(pg),
 	}
 }
 
 func makePodGroupInfoFromCPG(cpg *schedulingv1alpha3.CompositePodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		CompositePodGroup: cpg,
-		Type:              fwk.CompositePodGroupKeyType,
+		GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count_test.go
+++ b/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count_test.go
@@ -381,7 +381,13 @@ func TestNormalizePlacementScore(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pl := &PodGroupPodsCount{}
-			pgInfo := &framework.PodGroupInfo{Name: "pg1", Type: fwk.PodGroupKeyType}
+			pgInfo := &framework.PodGroupInfo{
+				AbstractPodGroup: framework.NewAbstractPodGroup(&schedulingapi.PodGroup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pg1",
+					},
+				}),
+			}
 			status := pl.NormalizePlacementScore(context.Background(), nil, pgInfo, tt.scores)
 			if tt.expectedError != "" {
 				if status.IsSuccess() {
@@ -406,19 +412,13 @@ func TestNormalizePlacementScore(t *testing.T) {
 
 func makePodGroupInfoFromPG(pg *schedulingapi.PodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:      pg.Name,
-		Namespace: pg.Namespace,
-		PodGroup:  pg,
-		Type:      fwk.PodGroupKeyType,
+		AbstractPodGroup: framework.NewAbstractPodGroup(pg),
 	}
 }
 
 func makePodGroupInfoFromCPG(cpg *schedulingv1alpha3.CompositePodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		CompositePodGroup: cpg,
-		Type:              fwk.CompositePodGroupKeyType,
+		AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg),
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
+++ b/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
@@ -476,19 +476,13 @@ func TestGeneratePlacements(t *testing.T) {
 
 func makePodGroupInfoFromPG(pg *schedulingapi.PodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:      pg.Name,
-		Namespace: pg.Namespace,
-		PodGroup:  pg,
-		Type:      fwk.PodGroupKeyType,
+		AbstractPodGroup: framework.NewAbstractPodGroup(pg),
 	}
 }
 
 func makePodGroupInfoFromCPG(cpg *schedulingv1alphav3.CompositePodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		CompositePodGroup: cpg,
-		Type:              fwk.CompositePodGroupKeyType,
+		AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg),
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
+++ b/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
@@ -476,19 +476,13 @@ func TestGeneratePlacements(t *testing.T) {
 
 func makePodGroupInfoFromPG(pg *schedulingapi.PodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:      pg.Name,
-		Namespace: pg.Namespace,
-		PodGroup:  pg,
-		Type:      fwk.PodGroupKeyType,
+		GenericPodGroup: framework.NewGenericPodGroup(pg),
 	}
 }
 
 func makePodGroupInfoFromCPG(cpg *schedulingv1alphav3.CompositePodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		CompositePodGroup: cpg,
-		Type:              fwk.CompositePodGroupKeyType,
+		GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
 	}
 }
 

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -983,10 +983,10 @@ func TestGetVictimsOnNode(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.enableGenericWorkload, tt.enableCompositePodGroup)
 			for _, pg := range tt.podGroups {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			for _, cpg := range tt.compositePodGroups {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(tt.pods, tt.nodes, tt.podGroups, tt.compositePodGroups)
 

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -983,10 +983,10 @@ func TestGetVictimsOnNode(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, tt.enableGenericWorkload, tt.enableCompositePodGroup)
 			for _, pg := range tt.podGroups {
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			for _, cpg := range tt.compositePodGroups {
-				cache.AddCompositePodGroup(logger, cpg)
+				cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 			}
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(tt.pods, tt.nodes, tt.podGroups, tt.compositePodGroups)
 

--- a/pkg/scheduler/framework/preemption/types_test.go
+++ b/pkg/scheduler/framework/preemption/types_test.go
@@ -894,11 +894,11 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 			}
 
 			for _, pg := range pgs {
-				cache.AddPodGroup(pg)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 			}
 			if tt.enableCompositePodGroup {
 				for _, cpg := range cpgs {
-					cache.AddCompositePodGroup(logger, cpg)
+					cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 				}
 			}
 

--- a/pkg/scheduler/framework/preemption/types_test.go
+++ b/pkg/scheduler/framework/preemption/types_test.go
@@ -894,11 +894,11 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 			}
 
 			for _, pg := range pgs {
-				cache.AddPodGroup(pg)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 			}
 			if tt.enableCompositePodGroup {
 				for _, cpg := range cpgs {
-					cache.AddCompositePodGroup(logger, cpg)
+					cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 				}
 			}
 
@@ -1154,25 +1154,20 @@ func TestNewDomainVictim(t *testing.T) {
 }
 
 func newTestPodGroupInfo(pg *schedulingv1beta1.PodGroup, cpg *schedulingv1alpha3.CompositePodGroup, pods []*v1.Pod) *framework.PodGroupInfo {
-	pgi := &framework.PodGroupInfo{
-		UnscheduledPods:   pods,
-		PodGroup:          pg,
-		CompositePodGroup: cpg,
-	}
 	if cpg != nil {
-		pgi.Name = cpg.Name
-		pgi.Namespace = cpg.Namespace
-		pgi.Type = fwk.CompositePodGroupKeyType
-		pgi.Children = []*framework.PodGroupInfo{
-			{
-				PodGroup:        &schedulingv1beta1.PodGroup{},
-				UnscheduledPods: pods,
+		return &framework.PodGroupInfo{
+			GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
+			UnscheduledPods: pods,
+			Children: []*framework.PodGroupInfo{
+				{
+					GenericPodGroup: framework.NewGenericPodGroup(&schedulingv1beta1.PodGroup{}),
+					UnscheduledPods: pods,
+				},
 			},
 		}
-	} else if pg != nil {
-		pgi.Name = pg.Name
-		pgi.Namespace = pg.Namespace
-		pgi.Type = fwk.PodGroupKeyType
 	}
-	return pgi
+	return &framework.PodGroupInfo{
+		GenericPodGroup: framework.NewGenericPodGroup(pg),
+		UnscheduledPods: pods,
+	}
 }

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -917,26 +918,20 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 		expectedResult      *fwk.PodGroupPostFilterResult
 	}{
 		{
-			name: "no registered plugins",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:                "no registered plugins",
+			podGroupInfo:        newQueuedPodGroupInfoForTest("default", "pg1"),
 			featureFlagEnabeled: true,
 			expectedStatus:      fwk.NewStatus(fwk.Unschedulable),
 		},
 		{
-			name: "generic workload feature is disabled",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:                "generic workload feature is disabled",
+			podGroupInfo:        newQueuedPodGroupInfoForTest("default", "pg1"),
 			featureFlagEnabeled: false,
 			expectedStatus:      fwk.NewStatus(fwk.Unschedulable, "generic workload feature is disabled, cannot perform PodGroupPostFilter"),
 		},
 		{
-			name: "first plugin returns error",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "first plugin returns error",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -949,10 +944,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			expectedStatus:      fwk.NewStatus(fwk.Error, "error in \"plugin1\" PodGroupPostFilter plugins: "+injectReason).WithPlugin("plugin1"),
 		},
 		{
-			name: "first plugin returns non supported status: Skip",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "first plugin returns non supported status: Skip",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -965,10 +958,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			expectedStatus:      fwk.NewStatus(fwk.Error, "error in \"plugin1\" PodGroupPostFilter plugins: "+injectReason).WithPlugin("plugin1"),
 		},
 		{
-			name: "first plugin returns success",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "first plugin returns success",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -997,10 +988,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			},
 		},
 		{
-			name: "first plugin returns UnschedulableAndUnresolvable",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "first plugin returns UnschedulableAndUnresolvable",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -1019,10 +1008,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			expectedStatus:      fwk.NewStatus(fwk.UnschedulableAndUnresolvable, injectReason).WithPlugin("plugin1"),
 		},
 		{
-			name: "first plugin returns Unschedulable, second returns success",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "first plugin returns Unschedulable, second returns success",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -1051,10 +1038,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			},
 		},
 		{
-			name: "all plugins return Unschedulable, aggregate reasons",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "all plugins return Unschedulable, aggregate reasons",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -4620,7 +4605,7 @@ func TestRecordingMetrics(t *testing.T) {
 				var pgSchedulingFunc fwk.PodGroupSchedulingFunc = func(_ context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 					return &fwk.PodGroupAssignments{}, nil
 				}
-				f.RunPodGroupPostFilterPlugins(ctx, state, &framework.QueuedPodGroupInfo{PodGroupInfo: &framework.PodGroupInfo{}}, pgSchedulingFunc)
+				f.RunPodGroupPostFilterPlugins(ctx, state, newQueuedPodGroupInfoForTest("", ""), pgSchedulingFunc)
 			},
 			inject:             injectedResult{PodGroupPostFilterStatus: int(fwk.Success)},
 			wantExtensionPoint: "PodGroupPostFilter",
@@ -4718,7 +4703,7 @@ func TestRecordingMetrics(t *testing.T) {
 				var pgSchedulingFunc fwk.PodGroupSchedulingFunc = func(_ context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 					return &fwk.PodGroupAssignments{}, nil
 				}
-				f.RunPodGroupPostFilterPlugins(ctx, state, &framework.QueuedPodGroupInfo{PodGroupInfo: &framework.PodGroupInfo{}}, pgSchedulingFunc)
+				f.RunPodGroupPostFilterPlugins(ctx, state, newQueuedPodGroupInfoForTest("", ""), pgSchedulingFunc)
 			},
 			inject:             injectedResult{PodGroupPostFilterStatus: int(fwk.Error)},
 			wantExtensionPoint: "PodGroupPostFilter",
@@ -5777,5 +5762,18 @@ scheduler_plugin_evaluation_total{extension_point="Score",plugin="plugin-eval-sc
 `
 	if err := testutil.GatherAndCompare(metrics.GetGather(), strings.NewReader(want), metrics.PluginEvaluationTotal.Name); err != nil {
 		t.Fatalf("unexpected plugin_evaluation_total metric output:\n%v", err)
+	}
+}
+
+func newQueuedPodGroupInfoForTest(ns, name string) *framework.QueuedPodGroupInfo {
+	return &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			AbstractPodGroup: framework.NewAbstractPodGroup(&schedulingv1beta1.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+					Name:      name,
+				},
+			}),
+		},
 	}
 }

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -917,26 +918,20 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 		expectedResult      *fwk.PodGroupPostFilterResult
 	}{
 		{
-			name: "no registered plugins",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:                "no registered plugins",
+			podGroupInfo:        newQueuedPodGroupInfoForTest("default", "pg1"),
 			featureFlagEnabeled: true,
 			expectedStatus:      fwk.NewStatus(fwk.Unschedulable),
 		},
 		{
-			name: "generic workload feature is disabled",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:                "generic workload feature is disabled",
+			podGroupInfo:        newQueuedPodGroupInfoForTest("default", "pg1"),
 			featureFlagEnabeled: false,
 			expectedStatus:      fwk.NewStatus(fwk.Unschedulable, "generic workload feature is disabled, cannot perform PodGroupPostFilter"),
 		},
 		{
-			name: "first plugin returns error",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "first plugin returns error",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -949,10 +944,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			expectedStatus:      fwk.NewStatus(fwk.Error, "error in \"plugin1\" PodGroupPostFilter plugins: "+injectReason).WithPlugin("plugin1"),
 		},
 		{
-			name: "first plugin returns non supported status: Skip",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "first plugin returns non supported status: Skip",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -965,10 +958,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			expectedStatus:      fwk.NewStatus(fwk.Error, "error in \"plugin1\" PodGroupPostFilter plugins: "+injectReason).WithPlugin("plugin1"),
 		},
 		{
-			name: "first plugin returns success",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "first plugin returns success",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -997,10 +988,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			},
 		},
 		{
-			name: "first plugin returns UnschedulableAndUnresolvable",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "first plugin returns UnschedulableAndUnresolvable",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -1019,10 +1008,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			expectedStatus:      fwk.NewStatus(fwk.UnschedulableAndUnresolvable, injectReason).WithPlugin("plugin1"),
 		},
 		{
-			name: "first plugin returns Unschedulable, second returns success",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "first plugin returns Unschedulable, second returns success",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -1051,10 +1038,8 @@ func TestRunPodGroupPostFilterPlugins(t *testing.T) {
 			},
 		},
 		{
-			name: "all plugins return Unschedulable, aggregate reasons",
-			podGroupInfo: &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{Namespace: "default", Name: "pg1"},
-			},
+			name:         "all plugins return Unschedulable, aggregate reasons",
+			podGroupInfo: newQueuedPodGroupInfoForTest("default", "pg1"),
 			plugins: []*TestPlugin{
 				{
 					name: "plugin1",
@@ -4620,7 +4605,7 @@ func TestRecordingMetrics(t *testing.T) {
 				var pgSchedulingFunc fwk.PodGroupSchedulingFunc = func(_ context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 					return &fwk.PodGroupAssignments{}, nil
 				}
-				f.RunPodGroupPostFilterPlugins(ctx, state, &framework.QueuedPodGroupInfo{PodGroupInfo: &framework.PodGroupInfo{}}, pgSchedulingFunc)
+				f.RunPodGroupPostFilterPlugins(ctx, state, newQueuedPodGroupInfoForTest("", ""), pgSchedulingFunc)
 			},
 			inject:             injectedResult{PodGroupPostFilterStatus: int(fwk.Success)},
 			wantExtensionPoint: "PodGroupPostFilter",
@@ -4718,7 +4703,7 @@ func TestRecordingMetrics(t *testing.T) {
 				var pgSchedulingFunc fwk.PodGroupSchedulingFunc = func(_ context.Context) (*fwk.PodGroupAssignments, *fwk.Status) {
 					return &fwk.PodGroupAssignments{}, nil
 				}
-				f.RunPodGroupPostFilterPlugins(ctx, state, &framework.QueuedPodGroupInfo{PodGroupInfo: &framework.PodGroupInfo{}}, pgSchedulingFunc)
+				f.RunPodGroupPostFilterPlugins(ctx, state, newQueuedPodGroupInfoForTest("", ""), pgSchedulingFunc)
 			},
 			inject:             injectedResult{PodGroupPostFilterStatus: int(fwk.Error)},
 			wantExtensionPoint: "PodGroupPostFilter",
@@ -5777,5 +5762,18 @@ scheduler_plugin_evaluation_total{extension_point="Score",plugin="plugin-eval-sc
 `
 	if err := testutil.GatherAndCompare(metrics.GetGather(), strings.NewReader(want), metrics.PluginEvaluationTotal.Name); err != nil {
 		t.Fatalf("unexpected plugin_evaluation_total metric output:\n%v", err)
+	}
+}
+
+func newQueuedPodGroupInfoForTest(ns, name string) *framework.QueuedPodGroupInfo {
+	return &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			GenericPodGroup: framework.NewGenericPodGroup(&schedulingv1beta1.PodGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ns,
+					Name:      name,
+				},
+			}),
+		},
 	}
 }

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -1041,70 +1041,17 @@ func (pgqi *QueuedPodGroupInfo) SetFlushTimestamp(t time.Time) {
 	pgqi.FlushTimestamp = t
 }
 
-// AddPodGroup adds a pod group to the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) AddPodGroup(pg *schedulingv1beta1.PodGroup) {
-	// We only add non-root pod groups to the hierarchy, because the root
-	// pod group is already present in the hierarchy.
-	if !utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) || pg.Spec.ParentCompositePodGroupName == nil {
+// AddAbstractPodGroup adds an abstract pod group to the queued pod group info hierarchy.
+func (pgqi *QueuedPodGroupInfo) AddAbstractPodGroup(apg *AbstractPodGroup, subtree *PodGroupInfo) {
+	parentName := apg.GetParentCompositePodGroupName()
+	if parentName == nil {
 		return
 	}
 
-	parent, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *pg.Spec.ParentCompositePodGroupName)
+	parent, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *parentName)
 	if parent != nil && parent.GetCompositePodGroup() != nil {
 		for _, child := range parent.Children {
-			if child.GetName() == pg.Name {
-				return
-			}
-		}
-		pgInfo := &PodGroupInfo{
-			Namespace: pg.Namespace,
-			Name:      pg.Name,
-			Type:      fwk.PodGroupKeyType,
-			PodGroup:  pg,
-			Children:  make([]*PodGroupInfo, 0),
-		}
-		parent.Children = append(parent.Children, pgInfo)
-	}
-}
-
-// UpdatePodGroup updates a pod group in the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) UpdatePodGroup(pg *schedulingv1beta1.PodGroup) {
-	node, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, pg.Name)
-	if node != nil && node.GetPodGroup() != nil {
-		node.PodGroup = pg
-	}
-}
-
-// RemovePodGroup removes a pod group from the queued pod group info hierarchy.
-// It returns a slice of all pods within the hierarchy of the removed pod group.
-func (pgqi *QueuedPodGroupInfo) RemovePodGroup(pg *schedulingv1beta1.PodGroup) []*QueuedPodInfo {
-	node, parent := findNodeAndParent(pgqi.PodGroupInfo, nil, pg.Name)
-	if node == nil {
-		return nil
-	}
-
-	if parent != nil {
-		for i, child := range parent.Children {
-			if child.GetName() == pg.Name {
-				parent.Children = append(parent.Children[:i], parent.Children[i+1:]...)
-				break
-			}
-		}
-	}
-
-	return pgqi.deleteSubtreePods(node)
-}
-
-// AddCompositePodGroup adds a composite pod group to the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) AddCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup, subtree *PodGroupInfo) {
-	if cpg.Spec.ParentCompositePodGroupName == nil {
-		return
-	}
-
-	parent, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *cpg.Spec.ParentCompositePodGroupName)
-	if parent != nil && parent.GetCompositePodGroup() != nil {
-		for _, child := range parent.Children {
-			if child.GetName() == cpg.Name {
+			if child.GetName() == apg.GetName() {
 				return
 			}
 		}
@@ -1112,25 +1059,29 @@ func (pgqi *QueuedPodGroupInfo) AddCompositePodGroup(cpg *schedulingv1alpha3.Com
 	}
 }
 
-// UpdateCompositePodGroup updates a composite pod group in the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) UpdateCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) {
-	node, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, cpg.Name)
-	if node != nil && node.GetCompositePodGroup() != nil {
-		node.CompositePodGroup = cpg
+// UpdateAbstractPodGroup updates an abstract pod group in the queued pod group info hierarchy.
+func (pgqi *QueuedPodGroupInfo) UpdateAbstractPodGroup(apg *AbstractPodGroup) {
+	node, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, apg.GetName())
+	if node != nil {
+		if apg.PodGroup != nil && node.GetPodGroup() != nil {
+			node.PodGroup = apg.PodGroup
+		} else if apg.CompositePodGroup != nil && node.GetCompositePodGroup() != nil {
+			node.CompositePodGroup = apg.CompositePodGroup
+		}
 	}
 }
 
-// RemoveCompositePodGroup removes a composite pod group from the queued pod group info hierarchy.
-// It returns a slice of all pods within the hierarchy of the removed composite pod group.
-func (pgqi *QueuedPodGroupInfo) RemoveCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) []*QueuedPodInfo {
-	node, parent := findNodeAndParent(pgqi.PodGroupInfo, nil, cpg.Name)
+// RemoveAbstractPodGroup removes an abstract pod group from the queued pod group info hierarchy.
+// It returns a slice of all pods within the hierarchy of the removed pod group / composite pod group.
+func (pgqi *QueuedPodGroupInfo) RemoveAbstractPodGroup(apg *AbstractPodGroup) []*QueuedPodInfo {
+	node, parent := findNodeAndParent(pgqi.PodGroupInfo, nil, apg.GetName())
 	if node == nil {
 		return nil
 	}
 
 	if parent != nil {
 		for i, child := range parent.Children {
-			if child.GetName() == cpg.Name {
+			if child.GetName() == apg.GetName() {
 				parent.Children = append(parent.Children[:i], parent.Children[i+1:]...)
 				break
 			}
@@ -1185,6 +1136,85 @@ func newQueuedPodGroupInfo(pg *schedulingv1beta1.PodGroup) *QueuedPodGroupInfo {
 		},
 		QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 	}
+}
+
+// AbstractPodGroup is a wrapper around either a PodGroup or a CompositePodGroup API object,
+// providing a unified interface for scheduler's internal operations on PodGroup objects.
+type AbstractPodGroup struct {
+	// PodGroup is a PodGroup API object.
+	PodGroup *schedulingv1beta1.PodGroup
+	// CompositePodGroup is a CompositePodGroup API object.
+	// It should be set only when CompositePodGroup feature is enabled.
+	CompositePodGroup *schedulingv1alpha3.CompositePodGroup
+}
+
+// NewAbstractPodGroup returns an AbstractPodGroup for a PodGroup.
+func NewAbstractPodGroup(pg *schedulingv1beta1.PodGroup) *AbstractPodGroup {
+	return &AbstractPodGroup{PodGroup: pg}
+}
+
+// NewAbstractCompositePodGroup returns an AbstractPodGroup for a CompositePodGroup.
+func NewAbstractCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) *AbstractPodGroup {
+	return &AbstractPodGroup{CompositePodGroup: cpg}
+}
+
+func (apg *AbstractPodGroup) GetName() string {
+	if apg.PodGroup != nil {
+		return apg.PodGroup.Name
+	}
+	if apg.CompositePodGroup != nil {
+		return apg.CompositePodGroup.Name
+	}
+	return ""
+}
+
+func (apg *AbstractPodGroup) GetNamespace() string {
+	if apg.PodGroup != nil {
+		return apg.PodGroup.Namespace
+	}
+	if apg.CompositePodGroup != nil {
+		return apg.CompositePodGroup.Namespace
+	}
+	return ""
+}
+
+func (apg *AbstractPodGroup) GetType() fwk.EntityKeyType {
+	if apg.PodGroup != nil {
+		return fwk.PodGroupKeyType
+	}
+	return fwk.CompositePodGroupKeyType
+}
+
+func (apg *AbstractPodGroup) GetKey() fwk.EntityKey {
+	if apg.PodGroup != nil {
+		return fwk.PodGroupKey(apg.PodGroup.Namespace, apg.PodGroup.Name)
+	}
+	if apg.CompositePodGroup != nil {
+		return fwk.CompositePodGroupKey(apg.CompositePodGroup.Namespace, apg.CompositePodGroup.Name)
+	}
+	return fwk.EntityKey{}
+}
+
+func (apg *AbstractPodGroup) GetParentCompositePodGroupName() *string {
+	if apg.PodGroup != nil {
+		return apg.PodGroup.Spec.ParentCompositePodGroupName
+	}
+	if apg.CompositePodGroup != nil {
+		return apg.CompositePodGroup.Spec.ParentCompositePodGroupName
+	}
+	return nil
+}
+
+func (apg *AbstractPodGroup) HasParent() bool {
+	return apg.GetParentCompositePodGroupName() != nil
+}
+
+func (apg *AbstractPodGroup) GetParentKey() (fwk.EntityKey, bool) {
+	parentName := apg.GetParentCompositePodGroupName()
+	if parentName == nil {
+		return fwk.EntityKey{}, false
+	}
+	return fwk.CompositePodGroupKey(apg.GetNamespace(), *parentName), true
 }
 
 // PodGroupInfo is a wrapper around the PodGroup API object together with a list of pods that belong to the pod group.

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -797,18 +797,6 @@ func (pgqi *QueuedPodGroupInfo) Type() fwk.EntityKeyType {
 // AddPod adds a pod to the queued pod group info, if the pod belongs to the pod group.
 // In case of hierarchy, we need to go to all leaf PodGroups.
 func (pgqi *QueuedPodGroupInfo) AddPod(pInfo *QueuedPodInfo) {
-	if pInfo.Pod.Namespace != pgqi.GetNamespace() {
-		return
-	}
-
-	if pgqi.GetPodGroup() == nil && pgqi.GetCompositePodGroup() == nil {
-		return
-	}
-
-	if pInfo.Pod.Spec.SchedulingGroup == nil || pInfo.Pod.Spec.SchedulingGroup.PodGroupName == nil {
-		return
-	}
-
 	leafPG, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *pInfo.Pod.Spec.SchedulingGroup.PodGroupName)
 	if leafPG == nil {
 		return
@@ -818,7 +806,7 @@ func (pgqi *QueuedPodGroupInfo) AddPod(pInfo *QueuedPodInfo) {
 		pgqi.QueuedPodInfos = make(map[fwk.EntityKey][]*QueuedPodInfo)
 	}
 
-	key := fwk.PodGroupKey(leafPG.Namespace, leafPG.Name)
+	key := fwk.PodGroupKey(leafPG.GetNamespace(), leafPG.GetName())
 	index, _ := slices.BinarySearchFunc(pgqi.QueuedPodInfos[key], pInfo, PodGroupMemberPodsOrderingFunc)
 
 	pgqi.QueuedPodInfos[key] = slices.Insert(pgqi.QueuedPodInfos[key], index, pInfo)
@@ -828,18 +816,6 @@ func (pgqi *QueuedPodGroupInfo) AddPod(pInfo *QueuedPodInfo) {
 // RemovePod removes a pod from the queued pod group info, if the pod belongs to the pod group.
 // In case of hierarchy, we need to go to all leaf PodGroups.
 func (pgqi *QueuedPodGroupInfo) RemovePod(pod *v1.Pod) *QueuedPodInfo {
-	if pod.Namespace != pgqi.GetNamespace() {
-		return nil
-	}
-
-	if pgqi.QueuedPodInfos == nil {
-		return nil
-	}
-
-	if pod.Spec.SchedulingGroup == nil || pod.Spec.SchedulingGroup.PodGroupName == nil {
-		return nil
-	}
-
 	key := fwk.PodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
 	list, exists := pgqi.QueuedPodInfos[key]
 	if !exists {
@@ -932,14 +908,6 @@ func (pgqi *QueuedPodGroupInfo) ForEachPodInfo(fn func(pInfo *QueuedPodInfo) boo
 }
 
 func (pgqi *QueuedPodGroupInfo) Update(pod *v1.Pod) (*QueuedPodInfo, error) {
-	if pgqi.QueuedPodInfos == nil {
-		return nil, fmt.Errorf("pod %s/%s to update not found in the queued group info", pod.Namespace, pod.Name)
-	}
-
-	if pod.Spec.SchedulingGroup == nil || pod.Spec.SchedulingGroup.PodGroupName == nil {
-		return nil, fmt.Errorf("pod %s/%s to update not found in the queued group info", pod.Namespace, pod.Name)
-	}
-
 	key := fwk.PodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
 	list, exists := pgqi.QueuedPodInfos[key]
 	if !exists {
@@ -970,17 +938,6 @@ func (pgqi *QueuedPodGroupInfo) Update(pod *v1.Pod) (*QueuedPodInfo, error) {
 // Gated returns true if the pod is gated by any plugin.
 func (pgqi *QueuedPodGroupInfo) Gated() bool {
 	return pgqi.QueueingParams.GatingPlugin != ""
-}
-
-// GetPriority returns the pod group's priority.
-func (pgqi *QueuedPodGroupInfo) GetPriority() int32 {
-	if pgqi.PodGroup != nil {
-		return schedutil.PodGroupPriority(pgqi.PodGroup)
-	}
-	if pgqi.CompositePodGroup != nil {
-		return schedutil.CompositePodGroupPriority(pgqi.CompositePodGroup)
-	}
-	return 0
 }
 
 func (pgqi *QueuedPodGroupInfo) Size() int {
@@ -1041,17 +998,17 @@ func (pgqi *QueuedPodGroupInfo) SetFlushTimestamp(t time.Time) {
 	pgqi.FlushTimestamp = t
 }
 
-// AddAbstractPodGroup adds an abstract pod group to the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) AddAbstractPodGroup(apg *AbstractPodGroup, subtree *PodGroupInfo) {
-	parentName := apg.GetParentCompositePodGroupName()
+// AddSubtree adds a subtree to the queued pod group info hierarchy.
+func (pgqi *QueuedPodGroupInfo) AddSubtree(subtree *PodGroupInfo) {
+	parentName := subtree.GetParentCompositePodGroupName()
 	if parentName == nil {
 		return
 	}
 
 	parent, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *parentName)
-	if parent != nil && parent.GetCompositePodGroup() != nil {
+	if parent != nil {
 		for _, child := range parent.Children {
-			if child.GetName() == apg.GetName() {
+			if child.GetName() == subtree.GetName() {
 				return
 			}
 		}
@@ -1063,11 +1020,7 @@ func (pgqi *QueuedPodGroupInfo) AddAbstractPodGroup(apg *AbstractPodGroup, subtr
 func (pgqi *QueuedPodGroupInfo) UpdateAbstractPodGroup(apg *AbstractPodGroup) {
 	node, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, apg.GetName())
 	if node != nil {
-		if apg.PodGroup != nil && node.GetPodGroup() != nil {
-			node.PodGroup = apg.PodGroup
-		} else if apg.CompositePodGroup != nil && node.GetCompositePodGroup() != nil {
-			node.CompositePodGroup = apg.CompositePodGroup
-		}
+		node.AbstractPodGroup = apg
 	}
 }
 
@@ -1097,11 +1050,9 @@ func findNodeAndParent(curr, parent *PodGroupInfo, name string) (*PodGroupInfo, 
 	if curr.GetName() == name {
 		return curr, parent
 	}
-	if curr.GetCompositePodGroup() != nil {
-		for _, child := range curr.Children {
-			if n, p := findNodeAndParent(child, curr, name); n != nil {
-				return n, p
-			}
+	for _, child := range curr.Children {
+		if n, p := findNodeAndParent(child, curr, name); n != nil {
+			return n, p
 		}
 	}
 	return nil, nil
@@ -1112,12 +1063,13 @@ func findNodeAndParent(curr, parent *PodGroupInfo, name string) (*PodGroupInfo, 
 // It returns a flat slice of all QueuedPodInfo elements that were successfully removed.
 func (pgqi *QueuedPodGroupInfo) deleteSubtreePods(curr *PodGroupInfo) []*QueuedPodInfo {
 	removedPods := make([]*QueuedPodInfo, 0)
-	if curr.GetPodGroup() != nil {
-		key := fwk.PodGroupKey(curr.Namespace, curr.Name)
+	if curr.GetType() == fwk.PodGroupKeyType {
+		key := fwk.PodGroupKey(curr.GetNamespace(), curr.GetName())
 		if pods, ok := pgqi.QueuedPodInfos[key]; ok {
 			removedPods = append(removedPods, pods...)
 			delete(pgqi.QueuedPodInfos, key)
 		}
+		return removedPods
 	}
 	for _, child := range curr.Children {
 		removedPods = append(removedPods, pgqi.deleteSubtreePods(child)...)
@@ -1128,11 +1080,8 @@ func (pgqi *QueuedPodGroupInfo) deleteSubtreePods(curr *PodGroupInfo) []*QueuedP
 func newQueuedPodGroupInfo(pg *schedulingv1beta1.PodGroup) *QueuedPodGroupInfo {
 	return &QueuedPodGroupInfo{
 		PodGroupInfo: &PodGroupInfo{
-			Namespace: pg.Namespace,
-			Name:      pg.Name,
-			Type:      fwk.PodGroupKeyType,
-			PodGroup:  pg,
-			Children:  make([]*PodGroupInfo, 0),
+			AbstractPodGroup: NewAbstractPodGroup(pg),
+			Children:         make([]*PodGroupInfo, 0),
 		},
 		QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 	}
@@ -1162,20 +1111,14 @@ func (apg *AbstractPodGroup) GetName() string {
 	if apg.PodGroup != nil {
 		return apg.PodGroup.Name
 	}
-	if apg.CompositePodGroup != nil {
-		return apg.CompositePodGroup.Name
-	}
-	return ""
+	return apg.CompositePodGroup.Name
 }
 
 func (apg *AbstractPodGroup) GetNamespace() string {
 	if apg.PodGroup != nil {
 		return apg.PodGroup.Namespace
 	}
-	if apg.CompositePodGroup != nil {
-		return apg.CompositePodGroup.Namespace
-	}
-	return ""
+	return apg.CompositePodGroup.Namespace
 }
 
 func (apg *AbstractPodGroup) GetType() fwk.EntityKeyType {
@@ -1189,20 +1132,14 @@ func (apg *AbstractPodGroup) GetKey() fwk.EntityKey {
 	if apg.PodGroup != nil {
 		return fwk.PodGroupKey(apg.PodGroup.Namespace, apg.PodGroup.Name)
 	}
-	if apg.CompositePodGroup != nil {
-		return fwk.CompositePodGroupKey(apg.CompositePodGroup.Namespace, apg.CompositePodGroup.Name)
-	}
-	return fwk.EntityKey{}
+	return fwk.CompositePodGroupKey(apg.CompositePodGroup.Namespace, apg.CompositePodGroup.Name)
 }
 
 func (apg *AbstractPodGroup) GetParentCompositePodGroupName() *string {
 	if apg.PodGroup != nil {
 		return apg.PodGroup.Spec.ParentCompositePodGroupName
 	}
-	if apg.CompositePodGroup != nil {
-		return apg.CompositePodGroup.Spec.ParentCompositePodGroupName
-	}
-	return nil
+	return apg.CompositePodGroup.Spec.ParentCompositePodGroupName
 }
 
 func (apg *AbstractPodGroup) HasParent() bool {
@@ -1217,44 +1154,36 @@ func (apg *AbstractPodGroup) GetParentKey() (fwk.EntityKey, bool) {
 	return fwk.CompositePodGroupKey(apg.GetNamespace(), *parentName), true
 }
 
+func (apg *AbstractPodGroup) GetPriority() int32 {
+	if apg.PodGroup != nil {
+		return schedutil.PodGroupPriority(apg.PodGroup)
+	}
+	return schedutil.CompositePodGroupPriority(apg.CompositePodGroup)
+}
+
+func (apg *AbstractPodGroup) GetCreationTimestamp() time.Time {
+	if apg.PodGroup != nil {
+		return apg.PodGroup.CreationTimestamp.Time
+	}
+	return apg.CompositePodGroup.CreationTimestamp.Time
+}
+
 // PodGroupInfo is a wrapper around the PodGroup API object together with a list of pods that belong to the pod group.
 // Typically used as an input to pod group scheduling cycle plugins.
 type PodGroupInfo struct {
-	// Namespace is a namespace of this pod group.
-	Namespace string
-	// Name is a name of this pod group.
-	Name string
-	// Type is a type of the pod group: either composite pod group or pod group.
-	Type fwk.EntityKeyType
+	*AbstractPodGroup
 	// UnscheduledPods are pods that are currently being considered for scheduling.
 	// It can be useful to also retrieve the scheduled (assumed or assigned) pods.
 	// PodGroupManager.PodGroupState can be used for that.
 	// The order of the pods is deterministic and based on signature, priority and timestamp.
 	// Only leaf pod groups have unscheduled pods.
 	UnscheduledPods []*v1.Pod
-	// PodGroup is a PodGroup API object.
-	PodGroup *schedulingv1beta1.PodGroup
-	// CompositePodGroup is a CompositePodGroup API object.
-	// It should be set only when CompositePodGroup feature is enabled.
-	CompositePodGroup *schedulingv1alpha3.CompositePodGroup
 	// Children are the child pod groups of this pod group. Only composite pod groups have children.
 	Children []*PodGroupInfo
 }
 
-func (pgi *PodGroupInfo) GetName() string {
-	return pgi.Name
-}
-
-func (pgi *PodGroupInfo) GetNamespace() string {
-	return pgi.Namespace
-}
-
-func (pgi *PodGroupInfo) GetType() fwk.EntityKeyType {
-	return pgi.Type
-}
-
 func (pgi *PodGroupInfo) GetKey() string {
-	return fmt.Sprintf("%s/%s/%s", pgi.Type, pgi.Namespace, pgi.Name)
+	return fmt.Sprintf("%s/%s/%s", pgi.GetType(), pgi.GetNamespace(), pgi.GetName())
 }
 
 // GetUnscheduledPods returns the unscheduled pods for this pod group.
@@ -1290,13 +1219,6 @@ func (pgi *PodGroupInfo) GetChildren() []fwk.PodGroupInfo {
 	return children
 }
 
-func (pgi *PodGroupInfo) GetCreationTimestamp() time.Time {
-	if pgi.PodGroup != nil {
-		return pgi.PodGroup.CreationTimestamp.Time
-	}
-	return pgi.CompositePodGroup.CreationTimestamp.Time
-}
-
 func (pgi *PodGroupInfo) GetChildGroups() []*PodGroupInfo {
 	if pgi.CompositePodGroup == nil {
 		// Only CompositePodGroups have children groups.
@@ -1315,9 +1237,9 @@ func (pgi *PodGroupInfo) GetChildGroups() []*PodGroupInfo {
 		if aTime.After(bTime) {
 			return 1
 		}
-		if a.Name < b.Name {
+		if a.GetName() < b.GetName() {
 			return -1
-		} else if a.Name > b.Name {
+		} else if a.GetName() > b.GetName() {
 			return 1
 		}
 		return 0

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -791,24 +791,12 @@ type QueuedPodGroupInfo struct {
 }
 
 func (pgqi *QueuedPodGroupInfo) Type() fwk.EntityKeyType {
-	return fwk.PodGroupKeyType
+	return pgqi.PodGroupInfo.GetType()
 }
 
 // AddPod adds a pod to the queued pod group info, if the pod belongs to the pod group.
 // In case of hierarchy, we need to go to all leaf PodGroups.
 func (pgqi *QueuedPodGroupInfo) AddPod(pInfo *QueuedPodInfo) {
-	if pInfo.Pod.Namespace != pgqi.GetNamespace() {
-		return
-	}
-
-	if pgqi.GetPodGroup() == nil && pgqi.GetCompositePodGroup() == nil {
-		return
-	}
-
-	if pInfo.Pod.Spec.SchedulingGroup == nil || pInfo.Pod.Spec.SchedulingGroup.PodGroupName == nil {
-		return
-	}
-
 	leafPG, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *pInfo.Pod.Spec.SchedulingGroup.PodGroupName)
 	if leafPG == nil {
 		return
@@ -818,7 +806,7 @@ func (pgqi *QueuedPodGroupInfo) AddPod(pInfo *QueuedPodInfo) {
 		pgqi.QueuedPodInfos = make(map[fwk.EntityKey][]*QueuedPodInfo)
 	}
 
-	key := fwk.PodGroupKey(leafPG.Namespace, leafPG.Name)
+	key := fwk.PodGroupKey(leafPG.GetNamespace(), leafPG.GetName())
 	index, _ := slices.BinarySearchFunc(pgqi.QueuedPodInfos[key], pInfo, PodGroupMemberPodsOrderingFunc)
 
 	pgqi.QueuedPodInfos[key] = slices.Insert(pgqi.QueuedPodInfos[key], index, pInfo)
@@ -828,18 +816,6 @@ func (pgqi *QueuedPodGroupInfo) AddPod(pInfo *QueuedPodInfo) {
 // RemovePod removes a pod from the queued pod group info, if the pod belongs to the pod group.
 // In case of hierarchy, we need to go to all leaf PodGroups.
 func (pgqi *QueuedPodGroupInfo) RemovePod(pod *v1.Pod) *QueuedPodInfo {
-	if pod.Namespace != pgqi.GetNamespace() {
-		return nil
-	}
-
-	if pgqi.QueuedPodInfos == nil {
-		return nil
-	}
-
-	if pod.Spec.SchedulingGroup == nil || pod.Spec.SchedulingGroup.PodGroupName == nil {
-		return nil
-	}
-
 	key := fwk.PodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
 	list, exists := pgqi.QueuedPodInfos[key]
 	if !exists {
@@ -932,14 +908,6 @@ func (pgqi *QueuedPodGroupInfo) ForEachPodInfo(fn func(pInfo *QueuedPodInfo) boo
 }
 
 func (pgqi *QueuedPodGroupInfo) Update(pod *v1.Pod) (*QueuedPodInfo, error) {
-	if pgqi.QueuedPodInfos == nil {
-		return nil, fmt.Errorf("pod %s/%s to update not found in the queued group info", pod.Namespace, pod.Name)
-	}
-
-	if pod.Spec.SchedulingGroup == nil || pod.Spec.SchedulingGroup.PodGroupName == nil {
-		return nil, fmt.Errorf("pod %s/%s to update not found in the queued group info", pod.Namespace, pod.Name)
-	}
-
 	key := fwk.PodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
 	list, exists := pgqi.QueuedPodInfos[key]
 	if !exists {
@@ -970,17 +938,6 @@ func (pgqi *QueuedPodGroupInfo) Update(pod *v1.Pod) (*QueuedPodInfo, error) {
 // Gated returns true if the pod is gated by any plugin.
 func (pgqi *QueuedPodGroupInfo) Gated() bool {
 	return pgqi.QueueingParams.GatingPlugin != ""
-}
-
-// GetPriority returns the pod group's priority.
-func (pgqi *QueuedPodGroupInfo) GetPriority() int32 {
-	if pgqi.PodGroup != nil {
-		return schedutil.PodGroupPriority(pgqi.PodGroup)
-	}
-	if pgqi.CompositePodGroup != nil {
-		return schedutil.CompositePodGroupPriority(pgqi.CompositePodGroup)
-	}
-	return 0
 }
 
 func (pgqi *QueuedPodGroupInfo) Size() int {
@@ -1041,70 +998,18 @@ func (pgqi *QueuedPodGroupInfo) SetFlushTimestamp(t time.Time) {
 	pgqi.FlushTimestamp = t
 }
 
-// AddPodGroup adds a pod group to the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) AddPodGroup(pg *schedulingv1beta1.PodGroup) {
-	// We only add non-root pod groups to the hierarchy, because the root
-	// pod group is already present in the hierarchy.
-	if !utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) || pg.Spec.ParentCompositePodGroupName == nil {
+// AddSubtree adds a subtree to the queued pod group info hierarchy.
+// It shouldn't be called when the QueuedPodGroupInfo's root is a PodGroup (not CompositePodGroup).
+func (pgqi *QueuedPodGroupInfo) AddSubtree(subtree *PodGroupInfo) {
+	parentName := subtree.GetParentCompositePodGroupName()
+	if parentName == nil {
 		return
 	}
 
-	parent, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *pg.Spec.ParentCompositePodGroupName)
-	if parent != nil && parent.GetCompositePodGroup() != nil {
-		for _, child := range parent.Children {
-			if child.GetName() == pg.Name {
-				return
-			}
-		}
-		pgInfo := &PodGroupInfo{
-			Namespace: pg.Namespace,
-			Name:      pg.Name,
-			Type:      fwk.PodGroupKeyType,
-			PodGroup:  pg,
-			Children:  make([]*PodGroupInfo, 0),
-		}
-		parent.Children = append(parent.Children, pgInfo)
-	}
-}
-
-// UpdatePodGroup updates a pod group in the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) UpdatePodGroup(pg *schedulingv1beta1.PodGroup) {
-	node, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, pg.Name)
-	if node != nil && node.GetPodGroup() != nil {
-		node.PodGroup = pg
-	}
-}
-
-// RemovePodGroup removes a pod group from the queued pod group info hierarchy.
-// It returns a slice of all pods within the hierarchy of the removed pod group.
-func (pgqi *QueuedPodGroupInfo) RemovePodGroup(pg *schedulingv1beta1.PodGroup) []*QueuedPodInfo {
-	node, parent := findNodeAndParent(pgqi.PodGroupInfo, nil, pg.Name)
-	if node == nil {
-		return nil
-	}
-
+	parent, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *parentName)
 	if parent != nil {
-		for i, child := range parent.Children {
-			if child.GetName() == pg.Name {
-				parent.Children = append(parent.Children[:i], parent.Children[i+1:]...)
-				break
-			}
-		}
-	}
-
-	return pgqi.deleteSubtreePods(node)
-}
-
-// AddCompositePodGroup adds a composite pod group to the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) AddCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup, subtree *PodGroupInfo) {
-	if cpg.Spec.ParentCompositePodGroupName == nil {
-		return
-	}
-
-	parent, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *cpg.Spec.ParentCompositePodGroupName)
-	if parent != nil && parent.GetCompositePodGroup() != nil {
 		for _, child := range parent.Children {
-			if child.GetName() == cpg.Name {
+			if child.GetName() == subtree.GetName() {
 				return
 			}
 		}
@@ -1112,25 +1017,25 @@ func (pgqi *QueuedPodGroupInfo) AddCompositePodGroup(cpg *schedulingv1alpha3.Com
 	}
 }
 
-// UpdateCompositePodGroup updates a composite pod group in the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) UpdateCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) {
-	node, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, cpg.Name)
-	if node != nil && node.GetCompositePodGroup() != nil {
-		node.CompositePodGroup = cpg
+// UpdateGenericPodGroup updates a generic pod group in the queued pod group info hierarchy.
+func (pgqi *QueuedPodGroupInfo) UpdateGenericPodGroup(gpg *GenericPodGroup) {
+	node, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, gpg.GetName())
+	if node != nil {
+		node.GenericPodGroup = gpg
 	}
 }
 
-// RemoveCompositePodGroup removes a composite pod group from the queued pod group info hierarchy.
-// It returns a slice of all pods within the hierarchy of the removed composite pod group.
-func (pgqi *QueuedPodGroupInfo) RemoveCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) []*QueuedPodInfo {
-	node, parent := findNodeAndParent(pgqi.PodGroupInfo, nil, cpg.Name)
+// RemoveGenericPodGroup removes a generic pod group from the queued pod group info hierarchy.
+// It returns a slice of all pods within the hierarchy of the removed pod group / composite pod group.
+func (pgqi *QueuedPodGroupInfo) RemoveGenericPodGroup(gpg *GenericPodGroup) []*QueuedPodInfo {
+	node, parent := findNodeAndParent(pgqi.PodGroupInfo, nil, gpg.GetName())
 	if node == nil {
 		return nil
 	}
 
 	if parent != nil {
 		for i, child := range parent.Children {
-			if child.GetName() == cpg.Name {
+			if child.GetName() == gpg.GetName() {
 				parent.Children = append(parent.Children[:i], parent.Children[i+1:]...)
 				break
 			}
@@ -1146,11 +1051,9 @@ func findNodeAndParent(curr, parent *PodGroupInfo, name string) (*PodGroupInfo, 
 	if curr.GetName() == name {
 		return curr, parent
 	}
-	if curr.GetCompositePodGroup() != nil {
-		for _, child := range curr.Children {
-			if n, p := findNodeAndParent(child, curr, name); n != nil {
-				return n, p
-			}
+	for _, child := range curr.Children {
+		if n, p := findNodeAndParent(child, curr, name); n != nil {
+			return n, p
 		}
 	}
 	return nil, nil
@@ -1161,12 +1064,13 @@ func findNodeAndParent(curr, parent *PodGroupInfo, name string) (*PodGroupInfo, 
 // It returns a flat slice of all QueuedPodInfo elements that were successfully removed.
 func (pgqi *QueuedPodGroupInfo) deleteSubtreePods(curr *PodGroupInfo) []*QueuedPodInfo {
 	removedPods := make([]*QueuedPodInfo, 0)
-	if curr.GetPodGroup() != nil {
-		key := fwk.PodGroupKey(curr.Namespace, curr.Name)
+	if curr.GetType() == fwk.PodGroupKeyType {
+		key := fwk.PodGroupKey(curr.GetNamespace(), curr.GetName())
 		if pods, ok := pgqi.QueuedPodInfos[key]; ok {
 			removedPods = append(removedPods, pods...)
 			delete(pgqi.QueuedPodInfos, key)
 		}
+		return removedPods
 	}
 	for _, child := range curr.Children {
 		removedPods = append(removedPods, pgqi.deleteSubtreePods(child)...)
@@ -1174,60 +1078,115 @@ func (pgqi *QueuedPodGroupInfo) deleteSubtreePods(curr *PodGroupInfo) []*QueuedP
 	return removedPods
 }
 
-func newQueuedPodGroupInfo(pg *schedulingv1beta1.PodGroup) *QueuedPodGroupInfo {
-	return &QueuedPodGroupInfo{
-		PodGroupInfo: &PodGroupInfo{
-			Namespace: pg.Namespace,
-			Name:      pg.Name,
-			Type:      fwk.PodGroupKeyType,
-			PodGroup:  pg,
-			Children:  make([]*PodGroupInfo, 0),
-		},
-		QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
-	}
+// GenericPodGroup is a wrapper around either a PodGroup or a CompositePodGroup API object,
+// providing a unified interface for scheduler's internal operations on PodGroup objects.
+type GenericPodGroup struct {
+	// PodGroup is a PodGroup API object.
+	PodGroup *schedulingv1beta1.PodGroup
+	// CompositePodGroup is a CompositePodGroup API object.
+	// It can be set only when CompositePodGroup feature is enabled.
+	CompositePodGroup *schedulingv1alpha3.CompositePodGroup
 }
 
-// PodGroupInfo is a wrapper around the PodGroup API object together with a list of pods that belong to the pod group.
-// Typically used as an input to pod group scheduling cycle plugins.
+// NewGenericPodGroup returns a GenericPodGroup for a PodGroup.
+func NewGenericPodGroup(pg *schedulingv1beta1.PodGroup) *GenericPodGroup {
+	return &GenericPodGroup{PodGroup: pg}
+}
+
+// NewGenericCompositePodGroup returns a GenericPodGroup for a CompositePodGroup.
+func NewGenericCompositePodGroup(cpg *schedulingv1alpha3.CompositePodGroup) *GenericPodGroup {
+	return &GenericPodGroup{CompositePodGroup: cpg}
+}
+
+func (gpg *GenericPodGroup) GetPodGroup() *schedulingv1beta1.PodGroup {
+	return gpg.PodGroup
+}
+
+func (gpg *GenericPodGroup) GetCompositePodGroup() *schedulingv1alpha3.CompositePodGroup {
+	return gpg.CompositePodGroup
+}
+
+func (gpg *GenericPodGroup) GetName() string {
+	if gpg.PodGroup != nil {
+		return gpg.PodGroup.Name
+	}
+	return gpg.CompositePodGroup.Name
+}
+
+func (gpg *GenericPodGroup) GetNamespace() string {
+	if gpg.PodGroup != nil {
+		return gpg.PodGroup.Namespace
+	}
+	return gpg.CompositePodGroup.Namespace
+}
+
+func (gpg *GenericPodGroup) GetType() fwk.EntityKeyType {
+	if gpg.PodGroup != nil {
+		return fwk.PodGroupKeyType
+	}
+	return fwk.CompositePodGroupKeyType
+}
+
+func (gpg *GenericPodGroup) GetKey() fwk.EntityKey {
+	if gpg.PodGroup != nil {
+		return fwk.PodGroupKey(gpg.PodGroup.Namespace, gpg.PodGroup.Name)
+	}
+	return fwk.CompositePodGroupKey(gpg.CompositePodGroup.Namespace, gpg.CompositePodGroup.Name)
+}
+
+// GetParentCompositePodGroupName returns the parent composite pod group name of the GenericPodGroup.
+// This should be used only when the feature feature gate CompositePodGroup is enabled.
+func (gpg *GenericPodGroup) GetParentCompositePodGroupName() *string {
+	if gpg.PodGroup != nil {
+		return gpg.PodGroup.Spec.ParentCompositePodGroupName
+	}
+	return gpg.CompositePodGroup.Spec.ParentCompositePodGroupName
+}
+
+// HasParent returns true if the GenericPodGroup has a parent.
+// This should be used only when the feature feature gate CompositePodGroup is enabled.
+func (gpg *GenericPodGroup) HasParent() bool {
+	return gpg.GetParentCompositePodGroupName() != nil
+}
+
+// GetParentKey returns the parent key of the GenericPodGroup.
+// This should be used only when the feature CompositePodGroup feature gate is enabled.
+func (gpg *GenericPodGroup) GetParentKey() (fwk.EntityKey, bool) {
+	parentName := gpg.GetParentCompositePodGroupName()
+	if parentName == nil {
+		return fwk.EntityKey{}, false
+	}
+	return fwk.CompositePodGroupKey(gpg.GetNamespace(), *parentName), true
+}
+
+func (gpg *GenericPodGroup) GetPriority() int32 {
+	if gpg.PodGroup != nil {
+		return schedutil.PodGroupPriority(gpg.PodGroup)
+	}
+	return schedutil.CompositePodGroupPriority(gpg.CompositePodGroup)
+}
+
+func (gpg *GenericPodGroup) GetCreationTimestamp() time.Time {
+	if gpg.PodGroup != nil {
+		return gpg.PodGroup.CreationTimestamp.Time
+	}
+	return gpg.CompositePodGroup.CreationTimestamp.Time
+}
+
+// PodGroupInfo enriches GenericPodGroup with information about pod group hierarchy.
+// For PodGroups, it contains a list of unscheduled pods.
+// For CompositePodGroups, it contains a list of children.
+// This type is typically used as an input to pod group scheduling cycle plugins.
 type PodGroupInfo struct {
-	// Namespace is a namespace of this pod group.
-	Namespace string
-	// Name is a name of this pod group.
-	Name string
-	// Type is a type of the pod group: either composite pod group or pod group.
-	Type fwk.EntityKeyType
+	*GenericPodGroup
 	// UnscheduledPods are pods that are currently being considered for scheduling.
 	// It can be useful to also retrieve the scheduled (assumed or assigned) pods.
 	// PodGroupManager.PodGroupState can be used for that.
 	// The order of the pods is deterministic and based on signature, priority and timestamp.
 	// Only leaf pod groups have unscheduled pods.
 	UnscheduledPods []*v1.Pod
-	// PodGroup is a PodGroup API object.
-	PodGroup *schedulingv1beta1.PodGroup
-	// CompositePodGroup is a CompositePodGroup API object.
-	// It should be set only when CompositePodGroup feature is enabled.
-	CompositePodGroup *schedulingv1alpha3.CompositePodGroup
 	// Children are the child pod groups of this pod group. Only composite pod groups have children.
 	Children []*PodGroupInfo
-}
-
-func (pgi *PodGroupInfo) GetName() string {
-	return pgi.Name
-}
-
-func (pgi *PodGroupInfo) GetNamespace() string {
-	return pgi.Namespace
-}
-
-func (pgi *PodGroupInfo) GetType() fwk.EntityKeyType {
-	return pgi.Type
-}
-
-func (pgi *PodGroupInfo) GetKey() fwk.EntityKey {
-	if pgi.Type == fwk.CompositePodGroupKeyType {
-		return fwk.CompositePodGroupKey(pgi.Namespace, pgi.Name)
-	}
-	return fwk.PodGroupKey(pgi.Namespace, pgi.Name)
 }
 
 // GetUnscheduledPods returns the unscheduled pods for this pod group.
@@ -1244,14 +1203,6 @@ func (pgi *PodGroupInfo) GetUnscheduledPods() []*v1.Pod {
 	return pods
 }
 
-func (pgi *PodGroupInfo) GetPodGroup() *schedulingv1beta1.PodGroup {
-	return pgi.PodGroup
-}
-
-func (pgi *PodGroupInfo) GetCompositePodGroup() *schedulingv1alpha3.CompositePodGroup {
-	return pgi.CompositePodGroup
-}
-
 func (pgi *PodGroupInfo) GetChildren() []fwk.PodGroupInfo {
 	if len(pgi.Children) == 0 {
 		return nil
@@ -1261,13 +1212,6 @@ func (pgi *PodGroupInfo) GetChildren() []fwk.PodGroupInfo {
 		children[i] = child
 	}
 	return children
-}
-
-func (pgi *PodGroupInfo) GetCreationTimestamp() time.Time {
-	if pgi.PodGroup != nil {
-		return pgi.PodGroup.CreationTimestamp.Time
-	}
-	return pgi.CompositePodGroup.CreationTimestamp.Time
 }
 
 func (pgi *PodGroupInfo) GetChildGroups() []*PodGroupInfo {
@@ -1288,9 +1232,9 @@ func (pgi *PodGroupInfo) GetChildGroups() []*PodGroupInfo {
 		if aTime.After(bTime) {
 			return 1
 		}
-		if a.Name < b.Name {
+		if a.GetName() < b.GetName() {
 			return -1
-		} else if a.Name > b.Name {
+		} else if a.GetName() > b.GetName() {
 			return 1
 		}
 		return 0

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -18,10 +18,11 @@ package framework
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"strings"
 	"testing"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
@@ -3691,7 +3692,7 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 			if tt.setup != nil {
 				tt.setup(qpgi)
 			}
-			qpgi.AddCompositePodGroup(tt.cpgToAdd, tt.subtree)
+			qpgi.AddAbstractPodGroup(NewAbstractCompositePodGroup(tt.cpgToAdd), tt.subtree)
 			tt.verify(t, qpgi)
 		})
 	}
@@ -3756,7 +3757,7 @@ func TestQueuedPodGroupInfo_UpdateCompositePodGroup(t *testing.T) {
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			tt.setup(qpgi)
-			qpgi.UpdateCompositePodGroup(tt.updateCPG)
+			qpgi.UpdateAbstractPodGroup(NewAbstractCompositePodGroup(tt.updateCPG))
 			tt.verify(t, qpgi)
 		})
 	}
@@ -3883,7 +3884,7 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			tt.setup(qpgi)
-			removed := qpgi.RemoveCompositePodGroup(tt.removeCPG)
+			removed := qpgi.RemoveAbstractPodGroup(NewAbstractCompositePodGroup(tt.removeCPG))
 			tt.verify(t, qpgi, removed)
 		})
 	}
@@ -3952,7 +3953,13 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
-			qpgi.AddPodGroup(tt.pgToAdd)
+			qpgi.AddAbstractPodGroup(NewAbstractPodGroup(tt.pgToAdd), &PodGroupInfo{
+				Namespace: tt.pgToAdd.Namespace,
+				Name:      tt.pgToAdd.Name,
+				Type:      fwk.PodGroupKeyType,
+				PodGroup:  tt.pgToAdd,
+				Children:  make([]*PodGroupInfo, 0),
+			})
 			tt.verify(t, qpgi)
 		})
 	}
@@ -4035,7 +4042,7 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := tt.setup()
-			qpgi.UpdatePodGroup(tt.updatePG)
+			qpgi.UpdateAbstractPodGroup(NewAbstractPodGroup(tt.updatePG))
 			tt.verify(t, qpgi)
 		})
 	}
@@ -4115,7 +4122,7 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			tt.setup(qpgi)
-			removed := qpgi.RemovePodGroup(tt.removePG)
+			removed := qpgi.RemoveAbstractPodGroup(NewAbstractPodGroup(tt.removePG))
 			tt.verify(t, qpgi, removed)
 		})
 	}

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -3537,15 +3537,13 @@ func TestPodGroupInfoGetChildrenSorting(t *testing.T) {
 	now := time.Now()
 	pgInfo := func(name, namespace string, creationTime time.Time) *PodGroupInfo {
 		return &PodGroupInfo{
-			Name:      name,
-			Namespace: namespace,
-			PodGroup: &schedulingv1beta1.PodGroup{
+			AbstractPodGroup: NewAbstractPodGroup(&schedulingv1beta1.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              name,
 					Namespace:         namespace,
 					CreationTimestamp: metav1.NewTime(creationTime),
 				},
-			},
+			}),
 		}
 	}
 
@@ -3557,10 +3555,13 @@ func TestPodGroupInfoGetChildrenSorting(t *testing.T) {
 	pgInfo4 := pgInfo("pg4", "default", now)
 
 	pgi := &PodGroupInfo{
-		Name:              "parent-cpg",
-		Namespace:         "default",
-		CompositePodGroup: &schedulingv1alpha3.CompositePodGroup{},
-		Children:          []*PodGroupInfo{pgInfo1, pgInfo2, pgInfo3, pgInfo4},
+		AbstractPodGroup: NewAbstractCompositePodGroup(&schedulingv1alpha3.CompositePodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "parent-cpg",
+				Namespace: "default",
+			},
+		}),
+		Children: []*PodGroupInfo{pgInfo1, pgInfo2, pgInfo3, pgInfo4},
 	}
 
 	expectedOrder := []*PodGroupInfo{pgInfo3, pgInfo1, pgInfo4, pgInfo2}
@@ -3592,10 +3593,9 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		{
 			name:       "Add child CPG to root",
 			initialCPG: cpgRoot,
-			cpgToAdd:   cpgChild,
-			subtree:    &PodGroupInfo{CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
+			subtree:    newCompositePodGroupInfoForTest(cpgChild),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].Name != "cpg-child" {
+				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].GetName() != "cpg-child" {
 					t.Errorf("Child CPG not added to root correctly")
 				}
 			},
@@ -3603,8 +3603,7 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		{
 			name:       "Add CPG with non-existent parent",
 			initialCPG: cpgRoot,
-			cpgToAdd:   cpgNotFoundParent,
-			subtree:    &PodGroupInfo{CompositePodGroup: cpgNotFoundParent, Name: "cpg-orphan", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
+			subtree:    newCompositePodGroupInfoForTest(cpgNotFoundParent),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 0 {
 					t.Errorf("CPG with non-existent parent should not be added")
@@ -3614,8 +3613,7 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		{
 			name:       "Add standalone CPG (no parent set)",
 			initialCPG: cpgRoot,
-			cpgToAdd:   st.MakeCompositePodGroup().Name("standalone-cpg").Namespace("ns1").Obj(),
-			subtree:    &PodGroupInfo{CompositePodGroup: st.MakeCompositePodGroup().Name("standalone-cpg").Namespace("ns1").Obj(), Name: "standalone-cpg", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
+			subtree:    newCompositePodGroupInfoForTest(st.MakeCompositePodGroup().Name("standalone-cpg").Namespace("ns1").Obj()),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 0 {
 					t.Errorf("Standalone CPG should not be added to another root")
@@ -3625,13 +3623,12 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		{
 			name:       "Add deeply nested CPG",
 			initialCPG: cpgRoot,
-			cpgToAdd:   cpgNested,
-			subtree:    &PodGroupInfo{CompositePodGroup: cpgNested, Name: "cpg-nested", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
+			subtree:    newCompositePodGroupInfoForTest(cpgNested),
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, &PodGroupInfo{CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)})
+				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, newCompositePodGroupInfoForTest(cpgChild))
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				if len(qpgi.PodGroupInfo.Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].Name != "cpg-nested" {
+				if len(qpgi.PodGroupInfo.Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].GetName() != "cpg-nested" {
 					t.Errorf("Deeply nested CPG not added correctly")
 				}
 			},
@@ -3639,38 +3636,19 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		{
 			name:       "Add CPG subtree with nested CPGs",
 			initialCPG: cpgRoot,
-			cpgToAdd:   cpgChild,
-			subtree: &PodGroupInfo{
-				CompositePodGroup: cpgChild,
-				Name:              "cpg-child",
-				Namespace:         "ns1",
-				Type:              fwk.CompositePodGroupKeyType,
-				Children: []*PodGroupInfo{
-					{
-						CompositePodGroup: cpgNested,
-						Name:              "cpg-nested",
-						Namespace:         "ns1",
-						Type:              fwk.CompositePodGroupKeyType,
-						Children: []*PodGroupInfo{
-							{
-								PodGroup:  st.MakePodGroup().Name("pg-nested-leaf").Namespace("ns1").ParentCompositePodGroup("cpg-nested").Obj(),
-								Name:      "pg-nested-leaf",
-								Namespace: "ns1",
-								Type:      fwk.PodGroupKeyType,
-								Children:  make([]*PodGroupInfo, 0),
-							},
-						},
-					},
-				},
-			},
+			subtree: newCompositePodGroupInfoForTest(cpgChild,
+				newCompositePodGroupInfoForTest(cpgNested,
+					newPodGroupInfoForTest(st.MakePodGroup().Name("pg-nested-leaf").Namespace("ns1").ParentCompositePodGroup("cpg-nested").Obj()),
+				),
+			),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].Name != "cpg-child" {
+				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].GetName() != "cpg-child" {
 					t.Errorf("Child CPG not added correctly")
 				}
-				if len(qpgi.PodGroupInfo.Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].Name != "cpg-nested" {
+				if len(qpgi.PodGroupInfo.Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].GetName() != "cpg-nested" {
 					t.Errorf("Nested CPG not added correctly as part of subtree")
 				}
-				if len(qpgi.PodGroupInfo.Children[0].Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].Children[0].Name != "pg-nested-leaf" {
+				if len(qpgi.PodGroupInfo.Children[0].Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].Children[0].GetName() != "pg-nested-leaf" {
 					t.Errorf("Leaf PodGroup not added correctly as part of subtree")
 				}
 			},
@@ -3681,18 +3659,15 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					CompositePodGroup: tt.initialCPG,
-					Name:              tt.initialCPG.Name,
-					Namespace:         tt.initialCPG.Namespace,
-					Type:              fwk.CompositePodGroupKeyType,
-					Children:          make([]*PodGroupInfo, 0),
+					AbstractPodGroup: NewAbstractCompositePodGroup(tt.initialCPG),
+					Children:         make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			if tt.setup != nil {
 				tt.setup(qpgi)
 			}
-			qpgi.AddAbstractPodGroup(NewAbstractCompositePodGroup(tt.cpgToAdd), tt.subtree)
+			qpgi.AddSubtree(tt.subtree)
 			tt.verify(t, qpgi)
 		})
 	}
@@ -3720,9 +3695,7 @@ func TestQueuedPodGroupInfo_UpdateCompositePodGroup(t *testing.T) {
 			initialCPG: cpgRoot,
 			updateCPG:  cpgChildUpdated,
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, &PodGroupInfo{
-					CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				})
+				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, newCompositePodGroupInfoForTest(cpgChild))
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].CompositePodGroup.Annotations["updated"] != "true" {
@@ -3748,11 +3721,8 @@ func TestQueuedPodGroupInfo_UpdateCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					CompositePodGroup: tt.initialCPG,
-					Name:              tt.initialCPG.Name,
-					Namespace:         tt.initialCPG.Namespace,
-					Type:              fwk.CompositePodGroupKeyType,
-					Children:          make([]*PodGroupInfo, 0),
+					AbstractPodGroup: NewAbstractCompositePodGroup(tt.initialCPG),
+					Children:         make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
@@ -3785,16 +3755,10 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 			name:      "Remove child CPG and its subtree pods",
 			removeCPG: cpgChild,
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				nestedInfo := &PodGroupInfo{
-					CompositePodGroup: cpgNested, Name: "cpg-nested", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{
-						{PodGroup: pgLeaf, Name: "pg-leaf", Namespace: "ns1", Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-					},
-				}
-				childInfo := &PodGroupInfo{
-					CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{nestedInfo},
-				}
+				nestedInfo := newCompositePodGroupInfoForTest(cpgNested,
+					newPodGroupInfoForTest(pgLeaf),
+				)
+				childInfo := newCompositePodGroupInfoForTest(cpgChild, nestedInfo)
 				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, childInfo)
 
 				pod := st.MakePod().Name("pod1").Namespace("ns1").Obj()
@@ -3817,9 +3781,7 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 			name:      "Remove non-existent CPG",
 			removeCPG: st.MakeCompositePodGroup().Name("non-existent").Namespace("ns1").Obj(),
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, &PodGroupInfo{
-					CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				})
+				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, newCompositePodGroupInfoForTest(cpgChild))
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo, removed []*QueuedPodInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 1 {
@@ -3835,17 +3797,11 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 			removeCPG: cpgNested,
 			setup: func(qpgi *QueuedPodGroupInfo) {
 				pgLeaf2 := st.MakePodGroup().Name("pg-leaf2").Namespace("ns1").ParentCompositePodGroup("cpg-nested").Obj()
-				nestedInfo := &PodGroupInfo{
-					CompositePodGroup: cpgNested, Name: "cpg-nested", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{
-						{PodGroup: pgLeaf, Name: "pg-leaf", Namespace: "ns1", Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-						{PodGroup: pgLeaf2, Name: "pg-leaf2", Namespace: "ns1", Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-					},
-				}
-				childInfo := &PodGroupInfo{
-					CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{nestedInfo},
-				}
+				nestedInfo := newCompositePodGroupInfoForTest(cpgNested,
+					newPodGroupInfoForTest(pgLeaf),
+					newPodGroupInfoForTest(pgLeaf2),
+				)
+				childInfo := newCompositePodGroupInfoForTest(cpgChild, nestedInfo)
 				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, childInfo)
 
 				pod1 := st.MakePod().Name("pod1").Namespace("ns1").Obj()
@@ -3875,11 +3831,8 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					CompositePodGroup: cpgRoot,
-					Name:              cpgRoot.Name,
-					Namespace:         cpgRoot.Namespace,
-					Type:              fwk.CompositePodGroupKeyType,
-					Children:          make([]*PodGroupInfo, 0),
+					AbstractPodGroup: NewAbstractCompositePodGroup(cpgRoot),
+					Children:         make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
@@ -3911,10 +3864,10 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 			initialCPG: cpgRoot,
 			pgToAdd:    pgChild,
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].Name != "pg-child" {
+				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].GetName() != "pg-child" {
 					t.Errorf("Child PG not added to root correctly")
 				}
-				if qpgi.PodGroupInfo.Children[0].Type != fwk.PodGroupKeyType {
+				if qpgi.PodGroupInfo.Children[0].GetType() != fwk.PodGroupKeyType {
 					t.Errorf("Child PG has wrong key type")
 				}
 			},
@@ -3945,21 +3898,12 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					CompositePodGroup: tt.initialCPG,
-					Name:              tt.initialCPG.Name,
-					Namespace:         tt.initialCPG.Namespace,
-					Type:              fwk.CompositePodGroupKeyType,
-					Children:          make([]*PodGroupInfo, 0),
+					AbstractPodGroup: NewAbstractCompositePodGroup(tt.initialCPG),
+					Children:         make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
-			qpgi.AddAbstractPodGroup(NewAbstractPodGroup(tt.pgToAdd), &PodGroupInfo{
-				Namespace: tt.pgToAdd.Namespace,
-				Name:      tt.pgToAdd.Name,
-				Type:      fwk.PodGroupKeyType,
-				PodGroup:  tt.pgToAdd,
-				Children:  make([]*PodGroupInfo, 0),
-			})
+			qpgi.AddSubtree(newPodGroupInfoForTest(tt.pgToAdd))
 			tt.verify(t, qpgi)
 		})
 	}
@@ -3987,12 +3931,9 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 			name: "Update child PG in CPG hierarchy",
 			setup: func() *QueuedPodGroupInfo {
 				return &QueuedPodGroupInfo{
-					PodGroupInfo: &PodGroupInfo{
-						CompositePodGroup: cpgRoot, Name: cpgRoot.Name, Namespace: cpgRoot.Namespace, Type: fwk.CompositePodGroupKeyType,
-						Children: []*PodGroupInfo{
-							{PodGroup: pgChild, Name: pgChild.Name, Namespace: pgChild.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-						},
-					},
+					PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+						newPodGroupInfoForTest(pgChild),
+					),
 					QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 				}
 			},
@@ -4007,9 +3948,7 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 			name: "Update standalone PG",
 			setup: func() *QueuedPodGroupInfo {
 				return &QueuedPodGroupInfo{
-					PodGroupInfo: &PodGroupInfo{
-						PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-					},
+					PodGroupInfo:   newPodGroupInfoForTest(pgStandalone),
 					QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 				}
 			},
@@ -4024,9 +3963,7 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 			name: "Update non-existent PG",
 			setup: func() *QueuedPodGroupInfo {
 				return &QueuedPodGroupInfo{
-					PodGroupInfo: &PodGroupInfo{
-						CompositePodGroup: cpgRoot, Name: cpgRoot.Name, Namespace: cpgRoot.Namespace, Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-					},
+					PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
 					QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 				}
 			},
@@ -4070,12 +4007,9 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 			name:     "Remove child PG and its pods",
 			removePG: pgChild,
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					CompositePodGroup: cpgRoot, Name: cpgRoot.Name, Namespace: cpgRoot.Namespace, Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{
-						{PodGroup: pgChild, Name: pgChild.Name, Namespace: pgChild.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-					},
-				}
+				qpgi.PodGroupInfo = newCompositePodGroupInfoForTest(cpgRoot,
+					newPodGroupInfoForTest(pgChild),
+				)
 				pod := st.MakePod().Name("pod1").Namespace("ns1").Obj()
 				pod.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-child"; return &s }()}
 				qpgi.QueuedPodInfos[podKeyChild] = []*QueuedPodInfo{{PodInfo: &PodInfo{Pod: pod}}}
@@ -4096,9 +4030,7 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 			name:     "Remove standalone PG and its pods (root removal)",
 			removePG: pgStandalone,
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				}
+				qpgi.PodGroupInfo = newPodGroupInfoForTest(pgStandalone)
 				pod := st.MakePod().Name("pod2").Namespace("ns1").Obj()
 				pod.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-standalone"; return &s }()}
 				qpgi.QueuedPodInfos[podKeyStandalone] = []*QueuedPodInfo{{PodInfo: &PodInfo{Pod: pod}}}
@@ -4150,12 +4082,9 @@ func TestQueuedPodGroupInfo_AddPod(t *testing.T) {
 				return p
 			}(),
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					CompositePodGroup: cpgRoot, Name: cpgRoot.Name, Namespace: cpgRoot.Namespace, Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{
-						{PodGroup: pgChild, Name: pgChild.Name, Namespace: pgChild.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-					},
-				}
+				qpgi.PodGroupInfo = newCompositePodGroupInfoForTest(cpgRoot,
+					newPodGroupInfoForTest(pgChild),
+				)
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.QueuedPodInfos[podKeyChild]) != 1 {
@@ -4171,9 +4100,7 @@ func TestQueuedPodGroupInfo_AddPod(t *testing.T) {
 				return p
 			}(),
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				}
+				qpgi.PodGroupInfo = newPodGroupInfoForTest(pgStandalone)
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.QueuedPodInfos[podKeyStandalone]) != 1 {
@@ -4189,27 +4116,11 @@ func TestQueuedPodGroupInfo_AddPod(t *testing.T) {
 				return p
 			}(),
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				}
+				qpgi.PodGroupInfo = newPodGroupInfoForTest(pgStandalone)
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.QueuedPodInfos) != 0 {
 					t.Errorf("Pod added despite non-existent leaf PG")
-				}
-			},
-		},
-		{
-			name: "Add pod without scheduling group",
-			pod:  st.MakePod().Name("pod4").Namespace("ns1").Obj(),
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				}
-			},
-			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				if len(qpgi.QueuedPodInfos) != 0 {
-					t.Errorf("Pod added despite no scheduling group")
 				}
 			},
 		},
@@ -4292,9 +4203,7 @@ func TestQueuedPodGroupInfo_UpdateAndRemovePod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
-				PodGroupInfo: &PodGroupInfo{
-					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				},
+				PodGroupInfo:   newPodGroupInfoForTest(pgStandalone),
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			pInfo1 := &QueuedPodInfo{PodInfo: &PodInfo{Pod: pod1}}
@@ -4365,27 +4274,23 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 		{
 			name: "Standalone PodGroupInfo with unscheduled pods",
 			pgi: &PodGroupInfo{
-				PodGroup:        pgStandalone,
-				UnscheduledPods: []*v1.Pod{pod1, pod2},
-				Type:            fwk.PodGroupKeyType,
+				AbstractPodGroup: NewAbstractPodGroup(pgStandalone),
+				UnscheduledPods:  []*v1.Pod{pod1, pod2},
 			},
 			expected: []*v1.Pod{pod1, pod2},
 		},
 		{
 			name: "PodGroupInfo with children",
 			pgi: &PodGroupInfo{
-				CompositePodGroup: cpgParent,
-				Type:              fwk.CompositePodGroupKeyType,
+				AbstractPodGroup: NewAbstractCompositePodGroup(cpgParent),
 				Children: []*PodGroupInfo{
 					{
-						PodGroup:        pgChild1,
-						UnscheduledPods: []*v1.Pod{pod1},
-						Type:            fwk.PodGroupKeyType,
+						AbstractPodGroup: NewAbstractPodGroup(pgChild1),
+						UnscheduledPods:  []*v1.Pod{pod1},
 					},
 					{
-						PodGroup:        pgChild2,
-						UnscheduledPods: []*v1.Pod{pod2, pod3},
-						Type:            fwk.PodGroupKeyType,
+						AbstractPodGroup: NewAbstractPodGroup(pgChild2),
+						UnscheduledPods:  []*v1.Pod{pod2, pod3},
 					},
 				},
 			},
@@ -4394,29 +4299,24 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 		{
 			name: "Multi-level PodGroupInfo with children",
 			pgi: &PodGroupInfo{
-				CompositePodGroup: cpgRoot,
-				Type:              fwk.CompositePodGroupKeyType,
+				AbstractPodGroup: NewAbstractCompositePodGroup(cpgRoot),
 				Children: []*PodGroupInfo{
 					{
-						CompositePodGroup: cpgSub,
-						Type:              fwk.CompositePodGroupKeyType,
+						AbstractPodGroup: NewAbstractCompositePodGroup(cpgSub),
 						Children: []*PodGroupInfo{
 							{
-								PodGroup:        pgChild1,
-								UnscheduledPods: []*v1.Pod{pod1},
-								Type:            fwk.PodGroupKeyType,
+								AbstractPodGroup: NewAbstractPodGroup(pgChild1),
+								UnscheduledPods:  []*v1.Pod{pod1},
 							},
 							{
-								PodGroup:        pgChild2,
-								UnscheduledPods: []*v1.Pod{pod2, pod3},
-								Type:            fwk.PodGroupKeyType,
+								AbstractPodGroup: NewAbstractPodGroup(pgChild2),
+								UnscheduledPods:  []*v1.Pod{pod2, pod3},
 							},
 						},
 					},
 					{
-						PodGroup:        pgChild3,
-						UnscheduledPods: []*v1.Pod{pod4},
-						Type:            fwk.PodGroupKeyType,
+						AbstractPodGroup: NewAbstractPodGroup(pgChild3),
+						UnscheduledPods:  []*v1.Pod{pod4},
 					},
 				},
 			},
@@ -4431,5 +4331,19 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 				t.Errorf("GetUnscheduledPods() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func newPodGroupInfoForTest(pg *schedulingv1beta1.PodGroup, children ...*PodGroupInfo) *PodGroupInfo {
+	return &PodGroupInfo{
+		AbstractPodGroup: NewAbstractPodGroup(pg),
+		Children:         children,
+	}
+}
+
+func newCompositePodGroupInfoForTest(cpg *schedulingv1alpha3.CompositePodGroup, children ...*PodGroupInfo) *PodGroupInfo {
+	return &PodGroupInfo{
+		AbstractPodGroup: NewAbstractCompositePodGroup(cpg),
+		Children:         children,
 	}
 }

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -327,7 +327,12 @@ func TestQueuedPodGroupInfoOrdering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pg := st.MakePodGroup().Namespace("default").Name("pg1").Obj()
-			pgqi := newQueuedPodGroupInfo(pg)
+			pgqi := &QueuedPodGroupInfo{
+				PodGroupInfo: &PodGroupInfo{
+					GenericPodGroup: NewGenericPodGroup(pg),
+				},
+				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
+			}
 			for _, p := range tt.podsToAdd {
 				pgqi.AddPod(p)
 			}
@@ -3573,15 +3578,13 @@ func TestPodGroupInfoGetChildrenSorting(t *testing.T) {
 	now := time.Now()
 	pgInfo := func(name, namespace string, creationTime time.Time) *PodGroupInfo {
 		return &PodGroupInfo{
-			Name:      name,
-			Namespace: namespace,
-			PodGroup: &schedulingv1beta1.PodGroup{
+			GenericPodGroup: NewGenericPodGroup(&schedulingv1beta1.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              name,
 					Namespace:         namespace,
 					CreationTimestamp: metav1.NewTime(creationTime),
 				},
-			},
+			}),
 		}
 	}
 
@@ -3593,10 +3596,13 @@ func TestPodGroupInfoGetChildrenSorting(t *testing.T) {
 	pgInfo4 := pgInfo("pg4", "default", now)
 
 	pgi := &PodGroupInfo{
-		Name:              "parent-cpg",
-		Namespace:         "default",
-		CompositePodGroup: &schedulingv1alpha3.CompositePodGroup{},
-		Children:          []*PodGroupInfo{pgInfo1, pgInfo2, pgInfo3, pgInfo4},
+		GenericPodGroup: NewGenericCompositePodGroup(&schedulingv1alpha3.CompositePodGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "parent-cpg",
+				Namespace: "default",
+			},
+		}),
+		Children: []*PodGroupInfo{pgInfo1, pgInfo2, pgInfo3, pgInfo4},
 	}
 
 	expectedOrder := []*PodGroupInfo{pgInfo3, pgInfo1, pgInfo4, pgInfo2}
@@ -3628,10 +3634,9 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		{
 			name:       "Add child CPG to root",
 			initialCPG: cpgRoot,
-			cpgToAdd:   cpgChild,
-			subtree:    &PodGroupInfo{CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
+			subtree:    newCompositePodGroupInfoForTest(cpgChild),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].Name != "cpg-child" {
+				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].GetName() != "cpg-child" {
 					t.Errorf("Child CPG not added to root correctly")
 				}
 			},
@@ -3639,8 +3644,7 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		{
 			name:       "Add CPG with non-existent parent",
 			initialCPG: cpgRoot,
-			cpgToAdd:   cpgNotFoundParent,
-			subtree:    &PodGroupInfo{CompositePodGroup: cpgNotFoundParent, Name: "cpg-orphan", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
+			subtree:    newCompositePodGroupInfoForTest(cpgNotFoundParent),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 0 {
 					t.Errorf("CPG with non-existent parent should not be added")
@@ -3650,8 +3654,7 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		{
 			name:       "Add standalone CPG (no parent set)",
 			initialCPG: cpgRoot,
-			cpgToAdd:   st.MakeCompositePodGroup().Name("standalone-cpg").Namespace("ns1").Obj(),
-			subtree:    &PodGroupInfo{CompositePodGroup: st.MakeCompositePodGroup().Name("standalone-cpg").Namespace("ns1").Obj(), Name: "standalone-cpg", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
+			subtree:    newCompositePodGroupInfoForTest(st.MakeCompositePodGroup().Name("standalone-cpg").Namespace("ns1").Obj()),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 0 {
 					t.Errorf("Standalone CPG should not be added to another root")
@@ -3661,13 +3664,12 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		{
 			name:       "Add deeply nested CPG",
 			initialCPG: cpgRoot,
-			cpgToAdd:   cpgNested,
-			subtree:    &PodGroupInfo{CompositePodGroup: cpgNested, Name: "cpg-nested", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
+			subtree:    newCompositePodGroupInfoForTest(cpgNested),
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, &PodGroupInfo{CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0)})
+				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, newCompositePodGroupInfoForTest(cpgChild))
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				if len(qpgi.PodGroupInfo.Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].Name != "cpg-nested" {
+				if len(qpgi.PodGroupInfo.Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].GetName() != "cpg-nested" {
 					t.Errorf("Deeply nested CPG not added correctly")
 				}
 			},
@@ -3675,38 +3677,19 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		{
 			name:       "Add CPG subtree with nested CPGs",
 			initialCPG: cpgRoot,
-			cpgToAdd:   cpgChild,
-			subtree: &PodGroupInfo{
-				CompositePodGroup: cpgChild,
-				Name:              "cpg-child",
-				Namespace:         "ns1",
-				Type:              fwk.CompositePodGroupKeyType,
-				Children: []*PodGroupInfo{
-					{
-						CompositePodGroup: cpgNested,
-						Name:              "cpg-nested",
-						Namespace:         "ns1",
-						Type:              fwk.CompositePodGroupKeyType,
-						Children: []*PodGroupInfo{
-							{
-								PodGroup:  st.MakePodGroup().Name("pg-nested-leaf").Namespace("ns1").ParentCompositePodGroup("cpg-nested").Obj(),
-								Name:      "pg-nested-leaf",
-								Namespace: "ns1",
-								Type:      fwk.PodGroupKeyType,
-								Children:  make([]*PodGroupInfo, 0),
-							},
-						},
-					},
-				},
-			},
+			subtree: newCompositePodGroupInfoForTest(cpgChild,
+				newCompositePodGroupInfoForTest(cpgNested,
+					newPodGroupInfoForTest(st.MakePodGroup().Name("pg-nested-leaf").Namespace("ns1").ParentCompositePodGroup("cpg-nested").Obj()),
+				),
+			),
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].Name != "cpg-child" {
+				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].GetName() != "cpg-child" {
 					t.Errorf("Child CPG not added correctly")
 				}
-				if len(qpgi.PodGroupInfo.Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].Name != "cpg-nested" {
+				if len(qpgi.PodGroupInfo.Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].GetName() != "cpg-nested" {
 					t.Errorf("Nested CPG not added correctly as part of subtree")
 				}
-				if len(qpgi.PodGroupInfo.Children[0].Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].Children[0].Name != "pg-nested-leaf" {
+				if len(qpgi.PodGroupInfo.Children[0].Children[0].Children) != 1 || qpgi.PodGroupInfo.Children[0].Children[0].Children[0].GetName() != "pg-nested-leaf" {
 					t.Errorf("Leaf PodGroup not added correctly as part of subtree")
 				}
 			},
@@ -3717,18 +3700,15 @@ func TestQueuedPodGroupInfo_AddCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					CompositePodGroup: tt.initialCPG,
-					Name:              tt.initialCPG.Name,
-					Namespace:         tt.initialCPG.Namespace,
-					Type:              fwk.CompositePodGroupKeyType,
-					Children:          make([]*PodGroupInfo, 0),
+					GenericPodGroup: NewGenericCompositePodGroup(tt.initialCPG),
+					Children:        make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			if tt.setup != nil {
 				tt.setup(qpgi)
 			}
-			qpgi.AddCompositePodGroup(tt.cpgToAdd, tt.subtree)
+			qpgi.AddSubtree(tt.subtree)
 			tt.verify(t, qpgi)
 		})
 	}
@@ -3756,9 +3736,7 @@ func TestQueuedPodGroupInfo_UpdateCompositePodGroup(t *testing.T) {
 			initialCPG: cpgRoot,
 			updateCPG:  cpgChildUpdated,
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, &PodGroupInfo{
-					CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				})
+				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, newCompositePodGroupInfoForTest(cpgChild))
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].CompositePodGroup.Annotations["updated"] != "true" {
@@ -3784,16 +3762,13 @@ func TestQueuedPodGroupInfo_UpdateCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					CompositePodGroup: tt.initialCPG,
-					Name:              tt.initialCPG.Name,
-					Namespace:         tt.initialCPG.Namespace,
-					Type:              fwk.CompositePodGroupKeyType,
-					Children:          make([]*PodGroupInfo, 0),
+					GenericPodGroup: NewGenericCompositePodGroup(tt.initialCPG),
+					Children:        make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			tt.setup(qpgi)
-			qpgi.UpdateCompositePodGroup(tt.updateCPG)
+			qpgi.UpdateGenericPodGroup(NewGenericCompositePodGroup(tt.updateCPG))
 			tt.verify(t, qpgi)
 		})
 	}
@@ -3821,16 +3796,10 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 			name:      "Remove child CPG and its subtree pods",
 			removeCPG: cpgChild,
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				nestedInfo := &PodGroupInfo{
-					CompositePodGroup: cpgNested, Name: "cpg-nested", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{
-						{PodGroup: pgLeaf, Name: "pg-leaf", Namespace: "ns1", Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-					},
-				}
-				childInfo := &PodGroupInfo{
-					CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{nestedInfo},
-				}
+				nestedInfo := newCompositePodGroupInfoForTest(cpgNested,
+					newPodGroupInfoForTest(pgLeaf),
+				)
+				childInfo := newCompositePodGroupInfoForTest(cpgChild, nestedInfo)
 				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, childInfo)
 
 				pod := st.MakePod().Name("pod1").Namespace("ns1").Obj()
@@ -3853,9 +3822,7 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 			name:      "Remove non-existent CPG",
 			removeCPG: st.MakeCompositePodGroup().Name("non-existent").Namespace("ns1").Obj(),
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, &PodGroupInfo{
-					CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				})
+				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, newCompositePodGroupInfoForTest(cpgChild))
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo, removed []*QueuedPodInfo) {
 				if len(qpgi.PodGroupInfo.Children) != 1 {
@@ -3871,17 +3838,11 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 			removeCPG: cpgNested,
 			setup: func(qpgi *QueuedPodGroupInfo) {
 				pgLeaf2 := st.MakePodGroup().Name("pg-leaf2").Namespace("ns1").ParentCompositePodGroup("cpg-nested").Obj()
-				nestedInfo := &PodGroupInfo{
-					CompositePodGroup: cpgNested, Name: "cpg-nested", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{
-						{PodGroup: pgLeaf, Name: "pg-leaf", Namespace: "ns1", Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-						{PodGroup: pgLeaf2, Name: "pg-leaf2", Namespace: "ns1", Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-					},
-				}
-				childInfo := &PodGroupInfo{
-					CompositePodGroup: cpgChild, Name: "cpg-child", Namespace: "ns1", Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{nestedInfo},
-				}
+				nestedInfo := newCompositePodGroupInfoForTest(cpgNested,
+					newPodGroupInfoForTest(pgLeaf),
+					newPodGroupInfoForTest(pgLeaf2),
+				)
+				childInfo := newCompositePodGroupInfoForTest(cpgChild, nestedInfo)
 				qpgi.PodGroupInfo.Children = append(qpgi.PodGroupInfo.Children, childInfo)
 
 				pod1 := st.MakePod().Name("pod1").Namespace("ns1").Obj()
@@ -3911,16 +3872,13 @@ func TestQueuedPodGroupInfo_RemoveCompositePodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					CompositePodGroup: cpgRoot,
-					Name:              cpgRoot.Name,
-					Namespace:         cpgRoot.Namespace,
-					Type:              fwk.CompositePodGroupKeyType,
-					Children:          make([]*PodGroupInfo, 0),
+					GenericPodGroup: NewGenericCompositePodGroup(cpgRoot),
+					Children:        make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			tt.setup(qpgi)
-			removed := qpgi.RemoveCompositePodGroup(tt.removeCPG)
+			removed := qpgi.RemoveGenericPodGroup(NewGenericCompositePodGroup(tt.removeCPG))
 			tt.verify(t, qpgi, removed)
 		})
 	}
@@ -3947,10 +3905,10 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 			initialCPG: cpgRoot,
 			pgToAdd:    pgChild,
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].Name != "pg-child" {
+				if len(qpgi.PodGroupInfo.Children) != 1 || qpgi.PodGroupInfo.Children[0].GetName() != "pg-child" {
 					t.Errorf("Child PG not added to root correctly")
 				}
-				if qpgi.PodGroupInfo.Children[0].Type != fwk.PodGroupKeyType {
+				if qpgi.PodGroupInfo.Children[0].GetType() != fwk.PodGroupKeyType {
 					t.Errorf("Child PG has wrong key type")
 				}
 			},
@@ -3981,15 +3939,12 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
 				PodGroupInfo: &PodGroupInfo{
-					CompositePodGroup: tt.initialCPG,
-					Name:              tt.initialCPG.Name,
-					Namespace:         tt.initialCPG.Namespace,
-					Type:              fwk.CompositePodGroupKeyType,
-					Children:          make([]*PodGroupInfo, 0),
+					GenericPodGroup: NewGenericCompositePodGroup(tt.initialCPG),
+					Children:        make([]*PodGroupInfo, 0),
 				},
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
-			qpgi.AddPodGroup(tt.pgToAdd)
+			qpgi.AddSubtree(newPodGroupInfoForTest(tt.pgToAdd))
 			tt.verify(t, qpgi)
 		})
 	}
@@ -4017,12 +3972,9 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 			name: "Update child PG in CPG hierarchy",
 			setup: func() *QueuedPodGroupInfo {
 				return &QueuedPodGroupInfo{
-					PodGroupInfo: &PodGroupInfo{
-						CompositePodGroup: cpgRoot, Name: cpgRoot.Name, Namespace: cpgRoot.Namespace, Type: fwk.CompositePodGroupKeyType,
-						Children: []*PodGroupInfo{
-							{PodGroup: pgChild, Name: pgChild.Name, Namespace: pgChild.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-						},
-					},
+					PodGroupInfo: newCompositePodGroupInfoForTest(cpgRoot,
+						newPodGroupInfoForTest(pgChild),
+					),
 					QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 				}
 			},
@@ -4037,9 +3989,7 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 			name: "Update standalone PG",
 			setup: func() *QueuedPodGroupInfo {
 				return &QueuedPodGroupInfo{
-					PodGroupInfo: &PodGroupInfo{
-						PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-					},
+					PodGroupInfo:   newPodGroupInfoForTest(pgStandalone),
 					QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 				}
 			},
@@ -4054,9 +4004,7 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 			name: "Update non-existent PG",
 			setup: func() *QueuedPodGroupInfo {
 				return &QueuedPodGroupInfo{
-					PodGroupInfo: &PodGroupInfo{
-						CompositePodGroup: cpgRoot, Name: cpgRoot.Name, Namespace: cpgRoot.Namespace, Type: fwk.CompositePodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-					},
+					PodGroupInfo:   newCompositePodGroupInfoForTest(cpgRoot),
 					QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 				}
 			},
@@ -4072,7 +4020,7 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := tt.setup()
-			qpgi.UpdatePodGroup(tt.updatePG)
+			qpgi.UpdateGenericPodGroup(NewGenericPodGroup(tt.updatePG))
 			tt.verify(t, qpgi)
 		})
 	}
@@ -4100,12 +4048,9 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 			name:     "Remove child PG and its pods",
 			removePG: pgChild,
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					CompositePodGroup: cpgRoot, Name: cpgRoot.Name, Namespace: cpgRoot.Namespace, Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{
-						{PodGroup: pgChild, Name: pgChild.Name, Namespace: pgChild.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-					},
-				}
+				qpgi.PodGroupInfo = newCompositePodGroupInfoForTest(cpgRoot,
+					newPodGroupInfoForTest(pgChild),
+				)
 				pod := st.MakePod().Name("pod1").Namespace("ns1").Obj()
 				pod.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-child"; return &s }()}
 				qpgi.QueuedPodInfos[podKeyChild] = []*QueuedPodInfo{{PodInfo: &PodInfo{Pod: pod}}}
@@ -4126,9 +4071,7 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 			name:     "Remove standalone PG and its pods (root removal)",
 			removePG: pgStandalone,
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				}
+				qpgi.PodGroupInfo = newPodGroupInfoForTest(pgStandalone)
 				pod := st.MakePod().Name("pod2").Namespace("ns1").Obj()
 				pod.Spec.SchedulingGroup = &v1.PodSchedulingGroup{PodGroupName: func() *string { s := "pg-standalone"; return &s }()}
 				qpgi.QueuedPodInfos[podKeyStandalone] = []*QueuedPodInfo{{PodInfo: &PodInfo{Pod: pod}}}
@@ -4152,7 +4095,7 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			tt.setup(qpgi)
-			removed := qpgi.RemovePodGroup(tt.removePG)
+			removed := qpgi.RemoveGenericPodGroup(NewGenericPodGroup(tt.removePG))
 			tt.verify(t, qpgi, removed)
 		})
 	}
@@ -4180,12 +4123,9 @@ func TestQueuedPodGroupInfo_AddPod(t *testing.T) {
 				return p
 			}(),
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					CompositePodGroup: cpgRoot, Name: cpgRoot.Name, Namespace: cpgRoot.Namespace, Type: fwk.CompositePodGroupKeyType,
-					Children: []*PodGroupInfo{
-						{PodGroup: pgChild, Name: pgChild.Name, Namespace: pgChild.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0)},
-					},
-				}
+				qpgi.PodGroupInfo = newCompositePodGroupInfoForTest(cpgRoot,
+					newPodGroupInfoForTest(pgChild),
+				)
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.QueuedPodInfos[podKeyChild]) != 1 {
@@ -4201,9 +4141,7 @@ func TestQueuedPodGroupInfo_AddPod(t *testing.T) {
 				return p
 			}(),
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				}
+				qpgi.PodGroupInfo = newPodGroupInfoForTest(pgStandalone)
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.QueuedPodInfos[podKeyStandalone]) != 1 {
@@ -4219,27 +4157,11 @@ func TestQueuedPodGroupInfo_AddPod(t *testing.T) {
 				return p
 			}(),
 			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				}
+				qpgi.PodGroupInfo = newPodGroupInfoForTest(pgStandalone)
 			},
 			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
 				if len(qpgi.QueuedPodInfos) != 0 {
 					t.Errorf("Pod added despite non-existent leaf PG")
-				}
-			},
-		},
-		{
-			name: "Add pod without scheduling group",
-			pod:  st.MakePod().Name("pod4").Namespace("ns1").Obj(),
-			setup: func(qpgi *QueuedPodGroupInfo) {
-				qpgi.PodGroupInfo = &PodGroupInfo{
-					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				}
-			},
-			verify: func(t *testing.T, qpgi *QueuedPodGroupInfo) {
-				if len(qpgi.QueuedPodInfos) != 0 {
-					t.Errorf("Pod added despite no scheduling group")
 				}
 			},
 		},
@@ -4322,9 +4244,7 @@ func TestQueuedPodGroupInfo_UpdateAndRemovePod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			qpgi := &QueuedPodGroupInfo{
-				PodGroupInfo: &PodGroupInfo{
-					PodGroup: pgStandalone, Name: pgStandalone.Name, Namespace: pgStandalone.Namespace, Type: fwk.PodGroupKeyType, Children: make([]*PodGroupInfo, 0),
-				},
+				PodGroupInfo:   newPodGroupInfoForTest(pgStandalone),
 				QueuedPodInfos: make(map[fwk.EntityKey][]*QueuedPodInfo),
 			}
 			pInfo1 := &QueuedPodInfo{PodInfo: &PodInfo{Pod: pod1}}
@@ -4395,27 +4315,23 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 		{
 			name: "Standalone PodGroupInfo with unscheduled pods",
 			pgi: &PodGroupInfo{
-				PodGroup:        pgStandalone,
+				GenericPodGroup: NewGenericPodGroup(pgStandalone),
 				UnscheduledPods: []*v1.Pod{pod1, pod2},
-				Type:            fwk.PodGroupKeyType,
 			},
 			expected: []*v1.Pod{pod1, pod2},
 		},
 		{
 			name: "PodGroupInfo with children",
 			pgi: &PodGroupInfo{
-				CompositePodGroup: cpgParent,
-				Type:              fwk.CompositePodGroupKeyType,
+				GenericPodGroup: NewGenericCompositePodGroup(cpgParent),
 				Children: []*PodGroupInfo{
 					{
-						PodGroup:        pgChild1,
+						GenericPodGroup: NewGenericPodGroup(pgChild1),
 						UnscheduledPods: []*v1.Pod{pod1},
-						Type:            fwk.PodGroupKeyType,
 					},
 					{
-						PodGroup:        pgChild2,
+						GenericPodGroup: NewGenericPodGroup(pgChild2),
 						UnscheduledPods: []*v1.Pod{pod2, pod3},
-						Type:            fwk.PodGroupKeyType,
 					},
 				},
 			},
@@ -4424,29 +4340,24 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 		{
 			name: "Multi-level PodGroupInfo with children",
 			pgi: &PodGroupInfo{
-				CompositePodGroup: cpgRoot,
-				Type:              fwk.CompositePodGroupKeyType,
+				GenericPodGroup: NewGenericCompositePodGroup(cpgRoot),
 				Children: []*PodGroupInfo{
 					{
-						CompositePodGroup: cpgSub,
-						Type:              fwk.CompositePodGroupKeyType,
+						GenericPodGroup: NewGenericCompositePodGroup(cpgSub),
 						Children: []*PodGroupInfo{
 							{
-								PodGroup:        pgChild1,
+								GenericPodGroup: NewGenericPodGroup(pgChild1),
 								UnscheduledPods: []*v1.Pod{pod1},
-								Type:            fwk.PodGroupKeyType,
 							},
 							{
-								PodGroup:        pgChild2,
+								GenericPodGroup: NewGenericPodGroup(pgChild2),
 								UnscheduledPods: []*v1.Pod{pod2, pod3},
-								Type:            fwk.PodGroupKeyType,
 							},
 						},
 					},
 					{
-						PodGroup:        pgChild3,
+						GenericPodGroup: NewGenericPodGroup(pgChild3),
 						UnscheduledPods: []*v1.Pod{pod4},
-						Type:            fwk.PodGroupKeyType,
 					},
 				},
 			},
@@ -4461,5 +4372,19 @@ func TestPodGroupInfo_GetUnscheduledPods(t *testing.T) {
 				t.Errorf("GetUnscheduledPods() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func newPodGroupInfoForTest(pg *schedulingv1beta1.PodGroup, children ...*PodGroupInfo) *PodGroupInfo {
+	return &PodGroupInfo{
+		GenericPodGroup: NewGenericPodGroup(pg),
+		Children:        children,
+	}
+}
+
+func newCompositePodGroupInfoForTest(cpg *schedulingv1alpha3.CompositePodGroup, children ...*PodGroupInfo) *PodGroupInfo {
+	return &PodGroupInfo{
+		GenericPodGroup: NewGenericCompositePodGroup(cpg),
+		Children:        children,
 	}
 }

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -98,9 +98,6 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 	if err := sched.reconcilePodGroupWithSnapshot(podGroupInfo.PodGroupInfo); err != nil {
 		// It can happen that the hierarchy was popped from the scheduling queue before it observed the change of shape.
 		// (Composite)PodGroup should come back to the scheduling queue.
-		// We set the underlying API object to nil to signify that we don't want to update its condition in failure handler.
-		podGroupInfo.PodGroup = nil
-		podGroupInfo.CompositePodGroup = nil
 		sched.handlePodGroupFailureBeforeScheduling(ctx, podGroupInfo, err)
 		return
 	}
@@ -132,8 +129,8 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 // This is needed because PodGroupInfo popped from the queue can have older PodGroup/CompositePodGroup objects.
 // Any differences in the hierarchy shape (added or removed subtrees) will result in error.
 func (sched *Scheduler) reconcilePodGroupWithSnapshot(pgi *framework.PodGroupInfo) error {
-	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) && (pgi.GetType() == fwk.CompositePodGroupKeyType || pgi.CompositePodGroup != nil) {
-		compositePodGroup, err := sched.nodeInfoSnapshot.CompositePodGroups().Get(pgi.Namespace, pgi.Name)
+	if pgi.GetType() == fwk.CompositePodGroupKeyType {
+		compositePodGroup, err := sched.nodeInfoSnapshot.CompositePodGroups().Get(pgi.GetNamespace(), pgi.GetName())
 		if err != nil {
 			return err
 		}
@@ -142,7 +139,7 @@ func (sched *Scheduler) reconcilePodGroupWithSnapshot(pgi *framework.PodGroupInf
 				ptr.Deref(compositePodGroup.Spec.ParentCompositePodGroupName, "[unset]"),
 				ptr.Deref(pgi.CompositePodGroup.Spec.ParentCompositePodGroupName, "[unset]"))
 		}
-		cpgs, err := sched.nodeInfoSnapshot.CompositePodGroupStates().Get(pgi.Namespace, pgi.Name)
+		cpgs, err := sched.nodeInfoSnapshot.CompositePodGroupStates().Get(pgi.GetNamespace(), pgi.GetName())
 		if err != nil {
 			return err
 		}
@@ -156,9 +153,9 @@ func (sched *Scheduler) reconcilePodGroupWithSnapshot(pgi *framework.PodGroupInf
 				return err
 			}
 		}
-		pgi.CompositePodGroup = compositePodGroup
+		pgi.AbstractPodGroup = framework.NewAbstractCompositePodGroup(compositePodGroup)
 	} else {
-		podGroup, err := sched.nodeInfoSnapshot.PodGroups().Get(pgi.Namespace, pgi.Name)
+		podGroup, err := sched.nodeInfoSnapshot.PodGroups().Get(pgi.GetNamespace(), pgi.GetName())
 		if err != nil {
 			return err
 		}
@@ -168,7 +165,7 @@ func (sched *Scheduler) reconcilePodGroupWithSnapshot(pgi *framework.PodGroupInf
 				ptr.Deref(podGroup.Spec.ParentCompositePodGroupName, "[unset]"),
 				ptr.Deref(pgi.PodGroup.Spec.ParentCompositePodGroupName, "[unset]"))
 		}
-		pgi.PodGroup = podGroup
+		pgi.AbstractPodGroup = framework.NewAbstractPodGroup(podGroup)
 	}
 	return nil
 }
@@ -310,7 +307,7 @@ func (sched *Scheduler) validateScheduledPods(podGroupInfo *framework.PodGroupIn
 		return nil
 	}
 
-	podGroupState, err := sched.nodeInfoSnapshot.PodGroupStates().Get(podGroupInfo.Namespace, podGroupInfo.Name)
+	podGroupState, err := sched.nodeInfoSnapshot.PodGroupStates().Get(podGroupInfo.GetNamespace(), podGroupInfo.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to get pod group state: %w", err)
 	}
@@ -429,7 +426,7 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 	pgResults := sched.runRootSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo)
 	rootStatus := pgResults[pgKey(rootPodGroupInfo.PodGroupInfo)].status
 	var completePGResults map[fwk.EntityKey]*podGroupAlgorithmResult
-	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) && rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
+	if rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
 		completePGResults = completeCompositePodGroupAlgorithmResult(ctx, rootPodGroupInfo, podGroupCycleState, pgResults)
 	} else {
 		// pgResults has exactly 1 element.
@@ -467,7 +464,7 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 func (sched *Scheduler) runRootSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, rootPodGroupInfo *framework.QueuedPodGroupInfo) map[fwk.EntityKey]*podGroupAlgorithmResult {
 	var revertFns revertFns
 	defer revertFns.revert()
-	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) && rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
+	if rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
 		result := map[fwk.EntityKey]*podGroupAlgorithmResult{}
 		rootResult, childRevertFns := sched.podGroupSchedulingRecursiveAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo, rootPodGroupInfo.PodGroupInfo, result)
 		revertFns = childRevertFns
@@ -574,7 +571,7 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Running a pod group scheduling algorithm", "podGroup", klog.KObj(podGroupInfo), "unscheduledPodsCount", len(queuedPodInfos))
 
-	podGroupState, err := sched.nodeInfoSnapshot.PodGroupStates().Get(podGroupInfo.Namespace, podGroupInfo.Name)
+	podGroupState, err := sched.nodeInfoSnapshot.PodGroupStates().Get(podGroupInfo.GetNamespace(), podGroupInfo.GetName())
 	if err != nil {
 		result.status = fwk.AsStatus(fmt.Errorf("failed to get podGroup state for podGroup %s to compute gang feasibility: %w", klog.KObj(podGroupInfo), err))
 		return result, nil
@@ -944,9 +941,13 @@ func (sched *Scheduler) updatePodGroupCondition(ctx context.Context,
 	podGroupInfo *framework.PodGroupInfo, condition *metav1.Condition) {
 	logger := klog.FromContext(ctx)
 
+	// Get the newest object from cache to ensure the update below serves on the newest object possible.
+	pg, err := sched.Cache.PodGroups().Get(podGroupInfo.GetNamespace(), podGroupInfo.GetName())
+	if err != nil {
+		return
+	}
 	// If the PodGroup was already successfully scheduled, don't regress the
 	// condition back to False on a subsequent cycle for extra pods.
-	pg := podGroupInfo.PodGroup
 	existing := apimeta.FindStatusCondition(pg.Status.Conditions, condition.Type)
 	if existing != nil && existing.Status == metav1.ConditionTrue && condition.Status != metav1.ConditionTrue {
 		return
@@ -958,7 +959,7 @@ func (sched *Scheduler) updatePodGroupCondition(ctx context.Context,
 		return
 	}
 
-	if err := util.PatchPodGroupStatus(ctx, sched.client, podGroupInfo.Name, podGroupInfo.Namespace, &pg.Status, newStatus); err != nil {
+	if err := util.PatchPodGroupStatus(ctx, sched.client, podGroupInfo.GetName(), podGroupInfo.GetNamespace(), &pg.Status, newStatus); err != nil {
 		utilruntime.HandleErrorWithLogger(logger, err, "Failed to update PodGroup status", "podGroup", klog.KObj(podGroupInfo))
 	}
 }
@@ -1293,11 +1294,11 @@ func (sched *Scheduler) podGroupSchedulingAlgorithm(ctx context.Context, schedFw
 // The returned revertFns propagates revert functions from all child pod group evaluations up to the root level.
 func (sched *Scheduler) podGroupSchedulingRecursiveAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, root *framework.QueuedPodGroupInfo, podGroupInfo *framework.PodGroupInfo, results map[fwk.EntityKey]*podGroupAlgorithmResult) (*podGroupAlgorithmResult, revertFns) {
 	logger := klog.FromContext(ctx)
-	logger.V(5).Info("Running recursive podgroup scheduling algorithm", "rootType", podGroupInfo.Type, "root", klog.KObj(podGroupInfo))
+	logger.V(5).Info("Running recursive podgroup scheduling algorithm", "rootType", podGroupInfo.GetType(), "root", klog.KObj(podGroupInfo))
 
 	var algorithmResult *podGroupAlgorithmResult
 	var childRevertFns revertFns
-	if podGroupInfo.Type == fwk.PodGroupKeyType {
+	if podGroupInfo.GetType() == fwk.PodGroupKeyType {
 		algorithmResult, childRevertFns = sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, podGroupInfo, root)
 		results[pgKey(podGroupInfo)] = algorithmResult
 	} else {
@@ -1379,10 +1380,10 @@ func (sched *Scheduler) compositePodGroupSchedulingDefaultAlgorithm(ctx context.
 }
 
 func pgKey(pgi *framework.PodGroupInfo) fwk.EntityKey {
-	if pgi.Type == fwk.CompositePodGroupKeyType {
-		return fwk.CompositePodGroupKey(pgi.Namespace, pgi.Name)
+	if pgi.GetType() == fwk.CompositePodGroupKeyType {
+		return fwk.CompositePodGroupKey(pgi.GetNamespace(), pgi.GetName())
 	}
-	return fwk.PodGroupKey(pgi.Namespace, pgi.Name)
+	return fwk.PodGroupKey(pgi.GetNamespace(), pgi.GetName())
 }
 
 // assumeSubtreeWithRevert runs assumeAndReserveWithRevert on all pods within the subtree.

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -62,9 +62,6 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 	if err := sched.reconcilePodGroupWithSnapshot(podGroupInfo.PodGroupInfo); err != nil {
 		// It can happen that the hierarchy was popped from the scheduling queue before it observed the change of shape.
 		// (Composite)PodGroup should come back to the scheduling queue.
-		// We set the underlying API object to nil to signify that we don't want to update its condition in failure handler.
-		podGroupInfo.PodGroup = nil
-		podGroupInfo.CompositePodGroup = nil
 		sched.handlePodGroupFailureBeforeScheduling(ctx, podGroupInfo, err)
 		return
 	}
@@ -96,8 +93,8 @@ func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *f
 // This is needed because PodGroupInfo popped from the queue can have older PodGroup/CompositePodGroup objects.
 // Any differences in the hierarchy shape (added or removed subtrees) will result in error.
 func (sched *Scheduler) reconcilePodGroupWithSnapshot(pgi *framework.PodGroupInfo) error {
-	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) && (pgi.GetType() == fwk.CompositePodGroupKeyType || pgi.CompositePodGroup != nil) {
-		compositePodGroup, err := sched.nodeInfoSnapshot.CompositePodGroups().Get(pgi.Namespace, pgi.Name)
+	if pgi.GetType() == fwk.CompositePodGroupKeyType {
+		compositePodGroup, err := sched.nodeInfoSnapshot.CompositePodGroups().Get(pgi.GetNamespace(), pgi.GetName())
 		if err != nil {
 			return err
 		}
@@ -106,7 +103,7 @@ func (sched *Scheduler) reconcilePodGroupWithSnapshot(pgi *framework.PodGroupInf
 				ptr.Deref(compositePodGroup.Spec.ParentCompositePodGroupName, "[unset]"),
 				ptr.Deref(pgi.CompositePodGroup.Spec.ParentCompositePodGroupName, "[unset]"))
 		}
-		cpgs, err := sched.nodeInfoSnapshot.CompositePodGroupStates().Get(pgi.Namespace, pgi.Name)
+		cpgs, err := sched.nodeInfoSnapshot.CompositePodGroupStates().Get(pgi.GetNamespace(), pgi.GetName())
 		if err != nil {
 			return err
 		}
@@ -120,9 +117,9 @@ func (sched *Scheduler) reconcilePodGroupWithSnapshot(pgi *framework.PodGroupInf
 				return err
 			}
 		}
-		pgi.CompositePodGroup = compositePodGroup
+		pgi.GenericPodGroup = framework.NewGenericCompositePodGroup(compositePodGroup)
 	} else {
-		podGroup, err := sched.nodeInfoSnapshot.PodGroups().Get(pgi.Namespace, pgi.Name)
+		podGroup, err := sched.nodeInfoSnapshot.PodGroups().Get(pgi.GetNamespace(), pgi.GetName())
 		if err != nil {
 			return err
 		}
@@ -132,7 +129,7 @@ func (sched *Scheduler) reconcilePodGroupWithSnapshot(pgi *framework.PodGroupInf
 				ptr.Deref(podGroup.Spec.ParentCompositePodGroupName, "[unset]"),
 				ptr.Deref(pgi.PodGroup.Spec.ParentCompositePodGroupName, "[unset]"))
 		}
-		pgi.PodGroup = podGroup
+		pgi.GenericPodGroup = framework.NewGenericPodGroup(podGroup)
 	}
 	return nil
 }
@@ -274,7 +271,7 @@ func (sched *Scheduler) validateScheduledPods(podGroupInfo *framework.PodGroupIn
 		return nil
 	}
 
-	podGroupState, err := sched.nodeInfoSnapshot.PodGroupStates().Get(podGroupInfo.Namespace, podGroupInfo.Name)
+	podGroupState, err := sched.nodeInfoSnapshot.PodGroupStates().Get(podGroupInfo.GetNamespace(), podGroupInfo.GetName())
 	if err != nil {
 		return fmt.Errorf("failed to get pod group state: %w", err)
 	}
@@ -384,7 +381,7 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 	pgResults := sched.runRootSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo)
 	rootStatus := pgResults[rootPodGroupInfo.PodGroupInfo.GetKey()].status
 	var completePGResults map[fwk.EntityKey]*podGroupAlgorithmResult
-	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) && rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
+	if rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
 		completePGResults = completeCompositePodGroupAlgorithmResult(ctx, rootPodGroupInfo, podGroupCycleState, pgResults)
 	} else {
 		// pgResults has exactly 1 element.
@@ -422,7 +419,7 @@ func (sched *Scheduler) podGroupCycle(ctx context.Context, schedFwk framework.Fr
 func (sched *Scheduler) runRootSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, rootPodGroupInfo *framework.QueuedPodGroupInfo) map[fwk.EntityKey]*podGroupAlgorithmResult {
 	var revertFns revertFns
 	defer revertFns.revert()
-	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) && rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
+	if rootPodGroupInfo.GetType() == fwk.CompositePodGroupKeyType {
 		result := map[fwk.EntityKey]*podGroupAlgorithmResult{}
 		rootResult, childRevertFns := sched.podGroupSchedulingRecursiveAlgorithm(ctx, schedFwk, podGroupCycleState, rootPodGroupInfo, rootPodGroupInfo.PodGroupInfo, result)
 		revertFns = childRevertFns
@@ -471,7 +468,7 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Running a pod group scheduling algorithm", "podGroup", klog.KObj(podGroupInfo), "unscheduledPodsCount", len(queuedPodInfos))
 
-	podGroupState, err := sched.nodeInfoSnapshot.PodGroupStates().Get(podGroupInfo.Namespace, podGroupInfo.Name)
+	podGroupState, err := sched.nodeInfoSnapshot.PodGroupStates().Get(podGroupInfo.GetNamespace(), podGroupInfo.GetName())
 	if err != nil {
 		result.status = fwk.AsStatus(fmt.Errorf("failed to get podGroup state for podGroup %s to compute gang feasibility: %w", klog.KObj(podGroupInfo), err))
 		return result, nil
@@ -856,9 +853,13 @@ func (sched *Scheduler) updatePodGroupCondition(ctx context.Context,
 	podGroupInfo *framework.PodGroupInfo, condition *metav1.Condition) {
 	logger := klog.FromContext(ctx)
 
+	// Get the newest object from cache to ensure the update below serves on the newest object possible.
+	pg, err := sched.Cache.PodGroups().Get(podGroupInfo.GetNamespace(), podGroupInfo.GetName())
+	if err != nil {
+		return
+	}
 	// If the PodGroup was already successfully scheduled, don't regress the
 	// condition back to False on a subsequent cycle for extra pods.
-	pg := podGroupInfo.PodGroup
 	existing := apimeta.FindStatusCondition(pg.Status.Conditions, condition.Type)
 	if existing != nil && existing.Status == metav1.ConditionTrue && condition.Status != metav1.ConditionTrue {
 		return
@@ -870,7 +871,7 @@ func (sched *Scheduler) updatePodGroupCondition(ctx context.Context,
 		return
 	}
 
-	if err := util.PatchPodGroupStatus(ctx, sched.client, podGroupInfo.Name, podGroupInfo.Namespace, &pg.Status, newStatus); err != nil {
+	if err := util.PatchPodGroupStatus(ctx, sched.client, podGroupInfo.GetName(), podGroupInfo.GetNamespace(), &pg.Status, newStatus); err != nil {
 		utilruntime.HandleErrorWithLogger(logger, err, "Failed to update PodGroup status", "podGroup", klog.KObj(podGroupInfo))
 	}
 }
@@ -1211,11 +1212,11 @@ func (sched *Scheduler) podGroupSchedulingAlgorithm(ctx context.Context, schedFw
 // The returned revertFns propagates revert functions from all child pod group evaluations up to the root level.
 func (sched *Scheduler) podGroupSchedulingRecursiveAlgorithm(ctx context.Context, schedFwk framework.Framework, podGroupCycleState *framework.CycleState, root *framework.QueuedPodGroupInfo, podGroupInfo *framework.PodGroupInfo, results map[fwk.EntityKey]*podGroupAlgorithmResult) (*podGroupAlgorithmResult, revertFns) {
 	logger := klog.FromContext(ctx)
-	logger.V(5).Info("Running recursive podgroup scheduling algorithm", "rootType", podGroupInfo.Type, "root", klog.KObj(podGroupInfo))
+	logger.V(5).Info("Running recursive podgroup scheduling algorithm", "rootType", podGroupInfo.GetType(), "root", klog.KObj(podGroupInfo))
 
 	var algorithmResult *podGroupAlgorithmResult
 	var childRevertFns revertFns
-	if podGroupInfo.Type == fwk.PodGroupKeyType {
+	if podGroupInfo.GetType() == fwk.PodGroupKeyType {
 		algorithmResult, childRevertFns = sched.podGroupSchedulingAlgorithm(ctx, schedFwk, podGroupCycleState, podGroupInfo, root)
 		results[podGroupInfo.GetKey()] = algorithmResult
 	} else {

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -157,7 +157,7 @@ func (mp *fakePlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, pl
 	}
 
 	total := len(podGroupInfo.GetUnscheduledPods())
-	if pgInfo, ok := podGroupInfo.(*framework.PodGroupInfo); ok && pgInfo.Type == fwk.CompositePodGroupKeyType {
+	if pgInfo, ok := podGroupInfo.(*framework.PodGroupInfo); ok && pgInfo.GetType() == fwk.CompositePodGroupKeyType {
 		total = len(pgInfo.Children)
 	}
 	evaluated := total - args.Remaining
@@ -579,12 +579,7 @@ func TestValidatePodGroup(t *testing.T) {
 			} else {
 				snapshot = internalcache.NewTestSnapshotWithPodGroups(tt.scheduledPods, nil, []*schedulingv1beta1.PodGroup{tt.podGroup})
 				podGroupInfo = &framework.QueuedPodGroupInfo{
-					PodGroupInfo: &framework.PodGroupInfo{
-						Name:      tt.podGroup.Name,
-						Namespace: tt.podGroup.Namespace,
-						Type:      fwk.PodGroupKeyType,
-						PodGroup:  tt.podGroup,
-					},
+					PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(tt.podGroup)},
 					QueuedPodInfos: make(map[fwk.EntityKey][]*framework.QueuedPodInfo),
 				}
 				for _, pod := range tt.pods {
@@ -635,13 +630,7 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2, qInfo3}},
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
-			UnscheduledPods: []*v1.Pod{p1, p2, p3},
-			PodGroup:        testPodGroup,
-		},
+		PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(testPodGroup), UnscheduledPods: []*v1.Pod{p1, p2, p3}},
 	}
 
 	logger, ctx := ktesting.NewTestContext(t)
@@ -809,13 +798,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
-			UnscheduledPods: []*v1.Pod{p1, p2},
-			PodGroup:        testPodGroup,
-		},
+		PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(testPodGroup), UnscheduledPods: []*v1.Pod{p1, p2}},
 	}
 
 	_, ctx := ktesting.NewTestContext(t)
@@ -893,13 +876,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
-			UnscheduledPods: []*v1.Pod{p1, p2, p3},
-			PodGroup:        testPodGroup,
-		},
+		PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(testPodGroup), UnscheduledPods: []*v1.Pod{p1, p2, p3}},
 	}
 
 	_, ctx := ktesting.NewTestContext(t)
@@ -1055,13 +1032,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 
 			podGroupInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
-				PodGroupInfo: &framework.PodGroupInfo{
-					Name:            "pg",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					UnscheduledPods: []*v1.Pod{p1, p2},
-					PodGroup:        testPodGroup,
-				},
+				PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(testPodGroup), UnscheduledPods: []*v1.Pod{p1, p2}},
 			}
 
 			_, ctx := ktesting.NewTestContext(t)
@@ -1183,13 +1154,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
-			UnscheduledPods: []*v1.Pod{p1, p2, p3},
-			PodGroup:        testPodGroup,
-		},
+		PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(testPodGroup), UnscheduledPods: []*v1.Pod{p1, p2, p3}},
 	}
 
 	tests := []struct {
@@ -1878,6 +1843,8 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
 			cache.AddNode(klog.FromContext(ctx), testNode)
+			apg := framework.NewAbstractPodGroup(pg)
+			cache.AddAbstractPodGroup(apg)
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			informerFactory.Start(ctx.Done())
@@ -1905,7 +1872,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			}
 
 			// Create the pod group and add the pods to queue and pop the group to set up internal queue state correctly.
-			schedulingQueue.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
+			schedulingQueue.AddAbstractPodGroup(logger, apg)
 			// Advance the clock between additions to keep pod ordering deterministic.
 			schedulingQueue.Add(ctx, p1)
 			fakeClock.Step(time.Second)
@@ -2319,10 +2286,14 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 				objects = append(objects, tt.existingPodGroup)
 			}
 			client := clientsetfake.NewClientset(objects...)
+			cache := internalcache.New(ctx, nil, true, true)
+			apg := framework.NewAbstractPodGroup(tt.existingPodGroup)
+			cache.AddAbstractPodGroup(apg)
+
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			informerFactory.Start(ctx.Done())
 			informerFactory.WaitForCacheSync(ctx.Done())
-			sched := &Scheduler{client: client}
+			sched := &Scheduler{client: client, Cache: cache}
 
 			var existingLTT metav1.Time
 			if existing := apimeta.FindStatusCondition(tt.existingPodGroup.Status.Conditions, schedulingapi.PodGroupInitiallyScheduled); existing != nil {
@@ -2330,12 +2301,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			}
 
 			podGroupInfo := &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: tt.namespace,
-					Name:      tt.podGroupName,
-					PodGroup:  tt.existingPodGroup,
-					Type:      fwk.PodGroupKeyType,
-				},
+				PodGroupInfo: &framework.PodGroupInfo{AbstractPodGroup: apg},
 			}
 			sched.updatePodGroupCondition(ctx, podGroupInfo.PodGroupInfo, tt.condition)
 
@@ -2488,13 +2454,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 	queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: podGroupPod}}}
 	pgInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
-			PodGroup:        testPodGroup,
-			UnscheduledPods: []*v1.Pod{podGroupPod},
-		},
+		PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(testPodGroup), UnscheduledPods: []*v1.Pod{podGroupPod}},
 	}
 
 	tests := map[string]struct {
@@ -2997,12 +2957,7 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: podGroupPod}}}
 				pgInfo := &framework.QueuedPodGroupInfo{
 					QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
-					PodGroupInfo: &framework.PodGroupInfo{
-						Name:            "pg",
-						Namespace:       "default",
-						Type:            fwk.PodGroupKeyType,
-						UnscheduledPods: []*v1.Pod{podGroupPod},
-					},
+					PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(&schedulingv1beta1.PodGroup{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg"}}), UnscheduledPods: []*v1.Pod{podGroupPod}},
 				}
 
 				placementPlugin := fakePlacementPlugin{
@@ -3247,12 +3202,7 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 			queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: podGroupPod}}}
 			pgInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): queuedPodInfos},
-				PodGroupInfo: &framework.PodGroupInfo{
-					Name:            "pg",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					UnscheduledPods: []*v1.Pod{podGroupPod},
-				},
+				PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(&schedulingv1beta1.PodGroup{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "pg"}}), UnscheduledPods: []*v1.Pod{podGroupPod}},
 			}
 
 			result, _ := sched.podGroupSchedulingPlacementAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo.PodGroupInfo, pgInfo)
@@ -3419,27 +3369,9 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 	}
 	queuedPodInfo1 := &framework.QueuedPodInfo{PodInfo: podInfo1}
 
-	leafPGInfo := &framework.PodGroupInfo{
-		Name:            pg.Name,
-		Namespace:       pg.Namespace,
-		Type:            fwk.PodGroupKeyType,
-		PodGroup:        pg,
-		UnscheduledPods: []*v1.Pod{p1},
-	}
-	midPGInfo := &framework.PodGroupInfo{
-		Name:              midcpg.Name,
-		Namespace:         midcpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		CompositePodGroup: midcpg,
-		Children:          []*framework.PodGroupInfo{leafPGInfo},
-	}
-	rootPGInfo := &framework.PodGroupInfo{
-		Name:              rootcpg.Name,
-		Namespace:         rootcpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		CompositePodGroup: rootcpg,
-		Children:          []*framework.PodGroupInfo{midPGInfo},
-	}
+	leafPGInfo := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(pg), UnscheduledPods: []*v1.Pod{p1}}
+	midPGInfo := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractCompositePodGroup(midcpg), Children: []*framework.PodGroupInfo{leafPGInfo}}
+	rootPGInfo := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractCompositePodGroup(rootcpg), Children: []*framework.PodGroupInfo{midPGInfo}}
 
 	logger, ctx := ktesting.NewTestContext(t)
 
@@ -3604,28 +3536,10 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 	queuedPodInfo1 := &framework.QueuedPodInfo{PodInfo: podInfo1}
 	queuedPodInfo2 := &framework.QueuedPodInfo{PodInfo: podInfo2}
 
-	childPGInfo1 := &framework.PodGroupInfo{
-		Name:            pg1.Name,
-		Namespace:       pg1.Namespace,
-		Type:            fwk.PodGroupKeyType,
-		PodGroup:        pg1,
-		UnscheduledPods: []*v1.Pod{p1},
-	}
-	childPGInfo2 := &framework.PodGroupInfo{
-		Name:            pg2.Name,
-		Namespace:       pg2.Namespace,
-		Type:            fwk.PodGroupKeyType,
-		PodGroup:        pg2,
-		UnscheduledPods: []*v1.Pod{p2},
-	}
+	childPGInfo1 := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}}
+	childPGInfo2 := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}}
 
-	rootPGInfo := &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		CompositePodGroup: cpg,
-		Children:          []*framework.PodGroupInfo{childPGInfo1, childPGInfo2},
-	}
+	rootPGInfo := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg), Children: []*framework.PodGroupInfo{childPGInfo1, childPGInfo2}}
 
 	defaultPlacementResults := map[string]map[string][]string{
 		rootPGInfo.GetKey(): {
@@ -4024,28 +3938,10 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 	queuedPodInfo1 := &framework.QueuedPodInfo{PodInfo: podInfo1}
 	queuedPodInfo2 := &framework.QueuedPodInfo{PodInfo: podInfo2}
 
-	childPGInfo1 := &framework.PodGroupInfo{
-		Name:            pg1.Name,
-		Namespace:       pg1.Namespace,
-		Type:            fwk.PodGroupKeyType,
-		PodGroup:        pg1,
-		UnscheduledPods: []*v1.Pod{p1},
-	}
-	childPGInfo2 := &framework.PodGroupInfo{
-		Name:            pg2.Name,
-		Namespace:       pg2.Namespace,
-		Type:            fwk.PodGroupKeyType,
-		PodGroup:        pg2,
-		UnscheduledPods: []*v1.Pod{p2},
-	}
+	childPGInfo1 := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}}
+	childPGInfo2 := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}}
 
-	rootPGInfo := &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		CompositePodGroup: cpg,
-		Children:          []*framework.PodGroupInfo{childPGInfo1, childPGInfo2},
-	}
+	rootPGInfo := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg), Children: []*framework.PodGroupInfo{childPGInfo1, childPGInfo2}}
 
 	placements := map[string]map[string][]string{
 		rootPGInfo.GetKey(): {
@@ -4299,13 +4195,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
-			UnscheduledPods: []*v1.Pod{p1, p2},
-			PodGroup:        testPodGroup,
-		},
+		PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(testPodGroup), UnscheduledPods: []*v1.Pod{p1, p2}},
 	}
 
 	_, ctx := ktesting.NewTestContext(t)
@@ -4424,13 +4314,7 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
-			PodGroup:        testPodGroup,
-			UnscheduledPods: []*v1.Pod{p1, p2},
-		},
+		PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(testPodGroup), UnscheduledPods: []*v1.Pod{p1, p2}},
 	}
 
 	_, ctx := ktesting.NewTestContext(t)
@@ -4501,14 +4385,10 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	testPodGroup := st.MakePodGroup().Name("pg").Namespace("default").Obj()
+	apg := framework.NewAbstractPodGroup(testPodGroup)
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.MustParseEntityKey("podgroup/default/pg"): {qInfo1, qInfo2}},
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:      "pg",
-			Namespace: "default",
-			Type:      fwk.PodGroupKeyType,
-			PodGroup:  testPodGroup,
-		},
+		PodGroupInfo:   &framework.PodGroupInfo{AbstractPodGroup: apg},
 	}
 	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
@@ -4546,6 +4426,9 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	}
 
 	client := clientsetfake.NewClientset(testPodGroup)
+	cache := internalcache.New(ctx, nil, true, false /* CompositePodGroup */)
+	cache.AddAbstractPodGroup(apg)
+
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
@@ -4553,7 +4436,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 		Profiles:        profile.Map{"sched1": schedFwk1, "sched2": schedFwk2},
 		SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 		Cache: &fakecache.Cache{
-			Cache: internalcache.New(ctx, nil, true, false /* CompositePodGroup */),
+			Cache: cache,
 			UpdateSnapshotFunc: func(nodeSnapshot *internalcache.Snapshot) error {
 				return nil
 			},
@@ -4633,35 +4516,11 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 
 	cpgRootInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfosMap,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         namespace,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			CompositePodGroup: cpgRoot,
-			UnscheduledPods:   []*v1.Pod{p1, p2, p3},
-			Children: []*framework.PodGroupInfo{
-				{
-					Name:            "pg1",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					PodGroup:        pg1,
-					UnscheduledPods: []*v1.Pod{p1},
-				},
-				{
-					Name:            "pg2",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					PodGroup:        pg2,
-					UnscheduledPods: []*v1.Pod{p2},
-				},
-				{
-					Name:            "pg3",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					PodGroup:        pg3,
-					UnscheduledPods: []*v1.Pod{p3},
-				},
-			},
+		PodGroupInfo: &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpgRoot), UnscheduledPods: []*v1.Pod{p1, p2, p3}, Children: []*framework.PodGroupInfo{
+			{AbstractPodGroup: framework.NewAbstractPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}},
+			{AbstractPodGroup: framework.NewAbstractPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}},
+			{AbstractPodGroup: framework.NewAbstractPodGroup(pg3), UnscheduledPods: []*v1.Pod{p3}},
+		},
 		},
 		QueueingParams: framework.QueueingParams{
 			Timestamp: time.Now(),
@@ -4913,45 +4772,24 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         ns,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			UnscheduledPods:   allPods,
-			CompositePodGroup: rootCPG,
-			Children: []*framework.PodGroupInfo{
-				{
-					Namespace:         ns,
-					Name:              "cpg-sub1",
-					Type:              fwk.CompositePodGroupKeyType,
-					CompositePodGroup: cpgSub1,
-					Children: []*framework.PodGroupInfo{
-						{Namespace: ns, Name: "pg1", Type: fwk.PodGroupKeyType, PodGroup: pg1, UnscheduledPods: pgPods["pg1"]},
-						{Namespace: ns, Name: "pg2", Type: fwk.PodGroupKeyType, PodGroup: pg2, UnscheduledPods: pgPods["pg2"]},
-						{Namespace: ns, Name: "pg3", Type: fwk.PodGroupKeyType, PodGroup: pg3, UnscheduledPods: pgPods["pg3"]},
-					},
-				},
-				{
-					Namespace:         ns,
-					Name:              "cpg-sub2",
-					Type:              fwk.CompositePodGroupKeyType,
-					CompositePodGroup: cpgSub2,
-					Children: []*framework.PodGroupInfo{
-						{Namespace: ns, Name: "pg4", Type: fwk.PodGroupKeyType, PodGroup: pg4, UnscheduledPods: pgPods["pg4"]},
-						{Namespace: ns, Name: "pg5", Type: fwk.PodGroupKeyType, PodGroup: pg5, UnscheduledPods: pgPods["pg5"]},
-					},
-				},
-				{
-					Namespace:         ns,
-					Name:              "cpg-sub3",
-					Type:              fwk.CompositePodGroupKeyType,
-					CompositePodGroup: cpgSub3,
-					Children: []*framework.PodGroupInfo{
-						{Namespace: ns, Name: "pg6", Type: fwk.PodGroupKeyType, PodGroup: pg6, UnscheduledPods: pgPods["pg6"]},
-						{Namespace: ns, Name: "pg7", Type: fwk.PodGroupKeyType, PodGroup: pg7, UnscheduledPods: pgPods["pg7"]},
-					},
-				},
+		PodGroupInfo: &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
+			{AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpgSub1), Children: []*framework.PodGroupInfo{
+				{AbstractPodGroup: framework.NewAbstractPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
+				{AbstractPodGroup: framework.NewAbstractPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
+				{AbstractPodGroup: framework.NewAbstractPodGroup(pg3), UnscheduledPods: pgPods["pg3"]},
 			},
+			},
+			{AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpgSub2), Children: []*framework.PodGroupInfo{
+				{AbstractPodGroup: framework.NewAbstractPodGroup(pg4), UnscheduledPods: pgPods["pg4"]},
+				{AbstractPodGroup: framework.NewAbstractPodGroup(pg5), UnscheduledPods: pgPods["pg5"]},
+			},
+			},
+			{AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpgSub3), Children: []*framework.PodGroupInfo{
+				{AbstractPodGroup: framework.NewAbstractPodGroup(pg6), UnscheduledPods: pgPods["pg6"]},
+				{AbstractPodGroup: framework.NewAbstractPodGroup(pg7), UnscheduledPods: pgPods["pg7"]},
+			},
+			},
+		},
 		},
 	}
 
@@ -5269,17 +5107,11 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         ns,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			UnscheduledPods:   allPods,
-			CompositePodGroup: rootCPG,
-			Children: []*framework.PodGroupInfo{
-				{Namespace: ns, Name: "pg1", Type: fwk.PodGroupKeyType, PodGroup: pg1, UnscheduledPods: pgPods["pg1"]},
-				{Namespace: ns, Name: "pg2", Type: fwk.PodGroupKeyType, PodGroup: pg2, UnscheduledPods: pgPods["pg2"]},
-				{Namespace: ns, Name: "pg3", Type: fwk.PodGroupKeyType, PodGroup: pg3, UnscheduledPods: pgPods["pg3"]},
-			},
+		PodGroupInfo: &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
+			{AbstractPodGroup: framework.NewAbstractPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
+			{AbstractPodGroup: framework.NewAbstractPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
+			{AbstractPodGroup: framework.NewAbstractPodGroup(pg3), UnscheduledPods: pgPods["pg3"]},
+		},
 		},
 	}
 
@@ -5496,16 +5328,10 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         ns,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			UnscheduledPods:   allPods,
-			CompositePodGroup: rootCPG,
-			Children: []*framework.PodGroupInfo{
-				{Namespace: ns, Name: "pg1", Type: fwk.PodGroupKeyType, PodGroup: pg1, UnscheduledPods: pgPods["pg1"]},
-				{Namespace: ns, Name: "pg2", Type: fwk.PodGroupKeyType, PodGroup: pg2, UnscheduledPods: pgPods["pg2"]},
-			},
+		PodGroupInfo: &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
+			{AbstractPodGroup: framework.NewAbstractPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
+			{AbstractPodGroup: framework.NewAbstractPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
+		},
 		},
 	}
 
@@ -5847,18 +5673,19 @@ func TestScorePlacementPodGroupAssignments(t *testing.T) {
 				for _, ch := range node.children {
 					children = append(children, buildTree(ch))
 				}
-				pgi := &framework.PodGroupInfo{
-					Name:      node.name,
-					Namespace: "default",
-					Children:  children,
-				}
+				pgi := &framework.PodGroupInfo{Children: children}
 				if len(children) > 0 {
-					pgi.Type = fwk.CompositePodGroupKeyType
-					pgi.CompositePodGroup = st.MakeCompositePodGroup().Name(node.name).Namespace("default").Obj()
+					cpg := st.MakeCompositePodGroup().Name(node.name).Namespace("default").Obj()
+					pgi.AbstractPodGroup = framework.
+						NewAbstractCompositePodGroup(cpg)
+
 				} else {
-					pgi.Type = fwk.PodGroupKeyType
-					pgi.PodGroup = st.MakePodGroup().Name(node.name).Namespace("default").Obj()
+					pg := st.MakePodGroup().Name(node.
+						name).Namespace("default").Obj()
+					pgi.AbstractPodGroup = framework.
+						NewAbstractPodGroup(pg)
 				}
+
 				nameToKey[node.name] = pgKey(pgi)
 				return pgi
 			}
@@ -5934,24 +5761,13 @@ func buildHierarchicalQueuedPodGroupInfo(
 
 	var buildTree func(cpg *schedulingv1alpha3.CompositePodGroup) *framework.PodGroupInfo
 	buildTree = func(cpg *schedulingv1alpha3.CompositePodGroup) *framework.PodGroupInfo {
-		info := &framework.PodGroupInfo{
-			Namespace:         cpg.Namespace,
-			Name:              cpg.Name,
-			Type:              fwk.CompositePodGroupKeyType,
-			CompositePodGroup: cpg,
-		}
+		info := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractCompositePodGroup(cpg)}
 		for _, childCPG := range cpgChildren[cpg.Name] {
 			info.Children = append(info.Children, buildTree(childCPG))
 		}
 		for _, childPG := range pgChildren[cpg.Name] {
 			pgKey := fwk.PodGroupKey(childPG.Namespace, childPG.Name)
-			pgInfo := &framework.PodGroupInfo{
-				Namespace:       childPG.Namespace,
-				Name:            childPG.Name,
-				Type:            fwk.PodGroupKeyType,
-				PodGroup:        childPG,
-				UnscheduledPods: podsByPG[pgKey],
-			}
+			pgInfo := &framework.PodGroupInfo{AbstractPodGroup: framework.NewAbstractPodGroup(childPG), UnscheduledPods: podsByPG[pgKey]}
 			info.Children = append(info.Children, pgInfo)
 		}
 		return info
@@ -5963,8 +5779,8 @@ func buildHierarchicalQueuedPodGroupInfo(
 	var allUnscheduled []*v1.Pod
 	var collectPods func(info *framework.PodGroupInfo)
 	collectPods = func(info *framework.PodGroupInfo) {
-		if info.Type == fwk.PodGroupKeyType {
-			pgKey := fwk.PodGroupKey(info.Namespace, info.Name)
+		if info.GetType() == fwk.PodGroupKeyType {
+			pgKey := fwk.PodGroupKey(info.GetNamespace(), info.GetName())
 			for _, p := range info.UnscheduledPods {
 				queuedPodInfos[pgKey] = append(queuedPodInfos[pgKey], &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p}})
 				allUnscheduled = append(allUnscheduled, p)

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -742,7 +742,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			}
 
 			cache := internalcache.New(ctx, nil, true, false)
-			cache.AddPodGroup(podGroup)
+			cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(podGroup))
 			cache.AddPodGroupMember(p1)
 			assumedP1 := p1.DeepCopy()
 			assumedP1.Spec.NodeName = "node1"
@@ -751,7 +751,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			}
 
 			queue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc())
-			queue.AddPodGroup(logger, podGroup)
+			queue.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
 			queue.Add(ctx, p1)
 			entity, err := queue.Pop(logger)
 			if err != nil {
@@ -950,7 +950,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
 	logger, ctx := ktesting.NewTestContext(t)
 	cache.AddNode(logger, testNode)
-	cache.AddPodGroup(testPodGroup)
+	cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(testPodGroup))
 
 	handledPods := make(map[string]*fwk.Status)
 	var lock sync.Mutex
@@ -1139,7 +1139,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 			cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
 			logger, ctx := ktesting.NewTestContext(t)
 			cache.AddNode(logger, testNode)
-			cache.AddPodGroup(testPodGroup)
+			cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(testPodGroup))
 
 			sched := &Scheduler{
 				Profiles:               profile.Map{"test-scheduler": schedFwk},
@@ -1497,7 +1497,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 
 					cache := internalcache.New(ctx, nil, true, cpgEnabled /* CompositePodGroup */)
 					cache.AddNode(logger, testNode)
-					cache.AddPodGroup(testPodGroup)
+					cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(testPodGroup))
 
 					sched := &Scheduler{
 						Cache:            cache,
@@ -1905,7 +1905,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			}
 
 			// Create the pod group and add the pods to queue and pop the group to set up internal queue state correctly.
-			schedulingQueue.AddPodGroup(logger, pg)
+			schedulingQueue.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(pg))
 			// Advance the clock between additions to keep pod ordering deterministic.
 			schedulingQueue.Add(ctx, p1)
 			fakeClock.Step(time.Second)
@@ -2852,7 +2852,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				for _, node := range nodes {
 					cache.AddNode(logger, node)
 				}
-				cache.AddPodGroup(testPodGroup)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(testPodGroup))
 
 				sched := &Scheduler{
 					Cache:            cache,
@@ -3060,7 +3060,7 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				testPodGroup := &schedulingv1beta1.PodGroup{
 					ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 				}
-				cache.AddPodGroup(testPodGroup)
+				cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(testPodGroup))
 
 				sched := &Scheduler{
 					Cache:            cache,
@@ -3230,7 +3230,7 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 			testPodGroup := &schedulingv1beta1.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 			}
-			cache.AddPodGroup(testPodGroup)
+			cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(testPodGroup))
 
 			sched := &Scheduler{
 				Cache:            cache,
@@ -3497,9 +3497,9 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 	for _, node := range nodes {
 		cache.AddNode(logger, node)
 	}
-	cache.AddCompositePodGroup(logger, rootcpg)
-	cache.AddCompositePodGroup(logger, midcpg)
-	cache.AddPodGroup(pg)
+	cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(rootcpg))
+	cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(midcpg))
+	cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 
 	sched := &Scheduler{
 		Cache:            cache,
@@ -3931,9 +3931,9 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 			for _, node := range nodes {
 				cache.AddNode(logger, node)
 			}
-			cache.AddCompositePodGroup(logger, cpg)
-			cache.AddPodGroup(pg1)
-			cache.AddPodGroup(pg2)
+			cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
+			cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg1))
+			cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg2))
 			cache.AddPodGroupMember(p1)
 			cache.AddPodGroupMember(p2)
 
@@ -4238,9 +4238,9 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 			for _, node := range nodes {
 				cache.AddNode(logger, node)
 			}
-			cache.AddCompositePodGroup(logger, cpg)
-			cache.AddPodGroup(pg1)
-			cache.AddPodGroup(pg2)
+			cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
+			cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg1))
+			cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg2))
 			cache.AddPodGroupMember(p1)
 			cache.AddPodGroupMember(p2)
 
@@ -4362,7 +4362,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 	}
 
 	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddPodGroup(testPodGroup)
+	cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(testPodGroup))
 	sched := &Scheduler{
 		Profiles:         profile.Map{"test-scheduler": schedFwk},
 		Cache:            cache,
@@ -4725,10 +4725,10 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 	}
 
 	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddCompositePodGroup(logger, cpgRoot)
-	cache.AddPodGroup(pg1)
-	cache.AddPodGroup(pg2)
-	cache.AddPodGroup(pg3)
+	cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpgRoot))
+	cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg1))
+	cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg2))
+	cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg3))
 
 	sched := &Scheduler{
 		Profiles:         profile.Map{"test-scheduler": schedFwk},
@@ -4844,7 +4844,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 				ParentCompositePodGroupName: new(parentCPG),
 			},
 		}
-		cache.AddPodGroup(pg)
+		cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 		return pg
 	}
 
@@ -4866,7 +4866,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 				ParentCompositePodGroupName: parentCPG,
 			},
 		}
-		cache.AddCompositePodGroup(logger, cpg)
+		cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 		return cpg
 	}
 
@@ -5128,7 +5128,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 				ParentCompositePodGroupName: parentCPG,
 			},
 		}
-		cache.AddCompositePodGroup(logger, cpg)
+		cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 		return cpg
 	}
 
@@ -5150,7 +5150,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 				ParentCompositePodGroupName: new(parentCPG),
 			},
 		}
-		cache.AddPodGroup(pg)
+		cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 		return pg
 	}
 
@@ -5360,7 +5360,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 				ParentCompositePodGroupName: parentCPG,
 			},
 		}
-		cache.AddCompositePodGroup(logger, cpg)
+		cache.AddAbstractPodGroup(framework.NewAbstractCompositePodGroup(cpg))
 		return cpg
 	}
 
@@ -5382,7 +5382,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 				ParentCompositePodGroupName: new(parentCPG),
 			},
 		}
-		cache.AddPodGroup(pg)
+		cache.AddAbstractPodGroup(framework.NewAbstractPodGroup(pg))
 		return pg
 	}
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -158,7 +158,7 @@ func (mp *fakePlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, pl
 	}
 
 	total := len(podGroupInfo.GetUnscheduledPods())
-	if pgInfo, ok := podGroupInfo.(*framework.PodGroupInfo); ok && pgInfo.Type == fwk.CompositePodGroupKeyType {
+	if pgInfo, ok := podGroupInfo.(*framework.PodGroupInfo); ok && pgInfo.GetType() == fwk.CompositePodGroupKeyType {
 		total = len(pgInfo.Children)
 	}
 	evaluated := total - args.Remaining
@@ -580,12 +580,7 @@ func TestValidatePodGroup(t *testing.T) {
 			} else {
 				snapshot = internalcache.NewTestSnapshotWithPodGroups(tt.scheduledPods, nil, []*schedulingv1beta1.PodGroup{tt.podGroup})
 				podGroupInfo = &framework.QueuedPodGroupInfo{
-					PodGroupInfo: &framework.PodGroupInfo{
-						Name:      tt.podGroup.Name,
-						Namespace: tt.podGroup.Namespace,
-						Type:      fwk.PodGroupKeyType,
-						PodGroup:  tt.podGroup,
-					},
+					PodGroupInfo:   &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(tt.podGroup)},
 					QueuedPodInfos: make(map[fwk.EntityKey][]*framework.QueuedPodInfo),
 				}
 				for _, pod := range tt.pods {
@@ -637,11 +632,8 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2, qInfo3}},
 		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
+			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2, p3},
-			PodGroup:        testPodGroup,
 		},
 	}
 
@@ -743,7 +735,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			}
 
 			cache := internalcache.New(ctx, nil, true, false)
-			cache.AddPodGroup(podGroup)
+			cache.AddGenericPodGroup(framework.NewGenericPodGroup(podGroup))
 			cache.AddPodGroupMember(p1)
 			assumedP1 := p1.DeepCopy()
 			assumedP1.Spec.NodeName = "node1"
@@ -752,7 +744,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			}
 
 			queue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc())
-			queue.AddPodGroup(logger, podGroup)
+			queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
 			queue.Add(ctx, p1)
 			entity, err := queue.Pop(logger)
 			if err != nil {
@@ -783,7 +775,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			if pendingPods := queue.PendingPodGroupPods(); len(pendingPods) != 0 {
 				t.Errorf("Expected no pending PodGroup members, got %v", pendingPods)
 			}
-			requeuedPodGroup, ok := queue.GetPodGroup(podGroup.Name, podGroup.Namespace, fwk.PodGroupKeyType)
+			requeuedPodGroup, ok := queue.GetPodGroup(podGroup.Name, podGroup.Namespace)
 			if !ok {
 				t.Fatalf("Expected PodGroup to be queued")
 			}
@@ -811,11 +803,8 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
+			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2},
-			PodGroup:        testPodGroup,
 		},
 	}
 
@@ -895,11 +884,8 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
+			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2, p3},
-			PodGroup:        testPodGroup,
 		},
 	}
 
@@ -951,7 +937,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
 	logger, ctx := ktesting.NewTestContext(t)
 	cache.AddNode(logger, testNode)
-	cache.AddPodGroup(testPodGroup)
+	cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
 
 	handledPods := make(map[string]*fwk.Status)
 	var lock sync.Mutex
@@ -1057,11 +1043,8 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 			podGroupInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 				PodGroupInfo: &framework.PodGroupInfo{
-					Name:            "pg",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
+					GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
 					UnscheduledPods: []*v1.Pod{p1, p2},
-					PodGroup:        testPodGroup,
 				},
 			}
 
@@ -1140,7 +1123,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 			cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
 			logger, ctx := ktesting.NewTestContext(t)
 			cache.AddNode(logger, testNode)
-			cache.AddPodGroup(testPodGroup)
+			cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
 
 			sched := &Scheduler{
 				Profiles:               profile.Map{"test-scheduler": schedFwk},
@@ -1185,11 +1168,8 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
+			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2, p3},
-			PodGroup:        testPodGroup,
 		},
 	}
 
@@ -1498,7 +1478,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 
 					cache := internalcache.New(ctx, nil, true, cpgEnabled /* CompositePodGroup */)
 					cache.AddNode(logger, testNode)
-					cache.AddPodGroup(testPodGroup)
+					cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
 
 					sched := &Scheduler{
 						Cache:            cache,
@@ -1911,6 +1891,8 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 
 			cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
 			cache.AddNode(klog.FromContext(ctx), testNode)
+			apg := framework.NewGenericPodGroup(pg)
+			cache.AddGenericPodGroup(apg)
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			informerFactory.Start(ctx.Done())
@@ -1938,7 +1920,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			}
 
 			// Create the pod group and add the pods to queue and pop the group to set up internal queue state correctly.
-			schedulingQueue.AddPodGroup(logger, pg)
+			schedulingQueue.AddGenericPodGroup(logger, apg)
 			// Advance the clock between additions to keep pod ordering deterministic.
 			schedulingQueue.Add(ctx, p1)
 			fakeClock.Step(time.Second)
@@ -2006,7 +1988,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 
 			// If there were any remaining pods of the podgroup requeued into the active queue, they must preserve their timestamp.
 			if tt.expectPodsInActiveQueue.Len() > 0 {
-				queuedPGInfo, ok := sched.SchedulingQueue.GetPodGroup("pg", "default", fwk.PodGroupKeyType)
+				queuedPGInfo, ok := sched.SchedulingQueue.GetPodGroup("pg", "default")
 				if !ok {
 					t.Errorf("Expected pod group pg to be requeued, but it was not found in the scheduling queue")
 				} else if !queuedPGInfo.Timestamp.Equal(oldTimestamp) {
@@ -2352,10 +2334,14 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 				objects = append(objects, tt.existingPodGroup)
 			}
 			client := clientsetfake.NewClientset(objects...)
+			cache := internalcache.New(ctx, nil, true, true)
+			apg := framework.NewGenericPodGroup(tt.existingPodGroup)
+			cache.AddGenericPodGroup(apg)
+
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			informerFactory.Start(ctx.Done())
 			informerFactory.WaitForCacheSync(ctx.Done())
-			sched := &Scheduler{client: client}
+			sched := &Scheduler{client: client, Cache: cache}
 
 			var existingLTT metav1.Time
 			if existing := apimeta.FindStatusCondition(tt.existingPodGroup.Status.Conditions, schedulingapi.PodGroupInitiallyScheduled); existing != nil {
@@ -2363,12 +2349,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			}
 
 			podGroupInfo := &framework.QueuedPodGroupInfo{
-				PodGroupInfo: &framework.PodGroupInfo{
-					Namespace: tt.namespace,
-					Name:      tt.podGroupName,
-					PodGroup:  tt.existingPodGroup,
-					Type:      fwk.PodGroupKeyType,
-				},
+				PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: apg},
 			}
 			sched.updatePodGroupCondition(ctx, podGroupInfo.PodGroupInfo, tt.condition)
 
@@ -2523,10 +2504,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 	pgInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{pgKeyVal: queuedPodInfos},
 		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
-			PodGroup:        testPodGroup,
+			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{podGroupPod},
 		},
 	}
@@ -2886,7 +2864,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 				for _, node := range nodes {
 					cache.AddNode(logger, node)
 				}
-				cache.AddPodGroup(testPodGroup)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
 
 				sched := &Scheduler{
 					Cache:            cache,
@@ -3030,12 +3008,11 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 
 				pgKeyVal := fwk.PodGroupKey("default", "pg")
 				queuedPodInfos := []*framework.QueuedPodInfo{{PodInfo: &framework.PodInfo{Pod: podGroupPod}}}
+				testPodGroup := st.MakePodGroup().Namespace("default").Name("pg").Obj()
 				pgInfo := &framework.QueuedPodGroupInfo{
 					QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{pgKeyVal: queuedPodInfos},
 					PodGroupInfo: &framework.PodGroupInfo{
-						Name:            "pg",
-						Namespace:       "default",
-						Type:            fwk.PodGroupKeyType,
+						GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
 						UnscheduledPods: []*v1.Pod{podGroupPod},
 					},
 				}
@@ -3092,10 +3069,7 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				for _, node := range nodes {
 					cache.AddNode(logger, node)
 				}
-				testPodGroup := &schedulingv1beta1.PodGroup{
-					ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
-				}
-				cache.AddPodGroup(testPodGroup)
+				cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
 
 				sched := &Scheduler{
 					Cache:            cache,
@@ -3265,7 +3239,7 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 			testPodGroup := &schedulingv1beta1.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 			}
-			cache.AddPodGroup(testPodGroup)
+			cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
 
 			sched := &Scheduler{
 				Cache:            cache,
@@ -3283,13 +3257,10 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 			pgInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): queuedPodInfos},
 				PodGroupInfo: &framework.PodGroupInfo{
-					Name:            "pg",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
+					GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
 					UnscheduledPods: []*v1.Pod{podGroupPod},
 				},
 			}
-
 			result, _ := sched.podGroupSchedulingPlacementAlgorithm(ctx, schedFwk, framework.NewCycleState(), pgInfo.PodGroupInfo, pgInfo)
 			if !result.status.IsSuccess() {
 				t.Fatalf("Expected success, got: %v", result.status)
@@ -3454,27 +3425,9 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 	}
 	queuedPodInfo1 := &framework.QueuedPodInfo{PodInfo: podInfo1}
 
-	leafPGInfo := &framework.PodGroupInfo{
-		Name:            pg.Name,
-		Namespace:       pg.Namespace,
-		Type:            fwk.PodGroupKeyType,
-		PodGroup:        pg,
-		UnscheduledPods: []*v1.Pod{p1},
-	}
-	midPGInfo := &framework.PodGroupInfo{
-		Name:              midcpg.Name,
-		Namespace:         midcpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		CompositePodGroup: midcpg,
-		Children:          []*framework.PodGroupInfo{leafPGInfo},
-	}
-	rootPGInfo := &framework.PodGroupInfo{
-		Name:              rootcpg.Name,
-		Namespace:         rootcpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		CompositePodGroup: rootcpg,
-		Children:          []*framework.PodGroupInfo{midPGInfo},
-	}
+	leafPGInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(pg), UnscheduledPods: []*v1.Pod{p1}}
+	midPGInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(midcpg), Children: []*framework.PodGroupInfo{leafPGInfo}}
+	rootPGInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(rootcpg), Children: []*framework.PodGroupInfo{midPGInfo}}
 
 	logger, ctx := ktesting.NewTestContext(t)
 
@@ -3532,9 +3485,9 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 	for _, node := range nodes {
 		cache.AddNode(logger, node)
 	}
-	cache.AddCompositePodGroup(logger, rootcpg)
-	cache.AddCompositePodGroup(logger, midcpg)
-	cache.AddPodGroup(pg)
+	cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(rootcpg))
+	cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(midcpg))
+	cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 
 	sched := &Scheduler{
 		Cache:            cache,
@@ -3639,28 +3592,10 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 	queuedPodInfo1 := &framework.QueuedPodInfo{PodInfo: podInfo1}
 	queuedPodInfo2 := &framework.QueuedPodInfo{PodInfo: podInfo2}
 
-	childPGInfo1 := &framework.PodGroupInfo{
-		Name:            pg1.Name,
-		Namespace:       pg1.Namespace,
-		Type:            fwk.PodGroupKeyType,
-		PodGroup:        pg1,
-		UnscheduledPods: []*v1.Pod{p1},
-	}
-	childPGInfo2 := &framework.PodGroupInfo{
-		Name:            pg2.Name,
-		Namespace:       pg2.Namespace,
-		Type:            fwk.PodGroupKeyType,
-		PodGroup:        pg2,
-		UnscheduledPods: []*v1.Pod{p2},
-	}
+	childPGInfo1 := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}}
+	childPGInfo2 := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}}
 
-	rootPGInfo := &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		CompositePodGroup: cpg,
-		Children:          []*framework.PodGroupInfo{childPGInfo1, childPGInfo2},
-	}
+	rootPGInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(cpg), Children: []*framework.PodGroupInfo{childPGInfo1, childPGInfo2}}
 
 	defaultPlacementResults := map[fwk.EntityKey]map[string][]string{
 		rootPGInfo.GetKey(): {
@@ -4068,9 +4003,9 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 			for _, node := range nodes {
 				cache.AddNode(logger, node)
 			}
-			cache.AddCompositePodGroup(logger, cpg)
-			cache.AddPodGroup(pg1)
-			cache.AddPodGroup(pg2)
+			cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+			cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg1))
+			cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg2))
 			cache.AddPodGroupMember(p1)
 			cache.AddPodGroupMember(p2)
 
@@ -4152,28 +4087,10 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 	queuedPodInfo1 := &framework.QueuedPodInfo{PodInfo: podInfo1}
 	queuedPodInfo2 := &framework.QueuedPodInfo{PodInfo: podInfo2}
 
-	childPGInfo1 := &framework.PodGroupInfo{
-		Name:            pg1.Name,
-		Namespace:       pg1.Namespace,
-		Type:            fwk.PodGroupKeyType,
-		PodGroup:        pg1,
-		UnscheduledPods: []*v1.Pod{p1},
-	}
-	childPGInfo2 := &framework.PodGroupInfo{
-		Name:            pg2.Name,
-		Namespace:       pg2.Namespace,
-		Type:            fwk.PodGroupKeyType,
-		PodGroup:        pg2,
-		UnscheduledPods: []*v1.Pod{p2},
-	}
+	childPGInfo1 := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}}
+	childPGInfo2 := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}}
 
-	rootPGInfo := &framework.PodGroupInfo{
-		Name:              cpg.Name,
-		Namespace:         cpg.Namespace,
-		Type:              fwk.CompositePodGroupKeyType,
-		CompositePodGroup: cpg,
-		Children:          []*framework.PodGroupInfo{childPGInfo1, childPGInfo2},
-	}
+	rootPGInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(cpg), Children: []*framework.PodGroupInfo{childPGInfo1, childPGInfo2}}
 
 	placements := map[fwk.EntityKey]map[string][]string{
 		rootPGInfo.GetKey(): {
@@ -4365,9 +4282,9 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 			for _, node := range nodes {
 				cache.AddNode(logger, node)
 			}
-			cache.AddCompositePodGroup(logger, cpg)
-			cache.AddPodGroup(pg1)
-			cache.AddPodGroup(pg2)
+			cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
+			cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg1))
+			cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg2))
 			cache.AddPodGroupMember(p1)
 			cache.AddPodGroupMember(p2)
 
@@ -4427,11 +4344,8 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
+			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2},
-			PodGroup:        testPodGroup,
 		},
 	}
 
@@ -4489,7 +4403,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 	}
 
 	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddPodGroup(testPodGroup)
+	cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
 	sched := &Scheduler{
 		Profiles:         profile.Map{"test-scheduler": schedFwk},
 		Cache:            cache,
@@ -4552,10 +4466,7 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
-			PodGroup:        testPodGroup,
+			GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
 			UnscheduledPods: []*v1.Pod{p1, p2},
 		},
 	}
@@ -4628,14 +4539,10 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	testPodGroup := st.MakePodGroup().Name("pg").Namespace("default").Obj()
+	apg := framework.NewGenericPodGroup(testPodGroup)
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
-		PodGroupInfo: &framework.PodGroupInfo{
-			Name:      "pg",
-			Namespace: "default",
-			Type:      fwk.PodGroupKeyType,
-			PodGroup:  testPodGroup,
-		},
+		PodGroupInfo:   &framework.PodGroupInfo{GenericPodGroup: apg},
 	}
 	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
@@ -4673,6 +4580,9 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	}
 
 	client := clientsetfake.NewClientset(testPodGroup)
+	cache := internalcache.New(ctx, nil, true, false /* CompositePodGroup */)
+	cache.AddGenericPodGroup(apg)
+
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
@@ -4680,7 +4590,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 		Profiles:        profile.Map{"sched1": schedFwk1, "sched2": schedFwk2},
 		SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
 		Cache: &fakecache.Cache{
-			Cache: internalcache.New(ctx, nil, true, false /* CompositePodGroup */),
+			Cache: cache,
 			UpdateSnapshotFunc: func(nodeSnapshot *internalcache.Snapshot) error {
 				return nil
 			},
@@ -4835,10 +4745,7 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 			podGroupInfo := &framework.QueuedPodGroupInfo{
 				QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2}},
 				PodGroupInfo: &framework.PodGroupInfo{
-					Name:            "pg",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					PodGroup:        testPodGroup,
+					GenericPodGroup: framework.NewGenericPodGroup(testPodGroup),
 					UnscheduledPods: []*v1.Pod{p1, p2},
 				},
 			}
@@ -4881,7 +4788,7 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			cache := internalcache.New(ctx, nil, true, false /* CompositePodGroup */)
-			cache.AddPodGroup(testPodGroup)
+			cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
 			queue := internalqueue.NewTestQueue(ctx, nil)
 
 			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
@@ -5007,35 +4914,11 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 
 	cpgRootInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfosMap,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         namespace,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			CompositePodGroup: cpgRoot,
-			UnscheduledPods:   []*v1.Pod{p1, p2, p3},
-			Children: []*framework.PodGroupInfo{
-				{
-					Name:            "pg1",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					PodGroup:        pg1,
-					UnscheduledPods: []*v1.Pod{p1},
-				},
-				{
-					Name:            "pg2",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					PodGroup:        pg2,
-					UnscheduledPods: []*v1.Pod{p2},
-				},
-				{
-					Name:            "pg3",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
-					PodGroup:        pg3,
-					UnscheduledPods: []*v1.Pod{p3},
-				},
-			},
+		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(cpgRoot), UnscheduledPods: []*v1.Pod{p1, p2, p3}, Children: []*framework.PodGroupInfo{
+			{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: []*v1.Pod{p1}},
+			{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: []*v1.Pod{p2}},
+			{GenericPodGroup: framework.NewGenericPodGroup(pg3), UnscheduledPods: []*v1.Pod{p3}},
+		},
 		},
 		QueueingParams: framework.QueueingParams{
 			Timestamp: time.Now(),
@@ -5099,10 +4982,10 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 	}
 
 	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
-	cache.AddCompositePodGroup(logger, cpgRoot)
-	cache.AddPodGroup(pg1)
-	cache.AddPodGroup(pg2)
-	cache.AddPodGroup(pg3)
+	cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpgRoot))
+	cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg1))
+	cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg2))
+	cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg3))
 
 	sched := &Scheduler{
 		Profiles:         profile.Map{"test-scheduler": schedFwk},
@@ -5218,7 +5101,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 				ParentCompositePodGroupName: new(parentCPG),
 			},
 		}
-		cache.AddPodGroup(pg)
+		cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 		return pg
 	}
 
@@ -5240,7 +5123,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 				ParentCompositePodGroupName: parentCPG,
 			},
 		}
-		cache.AddCompositePodGroup(logger, cpg)
+		cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 		return cpg
 	}
 
@@ -5287,45 +5170,24 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         ns,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			UnscheduledPods:   allPods,
-			CompositePodGroup: rootCPG,
-			Children: []*framework.PodGroupInfo{
-				{
-					Namespace:         ns,
-					Name:              "cpg-sub1",
-					Type:              fwk.CompositePodGroupKeyType,
-					CompositePodGroup: cpgSub1,
-					Children: []*framework.PodGroupInfo{
-						{Namespace: ns, Name: "pg1", Type: fwk.PodGroupKeyType, PodGroup: pg1, UnscheduledPods: pgPods["pg1"]},
-						{Namespace: ns, Name: "pg2", Type: fwk.PodGroupKeyType, PodGroup: pg2, UnscheduledPods: pgPods["pg2"]},
-						{Namespace: ns, Name: "pg3", Type: fwk.PodGroupKeyType, PodGroup: pg3, UnscheduledPods: pgPods["pg3"]},
-					},
-				},
-				{
-					Namespace:         ns,
-					Name:              "cpg-sub2",
-					Type:              fwk.CompositePodGroupKeyType,
-					CompositePodGroup: cpgSub2,
-					Children: []*framework.PodGroupInfo{
-						{Namespace: ns, Name: "pg4", Type: fwk.PodGroupKeyType, PodGroup: pg4, UnscheduledPods: pgPods["pg4"]},
-						{Namespace: ns, Name: "pg5", Type: fwk.PodGroupKeyType, PodGroup: pg5, UnscheduledPods: pgPods["pg5"]},
-					},
-				},
-				{
-					Namespace:         ns,
-					Name:              "cpg-sub3",
-					Type:              fwk.CompositePodGroupKeyType,
-					CompositePodGroup: cpgSub3,
-					Children: []*framework.PodGroupInfo{
-						{Namespace: ns, Name: "pg6", Type: fwk.PodGroupKeyType, PodGroup: pg6, UnscheduledPods: pgPods["pg6"]},
-						{Namespace: ns, Name: "pg7", Type: fwk.PodGroupKeyType, PodGroup: pg7, UnscheduledPods: pgPods["pg7"]},
-					},
-				},
+		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
+			{GenericPodGroup: framework.NewGenericCompositePodGroup(cpgSub1), Children: []*framework.PodGroupInfo{
+				{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
+				{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
+				{GenericPodGroup: framework.NewGenericPodGroup(pg3), UnscheduledPods: pgPods["pg3"]},
 			},
+			},
+			{GenericPodGroup: framework.NewGenericCompositePodGroup(cpgSub2), Children: []*framework.PodGroupInfo{
+				{GenericPodGroup: framework.NewGenericPodGroup(pg4), UnscheduledPods: pgPods["pg4"]},
+				{GenericPodGroup: framework.NewGenericPodGroup(pg5), UnscheduledPods: pgPods["pg5"]},
+			},
+			},
+			{GenericPodGroup: framework.NewGenericCompositePodGroup(cpgSub3), Children: []*framework.PodGroupInfo{
+				{GenericPodGroup: framework.NewGenericPodGroup(pg6), UnscheduledPods: pgPods["pg6"]},
+				{GenericPodGroup: framework.NewGenericPodGroup(pg7), UnscheduledPods: pgPods["pg7"]},
+			},
+			},
+		},
 		},
 	}
 
@@ -5501,7 +5363,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 				ParentCompositePodGroupName: parentCPG,
 			},
 		}
-		cache.AddCompositePodGroup(logger, cpg)
+		cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 		return cpg
 	}
 
@@ -5523,7 +5385,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 				ParentCompositePodGroupName: new(parentCPG),
 			},
 		}
-		cache.AddPodGroup(pg)
+		cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 		return pg
 	}
 
@@ -5641,17 +5503,11 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         ns,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			UnscheduledPods:   allPods,
-			CompositePodGroup: rootCPG,
-			Children: []*framework.PodGroupInfo{
-				{Namespace: ns, Name: "pg1", Type: fwk.PodGroupKeyType, PodGroup: pg1, UnscheduledPods: pgPods["pg1"]},
-				{Namespace: ns, Name: "pg2", Type: fwk.PodGroupKeyType, PodGroup: pg2, UnscheduledPods: pgPods["pg2"]},
-				{Namespace: ns, Name: "pg3", Type: fwk.PodGroupKeyType, PodGroup: pg3, UnscheduledPods: pgPods["pg3"]},
-			},
+		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
+			{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
+			{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
+			{GenericPodGroup: framework.NewGenericPodGroup(pg3), UnscheduledPods: pgPods["pg3"]},
+		},
 		},
 	}
 
@@ -5732,7 +5588,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 				ParentCompositePodGroupName: parentCPG,
 			},
 		}
-		cache.AddCompositePodGroup(logger, cpg)
+		cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 		return cpg
 	}
 
@@ -5754,7 +5610,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 				ParentCompositePodGroupName: new(parentCPG),
 			},
 		}
-		cache.AddPodGroup(pg)
+		cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 		return pg
 	}
 
@@ -5867,16 +5723,10 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
-		PodGroupInfo: &framework.PodGroupInfo{
-			Namespace:         ns,
-			Name:              "cpg-root",
-			Type:              fwk.CompositePodGroupKeyType,
-			UnscheduledPods:   allPods,
-			CompositePodGroup: rootCPG,
-			Children: []*framework.PodGroupInfo{
-				{Namespace: ns, Name: "pg1", Type: fwk.PodGroupKeyType, PodGroup: pg1, UnscheduledPods: pgPods["pg1"]},
-				{Namespace: ns, Name: "pg2", Type: fwk.PodGroupKeyType, PodGroup: pg2, UnscheduledPods: pgPods["pg2"]},
-			},
+		PodGroupInfo: &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(rootCPG), UnscheduledPods: allPods, Children: []*framework.PodGroupInfo{
+			{GenericPodGroup: framework.NewGenericPodGroup(pg1), UnscheduledPods: pgPods["pg1"]},
+			{GenericPodGroup: framework.NewGenericPodGroup(pg2), UnscheduledPods: pgPods["pg2"]},
+		},
 		},
 	}
 
@@ -6218,17 +6068,16 @@ func TestScorePlacementPodGroupAssignments(t *testing.T) {
 				for _, ch := range node.children {
 					children = append(children, buildTree(ch))
 				}
-				pgi := &framework.PodGroupInfo{
-					Name:      node.name,
-					Namespace: "default",
-					Children:  children,
-				}
+				pgi := &framework.PodGroupInfo{Children: children}
 				if len(children) > 0 {
-					pgi.Type = fwk.CompositePodGroupKeyType
-					pgi.CompositePodGroup = st.MakeCompositePodGroup().Name(node.name).Namespace("default").Obj()
+					cpg := st.MakeCompositePodGroup().Name(node.name).Namespace("default").Obj()
+					pgi.GenericPodGroup = framework.
+						NewGenericCompositePodGroup(cpg)
+
 				} else {
-					pgi.Type = fwk.PodGroupKeyType
-					pgi.PodGroup = st.MakePodGroup().Name(node.name).Namespace("default").Obj()
+					pg := st.MakePodGroup().Name(node.name).Namespace("default").Obj()
+					pgi.GenericPodGroup = framework.
+						NewGenericPodGroup(pg)
 				}
 				nameToKey[node.name] = pgi.GetKey()
 				return pgi
@@ -6305,24 +6154,13 @@ func buildHierarchicalQueuedPodGroupInfo(
 
 	var buildTree func(cpg *schedulingv1alpha3.CompositePodGroup) *framework.PodGroupInfo
 	buildTree = func(cpg *schedulingv1alpha3.CompositePodGroup) *framework.PodGroupInfo {
-		info := &framework.PodGroupInfo{
-			Namespace:         cpg.Namespace,
-			Name:              cpg.Name,
-			Type:              fwk.CompositePodGroupKeyType,
-			CompositePodGroup: cpg,
-		}
+		info := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericCompositePodGroup(cpg)}
 		for _, childCPG := range cpgChildren[cpg.Name] {
 			info.Children = append(info.Children, buildTree(childCPG))
 		}
 		for _, childPG := range pgChildren[cpg.Name] {
 			pgKey := fwk.PodGroupKey(childPG.Namespace, childPG.Name)
-			pgInfo := &framework.PodGroupInfo{
-				Namespace:       childPG.Namespace,
-				Name:            childPG.Name,
-				Type:            fwk.PodGroupKeyType,
-				PodGroup:        childPG,
-				UnscheduledPods: podsByPG[pgKey],
-			}
+			pgInfo := &framework.PodGroupInfo{GenericPodGroup: framework.NewGenericPodGroup(childPG), UnscheduledPods: podsByPG[pgKey]}
 			info.Children = append(info.Children, pgInfo)
 		}
 		return info
@@ -6334,8 +6172,8 @@ func buildHierarchicalQueuedPodGroupInfo(
 	var allUnscheduled []*v1.Pod
 	var collectPods func(info *framework.PodGroupInfo)
 	collectPods = func(info *framework.PodGroupInfo) {
-		if info.Type == fwk.PodGroupKeyType {
-			pgKey := fwk.PodGroupKey(info.Namespace, info.Name)
+		if info.GetType() == fwk.PodGroupKeyType {
+			pgKey := fwk.PodGroupKey(info.GetNamespace(), info.GetName())
 			for _, p := range info.UnscheduledPods {
 				queuedPodInfos[pgKey] = append(queuedPodInfos[pgKey], &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p}})
 				allUnscheduled = append(allUnscheduled, p)
@@ -6419,7 +6257,7 @@ func TestPodGroupPotentiallyFeasible(t *testing.T) {
 				UnscheduledPods: []*v1.Pod{
 					st.MakePod().Name("pod").UID("pod").PodGroupName("pg").Obj(),
 				},
-				PodGroup: st.MakePodGroup().Name("pg").Obj(),
+				GenericPodGroup: framework.NewGenericPodGroup(st.MakePodGroup().Name("pg").Obj()),
 			}
 			placementProgress := framework.PlacementProgress{
 				Remaining: 1,
@@ -6465,11 +6303,8 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 			fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2, qInfo3},
 		},
 		PodGroupInfo: &framework.PodGroupInfo{
-			Name:            "pg",
-			Namespace:       "default",
-			Type:            fwk.PodGroupKeyType,
 			UnscheduledPods: pg1Pods,
-			PodGroup:        pg1,
+			GenericPodGroup: framework.NewGenericPodGroup(pg1),
 		},
 	}
 
@@ -6479,24 +6314,15 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 			fwk.PodGroupKey("default", "pg3"): {qInfo5},
 		},
 		PodGroupInfo: &framework.PodGroupInfo{
-			Name:              "cpg",
-			Namespace:         "default",
-			Type:              fwk.CompositePodGroupKeyType,
-			CompositePodGroup: cpg,
+			GenericPodGroup: framework.NewGenericCompositePodGroup(cpg),
 			Children: []*framework.PodGroupInfo{
 				{
-					Name:            "pg2",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
 					UnscheduledPods: pg2Pods,
-					PodGroup:        pg2,
+					GenericPodGroup: framework.NewGenericPodGroup(pg2),
 				},
 				{
-					Name:            "pg3",
-					Namespace:       "default",
-					Type:            fwk.PodGroupKeyType,
 					UnscheduledPods: pg3Pods,
-					PodGroup:        pg3,
+					GenericPodGroup: framework.NewGenericPodGroup(pg3),
 				},
 			},
 		},
@@ -7496,10 +7322,10 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 					cache := internalcache.New(ctx, nil, true, cpgEnabled)
 					cache.AddNode(logger, testNode)
 					for _, cpg := range tt.compositePodGroups {
-						cache.AddCompositePodGroup(logger, cpg)
+						cache.AddGenericPodGroup(framework.NewGenericCompositePodGroup(cpg))
 					}
 					for _, pg := range tt.podGroups {
-						cache.AddPodGroup(pg)
+						cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
 					}
 					for _, p := range tt.pods {
 						cache.AddPodGroupMember(p)

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1084,7 +1084,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 
 		if scheduleAsPodGroup {
 			internalCache.AddPodGroupMember(item.sendPod)
-			internalCache.AddPodGroup(podGroup)
+			internalCache.AddAbstractPodGroup(framework.NewAbstractPodGroup(podGroup))
 		}
 		cache := &fakecache.Cache{
 			Cache: internalCache,
@@ -1167,7 +1167,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		informerFactory.WaitForCacheSync(ctx.Done())
 
 		if scheduleAsPodGroup {
-			queue.AddPodGroup(logger, podGroup)
+			queue.AddAbstractPodGroup(logger, framework.NewAbstractPodGroup(podGroup))
 		}
 		queue.Add(ctx, item.sendPod)
 

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1084,7 +1084,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 
 		if scheduleAsPodGroup {
 			internalCache.AddPodGroupMember(item.sendPod)
-			internalCache.AddPodGroup(podGroup)
+			internalCache.AddGenericPodGroup(framework.NewGenericPodGroup(podGroup))
 		}
 		cache := &fakecache.Cache{
 			Cache: internalCache,
@@ -1167,7 +1167,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		informerFactory.WaitForCacheSync(ctx.Done())
 
 		if scheduleAsPodGroup {
-			queue.AddPodGroup(logger, podGroup)
+			queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
 		}
 		queue.Add(ctx, item.sendPod)
 
@@ -1531,7 +1531,7 @@ func TestHandleSchedulingFailure_PodGroupFitErrorCloned(t *testing.T) {
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 
-	queue.AddPodGroup(logger, pg)
+	queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 	queue.Add(ctx, pod1)
 	queue.Add(ctx, pod2)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR unifies handling of PodGroup and CompositePodGroup objects in scheduling queue (including workload forest) using a new AbstractPodGroup type that abstracts both objects.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Generative AI was used in the PR preparation. Changes were carefully reviewed before pushing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
