### PR TITLE
kubelet: retry HasDedicatedImageFs on failure without blocking eviction sync loop

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -33,6 +33,7 @@ import (
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	"k8s.io/utils/clock"
+	"k8s.io/utils/ptr"
 
 	resourcehelper "k8s.io/component-helpers/resource"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -138,6 +139,7 @@ func NewManager(
 		splitContainerImageFs:         nil,
 		thresholdNotifiers:            []ThresholdNotifier{},
 		localStorageCapacityIsolation: localStorageCapacityIsolation,
+		signalToRankFunc:              buildNonDiskSignalToRankFunc(),
 	}
 	return manager, manager
 }
@@ -267,34 +269,36 @@ func (m *managerImpl) synchronize(ctx context.Context, diskInfoProvider DiskInfo
 	if m.dedicatedImageFs == nil {
 		hasImageFs, imageFsErr := diskInfoProvider.HasDedicatedImageFs(ctx)
 		if imageFsErr != nil {
-			// TODO: This should be refactored to log an error and retry the HasDedicatedImageFs
-			// If we have a transient error this will never be retried and we will not set eviction signals
 			logger.Error(imageFsErr, "Eviction manager: failed to get HasDedicatedImageFs")
-			return nil, fmt.Errorf("eviction manager: failed to get HasDedicatedImageFs: %w", imageFsErr)
-		}
-		m.dedicatedImageFs = &hasImageFs
-		splitContainerImageFs, splitErr := diskInfoProvider.HasDedicatedContainerFs(ctx)
-		if splitErr != nil {
-			// A common error case is when there is no split filesystem
-			// there is an error finding the split filesystem label and we want to ignore these errors
-			logger.Error(splitErr, "eviction manager: failed to check if we have separate container filesystem. Ignoring.")
-		}
+		} else {
+			m.dedicatedImageFs = &hasImageFs
+			splitContainerImageFs, splitErr := diskInfoProvider.HasDedicatedContainerFs(ctx)
+			if splitErr != nil {
+				// A common error case is when there is no split filesystem
+				// there is an error finding the split filesystem label and we want to ignore these errors
+				logger.Error(splitErr, "eviction manager: failed to check if we have separate container filesystem. Ignoring.")
+			}
 
-		// If we are a split filesystem but the feature is turned off
-		// we should return an error.
-		// This is a bad state.
-		if !utilfeature.DefaultFeatureGate.Enabled(features.KubeletSeparateDiskGC) && splitContainerImageFs {
-			splitDiskError := fmt.Errorf("KubeletSeparateDiskGC is turned off but we still have a split filesystem")
-			return nil, splitDiskError
+			// If we are a split filesystem but the feature is turned off
+			// we should return an error.
+			// This is a bad state.
+			if !utilfeature.DefaultFeatureGate.Enabled(features.KubeletSeparateDiskGC) && splitContainerImageFs {
+				splitDiskError := fmt.Errorf("KubeletSeparateDiskGC is turned off but we still have a split filesystem")
+				return nil, splitDiskError
+			}
+			thresholds, err := UpdateContainerFsThresholds(m.config.Thresholds, hasImageFs, splitContainerImageFs)
+			m.config.Thresholds = thresholds
+			if err != nil {
+				logger.Error(err, "eviction manager: found conflicting containerfs eviction. Ignoring.")
+			}
+			m.splitContainerImageFs = &splitContainerImageFs
+			m.signalToRankFunc = buildSignalToRankFunc(hasImageFs, splitContainerImageFs)
+			m.signalToNodeReclaimFuncs = buildSignalToNodeReclaimFuncs(m.imageGC, m.containerGC, hasImageFs, splitContainerImageFs)
 		}
-		thresholds, err := UpdateContainerFsThresholds(m.config.Thresholds, hasImageFs, splitContainerImageFs)
-		m.config.Thresholds = thresholds
-		if err != nil {
-			logger.Error(err, "eviction manager: found conflicting containerfs eviction. Ignoring.")
-		}
-		m.splitContainerImageFs = &splitContainerImageFs
-		m.signalToRankFunc = buildSignalToRankFunc(hasImageFs, splitContainerImageFs)
-		m.signalToNodeReclaimFuncs = buildSignalToNodeReclaimFuncs(m.imageGC, m.containerGC, hasImageFs, splitContainerImageFs)
+	}
+
+	if m.dedicatedImageFs == nil {
+		thresholds = filterDiskThresholds(thresholds)
 	}
 
 	logger.V(3).Info("FileSystem detection", "DedicatedImageFs", m.dedicatedImageFs, "SplitImageFs", m.splitContainerImageFs)
@@ -369,7 +373,7 @@ func (m *managerImpl) synchronize(ctx context.Context, diskInfoProvider DiskInfo
 
 	// evict pods if there is a resource usage violation from local volume temporary storage
 	// If eviction happens in localStorageEviction function, skip the rest of eviction action
-	if m.localStorageCapacityIsolation {
+	if m.localStorageCapacityIsolation && m.dedicatedImageFs != nil {
 		if evictedPods := m.localStorageEviction(logger, activePods, statsFunc); len(evictedPods) > 0 {
 			return evictedPods, nil
 		}
@@ -613,7 +617,7 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 
 	for _, containerStat := range podStats.Containers {
 		containerUsed := diskUsage(containerStat.Logs)
-		if !*m.dedicatedImageFs {
+		if !ptr.Deref(m.dedicatedImageFs, false) {
 			containerUsed.Add(*diskUsage(containerStat.Rootfs))
 		}
 

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -73,15 +73,23 @@ func (m *mockPodKiller) killPodNow(pod *v1.Pod, evict bool, gracePeriodOverride 
 type mockDiskInfoProvider struct {
 	dedicatedImageFs     *bool
 	dedicatedContainerFs *bool
+	imageFsError         error
+	containerFsError     error
 }
 
 // HasDedicatedImageFs returns the mocked value
 func (m *mockDiskInfoProvider) HasDedicatedImageFs(_ context.Context) (bool, error) {
+	if m.imageFsError != nil {
+		return false, m.imageFsError
+	}
 	return ptr.Deref(m.dedicatedImageFs, false), nil
 }
 
 // HasDedicatedContainerFs returns the mocked value
 func (m *mockDiskInfoProvider) HasDedicatedContainerFs(_ context.Context) (bool, error) {
+	if m.containerFsError != nil {
+		return false, m.containerFsError
+	}
 	return ptr.Deref(m.dedicatedContainerFs, false), nil
 }
 
@@ -3296,3 +3304,108 @@ func TestContainerEphemeralStorageLimitEvictionForRestartableInitContainers(t *t
 		t.Fatalf("Expected evicted pod %q, got %v", pod.Name, evictedPods)
 	}
 }
+
+func TestSynchronizeHasDedicatedImageFsError(t *testing.T) {
+	_, tCtx := ktesting.NewTestContext(t)
+	fakeClock := testingclock.NewFakeClock(time.Now())
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+			UID:       types.UID("test-pod-uid"),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "test-container",
+					Image: "image",
+				},
+			},
+		},
+	}
+
+	// Configure memory threshold and disk threshold
+	config := Config{
+		Thresholds: []evictionapi.Threshold{
+			{
+				Signal:   evictionapi.SignalMemoryAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: resource.NewQuantity(100, resource.BinarySI),
+				},
+			},
+			{
+				Signal:   evictionapi.SignalNodeFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: resource.NewQuantity(100, resource.BinarySI),
+				},
+			},
+		},
+	}
+
+	// Memory stat triggers threshold (available 50 < 100)
+	summaryProvider := &fakeSummaryProvider{
+		result: statsapi.Summary{
+			Node: statsapi.NodeStats{
+				Memory: &statsapi.MemoryStats{
+					AvailableBytes:  ptr.To(uint64(50)),
+					WorkingSetBytes: ptr.To(uint64(1000)),
+				},
+				Fs: &statsapi.FsStats{
+					AvailableBytes: ptr.To(uint64(50)),
+					CapacityBytes:  ptr.To(uint64(1000)),
+				},
+			},
+		},
+	}
+
+	nodeRef := &v1.ObjectReference{
+		Kind: "Node",
+		Name: "test-node",
+	}
+	podKiller := &mockPodKiller{}
+
+	mgrImpl, _ := NewManager(summaryProvider, config, podKiller.killPodNow, &mockDiskGC{}, &mockDiskGC{}, &record.FakeRecorder{}, nodeRef, fakeClock, false)
+	mgr := mgrImpl.(*managerImpl)
+
+	activePodsFunc := func() []*v1.Pod {
+		return []*v1.Pod{pod}
+	}
+
+	// Step 1: diskInfoProvider returns error for HasDedicatedImageFs
+	failingDiskInfoProvider := &mockDiskInfoProvider{
+		imageFsError: fmt.Errorf("transient CRI error"),
+	}
+
+	// synchronize should NOT return an error despite HasDedicatedImageFs error
+	evictedPods, err := mgr.synchronize(tCtx, failingDiskInfoProvider, activePodsFunc)
+	if err != nil {
+		t.Fatalf("synchronize should not return error when HasDedicatedImageFs fails, got: %v", err)
+	}
+
+	// Memory pressure condition should be set, but not disk pressure (since disk signals skipped)
+	if !mgr.IsUnderMemoryPressure() {
+		t.Errorf("Expected node to be under memory pressure")
+	}
+	if mgr.IsUnderDiskPressure() {
+		t.Errorf("Expected node NOT to be under disk pressure while HasDedicatedImageFs fails")
+	}
+	if len(evictedPods) != 1 {
+		t.Errorf("Expected memory eviction to evict 1 pod, got %d", len(evictedPods))
+	}
+
+	// Step 2: subsequent sync when HasDedicatedImageFs succeeds
+	workingDiskInfoProvider := &mockDiskInfoProvider{
+		dedicatedImageFs: ptr.To(false),
+	}
+	_, err = mgr.synchronize(tCtx, workingDiskInfoProvider, activePodsFunc)
+	if err != nil {
+		t.Fatalf("synchronize should succeed when HasDedicatedImageFs succeeds, got: %v", err)
+	}
+	if !mgr.IsUnderDiskPressure() {
+		t.Errorf("Expected node to be under disk pressure after HasDedicatedImageFs succeeds")
+	}
+}
+

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -1147,13 +1147,18 @@ func isAllocatableEvictionThreshold(threshold evictionapi.Threshold) bool {
 	return threshold.Signal == evictionapi.SignalAllocatableMemoryAvailable
 }
 
-// buildSignalToRankFunc returns ranking functions associated with resources
-func buildSignalToRankFunc(withImageFs bool, imageContainerSplitFs bool) map[evictionapi.Signal]rankFunc {
-	signalToRankFunc := map[evictionapi.Signal]rankFunc{
+// buildNonDiskSignalToRankFunc returns ranking functions for non-disk resources (memory, PID)
+func buildNonDiskSignalToRankFunc() map[evictionapi.Signal]rankFunc {
+	return map[evictionapi.Signal]rankFunc{
 		evictionapi.SignalMemoryAvailable:            rankMemoryPressure,
 		evictionapi.SignalAllocatableMemoryAvailable: rankMemoryPressure,
 		evictionapi.SignalPIDAvailable:               rankPIDPressure,
 	}
+}
+
+// buildSignalToRankFunc returns ranking functions associated with resources
+func buildSignalToRankFunc(withImageFs bool, imageContainerSplitFs bool) map[evictionapi.Signal]rankFunc {
+	signalToRankFunc := buildNonDiskSignalToRankFunc()
 	// usage of an imagefs is optional
 	// We have a dedicated Image filesystem (images and containers are on same disk)
 	// then we assume it is just a separate imagefs
@@ -1316,3 +1321,27 @@ func getThresholdMetInfo(resourceToReclaim v1.ResourceName, thresholds []evictio
 	}
 	return nil, nil
 }
+
+// hasDiskSignal returns true if the signal is a disk-related signal.
+func hasDiskSignal(signal evictionapi.Signal) bool {
+	switch signal {
+	case evictionapi.SignalNodeFsAvailable, evictionapi.SignalNodeFsInodesFree,
+		evictionapi.SignalImageFsAvailable, evictionapi.SignalImageFsInodesFree,
+		evictionapi.SignalContainerFsAvailable, evictionapi.SignalContainerFsInodesFree:
+		return true
+	default:
+		return false
+	}
+}
+
+// filterDiskThresholds returns a new slice of thresholds with disk-related signals removed.
+func filterDiskThresholds(thresholds []evictionapi.Threshold) []evictionapi.Threshold {
+	var filtered []evictionapi.Threshold
+	for _, threshold := range thresholds {
+		if !hasDiskSignal(threshold.Signal) {
+			filtered = append(filtered, threshold)
+		}
+	}
+	return filtered
+}
+


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Refactors `HasDedicatedImageFs` error handling in the kubelet eviction manager so that transient failures from `HasDedicatedImageFs` do not block the eviction control loop.

When `HasDedicatedImageFs` returns an error, the eviction manager logs the error and continues execution for the current cycle by skipping disk-related thresholds and local storage capacity isolation evictions. Non-disk eviction thresholds (memory, allocatable memory, PID) continue to be evaluated, node conditions (`NodeMemoryPressure`, `NodePIDPressure`) are updated, and non-disk evictions proceed normally. On subsequent sync cycles, `HasDedicatedImageFs` is retried until it succeeds.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/141119

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
