### PR TITLE
kubeletplugin: preserve Unix socket cleanup errors

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/endpoint.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/endpoint.go
@@ -54,7 +54,7 @@ func (e endpoint) listen(ctx context.Context) (net.Listener, error) {
 	listener, err := cfg.Listen(ctx, "unix", socketpath)
 	if err != nil {
 		if removeErr := e.removeSocket(); removeErr != nil {
-			err = errors.Join(err, err)
+			err = errors.Join(err, removeErr)
 		}
 		return nil, err
 	}
@@ -77,7 +77,7 @@ type unixListener struct {
 func (l *unixListener) Close() error {
 	err := l.Listener.Close()
 	if removeErr := l.endpoint.removeSocket(); removeErr != nil {
-		err = errors.Join(err, err)
+		err = errors.Join(err, removeErr)
 	}
 	return err
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/endpoint_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/endpoint_test.go
@@ -18,7 +18,9 @@ package kubeletplugin
 
 import (
 	"context"
+	"errors"
 	"net"
+	"os"
 	"path"
 	"testing"
 
@@ -52,4 +54,54 @@ func TestEndpointListener(t *testing.T) {
 	require.NoError(t, err, "listen")
 	assert.NoFileExists(t, path.Join(tempDir, socketname))
 	assert.Nil(t, listener)
+}
+
+// closeErrorListener is a net.Listener whose Close returns a fixed error. Only
+// Close is called here, so the embedded Listener is left nil.
+type closeErrorListener struct {
+	net.Listener
+	closeErr error
+}
+
+func (l closeErrorListener) Close() error { return l.closeErr }
+
+// unremovableSocket puts something at the socket path that os.Remove refuses to
+// delete. A directory that is not empty fails without depending on file
+// permissions or on which user runs the test.
+func unremovableSocket(t *testing.T, dir, file string) {
+	t.Helper()
+	require.NoError(t, os.Mkdir(path.Join(dir, file), 0700))
+	require.NoError(t, os.WriteFile(path.Join(dir, file, "occupied"), nil, 0600))
+}
+
+func TestEndpointCloseReportsFailedSocketRemoval(t *testing.T) {
+	tempDir := t.TempDir()
+	socketname := "test.sock"
+	unremovableSocket(t, tempDir, socketname)
+	listener := &unixListener{
+		Listener: closeErrorListener{},
+		endpoint: endpoint{dir: tempDir, file: socketname},
+	}
+
+	err := listener.Close()
+
+	require.Error(t, err, "closing must report the socket that was left behind")
+	assert.Contains(t, err.Error(), "remove Unix domain socket")
+}
+
+func TestEndpointCloseKeepsBothErrors(t *testing.T) {
+	tempDir := t.TempDir()
+	socketname := "test.sock"
+	unremovableSocket(t, tempDir, socketname)
+	closeErr := errors.New("close failed")
+	listener := &unixListener{
+		Listener: closeErrorListener{closeErr: closeErr},
+		endpoint: endpoint{dir: tempDir, file: socketname},
+	}
+
+	err := listener.Close()
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, closeErr, "the listener's own error")
+	assert.Contains(t, err.Error(), "remove Unix domain socket", "the removal error")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kubeletplugin/endpoint.go` has the same typo in both cleanup paths. The primary error is passed to `errors.Join` twice, so `removeErr` never reaches the returned error.

```go
	listener, err := cfg.Listen(ctx, "unix", socketpath)
	if err != nil {
		if removeErr := e.removeSocket(); removeErr != nil {
			err = errors.Join(err, err)
		}
		return nil, err
	}
```

```go
func (l *unixListener) Close() error {
	err := l.Listener.Close()
	if removeErr := l.endpoint.removeSocket(); removeErr != nil {
		err = errors.Join(err, err)
	}
	return err
}
```

The two halves differ in what can be seen today.

`listen` is the observable one. Its error goes through `startGRPCServer` to `kubeletplugin.Start`, so a driver that cannot bind its socket surfaces it. When the stale-socket removal also fails, that error reads:

```
listen error
listen error
```

The removal failure, which is the thing that explains why the bind could not happen, is gone.

`unixListener.Close` is currently latent. The listener usually closes cleanly, so `err` is nil and the call is `errors.Join(nil, nil)`, which is nil: `Close` returns success with the socket still on disk. Nothing observes that today, because the listener is handed to `grpc.Server.Serve`, which closes it in a deferred `ls.Close()` and discards the error, and `unixListener` is unexported. It is fixed because the code does not do what it says, not because something is failing because of it.

#### Which issue(s) this PR is related to:

None filed; found while reading these paths.

#### Special notes for your reviewer:

I traced the callers before writing this, since making a previously-nil `Close` return an error could have been a behaviour change. It is not: `endpoint.listen` has one caller, the listener goes to gRPC, and both `Serve`'s defer and `Server.Stop` drop the error from closing a listener.

The test covers `Close` only. `listen` removes the socket before binding and returns early when that fails, so getting a failure out of its second `removeSocket` would need the removal to succeed once and fail immediately after. Both sites are fixed anyway, since it is one typo.

The removal is made to fail by pointing the endpoint at a directory that is not empty. `os.Remove` refuses that, without depending on file permissions or on which user runs the test. The listener is a stub whose `Close` returns nil in the first test and a sentinel error in the second, so the second one also checks that the listener's own error survives the join.

#### Does this PR introduce a user-facing change?

```release-note
The DRA kubelet plugin helper now reports why removing a stale Unix domain socket failed when it cannot start its listener, instead of repeating the listen error twice.
```
