### PR TITLE
node e2e: fix the memory PSI test for new kernels and remove the CRI-O skip

### DIFF
--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -404,21 +404,6 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 		})
 
 		ginkgo.It("should report Memory pressure in PSI metrics", func(ctx context.Context) {
-			runtime, _, err := getCRIClient(ctx)
-			framework.ExpectNoError(err)
-			resp, err := runtime.Version(ctx, "")
-			framework.ExpectNoError(err)
-
-			if resp.GetRuntimeName() == "cri-o" {
-				// Skip this test for CRI-O (used on Fedora CoreOS in test CI) until automatic
-				// memory.high configuration is available. The test fails on Fedora CoreOS due to
-				// different page cache reclaim behavior. CRI-O is implementing a fix to automatically
-				// set memory.high to 95% of memory.max for cgroup v2 containers.
-				// See: https://github.com/cri-o/cri-o/pull/9714
-				// See: https://github.com/coreos/fedora-coreos-tracker/issues/2094
-				ginkgo.Skip("Skipping for CRI-O until automatic memory.high configuration is available")
-			}
-
 			podName := "memory-pressure-pod"
 			ginkgo.By("Creating a pod to generate Memory pressure")
 			// Create a pod that generates memory pressure by continuously writing to files,
@@ -426,10 +411,14 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 			podSpec := getStressTestPod(podName, "memory-stress", []string{})
 			podSpec.Spec.Containers[0].Command = []string{"/bin/sh", "-c"}
 			podSpec.Spec.Containers[0].Args = []string{
-				// This command runs an infinite loop that uses `dd` to write 50MB files,
-				// cycling through 5 files to target 250MB of reclaimable file cache usage.
-				// This exceeds the 200MB memory limit, forcing the kernel to reclaim memory and generate pressure stalls.
-				"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%5)); sleep 0.1; done",
+				// Write 50MB files in an infinite loop, cycling through 5 file names, so
+				// the kernel must keep reclaiming file cache inside the 200MB limit.
+				// The first pass writes small 10MB files: without that ramp, the very
+				// first pass fills the whole limit with dirty pages before writeback has
+				// started, and on filesystems that hold dirty data longer (XFS on Fedora
+				// CoreOS) the kernel OOM kills the container instead of reclaiming.
+				"i=0; while [ $i -lt 5 ]; do dd if=/dev/zero of=testfile.$i bs=1M count=10 &>/dev/null; i=$((i+1)); sleep 0.1; done; " +
+					"i=0; while true; do dd if=/dev/zero of=testfile.$i bs=1M count=50 &>/dev/null; i=$(((i+1)%5)); sleep 0.1; done",
 			}
 			podSpec.Spec.Containers[0].Resources = v1.ResourceRequirements{
 				Limits: v1.ResourceList{
@@ -444,16 +433,28 @@ var _ = SIGDescribe("Summary API", framework.WithNodeConformance(), func() {
 			ginkgo.By("Waiting for the pod to start")
 			framework.ExpectNoError(e2epod.WaitForPodRunningInNamespace(ctx, f.ClientSet, pod))
 
-			ginkgo.By("Validating that Memory PSI metrics reflect pressure")
-			gomega.Eventually(ctx, func(g gomega.Gomega) {
-				summary, err := getNodeSummary(ctx)
-				framework.ExpectNoError(err)
-				g.Expect(summary.Pods).To(gstruct.MatchElements(summaryObjectID, gstruct.IgnoreExtras, gstruct.Elements{
-					fmt.Sprintf("%s::%s", f.Namespace.Name, podName): gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Memory": pressureDetected("full", 0.1),
-					}),
-				}))
-			}, 2*time.Minute, 15*time.Second).Should(gomega.Succeed())
+			// Linux 6.16 and newer reclaim this workload's file cache without
+			// blocking the pod for long, so Full.Avg10 stays at zero and a
+			// check on the average cannot pass there. The total stall time
+			// still grows on every kernel, so check that Full.Total becomes
+			// positive and then keeps growing while the workload runs. An idle
+			// pod adds no stall time, so growth proves the pressure comes from
+			// this pod.
+			ginkgo.By("Validating that Memory PSI metrics report stall time")
+			var baselineTotal uint64
+			gomega.Eventually(ctx, func(ctx context.Context) (uint64, error) {
+				total, err := podMemoryPSIFullTotal(ctx, f.Namespace.Name, podName)
+				if err != nil {
+					return 0, err
+				}
+				baselineTotal = total
+				return total, nil
+			}, 2*time.Minute, 15*time.Second).Should(gomega.BeNumerically(">", uint64(0)))
+
+			ginkgo.By("Validating that Memory PSI total stall time grows under sustained pressure")
+			gomega.Eventually(ctx, func(ctx context.Context) (uint64, error) {
+				return podMemoryPSIFullTotal(ctx, f.Namespace.Name, podName)
+			}, 2*time.Minute, 15*time.Second).Should(gomega.BeNumerically(">", baselineTotal))
 			framework.ExpectNoError(e2epod.NewPodClient(f).Delete(ctx, pod.Name, metav1.DeleteOptions{}))
 		})
 
@@ -713,4 +714,23 @@ func pressureDetected(level string, threshold float64) types.GomegaMatcher {
 	return gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 		"PSI": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, fields)),
 	}))
+}
+
+// podMemoryPSIFullTotal returns the memory PSI full total stall time in
+// microseconds reported for the given pod in /stats/summary.
+func podMemoryPSIFullTotal(ctx context.Context, namespace, podName string) (uint64, error) {
+	summary, err := getNodeSummary(ctx)
+	if err != nil {
+		return 0, err
+	}
+	for _, pod := range summary.Pods {
+		if pod.PodRef.Namespace != namespace || pod.PodRef.Name != podName {
+			continue
+		}
+		if pod.Memory == nil || pod.Memory.PSI == nil {
+			return 0, fmt.Errorf("pod %s/%s has no memory PSI data in summary", namespace, podName)
+		}
+		return pod.Memory.PSI.Full.Total, nil
+	}
+	return 0, fmt.Errorf("pod %s/%s not found in summary", namespace, podName)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/sig node

#### What this PR does / why we need it:

PSI means Pressure Stall Information. The kernel counts how much time the tasks in a cgroup wait for memory, CPU, and IO. The kubelet reports these counters in /stats/summary. The test `should report Memory pressure in PSI metrics` starts a pod with a 200MB memory limit. The pod writes 50MB files in a loop, so the kernel must reclaim the pod's file cache again and again. This PR changes that one test, in one commit, in three ways.

**1. The test now checks the total stall counter, not the 10 second average.**

The old code checked that the pod's `Memory.PSI.Full.Avg10` went above 0.1 within 2 minutes. That check only passes when the kernel blocks the pod inside memory reclaim for long periods. The kernel removed that blocking in two steps:

- Linux v6.16 removed the ability of reclaim to write file pages to disk (torvalds/linux@6b0dfabb3555). ext4 also started to write large folios (torvalds/linux@16705e52e629).
- Linux v6.19 made reclaim move dirty file pages out of its path the first time it sees them (torvalds/linux@2f05435df932). That change removed the sleeps that produced the stall time.

The effect in CI is a gradient. Kernel 6.1 passes. Kernels 6.8 and 6.12 pass or fail, and the environment decides. Ubuntu 26.04 with kernel 7.0 fails on every run. Both EC2 serial jobs (`ci-containerd-node-e2e-serial-ec2` and the arm64 twin) fail on every run since 2026-07-29. Triage: https://go.k8s.io/triage#f1d598b9e6b23860ee05

The kubelet reports PSI correctly on all of these kernels. The workload's wait time only moved from the memory counters to the IO counters. We reproduced this on GCP instances with a bare cgroup and the same write loop, without Kubernetes. On kernel 7.0 the average stays at zero in every sample, and the total counter grows in every sample. An idle cgroup stays at exactly zero. MGLRU and memory.high settings do not change the result.

The new code polls `Memory.PSI.Full.Total` for the pod from /stats/summary, through a new helper (`podMemoryPSIFullTotal`). It checks two steps, each with the same 2 minute limit and 15 second poll as before. First, the counter must become more than zero. Second, the counter must grow past the value from the first step while the workload runs. An idle pod adds no stall time, so growth shows that the pressure comes from this pod. The CPU and IO tests do not change, because their checks pass on all kernels we measured.

**2. The test runs on CRI-O again.**

The commit deletes the runtime check that skipped the test on CRI-O. #136191 added that skip because the test failed on Fedora CoreOS (#134141). The skip named automatic memory.high configuration in CRI-O as the condition for removal, and that change (cri-o/cri-o#9714) closed without a merge. We also measured, on kernel 7.0, that memory.high does not make the old check pass. The v6.19 reclaim change removes the mechanism that memory.high would need, so we expect the same result on v6.19 and newer. The new check removes the reason for the skip.

**3. The workload writes a small first pass, so it survives its start on XFS.**

On Fedora CoreOS the kernel killed the stress container about half a second after start, so the pod often never ran. We reproduced this on GCP Fedora CoreOS images with a bare cgroup, on kernel 6.15.10 and on kernel 7.1.3. The cause: the first pass of writes fills the whole memory limit with dirty pages before the kernel starts to write them to disk. On XFS the kernel then finds nothing to reclaim and kills the container. With `memory.oom.group=1`, which is the setting the kubelet applies, 17 to 18 of 20 starts died on both kernels. On an ext4 disk on the same kernels the starts survived: zero kills on kernel 6.15, and on kernel 7.1 one dd child died once while the workload continued. That difference is why Ubuntu and COS nodes never showed the problem.

The commit changes the container command: it now writes one pass of the 5 files at 10MB each, and then it runs the same 50MB loop as before. The limit then fills slowly, and the disk writes run before the first reclaim. We measured 20 of 20 clean starts on both kernels with this ramp, and the total stall counter still grows for the test.

**CI results.** Runs of this change passed the PSI tests on all seven node environments: COS (kernel 6.12), Ubuntu GKE (6.8), Fedora CoreOS with CRI-O (7.1), and AL2023 (6.1) plus Ubuntu 26.04 (7.0) on EC2, on amd64 and on arm64.

#### Which issue(s) this PR is related to:

Related to #134141

#### Special notes for your reviewer:

- The two EC2 serial presubmits completed for the first time in their history on this PR, after kubernetes/test-infra#37612 gave them a 300 minute timeout.
- Pod level PSI counters keep their value when a container restarts. We checked this with a parent cgroup and a child cgroup that we deleted and created again six times.
- The new helper returns an error when the pod is not in the summary yet. The poll then retries instead of failing the test.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
