### PR TITLE
parsers: wrap parse errors with %w

### DIFF
--- a/pkg/util/parsers/parsers.go
+++ b/pkg/util/parsers/parsers.go
@@ -32,7 +32,7 @@ import (
 func ParseImageName(image string) (string, string, string, error) {
 	named, err := dockerref.ParseNormalizedNamed(image)
 	if err != nil {
-		return "", "", "", fmt.Errorf("couldn't parse image name %q: %v", image, err)
+		return "", "", "", fmt.Errorf("couldn't parse image name %q: %w", image, err)
 	}
 
 	repoToPull := named.Name()
@@ -60,7 +60,12 @@ func ParseCronScheduleWithPanicRecovery(schedule string) (sched cron.Schedule, e
 	defer func() {
 		if r := recover(); r != nil {
 			sched = nil
-			err = fmt.Errorf("invalid schedule format: %v", r)
+			// A recovered value is only wrap-able when it is itself an error.
+			if e, ok := r.(error); ok {
+				err = fmt.Errorf("invalid schedule format: %w", e)
+			} else {
+				err = fmt.Errorf("invalid schedule format: %v", r)
+			}
 		}
 	}()
 

--- a/pkg/util/parsers/parsers_test.go
+++ b/pkg/util/parsers/parsers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package parsers
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -56,6 +57,9 @@ func TestParseImageName(t *testing.T) {
 		case repo != testCase.Repo || tag != testCase.Tag || digest != testCase.Digest:
 			t.Errorf("Expected repo: %q, tag: %q and digest: %q, got %q, %q and %q", testCase.Repo, testCase.Tag, testCase.Digest,
 				repo, tag, digest)
+		}
+		if testCase.expectedError != "" && err != nil && errors.Unwrap(err) == nil {
+			t.Errorf("ParseImageName(%s) should wrap the underlying cause, but errors.Unwrap returned nil", testCase.Input)
 		}
 	}
 }
@@ -180,10 +184,10 @@ func TestParseCronSchedulePanicRecovery(t *testing.T) {
 				t.Errorf("Expected nil schedule for panic-causing schedule %q, but got: %v", schedule, sched)
 			}
 
-			// Error message should contain "invalid schedule format"
+			// Error message should still start with "invalid schedule format:"
 			errMsg := err.Error()
-			if !strings.Contains(errMsg, "invalid schedule format") {
-				t.Errorf("Expected error message to contain 'invalid schedule format', but got: %s", errMsg)
+			if !strings.HasPrefix(errMsg, "invalid schedule format:") {
+				t.Errorf("Expected error message to start with 'invalid schedule format:', but got: %s", errMsg)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Both error paths in `pkg/util/parsers/parsers.go` formatted the underlying error
with `%v`, which flattens it to a string and discards the wrap chain.
`ParseImageName` now wraps the `distribution/reference` parse error with `%w`, so
callers can use `errors.Is`/`errors.As` against the cause instead of
substring-matching the message. `ParseCronScheduleWithPanicRecovery` recovers an
arbitrary panic value (`any`), so it wraps with `%w` only when the recovered value
is itself an `error`, and keeps `%v` for non-error panics.

This PR was written in part with the assistance of generative AI. I have reviewed
and understand every change and take responsibility for its correctness.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

The rendered error strings are unchanged, so this is behaviour-preserving for
anyone reading `err.Error()` and strictly additive for anyone using
`errors.Is`/`errors.As`. The `invalid schedule format:` prefix is preserved, so
the existing substring matches in `pkg/apis/batch/validation` still pass. Note the
deliberate `%w`-vs-`%v` split on the recovered value: a non-`error` panic can't be
wrapped with `%w`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
