### PR TITLE
apiserver: merge duplicate new keys in CEL map-list concat

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/values_test.go
@@ -1385,6 +1385,10 @@ func TestListAdd(t *testing.T) {
 			expression: "(x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}])[2].value == 9",
 		}, skipSchemaless: true},
 		{testCase: testCase{
+			name:       "map list + literal list merges duplicate new keys",
+			expression: "size(x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}, {'key1': 'k1v9', 'key2': 'k2v9', 'value': 10}]) == 3 && (x.mapList + [{'key1': 'k1v9', 'key2': 'k2v9', 'value': 9}, {'key1': 'k1v9', 'key2': 'k2v9', 'value': 10}])[2].value == 10",
+		}, skipSchemaless: true},
+		{testCase: testCase{
 			name:       "chained map list merge",
 			expression: "(x.mapList + y.mapList + [{'key1': 'k1v3', 'key2': 'k2v3', 'value': 33}])[2].value == 33",
 		}, skipSchemaless: true},

--- a/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
+++ b/staging/src/k8s.io/apiserver/pkg/cel/common/valuesreflect.go
@@ -530,6 +530,9 @@ func addToMapList(elements []ref.Val, other traits.Lister, escapedKeyProps []str
 		if overwritePosition, ok := keyToIdx[k]; ok {
 			elements[overwritePosition] = v
 		} else {
+			// Index newly appended keys so later elements with the same key
+			// overwrite in place instead of duplicating the entry.
+			keyToIdx[k] = len(elements)
 			elements = append(elements, v)
 		}
 	}


### PR DESCRIPTION
# WARNING! AI ASSISTED PR 

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Schema-aware CEL map-list concatenation (`x-kubernetes-list-type: map`) did not update the key index when appending a **new** key from the right operand. A later element with that same key was appended again instead of overwriting in place.

Example (keyed by `key1,key2`): if `x.mapList` has two entries,

```cel
x.mapList + [
  {'key1': 'new', 'key2': 'key', 'value': 9},
  {'key1': 'new', 'key2': 'key', 'value': 10},
]
```

previously produced four entries; after this fix it produces three, with the last value for the new key (`10`).

That matches merge-by-key semantics and avoids duplicate map keys in mutation expressions.

#### Which issue(s) this PR fixes:

Fixes #140591

#### Special notes for your reviewer:

Change is in `addToMapList` (shared by typed/unstructured map-list `Add`). Unit test added in `TestListAdd`.

Verified:

```console
cd staging/src/k8s.io/apiserver
GOWORK=off go test ./pkg/cel/common -count=1
```

/sig api-machinery

#### Does this PR introduce a user-facing change?

```release-note
Fixed CEL map-list concatenation so duplicate new keys from the right operand merge instead of appending twice.
```