### PR TITLE
e2e: drop Slow tag from DNS configMap nameserver tests

### DIFF
--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -316,7 +316,7 @@ var _ = common.SIGDescribe("DNS configMap nameserver", func() {
 	ginkgo.Context("Change stubDomain", func() {
 		nsTest := &dnsNameserverTest{dnsTestCommon: newDNSTestCommon()}
 
-		framework.It("should be able to change stubDomain configuration", framework.WithSlow(), framework.WithSerial(), func(ctx context.Context) {
+		framework.It("should be able to change stubDomain configuration", framework.WithSerial(), func(ctx context.Context) {
 			nsTest.c = nsTest.f.ClientSet
 			nsTest.run(ctx, framework.TestContext.ClusterIsIPv6())
 		})
@@ -325,7 +325,7 @@ var _ = common.SIGDescribe("DNS configMap nameserver", func() {
 	ginkgo.Context("Forward PTR lookup", func() {
 		fwdTest := &dnsPtrFwdTest{dnsTestCommon: newDNSTestCommon()}
 
-		framework.It("should forward PTR records lookup to upstream nameserver", framework.WithSlow(), framework.WithSerial(), func(ctx context.Context) {
+		framework.It("should forward PTR records lookup to upstream nameserver", framework.WithSerial(), func(ctx context.Context) {
 			fwdTest.c = fwdTest.f.ClientSet
 			fwdTest.run(ctx, framework.TestContext.ClusterIsIPv6())
 		})
@@ -334,7 +334,7 @@ var _ = common.SIGDescribe("DNS configMap nameserver", func() {
 	ginkgo.Context("Forward external name lookup", func() {
 		externalNameTest := &dnsExternalNameTest{dnsTestCommon: newDNSTestCommon()}
 
-		framework.It("should forward externalname lookup to upstream nameserver", framework.WithSlow(), framework.WithSerial(), func(ctx context.Context) {
+		framework.It("should forward externalname lookup to upstream nameserver", framework.WithSerial(), func(ctx context.Context) {
 			externalNameTest.c = externalNameTest.f.ClientSet
 			externalNameTest.run(ctx, framework.TestContext.ClusterIsIPv6())
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Per the [Slow] definition (tests > ~5 minutes), three DNS configMap nameserver e2e tests were over-tagged.

Measured on `ci-kubernetes-e2e-gci-gce-serial` (3 recent SUCCESS runs; completed, not skipped):

| Test | median | max |
|------|--------|-----|
| change stubDomain configuration | 0.40m | 0.42m |
| forward PTR lookup to upstream | 0.42m | 0.42m |
| forward externalname to upstream | 0.30m | 0.30m |

Removed `framework.WithSlow()` only; kept `framework.WithSerial()`.

Note: `ci-kubernetes-e2e-kind-alpha-beta-features` uses `!Slow`, so it cannot validate Slow duration (all Slow tests are skipped there).

#### Which issue(s) this PR fixes:

Related to #131049

#### Special notes for your reviewer:

/sig network
/sig testing

#### Does this PR introduce a user-facing change?

```release-note
NONE
```