### PR TITLE
HPA: preserve spec replicas when average-value metrics are within tolerance

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -615,7 +615,7 @@ func (a *HorizontalController) computeStatusForObjectMetric(specReplicas, status
 		*status = metricStatus
 		return replicaCountProposal, timestampProposal, fmt.Sprintf("%s metric %s", metricSpec.Object.DescribedObject.Kind, metricSpec.Object.Metric.Name), autoscalingv2.HorizontalPodAutoscalerCondition{}, nil
 	} else if metricSpec.Object.Target.Type == autoscalingv2.AverageValueMetricType && metricSpec.Object.Target.AverageValue != nil {
-		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetObjectPerPodMetricReplicas(statusReplicas, metricSpec.Object.Target.AverageValue.MilliValue(), metricSpec.Object.Metric.Name, tolerances, hpa.Namespace, &metricSpec.Object.DescribedObject, metricSelector)
+		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetObjectPerPodMetricReplicas(specReplicas, statusReplicas, metricSpec.Object.Target.AverageValue.MilliValue(), metricSpec.Object.Metric.Name, tolerances, hpa.Namespace, &metricSpec.Object.DescribedObject, metricSelector)
 		if err != nil {
 			condition := a.getUnableComputeReplicaCountCondition(hpa, "FailedGetObjectMetric", err)
 			return 0, time.Time{}, "", condition, fmt.Errorf("failed to get %s object metric: %w", metricSpec.Object.Metric.Name, err)
@@ -754,7 +754,7 @@ func (a *HorizontalController) computeStatusForContainerResourceMetric(ctx conte
 func (a *HorizontalController) computeStatusForExternalMetric(specReplicas, statusReplicas int32, metricSpec autoscalingv2.MetricSpec, hpa *autoscalingv2.HorizontalPodAutoscaler, selector labels.Selector, status *autoscalingv2.MetricStatus) (replicaCountProposal int32, timestampProposal time.Time, metricNameProposal string, condition autoscalingv2.HorizontalPodAutoscalerCondition, err error) {
 	tolerances := a.tolerancesForHpa(hpa)
 	if metricSpec.External.Target.AverageValue != nil {
-		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetExternalPerPodMetricReplicas(statusReplicas, metricSpec.External.Target.AverageValue.MilliValue(), metricSpec.External.Metric.Name, tolerances, hpa.Namespace, metricSpec.External.Metric.Selector)
+		replicaCountProposal, usageProposal, timestampProposal, err := a.replicaCalc.GetExternalPerPodMetricReplicas(specReplicas, statusReplicas, metricSpec.External.Target.AverageValue.MilliValue(), metricSpec.External.Metric.Name, tolerances, hpa.Namespace, metricSpec.External.Metric.Selector)
 		if err != nil {
 			condition = a.getUnableComputeReplicaCountCondition(hpa, "FailedGetExternalMetric", err)
 			return 0, time.Time{}, "", condition, fmt.Errorf("failed to get %s external metric: %w", metricSpec.External.Metric.Name, err)

--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -307,16 +307,22 @@ func (c *ReplicaCalculator) getUsageRatioReplicaCount(currentReplicas int32, usa
 }
 
 // GetObjectPerPodMetricReplicas calculates the desired replica count based on a target metric usage (as a milli-value)
-// for the given object in the given namespace, and the current replica count.
-func (c *ReplicaCalculator) GetObjectPerPodMetricReplicas(statusReplicas int32, targetAverageUsage int64, metricName string, tolerances Tolerances, namespace string, objectRef *autoscaling.CrossVersionObjectReference, metricSelector labels.Selector) (replicaCount int32, usage int64, timestamp time.Time, err error) {
+// for the given object in the given namespace.
+//
+// statusReplicas is used only to evaluate utilization (how load is currently
+// distributed). When the ratio is within tolerance, specReplicas is returned so
+// transient status drift (e.g. rolling-update surge or lag) does not rewrite the
+// desired scale. See https://github.com/kubernetes/kubernetes/issues/138505.
+func (c *ReplicaCalculator) GetObjectPerPodMetricReplicas(specReplicas, statusReplicas int32, targetAverageUsage int64, metricName string, tolerances Tolerances, namespace string, objectRef *autoscaling.CrossVersionObjectReference, metricSelector labels.Selector) (replicaCount int32, usage int64, timestamp time.Time, err error) {
 	usage, timestamp, err = c.metricsClient.GetObjectMetric(metricName, namespace, objectRef, metricSelector)
 	if err != nil {
 		return 0, 0, time.Time{}, fmt.Errorf("unable to get metric %s on %s %s/%s: %w", metricName, objectRef.Kind, namespace, objectRef.Name, err)
 	}
 
-	replicaCount = statusReplicas
-	usageRatio := float64(usage) / (float64(targetAverageUsage) * float64(replicaCount))
-	if !tolerances.isWithin(usageRatio) {
+	usageRatio := float64(usage) / (float64(targetAverageUsage) * float64(statusReplicas))
+	if tolerances.isWithin(usageRatio) {
+		replicaCount = specReplicas
+	} else {
 		// update number of replicas if change is large enough
 		replicaCount = int32(math.Ceil(float64(usage) / float64(targetAverageUsage)))
 	}
@@ -378,8 +384,13 @@ func (c *ReplicaCalculator) GetExternalMetricReplicas(currentReplicas int32, tar
 
 // GetExternalPerPodMetricReplicas calculates the desired replica count based on a
 // target metric value per pod (as a milli-value) for the external metric in the
-// given namespace, and the current replica count.
-func (c *ReplicaCalculator) GetExternalPerPodMetricReplicas(statusReplicas int32, targetUsagePerPod int64, metricName string, tolerances Tolerances, namespace string, metricSelector *metav1.LabelSelector) (replicaCount int32, usage int64, timestamp time.Time, err error) {
+// given namespace.
+//
+// statusReplicas is used only to evaluate utilization (how load is currently
+// distributed). When the ratio is within tolerance, specReplicas is returned so
+// transient status drift (e.g. rolling-update surge or lag) does not rewrite the
+// desired scale. See https://github.com/kubernetes/kubernetes/issues/138505.
+func (c *ReplicaCalculator) GetExternalPerPodMetricReplicas(specReplicas, statusReplicas int32, targetUsagePerPod int64, metricName string, tolerances Tolerances, namespace string, metricSelector *metav1.LabelSelector) (replicaCount int32, usage int64, timestamp time.Time, err error) {
 	metricLabelSelector, err := metav1.LabelSelectorAsSelector(metricSelector)
 	if err != nil {
 		return 0, 0, time.Time{}, err
@@ -398,9 +409,10 @@ func (c *ReplicaCalculator) GetExternalPerPodMetricReplicas(statusReplicas int32
 		}
 	}
 
-	replicaCount = statusReplicas
-	usageRatio := float64(usage) / (float64(targetUsagePerPod) * float64(replicaCount))
-	if !tolerances.isWithin(usageRatio) {
+	usageRatio := float64(usage) / (float64(targetUsagePerPod) * float64(statusReplicas))
+	if tolerances.isWithin(usageRatio) {
+		replicaCount = specReplicas
+	} else {
 		// update number of replicas if the change is large enough
 		replicaCountResult := math.Ceil(float64(usage) / float64(targetUsagePerPod))
 		// Ensure that the result exceeds the bounds of an int32

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -199,6 +199,11 @@ type perPodMetricCase struct {
 	name    string
 	fixture calcScenario
 
+	// statusReplicas is the observed scale.Status.Replicas used for the
+	// utilization ratio. Zero means use fixture.currentReplicas (stable case).
+	// fixture.currentReplicas is treated as scale.Spec.Replicas.
+	statusReplicas int32
+
 	perPodTargetUsage int64
 	expectedReplicas  int32
 	expectedUsage     int64
@@ -939,6 +944,30 @@ func TestReplicaCalcExternalPerPodMetric(t *testing.T) {
 			expectedReplicas:  4,
 			expectedUsage:     2867,
 		},
+		// Regression for https://github.com/kubernetes/kubernetes/issues/138505:
+		// within-tolerance must preserve spec.replicas when status drifts (surge/lag).
+		{
+			name: "within tolerance with status surge keeps spec replicas",
+			fixture: calcScenario{
+				currentReplicas: 22,
+				metric:          externalPerPodMetric(22),
+			},
+			statusReplicas:    23,
+			perPodTargetUsage: 1,
+			expectedReplicas:  22,
+			expectedUsage:     1,
+		},
+		{
+			name: "within tolerance with status lag keeps spec replicas",
+			fixture: calcScenario{
+				currentReplicas: 22,
+				metric:          externalPerPodMetric(22),
+			},
+			statusReplicas:    21,
+			perPodTargetUsage: 1,
+			expectedReplicas:  22,
+			expectedUsage:     2, // ceil(22/21)
+		},
 	}
 
 	for _, tc := range cases {
@@ -947,8 +976,12 @@ func TestReplicaCalcExternalPerPodMetric(t *testing.T) {
 			if tc.tolerances != nil {
 				h.tolerances = *tc.tolerances
 			}
+			statusReplicas := tc.fixture.currentReplicas
+			if tc.statusReplicas != 0 {
+				statusReplicas = tc.statusReplicas
+			}
 			replicas, usage, ts, err := h.calc.GetExternalPerPodMetricReplicas(
-				tc.fixture.currentReplicas, tc.perPodTargetUsage, tc.fixture.metric.name,
+				tc.fixture.currentReplicas, statusReplicas, tc.perPodTargetUsage, tc.fixture.metric.name,
 				h.tolerances, h.namespace, tc.fixture.metric.selector,
 			)
 			assertMetricReplicas(t,
@@ -1208,6 +1241,29 @@ func TestReplicaCalcObjectPerPodMetric(t *testing.T) {
 			expectedReplicas:  5,
 			expectedUsage:     5052,
 		},
+		// Regression for https://github.com/kubernetes/kubernetes/issues/138505.
+		{
+			name: "within tolerance with status surge keeps spec replicas",
+			fixture: calcScenario{
+				currentReplicas: 22,
+				metric:          perPodMetric(22),
+			},
+			statusReplicas:    23,
+			perPodTargetUsage: 1,
+			expectedReplicas:  22,
+			expectedUsage:     1,
+		},
+		{
+			name: "within tolerance with status lag keeps spec replicas",
+			fixture: calcScenario{
+				currentReplicas: 22,
+				metric:          perPodMetric(22),
+			},
+			statusReplicas:    21,
+			perPodTargetUsage: 1,
+			expectedReplicas:  22,
+			expectedUsage:     2, // ceil(22/21)
+		},
 	}
 
 	for _, tc := range cases {
@@ -1216,8 +1272,12 @@ func TestReplicaCalcObjectPerPodMetric(t *testing.T) {
 			if tc.tolerances != nil {
 				h.tolerances = *tc.tolerances
 			}
+			statusReplicas := tc.fixture.currentReplicas
+			if tc.statusReplicas != 0 {
+				statusReplicas = tc.statusReplicas
+			}
 			replicas, usage, ts, err := h.calc.GetObjectPerPodMetricReplicas(
-				tc.fixture.currentReplicas, tc.perPodTargetUsage, tc.fixture.metric.name,
+				tc.fixture.currentReplicas, statusReplicas, tc.perPodTargetUsage, tc.fixture.metric.name,
 				h.tolerances, h.namespace, tc.fixture.metric.singleObject, nil,
 			)
 			assertMetricReplicas(t,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For External and Object metrics that use `AverageValue`, the HPA replica
calculator used `scale.Status.Replicas` as the desired count when utilization
was inside the tolerance range.

"Within tolerance" is meant to mean "do not change the scale". But status can
be higher than spec during a rolling update (for example because of maxSurge).
In that case HPA wrote status back into spec and the workload scaled up even
when the metric did not ask for more pods. The same problem can scale down
when status is temporarily lower than spec.

This can also affect Cluster Autoscaler: an extra pod may go Pending and cause
an unnecessary node scale-up.

**Fix:** still use status to compute the utilization ratio (how load is shared
right now). When the ratio is within tolerance, return `scale.Spec.Replicas`
so the desired scale does not change. Outside tolerance the old formula is
unchanged: `ceil(usage / targetPerPod)`.

#### Which issue(s) this PR fixes:

Fixes #138505

#### Special notes for your reviewer:

Only these two paths were wrong:
- `GetExternalPerPodMetricReplicas`
- `GetObjectPerPodMetricReplicas`

Resource, Pods, and Value-target paths already used the scale desired count.

**AI assistance:** AI tools were used to help investigate the issue, implement
the fix, and draft this PR. I reviewed the change and the unit tests myself.

#### Does this PR introduce a user-facing change?

```release-note
HPA no longer scales a workload only because scale status moved away from spec during a rolling update, when External or Object AverageValue metrics are still within tolerance.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```