### PR TITLE
kubectl wait: support !=, <= and >= in --for=jsonpath filter expressions

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -283,8 +283,9 @@ func processJSONPathInput(input string) (string, string, error) {
 	return relaxedJSONPathExp, jsonPathValue, nil
 }
 
-// splitJSONPathInput splits the provided input string on single '='. Double '==' will not cause the string to be
-// split. E.g., "a.b.c====d.e.f===g.h.i===" will split to ["a.b.c====d.e.f==","g.h.i==",""].
+// splitJSONPathInput splits the provided input string on single '='. An '=' that forms part of a comparison operator
+// ('==', '!=', '<=' or '>=') will not cause the string to be split, so that filter expressions survive intact.
+// E.g., "a.b.c====d.e.f===g.h.i===" will split to ["a.b.c====d.e.f==","g.h.i==",""].
 func splitJSONPathInput(input string) []string {
 	var output []string
 	var element strings.Builder
@@ -293,6 +294,10 @@ func splitJSONPathInput(input string) []string {
 			if i < len(input)-1 && input[i+1] == '=' {
 				element.WriteString("==")
 				i++
+				continue
+			}
+			if i > 0 && (input[i-1] == '!' || input[i-1] == '<' || input[i-1] == '>') {
+				element.WriteByte('=')
 				continue
 			}
 			output = append(output, element.String())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -1755,6 +1755,31 @@ func TestConditionFuncFor(t *testing.T) {
 			condition:   []string{"jsonpath={.status.phase}=Running", "jsonpath={.metadata.name}=foo"},
 			expectedErr: None,
 		},
+		{
+			name:        "jsonpath filtering with != and a value",
+			condition:   []string{`jsonpath={.status.conditions[?(@.type!="Failed")].status}=True`},
+			expectedErr: None,
+		},
+		{
+			name:        "jsonpath filtering with != without a value",
+			condition:   []string{`jsonpath={.status.conditions[?(@.type!="Failed")].status}`},
+			expectedErr: None,
+		},
+		{
+			name:        "jsonpath filtering with >=",
+			condition:   []string{"jsonpath={.status.conditions[?(@.observedGeneration>=2)].status}=True"},
+			expectedErr: None,
+		},
+		{
+			name:        "jsonpath filtering with <=",
+			condition:   []string{"jsonpath={.status.conditions[?(@.observedGeneration<=2)].status}=True"},
+			expectedErr: None,
+		},
+		{
+			name:        "jsonpath filtering with != relaxed parsing",
+			condition:   []string{`jsonpath=status.conditions[?(@.type!="Failed")].status=True`},
+			expectedErr: None,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1769,6 +1794,61 @@ func TestConditionFuncFor(t *testing.T) {
 					t.Fatalf("expected error %q, got %q", test.expectedErr, err.Error())
 				}
 			}
+		})
+	}
+}
+
+// TestSplitJSONPathInput tests that the input is only split on the '=' separating the expression from its value.
+func TestSplitJSONPathInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "documented example",
+			input:    "a.b.c====d.e.f===g.h.i===",
+			expected: []string{"a.b.c====d.e.f==", "g.h.i==", ""},
+		},
+		{
+			name:     "expression and value",
+			input:    "{.status.readyReplicas}=3",
+			expected: []string{"{.status.readyReplicas}", "3"},
+		},
+		{
+			name:     "expression without value",
+			input:    "{.status.readyReplicas}",
+			expected: []string{"{.status.readyReplicas}"},
+		},
+		{
+			name:     "equality filter is preserved",
+			input:    `{.status.conditions[?(@.type=="Complete")].status}=True`,
+			expected: []string{`{.status.conditions[?(@.type=="Complete")].status}`, "True"},
+		},
+		{
+			name:     "inequality filter is preserved",
+			input:    `{.status.conditions[?(@.type!="Failed")].status}=True`,
+			expected: []string{`{.status.conditions[?(@.type!="Failed")].status}`, "True"},
+		},
+		{
+			name:     "greater-or-equal filter is preserved",
+			input:    "{.status.conditions[?(@.observedGeneration>=2)].status}=True",
+			expected: []string{"{.status.conditions[?(@.observedGeneration>=2)].status}", "True"},
+		},
+		{
+			name:     "less-or-equal filter is preserved",
+			input:    "{.status.conditions[?(@.observedGeneration<=2)].status}=True",
+			expected: []string{"{.status.conditions[?(@.observedGeneration<=2)].status}", "True"},
+		},
+		{
+			name:     "ambiguous value is still split",
+			input:    "{.metadata.name}='test=wrong'",
+			expected: []string{"{.metadata.name}", "'test", "wrong'"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, splitJSONPathInput(test.input))
 		})
 	}
 }

--- a/test/cmd/wait.sh
+++ b/test/cmd/wait.sh
@@ -163,12 +163,17 @@ EOF
         deploy/test-3)
     # Command: Wait with jsonpath without value with check-once behavior
     output_message_2=$(kubectl wait --for=jsonpath='{.status.replicas}' deploy/test-3 --timeout=0 2>&1)
+    # Command: Wait with a filter expression using the != operator
+    output_message_3=$(kubectl wait \
+        --for='jsonpath={.spec.template.spec.containers[?(@.name!="nginx")].image}=busybox' \
+        deploy/test-3)
     set -o errexit
 
     # Post-Condition: Wait succeed
     kube::test::if_has_string "${output_message_0}" 'deployment.apps/test-3 condition met'
     kube::test::if_has_string "${output_message_1}" 'deployment.apps/test-3 condition met'
     kube::test::if_has_string "${output_message_2}" 'deployment.apps/test-3 condition met'
+    kube::test::if_has_string "${output_message_3}" 'deployment.apps/test-3 condition met'
 
     # Clean deployment
     kubectl delete deployment test-3


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`--for=jsonpath` rejects any filter expression that uses `!=`, `<=` or `>=`. Only `==` survives the split that separates the expression from its expected value.

```
$ kubectl wait --for='jsonpath={.status.conditions[?(@.type!="Failed")].status}=True' job/test
error: jsonpath wait format must be --for=jsonpath='{.status.readyReplicas}'=3 or --for=jsonpath='{.status.readyReplicas}'

$ kubectl wait --for='jsonpath={.status.conditions[?(@.observedGeneration>=1)].status}' job/test
error: unexpected path string, expected a 'name1.name2' or '.name1.name2' or '{name1.name2}' or '{.name1.name2}'
```

Reproduced on v1.36.3 and on master.

`client-go/util/jsonpath` evaluates `!=`, `<=` and `>=` correctly, so `splitJSONPathInput` is the only thing blocking them. This treats an `=` that completes a comparison operator as part of the expression rather than as the value separator.

Follow up to #118748, which fixed the same class of bug for `==`.

Out of scope: `||` still fails with `unrecognized character in action: U+007C '|'`. That is a limitation of client-go's JSONPath implementation and not of the value split, so it needs its own change.

#### Which issue(s) this PR is related to:

Related to https://github.com/kubernetes/kubectl/issues/1448. I can open a kubectl issue for this if sig-cli wants it tracked separately.

#### Special notes for your reviewer:

Two behaviours deliberately unchanged, both now covered by `TestSplitJSONPathInput`:

1. A value containing a bare `=` is still rejected as ambiguous, so `{.metadata.name}='test=wrong'` keeps erroring.
2. The split documented in the `splitJSONPathInput` comment is unchanged. The documented `"a.b.c====d.e.f===g.h.i==="` example still splits to `["a.b.c====d.e.f==","g.h.i==",""]`.

Relaxed (unbracketed) parsing still works, so `jsonpath=status.conditions[?(@.type!="Failed")].status=True` parses too.

`test/cmd/wait.sh` gets one `!=` case against the existing `test-3` deployment.

#### Does this PR introduce a user-facing change?

```release-note
Fixed `kubectl wait --for=jsonpath` rejecting filter expressions that use the `!=`, `<=` or `>=` operators.
```
