### PR TITLE
cluster/gce: pick exactly one image when the family lists multiple

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -59,7 +59,8 @@ fi
 kube_master_image="${KUBE_GCE_MASTER_IMAGE:-}"
 if [[ -z "${kube_master_image}" ]]; then
   # remove architecture:X86_64 once we move on from ubuntu jammy as that image family has both X86_64 and ARM images
-  kube_master_image=$(gcloud compute images list --project="${MASTER_IMAGE_PROJECT}" --no-standard-images --filter="family:${MASTER_IMAGE_FAMILY} architecture:X86_64" --format 'value(name)')
+  # a family may briefly contain more than one non-deprecated image; take the newest (the family head)
+  kube_master_image=$(gcloud compute images list --project="${MASTER_IMAGE_PROJECT}" --no-standard-images --filter="family:${MASTER_IMAGE_FAMILY} architecture:X86_64" --sort-by='~creationTimestamp' --limit=1 --format 'value(name)')
 fi
 
 echo "Using image: ${kube_master_image} from project: ${MASTER_IMAGE_PROJECT} as master image" >&2
@@ -79,7 +80,8 @@ function set-linux-node-image() {
   kube_node_image="${KUBE_GCE_NODE_IMAGE:-}"
   if [[ -z "${kube_node_image}" ]]; then
     # remove architecture:X86_64 once we move on from ubuntu jammy as that image family has both X86_64 and ARM images
-    kube_node_image=$(gcloud compute images list --project="${NODE_IMAGE_PROJECT}" --no-standard-images --filter="family:${NODE_IMAGE_FAMILY} architecture:X86_64" --format 'value(name)')
+    # a family may briefly contain more than one non-deprecated image; take the newest (the family head)
+    kube_node_image=$(gcloud compute images list --project="${NODE_IMAGE_PROJECT}" --no-standard-images --filter="family:${NODE_IMAGE_FAMILY} architecture:X86_64" --sort-by='~creationTimestamp' --limit=1 --format 'value(name)')
   fi
 
   echo "Using image: ${kube_node_image} from project: ${NODE_IMAGE_PROJECT} as node image" >&2


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind failing-test
/sig cluster-lifecycle

#### What this PR does / why we need it:

`kube-up` on GCE resolves the master/node boot image with `gcloud compute images list --filter="family:<family> ..."`, which returns *every* non-deprecated image in the family. On 2026-07-31, `cos-cloud` briefly carried two active images in `cos-129-lts` (`cos-129-19506-299-61` was published at 00:14 UTC without deprecating `-60`, then rolled back ~6h later). The two newline-joined names produced an invalid `sourceImage` URL, and every GCE e2e job (~152 builds across 51 jobs) failed cluster bring-up with:

```
ERROR: (gcloud.compute.instances.create) Could not fetch resource:
 - Invalid value for field 'resource.disks[0].initializeParams.sourceImage': '.../images/cos-129-19506-299-60
cos-129-19506-299-61'. The referenced image resource cannot be found.
Failed to create master instance due to non-retryable error
```

Sort by creation timestamp (newest first) and take exactly one image, matching the image-family "head" semantics, so the next multi-active-image window in `cos-cloud` (or any image project) doesn't take down all GCE e2e jobs.

#### Which issue(s) this PR fixes:

Fixes #141080

#### Special notes for your reviewer:

- gcloud applies `--sort-by` before `--limit` (verified empirically: descending sort with `--limit=1` over the two 299-60/-61 images returns `-61`; ascending returns the oldest).
- Kept `images list` rather than switching to `describe-from-family` to preserve the existing `architecture:X86_64` filter needed for mixed-arch families.
- Verified the exact modified command against `cos-cloud` returns a single line: `cos-129-19506-299-60`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
