### PR TITLE
make test: collect coverage only for the main workspace

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -253,6 +253,7 @@ runTests() {
   # Enable coverage data collection?
   local cover_msg
   local COMBINED_COVER_PROFILE
+  local cover_flags=()
 
   if [[ ${KUBE_COVER} =~ ^[yY]$ ]]; then
     cover_msg="with code coverage"
@@ -264,7 +265,7 @@ runTests() {
     kube::log::status "Saving coverage output in '${cover_report_dir}'"
     mkdir -p "${@+${@/#/${cover_report_dir}/}}"
     COMBINED_COVER_PROFILE="${cover_report_dir}/combined-coverage.out"
-    goflags+=(-cover -covermode="${KUBE_COVERMODE}" -coverprofile="${COMBINED_COVER_PROFILE}")
+    cover_flags=(-cover -covermode="${KUBE_COVERMODE}" -coverprofile="${COMBINED_COVER_PROFILE}")
   else
     cover_msg="without code coverage"
   fi
@@ -300,6 +301,11 @@ runTests() {
     if ! (
            case "${prefix}" in
              "")
+               # Collect coverage only for the main workspace. Every "go test"
+               # invocation overwrites the shared profile file, and
+               # "go tool cover" below cannot resolve packages that are
+               # outside the workspace.
+               goflags+=("${cover_flags[@]:+${cover_flags[@]}}")
                ;;
              "vendor/")
                # Upstream tests are not vendored, so we have to download without modifying the vendor directory.


### PR DESCRIPTION
**What type of PR is this?**

Fix for `ci-kubernetes-coverage-unit`:
  - https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-unit
  - https://prow.k8s.io/?job=ci-kubernetes-coverage-unit
  - https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-coverage-unit

/kind failing-test
/sig testing

**What this PR does / why we need it:**

`make test KUBE_COVER=y` runs `go test` several times: once for the main workspace, once for the vendored upstream tests, and once for each module under `hack/tools`. All of the runs write to the same `-coverprofile` file, so each run overwrites the one before it. The combined profile ends up holding only the coverage of the last module, which is `hack/tools/instrumentation`.

After the tests, `go tool cover -html` runs from the repository root and fails, because the instrumentation module is not part of the workspace there:

    cover: cannot find module providing package k8s.io/kubernetes/hack/tools/instrumentation: import lookup disabled by -mod=vendor
        (Go version in go.work is at least 1.14 and vendor directory exists.)

The failure has kept [ci-kubernetes-coverage-unit](https://testgrid.k8s.io/sig-testing-canaries#ci-kubernetes-coverage-unit) red on every run for at least the last 90 days ([job history](https://prow.k8s.io/job-history/gs/kubernetes-ci-logs/logs/ci-kubernetes-coverage-unit)), and the coverage data on testgrid covers only the instrumentation tool instead of the whole repository.

The fix passes the coverage flags only to the main workspace invocation. The other invocations no longer write a profile, the combined profile holds the workspace coverage again, and `go tool cover -html` works.

**Which issue(s) this PR fixes:**

None

**Special notes for your reviewer:**

The extra `go test` invocations came from #137105. The coverage presubmit could not catch the breakage because it always exits 0.

I reproduced the failure locally at a818af18fe2 by replaying the invocations: two `go test` runs sharing one profile file produce the exact error above. With the fix, `make test KUBE_COVER=y WHAT=./pkg/util/parsers` writes a profile with the workspace coverage and the html step succeeds. `pull-kubernetes-coverage-unit` can run the full flow on this PR, but it hides failures, so please check its log rather than its result.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
