### PR TITLE
hack: add verify script for slow e2e tests

### DIFF
--- a/hack/tools/verify-slow-e2e/main.go
+++ b/hack/tools/verify-slow-e2e/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// TestSuites represents the root of a JUnit XML file
+type TestSuites struct {
+	Suites []TestSuite `xml:"testsuite"`
+}
+
+type TestSuite struct {
+	TestCases []TestCase `xml:"testcase"`
+}
+
+type TestCase struct {
+	Name    string   `xml:"name,attr"`
+	Time    float64  `xml:"time,attr"`
+	Skipped *Skipped `xml:"skipped"`
+	Failure *Failure `xml:"failure"`
+}
+
+type Skipped struct{}
+type Failure struct{}
+
+const slowThresholdSeconds = 300.0
+
+func main() {
+	flag.Parse()
+	files := flag.Args()
+	if len(files) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: verify-slow-e2e <junit.xml> [junit2.xml...]")
+		os.Exit(1)
+	}
+
+	exitCode := 0
+
+	for _, file := range files {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading file %s: %v\n", file, err)
+			exitCode = 1
+			continue
+		}
+
+		var suites TestSuites
+		if err := xml.Unmarshal(data, &suites); err != nil {
+			// Some junit files don't have <testsuites> at the root, they start with <testsuite>
+			var suite TestSuite
+			if err2 := xml.Unmarshal(data, &suite); err2 != nil {
+				fmt.Fprintf(os.Stderr, "Error parsing XML in %s: %v\n", file, err)
+				exitCode = 1
+				continue
+			}
+			suites.Suites = []TestSuite{suite}
+		}
+
+		for _, suite := range suites.Suites {
+			for _, tc := range suite.TestCases {
+				if tc.Skipped != nil {
+					continue
+				}
+
+				hasSlow := strings.Contains(tc.Name, "[Slow]")
+				isSlow := tc.Time > slowThresholdSeconds
+
+				if isSlow && !hasSlow {
+					fmt.Printf("MISSING [Slow] tag (took %.1fs): %s\n", tc.Time, tc.Name)
+					exitCode = 1
+				} else if !isSlow && hasSlow && tc.Time > 0 {
+					// Add a buffer to avoid flapping tests. If it completes in less than 240 seconds
+					// consistently but is tagged [Slow], it might be unnecessary.
+					if tc.Time < 180.0 {
+						fmt.Printf("UNNECESSARY [Slow] tag (took %.1fs): %s\n", tc.Time, tc.Name)
+						exitCode = 1
+					}
+				}
+			}
+		}
+	}
+
+	os.Exit(exitCode)
+}

--- a/hack/verify-slow-e2e.sh
+++ b/hack/verify-slow-e2e.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: hack/verify-slow-e2e.sh <path-to-junit.xml> [more-junit.xml...]"
+  echo ""
+  echo "This tool parses JUnit XML output from e2e test runs to verify that"
+  echo "tests taking > 5 minutes have the [Slow] tag, and tests taking < 3 minutes"
+  echo "do not incorrectly retain the [Slow] tag."
+  exit 1
+fi
+
+kube::golang::setup_env
+
+# Run the verify tool
+echo "Running slow e2e verification tool..."
+go run "${KUBE_ROOT}/hack/tools/verify-slow-e2e/main.go" "$@"


### PR DESCRIPTION
Automates the verification of [Slow] test tags based on
JUnit XML output. The test descriptions in the e2e suites frequently diverge
from actual test execution durations. Maintainers can use this tool to easily
find out-of-sync tests by feeding it a JUnit xml artifact.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/sig testing

#### What this PR does / why we need it:
This PR automates the verification of `[Slow]` test tags in our e2e suites based on JUnit XML output. Test execution durations frequently drift, causing the test names to diverge from reality (e.g. tests taking >5m without the tag, or fast tests retaining it). 

Rather than relying on one-off manual audits or flaky web scraping, this introduces a maintainer-friendly CLI tool (`hack/tools/verify-slow-e2e`) and wrapper script (`hack/verify-slow-e2e.sh`). Maintainers or Prow jobs can feed it a JUnit XML artifact to easily find out-of-sync tests.

#### Which issue(s) this PR is related to:

Fixes #131049

#### Special notes for your reviewer:
The script implements a 300s upper threshold for identifying missing `[Slow]` tags, and a 180s lower threshold (a 2-minute buffer) to identify unnecessary `[Slow]` tags in order to prevent flapping if test durations vary slightly across CI runs.

#### Does this PR introduce a user-facing change?

```release-note
NONE