### PR TITLE
kubelet: fix wrong variable in container memory resize validation

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1211,7 +1211,7 @@ func (m *kubeGenericRuntimeManager) validateMemoryResizeAction(
 				errs = append(errs, fmt.Errorf("missing container %q memory usage", cStats.Name))
 			} else if *cStats.Memory.UsageBytes >= uint64(desiredLimit) {
 				errs = append(errs, fmt.Errorf("attempting to set container %q memory limit (%d) below current usage (%d)",
-					cStats.Name, desiredLimit, *podUsageStats.Memory.UsageBytes))
+					cStats.Name, desiredLimit, *cStats.Memory.UsageBytes))
 			}
 		}
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -5498,6 +5498,18 @@ func TestValidatePodResizeAction(t *testing.T) {
 			expectedError:        true,
 		},
 		{
+			testName: "Decrease container limits, high usage, missing pod usage",
+			currentResources: resourceRequirements{
+				memoryRequest: 100, memoryLimit: 200,
+			},
+			desiredResources: resourceRequirements{
+				memoryRequest: 100, memoryLimit: 100,
+			},
+			containerMemoryUsage: ptr.To[uint64](150),
+			podMemoryUsage:       nil,
+			expectedError:        true,
+		},
+		{
 			testName: "Add pod limit, low usage",
 			currentResources: resourceRequirements{
 				memoryRequest: 100, memoryLimit: 100,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig node

**What this PR does / why we need it:**

`validateMemoryResizeAction` has a copy/paste slip in the per-container check: the error message reports `*podUsageStats.Memory.UsageBytes` (the pod-level usage) where it means the container's usage:

```go
if cStats.Memory == nil || cStats.Memory.UsageBytes == nil {
    errs = append(errs, fmt.Errorf("missing container %q memory usage", cStats.Name))
} else if *cStats.Memory.UsageBytes >= uint64(desiredLimit) {
    errs = append(errs, fmt.Errorf("attempting to set container %q memory limit (%d) below current usage (%d)",
        cStats.Name, desiredLimit, *podUsageStats.Memory.UsageBytes))  // pod usage, and unguarded
}
```

Beyond reporting the wrong number, this dereferences `podUsageStats.Memory`/`UsageBytes` on a path where neither is guaranteed non-nil: pod-level usage is only nil-checked inside the `podLimitDecreasing` branch. When only a **container** limit is being decreased and the runtime doesn't report pod-level memory stats (`addCRIPodMemoryStats` returns without setting `ps.Memory` when `criPodStat.Linux == nil || criPodStat.Linux.Memory == nil`; the cadvisor provider only sets `podStats.Memory` when the pod cgroup entry is in its cache), the pod worker panics in `doPodResizeAction` instead of rejecting the resize with the intended error.

The fix uses the container's own usage, which the preceding nil-check already guards.

The added test case (`Decrease container limits, high usage, missing pod usage`) fails with the panic without the fix:

```
--- FAIL: TestValidatePodResizeAction/Decrease_container_limits,_high_usage,_missing_pod_usage (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
```

**Which issue(s) this PR fixes:**

None

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?**

```release-note
Fixed a kubelet panic when validating an in-place decrease of a container memory limit while pod-level memory usage stats are unavailable.
```
