### PR TITLE
DRA: Fix ExtendedResourceCache handling of DeviceClass collisions

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
@@ -144,17 +144,26 @@ func (c *ExtendedResourceCache) OnUpdate(oldObj, newObj interface{}) {
 
 // OnDelete handles deletion of a device class.
 func (c *ExtendedResourceCache) OnDelete(obj interface{}) {
+	className := ""
 	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		obj = tombstone.Obj
-	}
-	deviceClass, ok := obj.(*resourceapi.DeviceClass)
-	if !ok {
+		if deviceClass, ok := tombstone.Obj.(*resourceapi.DeviceClass); ok {
+			className = deviceClass.Name
+		} else {
+			// DeltaFIFO.Replace can emit a key-only tombstone with a nil
+			// Obj when the key is no longer available from knownObjects.
+			// DeviceClass is cluster-scoped and all mappings are keyed by
+			// class name, so the key alone is enough to remove them all.
+			className = tombstone.Key
+		}
+	} else if deviceClass, ok := obj.(*resourceapi.DeviceClass); ok {
+		className = deviceClass.Name
+	} else {
 		utilruntime.HandleErrorWithLogger(c.logger, nil, "Expected DeviceClass", "actual", fmt.Sprintf("%T", obj))
 		return
 	}
-	c.logger.V(5).Info("DeviceClass deleted", "deviceClass", klog.KObj(deviceClass))
-	c.removeResourceName2class(deviceClass)
-	c.removeClass2ResourceName(deviceClass)
+	c.logger.V(5).Info("DeviceClass deleted", "deviceClass", className)
+	c.removeResourceName2class(className)
+	c.removeClass2ResourceName(className)
 
 	for _, handler := range c.handlers {
 		handler.OnDelete(obj)
@@ -268,36 +277,36 @@ func (c *ExtendedResourceCache) updateClass2ResourceName(deviceClass *resourceap
 // The class is dropped from the candidates of all explicit names, because the
 // ExtendedResourceName in the deleted object may be stale, and the next best
 // candidate is promoted, if any.
-func (c *ExtendedResourceCache) removeResourceName2class(deviceClass *resourceapi.DeviceClass) {
+func (c *ExtendedResourceCache) removeResourceName2class(className string) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	// The default mapping is unique to the class and cannot be shared.
-	delete(c.resourceName2class, v1.ResourceName(resourceapi.ResourceDeviceClassPrefix+deviceClass.Name))
+	delete(c.resourceName2class, v1.ResourceName(resourceapi.ResourceDeviceClassPrefix+className))
 
 	// Drop the class from the candidates of all explicit names. This only
 	// affects mappings owned by the deleted class; the winner of a name
 	// claimed by other classes stays in place or is replaced by the next
 	// best candidate.
 	for explicitName, classes := range c.explicitResourceName2classes {
-		if _, ok := classes[deviceClass.Name]; !ok {
+		if _, ok := classes[className]; !ok {
 			continue
 		}
-		delete(classes, deviceClass.Name)
+		delete(classes, className)
 		if len(classes) == 0 {
 			delete(c.explicitResourceName2classes, explicitName)
 		}
 		c.recomputeWinner(explicitName)
 	}
 	c.logger.V(5).Info("Removed extended resource from cache",
-		"deviceClass", deviceClass.Name)
+		"deviceClass", className)
 }
 
 // removeClass2ResourceName removes the device class mapping from the cache.
-func (c *ExtendedResourceCache) removeClass2ResourceName(deviceClass *resourceapi.DeviceClass) {
+func (c *ExtendedResourceCache) removeClass2ResourceName(className string) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	delete(c.class2ResourceName, deviceClass.Name)
-	c.logger.V(5).Info("Removed device class", "deviceClass", deviceClass.Name)
+	delete(c.class2ResourceName, className)
+	c.logger.V(5).Info("Removed device class", "deviceClass", className)
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
@@ -35,11 +35,12 @@ type ExtendedResourceCache struct {
 	handlers []cache.ResourceEventHandler
 
 	mutex sync.RWMutex
-	// explicitResourceName2classes maps an explicit extended resource name to
-	// the set of device classes which declare it. Several classes may declare
-	// the same name, for example while migrating from one class to another;
-	// the winner is the "best" class according to betterDeviceClass.
-	explicitResourceName2classes map[string]map[string]*resourceapi.DeviceClass
+	// explicitResourceName2classes maps an explicit extended resource name
+	// (the first map key) to the classes which declare it, keyed by class
+	// name (the second map key) with the class as value. Several classes may
+	// declare the same name, for example while migrating from one class to
+	// another; the winner is the "best" class according to betterDeviceClass.
+	explicitResourceName2classes map[v1.ResourceName]map[string]*resourceapi.DeviceClass
 	// resourceName2class maps extended resource name to device class. For
 	// explicit names it holds the current winner of
 	// explicitResourceName2classes, for implicit
@@ -67,7 +68,7 @@ func NewExtendedResourceCache(logger klog.Logger, handlers ...cache.ResourceEven
 	cache := &ExtendedResourceCache{
 		logger:                       logger,
 		handlers:                     handlers,
-		explicitResourceName2classes: make(map[string]map[string]*resourceapi.DeviceClass),
+		explicitResourceName2classes: make(map[v1.ResourceName]map[string]*resourceapi.DeviceClass),
 		resourceName2class:           make(map[v1.ResourceName]*resourceapi.DeviceClass),
 		class2ResourceName:           make(map[string]string),
 	}
@@ -149,23 +150,17 @@ func (c *ExtendedResourceCache) OnUpdate(oldObj, newObj interface{}) {
 
 // OnDelete handles deletion of a device class.
 func (c *ExtendedResourceCache) OnDelete(obj interface{}) {
-	className := ""
-	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		if deviceClass, ok := tombstone.Obj.(*resourceapi.DeviceClass); ok {
-			className = deviceClass.Name
-		} else {
-			// DeltaFIFO.Replace can emit a key-only tombstone with a nil
-			// Obj when the key is no longer available from knownObjects.
-			// DeviceClass is cluster-scoped and all mappings are keyed by
-			// class name, so the key alone is enough to remove them all.
-			className = tombstone.Key
-		}
-	} else if deviceClass, ok := obj.(*resourceapi.DeviceClass); ok {
-		className = deviceClass.Name
-	} else {
+	// DeltaFIFO.Replace can emit a key-only tombstone with a nil Obj when
+	// the key is no longer available from knownObjects.
+	// DeletionHandlingObjectToName falls back to the tombstone key in that
+	// case, which is enough because DeviceClass is cluster-scoped and all
+	// mappings are keyed by class name.
+	objName, err := cache.DeletionHandlingObjectToName(obj)
+	if err != nil {
 		utilruntime.HandleErrorWithLogger(c.logger, nil, "Expected DeviceClass", "actual", fmt.Sprintf("%T", obj))
 		return
 	}
+	className := objName.Name
 	c.logger.V(5).Info("DeviceClass deleted", "deviceClass", className)
 	c.removeMappings(className)
 
@@ -176,9 +171,13 @@ func (c *ExtendedResourceCache) OnDelete(obj interface{}) {
 
 // betterDeviceClass returns true if class a should win the explicit extended
 // resource name over class b: the newer class wins, with the alphabetically
-// lower name as tie-breaker. This matches the arbitration documented in
-// DeviceClassSpec.ExtendedResourceName.
+// lower name as tie-breaker. A nil class never wins, so a nil b (no current
+// winner) always loses against a non-nil a. This matches the arbitration
+// documented in DeviceClassSpec.ExtendedResourceName.
 func betterDeviceClass(a, b *resourceapi.DeviceClass) bool {
+	if a == nil {
+		return false
+	}
 	if b == nil {
 		return true
 	}
@@ -243,13 +242,16 @@ func (c *ExtendedResourceCache) updateResourceName2class(newDeviceClass, oldDevi
 				delete(c.explicitResourceName2classes, explicitName)
 			}
 			c.recomputeWinner(explicitName)
+			// A class declares at most one explicit name, so it can be a
+			// candidate of a single resource name only.
+			break
 		}
 	}
 
 	// Add this class to the candidates of its new explicit name, if any. The
 	// freshly updated object replaces a stale cached one.
 	if newDeviceClass.Spec.ExtendedResourceName != nil {
-		explicitName := *newDeviceClass.Spec.ExtendedResourceName
+		explicitName := v1.ResourceName(*newDeviceClass.Spec.ExtendedResourceName)
 		classes := c.explicitResourceName2classes[explicitName]
 		if classes == nil {
 			classes = make(map[string]*resourceapi.DeviceClass)
@@ -259,8 +261,9 @@ func (c *ExtendedResourceCache) updateResourceName2class(newDeviceClass, oldDevi
 		c.recomputeWinner(explicitName)
 	}
 
-	// Always add the default mapping; it is unique to this class and
-	// independent of any explicit name arbitration.
+	// Always add the implicit extended resource name
+	// deviceclass.resource.kubernetes.io/<class name>; it is unique to this
+	// class and independent of any explicit name arbitration.
 	defaultResourceName := v1.ResourceName(resourceapi.ResourceDeviceClassPrefix + newDeviceClass.Name)
 	c.resourceName2class[defaultResourceName] = newDeviceClass
 	c.logger.V(5).Info("Updated extended resource cache for default mapping",
@@ -270,7 +273,7 @@ func (c *ExtendedResourceCache) updateResourceName2class(newDeviceClass, oldDevi
 
 // recomputeWinner makes explicitName map to the best candidate device class,
 // removing the mapping if no candidate remains.
-func (c *ExtendedResourceCache) recomputeWinner(explicitName string) {
+func (c *ExtendedResourceCache) recomputeWinner(explicitName v1.ResourceName) {
 	classes := c.explicitResourceName2classes[explicitName]
 	var winner *resourceapi.DeviceClass
 	for _, class := range classes {
@@ -279,10 +282,10 @@ func (c *ExtendedResourceCache) recomputeWinner(explicitName string) {
 		}
 	}
 	if winner == nil {
-		delete(c.resourceName2class, v1.ResourceName(explicitName))
+		delete(c.resourceName2class, explicitName)
 		return
 	}
-	c.resourceName2class[v1.ResourceName(explicitName)] = winner
+	c.resourceName2class[explicitName] = winner
 	c.logger.V(5).Info("Updated extended resource cache for explicit mapping",
 		"extendedResource", explicitName,
 		"deviceClass", winner.Name)
@@ -323,6 +326,9 @@ func (c *ExtendedResourceCache) removeResourceName2class(className string) {
 			delete(c.explicitResourceName2classes, explicitName)
 		}
 		c.recomputeWinner(explicitName)
+		// A class declares at most one explicit name, so it can be a
+		// candidate of a single resource name only.
+		break
 	}
 	c.logger.V(5).Info("Removed extended resource from cache",
 		"deviceClass", className)

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
@@ -35,7 +35,16 @@ type ExtendedResourceCache struct {
 	handlers []cache.ResourceEventHandler
 
 	mutex sync.RWMutex
-	// resourceName2class maps extended resource name to device class
+	// explicitResourceName2classes maps an explicit extended resource name to
+	// the set of device classes which declare it. Several classes may declare
+	// the same name, for example while migrating from one class to another;
+	// the winner is the "best" class according to betterDeviceClass.
+	explicitResourceName2classes map[string]map[string]*resourceapi.DeviceClass
+	// resourceName2class maps extended resource name to device class. For
+	// explicit names it holds the current winner of
+	// explicitResourceName2classes, for implicit
+	// deviceclass.resource.kubernetes.io/<class name> names it holds the
+	// class itself.
 	resourceName2class map[v1.ResourceName]*resourceapi.DeviceClass
 	// class2ResourceName maps device class name to extended resource name
 	class2ResourceName map[string]string
@@ -49,10 +58,11 @@ var _ cache.ResourceEventHandler = &ExtendedResourceCache{}
 // Additional event handlers may be registered here or via AddEventHandler.
 func NewExtendedResourceCache(logger klog.Logger, handlers ...cache.ResourceEventHandler) *ExtendedResourceCache {
 	cache := &ExtendedResourceCache{
-		logger:             logger,
-		handlers:           handlers,
-		resourceName2class: make(map[v1.ResourceName]*resourceapi.DeviceClass),
-		class2ResourceName: make(map[string]string),
+		logger:                       logger,
+		handlers:                     handlers,
+		explicitResourceName2classes: make(map[string]map[string]*resourceapi.DeviceClass),
+		resourceName2class:           make(map[v1.ResourceName]*resourceapi.DeviceClass),
+		class2ResourceName:           make(map[string]string),
 	}
 
 	return cache
@@ -151,62 +161,93 @@ func (c *ExtendedResourceCache) OnDelete(obj interface{}) {
 	}
 }
 
+// betterDeviceClass returns true if class a should win the explicit extended
+// resource name over class b: the newer class wins, with the alphabetically
+// lower name as tie-breaker. This matches the arbitration documented in
+// DeviceClassSpec.ExtendedResourceName.
+func betterDeviceClass(a, b *resourceapi.DeviceClass) bool {
+	if b == nil {
+		return true
+	}
+	if cmp := cmp.Compare(a.CreationTimestamp.UnixNano(), b.CreationTimestamp.UnixNano()); cmp != 0 {
+		return cmp > 0
+	}
+	return a.Name < b.Name
+}
+
 // updateResourceName2class updates the cache with the device class mapping.
 // It first removes any existing mappings for this device class to handle
 // ExtendedResourceName changes, then adds the new mappings.
+//
+// Different DeviceClasses may specify the same ExtendedResourceName, for
+// example while migrating from one DeviceClass to another. All candidates are
+// kept and the winner is derived from them on each event, so that a rename or
+// deletion of the current winner promotes the next candidate instead of
+// leaving the mapping dangling. The implicit
+// deviceclass.resource.kubernetes.io/<class name> mapping is always unique
+// (it cannot appear in a different class as ExtendedResourceName, prevented
+// by validation), so it is registered independently of the explicit name
+// arbitration.
 func (c *ExtendedResourceCache) updateResourceName2class(newDeviceClass, oldDeviceClass *resourceapi.DeviceClass) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	// Different DeviceClasses could specify the same ExtendedResourceName.
-	// If we find such a clash, we need to pick one of them.
-	//
-	// Such a clash should be rare, but can occur while migrating from one
-	// DeviceClass to another. To support such a migration, we prefer the
-	// newer DeviceClass. The name serves as tie-breaker.
-	//
-	// The implicit deviceclass.resource.kubernetes.io/<class name> is always
-	// unique and also cannot appear in a different class as ExtendedResourceName
-	// (prevented by validation), so we don't need to do the same check for
-	// implicit mappings.
-	var classWithSameExtendedResourceName *resourceapi.DeviceClass
-	if newDeviceClass.Spec.ExtendedResourceName != nil {
-		classWithSameExtendedResourceName = c.resourceName2class[v1.ResourceName(*newDeviceClass.Spec.ExtendedResourceName)]
-	}
-	if classWithSameExtendedResourceName != nil {
-		switch cmp.Compare(newDeviceClass.CreationTimestamp.UnixNano(), classWithSameExtendedResourceName.CreationTimestamp.UnixNano()) {
-		case -1:
-			// New class is older, keep the current more recent one.
-			return
-		case 0:
-			// Equal, arbitrarily prefer "lower" name.
-			if newDeviceClass.Name >= classWithSameExtendedResourceName.Name {
-				return
-			}
-		}
-	}
-
-	// Remove old mappings first to handle ExtendedResourceName changes
+	// Drop this class from the candidates of all explicit names, not just
+	// the one in the old object, because the old object's
+	// ExtendedResourceName may be stale.
 	if oldDeviceClass != nil {
-		delete(c.resourceName2class, v1.ResourceName(resourceapi.ResourceDeviceClassPrefix+oldDeviceClass.Name))
-		if oldDeviceClass.Spec.ExtendedResourceName != nil {
-			delete(c.resourceName2class, v1.ResourceName(*oldDeviceClass.Spec.ExtendedResourceName))
+		for explicitName, classes := range c.explicitResourceName2classes {
+			if _, ok := classes[oldDeviceClass.Name]; !ok {
+				continue
+			}
+			delete(classes, oldDeviceClass.Name)
+			if len(classes) == 0 {
+				delete(c.explicitResourceName2classes, explicitName)
+			}
+			c.recomputeWinner(explicitName)
 		}
 	}
 
-	// Add new mappings
+	// Add this class to the candidates of its new explicit name, if any. The
+	// freshly updated object replaces a stale cached one.
 	if newDeviceClass.Spec.ExtendedResourceName != nil {
-		c.resourceName2class[v1.ResourceName(*newDeviceClass.Spec.ExtendedResourceName)] = newDeviceClass
-		c.logger.V(5).Info("Updated extended resource cache for explicit mapping",
-			"extendedResource", *newDeviceClass.Spec.ExtendedResourceName,
-			"deviceClass", newDeviceClass.Name)
+		explicitName := *newDeviceClass.Spec.ExtendedResourceName
+		classes := c.explicitResourceName2classes[explicitName]
+		if classes == nil {
+			classes = make(map[string]*resourceapi.DeviceClass)
+			c.explicitResourceName2classes[explicitName] = classes
+		}
+		classes[newDeviceClass.Name] = newDeviceClass
+		c.recomputeWinner(explicitName)
 	}
-	// Always add the default mapping
+
+	// Always add the default mapping; it is unique to this class and
+	// independent of any explicit name arbitration.
 	defaultResourceName := v1.ResourceName(resourceapi.ResourceDeviceClassPrefix + newDeviceClass.Name)
 	c.resourceName2class[defaultResourceName] = newDeviceClass
 	c.logger.V(5).Info("Updated extended resource cache for default mapping",
 		"extendedResource", defaultResourceName,
 		"deviceClass", newDeviceClass.Name)
+}
+
+// recomputeWinner makes explicitName map to the best candidate device class,
+// removing the mapping if no candidate remains.
+func (c *ExtendedResourceCache) recomputeWinner(explicitName string) {
+	classes := c.explicitResourceName2classes[explicitName]
+	var winner *resourceapi.DeviceClass
+	for _, class := range classes {
+		if betterDeviceClass(class, winner) {
+			winner = class
+		}
+	}
+	if winner == nil {
+		delete(c.resourceName2class, v1.ResourceName(explicitName))
+		return
+	}
+	c.resourceName2class[v1.ResourceName(explicitName)] = winner
+	c.logger.V(5).Info("Updated extended resource cache for explicit mapping",
+		"extendedResource", explicitName,
+		"deviceClass", winner.Name)
 }
 
 // updateClass2ResourceName updates the cache with the device class mapping.
@@ -224,17 +265,29 @@ func (c *ExtendedResourceCache) updateClass2ResourceName(deviceClass *resourceap
 }
 
 // removeResourceName2class removes the device class mapping from the cache.
-// It searches for all mappings to the given device class name and removes them,
-// because the ExtendedResourceName in the deviceClass object may be stale.
+// The class is dropped from the candidates of all explicit names, because the
+// ExtendedResourceName in the deleted object may be stale, and the next best
+// candidate is promoted, if any.
 func (c *ExtendedResourceCache) removeResourceName2class(deviceClass *resourceapi.DeviceClass) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	// Remove the default mapping
+	// The default mapping is unique to the class and cannot be shared.
 	delete(c.resourceName2class, v1.ResourceName(resourceapi.ResourceDeviceClassPrefix+deviceClass.Name))
-	// Remove the explicit mapping
-	if deviceClass.Spec.ExtendedResourceName != nil {
-		delete(c.resourceName2class, v1.ResourceName(*deviceClass.Spec.ExtendedResourceName))
+
+	// Drop the class from the candidates of all explicit names. This only
+	// affects mappings owned by the deleted class; the winner of a name
+	// claimed by other classes stays in place or is replaced by the next
+	// best candidate.
+	for explicitName, classes := range c.explicitResourceName2classes {
+		if _, ok := classes[deviceClass.Name]; !ok {
+			continue
+		}
+		delete(classes, deviceClass.Name)
+		if len(classes) == 0 {
+			delete(c.explicitResourceName2classes, explicitName)
+		}
+		c.recomputeWinner(explicitName)
 	}
 	c.logger.V(5).Info("Removed extended resource from cache",
 		"deviceClass", deviceClass.Name)

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache.go
@@ -48,6 +48,13 @@ type ExtendedResourceCache struct {
 	resourceName2class map[v1.ResourceName]*resourceapi.DeviceClass
 	// class2ResourceName maps device class name to extended resource name
 	class2ResourceName map[string]string
+
+	// testHook is invoked between the forward and reverse mapping updates of
+	// updateMappings, while the write lock is held. Tests use it to suspend
+	// an event mid-flight and verify that readers cannot observe a partial
+	// update. It must not call any method on the cache, because that would
+	// deadlock while the write lock is held. Nil except in tests.
+	testHook func()
 }
 
 var _ cache.ResourceEventHandler = &ExtendedResourceCache{}
@@ -113,8 +120,7 @@ func (c *ExtendedResourceCache) OnAdd(obj interface{}, isInInitialList bool) {
 		return
 	}
 	c.logger.V(5).Info("DeviceClass added", "deviceClass", klog.KObj(deviceClass))
-	c.updateResourceName2class(deviceClass, nil)
-	c.updateClass2ResourceName(deviceClass)
+	c.updateMappings(deviceClass, nil)
 
 	for _, handler := range c.handlers {
 		handler.OnAdd(obj, isInInitialList)
@@ -134,8 +140,7 @@ func (c *ExtendedResourceCache) OnUpdate(oldObj, newObj interface{}) {
 		return
 	}
 	c.logger.V(5).Info("DeviceClass updated", "deviceClass", klog.KObj(deviceClass))
-	c.updateResourceName2class(deviceClass, oldDeviceClass)
-	c.updateClass2ResourceName(deviceClass)
+	c.updateMappings(deviceClass, oldDeviceClass)
 
 	for _, handler := range c.handlers {
 		handler.OnUpdate(oldObj, newObj)
@@ -162,8 +167,7 @@ func (c *ExtendedResourceCache) OnDelete(obj interface{}) {
 		return
 	}
 	c.logger.V(5).Info("DeviceClass deleted", "deviceClass", className)
-	c.removeResourceName2class(className)
-	c.removeClass2ResourceName(className)
+	c.removeMappings(className)
 
 	for _, handler := range c.handlers {
 		handler.OnDelete(obj)
@@ -184,6 +188,32 @@ func betterDeviceClass(a, b *resourceapi.DeviceClass) bool {
 	return a.Name < b.Name
 }
 
+// updateMappings updates the forward and reverse mappings for one device
+// class event under a single write lock. Readers therefore never observe the
+// two maps in a state where only one of them reflects the event. Handlers
+// must be invoked by the caller after this returns.
+func (c *ExtendedResourceCache) updateMappings(newDeviceClass, oldDeviceClass *resourceapi.DeviceClass) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.updateResourceName2class(newDeviceClass, oldDeviceClass)
+	if c.testHook != nil {
+		c.testHook()
+	}
+	c.updateClass2ResourceName(newDeviceClass)
+}
+
+// removeMappings removes the forward and reverse mappings for one device
+// class under a single write lock, for the same atomicity reason as
+// updateMappings. Handlers must be invoked by the caller after this returns.
+func (c *ExtendedResourceCache) removeMappings(className string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.removeResourceName2class(className)
+	c.removeClass2ResourceName(className)
+}
+
 // updateResourceName2class updates the cache with the device class mapping.
 // It first removes any existing mappings for this device class to handle
 // ExtendedResourceName changes, then adds the new mappings.
@@ -197,10 +227,9 @@ func betterDeviceClass(a, b *resourceapi.DeviceClass) bool {
 // (it cannot appear in a different class as ExtendedResourceName, prevented
 // by validation), so it is registered independently of the explicit name
 // arbitration.
+//
+// Must be called with c.mutex held.
 func (c *ExtendedResourceCache) updateResourceName2class(newDeviceClass, oldDeviceClass *resourceapi.DeviceClass) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
 	// Drop this class from the candidates of all explicit names, not just
 	// the one in the old object, because the old object's
 	// ExtendedResourceName may be stale.
@@ -260,10 +289,8 @@ func (c *ExtendedResourceCache) recomputeWinner(explicitName string) {
 }
 
 // updateClass2ResourceName updates the cache with the device class mapping.
+// Must be called with c.mutex held.
 func (c *ExtendedResourceCache) updateClass2ResourceName(deviceClass *resourceapi.DeviceClass) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
 	if deviceClass.Spec.ExtendedResourceName == nil {
 		delete(c.class2ResourceName, deviceClass.Name)
 		return
@@ -277,10 +304,9 @@ func (c *ExtendedResourceCache) updateClass2ResourceName(deviceClass *resourceap
 // The class is dropped from the candidates of all explicit names, because the
 // ExtendedResourceName in the deleted object may be stale, and the next best
 // candidate is promoted, if any.
+//
+// Must be called with c.mutex held.
 func (c *ExtendedResourceCache) removeResourceName2class(className string) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
 	// The default mapping is unique to the class and cannot be shared.
 	delete(c.resourceName2class, v1.ResourceName(resourceapi.ResourceDeviceClassPrefix+className))
 
@@ -303,10 +329,8 @@ func (c *ExtendedResourceCache) removeResourceName2class(className string) {
 }
 
 // removeClass2ResourceName removes the device class mapping from the cache.
+// Must be called with c.mutex held.
 func (c *ExtendedResourceCache) removeClass2ResourceName(className string) {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
 	delete(c.class2ResourceName, className)
 	c.logger.V(5).Info("Removed device class", "deviceClass", className)
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
@@ -27,7 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/tools/cache"
+	clientcache "k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2/ktesting"
 	_ "k8s.io/klog/v2/ktesting/init" // Add command line flags.
 	"k8s.io/utils/ptr"
@@ -61,7 +61,7 @@ func TestHandlers(t *testing.T) {
 	updatedClass := class.DeepCopy()
 	updatedClass.Spec.ExtendedResourceName = nil
 
-	firstHandler := &cache.ResourceEventHandlerFuncs{
+	firstHandler := &clientcache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			if obj != class {
 				t.Errorf("first handler expected added object %v, got %v", class, obj)
@@ -94,7 +94,7 @@ func TestHandlers(t *testing.T) {
 		},
 	}
 	erCache := NewExtendedResourceCache(logger, firstHandler)
-	secondHandler := &cache.ResourceEventHandlerFuncs{
+	secondHandler := &clientcache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			if obj != class {
 				t.Errorf("second handler expected added object %v, got %v", class, obj)
@@ -386,7 +386,8 @@ func newDeviceClass(name, explicitName string, created time.Time) *resourceapi.D
 		},
 	}
 	if explicitName != "" {
-		class.Spec.ExtendedResourceName = ptr.To(explicitName)
+		class.Spec.ExtendedResourceName = new(string)
+		*class.Spec.ExtendedResourceName = explicitName
 	}
 	return class
 }
@@ -490,7 +491,8 @@ func TestCollisionWinnerRenamePromotesRunnerUp(t *testing.T) {
 	cache.OnAdd(newer, false)
 
 	renamed := newer.DeepCopy()
-	renamed.Spec.ExtendedResourceName = ptr.To("new.example.com/gpu")
+	renamed.Spec.ExtendedResourceName = new(string)
+	*renamed.Spec.ExtendedResourceName = "new.example.com/gpu"
 	cache.OnUpdate(newer, renamed)
 
 	// Renaming the winner must promote the runner-up for the old name.
@@ -515,7 +517,8 @@ func TestCollisionLoserRenameKeepsWinner(t *testing.T) {
 	cache.OnAdd(loser, false)
 
 	renamed := loser.DeepCopy()
-	renamed.Spec.ExtendedResourceName = ptr.To("new.example.com/gpu")
+	renamed.Spec.ExtendedResourceName = new(string)
+	*renamed.Spec.ExtendedResourceName = "new.example.com/gpu"
 	cache.OnUpdate(loser, renamed)
 
 	// Renaming the loser must not take down the winner's mapping for the
@@ -528,6 +531,55 @@ func TestCollisionLoserRenameKeepsWinner(t *testing.T) {
 	}
 	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-loser"); got != renamed {
 		t.Errorf("expected the renamed class's default mapping to be updated, got %v", got)
+	}
+}
+
+func TestCollisionWinnerKeyOnlyTombstonePromotesRunnerUp(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cache := NewExtendedResourceCache(logger)
+
+	older := newDeviceClass("class-older", "example.com/gpu", time.Unix(100, 0))
+	newer := newDeviceClass("class-newer", "example.com/gpu", time.Unix(200, 0))
+	cache.OnAdd(older, false)
+	cache.OnAdd(newer, false)
+
+	// DeltaFIFO.Replace can emit a tombstone whose Obj is nil when the key
+	// is no longer available from knownObjects. All mappings are keyed by
+	// class name, so the key alone must suffice to remove the deleted class.
+	cache.OnDelete(clientcache.DeletedFinalStateUnknown{Key: newer.Name, Obj: nil})
+
+	// The runner-up must be promoted despite the missing object.
+	if got := cache.GetDeviceClass("example.com/gpu"); got != older {
+		t.Errorf("expected the runner-up to be promoted, got %v", got)
+	}
+	// The default mapping and the reverse mapping must be removed.
+	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-newer"); got != nil {
+		t.Errorf("expected the deleted class's default mapping to be removed, got %v", got)
+	}
+	if got := cache.GetExtendedResource("class-newer"); got != "" {
+		t.Errorf("expected the deleted class's reverse mapping to be removed, got %q", got)
+	}
+}
+
+func TestCollisionPromotedLoserIsFresh(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cache := NewExtendedResourceCache(logger)
+
+	winner := newDeviceClass("class-winner", "example.com/gpu", time.Unix(200, 0))
+	loser := newDeviceClass("class-loser", "example.com/gpu", time.Unix(100, 0))
+	cache.OnAdd(winner, false)
+	cache.OnAdd(loser, false)
+
+	// Update the loser while it is still the runner-up.
+	updatedLoser := loser.DeepCopy()
+	updatedLoser.Spec.Config = []resourceapi.DeviceClassConfiguration{{}}
+	cache.OnUpdate(loser, updatedLoser)
+
+	// Deleting the winner must promote the freshly updated runner-up, not a
+	// stale copy of the loser.
+	cache.OnDelete(winner)
+	if got := cache.GetDeviceClass("example.com/gpu"); got != updatedLoser {
+		t.Errorf("expected the fresh runner-up to be promoted, got %v", got)
 	}
 }
 
@@ -546,7 +598,8 @@ func TestCollisionEqualTimestampTieBreak(t *testing.T) {
 	}
 
 	renamed := classA.DeepCopy()
-	renamed.Spec.ExtendedResourceName = ptr.To("new.example.com/gpu")
+	renamed.Spec.ExtendedResourceName = new(string)
+	*renamed.Spec.ExtendedResourceName = "new.example.com/gpu"
 	cache.OnUpdate(classA, renamed)
 
 	// Renaming the tie winner promotes the runner-up.
@@ -578,7 +631,7 @@ func setup(t *testing.T) (context.Context, *fake.Clientset, *ExtendedResourceCac
 		informerFactory.Shutdown()
 	})
 	informerFactory.WaitForCacheSync(ctx.Done())
-	cache.WaitForNamedCacheSyncWithContext(ctx, handle.HasSynced)
+	clientcache.WaitForNamedCacheSyncWithContext(ctx, handle.HasSynced)
 
 	// fake.Clientset suffers from a race condition related to informers:
 	// it does not implement resource version support in its Watch

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
@@ -682,6 +682,41 @@ func TestCollisionEqualTimestampTieBreak(t *testing.T) {
 	}
 }
 
+func TestBetterDeviceClass(t *testing.T) {
+	older := newDeviceClass("class-older", "example.com/gpu", time.Unix(100, 0))
+	newer := newDeviceClass("class-newer", "example.com/gpu", time.Unix(200, 0))
+	other := newDeviceClass("class-a", "example.com/gpu", time.Unix(100, 0))
+
+	// Newer classes win over older ones.
+	if betterDeviceClass(older, newer) {
+		t.Error("expected the older class to lose")
+	}
+	if !betterDeviceClass(newer, older) {
+		t.Error("expected the newer class to win")
+	}
+	// Equal creation timestamps: the lexicographically first name wins.
+	if !betterDeviceClass(other, older) {
+		t.Error("expected the lexicographically first name to win the tie")
+	}
+	if betterDeviceClass(older, other) {
+		t.Error("expected the lexicographically later name to lose the tie")
+	}
+	// A class is never better than itself.
+	if betterDeviceClass(older, older) {
+		t.Error("expected a class to not be better than itself")
+	}
+	// A nil class never wins, and never blocks a non-nil one.
+	if betterDeviceClass(nil, older) {
+		t.Error("expected a nil class to lose")
+	}
+	if betterDeviceClass(nil, nil) {
+		t.Error("expected a nil class to lose against another nil class")
+	}
+	if !betterDeviceClass(older, nil) {
+		t.Error("expected a class to win against a nil incumbent")
+	}
+}
+
 func setup(t *testing.T) (context.Context, *fake.Clientset, *ExtendedResourceCache) {
 	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
@@ -289,8 +289,9 @@ func testExtendedResourceCache(t *testing.T) {
 		t.Errorf("Expected to find device class 'gpu-class-0' for 'test.com/gpu' after modification, got %v", deviceClass)
 	}
 	// Should not have the old mapping for example.com/gpu
-	if cache.GetDeviceClass("example.com/gpu") != nil {
-		t.Errorf("Expected 'example.com/gpu' to be removed after modification, got %s", cache.GetDeviceClass("example.com/gpu"))
+	deviceClass = cache.GetDeviceClass("example.com/gpu")
+	if deviceClass == nil || deviceClass.Name != "gpu-class-4" {
+		t.Errorf("Expected 'example.com/gpu' to be promoted to 'gpu-class-4' after modification, got %v", deviceClass)
 	}
 
 	// Test deleting a device class
@@ -374,6 +375,186 @@ func testDeviceClassMapping(t *testing.T) {
 	name = cache.GetExtendedResource("gpu-class")
 	if name != "" {
 		t.Error("Expected 'gpu-class' not found after deletion")
+	}
+}
+
+func newDeviceClass(name, explicitName string, created time.Time) *resourceapi.DeviceClass {
+	class := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			CreationTimestamp: metav1.Time{Time: created},
+		},
+	}
+	if explicitName != "" {
+		class.Spec.ExtendedResourceName = ptr.To(explicitName)
+	}
+	return class
+}
+
+func TestSameClassUpdateReplacesStaleObject(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cache := NewExtendedResourceCache(logger)
+
+	class := newDeviceClass("class-a", "example.com/gpu", time.Unix(100, 0))
+	cache.OnAdd(class, false)
+
+	// Update the class while keeping the same extended resource name and
+	// creation timestamp. The cache must serve the freshly updated object,
+	// not the stale one.
+	updated := class.DeepCopy()
+	updated.Spec.Config = []resourceapi.DeviceClassConfiguration{{}}
+	cache.OnUpdate(class, updated)
+
+	if got := cache.GetDeviceClass("example.com/gpu"); got != updated {
+		t.Errorf("expected explicit mapping to point at the updated object, got %v", got)
+	}
+	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-a"); got != updated {
+		t.Errorf("expected default mapping to point at the updated object, got %v", got)
+	}
+}
+
+func TestCollisionLoserKeepsImplicitMapping(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cache := NewExtendedResourceCache(logger)
+
+	winner := newDeviceClass("class-winner", "example.com/gpu", time.Unix(200, 0))
+	loser := newDeviceClass("class-loser", "example.com/gpu", time.Unix(100, 0))
+	cache.OnAdd(winner, false)
+	cache.OnAdd(loser, false)
+
+	if got := cache.GetDeviceClass("example.com/gpu"); got != winner {
+		t.Errorf("expected the newer class to win the explicit mapping, got %v", got)
+	}
+	// The loser stays reachable via its own unique implicit name, which
+	// cannot collide with the explicit name of another class.
+	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-loser"); got != loser {
+		t.Errorf("expected the loser's default mapping to be registered, got %v", got)
+	}
+	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-winner"); got != winner {
+		t.Errorf("expected the winner's default mapping to be registered, got %v", got)
+	}
+}
+
+func TestCollisionLoserDeleteKeepsWinner(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cache := NewExtendedResourceCache(logger)
+
+	winner := newDeviceClass("class-winner", "example.com/gpu", time.Unix(200, 0))
+	loser := newDeviceClass("class-loser", "example.com/gpu", time.Unix(100, 0))
+	cache.OnAdd(winner, false)
+	cache.OnAdd(loser, false)
+
+	cache.OnDelete(loser)
+
+	// Deleting the loser must not take down the winner's mapping for the
+	// shared explicit name.
+	if got := cache.GetDeviceClass("example.com/gpu"); got != winner {
+		t.Errorf("expected the winner to keep the explicit mapping, got %v", got)
+	}
+	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-loser"); got != nil {
+		t.Errorf("expected the loser's default mapping to be removed, got %v", got)
+	}
+}
+
+func TestCollisionWinnerDeletePromotesRunnerUp(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cache := NewExtendedResourceCache(logger)
+
+	older := newDeviceClass("class-older", "example.com/gpu", time.Unix(100, 0))
+	newer := newDeviceClass("class-newer", "example.com/gpu", time.Unix(200, 0))
+	cache.OnAdd(older, false)
+	cache.OnAdd(newer, false)
+
+	// Deleting the winner must promote the runner-up.
+	cache.OnDelete(newer)
+	if got := cache.GetDeviceClass("example.com/gpu"); got != older {
+		t.Errorf("expected the runner-up to be promoted, got %v", got)
+	}
+
+	cache.OnDelete(older)
+	if got := cache.GetDeviceClass("example.com/gpu"); got != nil {
+		t.Errorf("expected the explicit mapping to be removed once all candidates are gone, got %v", got)
+	}
+	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-newer"); got != nil {
+		t.Errorf("expected the winner's default mapping to be removed, got %v", got)
+	}
+}
+
+func TestCollisionWinnerRenamePromotesRunnerUp(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cache := NewExtendedResourceCache(logger)
+
+	older := newDeviceClass("class-older", "example.com/gpu", time.Unix(100, 0))
+	newer := newDeviceClass("class-newer", "example.com/gpu", time.Unix(200, 0))
+	cache.OnAdd(older, false)
+	cache.OnAdd(newer, false)
+
+	renamed := newer.DeepCopy()
+	renamed.Spec.ExtendedResourceName = ptr.To("new.example.com/gpu")
+	cache.OnUpdate(newer, renamed)
+
+	// Renaming the winner must promote the runner-up for the old name.
+	if got := cache.GetDeviceClass("example.com/gpu"); got != older {
+		t.Errorf("expected the runner-up to be promoted after winner rename, got %v", got)
+	}
+	if got := cache.GetDeviceClass("new.example.com/gpu"); got != renamed {
+		t.Errorf("expected the renamed class to own its new name, got %v", got)
+	}
+	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-newer"); got != renamed {
+		t.Errorf("expected the renamed class's default mapping to be updated, got %v", got)
+	}
+}
+
+func TestCollisionLoserRenameKeepsWinner(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cache := NewExtendedResourceCache(logger)
+
+	winner := newDeviceClass("class-winner", "example.com/gpu", time.Unix(200, 0))
+	loser := newDeviceClass("class-loser", "example.com/gpu", time.Unix(100, 0))
+	cache.OnAdd(winner, false)
+	cache.OnAdd(loser, false)
+
+	renamed := loser.DeepCopy()
+	renamed.Spec.ExtendedResourceName = ptr.To("new.example.com/gpu")
+	cache.OnUpdate(loser, renamed)
+
+	// Renaming the loser must not take down the winner's mapping for the
+	// old name, even though the loser used to declare it.
+	if got := cache.GetDeviceClass("example.com/gpu"); got != winner {
+		t.Errorf("expected the winner to keep the explicit mapping, got %v", got)
+	}
+	if got := cache.GetDeviceClass("new.example.com/gpu"); got != renamed {
+		t.Errorf("expected the renamed class to own its new name, got %v", got)
+	}
+	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-loser"); got != renamed {
+		t.Errorf("expected the renamed class's default mapping to be updated, got %v", got)
+	}
+}
+
+func TestCollisionEqualTimestampTieBreak(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cache := NewExtendedResourceCache(logger)
+
+	classA := newDeviceClass("class-a", "example.com/gpu", time.Unix(100, 0))
+	classB := newDeviceClass("class-b", "example.com/gpu", time.Unix(100, 0))
+	cache.OnAdd(classA, false)
+	cache.OnAdd(classB, false)
+
+	// Equal creation timestamps: the lexicographically first name wins.
+	if got := cache.GetDeviceClass("example.com/gpu"); got != classA {
+		t.Errorf("expected the lexicographically first name to win the tie, got %v", got)
+	}
+
+	renamed := classA.DeepCopy()
+	renamed.Spec.ExtendedResourceName = ptr.To("new.example.com/gpu")
+	cache.OnUpdate(classA, renamed)
+
+	// Renaming the tie winner promotes the runner-up.
+	if got := cache.GetDeviceClass("example.com/gpu"); got != classB {
+		t.Errorf("expected the runner-up to be promoted after tie winner rename, got %v", got)
+	}
+	if got := cache.GetDeviceClass("new.example.com/gpu"); got != renamed {
+		t.Errorf("expected the renamed class to own its new name, got %v", got)
 	}
 }
 

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
@@ -392,6 +392,59 @@ func newDeviceClass(name, explicitName string, created time.Time) *resourceapi.D
 	return class
 }
 
+func TestReadersCannotObservePartialUpdate(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	cache := NewExtendedResourceCache(logger)
+
+	class := newDeviceClass("class-a", "example.com/gpu", time.Unix(100, 0))
+	cache.OnAdd(class, false)
+
+	renamed := class.DeepCopy()
+	renamed.Spec.ExtendedResourceName = new(string)
+	*renamed.Spec.ExtendedResourceName = "my.com/gpu"
+
+	// Suspend the update right between the forward and reverse mapping
+	// updates, then check that readers still observe a consistent state.
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	cache.testHook = func() {
+		close(entered)
+		<-release
+	}
+
+	updateDone := make(chan struct{})
+	go func() {
+		cache.OnUpdate(class, renamed)
+		close(updateDone)
+	}()
+
+	<-entered
+	// The forward mapping was updated already, the reverse mapping is not
+	// yet. A reader starting now must not observe anything until the whole
+	// event has been applied.
+	read := make(chan string, 1)
+	go func() {
+		read <- cache.GetExtendedResource("class-a")
+	}()
+	select {
+	case name := <-read:
+		close(release)
+		t.Fatalf("reader observed the reverse mapping while the update was in flight: %q", name)
+	case <-time.After(time.Second):
+	}
+	close(release)
+	<-updateDone
+	if name := <-read; name != "my.com/gpu" {
+		t.Errorf("expected the reverse mapping to be updated atomically with the forward mapping, got %q", name)
+	}
+	if got := cache.GetDeviceClass("my.com/gpu"); got != renamed {
+		t.Errorf("expected the new explicit mapping to be visible, got %v", got)
+	}
+	if got := cache.GetDeviceClass("example.com/gpu"); got != nil {
+		t.Errorf("expected the old explicit mapping to be removed, got %v", got)
+	}
+}
+
 func TestSameClassUpdateReplacesStaleObject(t *testing.T) {
 	logger, _ := ktesting.NewTestContext(t)
 	cache := NewExtendedResourceCache(logger)
@@ -411,6 +464,9 @@ func TestSameClassUpdateReplacesStaleObject(t *testing.T) {
 	}
 	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-a"); got != updated {
 		t.Errorf("expected default mapping to point at the updated object, got %v", got)
+	}
+	if got := cache.GetExtendedResource("class-a"); got != "example.com/gpu" {
+		t.Errorf("expected the reverse mapping to be preserved, got %q", got)
 	}
 }
 
@@ -455,6 +511,9 @@ func TestCollisionLoserDeleteKeepsWinner(t *testing.T) {
 	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-loser"); got != nil {
 		t.Errorf("expected the loser's default mapping to be removed, got %v", got)
 	}
+	if got := cache.GetExtendedResource("class-loser"); got != "" {
+		t.Errorf("expected the loser's reverse mapping to be removed, got %q", got)
+	}
 }
 
 func TestCollisionWinnerDeletePromotesRunnerUp(t *testing.T) {
@@ -478,6 +537,9 @@ func TestCollisionWinnerDeletePromotesRunnerUp(t *testing.T) {
 	}
 	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-newer"); got != nil {
 		t.Errorf("expected the winner's default mapping to be removed, got %v", got)
+	}
+	if got := cache.GetExtendedResource("class-newer"); got != "" {
+		t.Errorf("expected the winner's reverse mapping to be removed, got %q", got)
 	}
 }
 
@@ -505,6 +567,9 @@ func TestCollisionWinnerRenamePromotesRunnerUp(t *testing.T) {
 	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-newer"); got != renamed {
 		t.Errorf("expected the renamed class's default mapping to be updated, got %v", got)
 	}
+	if got := cache.GetExtendedResource("class-newer"); got != "new.example.com/gpu" {
+		t.Errorf("expected the renamed class's reverse mapping to be updated, got %q", got)
+	}
 }
 
 func TestCollisionLoserRenameKeepsWinner(t *testing.T) {
@@ -531,6 +596,9 @@ func TestCollisionLoserRenameKeepsWinner(t *testing.T) {
 	}
 	if got := cache.GetDeviceClass("deviceclass.resource.kubernetes.io/class-loser"); got != renamed {
 		t.Errorf("expected the renamed class's default mapping to be updated, got %v", got)
+	}
+	if got := cache.GetExtendedResource("class-loser"); got != "new.example.com/gpu" {
+		t.Errorf("expected the renamed loser's reverse mapping to be updated, got %q", got)
 	}
 }
 
@@ -608,6 +676,9 @@ func TestCollisionEqualTimestampTieBreak(t *testing.T) {
 	}
 	if got := cache.GetDeviceClass("new.example.com/gpu"); got != renamed {
 		t.Errorf("expected the renamed class to own its new name, got %v", got)
+	}
+	if got := cache.GetExtendedResource("class-a"); got != "new.example.com/gpu" {
+		t.Errorf("expected the renamed class's reverse mapping to be updated, got %q", got)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The extended resource cache only stored the current winner for an explicit ExtendedResourceName. As a result, updates, renames, and deletions could leave stale mappings, remove the winner, or prevent promotion of the next eligible DeviceClass.

This PR stores the candidate DeviceClass objects for each explicit resource name and recomputes the winner after every add, update, and delete event. It also keeps implicit deviceclass.resource.kubernetes.io/<class> mappings independent of explicit-name arbitration.

Regression tests have been added to cover:

Same-class updates replacing stale cached objects.
Collision losers retaining their implicit mappings.
Deleting a collision loser preserving the winner.
Deleting or renaming the winner promoting the runner-up.
Renaming the loser preserving the winner.
Equal-timestamp tie-break behavior.
#### Which issue(s) this PR is related to:
Fixes #141103
 


#### Special notes for your reviewer:
Fixes
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix incorrect ExtendedResourceCache mappings when multiple DeviceClasses use the same extended resource name, which could cause stale or incorrect resource-to-DeviceClass mappings after DeviceClass updates or deletion.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
