### PR TITLE
Seed ClusterIP allocator metrics on EnableMetrics()

### DIFF
--- a/pkg/registry/core/service/ipallocator/bitmap.go
+++ b/pkg/registry/core/service/ipallocator/bitmap.go
@@ -341,6 +341,9 @@ func (r *Range) Destroy() {
 func (r *Range) EnableMetrics() {
 	registerMetrics()
 	r.metrics = &metricsRecorder{}
+	// Seed gauges so metrics are non-zero before the first allocation.
+	r.metrics.setAllocated(r.net.String(), r.Used())
+	r.metrics.setAvailable(r.net.String(), r.Free())
 }
 
 // calculateIPOffset calculates the integer offset of ip from base such that

--- a/pkg/registry/core/service/ipallocator/bitmap_test.go
+++ b/pkg/registry/core/service/ipallocator/bitmap_test.go
@@ -449,16 +449,16 @@ func TestClusterIPMetrics(t *testing.T) {
 		t.Fatalf("unexpected error creating CidrSet: %v", err)
 	}
 
-	// Check initial state
+	// Check initial state: gauges are seeded by EnableMetrics
 	em := testMetrics{
-		free:      0,
+		free:      254,
 		used:      0,
 		allocated: 0,
 		errors:    0,
 	}
 	expectMetrics(t, cidrIPv4, em)
 	em = testMetrics{
-		free:      0,
+		free:      65535,
 		used:      0,
 		allocated: 0,
 		errors:    0,
@@ -554,7 +554,7 @@ func TestClusterIPAllocatedMetrics(t *testing.T) {
 	a.EnableMetrics()
 
 	em := testMetrics{
-		free:      0,
+		free:      126,
 		used:      0,
 		allocated: 0,
 		errors:    0,
@@ -618,9 +618,9 @@ func TestMetricsDisabled(t *testing.T) {
 		t.Fatalf("unexpected error creating CidrSet: %v", err)
 	}
 
-	// Check initial state
+	// Check initial state: gauges seeded by a.EnableMetrics()
 	em := testMetrics{
-		free:      0,
+		free:      254,
 		used:      0,
 		allocated: 0,
 		errors:    0,

--- a/pkg/registry/core/service/ipallocator/cidrallocator_test.go
+++ b/pkg/registry/core/service/ipallocator/cidrallocator_test.go
@@ -819,9 +819,9 @@ func TestCIDRAllocatorClusterIPAllocatedMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Check initial metrics for first CIDR
+	// Check initial metrics for first CIDR: gauges seeded by EnableMetrics
 	em1 := testMetrics{
-		free:      0,
+		free:      2,
 		used:      0,
 		allocated: 0,
 		errors:    0,
@@ -878,9 +878,9 @@ func TestCIDRAllocatorClusterIPAllocatedMetrics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Check initial metrics for second CIDR
+	// Check initial metrics for second CIDR: gauges seeded by EnableMetrics
 	em2 := testMetrics{
-		free:      0,
+		free:      6,
 		used:      0,
 		allocated: 0,
 		errors:    0,

--- a/pkg/registry/core/service/ipallocator/ipallocator.go
+++ b/pkg/registry/core/service/ipallocator/ipallocator.go
@@ -488,6 +488,9 @@ func (a *Allocator) DryRun() Interface {
 func (a *Allocator) EnableMetrics() {
 	registerMetrics()
 	a.metrics = &metricsRecorder{}
+	// Seed gauges so metrics are non-zero before the first allocation.
+	a.metrics.setAllocated(a.metricLabel, a.Used())
+	a.metrics.setAvailable(a.metricLabel, a.Free())
 }
 
 // dryRunRange is a shim to satisfy Interface without persisting state.

--- a/pkg/registry/core/service/ipallocator/ipallocator_test.go
+++ b/pkg/registry/core/service/ipallocator/ipallocator_test.go
@@ -428,16 +428,16 @@ func TestIPAllocatorClusterIPMetrics(t *testing.T) {
 	}
 	b.EnableMetrics()
 
-	// Check initial state
+	// Check initial state: gauges are seeded by EnableMetrics
 	em := testMetrics{
-		free:      0,
+		free:      254,
 		used:      0,
 		allocated: 0,
 		errors:    0,
 	}
 	expectMetrics(t, cidrIPv4, em)
 	em = testMetrics{
-		free:      0,
+		free:      65535,
 		used:      0,
 		allocated: 0,
 		errors:    0,
@@ -533,7 +533,7 @@ func TestIPAllocatorClusterIPAllocatedMetrics(t *testing.T) {
 	a.EnableMetrics()
 
 	em := testMetrics{
-		free:      0,
+		free:      126,
 		used:      0,
 		allocated: 0,
 		errors:    0,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`EnableMetrics()` registered Prometheus gauges (`kube_apiserver_clusterip_allocator_allocated_ips` and `kube_apiserver_clusterip_allocator_available_ips`) but never initialized their values. The gauges remained at 0 until the first `Allocate`/`AllocateNext`/`Release` call updated them.

If the apiserver restarted and no new Service IP allocations occurred, monitoring would show 0 available IPs indefinitely, breaking alerting on IP exhaustion.

This adds `setAllocated` and `setAvailable` calls in `EnableMetrics()` for both allocator implementations (`Allocator` and `Range`) so the gauges reflect the actual state immediately upon startup.

#### Which issue(s) this PR is related to:

Fixes https://github.com/kubernetes/kubernetes/issues/139134

#### Special notes for your reviewer:

The fix is exactly as [suggested by @aojea](https://github.com/kubernetes/kubernetes/issues/139134#issuecomment-4488773819).

Both the `Allocator` (MultiCIDR/ipallocator.go) and `Range` (bitmap.go) implementations are fixed. The `MetaAllocator` (cidrallocator.go) automatically propagates because it calls `EnableMetrics()` on child allocators at creation time.

All 160 existing tests pass with `-race`.

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug where ClusterIP allocator metrics (allocated_ips, available_ips) were not populated until the first Service IP allocation after apiserver startup.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
