### PR TITLE
dra/client: use the v1beta2 client for UpdateStatus

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/client/client_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/client_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package client
 
 import (
+	"context"
 	"testing"
 
+	resourceapi "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
@@ -51,5 +54,40 @@ func TestDoesClientSupportWatchListSemantics(t *testing.T) {
 				t.Fatalf("watchlist.DoesClientNotSupportWatchListSemantics, got: %v, want: %v", actual, scenario.expectedDoesClientNotSupportWatchListSemantics)
 			}
 		})
+	}
+}
+
+// TestConvertingClientUpdateStatusUsesV1beta2 forces the converting client onto
+// the v1beta2 path and checks that UpdateStatus issues the request through the
+// v1beta2 client. The buggy code asserted the v1beta1 client to an interface
+// parameterized with v1beta2 object types, which panics before any request is
+// sent. The claim does not need to exist: the fix is about which client is
+// used, and the recorded action proves the v1beta2 client was selected.
+func TestConvertingClientUpdateStatusUsesV1beta2(t *testing.T) {
+	ctx := context.Background()
+	const ns = "default"
+	claim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: "test-claim", Namespace: ns}}
+	fakeClientset := fake.NewClientset()
+
+	c := New(fakeClientset)
+	c.useAPI.Store(useV1beta2API) // force the v1beta2 code path
+
+	var panicValue any
+	func() {
+		defer func() { panicValue = recover() }()
+		_, _ = c.ResourceClaims(ns).UpdateStatus(ctx, claim, metav1.UpdateOptions{})
+	}()
+	if panicValue != nil {
+		t.Fatalf("UpdateStatus panicked on the v1beta2 path (v1beta1 client asserted to a v1beta2-typed interface): %v", panicValue)
+	}
+
+	var sawV1beta2StatusUpdate bool
+	for _, a := range fakeClientset.Actions() {
+		if a.GetVerb() == "update" && a.GetSubresource() == "status" && a.GetResource().Version == "v1beta2" {
+			sawV1beta2StatusUpdate = true
+		}
+	}
+	if !sawV1beta2StatusUpdate {
+		t.Errorf("expected an UpdateStatus request through resource.k8s.io/v1beta2; got actions %v", fakeClientset.Actions())
 	}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/client/client_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/client_test.go
@@ -19,6 +19,11 @@ package client
 import (
 	"testing"
 
+	resourceapi "k8s.io/api/resource/v1"
+	resourcev1beta1 "k8s.io/api/resource/v1beta1"
+	resourcev1beta2 "k8s.io/api/resource/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
@@ -49,6 +54,52 @@ func TestDoesClientSupportWatchListSemantics(t *testing.T) {
 			actual := watchlist.DoesClientNotSupportWatchListSemantics(target)
 			if actual != scenario.expectedDoesClientNotSupportWatchListSemantics {
 				t.Fatalf("watchlist.DoesClientNotSupportWatchListSemantics, got: %v, want: %v", actual, scenario.expectedDoesClientNotSupportWatchListSemantics)
+			}
+		})
+	}
+}
+
+// TestConvertingClientUpdateStatusUsesSelectedAPI verifies that UpdateStatus is
+// served by the client for the API version the converting client has selected,
+// like every other verb it forwards.
+func TestConvertingClientUpdateStatusUsesSelectedAPI(t *testing.T) {
+	objectMeta := metav1.ObjectMeta{Name: "test-claim", Namespace: "default"}
+
+	scenarios := []struct {
+		name     string
+		useAPI   int32
+		expected schema.GroupVersion
+	}{
+		{name: "latest", useAPI: useLatestAPI, expected: resourceapi.SchemeGroupVersion},
+		{name: "v1beta2", useAPI: useV1beta2API, expected: resourcev1beta2.SchemeGroupVersion},
+		{name: "v1beta1", useAPI: useV1beta1API, expected: resourcev1beta1.SchemeGroupVersion},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			// Every version needs its own claim. A version that does not have it
+			// answers "not found", which sends the call on to the next version.
+			fakeClientset := fake.NewClientset(
+				&resourceapi.ResourceClaim{ObjectMeta: objectMeta},
+				&resourcev1beta1.ResourceClaim{ObjectMeta: objectMeta},
+				&resourcev1beta2.ResourceClaim{ObjectMeta: objectMeta},
+			)
+			target := New(fakeClientset)
+			target.useAPI.Store(scenario.useAPI)
+
+			claim := &resourceapi.ResourceClaim{ObjectMeta: objectMeta}
+			if _, err := target.ResourceClaims(objectMeta.Namespace).UpdateStatus(t.Context(), claim, metav1.UpdateOptions{}); err != nil {
+				t.Fatalf("UpdateStatus: %v", err)
+			}
+
+			var actual []schema.GroupVersion
+			for _, action := range fakeClientset.Actions() {
+				if action.GetVerb() == "update" && action.GetSubresource() == "status" {
+					actual = append(actual, action.GetResource().GroupVersion())
+				}
+			}
+			if len(actual) != 1 || actual[0] != scenario.expected {
+				t.Errorf("status update issued through %v, want exactly one through %v", actual, scenario.expected)
 			}
 		})
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
@@ -125,7 +125,7 @@ func (t *convertingClient[NP, N, NL, NAC, OP, O, OL, OAC, O2P, O2, O2L, O2AC]) U
 			})
 		case useV1beta2API:
 			return putWithConversion(obj, func(obj *O2) (*O2, error) {
-				return t.v1beta1.(funcsWithStatus[O2, O2L, O2AC]).UpdateStatus(ctx, obj, opts)
+				return t.v1beta2.(funcsWithStatus[O2, O2L, O2AC]).UpdateStatus(ctx, obj, opts)
 			})
 		default:
 			return t.native.(funcsWithStatus[N, NL, NAC]).UpdateStatus(ctx, obj, opts)


### PR DESCRIPTION
**What this PR does / why we need it**:

The DRA converting client keeps separate v1, v1beta2, and v1beta1 clients and caches the API version that succeeds. In `UpdateStatus`, the `useV1beta2API` case incorrectly calls `t.v1beta1` while asserting it as a v1beta2 status client:

```go
case useV1beta2API:
    return putWithConversion(obj, func(obj *O2) (*O2, error) {
        return t.v1beta1.(funcsWithStatus[O2, O2L, O2AC]).UpdateStatus(ctx, obj, opts)
    })
```

That assertion cannot succeed and panics before an API request is sent.

A direct cross-version trigger is a DRA driver built with the v1-based helper running against a Kubernetes 1.33 API server. Kubernetes 1.33 serves `resource.k8s.io/v1beta2` and `v1beta1`, but not `v1`. Because the selection order is v1 -> v1beta2 -> v1beta1, an operation such as `Get` selects and caches v1beta2, and a subsequent `ResourceClaim.UpdateStatus` reaches the faulty branch.

The branch can also be reached on a v1-capable cluster. `callSequence.run()` treats any `NotFound`, including an object-level `NotFound` caused by a ResourceClaim being deleted between `Get` and `UpdateStatus`, as a signal to try the next API version. The next version after v1 is v1beta2, where the same assertion panics.

A concrete upstream consumer is the optional `gpuDeviceStatus` path in `kubernetes-sigs/dra-example-driver`, which performs `Get` followed by `UpdateStatus`. It currently consumes `k8s.io/dynamic-resource-allocation v0.37.0`, and that path is off by default: it is gated by the driver's `gpuDeviceStatus` option (the `--gpu-device-status` flag, Helm value `gpuDeviceStatus`, default `false`).

The fix calls `t.v1beta2`, matching the selected API version and all other version-specific branches. Every other v1beta2 case, and the v1beta1 and native `UpdateStatus` branches, already use their own version's client.

**Testing**:

`TestConvertingClientUpdateStatusUsesSelectedAPI` covers v1, v1beta2, and v1beta1 and verifies that exactly one status update is issued through the selected group/version. The v1beta2 case panics without this fix.

**Backport assessment**:

The faulty line is present in `release-1.34` through `release-1.37`. This code is linked into consumers of the Go module rather than executed by the Kubernetes control plane, so an existing driver binary must be rebuilt with a fixed module; upgrading the API server alone does not repair it.

Given the limited confirmed caller scope and the example-driver path being off by default, I am not requesting cherry-picks.

**Does this PR introduce a user-facing change?**

```release-note
Fixed a panic in DRA drivers that use `k8s.io/dynamic-resource-allocation/client` to `Get` a ResourceClaim and then call `UpdateStatus` on it, once the client has selected `resource.k8s.io/v1beta2`. That selection happens when a driver built with the v1-based helper runs against a Kubernetes 1.33 API server, and also when an object-level `NotFound` makes the client fall back from v1 to v1beta2.
```

/kind bug
/sig node
/wg device-management

---

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
