### PR TITLE
kubectl kuberc view: fix panic when declining to generate a default file

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view.go
@@ -132,6 +132,9 @@ func (o *ViewOptions) Run() error {
 			pref := kuberc.CreateDefaultPreference()
 			return kuberc.SavePreference(pref, o.KubeRCFile, o.Out)
 		}
+		// The user declined to generate a default kuberc file,
+		// so there is nothing to print.
+		return nil
 	}
 
 	if pref.Aliases == nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/kuberc/view_test.go
@@ -19,6 +19,7 @@ package kuberc
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -83,6 +84,29 @@ aliases:
 			outputFormat: "json",
 		},
 	}
+
+	t.Run("declining to generate a default kuberc", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		kubercPath := filepath.Join(tmpDir, "kuberc")
+
+		streams, in, out, _ := genericiooptions.NewTestIOStreams()
+		in.WriteString("n\n")
+		o := &ViewOptions{
+			KubeRCFile: kubercPath,
+			PrintFlags: genericclioptions.NewPrintFlags("").WithDefaultOutput("yaml"),
+			IOStreams:  streams,
+		}
+
+		if err := o.Run(); err != nil {
+			t.Fatalf("Run() unexpected error = %v", err)
+		}
+		if _, err := os.Stat(kubercPath); !os.IsNotExist(err) {
+			t.Errorf("expected no kuberc file to be created, stat returned: %v", err)
+		}
+		if got := out.String(); !strings.Contains(got, "kuberc file not found") {
+			t.Errorf("expected the missing-file notice in output, got: %q", got)
+		}
+	})
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig cli

**What this PR does / why we need it:**

`kubectl kuberc view` panics when no kuberc file exists and the user answers anything but `y` at the prompt (including the documented default `N`):

```
$ kubectl kuberc view
kuberc file not found at /home/user/.kube/kuberc
Would you like to generate a default kuberc file with recommended options? (y/N): n
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x38 pc=...]

goroutine 1 [running]:
k8s.io/kubectl/pkg/cmd/kuberc.(*ViewOptions).Run(...)
        .../pkg/cmd/kuberc/view.go:137 +0x18c
```

`LoadPreference` returns a nil `pref` on ENOENT. The missing-file branch handles the "generate" answer and the `Fscanln` error, but the "declined" answer falls out of the branch and dereferences the still-nil `pref` at `pref.Aliases`.

The fix returns early after the user declines - there is no kuberc to print.

The existing tests didn't catch this because they run with an empty stdin, which makes `Fscanln` fail and takes the other early return. The new subtest answers `n` and panics without the fix.

**Which issue(s) this PR fixes:**

None

**Special notes for your reviewer:**

Reproduced on current master (darwin and linux builds behave the same).

**Does this PR introduce a user-facing change?**

```release-note
Fixed a panic in `kubectl kuberc view` when no kuberc file exists and the user declines to generate a default one.
```
