### PR TITLE
resourceclaim: copy template annotations before creating claims

### DIFF
--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -1104,7 +1104,7 @@ func (ec *Controller) handleClaim(ctx context.Context, pod *v1.Pod, podGroup *sc
 			// Create the ResourceClaim with pod as owner, with a generated name that uses
 			// <pod>-<claim name> as base.
 			isTrue := true
-			annotations := template.Spec.ObjectMeta.Annotations
+			annotations := maps.Clone(template.Spec.ObjectMeta.Annotations)
 			if annotations == nil {
 				annotations = make(map[string]string)
 			}
@@ -1346,7 +1346,7 @@ func (ec *Controller) handlePodGroupClaim(ctx context.Context, podGroup *schedul
 		// Create the ResourceClaim with PodGroup as owner, with a generated name that uses
 		// <podgroup>-<claim name> as base.
 		isTrue := true
-		annotations := template.Spec.ObjectMeta.Annotations
+		annotations := maps.Clone(template.Spec.ObjectMeta.Annotations)
 		if annotations == nil {
 			annotations = make(map[string]string)
 		}

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -191,6 +191,70 @@ var (
 )
 
 func TestSyncHandler(t *testing.T) { testSyncHandler(ktesting.Init(t)) }
+
+// TestCreateClaimDoesNotMutateTemplate verifies that creating a ResourceClaim
+// from a ResourceClaimTemplate does not mutate the shared informer-cached
+// template. The controller adds the PodResourceClaimAnnotation to the generated
+// claim and must copy the template's annotations first rather than writing into
+// the template's own (shared, immutable) map. The bug only reproduces when the
+// template already has a non-nil annotations map, which is why the other tests,
+// whose templates have no annotations, do not catch it.
+func TestCreateClaimDoesNotMutateTemplate(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
+	template := makeTemplate(templateName, testNamespace, nil)
+	template.Spec.ObjectMeta.Annotations = map[string]string{"example.com/color": "blue"}
+	pod := testPodWithResource.DeepCopy()
+
+	fakeKubeClient := createTestClient(pod, template)
+	informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
+	podInformer := informerFactory.Core().V1().Pods()
+	podGroupInformer := informerFactory.Scheduling().V1beta1().PodGroups()
+	claimInformer := informerFactory.Resource().V1().ResourceClaims()
+	templateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
+	setupMetrics()
+
+	ec, err := newControllerWithFeatures(tCtx.Logger(), fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer, controllerFeatures{})
+	if err != nil {
+		tCtx.Fatalf("error creating controller: %v", err)
+	}
+
+	informerFactory.Start(tCtx.Done())
+	defer func() {
+		tCtx.Cancel("stopping informers")
+		informerFactory.Shutdown()
+	}()
+	informerFactory.WaitForCacheSync(tCtx.Done())
+
+	// cachedTemplate is the object the controller reads from the shared informer
+	// cache; snapshot it so any in-place mutation is detectable.
+	cachedTemplate, err := templateInformer.Lister().ResourceClaimTemplates(testNamespace).Get(templateName)
+	if err != nil {
+		tCtx.Fatalf("template not in informer cache: %v", err)
+	}
+	templateBefore := cachedTemplate.DeepCopy()
+
+	if err := ec.syncHandler(tCtx, podKey(pod)); err != nil {
+		tCtx.Fatalf("syncHandler: %v", err)
+	}
+
+	assert.Equal(tCtx, templateBefore, cachedTemplate, "controller must not mutate the shared informer-cached ResourceClaimTemplate")
+	if _, leaked := cachedTemplate.Spec.ObjectMeta.Annotations[resourceapi.PodResourceClaimAnnotation]; leaked {
+		tCtx.Errorf("PodResourceClaimAnnotation leaked into the shared template's annotations")
+	}
+
+	// The generated claim must still carry both the template's annotation and
+	// the controller-added PodResourceClaimAnnotation.
+	claims, err := fakeKubeClient.ResourceV1().ResourceClaims(testNamespace).List(tCtx, metav1.ListOptions{})
+	if err != nil {
+		tCtx.Fatalf("listing claims: %v", err)
+	}
+	if assert.Len(tCtx, claims.Items, 1, "exactly one claim should be created") {
+		created := claims.Items[0]
+		assert.Equal(tCtx, "blue", created.Annotations["example.com/color"], "template annotation should be copied to the claim")
+		assert.Equal(tCtx, podResourceClaimName, created.Annotations[resourceapi.PodResourceClaimAnnotation], "claim should carry the PodResourceClaimAnnotation")
+	}
+}
 func testSyncHandler(tCtx ktesting.TContext) {
 	tests := []struct {
 		name                     string

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -191,6 +191,77 @@ var (
 )
 
 func TestSyncHandler(t *testing.T) { testSyncHandler(ktesting.Init(t)) }
+
+// TestCreateClaimDoesNotMutateTemplate verifies that creating a ResourceClaim
+// from a ResourceClaimTemplate with pre-existing annotations copies the map and
+// leaves the shared informer-cached template unmodified, on both claim paths.
+func TestCreateClaimDoesNotMutateTemplate(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		trigger  runtime.Object
+		key      string
+		features controllerFeatures
+	}{
+		{"pod", testPodWithResource.DeepCopy(), podKey(testPodWithResource), controllerFeatures{}},
+		{"podGroup", testPodGroupWithResource.DeepCopy(), testPodGroupKey, controllerFeatures{GenericWorkload: true, WorkloadResourceClaims: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+
+			template := makeTemplate(templateName, testNamespace, nil)
+			template.Spec.ObjectMeta.Annotations = map[string]string{"example.com/color": "blue"}
+
+			fakeKubeClient := createTestClient(tc.trigger, template)
+			informerFactory := informers.NewSharedInformerFactory(fakeKubeClient, controller.NoResyncPeriodFunc())
+			podInformer := informerFactory.Core().V1().Pods()
+			podGroupInformer := informerFactory.Scheduling().V1beta1().PodGroups()
+			claimInformer := informerFactory.Resource().V1().ResourceClaims()
+			templateInformer := informerFactory.Resource().V1().ResourceClaimTemplates()
+			setupMetrics()
+
+			ec, err := newControllerWithFeatures(tCtx.Logger(), fakeKubeClient, podInformer, podGroupInformer, claimInformer, templateInformer, tc.features)
+			if err != nil {
+				tCtx.Fatalf("error creating controller: %v", err)
+			}
+
+			informerFactory.Start(tCtx.Done())
+			defer func() {
+				tCtx.Cancel("stopping informers")
+				informerFactory.Shutdown()
+			}()
+			informerFactory.WaitForCacheSync(tCtx.Done())
+
+			// cachedTemplate is the object the controller reads from the shared informer
+			// cache; snapshot it so any in-place mutation is detectable.
+			cachedTemplate, err := templateInformer.Lister().ResourceClaimTemplates(testNamespace).Get(templateName)
+			if err != nil {
+				tCtx.Fatalf("template not in informer cache: %v", err)
+			}
+			templateBefore := cachedTemplate.DeepCopy()
+
+			if err := ec.syncHandler(tCtx, tc.key); err != nil {
+				tCtx.Fatalf("syncHandler: %v", err)
+			}
+
+			assert.Equal(tCtx, templateBefore, cachedTemplate, "controller must not mutate the shared informer-cached ResourceClaimTemplate")
+			if _, leaked := cachedTemplate.Spec.ObjectMeta.Annotations[resourceapi.PodResourceClaimAnnotation]; leaked {
+				tCtx.Errorf("PodResourceClaimAnnotation leaked into the shared template's annotations")
+			}
+
+			// The generated claim must still carry both the template's annotation and
+			// the controller-added PodResourceClaimAnnotation.
+			claims, err := fakeKubeClient.ResourceV1().ResourceClaims(testNamespace).List(tCtx, metav1.ListOptions{})
+			if err != nil {
+				tCtx.Fatalf("listing claims: %v", err)
+			}
+			if assert.Len(tCtx, claims.Items, 1, "exactly one claim should be created") {
+				created := claims.Items[0]
+				assert.Equal(tCtx, "blue", created.Annotations["example.com/color"], "template annotation should be copied to the claim")
+				assert.Equal(tCtx, podResourceClaimName, created.Annotations[resourceapi.PodResourceClaimAnnotation], "claim should carry the PodResourceClaimAnnotation")
+			}
+		})
+	}
+}
 func testSyncHandler(tCtx ktesting.TContext) {
 	tests := []struct {
 		name                     string


### PR DESCRIPTION
**What this PR does / why we need it**:

When the resourceclaim controller creates a ResourceClaim from a ResourceClaimTemplate, it reused the annotations map from the shared informer-cached template and then added the pod-claim-name annotation to it:

```go
annotations := template.Spec.ObjectMeta.Annotations
if annotations == nil {
    annotations = make(map[string]string)
}
annotations[resourceapi.PodResourceClaimAnnotation] = podClaim.Name
```

If the template already has a non-nil annotations map, `annotations` aliases the template's map, so this writes the controller-owned annotation into the object held by the shared lister, whose objects are documented as immutable. Two workers creating claims from the same template also race on that map, each writing its own claim name.

This copies the annotations with `maps.Clone` before adding the annotation, in both the Pod and the PodGroup paths. The template's `Labels` and `Spec` are also aliased but are not mutated today, so I left them as is; happy to switch to a full copy-on-create if you prefer.

**Which issue(s) this PR fixes**:

This is a different root cause from #140217, which was a `MutationCache` eviction.

**Special notes for your reviewer**:

Added `TestCreateClaimDoesNotMutateTemplate`. It uses a template that carries a user annotation, which the existing tests do not, so they never exercise this path. The test reproduces the mutation without the fix and verifies the generated claim still receives both the template annotation and the `PodResourceClaimAnnotation`.

**Does this PR introduce a user-facing change?**

```release-note
Fixed the resourceclaim controller mutating the shared informer cache when creating a ResourceClaim from a ResourceClaimTemplate that has annotations.
```

/sig node
/wg device-management
