### PR TITLE
conformance: fix up group discovery endpoint exemptions

### DIFF
--- a/test/conformance/testdata/ineligible_endpoints.yaml
+++ b/test/conformance/testdata/ineligible_endpoints.yaml
@@ -265,15 +265,12 @@
 - endpoint: createAuthenticationV1SelfSubjectReview
   reason: Cluster providers are allowed to choose to not serve this API, and the whoami command handles unavailability gracefully.
   link: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/3325-self-subject-attributes-review-api/README.md#ga
-- endpoint: getInternalApiserverAPIGroup
-  reason: The endpoint is part of a group that has no stable endpoints yet, reporting as a stable endpoint in apisnoop.
-  link: https://github.com/kubernetes/issues/124248
 - endpoint: getResourceAPIGroup
-  reason: The endpoint is part of a group that has no stable endpoints yet, reporting as a stable endpoint in apisnoop.
-  link: https://github.com/kubernetes/issues/124248
+  reason: Group discovery endpoint for a GA group, not exercised by any conformance test.
+  link: https://github.com/kubernetes/kubernetes/issues/141065
 - endpoint: getStoragemigrationAPIGroup
-  reason: The endpoint is part of a group that has no stable endpoints yet, reporting as a stable endpoint in apisnoop.
-  link: https://github.com/kubernetes/issues/124248
+  reason: Group discovery endpoint for a GA group, not exercised by any conformance test.
+  link: https://github.com/kubernetes/kubernetes/issues/141065
 - endpoint: createNetworkingV1ServiceCIDR
   reason: Kubernetes distribution would reasonably not allow this action via the API
   link: https://github.com/kubernetes/enhancements/pull/4983#issuecomment-2541699445

--- a/test/conformance/testdata/pending_eligible_endpoints.yaml
+++ b/test/conformance/testdata/pending_eligible_endpoints.yaml
@@ -1,3 +1,1 @@
----
-# https://github.com/kubernetes/kubernetes/issues/140523
-- getLifecycleAPIGroup
+# No pending eligible endpoints.


### PR DESCRIPTION
Three entries in this directory were compensating for a bug in how apisnoop and test-infra's audit_log_parser.py classify group discovery endpoints. A group discovery operation, /apis/<group>/, carries no version in its path and none in its operation id, because it is the operation you call to find out what the versions are. Both checkers therefore read it as stable even when the group only serves alpha.

That is now fixed at the source in both checkers, so the entries can be corrected to say what is actually true.

getLifecycleAPIGroup: removed from pending_eligible_endpoints.yaml. lifecycle.k8s.io serves only v1alpha1, so it is not an eligible endpoint awaiting a test, it was being misread as stable. Both checkers now derive that from the versions the group serves.

getInternalApiserverAPIGroup: removed from ineligible_endpoints.yaml. internal.apiserver.k8s.io is still v1alpha1 only, so it is excluded by the same derivation and no longer needs an entry.

getResourceAPIGroup and getStoragemigrationAPIGroup: kept, reason corrected. Their stated reason, that the group has no stable endpoints yet, expired. resource.k8s.io has served v1 since 1.34 and storagemigration.k8s.io serves v1 as of this cycle. They are GA group discovery endpoints that no conformance test exercises, which is a different thing and worth stating plainly rather than leaving behind a condition that no longer holds. Refs #141065.

Also fixes the link on those entries, which was missing a path segment and 404d.