### PR TITLE
Fix StatefulSet bug of matching leading-zero pod name

### DIFF
--- a/pkg/controller/statefulset/stateful_set_test.go
+++ b/pkg/controller/statefulset/stateful_set_test.go
@@ -558,14 +558,19 @@ func TestGetPodsForStatefulSetAdopt(t *testing.T) {
 	pod4 := newStatefulSetPod(set, 4)
 	pod4.OwnerReferences = nil
 	pod4.Name = "x" + pod4.Name
+	// A leading-zero ordinal must stay unclaimed so it cannot hide the canonical Pod.
+	pod5 := newStatefulSetPod(set, 1)
+	pod5.OwnerReferences = nil
+	pod5.Name = set.Name + "-01"
 
 	_, ctx := ktesting.NewTestContext(t)
-	ssc, _, om, _ := newFakeStatefulSetController(ctx, set, pod1, pod2, pod3, pod4)
+	ssc, _, om, _ := newFakeStatefulSetController(ctx, set, pod1, pod2, pod3, pod4, pod5)
 
 	om.podsIndexer.Add(pod1)
 	om.podsIndexer.Add(pod2)
 	om.podsIndexer.Add(pod3)
 	om.podsIndexer.Add(pod4)
+	om.podsIndexer.Add(pod5)
 	selector, err := metav1.LabelSelectorAsSelector(set.Spec.Selector)
 	if err != nil {
 		t.Fatal(err)
@@ -578,7 +583,7 @@ func TestGetPodsForStatefulSetAdopt(t *testing.T) {
 	for _, pod := range pods {
 		got.Insert(pod.Name)
 	}
-	// pod2 should be claimed, pod3 and pod4 ignored
+	// pod2 should be claimed, pod3, pod4, and pod5 ignored.
 	want := sets.NewString(pod1.Name, pod2.Name)
 	if !got.Equal(want) {
 		t.Errorf("getPodsForStatefulSet() = %v, want %v", got, want)
@@ -643,11 +648,15 @@ func TestGetPodsForStatefulSetRelease(t *testing.T) {
 	pod4 := newStatefulSetPod(set, 4)
 	pod4.OwnerReferences = nil
 	pod4.Labels = nil
+	// A leading-zero ordinal must be released so it cannot hide the canonical Pod.
+	pod5 := newStatefulSetPod(set, 1)
+	pod5.Name = set.Name + "-01"
 
 	om.podsIndexer.Add(pod1)
 	om.podsIndexer.Add(pod2)
 	om.podsIndexer.Add(pod3)
 	om.podsIndexer.Add(pod4)
+	om.podsIndexer.Add(pod5)
 	selector, err := metav1.LabelSelectorAsSelector(set.Spec.Selector)
 	if err != nil {
 		t.Fatal(err)
@@ -661,7 +670,7 @@ func TestGetPodsForStatefulSetRelease(t *testing.T) {
 		got.Insert(pod.Name)
 	}
 
-	// Expect only pod1 (pod2 and pod3 should be released, pod4 ignored).
+	// Expect only pod1 (pod2, pod3, and pod5 should be released, pod4 ignored).
 	want := sets.NewString(pod1.Name)
 	if !got.Equal(want) {
 		t.Errorf("getPodsForStatefulSet() = %v, want %v", got, want)

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -130,8 +130,10 @@ func getPersistentVolumeClaimName(set *apps.StatefulSet, claim *v1.PersistentVol
 
 // isMemberOf tests if pod is a member of set.
 func isMemberOf(set *apps.StatefulSet, pod *v1.Pod) bool {
-	parent, _ := getParentNameAndOrdinal(pod)
-	return parent == set.Name
+	parent, ordinal := getParentNameAndOrdinal(pod)
+	return ordinal >= 0 &&
+		parent == set.Name &&
+		pod.Name == getPodName(set, ordinal)
 }
 
 // identityMatches returns true if pod has a valid identity and network identity for a member of set.

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -195,6 +195,10 @@ func TestIsMemberOf(t *testing.T) {
 	if isMemberOf(set2, pod) {
 		t.Error("isMemberOf returned false positive")
 	}
+	pod.Name = set.Name + "-01"
+	if isMemberOf(set, pod) {
+		t.Error("isMemberOf returned true for a non-canonical Pod name")
+	}
 }
 
 func TestIdentityMatches(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes a bug that prevents the StatefulSet controller from reconciling pods when there are existing pods with certain names.

Before this PR, the StatefulSet controller's `isMemberOf` treats a pod whose name has a leading-zero ordinal as a member, e.g., `sts-01`.
```
func isMemberOf(set *apps.StatefulSet, pod *v1.Pod) bool {
    parent, _ := getParentNameAndOrdinal(pod)
    return parent == set.Name // "sts-01" is allowed to be a member of `sts`
}
```
However, later the StatefulSet controller will try to update the pod, including updating the pod name from `sts-01` to `sts-1`:
```
func updateIdentity(set *apps.StatefulSet, pod *v1.Pod) {
	ordinal := getOrdinal(pod)
	pod.Name = getPodName(set, ordinal) // "sts-01" -> "sts-1"
	...
}
```
The update request to the API server is destined to fail because the name is immutable. The StatefulSet controller cannot make progress as long as `sts-01` still exists.

This PR fixes the bug by enhancing the membership check to:
```
func isMemberOf(set *apps.StatefulSet, pod *v1.Pod) bool {
	parent, ordinal := getParentNameAndOrdinal(pod)
	return ordinal >= 0 &&
		parent == set.Name &&
		pod.Name == getPodName(set, ordinal) // this line rejects leading-zero ordinal
}
```
So pods like `sts-01` will no longer be treated as a member and will not block the StatefulSet controller.

This PR also enhances existing tests to cover the leading-zero case.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
