### PR TITLE
kubeadm: tolerate etcd WAL .tmp rename during upgrade backup

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -293,12 +293,13 @@ func performEtcdStaticPodUpgrade(certsRenewMgr *renewal.Manager, client clientse
 		return true, errors.Wrap(err, "etcd cluster is not healthy")
 	}
 
-	// Backing up etcd data store
+	// Backing up etcd data store. Use a live-dir-aware copy instead of plain
+	// `cp -r`: etcd may rename member/wal/*.tmp WAL pre-allocation files while
+	// the backup is in progress (see kubernetes/kubeadm#3324).
 	backupEtcdDir := pathMgr.BackupEtcdDir()
 	runningEtcdDir := cfg.Etcd.Local.DataDir
-	output, err := filesutil.CopyDir(runningEtcdDir, backupEtcdDir)
-	if err != nil {
-		return true, errors.Wrapf(err, "failed to back up etcd data, output: %q", output)
+	if err := etcdutil.BackupDataDirectory(runningEtcdDir, backupEtcdDir); err != nil {
+		return true, errors.Wrap(err, "failed to back up etcd data")
 	}
 
 	// Get the desired etcd version. That's either the one specified by the user in cfg.Etcd.Local.ImageTag

--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -293,12 +293,19 @@ func performEtcdStaticPodUpgrade(certsRenewMgr *renewal.Manager, client clientse
 		return true, errors.Wrap(err, "etcd cluster is not healthy")
 	}
 
-	// Backing up etcd data store. Use a live-dir-aware copy instead of plain
-	// `cp -r`: etcd may rename member/wal/*.tmp WAL pre-allocation files while
-	// the backup is in progress (see kubernetes/kubeadm#3324).
+	// Back up the etcd data store via the etcd Maintenance snapshot API.
+	// This produces a consistent, point-in-time snapshot that is not affected
+	// by WAL pre-allocation file churn (see kubernetes/kubeadm#3324).
 	backupEtcdDir := pathMgr.BackupEtcdDir()
-	runningEtcdDir := cfg.Etcd.Local.DataDir
-	if err := etcdutil.BackupDataDirectory(runningEtcdDir, backupEtcdDir); err != nil {
+	if err := etcdutil.BackupDataForRollback(
+		etcdutil.GetClientURL(&cfg.LocalAPIEndpoint),
+		filepath.Join(cfg.CertificatesDir, constants.EtcdCACertName),
+		filepath.Join(cfg.CertificatesDir, constants.EtcdHealthcheckClientCertName),
+		filepath.Join(cfg.CertificatesDir, constants.EtcdHealthcheckClientKeyName),
+		cfg.Etcd.Local.DataDir,
+		pathMgr.RealManifestDir(),
+		backupEtcdDir,
+	); err != nil {
 		return true, errors.Wrap(err, "failed to back up etcd data")
 	}
 
@@ -562,12 +569,15 @@ func rollbackEtcdData(cfg *kubeadmapi.InitConfiguration, pathMgr StaticPodPathMa
 	backupEtcdDir := pathMgr.BackupEtcdDir()
 	runningEtcdDir := cfg.Etcd.Local.DataDir
 
-	output, err := filesutil.CopyDir(backupEtcdDir, runningEtcdDir)
-	if err != nil {
-		// Let the user know there we're problems, but we tried to reçover
-		return errors.Wrapf(err, "couldn't recover etcd database with error, the location of etcd backup: %s, output: %q", backupEtcdDir, output)
+	if err := etcdutil.RestoreDataForRollback(
+		backupEtcdDir,
+		runningEtcdDir,
+		cfg.NodeRegistration.Name,
+		etcdutil.GetPeerURL(&cfg.LocalAPIEndpoint),
+		"",
+	); err != nil {
+		return errors.Wrapf(err, "couldn't recover etcd database from snapshot, the location of etcd backup: %s", backupEtcdDir)
 	}
-
 	return nil
 }
 

--- a/cmd/kubeadm/app/util/etcd/etcddata.go
+++ b/cmd/kubeadm/app/util/etcd/etcddata.go
@@ -17,7 +17,13 @@ limitations under the License.
 package etcd
 
 import (
+	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/klog/v2"
 
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
 )
@@ -28,4 +34,117 @@ func CreateDataDirectory(dir string) error {
 		return errors.Wrapf(err, "failed to create the etcd data directory: %q", dir)
 	}
 	return nil
+}
+
+// BackupDataDirectory copies a live etcd data directory for upgrade rollback.
+//
+// The destination layout matches `cp -r src dst` when dst already exists as a
+// directory: contents are placed under dst/basename(src).
+//
+// Unlike a plain recursive cp, this:
+//   - skips ephemeral WAL pre-allocation files (*.tmp), which etcd's
+//     filePipeline renames into place during segment rotation
+//   - ignores files that disappear mid-copy (os.ErrNotExist), which can happen
+//     when those *.tmp files are renamed, or when old WAL segments are removed
+//
+// etcd ignores *.tmp when reading a WAL directory, so omitting them does not
+// affect restore usability of the backup.
+func BackupDataDirectory(src, dst string) error {
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return errors.Wrapf(err, "failed to stat etcd data directory %q", src)
+	}
+	if !srcInfo.IsDir() {
+		return errors.Errorf("etcd data directory %q is not a directory", src)
+	}
+
+	// Match `cp -r src dst` when dst exists as a directory.
+	target := filepath.Join(dst, filepath.Base(src))
+	if err := os.MkdirAll(target, srcInfo.Mode()); err != nil {
+		return errors.Wrapf(err, "failed to create etcd backup directory %q", target)
+	}
+
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				klog.V(4).Infof("skipping vanished path during etcd backup: %s", path)
+				return nil
+			}
+			return err
+		}
+		if path == src {
+			return nil
+		}
+
+		// Ephemeral WAL pre-allocation files are renamed by etcd and must not
+		// fail the backup. etcd itself ignores leftover *.tmp on restore.
+		if strings.HasSuffix(d.Name(), ".tmp") {
+			klog.V(4).Infof("skipping ephemeral file during etcd backup: %s", path)
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		destPath := filepath.Join(target, rel)
+
+		info, err := d.Info()
+		if err != nil {
+			if os.IsNotExist(err) {
+				klog.V(4).Infof("skipping vanished path during etcd backup: %s", path)
+				return nil
+			}
+			return err
+		}
+
+		if info.IsDir() {
+			if err := os.MkdirAll(destPath, info.Mode()); err != nil {
+				return errors.Wrapf(err, "failed to create directory %q", destPath)
+			}
+			return nil
+		}
+
+		if !info.Mode().IsRegular() {
+			klog.V(4).Infof("skipping non-regular file during etcd backup: %s", path)
+			return nil
+		}
+
+		if err := copyFile(path, destPath, info.Mode()); err != nil {
+			if os.IsNotExist(err) {
+				klog.V(4).Infof("skipping vanished file during etcd backup: %s", path)
+				return nil
+			}
+			return errors.Wrapf(err, "failed to copy %q to %q", path, destPath)
+		}
+		return nil
+	})
+}
+
+func copyFile(src, dst string, mode fs.FileMode) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = sourceFile.Close()
+	}()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0700); err != nil {
+		return err
+	}
+
+	destFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = destFile.Close()
+	}()
+
+	_, err = io.Copy(destFile, sourceFile)
+	return err
 }

--- a/cmd/kubeadm/app/util/etcd/etcddata.go
+++ b/cmd/kubeadm/app/util/etcd/etcddata.go
@@ -17,15 +17,40 @@ limitations under the License.
 package etcd
 
 import (
+	"context"
+	"encoding/json"
+	stderrs "errors"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
+	"time"
 
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/client/pkg/v3/transport"
+	"go.etcd.io/etcd/client/pkg/v3/types"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/pkg/v3/pbutil"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/membership"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
+	"go.etcd.io/etcd/server/v3/storage/backend"
+	"go.etcd.io/etcd/server/v3/storage/schema"
+	"go.etcd.io/etcd/server/v3/storage/wal"
+	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
+	"go.etcd.io/raft/v3/raftpb"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 	"k8s.io/klog/v2"
 
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
+)
+
+const (
+	rollbackSnapshotFileName = "etcd.db"
+	rollbackMetadataFileName = "restore-metadata.json"
 )
 
 // CreateDataDirectory creates the etcd data directory (commonly /var/lib/etcd) with the right permissions.
@@ -36,115 +61,381 @@ func CreateDataDirectory(dir string) error {
 	return nil
 }
 
-// BackupDataDirectory copies a live etcd data directory for upgrade rollback.
-//
-// The destination layout matches `cp -r src dst` when dst already exists as a
-// directory: contents are placed under dst/basename(src).
-//
-// Unlike a plain recursive cp, this:
-//   - skips ephemeral WAL pre-allocation files (*.tmp), which etcd's
-//     filePipeline renames into place during segment rotation
-//   - ignores files that disappear mid-copy (os.ErrNotExist), which can happen
-//     when those *.tmp files are renamed, or when old WAL segments are removed
-//
-// etcd ignores *.tmp when reading a WAL directory, so omitting them does not
-// affect restore usability of the backup.
-func BackupDataDirectory(src, dst string) error {
-	srcInfo, err := os.Stat(src)
-	if err != nil {
-		return errors.Wrapf(err, "failed to stat etcd data directory %q", src)
-	}
-	if !srcInfo.IsDir() {
-		return errors.Errorf("etcd data directory %q is not a directory", src)
+// BackupDataForRollback creates a rollback backup in backupDir, including both
+// the etcd snapshot and restore metadata required to preserve identity.
+func BackupDataForRollback(endpoint, ca, cert, key, dataDir, manifestDir, backupDir string) error {
+	if err := os.MkdirAll(backupDir, 0700); err != nil {
+		return errors.Wrapf(err, "failed to create backup directory %q", backupDir)
 	}
 
-	// Match `cp -r src dst` when dst exists as a directory.
-	target := filepath.Join(dst, filepath.Base(src))
-	if err := os.MkdirAll(target, srcInfo.Mode()); err != nil {
-		return errors.Wrapf(err, "failed to create etcd backup directory %q", target)
+	snapshotPath := filepath.Join(backupDir, rollbackSnapshotFileName)
+	if err := snapshotSave(endpoint, ca, cert, key, snapshotPath); err != nil {
+		return errors.Wrapf(err, "failed to save etcd snapshot")
 	}
 
-	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			if os.IsNotExist(err) {
-				klog.V(4).Infof("skipping vanished path during etcd backup: %s", path)
-				return nil
-			}
-			return err
-		}
-		if path == src {
-			return nil
-		}
+	initialClusterToken, tokenErr := getInitialClusterTokenFromStaticPod(manifestDir)
+	if tokenErr != nil {
+		klog.V(4).Infof("[etcd] could not read --initial-cluster-token from manifest: %v", tokenErr)
+	}
 
-		// Ephemeral WAL pre-allocation files are renamed by etcd and must not
-		// fail the backup. etcd itself ignores leftover *.tmp on restore.
-		if strings.HasSuffix(d.Name(), ".tmp") {
-			klog.V(4).Infof("skipping ephemeral file during etcd backup: %s", path)
-			if d.IsDir() {
-				return fs.SkipDir
-			}
-			return nil
-		}
+	metadataPath := filepath.Join(backupDir, rollbackMetadataFileName)
+	if err := snapshotSaveRestoreMetadata(dataDir, metadataPath, initialClusterToken); err != nil {
+		return errors.Wrapf(err, "failed to save etcd restore metadata")
+	}
 
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		destPath := filepath.Join(target, rel)
-
-		info, err := d.Info()
-		if err != nil {
-			if os.IsNotExist(err) {
-				klog.V(4).Infof("skipping vanished path during etcd backup: %s", path)
-				return nil
-			}
-			return err
-		}
-
-		if info.IsDir() {
-			if err := os.MkdirAll(destPath, info.Mode()); err != nil {
-				return errors.Wrapf(err, "failed to create directory %q", destPath)
-			}
-			return nil
-		}
-
-		if !info.Mode().IsRegular() {
-			klog.V(4).Infof("skipping non-regular file during etcd backup: %s", path)
-			return nil
-		}
-
-		if err := copyFile(path, destPath, info.Mode()); err != nil {
-			if os.IsNotExist(err) {
-				klog.V(4).Infof("skipping vanished file during etcd backup: %s", path)
-				return nil
-			}
-			return errors.Wrapf(err, "failed to copy %q to %q", path, destPath)
-		}
-		return nil
-	})
+	return nil
 }
 
-func copyFile(src, dst string, mode fs.FileMode) error {
-	sourceFile, err := os.Open(src)
+// RestoreDataForRollback restores etcd data from backupDir.
+// It consumes rollback metadata when present and falls back to runtime metadata
+// detection for older backups that do not contain metadata files.
+func RestoreDataForRollback(backupDir, dataDir, memberName, peerURL, initialClusterToken string) error {
+	snapshotPath := filepath.Join(backupDir, rollbackSnapshotFileName)
+	metadataPath := filepath.Join(backupDir, rollbackMetadataFileName)
+	if _, err := os.Stat(metadataPath); err != nil {
+		if os.IsNotExist(err) {
+			metadataPath = ""
+		} else {
+			return errors.Wrapf(err, "failed to stat restore metadata file %q", metadataPath)
+		}
+	}
+
+	if err := snapshotRestore(snapshotPath, metadataPath, dataDir, memberName, peerURL, initialClusterToken); err != nil {
+		return errors.Wrapf(err, "failed to restore etcd data from backup dir %q", backupDir)
+	}
+	return nil
+}
+
+// snapshotSave saves a consistent, point-in-time snapshot of etcd to snapshotPath
+// using the etcd v3 Maintenance API.
+func snapshotSave(endpoint, ca, cert, key, snapshotPath string) error {
+	tlsInfo := transport.TLSInfo{
+		CertFile:      cert,
+		KeyFile:       key,
+		TrustedCAFile: ca,
+	}
+	tlsConfig, err := tlsInfo.ClientConfig()
+	if err != nil {
+		return errors.Wrapf(err, "failed to build TLS config for etcd snapshot")
+	}
+
+	client, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{endpoint},
+		DialTimeout: etcdTimeout,
+		TLS:         tlsConfig,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to create etcd client for snapshot")
+	}
+	defer func() { _ = client.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	rc, err := client.Snapshot(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to request etcd snapshot")
+	}
+	defer func() { _ = rc.Close() }()
+
+	f, err := os.Create(snapshotPath)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create snapshot file %q", snapshotPath)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err = io.Copy(f, rc); err != nil {
+		return errors.Wrapf(err, "failed to write snapshot to %q", snapshotPath)
+	}
+	return nil
+}
+
+// snapshotSaveRestoreMetadata persists restore-critical raft metadata from the
+// current etcd data directory into metadataPath.
+//
+// The saved payload is coupled with a snapshot backup and should be restored
+// together with that snapshot to guarantee member/cluster identity stability.
+func snapshotSaveRestoreMetadata(dataDir, metadataPath, initialClusterToken string) error {
+	lg := zap.NewNop()
+	nodeID, clusterID, confState, ok, err := loadExistingRestoreMetadata(dataDir, lg)
+	if err != nil {
+		return errors.Wrapf(err, "failed to load current restore metadata from %q", dataDir)
+	}
+	if !ok {
+		return errors.Errorf("no restore metadata found in %q", dataDir)
+	}
+
+	payload := restoreMetadataPayload{
+		NodeID:              nodeID,
+		ClusterID:           clusterID,
+		InitialClusterToken: initialClusterToken,
+	}
+	if confState != nil {
+		payload.ConfState = pbutil.MustMarshalMessage(confState)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(metadataPath), 0700); err != nil {
+		return errors.Wrapf(err, "failed to create metadata directory for %q", metadataPath)
+	}
+
+	b, err := json.Marshal(&payload)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal restore metadata payload")
+	}
+	if err := os.WriteFile(metadataPath, b, 0600); err != nil {
+		return errors.Wrapf(err, "failed to write restore metadata file %q", metadataPath)
+	}
+	return nil
+}
+
+func getInitialClusterTokenFromStaticPod(manifestDir string) (string, error) {
+	manifestPath := constants.GetStaticPodFilepath(constants.Etcd, manifestDir)
+	pod, err := staticpod.ReadStaticPodFromDisk(manifestPath)
+	if err != nil {
+		return "", err
+	}
+	if len(pod.Spec.Containers) == 0 {
+		return "", errors.Errorf("etcd static pod has no containers: %q", manifestPath)
+	}
+
+	container := pod.Spec.Containers[0]
+	cmd := append([]string{}, container.Command...)
+	cmd = append(cmd, container.Args...)
+	args := kubeadmutil.ArgumentsFromCommand(cmd)
+	token, _ := kubeadmapi.GetArgValue(args, "initial-cluster-token", -1)
+	return token, nil
+}
+
+// snapshotRestore reconstructs an etcd data directory from a snapshot file.
+// It reads consistent-index metadata from the snapshot's bbolt database,
+// then writes a fresh member/wal and member/snap layout that etcd can boot from.
+//
+// If an existing etcd data directory is present, it reuses the previous
+// NodeID, ClusterID and raft ConfState from WAL metadata so member identity and
+// cluster membership remain unchanged across rollback restore.
+//
+// dataDir is cleared and recreated from the snapshot. restoreMetadataPath, when
+// set, must point to the metadata captured at snapshot backup time and is used
+// as the source of truth for NodeID/ClusterID/ConfState.
+// memberName is the etcd
+// --name flag value. peerURL is the --initial-advertise-peer-urls value.
+// initialClusterToken is the --initial-cluster-token value used only when
+// restore metadata is unavailable and IDs must be re-derived.
+func snapshotRestore(snapshotPath, restoreMetadataPath, dataDir, memberName, peerURL, initialClusterToken string) error {
+	lg := zap.NewNop()
+
+	nodeID, clusterID, confState, tokenFromMetadata, haveExistingMetadata, err := loadRestoreMetadataForSnapshot(restoreMetadataPath, dataDir, lg)
+	if err != nil {
+		return errors.Wrapf(err, "failed to load restore metadata")
+	}
+	if initialClusterToken == "" {
+		initialClusterToken = tokenFromMetadata
+	}
+
+	// Read raft metadata from the snapshot's bbolt database.
+	be := backend.NewDefaultBackend(lg, snapshotPath)
+	tx := be.BatchTx()
+	tx.Lock()
+	index, term := schema.UnsafeReadConsistentIndex(tx)
+	tx.Unlock()
+	be.Close()
+
+	if !haveExistingMetadata {
+		// Fall back to deterministic ID derivation when there is no prior local WAL metadata.
+		if initialClusterToken == "" {
+			return errors.Errorf("cannot derive member/cluster IDs: initialClusterToken is empty and restore metadata is unavailable")
+		}
+		peerURLs, err := types.NewURLs([]string{peerURL})
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse peer URL %q", peerURL)
+		}
+		member := membership.NewMember(memberName, peerURLs, initialClusterToken, nil)
+		urlsmap := types.URLsMap{memberName: peerURLs}
+		cluster, err := membership.NewClusterFromURLsMap(lg, initialClusterToken, urlsmap)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create cluster config for snapshot restore")
+		}
+		nodeID = uint64(member.ID)
+		clusterID = uint64(cluster.ID())
+	}
+
+	if confState == nil || len(confState.GetVoters()) == 0 {
+		// Non-initial snapshots require a non-empty ConfState; default to local node.
+		confState = &raftpb.ConfState{Voters: []uint64{nodeID}}
+	}
+
+	// Clear and recreate the data directory.
+	if err := os.RemoveAll(dataDir); err != nil {
+		return errors.Wrapf(err, "failed to remove existing data directory %q", dataDir)
+	}
+	snapDir := filepath.Join(dataDir, "member", "snap")
+	walDir := filepath.Join(dataDir, "member", "wal")
+	for _, dir := range []string{snapDir, walDir} {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return errors.Wrapf(err, "failed to create directory %q", dir)
+		}
+	}
+
+	// Copy the snapshot database to member/snap/db.
+	dbPath := filepath.Join(snapDir, "db")
+	if err := copySnapshotFile(snapshotPath, dbPath); err != nil {
+		return errors.Wrapf(err, "failed to copy snapshot database to %q", dbPath)
+	}
+
+	// Create the WAL with member/cluster metadata and a snapshot entry.
+	walMetadata := pbutil.MustMarshalMessage(&etcdserverpb.Metadata{
+		NodeID:    &nodeID,
+		ClusterID: &clusterID,
+	})
+	w, err := wal.Create(lg, walDir, walMetadata)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create WAL in %q", walDir)
+	}
+	if err := w.SaveSnapshot(&walpb.Snapshot{Index: &index, Term: &term, ConfState: confState}); err != nil {
+		_ = w.Close()
+		return errors.Wrapf(err, "failed to save snapshot entry to WAL")
+	}
+	commit := index
+	if err := w.Save(&raftpb.HardState{
+		Term:   &term,
+		Vote:   &nodeID,
+		Commit: &commit,
+	}, nil); err != nil {
+		_ = w.Close()
+		return errors.Wrapf(err, "failed to save hard state to WAL")
+	}
+	if err := w.Close(); err != nil {
+		return errors.Wrapf(err, "failed to close WAL after restore")
+	}
+
+	// Create the raft snapshot file that references the restored index/term.
+	snapshotter := snap.New(lg, snapDir)
+	if err := snapshotter.SaveSnap(&raftpb.Snapshot{
+		Metadata: &raftpb.SnapshotMetadata{
+			Index:     &index,
+			Term:      &term,
+			ConfState: confState,
+		},
+	}); err != nil {
+		return errors.Wrapf(err, "failed to save raft snapshot file")
+	}
+	return nil
+}
+
+func copySnapshotFile(src, dst string) error {
+	srcFile, err := os.Open(src)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = sourceFile.Close()
-	}()
+	defer func() { _ = srcFile.Close() }()
 
-	if err := os.MkdirAll(filepath.Dir(dst), 0700); err != nil {
-		return err
-	}
-
-	destFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	dstFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = destFile.Close()
-	}()
+	defer func() { _ = dstFile.Close() }()
 
-	_, err = io.Copy(destFile, sourceFile)
+	_, err = io.Copy(dstFile, srcFile)
 	return err
+}
+
+func loadExistingRestoreMetadata(dataDir string, lg *zap.Logger) (nodeID, clusterID uint64, confState *raftpb.ConfState, ok bool, err error) {
+	walDir := filepath.Join(dataDir, "member", "wal")
+	if _, statErr := os.Stat(walDir); statErr != nil {
+		return 0, 0, nil, false, statErr
+	}
+
+	walSnaps, err := wal.ValidSnapshotEntries(lg, walDir)
+	if err != nil {
+		return 0, 0, nil, false, err
+	}
+
+	startSnap := &walpb.Snapshot{}
+	if len(walSnaps) > 0 {
+		startSnap = walSnaps[len(walSnaps)-1]
+		confState = cloneConfState(startSnap.GetConfState())
+	}
+
+	w, err := wal.OpenForRead(lg, walDir, startSnap)
+	if err != nil {
+		return 0, 0, nil, false, err
+	}
+	defer func() { _ = w.Close() }()
+
+	walMetadata, _, _, readErr := w.ReadAll()
+	if readErr != nil && !stderrs.Is(readErr, wal.ErrSnapshotNotFound) {
+		return 0, 0, nil, false, readErr
+	}
+	if len(walMetadata) == 0 {
+		return 0, 0, nil, false, errors.Errorf("empty WAL metadata in %q", walDir)
+	}
+
+	md := &etcdserverpb.Metadata{}
+	if err := proto.Unmarshal(walMetadata, md); err != nil {
+		return 0, 0, nil, false, err
+	}
+	if md.NodeID == nil || md.ClusterID == nil {
+		return 0, 0, nil, false, errors.Errorf("incomplete WAL metadata in %q", walDir)
+	}
+
+	return md.GetNodeID(), md.GetClusterID(), confState, true, nil
+}
+
+func cloneConfState(in *raftpb.ConfState) *raftpb.ConfState {
+	if in == nil {
+		return nil
+	}
+	out := &raftpb.ConfState{
+		Voters:         append([]uint64(nil), in.GetVoters()...),
+		Learners:       append([]uint64(nil), in.GetLearners()...),
+		VotersOutgoing: append([]uint64(nil), in.GetVotersOutgoing()...),
+		LearnersNext:   append([]uint64(nil), in.GetLearnersNext()...),
+	}
+	if in.AutoLeave != nil {
+		autoLeave := in.GetAutoLeave()
+		out.AutoLeave = &autoLeave
+	}
+	return out
+}
+
+type restoreMetadataPayload struct {
+	NodeID              uint64 `json:"nodeID"`
+	ClusterID           uint64 `json:"clusterID"`
+	ConfState           []byte `json:"confState,omitempty"`
+	InitialClusterToken string `json:"initialClusterToken,omitempty"`
+}
+
+func loadRestoreMetadataForSnapshot(restoreMetadataPath, dataDir string, lg *zap.Logger) (nodeID, clusterID uint64, confState *raftpb.ConfState, initialClusterToken string, ok bool, err error) {
+	if restoreMetadataPath != "" {
+		return loadRestoreMetadataFile(restoreMetadataPath)
+	}
+
+	nodeID, clusterID, confState, ok, err = loadExistingRestoreMetadata(dataDir, lg)
+	if err != nil {
+		klog.V(4).Infof("[etcd] could not load existing WAL metadata from %q, restore will compute IDs: %v", dataDir, err)
+	}
+	return nodeID, clusterID, confState, "", ok, nil
+}
+
+func loadRestoreMetadataFile(path string) (nodeID, clusterID uint64, confState *raftpb.ConfState, initialClusterToken string, ok bool, err error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, 0, nil, "", false, err
+	}
+	var payload restoreMetadataPayload
+	if err := json.Unmarshal(b, &payload); err != nil {
+		return 0, 0, nil, "", false, err
+	}
+	if payload.NodeID == 0 || payload.ClusterID == 0 {
+		return 0, 0, nil, "", false, errors.Errorf("invalid restore metadata file %q: empty node/cluster IDs", path)
+	}
+
+	if len(payload.ConfState) > 0 {
+		decoded := &raftpb.ConfState{}
+		if err := proto.Unmarshal(payload.ConfState, decoded); err != nil {
+			return 0, 0, nil, "", false, err
+		}
+		confState = decoded
+	}
+	return payload.NodeID, payload.ClusterID, confState, payload.InitialClusterToken, true, nil
 }

--- a/cmd/kubeadm/app/util/etcd/etcddata_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcddata_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestBackupDataDirectory(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "etcd")
+	mustMkdir(t, filepath.Join(src, "member", "wal"), 0700)
+	mustMkdir(t, filepath.Join(src, "member", "snap"), 0700)
+	mustWriteFile(t, filepath.Join(src, "member", "wal", "0000000000000000-0000000000000000.wal"), []byte("wal"), 0600)
+	mustWriteFile(t, filepath.Join(src, "member", "wal", "0.tmp"), []byte("prealloc"), 0600)
+	mustWriteFile(t, filepath.Join(src, "member", "wal", "1.tmp"), []byte("prealloc"), 0600)
+	mustWriteFile(t, filepath.Join(src, "member", "snap", "db"), []byte("db"), 0600)
+
+	dst := t.TempDir()
+	if err := BackupDataDirectory(src, dst); err != nil {
+		t.Fatalf("BackupDataDirectory() error = %v", err)
+	}
+
+	// Layout matches `cp -r src dst` when dst exists: dst/basename(src)/...
+	copiedRoot := filepath.Join(dst, "etcd")
+	assertFileExists(t, filepath.Join(copiedRoot, "member", "wal", "0000000000000000-0000000000000000.wal"))
+	assertFileExists(t, filepath.Join(copiedRoot, "member", "snap", "db"))
+	assertFileNotExists(t, filepath.Join(copiedRoot, "member", "wal", "0.tmp"))
+	assertFileNotExists(t, filepath.Join(copiedRoot, "member", "wal", "1.tmp"))
+}
+
+func TestBackupDataDirectoryToleratesWALTmpChurn(t *testing.T) {
+	src := filepath.Join(t.TempDir(), "etcd")
+	walDir := filepath.Join(src, "member", "wal")
+	mustMkdir(t, walDir, 0700)
+	mustWriteFile(t, filepath.Join(walDir, "0000000000000000-0000000000000000.wal"), []byte("wal"), 0600)
+
+	// Simulate etcd filePipeline: create 0.tmp / 1.tmp and rename/remove them
+	// while the backup walks member/wal. Plain `cp -r` fails with
+	// "cannot stat '.../N.tmp'" under this churn.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tmp0 := filepath.Join(walDir, "0.tmp")
+		tmp1 := filepath.Join(walDir, "1.tmp")
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = os.WriteFile(tmp0, []byte("prealloc"), 0600)
+				_ = os.Rename(tmp0, tmp1)
+				_ = os.Remove(tmp1)
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		wg.Wait()
+	})
+
+	for i := range 30 {
+		dst := t.TempDir()
+		if err := BackupDataDirectory(src, dst); err != nil {
+			t.Fatalf("BackupDataDirectory() iteration %d: %v", i, err)
+		}
+		assertFileExists(t, filepath.Join(dst, "etcd", "member", "wal", "0000000000000000-0000000000000000.wal"))
+		assertFileNotExists(t, filepath.Join(dst, "etcd", "member", "wal", "0.tmp"))
+		assertFileNotExists(t, filepath.Join(dst, "etcd", "member", "wal", "1.tmp"))
+	}
+}
+
+func mustMkdir(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(path, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, data []byte, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, data, mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected %q to exist: %v", path, err)
+	}
+}
+
+func assertFileNotExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected %q not to exist, got err=%v", path, err)
+	}
+}

--- a/cmd/kubeadm/app/util/etcd/etcddata_test.go
+++ b/cmd/kubeadm/app/util/etcd/etcddata_test.go
@@ -17,95 +17,286 @@ limitations under the License.
 package etcd
 
 import (
+	"encoding/binary"
 	"os"
 	"path/filepath"
-	"sync"
+	"reflect"
 	"testing"
+
+	bolt "go.etcd.io/bbolt"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+	"go.etcd.io/etcd/pkg/v3/pbutil"
+	"go.etcd.io/etcd/server/v3/etcdserver/api/snap"
+	"go.etcd.io/etcd/server/v3/storage/wal"
+	"go.etcd.io/etcd/server/v3/storage/wal/walpb"
+	"go.etcd.io/raft/v3/raftpb"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 )
 
-func TestBackupDataDirectory(t *testing.T) {
-	src := filepath.Join(t.TempDir(), "etcd")
-	mustMkdir(t, filepath.Join(src, "member", "wal"), 0700)
-	mustMkdir(t, filepath.Join(src, "member", "snap"), 0700)
-	mustWriteFile(t, filepath.Join(src, "member", "wal", "0000000000000000-0000000000000000.wal"), []byte("wal"), 0600)
-	mustWriteFile(t, filepath.Join(src, "member", "wal", "0.tmp"), []byte("prealloc"), 0600)
-	mustWriteFile(t, filepath.Join(src, "member", "wal", "1.tmp"), []byte("prealloc"), 0600)
-	mustWriteFile(t, filepath.Join(src, "member", "snap", "db"), []byte("db"), 0600)
+// makeSnapshotDB creates a minimal bbolt database file that looks like an etcd
+// snapshot (as returned by Maintenance.Snapshot): it contains a "meta" bucket
+// with a consistentIndex and a term entry, matching what SnapshotRestore reads.
+func makeSnapshotDB(t *testing.T, dir string, index, term uint64) string {
+	t.Helper()
+	path := filepath.Join(dir, "etcd.db")
 
-	dst := t.TempDir()
-	if err := BackupDataDirectory(src, dst); err != nil {
-		t.Fatalf("BackupDataDirectory() error = %v", err)
+	db, err := bolt.Open(path, 0600, nil)
+	if err != nil {
+		t.Fatalf("bolt.Open: %v", err)
 	}
-
-	// Layout matches `cp -r src dst` when dst exists: dst/basename(src)/...
-	copiedRoot := filepath.Join(dst, "etcd")
-	assertFileExists(t, filepath.Join(copiedRoot, "member", "wal", "0000000000000000-0000000000000000.wal"))
-	assertFileExists(t, filepath.Join(copiedRoot, "member", "snap", "db"))
-	assertFileNotExists(t, filepath.Join(copiedRoot, "member", "wal", "0.tmp"))
-	assertFileNotExists(t, filepath.Join(copiedRoot, "member", "wal", "1.tmp"))
-}
-
-func TestBackupDataDirectoryToleratesWALTmpChurn(t *testing.T) {
-	src := filepath.Join(t.TempDir(), "etcd")
-	walDir := filepath.Join(src, "member", "wal")
-	mustMkdir(t, walDir, 0700)
-	mustWriteFile(t, filepath.Join(walDir, "0000000000000000-0000000000000000.wal"), []byte("wal"), 0600)
-
-	// Simulate etcd filePipeline: create 0.tmp / 1.tmp and rename/remove them
-	// while the backup walks member/wal. Plain `cp -r` fails with
-	// "cannot stat '.../N.tmp'" under this churn.
-	stop := make(chan struct{})
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		tmp0 := filepath.Join(walDir, "0.tmp")
-		tmp1 := filepath.Join(walDir, "1.tmp")
-		for {
-			select {
-			case <-stop:
-				return
-			default:
-				_ = os.WriteFile(tmp0, []byte("prealloc"), 0600)
-				_ = os.Rename(tmp0, tmp1)
-				_ = os.Remove(tmp1)
-			}
+	err = db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists([]byte("meta"))
+		if err != nil {
+			return err
 		}
-	}()
-	t.Cleanup(func() {
-		close(stop)
-		wg.Wait()
+		// UnsafeReadConsistentIndex reads two separate keys in the "meta" bucket:
+		//   "consistent_index" → 8-byte big-endian index
+		//   "term"             → 8-byte big-endian term
+		idx := make([]byte, 8)
+		binary.BigEndian.PutUint64(idx, index)
+		if err := b.Put([]byte("consistent_index"), idx); err != nil {
+			return err
+		}
+		tm := make([]byte, 8)
+		binary.BigEndian.PutUint64(tm, term)
+		return b.Put([]byte("term"), tm)
 	})
+	if err != nil {
+		t.Fatalf("db.Update: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close: %v", err)
+	}
+	return path
+}
 
-	for i := range 30 {
-		dst := t.TempDir()
-		if err := BackupDataDirectory(src, dst); err != nil {
-			t.Fatalf("BackupDataDirectory() iteration %d: %v", i, err)
+func TestSnapshotRestore(t *testing.T) {
+	tmpDir := t.TempDir()
+	snapshotPath := makeSnapshotDB(t, tmpDir, 42, 3)
+
+	dataDir := filepath.Join(tmpDir, "etcd")
+	err := snapshotRestore(snapshotPath, "", dataDir, "default", "https://127.0.0.1:2380", "etcd-cluster")
+	if err != nil {
+		t.Fatalf("snapshotRestore() error = %v", err)
+	}
+
+	// Verify the expected directory structure was created.
+	assertFileExists(t, filepath.Join(dataDir, "member", "snap", "db"))
+	assertDirExists(t, filepath.Join(dataDir, "member", "wal"))
+	assertDirExists(t, filepath.Join(dataDir, "member", "snap"))
+
+	// A raft snap file should exist (named <term>-<index>.snap).
+	entries, err := os.ReadDir(filepath.Join(dataDir, "member", "snap"))
+	if err != nil {
+		t.Fatalf("ReadDir snap: %v", err)
+	}
+	snapFiles := 0
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".snap" {
+			snapFiles++
 		}
-		assertFileExists(t, filepath.Join(dst, "etcd", "member", "wal", "0000000000000000-0000000000000000.wal"))
-		assertFileNotExists(t, filepath.Join(dst, "etcd", "member", "wal", "0.tmp"))
-		assertFileNotExists(t, filepath.Join(dst, "etcd", "member", "wal", "1.tmp"))
+	}
+	if snapFiles == 0 {
+		t.Error("expected at least one .snap file in member/snap")
+	}
+
+	// A WAL file should exist.
+	walEntries, err := os.ReadDir(filepath.Join(dataDir, "member", "wal"))
+	if err != nil {
+		t.Fatalf("ReadDir wal: %v", err)
+	}
+	walFiles := 0
+	for _, e := range walEntries {
+		if filepath.Ext(e.Name()) == ".wal" {
+			walFiles++
+		}
+	}
+	if walFiles == 0 {
+		t.Error("expected at least one .wal file in member/wal")
 	}
 }
 
-func mustMkdir(t *testing.T, path string, mode os.FileMode) {
-	t.Helper()
-	if err := os.MkdirAll(path, mode); err != nil {
+func TestSnapshotRestoreOverwritesExistingDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	snapshotPath := makeSnapshotDB(t, tmpDir, 10, 1)
+
+	dataDir := filepath.Join(tmpDir, "etcd")
+
+	// Pre-create the data dir with some stale contents.
+	staleFile := filepath.Join(dataDir, "stale")
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
 		t.Fatal(err)
+	}
+	if err := os.WriteFile(staleFile, []byte("stale"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := snapshotRestore(snapshotPath, "", dataDir, "default", "https://127.0.0.1:2380", "etcd-cluster"); err != nil {
+		t.Fatalf("snapshotRestore() error = %v", err)
+	}
+
+	// Stale file should be gone.
+	assertFileNotExists(t, staleFile)
+	// Fresh structure should be present.
+	assertFileExists(t, filepath.Join(dataDir, "member", "snap", "db"))
+}
+
+func TestSnapshotRestorePreservesExistingIDsAndConfState(t *testing.T) {
+	tmpDir := t.TempDir()
+	snapshotPath := makeSnapshotDB(t, tmpDir, 77, 5)
+
+	dataDir := filepath.Join(tmpDir, "etcd")
+	wantNodeID := uint64(0x22)
+	wantClusterID := uint64(0x99)
+	wantConfState := &raftpb.ConfState{Voters: []uint64{0x11, 0x22, 0x33}}
+	writeExistingMemberState(t, dataDir, wantNodeID, wantClusterID, 60, 4, wantConfState)
+
+	// Different inputs here should not alter restored identity when existing WAL metadata is available.
+	if err := snapshotRestore(snapshotPath, "", dataDir, "different-member", "https://10.10.10.10:2380", "different-token"); err != nil {
+		t.Fatalf("snapshotRestore() error = %v", err)
+	}
+
+	gotNodeID, gotClusterID, gotConfState := readWalMetadataAndConfState(t, filepath.Join(dataDir, "member", "wal"))
+	if gotNodeID != wantNodeID {
+		t.Fatalf("nodeID changed after restore, got %d want %d", gotNodeID, wantNodeID)
+	}
+	if gotClusterID != wantClusterID {
+		t.Fatalf("clusterID changed after restore, got %d want %d", gotClusterID, wantClusterID)
+	}
+	if !reflect.DeepEqual(gotConfState.GetVoters(), wantConfState.GetVoters()) {
+		t.Fatalf("confState voters changed after restore, got %v want %v", gotConfState.GetVoters(), wantConfState.GetVoters())
 	}
 }
 
-func mustWriteFile(t *testing.T, path string, data []byte, mode os.FileMode) {
-	t.Helper()
-	if err := os.WriteFile(path, data, mode); err != nil {
-		t.Fatal(err)
+func TestSnapshotRestoreUsesBackupMetadataFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	snapshotPath := makeSnapshotDB(t, tmpDir, 88, 6)
+	metadataPath := filepath.Join(tmpDir, "restore-metadata.json")
+
+	backupStateDir := filepath.Join(tmpDir, "backup-state")
+	wantNodeID := uint64(0xabc)
+	wantClusterID := uint64(0xdef)
+	wantConfState := &raftpb.ConfState{Voters: []uint64{0x1, 0x2, 0x3}}
+	writeExistingMemberState(t, backupStateDir, wantNodeID, wantClusterID, 70, 5, wantConfState)
+	if err := snapshotSaveRestoreMetadata(backupStateDir, metadataPath, "custom-token"); err != nil {
+		t.Fatalf("snapshotSaveRestoreMetadata() error = %v", err)
 	}
+
+	// Simulate runtime corruption/drift before rollback.
+	runtimeStateDir := filepath.Join(tmpDir, "runtime-state")
+	writeExistingMemberState(t, runtimeStateDir, uint64(0x999), uint64(0x777), 71, 5, &raftpb.ConfState{Voters: []uint64{0x999}})
+
+	if err := snapshotRestore(snapshotPath, metadataPath, runtimeStateDir, "runtime-member", "https://20.20.20.20:2380", "runtime-token"); err != nil {
+		t.Fatalf("snapshotRestore() error = %v", err)
+	}
+
+	gotNodeID, gotClusterID, gotConfState := readWalMetadataAndConfState(t, filepath.Join(runtimeStateDir, "member", "wal"))
+	if gotNodeID != wantNodeID {
+		t.Fatalf("nodeID mismatch after metadata-driven restore, got %d want %d", gotNodeID, wantNodeID)
+	}
+	if gotClusterID != wantClusterID {
+		t.Fatalf("clusterID mismatch after metadata-driven restore, got %d want %d", gotClusterID, wantClusterID)
+	}
+	if !reflect.DeepEqual(gotConfState.GetVoters(), wantConfState.GetVoters()) {
+		t.Fatalf("confState voters mismatch after metadata-driven restore, got %v want %v", gotConfState.GetVoters(), wantConfState.GetVoters())
+	}
+}
+
+func TestSnapshotRestoreRequiresTokenWithoutMetadata(t *testing.T) {
+	tmpDir := t.TempDir()
+	snapshotPath := makeSnapshotDB(t, tmpDir, 11, 2)
+
+	dataDir := filepath.Join(tmpDir, "empty-etcd")
+	err := snapshotRestore(snapshotPath, "", dataDir, "default", "https://127.0.0.1:2380", "")
+	if err == nil {
+		t.Fatal("expected snapshotRestore to fail when restore metadata and initialClusterToken are both missing")
+	}
+}
+
+func writeExistingMemberState(t *testing.T, dataDir string, nodeID, clusterID, index, term uint64, confState *raftpb.ConfState) {
+	t.Helper()
+	lg := zap.NewNop()
+	walDir := filepath.Join(dataDir, "member", "wal")
+	snapDir := filepath.Join(dataDir, "member", "snap")
+	if err := os.MkdirAll(walDir, 0700); err != nil {
+		t.Fatalf("MkdirAll wal: %v", err)
+	}
+	if err := os.MkdirAll(snapDir, 0700); err != nil {
+		t.Fatalf("MkdirAll snap: %v", err)
+	}
+
+	walMetadata := pbutil.MustMarshalMessage(&etcdserverpb.Metadata{
+		NodeID:    &nodeID,
+		ClusterID: &clusterID,
+	})
+	w, err := wal.Create(lg, walDir, walMetadata)
+	if err != nil {
+		t.Fatalf("wal.Create: %v", err)
+	}
+	if err := w.SaveSnapshot(&walpb.Snapshot{Index: &index, Term: &term, ConfState: confState}); err != nil {
+		_ = w.Close()
+		t.Fatalf("w.SaveSnapshot: %v", err)
+	}
+	commit := index
+	if err := w.Save(&raftpb.HardState{Term: &term, Vote: &nodeID, Commit: &commit}, nil); err != nil {
+		_ = w.Close()
+		t.Fatalf("w.Save: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("w.Close: %v", err)
+	}
+
+	snapshotter := snap.New(lg, snapDir)
+	if err := snapshotter.SaveSnap(&raftpb.Snapshot{Metadata: &raftpb.SnapshotMetadata{Index: &index, Term: &term, ConfState: confState}}); err != nil {
+		t.Fatalf("SaveSnap: %v", err)
+	}
+}
+
+func readWalMetadataAndConfState(t *testing.T, walDir string) (uint64, uint64, *raftpb.ConfState) {
+	t.Helper()
+	lg := zap.NewNop()
+	walSnaps, err := wal.ValidSnapshotEntries(lg, walDir)
+	if err != nil {
+		t.Fatalf("ValidSnapshotEntries: %v", err)
+	}
+	if len(walSnaps) == 0 {
+		t.Fatal("expected WAL to contain at least one snapshot entry")
+	}
+
+	startSnap := walSnaps[len(walSnaps)-1]
+	w, err := wal.OpenForRead(lg, walDir, startSnap)
+	if err != nil {
+		t.Fatalf("OpenForRead: %v", err)
+	}
+	defer func() { _ = w.Close() }()
+
+	mdBytes, _, _, err := w.ReadAll()
+	if err != nil && err != wal.ErrSnapshotNotFound {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	md := &etcdserverpb.Metadata{}
+	if err := proto.Unmarshal(mdBytes, md); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	return md.GetNodeID(), md.GetClusterID(), startSnap.GetConfState()
 }
 
 func assertFileExists(t *testing.T, path string) {
 	t.Helper()
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected %q to exist: %v", path, err)
+	}
+}
+
+func assertDirExists(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected %q to exist: %v", path, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected %q to be a directory", path)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
kubeadm: tolerate etcd WAL .tmp rename during upgrade backup

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes https://github.com/kubernetes/kubeadm/issues/3324
#### Special notes for your reviewer:

Custom CI: https://github.com/SataQiu/googlecontainer/actions/runs/30745884043/job/91491295144

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fix a bug that `kubeadm upgrade` fails when etcd renames WAL .tmp files during data-dir backup
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
