### PR TITLE
client-go: fix RealFIFO.Resync wrapping the wrong error

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
@@ -779,7 +779,7 @@ func (f *RealFIFO) Resync() error {
 
 		retErr := f.addToItems_locked(Sync, true, knownObj)
 		if retErr != nil {
-			return fmt.Errorf("couldn't queue object: %w", err)
+			return fmt.Errorf("couldn't queue object: %w", retErr)
 		}
 	}
 

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
@@ -575,6 +575,29 @@ func TestRealFIFO_Resync(t *testing.T) {
 	}
 }
 
+func TestRealFIFO_ResyncPropagatesQueueError(t *testing.T) {
+	sentinel := errors.New("computing key failed")
+	f := NewRealFIFO(
+		func(obj interface{}) (string, error) {
+			if fifoObj, ok := obj.(testFifoObject); ok && fifoObj.name == "broken" {
+				return "", sentinel
+			}
+			return testFifoObjectKeyFunc(obj)
+		},
+		literalListerGetter(func() []testFifoObject {
+			return []testFifoObject{mkFifoObj("broken", 5)}
+		}),
+		nil,
+	)
+	err := f.Resync()
+	if err == nil {
+		t.Fatal("expected Resync to return an error when the object cannot be queued")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected the underlying queueing error to be wrapped, got: %v", err)
+	}
+}
+
 func TestRealFIFO_DeleteExistingNonPropagated(t *testing.T) {
 	f := NewRealFIFO(
 		testFifoObjectKeyFunc,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig api-machinery

**What this PR does / why we need it:**

`RealFIFO.Resync` wraps the wrong error variable when queueing a known object fails:

```go
knownObj, exists, err := f.knownObjects.GetByKey(knownKey)
if err != nil { ... continue }
} else if !exists { ... continue }

retErr := f.addToItems_locked(Sync, true, knownObj)
if retErr != nil {
    return fmt.Errorf("couldn't queue object: %w", err)  // err is always nil here
}
```

Both non-nil branches of the `GetByKey` check `continue` the loop, so `err` is provably nil by the time `retErr` is checked. The caller ends up with the literal string `couldn't queue object: %!w(<nil>)`: the real cause is dropped and `errors.Is`/`errors.As` can't match anything. This error surfaces through `Reflector.startResync` -> `resyncerrc` -> the watch error handler, which is exactly where you'd be looking while debugging a stuck informer.

The sibling code in `delta_fifo.go` wraps the right variable, so this looks like a copy/paste slip when `RealFIFO` was introduced.

Includes a regression test; with the old code it fails with:

```
expected the underlying queueing error to be wrapped, got: couldn't queue object: %!w(<nil>)
```

**Which issue(s) this PR fixes:**

None

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
