### PR TITLE
gotemplate: make include and generate errors actionable

### DIFF
--- a/cmd/gotemplate/gotemplate.go
+++ b/cmd/gotemplate/gotemplate.go
@@ -56,7 +56,7 @@ func main() {
 func generate(in io.Reader, out io.Writer, data interface{}) error {
 	var buf bytes.Buffer
 	if _, err := buf.ReadFrom(in); err != nil {
-		return fmt.Errorf("reading input: %v", err)
+		return fmt.Errorf("reading input: %w", err)
 	}
 
 	funcMap := template.FuncMap{
@@ -67,11 +67,11 @@ func generate(in io.Reader, out io.Writer, data interface{}) error {
 
 	tmpl, err := template.New("").Funcs(funcMap).Parse(buf.String())
 	if err != nil {
-		return fmt.Errorf("parsing input as text template: %v", err)
+		return fmt.Errorf("parsing input as text template: %w", err)
 	}
 
 	if err := tmpl.Execute(out, data); err != nil {
-		return fmt.Errorf("generating result: %v", err)
+		return fmt.Errorf("generating result: %w", err)
 	}
 	return nil
 }
@@ -79,7 +79,7 @@ func generate(in io.Reader, out io.Writer, data interface{}) error {
 func include(filename string) (string, error) {
 	content, err := os.ReadFile(filename)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("include %q: %w", filename, err)
 	}
 	return string(content), nil
 }

--- a/cmd/gotemplate/gotemplate_test.go
+++ b/cmd/gotemplate/gotemplate_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"io/fs"
 	"os"
 	"path"
 	"strings"
@@ -36,10 +37,14 @@ func TestGenerate(t *testing.T) {
 		files       map[string]string
 		expected    string
 		expectedErr string
+		errContains []string
+		errIs       error
 	}{
 		"missing-file": {
 			in:          `{{include "no-such-file.txt"}}`,
 			expectedErr: noFileErr.Error(),
+			errContains: []string{`include "no-such-file.txt"`},
+			errIs:       fs.ErrNotExist,
 		},
 		"data": {
 			in:       `{{.Hello}} {{.World}}`,
@@ -71,6 +76,12 @@ func TestGenerate(t *testing.T) {
 				require.Equal(t, tt.expected, out.String())
 			} else {
 				require.ErrorContains(t, err, tt.expectedErr)
+				for _, sub := range tt.errContains {
+					require.ErrorContains(t, err, sub)
+				}
+				if tt.errIs != nil {
+					require.ErrorIs(t, err, tt.errIs)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

`gotemplate` is a small codegen helper whose only UX is its error output, but two
paths dropped useful context. `include()` returned the bare `os.ReadFile` error, so
a template that includes several files didn't clearly say which one was missing. It
now wraps the error with the file name and `%w`. `generate()`'s three error paths
used `%v`, which flattens the wrap chain; they now use `%w`, so the underlying cause
(e.g. `fs.ErrNotExist`) stays inspectable via `errors.Is`/`errors.As`.

This PR was written in part with the assistance of generative AI. I have reviewed
and understand every change and take responsibility for its correctness.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

No behaviour change beyond error text; return values are unchanged and the previous
message substrings are preserved (so the existing `missing-file` test still passes).
The test is extended to assert the new `include "<file>"` context and that
`errors.Is(err, fs.ErrNotExist)` holds through both wrap layers. The pre-existing
`interface{}` in `generate`'s signature is intentionally left untouched to keep this
PR focused.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
