### PR TITLE
scheduler: make cache dumper log nodes as struct in JSON, string in text

### DIFF
--- a/pkg/scheduler/backend/cache/debugger/dumper.go
+++ b/pkg/scheduler/backend/cache/debugger/dumper.go
@@ -44,45 +44,150 @@ func (d *CacheDumper) DumpAll(logger klog.Logger) {
 // dumpNodes writes NodeInfo to the scheduler logs.
 func (d *CacheDumper) dumpNodes(logger klog.Logger) {
 	dump := d.cache.Dump()
-	nodeInfos := make([]string, 0, len(dump.Nodes))
+	nodes := make(nodeDumps, 0, len(dump.Nodes))
 	for name, nodeInfo := range dump.Nodes {
-		nodeInfos = append(nodeInfos, d.printNodeInfo(name, nodeInfo))
+		nodes = append(nodes, d.dumpNodeInfo(name, nodeInfo))
 	}
-	// Extra blank line added between node entries for readability.
-	logger.Info("Dump of cached NodeInfo", "nodes", strings.Join(nodeInfos, "\n\n"))
+	logger.Info("Dump of cached NodeInfo", "nodes", nodes)
 }
 
 // dumpSchedulingQueue writes pods in the scheduling queue to the scheduler logs.
 func (d *CacheDumper) dumpSchedulingQueue(logger klog.Logger) {
 	pendingPods, s := d.podQueue.PendingPods()
-	var podData strings.Builder
+	pods := make(podDumps, 0, len(pendingPods))
 	for _, p := range pendingPods {
-		podData.WriteString(printPod(p))
+		pods = append(pods, dumpPod(p))
 	}
-	logger.Info("Dump of scheduling queue", "summary", s, "pods", podData.String())
+	logger.Info("Dump of scheduling queue", "summary", s, "pods", pods)
 }
 
-// printNodeInfo writes parts of NodeInfo to a string.
-func (d *CacheDumper) printNodeInfo(name string, n *framework.NodeInfo) string {
-	var nodeData strings.Builder
-	nodeData.WriteString(fmt.Sprintf("Node name: %s\nDeleted: %t\nRequested Resources: %+v\nAllocatable Resources:%+v\nScheduled Pods(number: %v):\n",
-		name, n.Node() == nil, n.Requested, n.Allocatable, len(n.Pods)))
-	// Dumping Pod Info
+// dumpNodeInfo collects the parts of NodeInfo that are useful for debugging.
+func (d *CacheDumper) dumpNodeInfo(name string, n *framework.NodeInfo) nodeDump {
+	pods := make(podDumps, 0, len(n.Pods))
 	for _, p := range n.Pods {
-		nodeData.WriteString(printPod(p.GetPod()))
+		pods = append(pods, dumpPod(p.GetPod()))
 	}
-	// Dumping nominated pods info on the node
-	nominatedPodInfos := d.podQueue.NominatedPodsForNode(name)
-	if len(nominatedPodInfos) != 0 {
-		nodeData.WriteString(fmt.Sprintf("Nominated Pods(number: %v):\n", len(nominatedPodInfos)))
-		for _, pi := range nominatedPodInfos {
-			nodeData.WriteString(printPod(pi.GetPod()))
+	nominated := d.podQueue.NominatedPodsForNode(name)
+	nominatedPods := make(podDumps, 0, len(nominated))
+	for _, pi := range nominated {
+		nominatedPods = append(nominatedPods, dumpPod(pi.GetPod()))
+	}
+	return nodeDump{
+		Name:          name,
+		Deleted:       n.Node() == nil,
+		Requested:     newResourceDump(n.Requested),
+		Allocatable:   newResourceDump(n.Allocatable),
+		Pods:          pods,
+		NominatedPods: nominatedPods,
+	}
+}
+
+// dumpPod collects the parts of a Pod object that are useful for debugging.
+func dumpPod(p *v1.Pod) podDump {
+	return podDump{
+		Name:          p.Name,
+		Namespace:     p.Namespace,
+		UID:           string(p.UID),
+		Phase:         p.Status.Phase,
+		NominatedNode: p.Status.NominatedNodeName,
+	}
+}
+
+// resourceDump is a loggable view of framework.Resource.
+type resourceDump struct {
+	MilliCPU         int64                     `json:"milliCPU"`
+	Memory           int64                     `json:"memory"`
+	EphemeralStorage int64                     `json:"ephemeralStorage"`
+	AllowedPodNumber int                       `json:"allowedPodNumber"`
+	ScalarResources  map[v1.ResourceName]int64 `json:"scalarResources,omitempty"`
+}
+
+func newResourceDump(r *framework.Resource) resourceDump {
+	if r == nil {
+		return resourceDump{}
+	}
+	return resourceDump{
+		MilliCPU:         r.MilliCPU,
+		Memory:           r.Memory,
+		EphemeralStorage: r.EphemeralStorage,
+		AllowedPodNumber: r.AllowedPodNumber,
+		ScalarResources:  r.ScalarResources,
+	}
+}
+
+// podDump is a loggable view of a Pod.
+type podDump struct {
+	Name          string      `json:"name"`
+	Namespace     string      `json:"namespace"`
+	UID           string      `json:"uid"`
+	Phase         v1.PodPhase `json:"phase"`
+	NominatedNode string      `json:"nominatedNode,omitempty"`
+}
+
+func (p podDump) String() string {
+	return fmt.Sprintf("name: %v, namespace: %v, uid: %v, phase: %v, nominated node: %v",
+		p.Name, p.Namespace, p.UID, p.Phase, p.NominatedNode)
+}
+
+// nodeDump is a loggable view of framework.NodeInfo.
+type nodeDump struct {
+	Name          string       `json:"name"`
+	Deleted       bool         `json:"deleted"`
+	Requested     resourceDump `json:"requested"`
+	Allocatable   resourceDump `json:"allocatable"`
+	Pods          podDumps     `json:"pods"`
+	NominatedPods podDumps     `json:"nominatedPods,omitempty"`
+}
+
+func (n nodeDump) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Node name: %s\nDeleted: %t\nRequested Resources: %+v\nAllocatable Resources: %+v\nScheduled Pods(number: %v):\n",
+		n.Name, n.Deleted, n.Requested, n.Allocatable, len(n.Pods))
+	for _, p := range n.Pods {
+		fmt.Fprintf(&b, "%s\n", p.String())
+	}
+	if len(n.NominatedPods) != 0 {
+		fmt.Fprintf(&b, "Nominated Pods(number: %v):\n", len(n.NominatedPods))
+		for _, p := range n.NominatedPods {
+			fmt.Fprintf(&b, "%s\n", p.String())
 		}
 	}
-	return nodeData.String()
+	return b.String()
 }
 
-// printPod writes parts of a Pod object to a string.
-func printPod(p *v1.Pod) string {
-	return fmt.Sprintf("name: %v, namespace: %v, uid: %v, phase: %v, nominated node: %v\n", p.Name, p.Namespace, p.UID, p.Status.Phase, p.Status.NominatedNodeName)
+// podDumps renders as readable multi-line text when logged in text format
+// (via String) and as a JSON array of objects in JSON format (via MarshalLog).
+type podDumps []podDump
+
+func (ps podDumps) String() string {
+	var b strings.Builder
+	for _, p := range ps {
+		fmt.Fprintf(&b, "%s\n", p.String())
+	}
+	return b.String()
+}
+
+// MarshalLog returns a plain slice so that the JSON logging backend encodes it
+// as an array of structs instead of as the String() representation.
+func (ps podDumps) MarshalLog() any {
+	return []podDump(ps)
+}
+
+// nodeDumps renders as readable multi-line text when logged in text format
+// (via String) and as a JSON array of objects in JSON format (via MarshalLog).
+type nodeDumps []nodeDump
+
+func (ns nodeDumps) String() string {
+	entries := make([]string, 0, len(ns))
+	for _, n := range ns {
+		entries = append(entries, n.String())
+	}
+	// Extra blank line added between node entries for readability.
+	return strings.Join(entries, "\n\n")
+}
+
+// MarshalLog returns a plain slice so that the JSON logging backend encodes it
+// as an array of structs instead of as the String() representation.
+func (ns nodeDumps) MarshalLog() any {
+	return []nodeDump(ns)
 }

--- a/pkg/scheduler/backend/cache/debugger/dumper_format_test.go
+++ b/pkg/scheduler/backend/cache/debugger/dumper_format_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debugger
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/api/core/v1"
+	componentbasejson "k8s.io/component-base/logs/json"
+	"k8s.io/klog/v2/textlogger"
+)
+
+func sampleNodes() nodeDumps {
+	return nodeDumps{{
+		Name:        "node-1",
+		Deleted:     false,
+		Requested:   resourceDump{MilliCPU: 1500, Memory: 2147483648},
+		Allocatable: resourceDump{MilliCPU: 4000, Memory: 8589934592},
+		Pods: podDumps{
+			{Name: "web-0", Namespace: "default", UID: "a1b2", Phase: v1.PodRunning},
+		},
+		NominatedPods: podDumps{
+			{Name: "batch-9", Namespace: "default", UID: "e5f6", Phase: v1.PodPending, NominatedNode: "node-1"},
+		},
+	}}
+}
+
+// TestDumpNodesTextFormat verifies the text backend renders nodes as the
+// readable multi-line value (via String), using klog's line-continuation.
+func TestDumpNodesTextFormat(t *testing.T) {
+	var buf bytes.Buffer
+	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Output(&buf)))
+	logger.Info("Dump of cached NodeInfo", "nodes", sampleNodes())
+
+	out := buf.String()
+	t.Logf("text output:\n%s", out)
+	for _, want := range []string{
+		"nodes=<",           // multi-line value delimiter
+		"Node name: node-1", // human-readable field
+		"name: web-0",       // scheduled pod
+		"Nominated Pods",    // nominated section
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output missing %q", want)
+		}
+	}
+	// Must NOT be a flattened single-line escaped string.
+	if strings.Contains(out, `nodes="`) {
+		t.Errorf("nodes was emitted as a quoted string, expected multi-line block:\n%s", out)
+	}
+}
+
+// TestDumpNodesJSONFormat verifies the JSON backend (zap/zapr) encodes nodes as
+// a nested array of structs (via MarshalLog), not as an escaped string.
+func TestDumpNodesJSONFormat(t *testing.T) {
+	var buf bytes.Buffer
+	logger, _ := componentbasejson.NewJSONLogger(0, zapcore.AddSync(&buf), nil, nil)
+	logger.Info("Dump of cached NodeInfo", "nodes", sampleNodes())
+
+	out := buf.Bytes()
+	t.Logf("json output:\n%s", out)
+
+	var entry struct {
+		Nodes []struct {
+			Name        string `json:"name"`
+			Deleted     bool   `json:"deleted"`
+			Allocatable struct {
+				MilliCPU int64 `json:"milliCPU"`
+			} `json:"allocatable"`
+			Pods []struct {
+				Name string `json:"name"`
+			} `json:"pods"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal(out, &entry); err != nil {
+		t.Fatalf("output is not a JSON object with a structured nodes field (got escaped string?): %v\n%s", err, out)
+	}
+	if len(entry.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(entry.Nodes))
+	}
+	n := entry.Nodes[0]
+	if n.Name != "node-1" || n.Allocatable.MilliCPU != 4000 || len(n.Pods) != 1 || n.Pods[0].Name != "web-0" {
+		t.Errorf("nodes not encoded as queryable struct: %+v", n)
+	}
+}

--- a/pkg/scheduler/backend/cache/debugger/dumper_format_test.go
+++ b/pkg/scheduler/backend/cache/debugger/dumper_format_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debugger
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/api/core/v1"
+	componentbasejson "k8s.io/component-base/logs/json"
+	"k8s.io/klog/v2/textlogger"
+)
+
+func sampleNodes() nodeDumps {
+	return nodeDumps{{
+		Name:        "node-1",
+		Deleted:     false,
+		Requested:   resourceDump{MilliCPU: 1500, Memory: 2147483648},
+		Allocatable: resourceDump{MilliCPU: 4000, Memory: 8589934592},
+		Pods: podDumps{
+			{Name: "web-0", Namespace: "default", UID: "a1b2", Phase: v1.PodRunning},
+		},
+		NominatedPods: podDumps{
+			{Name: "batch-9", Namespace: "default", UID: "e5f6", Phase: v1.PodPending, NominatedNode: "node-1"},
+		},
+	}}
+}
+
+// TestDumpNodesTextFormat verifies the text backend renders nodes as the
+// readable multi-line value (via String), using klog's line-continuation.
+func TestDumpNodesTextFormat(t *testing.T) {
+	var buf bytes.Buffer
+	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Output(&buf)))
+	logger.Info("Dump of cached NodeInfo", "nodes", sampleNodes())
+
+	out := buf.String()
+	t.Logf("text output:\n%s", out)
+	for _, want := range []string{
+		"nodes=<",           // multi-line value delimiter
+		"Node name: node-1", // human-readable field
+		"name: web-0",       // scheduled pod
+		"Nominated Pods",    // nominated section
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output missing %q", want)
+		}
+	}
+	// Must NOT be a flattened single-line escaped string.
+	if strings.Contains(out, `nodes="`) {
+		t.Errorf("nodes was emitted as a quoted string, expected multi-line block:\n%s", out)
+	}
+}
+
+// TestDumpNodesJSONFormat verifies the JSON backend (zap/zapr) encodes nodes as
+// a nested array of structs (via MarshalLog), not as an escaped string.
+func TestDumpNodesJSONFormat(t *testing.T) {
+	var buf bytes.Buffer
+	logger, _ := componentbasejson.NewJSONLogger(0, zapcore.AddSync(&buf), nil, nil)
+	logger.Info("Dump of cached NodeInfo", "nodes", sampleNodes())
+
+	out := buf.Bytes()
+	t.Logf("json output:\n%s", out)
+
+	var entry struct {
+		Nodes []struct {
+			Name        string `json:"name"`
+			Deleted     bool   `json:"deleted"`
+			Allocatable struct {
+				MilliCPU int64 `json:"milliCPU"`
+			} `json:"allocatable"`
+			Pods []struct {
+				Name string `json:"name"`
+			} `json:"pods"`
+		} `json:"nodes"`
+	}
+	if err := json.Unmarshal(out, &entry); err != nil {
+		t.Fatalf("output is not a JSON object with a structured nodes field (got escaped string?): %v\n%s", err, out)
+	}
+	if len(entry.Nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(entry.Nodes))
+	}
+	n := entry.Nodes[0]
+	if n.Name != "node-1" || n.Allocatable.MilliCPU != 4000 || len(n.Pods) != 1 || n.Pods[0].Name != "web-0" {
+		t.Errorf("nodes not encoded as queryable struct: %+v", n)
+	}
+}


### PR DESCRIPTION
The cache dumper pre-formatted NodeInfo into a single multi-line string and logged it under the "nodes" key. In JSON logging format this ends up as one escaped string, so consumers cannot query individual fields (e.g. via SQL).

Make the logged value a type that implements both fmt.Stringer and logr.Marshaler so each backend picks the right encoding:
- text backend uses String() -> readable multi-line output (unchanged)
- JSON backend uses MarshalLog() -> nested array of structs

This keeps a single log entry per dump (no line splitting) while giving JSON consumers structured, queryable data. Also structures the scheduling queue pods the same way.

Refs kubernetes#139640

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
#139640 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
support json output for scheduler dumper
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
