### PR TITLE
client-go: replace deprecated wait.PollXxx calls with context-based alternatives

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -243,7 +243,7 @@ func TestHammerController(t *testing.T) {
 	}()
 
 	// Let's wait for the controller to do its initial sync
-	wait.Poll(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, false, func(_ context.Context) (bool, error) {
 		return controller.HasSynced(), nil
 	})
 	if !controller.HasSynced() {

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -64,7 +65,7 @@ func TestMutationDetector(t *testing.T) {
 
 	fakeWatch.Add(pod)
 
-	wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+	wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, wait.ForeverTestTimeout, true, func(_ context.Context) (bool, error) {
 		detector.addedObjsLock.Lock()
 		addedLen := len(detector.addedObjs)
 		detector.addedObjsLock.Unlock()

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -536,16 +536,16 @@ func WaitForNamedCacheSyncWithContext(ctx context.Context, cacheSyncs ...Informe
 // if the controller should shutdown
 // callers should prefer WaitForNamedCacheSync()
 func WaitForCacheSync(stopCh <-chan struct{}, cacheSyncs ...InformerSynced) bool {
-	err := wait.PollImmediateUntil(syncedPollPeriod,
-		func() (bool, error) {
+	ctx := wait.ContextForChannel(stopCh)
+	err := wait.PollUntilContextCancel(ctx, syncedPollPeriod, true,
+		func(_ context.Context) (bool, error) {
 			for _, syncFunc := range cacheSyncs {
 				if !syncFunc() {
 					return false, nil
 				}
 			}
 			return true, nil
-		},
-		stopCh)
+		})
 	if err != nil {
 		return false
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -95,7 +95,7 @@ func (l *testListener) handle(obj interface{}) {
 
 func (l *testListener) ok() bool {
 	l.println("polling")
-	err := wait.PollImmediate(100*time.Millisecond, 2*time.Second, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 2*time.Second, true, func(_ context.Context) (bool, error) {
 		if l.satisfiedExpectations() {
 			return true, nil
 		}
@@ -1012,7 +1012,7 @@ func TestAddOnStoppedSharedInformer(t *testing.T) {
 	defer wg.Wait()
 	close(stop)
 
-	err := wait.PollImmediate(100*time.Millisecond, 2*time.Second, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 2*time.Second, true, func(_ context.Context) (bool, error) {
 		if informer.IsStopped() {
 			return true, nil
 		}

--- a/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
@@ -206,8 +206,8 @@ func TestEventSeriesWithEventSinkImplRace(t *testing.T) {
 	recorder.Eventf(&v1.ObjectReference{}, nil, v1.EventTypeNormal, "reason", "action", "", "")
 	recorder.Eventf(&v1.ObjectReference{}, nil, v1.EventTypeNormal, "reason", "action", "", "")
 
-	err := wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (done bool, err error) {
-		events, err := kubeClient.EventsV1().Events(metav1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
+	err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (done bool, err error) {
+		events, err := kubeClient.EventsV1().Events(metav1.NamespaceDefault).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/retrywatcher_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package watch
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -613,7 +614,7 @@ func TestRetryWatcher(t *testing.T) {
 			var counter uint32
 			// We always count with the last watch reestablishing which is imminent but still a race.
 			// We will wait for the last watch to reestablish to avoid it.
-			err = wait.PollImmediate(10*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+			err = wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 10*time.Second, true, func(_ context.Context) (done bool, err error) {
 				counter = atomic.LoadUint32(atomicCounter)
 				return counter == tc.watchCount, nil
 			})

--- a/staging/src/k8s.io/client-go/transport/cert_rotation.go
+++ b/staging/src/k8s.io/client-go/transport/cert_rotation.go
@@ -18,6 +18,7 @@ package transport
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"reflect"
 	"sync"
@@ -143,10 +144,10 @@ func (c *dynamicClientCert) run(stopCh <-chan struct{}) {
 
 	go wait.Until(c.runWorker, time.Second, stopCh)
 
-	go wait.PollImmediateUntil(CertCallbackRefreshDuration, func() (bool, error) {
+	go wait.PollUntilContextCancel(wait.ContextForChannel(stopCh), CertCallbackRefreshDuration, true, func(_ context.Context) (bool, error) {
 		c.queue.Add(workItemKey)
 		return false, nil
-	}, stopCh)
+	})
 
 	<-stopCh
 }

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workqueue
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -53,7 +54,7 @@ func TestSimpleQueue(t *testing.T) {
 	// step past the next heartbeat
 	fakeClock.Step(10 * time.Second)
 
-	err := wait.Poll(1*time.Millisecond, 30*time.Millisecond, func() (done bool, err error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 1*time.Millisecond, 30*time.Millisecond, false, func(_ context.Context) (done bool, err error) {
 		if q.Len() > 0 {
 			return false, fmt.Errorf("added to queue")
 		}
@@ -230,7 +231,7 @@ func BenchmarkDelayingQueue_AddAfter(b *testing.B) {
 }
 
 func waitForAdded(q DelayingInterface, depth int) error {
-	return wait.Poll(1*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 1*time.Millisecond, 10*time.Second, false, func(_ context.Context) (done bool, err error) {
 		if q.Len() == depth {
 			return true, nil
 		}
@@ -240,7 +241,7 @@ func waitForAdded(q DelayingInterface, depth int) error {
 }
 
 func waitForWaitingQueueToFill(q DelayingInterface) error {
-	return wait.Poll(1*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+	return wait.PollUntilContextTimeout(context.Background(), 1*time.Millisecond, 10*time.Second, false, func(_ context.Context) (done bool, err error) {
 		if len(q.(*delayingType[any]).waitingForAddCh) == 0 {
 			return true, nil
 		}

--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workqueue_test
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"sync"
@@ -452,7 +453,7 @@ func mustGarbageCollect(t *testing.T, i interface{}) {
 		atomic.StoreInt32(&collected, 1)
 	})
 	t.Cleanup(func() {
-		if err := wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (done bool, err error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), time.Millisecond*100, wait.ForeverTestTimeout, true, func(_ context.Context) (done bool, err error) {
 			// Trigger GC explicitly, otherwise we may need to wait a long time for it to run
 			runtime.GC()
 			return atomic.LoadInt32(&collected) == 1, nil


### PR DESCRIPTION
## What

Replace all deprecated `wait.Poll`, `wait.PollImmediate`, and `wait.PollImmediateUntil` calls in `staging/src/k8s.io/client-go/` with the recommended context-based replacements from `k8s.io/apimachinery/pkg/util/wait`.

## Why

These functions are all marked as deprecated:

- `wait.PollImmediateUntil` → use `wait.PollUntilContextCancel`
- `wait.PollImmediate` → use `wait.PollUntilContextTimeout` (with `immediate=true`)
- `wait.Poll` → use `wait.PollUntilContextTimeout` (with `immediate=false`)

The deprecation notes state these will be removed in a future release and that the new context-based variants provide better error handling via context cancellation.

Ref: #138353

## Changes

### Production code
- **`tools/cache/shared_informer.go`**: `WaitForCacheSync` — `PollImmediateUntil(stopCh)` → `PollUntilContextCancel(ContextForChannel(stopCh), ..., true, ...)`
- **`transport/cert_rotation.go`**: `dynamicClientCert.run` — `PollImmediateUntil(stopCh)` → `PollUntilContextCancel(ContextForChannel(stopCh), ..., true, ...)`

### Test code
- **`tools/events/eventseries_test.go`**: `PollImmediate` → `PollUntilContextTimeout(context.Background(), ..., true, ...)`
- **`tools/watch/retrywatcher_test.go`**: `PollImmediate` → `PollUntilContextTimeout(context.Background(), ..., true, ...)`
- **`util/workqueue/delaying_queue_test.go`**: `Poll` → `PollUntilContextTimeout(context.Background(), ..., false, ...)`
- **`util/workqueue/queue_test.go`**: `PollImmediate` → `PollUntilContextTimeout(context.Background(), ..., true, ...)`
- **`tools/cache/shared_informer_test.go`**: `PollImmediate` → `PollUntilContextTimeout(context.Background(), ..., true, ...)` (2 sites)
- **`tools/cache/controller_test.go`**: `Poll` → `PollUntilContextTimeout(context.Background(), ..., false, ...)`
- **`tools/cache/mutation_detector_test.go`**: `PollImmediate` → `PollUntilContextTimeout(context.Background(), ..., true, ...)`

## Testing

No behavioral changes. The `immediate` flag preserves the original first-invocation semantics:
- `PollImmediate*` → `immediate=true` (condition called before first interval wait)
- `Poll*` → `immediate=false` (condition called after first interval wait)