### PR TITLE
kubectl: propagate PrintObj errors in human-readable output loop

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -134,7 +134,9 @@ func (p *pruner) prune(namespace string, mapping *meta.RESTMapping) error {
 		if err != nil {
 			return err
 		}
-		printer.PrintObj(obj, p.out)
+		if err := printer.PrintObj(obj, p.out); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/printers"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+// errPrinter is a ResourcePrinter whose PrintObj always returns an error.
+// It is used to verify that callers correctly propagate PrintObj errors.
+type errPrinter struct{ err error }
+
+func (e *errPrinter) PrintObj(_ runtime.Object, _ io.Writer) error { return e.err }
+
+// TestPrunePropagatePrintObjError is a regression test for the bug where
+// printer.PrintObj(obj, p.out) had its return value ignored inside the
+// prune() loop, so any write failure (e.g. a broken pipe) was invisible
+// and the command exited 0.
+//
+// After the fix, prune() must propagate the error returned by PrintObj.
+func TestPrunePropagatePrintObjError(t *testing.T) {
+	// Build a fake dynamic client pre-populated with one pod that carries the
+	// last-applied-configuration annotation so the pruner will attempt to
+	// print it as a "pruned" resource.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prune-me",
+			Namespace: "default",
+			UID:       types.UID("abc-123"),
+			Annotations: map[string]string{
+				corev1.LastAppliedConfigAnnotation: `{}`,
+			},
+		},
+	}
+
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	fakeClient := dynamicfake.NewSimpleDynamicClient(scheme.Scheme, pod)
+
+	printErr := fmt.Errorf("simulated write error: broken pipe")
+
+	p := pruner{
+		dynamicClient: fakeClient,
+		// Empty visitedUids means the pod is not in the visited set → it will
+		// fall through to the print path.
+		visitedUids:       sets.New[types.UID](),
+		visitedNamespaces: sets.New[string](),
+		// DryRunClient skips the actual DELETE call; we only care about the
+		// print path triggered afterward.
+		dryRunStrategy: cmdutil.DryRunClient,
+		toPrinter: func(_ string) (printers.ResourcePrinter, error) {
+			return &errPrinter{err: printErr}, nil
+		},
+		out: io.Discard,
+	}
+
+	mapping := &meta.RESTMapping{
+		Resource: gvr,
+		GroupVersionKind: schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Pod",
+		},
+		// meta.RESTScopeNamespace is the exported package-level var for namespace scope.
+		Scope: meta.RESTScopeNamespace,
+	}
+
+	err := p.prune("default", mapping)
+	if err == nil {
+		t.Fatal("expected prune() to return an error when PrintObj fails, but got nil")
+	}
+	if !strings.Contains(err.Error(), printErr.Error()) {
+		t.Errorf("expected error to contain %q, got: %v", printErr.Error(), err)
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -566,7 +566,12 @@ func (o *GetOptions) Run(f cmdutil.Factory, args []string) error {
 			lastMapping = mapping
 		}
 
-		printer.PrintObj(info.Object, w)
+		if err := printer.PrintObj(info.Object, w); err != nil {
+			if !errs.Has(err.Error()) {
+				errs.Insert(err.Error())
+				allErrs = append(allErrs, err)
+			}
+		}
 	}
 	w.Flush()
 	if trackingWriter.Written == 0 && !o.IgnoreNotFound && len(allErrs) == 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -3211,3 +3211,52 @@ func replicationControllersScaleSubresourceTableObjBody(codec runtime.Codec, rep
 	}
 	return cmdtesting.ObjBody(codec, table)
 }
+
+// errWriter is an io.Writer that always returns an error, used to simulate
+// a broken-pipe or closed-writer scenario in printer tests.
+type errWriter struct{ err error }
+
+func (e *errWriter) Write(p []byte) (int, error) { return 0, e.err }
+
+// TestRunHumanReadablePrinterPropagatesPrintObjError is a regression test for
+// the bug where errors returned by printer.PrintObj were silently discarded in
+// the human-readable output loop of Run(), causing kubectl to exit 0 even when
+// output to the writer had failed (e.g. broken pipe).
+func TestRunHumanReadablePrinterPropagatesPrintObjError(t *testing.T) {
+	pods, _, _ := cmdtesting.TestData()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, &pods.Items[0])},
+	}
+
+	streams, _, _, _ := genericiooptions.NewTestIOStreams()
+
+	// Replace the standard Out with a writer that always fails, simulating a
+	// closed pipe or any IO error that occurs while writing output.
+	writeErr := fmt.Errorf("simulated write error: broken pipe")
+	streams.Out = &errWriter{err: writeErr}
+
+	o := NewGetOptions("kubectl", streams)
+	// Force human-readable (table) output — the code path under test.
+	outputFmt := ""
+	o.PrintFlags.OutputFormat = &outputFmt
+	o.IsHumanReadablePrinter = true
+
+	cmd := NewCmdGet("kubectl", tf, streams)
+	if err := o.Complete(tf, cmd, []string{"pods", "foo"}); err != nil {
+		t.Fatalf("Complete() returned unexpected error: %v", err)
+	}
+
+	err := o.Run(tf, []string{"pods", "foo"})
+	if err == nil {
+		t.Fatal("expected Run() to return an error when PrintObj fails, but got nil")
+	}
+	if !strings.Contains(err.Error(), writeErr.Error()) {
+		t.Errorf("expected error to contain %q, got: %v", writeErr.Error(), err)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

In the human-readable output loop of `get.go`'s `Run()`, `printer.PrintObj(info.Object, w)` was called without checking the error return. The function already maintains an `allErrs` slice returned via `utilerrors.NewAggregate` `PrintObj` errors are now fed into it, consistent with how `ToPrinter` errors are already handled in the same loop.

In `pruner.prune()`, `printer.PrintObj(obj, p.out)` discarded its error return. Since the function already returns `error`, the fix wraps the call and returns the error directly.

Both bugs allowed IO failures (broken pipe, closed writer) to go undetected, with the command exiting 0 despite incomplete output.

**Which issue(s) this PR is related to:**

Fixes #141115

**Special notes :**

Two call sites are fixed in the same PR since they share the same root cause silent `PrintObj` error discard. Each fix follows the error-handling pattern already established in its surrounding code, so no new patterns are introduced.

**Does this PR introduce a user-facing change?**

```release-note
Fixed `kubectl get` and `kubectl apply --prune` silently ignoring IO errors (e.g. broken pipe) from the output printer. Both commands now exit non-zero when output fails.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**

```docs

```