### PR TITLE
Add atomic struct markers to EventSeries

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -8040,7 +8040,8 @@
           "description": "Time of the last occurrence observed"
         }
       },
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.api.core.v1.EventSource": {
       "description": "EventSource contains information for an event.",
@@ -13798,7 +13799,8 @@
         "count",
         "lastObservedTime"
       ],
-      "type": "object"
+      "type": "object",
+      "x-kubernetes-map-type": "atomic"
     },
     "io.k8s.api.flowcontrol.v1.ExemptPriorityLevelConfiguration": {
       "description": "ExemptPriorityLevelConfiguration describes the configurable aspects of the handling of exempt requests. In the mandatory exempt configuration object the values in the fields here can be modified by authorized users, unlike the rest of the `spec`.",

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -2440,7 +2440,8 @@
             "description": "Time of the last occurrence observed"
           }
         },
-        "type": "object"
+        "type": "object",
+        "x-kubernetes-map-type": "atomic"
       },
       "io.k8s.api.core.v1.EventSource": {
         "description": "EventSource contains information for an event.",

--- a/api/openapi-spec/v3/apis__events.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__events.k8s.io__v1_openapi.json
@@ -232,7 +232,8 @@
           "count",
           "lastObservedTime"
         ],
-        "type": "object"
+        "type": "object",
+        "x-kubernetes-map-type": "atomic"
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",

--- a/pkg/generated/openapi/openapi_test.go
+++ b/pkg/generated/openapi/openapi_test.go
@@ -20,6 +20,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+	eventsv1beta1 "k8s.io/api/events/v1beta1"
+
 	"github.com/go-openapi/jsonreference"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -64,6 +68,33 @@ func TestOpenAPIRoundtrip(t *testing.T) {
 			if !cmp.Equal(value.Schema, roundTripped, opts...) {
 				t.Errorf("unexpected diff (a=expected,b=roundtripped):\n%s", cmp.Diff(value.Schema, roundTripped, opts...))
 				return
+			}
+		})
+	}
+}
+
+func TestEventSeriesSchemasAreAtomic(t *testing.T) {
+	dummyRef := func(name string) spec.Ref { return spec.MustCreateRef("#/definitions/dummy") }
+	testCases := map[string]string{
+		"core/v1":               corev1.EventSeries{}.OpenAPIModelName(),
+		"events.k8s.io/v1":      eventsv1.EventSeries{}.OpenAPIModelName(),
+		"events.k8s.io/v1beta1": eventsv1beta1.EventSeries{}.OpenAPIModelName(),
+	}
+
+	definitions := GetOpenAPIDefinitions(dummyRef)
+	for name, modelName := range testCases {
+		t.Run(name, func(t *testing.T) {
+			definition, ok := definitions[modelName]
+			if !ok {
+				t.Fatalf("missing OpenAPI definition for %s", modelName)
+			}
+
+			got, ok := definition.Schema.Extensions["x-kubernetes-map-type"].(string)
+			if !ok {
+				t.Fatalf("missing x-kubernetes-map-type extension for %s", modelName)
+			}
+			if got != "atomic" {
+				t.Fatalf("expected x-kubernetes-map-type=atomic for %s, got %q", modelName, got)
 			}
 		})
 	}

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -23506,6 +23506,11 @@ func schema_k8sio_api_core_v1_EventSeries(ref common.ReferenceCallback) common.O
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-map-type": "atomic",
+				},
+			},
 		},
 		Dependencies: []string{
 			metav1.MicroTime{}.OpenAPIModelName()},
@@ -35137,6 +35142,11 @@ func schema_k8sio_api_events_v1_EventSeries(ref common.ReferenceCallback) common
 				},
 				Required: []string{"count", "lastObservedTime"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-map-type": "atomic",
+				},
+			},
 		},
 		Dependencies: []string{
 			metav1.MicroTime{}.OpenAPIModelName()},
@@ -35346,6 +35356,11 @@ func schema_k8sio_api_events_v1beta1_EventSeries(ref common.ReferenceCallback) c
 					},
 				},
 				Required: []string{"count", "lastObservedTime"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"x-kubernetes-map-type": "atomic",
+				},
 			},
 		},
 		Dependencies: []string{

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -1834,6 +1834,7 @@ message EventList {
 
 // EventSeries contain information on series of events, i.e. thing that was/is happening
 // continuously for some time.
+// +structType=atomic
 message EventSeries {
   // Number of occurrences in this series up to the last heartbeat time
   optional int32 count = 1;

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7996,6 +7996,7 @@ type Event struct {
 
 // EventSeries contain information on series of events, i.e. thing that was/is happening
 // continuously for some time.
+// +structType=atomic
 type EventSeries struct {
 	// Number of occurrences in this series up to the last heartbeat time
 	Count int32 `json:"count,omitempty" protobuf:"varint,1,name=count"`

--- a/staging/src/k8s.io/api/events/v1/generated.proto
+++ b/staging/src/k8s.io/api/events/v1/generated.proto
@@ -118,6 +118,7 @@ message EventList {
 // continuously for some time. How often to update the EventSeries is up to the event reporters.
 // The default event reporter in "k8s.io/client-go/tools/events/event_broadcaster.go" shows
 // how this struct is updated on heartbeats and can guide customized reporter implementations.
+// +structType=atomic
 message EventSeries {
   // count is the number of occurrences in this series up to the last heartbeat time.
   optional int32 count = 1;

--- a/staging/src/k8s.io/api/events/v1/types.go
+++ b/staging/src/k8s.io/api/events/v1/types.go
@@ -102,6 +102,7 @@ type Event struct {
 // continuously for some time. How often to update the EventSeries is up to the event reporters.
 // The default event reporter in "k8s.io/client-go/tools/events/event_broadcaster.go" shows
 // how this struct is updated on heartbeats and can guide customized reporter implementations.
+// +structType=atomic
 type EventSeries struct {
 	// count is the number of occurrences in this series up to the last heartbeat time.
 	Count int32 `json:"count" protobuf:"varint,1,opt,name=count"`

--- a/staging/src/k8s.io/api/events/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/events/v1beta1/generated.proto
@@ -120,6 +120,7 @@ message EventList {
 
 // EventSeries contain information on series of events, i.e. thing that was/is happening
 // continuously for some time.
+// +structType=atomic
 message EventSeries {
   // count is the number of occurrences in this series up to the last heartbeat time.
   optional int32 count = 1;

--- a/staging/src/k8s.io/api/events/v1beta1/types.go
+++ b/staging/src/k8s.io/api/events/v1beta1/types.go
@@ -105,6 +105,7 @@ type Event struct {
 
 // EventSeries contain information on series of events, i.e. thing that was/is happening
 // continuously for some time.
+// +structType=atomic
 type EventSeries struct {
 	// count is the number of occurrences in this series up to the last heartbeat time.
 	Count int32 `json:"count" protobuf:"varint,1,opt,name=count"`

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -5555,6 +5555,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: lastObservedTime
       type:
         namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+    elementRelationship: atomic
 - name: io.k8s.api.core.v1.EventSource
   map:
     fields:
@@ -9147,6 +9148,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: lastObservedTime
       type:
         namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+    elementRelationship: atomic
 - name: io.k8s.api.events.v1beta1.Event
   map:
     fields:
@@ -9214,6 +9216,7 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: lastObservedTime
       type:
         namedType: io.k8s.apimachinery.pkg.apis.meta.v1.MicroTime
+    elementRelationship: atomic
 - name: io.k8s.api.extensions.v1beta1.DaemonSet
   map:
     fields:

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -3989,14 +3989,10 @@ func TestApplyFormerlyAtomicFields(t *testing.T) {
 }
 
 func TestApplyEventSeriesGranularToAtomic(t *testing.T) {
-	// 1. Create an Event with its Series owned by granular fields
-	// 2. Attempt to re-apply the original Event using Server-Side Apply
-	// 3. Check that the operation was successful and the managed fields are atomic
-
 	client, closeFn := setup(t)
 	defer closeFn()
 
-	oldEvent := []byte(`{
+	event := []byte(`{
 		"apiVersion": "v1",
 		"kind": "Event",
 		"metadata": {
@@ -4012,7 +4008,7 @@ func TestApplyEventSeriesGranularToAtomic(t *testing.T) {
 		"message": "TestMessage",
 		"type": "Normal",
 		"series": {
-			"count": 1,
+			"count": 2,
 			"lastObservedTime": "2023-01-01T00:00:00.000000Z"
 		}
 	}`)
@@ -4028,21 +4024,18 @@ func TestApplyEventSeriesGranularToAtomic(t *testing.T) {
 					"apiVersion": "v1",
 					"fieldsType": "FieldsV1",
 					"fieldsV1": {
-						"f:involvedObject": {
-							"f:kind": {},
-							"f:name": {},
-							"f:namespace": {}
-						},
+						"f:involvedObject": {},
 						"f:message": {},
 						"f:reason": {},
 						"f:series": {
+							".": {},
 							"f:count": {},
 							"f:lastObservedTime": {}
 						},
 						"f:type": {}
 					},
-					"manager": "apply_test",
-					"operation": "Apply",
+					"manager": "recorder",
+					"operation": "Update",
 					"time": "2023-01-01T00:00:00.000000Z"
 				}
 			]
@@ -4057,46 +4050,54 @@ func TestApplyEventSeriesGranularToAtomic(t *testing.T) {
 			"namespace": "default"
 		},
 		"series": {
-			"count": 2,
+			"count": 3,
 			"lastObservedTime": "2023-01-01T00:01:00.000000Z"
 		}
 	}`)
 
-	// Create Event
-	originalObj, err := client.CoreV1().RESTClient().
+	_, err := client.CoreV1().RESTClient().
 		Post().
-		Param("fieldManager", "apply_test").
+		Param("fieldManager", "recorder").
 		Resource("events").
 		Namespace("default").
-		Body(oldEvent).
+		Body(event).
 		Do(context.TODO()).
 		Get()
-
 	if err != nil {
-		t.Fatalf("Failed to apply object: %v", err)
-	} else if _, ok := originalObj.(*v1.Event); !ok {
-		t.Fatalf("returned object is incorrect type: %T", originalObj)
+		t.Fatalf("Failed to create object: %v", err)
 	}
 
-	// Directly set managed fields to object using StrategicMergePatch
-	newObj, err := client.CoreV1().RESTClient().
+	// Set managed fields to object
+	_, err = client.CoreV1().RESTClient().
 		Patch(types.StrategicMergePatchType).
 		Name("test-event").
 		Namespace("default").
-		Param("fieldManager", "apply_test").
+		Param("fieldManager", "recorder").
 		Resource("events").
 		Body(managedFieldsUpdate).
 		Do(context.TODO()).
 		Get()
-
 	if err != nil {
-		t.Fatalf("Failed to apply object: %v", err)
-	} else if _, ok := newObj.(*v1.Event); !ok {
-		t.Fatalf("returned object is incorrect type: %T", newObj)
+		t.Fatalf("Failed to set managed fields: %v", err)
 	}
 
-	// Re-apply using Server-Side Apply
-	newObj, err = client.CoreV1().RESTClient().
+	_, err = client.CoreV1().RESTClient().
+		Patch(types.ApplyPatchType).
+		Name("test-event").
+		Namespace("default").
+		Param("fieldManager", "apply_test").
+		Resource("events").
+		Body(applyEvent).
+		Do(context.TODO()).
+		Get()
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("expected conflict on series, got: %v", err)
+	}
+	if cause, ok := apierrors.StatusCause(err, metav1.CauseTypeFieldManagerConflict); !ok || cause.Field != ".series" {
+		t.Fatalf("expected conflict on .series, got: %v", err)
+	}
+
+	newObj, err := client.CoreV1().RESTClient().
 		Patch(types.ApplyPatchType).
 		Name("test-event").
 		Namespace("default").
@@ -4106,30 +4107,37 @@ func TestApplyEventSeriesGranularToAtomic(t *testing.T) {
 		Body(applyEvent).
 		Do(context.TODO()).
 		Get()
-
 	if err != nil {
 		t.Fatalf("Failed to apply object: %v", err)
 	}
 
-	// Verify the new object's managedFields
-	managedFields := newObj.(*v1.Event).ManagedFields
-	if len(managedFields) == 0 {
-		t.Fatalf("expected managed fields to be present")
+	var expectedManagedFields []metav1.ManagedFieldsEntry
+	expectedManagedFieldsString := []byte(`[
+		{
+			"apiVersion": "v1",
+			"fieldsType": "FieldsV1",
+			"fieldsV1": {"f:series":{}},
+			"manager": "apply_test",
+			"operation": "Apply"
+		},
+		{
+			"apiVersion": "v1",
+			"fieldsType": "FieldsV1",
+			"fieldsV1": {"f:involvedObject":{},"f:message":{},"f:reason":{},"f:type":{}},
+			"manager": "recorder",
+			"operation": "Update"
+		}
+	]`)
+	if err := json.Unmarshal(expectedManagedFieldsString, &expectedManagedFields); err != nil {
+		t.Fatalf("unexpectedly failed to decode expected managed fields: %v", err)
 	}
 
-	foundSeries := false
-	for _, entry := range managedFields {
-		if entry.Manager == "apply_test" {
-			fieldsV1 := string(entry.FieldsV1.GetRawBytes())
-			if !strings.Contains(fieldsV1, `"f:series":{}`) {
-				t.Fatalf("expected atomic f:series:{}, but got %s", fieldsV1)
-			}
-			foundSeries = true
-			break
-		}
+	managedFields := newObj.(*v1.Event).ManagedFields
+	for i := range managedFields {
+		managedFields[i].Time = nil
 	}
-	if !foundSeries {
-		t.Fatalf("could not find managed fields for apply_test manager")
+	if !reflect.DeepEqual(expectedManagedFields, managedFields) {
+		t.Fatalf("unexpected managed fields: %v", cmp.Diff(expectedManagedFields, managedFields))
 	}
 }
 

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -3988,6 +3988,151 @@ func TestApplyFormerlyAtomicFields(t *testing.T) {
 	}
 }
 
+func TestApplyEventSeriesGranularToAtomic(t *testing.T) {
+	// 1. Create an Event with its Series owned by granular fields
+	// 2. Attempt to re-apply the original Event using Server-Side Apply
+	// 3. Check that the operation was successful and the managed fields are atomic
+
+	client, closeFn := setup(t)
+	defer closeFn()
+
+	oldEvent := []byte(`{
+		"apiVersion": "v1",
+		"kind": "Event",
+		"metadata": {
+			"name": "test-event",
+			"namespace": "default"
+		},
+		"involvedObject": {
+			"kind": "Pod",
+			"name": "test-pod",
+			"namespace": "default"
+		},
+		"reason": "TestReason",
+		"message": "TestMessage",
+		"type": "Normal",
+		"series": {
+			"count": 1,
+			"lastObservedTime": "2023-01-01T00:00:00.000000Z"
+		}
+	}`)
+
+	managedFieldsUpdate := []byte(`{
+		"apiVersion": "v1",
+		"kind": "Event",
+		"metadata": {
+			"name": "test-event",
+			"namespace": "default",
+			"managedFields": [
+				{
+					"apiVersion": "v1",
+					"fieldsType": "FieldsV1",
+					"fieldsV1": {
+						"f:involvedObject": {
+							"f:kind": {},
+							"f:name": {},
+							"f:namespace": {}
+						},
+						"f:message": {},
+						"f:reason": {},
+						"f:series": {
+							"f:count": {},
+							"f:lastObservedTime": {}
+						},
+						"f:type": {}
+					},
+					"manager": "apply_test",
+					"operation": "Apply",
+					"time": "2023-01-01T00:00:00.000000Z"
+				}
+			]
+		}
+	}`)
+
+	applyEvent := []byte(`{
+		"apiVersion": "v1",
+		"kind": "Event",
+		"metadata": {
+			"name": "test-event",
+			"namespace": "default"
+		},
+		"series": {
+			"count": 2,
+			"lastObservedTime": "2023-01-01T00:01:00.000000Z"
+		}
+	}`)
+
+	// Create Event
+	originalObj, err := client.CoreV1().RESTClient().
+		Post().
+		Param("fieldManager", "apply_test").
+		Resource("events").
+		Namespace("default").
+		Body(oldEvent).
+		Do(context.TODO()).
+		Get()
+
+	if err != nil {
+		t.Fatalf("Failed to apply object: %v", err)
+	} else if _, ok := originalObj.(*v1.Event); !ok {
+		t.Fatalf("returned object is incorrect type: %T", originalObj)
+	}
+
+	// Directly set managed fields to object using StrategicMergePatch
+	newObj, err := client.CoreV1().RESTClient().
+		Patch(types.StrategicMergePatchType).
+		Name("test-event").
+		Namespace("default").
+		Param("fieldManager", "apply_test").
+		Resource("events").
+		Body(managedFieldsUpdate).
+		Do(context.TODO()).
+		Get()
+
+	if err != nil {
+		t.Fatalf("Failed to apply object: %v", err)
+	} else if _, ok := newObj.(*v1.Event); !ok {
+		t.Fatalf("returned object is incorrect type: %T", newObj)
+	}
+
+	// Re-apply using Server-Side Apply
+	newObj, err = client.CoreV1().RESTClient().
+		Patch(types.ApplyPatchType).
+		Name("test-event").
+		Namespace("default").
+		Param("fieldManager", "apply_test").
+		Param("force", "true").
+		Resource("events").
+		Body(applyEvent).
+		Do(context.TODO()).
+		Get()
+
+	if err != nil {
+		t.Fatalf("Failed to apply object: %v", err)
+	}
+
+	// Verify the new object's managedFields
+	managedFields := newObj.(*v1.Event).ManagedFields
+	if len(managedFields) == 0 {
+		t.Fatalf("expected managed fields to be present")
+	}
+
+	foundSeries := false
+	for _, entry := range managedFields {
+		if entry.Manager == "apply_test" {
+			fieldsV1 := string(entry.FieldsV1.Raw)
+			if !strings.Contains(fieldsV1, `"f:series":{}`) {
+				t.Fatalf("expected atomic f:series:{}, but got %s", fieldsV1)
+			}
+			foundSeries = true
+			break
+		}
+	}
+	if !foundSeries {
+		t.Fatalf("could not find managed fields for apply_test manager")
+	}
+}
+
 func TestDuplicatesInAssociativeLists(t *testing.T) {
 	client, closeFn := setup(t)
 	defer closeFn()

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -4120,7 +4120,7 @@ func TestApplyEventSeriesGranularToAtomic(t *testing.T) {
 	foundSeries := false
 	for _, entry := range managedFields {
 		if entry.Manager == "apply_test" {
-			fieldsV1 := string(entry.FieldsV1.Raw)
+			fieldsV1 := string(entry.FieldsV1.GetRawBytes())
 			if !strings.Contains(fieldsV1, `"f:series":{}`) {
 				t.Fatalf("expected atomic f:series:{}, but got %s", fieldsV1)
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Marks the versioned `EventSeries` types as atomic so the generated OpenAPI schemas include `x-kubernetes-map-type=atomic`. This prevents managed-fields and `FieldsV1` from representing `EventSeries` with a `"."` field entry that breaks Elasticsearch/OpenSearch-based event pipelines.

#### Which issue(s) this PR is related to:

Fixes #140957

#### Special notes for your reviewer:

This change is limited to the versioned API types and the generated OpenAPI output. The internal type is unchanged because the schema is generated from the versioned types.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
N/A
```
