### PR TITLE
DRA: invoke ResourceSlice update errors outside the controller lock

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -421,18 +421,19 @@ func (c *Controller) Stop() {
 // the instance once Update returns. Nil is valid and the same
 // as an empty resources struct.
 func (c *Controller) Update(resources *DriverResources) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
-	// Sync all old pools..
-	if c.resources != nil {
-		for poolName := range c.resources.Pools {
-			c.queue.Add(poolName)
-		}
-	}
-
+	// Validate the caller's input and build the new desired state *before*
+	// taking c.mutex. errorHandler is caller-provided code and, per its
+	// contract, may react to a rejected update by replacing the slices; the
+	// only public API for doing so is Update itself. Because Go mutexes are not
+	// reentrant, calling the handler while holding c.mutex would deadlock such a
+	// caller. More generally, caller callbacks must not run under this lock.
+	//
+	// reconcilePoolWithName and errorHandler are set once in newController and
+	// are never mutated afterwards, so reading them here without the lock is
+	// safe.
+	var newResources *DriverResources
 	if resources == nil {
-		c.resources = &DriverResources{}
+		newResources = &DriverResources{}
 	} else {
 		// If reconcilePoolWithName is set, we expect to reconcile only a single pool.
 		// Having additional pools is considered an error. However, an empty pool list
@@ -448,9 +449,21 @@ func (c *Controller) Update(resources *DriverResources) {
 			}
 		}
 
-		c.resources = resources.DeepCopy()
-		roundTaintTimeAdded(c.resources)
+		newResources = resources.DeepCopy()
+		roundTaintTimeAdded(newResources)
 	}
+
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	// Sync all old pools..
+	if c.resources != nil {
+		for poolName := range c.resources.Pools {
+			c.queue.Add(poolName)
+		}
+	}
+
+	c.resources = newResources
 
 	// ... and the new ones (might be the same).
 	for poolName := range c.resources.Pools {

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller_test.go
@@ -1780,6 +1780,65 @@ func TestControllerUpdateReconcilePoolWithNameValidation(t *testing.T) {
 	}
 }
 
+// TestControllerUpdateErrorHandlerCanReplaceResources verifies that an
+// ErrorHandler which reacts to a rejected update by supplying corrected
+// resources through Update does not deadlock. Update must not hold c.mutex
+// while invoking the caller-provided error handler, because Go mutexes are not
+// reentrant and Update is the only public API for replacing the desired state.
+func TestControllerUpdateErrorHandlerCanReplaceResources(t *testing.T) {
+	const poolName = "pool"
+
+	validResources := func() *DriverResources {
+		return &DriverResources{
+			Pools: map[string]Pool{
+				poolName: {Slices: []Slice{{Devices: []resourceapi.Device{}}}},
+			},
+		}
+	}
+	invalidResources := &DriverResources{
+		Pools: map[string]Pool{
+			poolName:     {Slices: []Slice{{Devices: []resourceapi.Device{}}}},
+			"other-pool": {Slices: []Slice{{Devices: []resourceapi.Device{}}}},
+		},
+	}
+
+	ctrl := &Controller{
+		reconcilePoolWithName: poolName,
+		queue:                 ptr.To(workqueue.Mock[string]{}),
+	}
+
+	// The handler reacts to the rejected input by replacing it with a valid
+	// single-pool set via Update, exactly as the ErrorHandler contract allows.
+	// Before the fix this re-entered c.mutex and deadlocked.
+	var handlerErr error
+	completed := make(chan struct{})
+	ctrl.errorHandler = func(_ context.Context, err error, _ string) {
+		handlerErr = err
+		ctrl.Update(validResources())
+		close(completed)
+	}
+
+	go ctrl.Update(invalidResources)
+
+	select {
+	case <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("ErrorHandler deadlocked while replacing resources")
+	}
+
+	require.Error(t, handlerErr)
+
+	// The corrected pool must be installed as the desired state, and the
+	// rejected input must not have replaced it.
+	ctrl.mutex.Lock()
+	defer ctrl.mutex.Unlock()
+	require.NotNil(t, ctrl.resources)
+	_, hasCorrected := ctrl.resources.Pools[poolName]
+	assert.True(t, hasCorrected, "expected corrected pool %q to be installed, got pools: %v", poolName, ctrl.resources.Pools)
+	_, hasRejected := ctrl.resources.Pools["other-pool"]
+	assert.False(t, hasRejected, "rejected pool set must not be installed as desired state")
+}
+
 func TestControllerPoolNameFieldSelector(t *testing.T) {
 	const (
 		driverName = "test-driver"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`Controller.Update` reports invalid `ReconcilePoolWithName` input by calling the caller-provided `ErrorHandler` while holding `c.mutex`:

```go
func (c *Controller) Update(resources *DriverResources) {
	c.mutex.Lock()
	defer c.mutex.Unlock()
	...
	c.errorHandler(context.Background(),
		fmt.Errorf("ReconcilePoolWithName=%q, but found %d pools; ...", ...),
		"processing update DriverResources")
	return
	...
}
```

`ErrorHandler` is documented to react to publish failures, including to "replace the slices if they cannot be published", and `Update` is the only public API for setting the desired state. A handler that replaces the slices synchronously calls `Update` again, which re-enters the same, non-reentrant mutex and deadlocks:

```
Update(invalid)
  mutex.Lock
  ErrorHandler
    Update(corrected)
      mutex.Lock   <- blocks forever (same goroutine, non-reentrant)
```

More generally, running a caller-provided callback while holding an internal lock is unsafe regardless of reentrancy.

This validates the caller input and builds the new desired state (deep copy + `roundTaintTimeAdded`) before taking the lock, and takes the lock only for the queue and state mutation. An invalid update is now rejected before the queue is touched, so it no longer re-enqueues the old pools. `reconcilePoolWithName` and `errorHandler` are set once in `newController` and never mutated afterwards, so reading them without the lock is safe.

#### Which issue(s) this PR is related to:

None filed; found while reading this controller.

#### Special notes for your reviewer:

The existing `TestControllerUpdateReconcilePoolWithNameValidation` only checks that invalid input produces the expected error; its handler collects the error and never calls `Update`, so the deadlock was never exercised.

The new `TestControllerUpdateErrorHandlerCanReplaceResources` has the handler replace the rejected input with a valid single-pool set via `Update`, and fails (the handler deadlocks, caught by a 1s timeout) without this change. It also asserts the corrected pool is installed as the desired state and that the rejected input did not replace it. Verified with `go test -race`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a deadlock in the DRA ResourceSlice controller: an ErrorHandler that replaced the desired ResourceSlices by calling Update again would block forever, because Update invoked the handler while holding the controller lock.
```
