### PR TITLE
DRA: preserve TimeAdded for every matching device taint

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -1090,35 +1090,39 @@ func copyServerDefaults(desiredSlice, actualSlice *resourceapi.ResourceSlice) bo
 // slices are read-only.
 func copyTaintTimeAdded(from, to []resourceapi.Device) []resourceapi.Device {
 	to = slices.Clone(to)
-	for i, toDevice := range to {
-		index := slices.IndexFunc(from, func(fromDevice resourceapi.Device) bool {
-			return fromDevice.Name == toDevice.Name
+	for i := range to {
+		deviceIndex := slices.IndexFunc(from, func(fromDevice resourceapi.Device) bool {
+			return fromDevice.Name == to[i].Name
 		})
-		if index < 0 {
+		if deviceIndex < 0 {
 			// No matching device.
 			continue
 		}
-		fromDevice := from[index]
-		for j, toTaint := range toDevice.Taints {
+		fromDevice := from[deviceIndex]
+		taintsCloned := false
+		for j := range to[i].Taints {
+			toTaint := to[i].Taints[j]
 			if toTaint.TimeAdded != nil {
 				// Already set.
 				continue
 			}
 			// Preserve the old TimeAdded if all other fields are the same.
-			index := slices.IndexFunc(fromDevice.Taints, func(fromTaint resourceapi.DeviceTaint) bool {
+			taintIndex := slices.IndexFunc(fromDevice.Taints, func(fromTaint resourceapi.DeviceTaint) bool {
 				return toTaint.Key == fromTaint.Key &&
 					toTaint.Value == fromTaint.Value &&
 					toTaint.Effect == fromTaint.Effect
 			})
-			if index < 0 {
+			if taintIndex < 0 {
 				// No matching old taint.
 				continue
 			}
-			// In practice, devices are unlikely to have many
-			// taints.  Just clone the entire device before we
-			// motify it, it's unlikely that we do this more than once.
-			to[i] = *toDevice.DeepCopy()
-			to[i].Taints[j].TimeAdded = fromDevice.Taints[index].TimeAdded
+			// slices.Clone(to) copied the devices, not the taint slices they
+			// point at, so copy this one before the first write into it.
+			if !taintsCloned {
+				to[i].Taints = slices.Clone(to[i].Taints)
+				taintsCloned = true
+			}
+			to[i].Taints[j].TimeAdded = fromDevice.Taints[taintIndex].TimeAdded
 		}
 	}
 	return to

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -1090,16 +1090,18 @@ func copyServerDefaults(desiredSlice, actualSlice *resourceapi.ResourceSlice) bo
 // slices are read-only.
 func copyTaintTimeAdded(from, to []resourceapi.Device) []resourceapi.Device {
 	to = slices.Clone(to)
-	for i, toDevice := range to {
+	for i := range to {
 		index := slices.IndexFunc(from, func(fromDevice resourceapi.Device) bool {
-			return fromDevice.Name == toDevice.Name
+			return fromDevice.Name == to[i].Name
 		})
 		if index < 0 {
 			// No matching device.
 			continue
 		}
 		fromDevice := from[index]
-		for j, toTaint := range toDevice.Taints {
+		cloned := false
+		for j := range to[i].Taints {
+			toTaint := to[i].Taints[j]
 			if toTaint.TimeAdded != nil {
 				// Already set.
 				continue
@@ -1114,10 +1116,14 @@ func copyTaintTimeAdded(from, to []resourceapi.Device) []resourceapi.Device {
 				// No matching old taint.
 				continue
 			}
-			// In practice, devices are unlikely to have many
-			// taints.  Just clone the entire device before we
-			// motify it, it's unlikely that we do this more than once.
-			to[i] = *toDevice.DeepCopy()
+			// In practice, devices are unlikely to have many taints.
+			// Just clone the entire device before we modify it, and
+			// only once: cloning again would restore the taints
+			// preserved so far from the unmodified input.
+			if !cloned {
+				to[i] = *to[i].DeepCopy()
+				cloned = true
+			}
 			to[i].Taints[j].TimeAdded = fromDevice.Taints[index].TimeAdded
 		}
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -231,6 +232,81 @@ func TestControllerSyncPool(t *testing.T) {
 							resourceapi.DeviceTaint{
 								Effect:    resourceapi.DeviceTaintEffectNoExecute,
 								TimeAdded: &timeAdded,
+							},
+						)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).
+					Obj(),
+			},
+		},
+		// Two taints whose TimeAdded has to survive an update triggered by
+		// something else. With one taint the previous case passes either way.
+		"keep-time-added-of-every-taint": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).
+					Devices([]resourceapi.Device{
+						newDevice(
+							deviceName,
+							resourceapi.DeviceTaint{
+								Key:       "taint-a",
+								Effect:    resourceapi.DeviceTaintEffectNoExecute,
+								TimeAdded: &timeAdded,
+							},
+							resourceapi.DeviceTaint{
+								Key:       "taint-b",
+								Effect:    resourceapi.DeviceTaintEffectNoExecute,
+								TimeAdded: &timeAddedLater,
+							},
+						)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).
+					Obj(),
+			},
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						Generation: 1,
+						Slices: []Slice{{Devices: []resourceapi.Device{
+							newDevice(
+								deviceName,
+								// The attribute is what makes the controller update the
+								// slice. A change in TimeAdded alone would not.
+								attrs,
+								resourceapi.DeviceTaint{
+									Key:    "taint-a",
+									Effect: resourceapi.DeviceTaintEffectNoExecute,
+								},
+								resourceapi.DeviceTaint{
+									Key:    "taint-b",
+									Effect: resourceapi.DeviceTaintEffectNoExecute,
+								},
+							),
+						}}},
+					},
+				},
+			},
+			expectedStats: Stats{
+				NumUpdates: 1,
+			},
+			expectedResourceSlices: []resourceapi.ResourceSlice{
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("1").
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).
+					Devices([]resourceapi.Device{
+						newDevice(
+							deviceName,
+							attrs,
+							resourceapi.DeviceTaint{
+								Key:       "taint-a",
+								Effect:    resourceapi.DeviceTaintEffectNoExecute,
+								TimeAdded: &timeAdded,
+							},
+							resourceapi.DeviceTaint{
+								Key:       "taint-b",
+								Effect:    resourceapi.DeviceTaintEffectNoExecute,
+								TimeAdded: &timeAddedLater,
 							},
 						)}).
 					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).
@@ -2328,4 +2404,58 @@ func getExpectedForLargeInt(val int64) int {
 		return -1
 	}
 	return int(val)
+}
+
+func TestCopyTaintTimeAdded(t *testing.T) {
+	t1 := metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	t2 := metav1.Time{Time: time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC)}
+	t3 := metav1.Time{Time: time.Date(2026, 3, 3, 0, 0, 0, 0, time.UTC)}
+	taint := func(key string, timeAdded *metav1.Time) resourceapi.DeviceTaint {
+		return resourceapi.DeviceTaint{
+			Key:       key,
+			Value:     "value-" + key,
+			Effect:    resourceapi.DeviceTaintEffectNoExecute,
+			TimeAdded: timeAdded,
+		}
+	}
+	device := func(taints ...resourceapi.DeviceTaint) []resourceapi.Device {
+		return []resourceapi.Device{{Name: "device-0", Taints: taints}}
+	}
+
+	for name, tc := range map[string]struct {
+		from, to, want []resourceapi.Device
+	}{
+		"every-matching-taint": {
+			from: device(taint("a", &t1), taint("b", &t2)),
+			to:   device(taint("a", nil), taint("b", nil)),
+			want: device(taint("a", &t1), taint("b", &t2)),
+		},
+		"matched-by-content-not-position": {
+			from: device(taint("b", &t2), taint("a", &t1)),
+			to:   device(taint("a", nil), taint("b", nil)),
+			want: device(taint("a", &t1), taint("b", &t2)),
+		},
+		"explicit-time-wins": {
+			from: device(taint("a", &t1), taint("b", &t2)),
+			to:   device(taint("a", &t3), taint("b", nil)),
+			want: device(taint("a", &t3), taint("b", &t2)),
+		},
+		"no-matching-device": {
+			from: []resourceapi.Device{{Name: "other", Taints: []resourceapi.DeviceTaint{taint("a", &t1)}}},
+			to:   device(taint("a", nil)),
+			want: device(taint("a", nil)),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fromBefore := slices.Clone(tc.from)
+			toBefore := slices.Clone(tc.to)
+
+			got := copyTaintTimeAdded(tc.from, tc.to)
+
+			assert.Equal(t, tc.want, got)
+			// Both inputs are documented as read-only.
+			assert.Equal(t, fromBefore, tc.from, "from was modified")
+			assert.Equal(t, toBefore, tc.to, "to was modified")
+		})
+	}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
@@ -237,6 +237,81 @@ func TestControllerSyncPool(t *testing.T) {
 					Obj(),
 			},
 		},
+		// Two taints whose TimeAdded has to survive an update triggered by
+		// something else. With one taint the previous case passes either way.
+		"keep-time-added-of-every-taint": {
+			nodeUID: nodeUID,
+			initialObjects: []runtime.Object{
+				MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).
+					Devices([]resourceapi.Device{
+						newDevice(
+							deviceName,
+							resourceapi.DeviceTaint{
+								Key:       "taint-a",
+								Effect:    resourceapi.DeviceTaintEffectNoExecute,
+								TimeAdded: &timeAdded,
+							},
+							resourceapi.DeviceTaint{
+								Key:       "taint-b",
+								Effect:    resourceapi.DeviceTaintEffectNoExecute,
+								TimeAdded: &timeAddedLater,
+							},
+						)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).
+					Obj(),
+			},
+			inputDriverResources: &DriverResources{
+				Pools: map[string]Pool{
+					poolName: {
+						Generation: 1,
+						Slices: []Slice{{Devices: []resourceapi.Device{
+							newDevice(
+								deviceName,
+								// The attribute is what makes the controller update the
+								// slice. A change in TimeAdded alone would not.
+								attrs,
+								resourceapi.DeviceTaint{
+									Key:    "taint-a",
+									Effect: resourceapi.DeviceTaintEffectNoExecute,
+								},
+								resourceapi.DeviceTaint{
+									Key:    "taint-b",
+									Effect: resourceapi.DeviceTaintEffectNoExecute,
+								},
+							),
+						}}},
+					},
+				},
+			},
+			expectedStats: Stats{
+				NumUpdates: 1,
+			},
+			expectedResourceSlices: []resourceapi.ResourceSlice{
+				*MakeResourceSlice().Name(resourceSlice1).GenerateName(generateName1).
+					ResourceVersion("1").
+					NodeOwnerReferences(ownerName, string(nodeUID)).NodeName(ownerName).
+					Driver(driverName).
+					Devices([]resourceapi.Device{
+						newDevice(
+							deviceName,
+							attrs,
+							resourceapi.DeviceTaint{
+								Key:       "taint-a",
+								Effect:    resourceapi.DeviceTaintEffectNoExecute,
+								TimeAdded: &timeAdded,
+							},
+							resourceapi.DeviceTaint{
+								Key:       "taint-b",
+								Effect:    resourceapi.DeviceTaintEffectNoExecute,
+								TimeAdded: &timeAddedLater,
+							},
+						)}).
+					Pool(resourceapi.ResourcePool{Name: poolName, Generation: 1, ResourceSliceCount: 1}).
+					Obj(),
+			},
+		},
 		"add-taints": {
 			nodeUID: nodeUID,
 			initialObjects: []runtime.Object{
@@ -2328,4 +2403,91 @@ func getExpectedForLargeInt(val int64) int {
 		return -1
 	}
 	return int(val)
+}
+
+func deepCopyDevices(devices []resourceapi.Device) []resourceapi.Device {
+	out := make([]resourceapi.Device, len(devices))
+	for i := range devices {
+		out[i] = *devices[i].DeepCopy()
+	}
+	return out
+}
+
+func TestCopyTaintTimeAdded(t *testing.T) {
+	t1 := metav1.Time{Time: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)}
+	t2 := metav1.Time{Time: time.Date(2026, 2, 2, 0, 0, 0, 0, time.UTC)}
+	t3 := metav1.Time{Time: time.Date(2026, 3, 3, 0, 0, 0, 0, time.UTC)}
+	taint := func(key, value string, timeAdded *metav1.Time) resourceapi.DeviceTaint {
+		return resourceapi.DeviceTaint{
+			Key:       key,
+			Value:     value,
+			Effect:    resourceapi.DeviceTaintEffectNoExecute,
+			TimeAdded: timeAdded,
+		}
+	}
+	device := func(taints ...resourceapi.DeviceTaint) []resourceapi.Device {
+		return []resourceapi.Device{newDevice("device-0", taints)}
+	}
+
+	for name, tc := range map[string]struct {
+		from, to, want []resourceapi.Device
+	}{
+		"every-matching-taint": {
+			from: device(taint("a", "value-a", &t1), taint("b", "value-b", &t2)),
+			to:   device(taint("a", "value-a", nil), taint("b", "value-b", nil)),
+			want: device(taint("a", "value-a", &t1), taint("b", "value-b", &t2)),
+		},
+		"matched-by-content-not-position": {
+			from: device(taint("b", "value-b", &t2), taint("a", "value-a", &t1)),
+			to:   device(taint("a", "value-a", nil), taint("b", "value-b", nil)),
+			want: device(taint("a", "value-a", &t1), taint("b", "value-b", &t2)),
+		},
+		"explicit-time-wins": {
+			from: device(taint("a", "value-a", &t1), taint("b", "value-b", &t2)),
+			to:   device(taint("a", "value-a", &t3), taint("b", "value-b", nil)),
+			want: device(taint("a", "value-a", &t3), taint("b", "value-b", &t2)),
+		},
+		"no-matching-device": {
+			from: []resourceapi.Device{newDevice("other", taint("a", "value-a", &t1))},
+			to:   device(taint("a", "value-a", nil)),
+			want: device(taint("a", "value-a", nil)),
+		},
+		// A taint is the whole of key, value and effect, so an edit to any of
+		// them is a different taint and starts its own clock.
+		"changed-taint-does-not-inherit-the-old-time": {
+			from: device(taint("a", "value-a", &t1), taint("b", "old", &t2)),
+			to:   device(taint("a", "value-a", nil), taint("b", "new", nil), taint("c", "value-c", nil)),
+			want: device(taint("a", "value-a", &t1), taint("b", "new", nil), taint("c", "value-c", nil)),
+		},
+		// from is in the other order, so a device read by position rather than
+		// by name would take the wrong one's times.
+		"devices-are-matched-by-name": {
+			from: []resourceapi.Device{
+				newDevice("device-1", taint("b", "value-b", &t2)),
+				newDevice("device-0", taint("a", "value-a", &t1)),
+			},
+			to: []resourceapi.Device{
+				newDevice("device-0", taint("a", "value-a", nil)),
+				newDevice("device-1", taint("b", "value-b", nil)),
+			},
+			want: []resourceapi.Device{
+				newDevice("device-0", taint("a", "value-a", &t1)),
+				newDevice("device-1", taint("b", "value-b", &t2)),
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			// Deep copies: a shallow one keeps pointing at the same taints,
+			// so a write into them would show up in the baseline as well.
+			fromBefore := deepCopyDevices(tc.from)
+			toBefore := deepCopyDevices(tc.to)
+
+			got := copyTaintTimeAdded(tc.from, tc.to)
+
+			assert.Equal(t, tc.want, got)
+			// Both inputs are documented as read-only.
+			assert.Equal(t, fromBefore, tc.from, "from was modified")
+			assert.Equal(t, toBefore, tc.to, "to was modified")
+		})
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`copyTaintTimeAdded` previously deep-copied the range value for each matching taint. For devices with multiple unchanged taints, each copy discarded timestamps preserved by earlier iterations, so only the last matching taint kept its `TimeAdded`. The missing timestamps were then defaulted to the update time.

The fix clones each affected taint slice once before the first write, preserving all matching timestamps without modifying either input. Regression tests cover the multi-taint case and input immutability.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the DRA ResourceSlice controller to preserve `TimeAdded` for every unchanged device taint when updating a ResourceSlice.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

---

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
