### PR TITLE
hack/README.md: fix comma splices, missing space, and prose quality issues

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -1,24 +1,24 @@
 # Kubernetes hack GuideLines
 
-This document describes how you can use the scripts from [`hack`](.) directory 
-and gives a brief introduction and explanation of these scripts. 
+This document describes how you can use the scripts from [`hack`](.) directory
+and gives a brief introduction and explanation of these scripts.
 
 ## Overview
 
-The [`hack`](.) directory contains many scripts that ensure continuous development of kubernetes, 
-enhance the robustness of the code, improve development efficiency, etc. 
-The explanations and descriptions of these scripts are helpful for contributors. 
+The [`hack`](.) directory contains scripts that ensure continuous development of kubernetes,
+enhance the robustness of the code, improve development efficiency, etc.
+The explanations and descriptions of these scripts are helpful for contributors.
 For details, refer to the following guidelines.
 
 ## Key scripts
 
-* [`verify-all.sh`](verify-all.sh): This script is a vestigial redirection, Please do not add "real" logic. It is equivalent to `make verify`.
-* [`update-all.sh`](update-all.sh): This script is a vestigial redirection, Please do not add "real" logic. 
-The `true` target of this makerule is `hack/make-rules/update.sh`.It is equivalent to `make update`.
+* [`verify-all.sh`](verify-all.sh): This script is a vestigial redirection. Do not add "real" logic. Runs as `make verify`.
+* [`update-all.sh`](update-all.sh): This script is a vestigial redirection. Do not add "real" logic.
+The `true` target of this makerule is `hack/make-rules/update.sh`. Runs as `make update`.
 
 ## Attention
-Note that all scripts must be run from the Kubernetes root directory. 
-**We should run `hack/verify-all.sh` before submitting a PR and if anything fails run `hack/update-all.sh`**. 
- 
+Run all scripts from the Kubernetes root directory.
+**Run `hack/verify-all.sh` before submitting a PR. If anything fails, run `hack/update-all.sh`**.
+
 
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Improves the prose quality of `hack/README.md`, which had several writing issues:

- Line 8: replaced the weasel word "many" with more precise phrasing.
- Lines 15–16 and the equivalent `update-all.sh` line: fixed a comma splice "This script is a vestigial redirection, Please do not add..." incorrectly joined two independent clauses with a comma instead of a period. Both occurrences in the file are corrected.
- Lines 15 & 17: reworded "It is equivalent to" for conciseness.
- Line 17: fixed a missing space `hack/make-rules/update.sh.It is equivalent` had no space after the period.
- Line 20: reworded "must be run" from passive to active voice.

None of these are functional changes this is a documentation-only cleanup that makes `hack/README.md` easier to read correctly.

**Which issue(s) this PR is related to:**

Fixes #141121

**Special notes:**

This PR only touches `hack/README.md`. The comma-splice and missing-space fixes are objective corrections; the weasel-word, wordiness, and passive-voice changes are prose-quality improvements flagged by `write-good` happy to adjust wording on any of these per reviewer preference, since these are stylistic rather than functional.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**

```docs

```