### PR TITLE
fix: propagate PrintObj errors in kubectl get and kubectl apply --prune

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -134,7 +134,9 @@ func (p *pruner) prune(namespace string, mapping *meta.RESTMapping) error {
 		if err != nil {
 			return err
 		}
-		printer.PrintObj(obj, p.out)
+		if err := printer.PrintObj(obj, p.out); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/printers"
+	dynamicfakeclient "k8s.io/client-go/dynamic/fake"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+// errPrinter is a ResourcePrinter whose PrintObj always returns a fixed error.
+type errPrinter struct{ err error }
+
+func (e *errPrinter) PrintObj(_ runtime.Object, _ io.Writer) error { return e.err }
+
+// TestPrunerPropagatesPrintObjError verifies that a printer error inside
+// pruner.prune is returned to the caller rather than silently discarded.
+// Regression test for the silent-discard bug at prune.go#L137.
+func TestPrunerPropagatesPrintObjError(t *testing.T) {
+	// Build a ConfigMap that looks like it was created by kubectl apply
+	// (has LastAppliedConfigAnnotation) so that pruner will try to print it.
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      "to-prune",
+				"namespace": "test",
+				"uid":       "uid-prune",
+				"annotations": map[string]interface{}{
+					corev1.LastAppliedConfigAnnotation: "{}",
+				},
+			},
+		},
+	}
+
+	// NewSimpleDynamicClient pre-seeds the object; no separate Create needed.
+	dynamicClient := dynamicfakeclient.NewSimpleDynamicClient(scheme.Scheme, obj)
+
+	// Mapper that resolves ConfigMap to the namespaced REST mapping.
+	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{{Group: "", Version: "v1"}})
+	mapper.Add(corev1.SchemeGroupVersion.WithKind("ConfigMap"), meta.RESTScopeNamespace)
+
+	wantErr := fmt.Errorf("simulated printer failure")
+	p := &pruner{
+		mapper:        mapper,
+		dynamicClient: dynamicClient,
+
+		// No visited UIDs → the object will not be skipped.
+		visitedUids:       sets.New[types.UID](),
+		visitedNamespaces: sets.New[string](),
+
+		// DryRunClient so pruner.delete is never called; we only test the print path.
+		dryRunStrategy: cmdutil.DryRunClient,
+
+		toPrinter: func(_ string) (printers.ResourcePrinter, error) {
+			return &errPrinter{err: wantErr}, nil
+		},
+		out: io.Discard,
+	}
+
+	mapping, err := mapper.RESTMapping(corev1.SchemeGroupVersion.WithKind("ConfigMap").GroupKind(), "v1")
+	if err != nil {
+		t.Fatalf("RESTMapping: %v", err)
+	}
+
+	err = p.prune("test", mapping)
+	if err == nil {
+		t.Fatal("expected prune to return an error, got nil")
+	}
+	if err.Error() != wantErr.Error() {
+		t.Errorf("expected error %q, got %q", wantErr.Error(), err.Error())
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -566,7 +566,12 @@ func (o *GetOptions) Run(f cmdutil.Factory, args []string) error {
 			lastMapping = mapping
 		}
 
-		printer.PrintObj(info.Object, w)
+		if err := printer.PrintObj(info.Object, w); err != nil {
+			if !errs.Has(err.Error()) {
+				errs.Insert(err.Error())
+				allErrs = append(allErrs, err)
+			}
+		}
 	}
 	w.Flush()
 	if trackingWriter.Written == 0 && !o.IgnoreNotFound && len(allErrs) == 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -34,12 +34,14 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
@@ -3210,4 +3212,52 @@ func replicationControllersScaleSubresourceTableObjBody(codec runtime.Codec, rep
 		})
 	}
 	return cmdtesting.ObjBody(codec, table)
+}
+
+// errWriter always returns an error on Write, simulating a broken pipe or closed writer.
+type errWriter struct{ err error }
+
+func (e *errWriter) Write(_ []byte) (int, error) { return 0, e.err }
+
+// TestGetPropagatesPrintObjError verifies that an IO error returned by PrintObj
+// in the human-readable output loop is collected into allErrs and surfaced to
+// the caller. Regression test for the silent-discard bug at get.go#L569.
+func TestGetPropagatesPrintObjError(t *testing.T) {
+	pods, _, _ := cmdtesting.TestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])},
+	}
+
+	streams, _, _, _ := genericiooptions.NewTestIOStreams()
+	cmd := NewCmdGet("kubectl", tf, streams)
+	o := NewGetOptions("kubectl", streams)
+
+	if err := o.Complete(tf, cmd, []string{"pods", "foo"}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	// Override ToPrinter after Complete (which sets it) so the ResourcePrinterFunc
+	// always errors, simulating a broken-pipe or closed-writer condition.
+	wantErr := fmt.Errorf("simulated write error")
+	o.ToPrinter = func(_ *meta.RESTMapping, _ *bool, _, _ bool) (printers.ResourcePrinterFunc, error) {
+		return func(_ runtime.Object, _ io.Writer) error {
+			return wantErr
+		}, nil
+	}
+	o.IsHumanReadablePrinter = true
+	o.ServerPrint = false
+
+	err := o.Run(tf, []string{"pods", "foo"})
+	if err == nil {
+		t.Fatal("expected an error from Run, got nil")
+	}
+	if !strings.Contains(err.Error(), wantErr.Error()) {
+		t.Errorf("expected error to contain %q, got %q", wantErr.Error(), err.Error())
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

In the human-readable output loop of `get.go`'s `Run()`, `printer.PrintObj(info.Object, w)` was called without checking the error return. The function already maintains an `allErrs` slice returned via `utilerrors.NewAggregate` `PrintObj` errors are now fed into it, consistent with how `ToPrinter` errors are already handled in the same loop.

In `pruner.prune()`, `printer.PrintObj(obj, p.out)` discarded its error return. Since the function already returns `error`, the fix wraps the call and returns the error directly.

Both bugs allowed IO failures (broken pipe, closed writer) to go undetected, with the command exiting 0 despite incomplete output.

**Which issue(s) this PR is related to:**

Fixes #141115

**Special notes :**

Two call sites are fixed in the same PR since they share the same root cause silent `PrintObj` error discard. Each fix follows the error-handling pattern already established in its surrounding code, so no new patterns are introduced.

**Does this PR introduce a user-facing change?**

```release-note
Fixed `kubectl get` and `kubectl apply --prune` silently ignoring IO errors (e.g. broken pipe) from the output printer. Both commands now exit non-zero when output fails.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**

```docs

```