### PR TITLE
DRA: treat feature-unusable devices as non-matching in isSelectable

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/allocatortesting/allocator_testing.go
@@ -1472,6 +1472,50 @@ func TestAllocator(t *testing.T,
 
 			expectResults: []any{},
 		},
+		"optional-node-operations-other-device-available": {
+			features: Features{OptionalNodeOperations: true},
+			claimsToAllocate: objects(
+				claimWithRequests(claim0, nil,
+					request(req0, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+				).withSkipNodeOperations(resourceapi.SkipNodeOperationAll),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 2), driverA,
+					device(device2, nil, nil),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+			)},
+		},
+		"optional-node-operations-allocation-mode-all-skips-unusable": {
+			features: Features{OptionalNodeOperations: true},
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(
+					allDeviceRequest(req0, classA),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil),
+				).withSkipNodeOperations(resourceapi.SkipNodeOperationAll),
+				sliceWithDevices(slice2, node1, resourcePool(pool1, 2), driverA,
+					device(device2, nil, nil),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+			)},
+		},
 		"other-node": {
 			claimsToAllocate: objects(claimWithRequest(claim0, req0, classA)),
 			classes:          objects(class(classA, driverA)),
@@ -4412,6 +4456,41 @@ func TestAllocator(t *testing.T,
 			claimsToAllocate: objects(
 				claimWithRequests(claim0, nil,
 					request(req0, classA, 1),
+				),
+			),
+			classes: objects(class(classA, driverA)),
+			slices: unwrapResourceSlices(
+				sliceWithDevices(slice1, node1, resourcePool(pool1, 2), driverA,
+					device(device1, nil, nil).withDeviceCounterConsumption(
+						deviceCounterConsumption(counterSet1,
+							map[string]resource.Quantity{
+								"memory": resource.MustParse("4Gi"),
+							},
+						),
+					),
+					device(device2, nil, nil),
+				),
+				sliceWithCounterSets(slice2, node1, resourcePool(pool1, 2), driverA,
+					counterSet(counterSet1,
+						map[string]resource.Quantity{
+							"memory": resource.MustParse("18Gi"),
+						},
+					),
+				),
+			),
+			node: node(node1, region1),
+			expectResults: []any{allocationResult(
+				localNodeSelector(node1),
+				deviceAllocationResult(req0, driverA, pool1, device2, false),
+			)},
+		},
+		"partitionable-devices-disabled-allocation-mode-all-skips-counter-devices": {
+			features: Features{
+				PartitionableDevices: false,
+			},
+			claimsToAllocate: objects(
+				claim(claim0).withRequests(
+					allDeviceRequest(req0, classA),
 				),
 			),
 			classes: objects(class(classA, driverA)),

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/allocator_experimental.go
@@ -1457,6 +1457,18 @@ func (alloc *allocator) isSelectable(r requestIndices, requestData requestData, 
 		// Devices with binding conditions are not supported, feature is off.
 		return false, nil
 	}
+	if !alloc.features.PartitionableDevices && len(device.ConsumesCounters) > 0 {
+		// Devices that consume counters are not supported, feature is off.
+		return false, nil
+	}
+	if len(slice.Spec.SkipNodeOperations) > 0 {
+		if !alloc.features.OptionalNodeOperations {
+			return false, nil
+		}
+		if !slices.Contains(alloc.node.Status.DeclaredFeatures, draoptionalnodeoperations.DRAOptionalNodeOperationsFeatureGate) {
+			return false, nil
+		}
+	}
 
 	deviceID := DeviceID{Driver: slice.Spec.Driver, Pool: slice.Spec.Pool.Name, Device: slice.Spec.Devices[deviceIndex].Name}
 	matchKey := matchKey{DeviceID: deviceID, requestIndices: r}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/allocator_incubating.go
@@ -1216,6 +1216,10 @@ func (alloc *allocator) isSelectable(r requestIndices, requestData requestData, 
 		// Devices with binding conditions are not supported, feature is off.
 		return false, nil
 	}
+	if !alloc.features.PartitionableDevices && len(device.ConsumesCounters) > 0 {
+		// Devices that consume counters are not supported, feature is off.
+		return false, nil
+	}
 
 	deviceID := DeviceID{Driver: slice.Spec.Driver, Pool: slice.Spec.Pool.Name, Device: slice.Spec.Devices[deviceIndex].Name}
 	matchKey := matchKey{DeviceID: deviceID, requestIndices: r}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/allocator_stable.go
@@ -1040,6 +1040,10 @@ func (alloc *allocator) isSelectable(r requestIndices, requestData requestData, 
 		// Devices with binding conditions are not supported, feature is off.
 		return false, nil
 	}
+	if !alloc.features.PartitionableDevices && len(device.ConsumesCounters) > 0 {
+		// Devices that consume counters are not supported, feature is off.
+		return false, nil
+	}
 
 	deviceID := DeviceID{Driver: slice.Spec.Driver, Pool: slice.Spec.Pool.Name, Device: slice.Spec.Devices[deviceIndex].Name}
 	matchKey := matchKey{DeviceID: deviceID, requestIndices: r}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does:

Fixes structured DRA allocator behavior for `allocationMode: All` when some devices in a pool are unusable because a feature (or node capability) is off. Assuming`All` means “all **matching** devices. Devices that BindingConditions already
filters in `isSelectable` when that feature is off are treated as non-matching.

- Two similar cases were only soft-failed later in `allocateDevice`:

1. `ConsumesCounters` while `DRAPartitionableDevices` is disabled
2. `SkipNodeOperations` while `DRAOptionalNodeOperations` is disabled, or the node does not declare that feature

ExactCount already skipped those devices and could allocate a plain sibling.
All still counted them into `allDevices`, then failed the whole request when
one soft-failed.

**Example:**  
- pool has device-1 (needs feature X) and device-2 (plain).
- Feature X is off. ExactCount gets device-2. 
- All used to get nothing, but it should get device-2. 
- After this fix, All gets device-2.

**Impact:** claims/pods using All could stay unallocated (pending) even though usable devices remained on the node, typically during feature rollback, mixed driver publication, or nodes without OptionalNodeOperations declared.

**Fix:** filter those devices in `isSelectable` (same place as BindingConditions). Keep the `allocateDevice` soft-fails as defense in depth.

- Partitionable gate: experimental + incubating + stable
- SkipNode gate: experimental only (that feature lives there)

Table tests added to existing siblings:

- `partitionable-devices-disabled-allocation-mode-all-skips-counter-devices`
- `optional-node-operations-other-device-available`
- `optional-node-operations-allocation-mode-all-skips-unusable`

No API or user-doc change; behavior matches existing All matching contract.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- Opposite of the consumable-capacity All contract (PR #140769) which I contributed before, there a device *otherwise matches* but cannot be allocated → All must fail. Here the device must not match when the feature/node cannot support it.
- SkipNode table cases require `OptionalNodeOperations` and are skipped on incubating/stable allocators (same as existing optional-node-operations tests).

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where ResourceClaims using allocationMode All could fail to allocate when a pool also advertised devices that were unusable because PartitionableDevices or OptionalNodeOperations was unavailable. Those devices are now treated as
non-matching so All can allocate the remaining usable devices.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
