### PR TITLE
importverifier: improve error handling and add tests

### DIFF
--- a/cmd/importverifier/importverifier.go
+++ b/cmd/importverifier/importverifier.go
@@ -214,12 +214,12 @@ func main() {
 func loadImportRestrictions(configFile string) ([]ImportRestriction, error) {
 	config, err := os.ReadFile(configFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load configuration from %s: %v", configFile, err)
+		return nil, fmt.Errorf("failed to load configuration from %s: %w", configFile, err)
 	}
 
 	var importRestrictions []ImportRestriction
 	if err := yaml.Unmarshal(config, &importRestrictions); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal from %s: %v", configFile, err)
+		return nil, fmt.Errorf("failed to unmarshal from %s: %w", configFile, err)
 	}
 
 	return importRestrictions, nil
@@ -242,7 +242,7 @@ func resolvePackageTree(treeBase string) ([]Package, error) {
 
 	packages, err := decodePackages(bytes.NewReader(stdout))
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode packages: %v", err)
+		return nil, fmt.Errorf("failed to decode packages: %w", err)
 	}
 
 	return packages, nil
@@ -259,7 +259,7 @@ func decodePackages(r io.Reader) ([]Package, error) {
 	for decoder.More() {
 		var pkg Package
 		if err := decoder.Decode(&pkg); err != nil {
-			return nil, fmt.Errorf("invalid package: %v", err)
+			return nil, fmt.Errorf("invalid package: %w", err)
 		}
 		packages = append(packages, pkg)
 	}

--- a/cmd/importverifier/importverifier_test.go
+++ b/cmd/importverifier/importverifier_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadImportRestrictions(t *testing.T) {
+	t.Run("missing config", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "does-not-exist.json")
+		_, err := loadImportRestrictions(path)
+		if err == nil {
+			t.Fatal("expected an error for a missing config file, got nil")
+		}
+		// %w keeps the cause inspectable, so callers can match on it directly.
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Errorf("expected error to wrap fs.ErrNotExist, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "failed to load configuration from") {
+			t.Errorf("expected error to mention the config path, got: %v", err)
+		}
+	})
+
+	t.Run("malformed config", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "bad.yaml")
+		if err := os.WriteFile(path, []byte("this is not a list"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := loadImportRestrictions(path)
+		if err == nil {
+			t.Fatal("expected an error for a malformed config file, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to unmarshal from") {
+			t.Errorf("expected an unmarshal error, got: %v", err)
+		}
+		if errors.Unwrap(err) == nil {
+			t.Error("expected the unmarshal error to be wrapped, but errors.Unwrap returned nil")
+		}
+	})
+
+	t.Run("valid config", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "good.yaml")
+		content := `- baseImportPath: k8s.io/kubernetes/pkg/
+  allowedImports:
+  - k8s.io/kubernetes/pkg/
+`
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		restrictions, err := loadImportRestrictions(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(restrictions) != 1 {
+			t.Fatalf("expected 1 import restriction, got %d", len(restrictions))
+		}
+		if got := restrictions[0].BaseDir; got != "k8s.io/kubernetes/pkg/" {
+			t.Errorf("unexpected BaseDir: got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

`importverifier` is a CI gate whose error output is all a developer has to go on
when its config is broken or `go list` output can't be decoded. Four error paths in
`loadImportRestrictions` and `decodePackages` formatted the underlying error with
`%v`, which flattens the wrap chain. They now use `%w`, so the cause (e.g.
`fs.ErrNotExist` for a missing config) stays inspectable via `errors.Is`/`errors.As`
instead of requiring callers to match message text.

It also adds the package's first unit test — a new `importverifier_test.go` with
`TestLoadImportRestrictions`, covering the missing-config, malformed-config, and
valid-config paths and asserting the wrap chain (`errors.Is`/`errors.Unwrap`).

This PR was written in part with the assistance of generative AI. I have reviewed
and understand every change and take responsibility for its correctness.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A

#### Special notes for your reviewer:

No behaviour change beyond error text; return values are unchanged and the previous
message substrings are preserved. The `exec` message in `resolvePackageTree` is a
pre-formatted string, not an `error`, so it intentionally keeps `%v`. The new test
is hermetic (`t.TempDir()`, stdlib only) and covers the missing-config,
malformed-config, and valid-config paths.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
