### PR TITLE
apiserver: drop hardcoded storage version overrides

### DIFF
--- a/pkg/kubeapiserver/default_storage_factory_builder.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder.go
@@ -29,17 +29,11 @@ import (
 	basecompatibility "k8s.io/component-base/compatibility"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/apps"
-	"k8s.io/kubernetes/pkg/apis/certificates"
-	"k8s.io/kubernetes/pkg/apis/coordination"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/events"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-	"k8s.io/kubernetes/pkg/apis/lifecycle"
 	"k8s.io/kubernetes/pkg/apis/networking"
 	"k8s.io/kubernetes/pkg/apis/policy"
-	"k8s.io/kubernetes/pkg/apis/resource"
-	"k8s.io/kubernetes/pkg/apis/scheduling"
-	"k8s.io/kubernetes/pkg/apis/storagemigration"
 )
 
 // SpecialDefaultResourcePrefixes are prefixes compiled into Kubernetes.
@@ -69,28 +63,15 @@ func NewStorageFactoryConfig() *StorageFactoryConfig {
 // NewStorageFactoryConfigEffectiveVersion returns a new StorageFactoryConfig set up with necessary resource overrides for a given EffectiveVersion.
 func NewStorageFactoryConfigEffectiveVersion(effectiveVersion basecompatibility.EffectiveVersion) *StorageFactoryConfig {
 	resources := []schema.GroupVersionResource{
-		// If a resource has to be stored in a version that is not the
-		// latest, then it can be listed here. Usually this is the case
-		// when a new version for a resource gets introduced and a
-		// downgrade to an older apiserver that doesn't know the new
-		// version still needs to be supported for one release.
+		// The storage version is picked automatically:
 		//
-		// Example from Kubernetes 1.24 where csistoragecapacities had just
-		// graduated to GA:
+		//   - a new beta replacing an alpha takes over right away
+		//   - a new GA (or a beta replacing an older beta) waits one release, so a
+		//     downgrade to the previous apiserver can still read what was written
 		//
-		// TODO (https://github.com/kubernetes/kubernetes/issues/108451): remove the override in 1.25.
-		// apisstorage.Resource("csistoragecapacities").WithVersion("v1beta1"),
-		coordination.Resource("leasecandidates").WithVersion("v1beta1"),
-		certificates.Resource("clustertrustbundles").WithVersion("v1beta1"), // TODO: remove in 1.38
-		certificates.Resource("podcertificaterequests").WithVersion("v1beta1"),
-		storagemigration.Resource("storageversionmigrations").WithVersion("v1beta1"),
-		resource.Resource("devicetaintrules").WithVersion("v1beta2"),
-		resource.Resource("resourcepoolstatusrequests").WithVersion("v1alpha3"),
-		scheduling.Resource("workloads").WithVersion("v1beta1"),
-		scheduling.Resource("podgroups").WithVersion("v1beta1"),
-		scheduling.Resource("compositepodgroups").WithVersion("v1alpha3"),
-		lifecycle.Resource("evictions").WithVersion("v1alpha1"),
-		lifecycle.Resource("evictionrequests").WithVersion("v1alpha1"),
+		// Almost every resource wants that. If a resource has to be stored in a
+		// version that is not the one picked automatically, then it can be
+		// listed here.
 	}
 	return &StorageFactoryConfig{
 		Serializer:                legacyscheme.Codecs,

--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -19,11 +19,14 @@ package registrytest
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/server/options"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/kubeapiserver"
 )
 
@@ -44,9 +47,30 @@ func NewEtcdStorageForResource(t *testing.T, resource schema.GroupResource) (*st
 	if err != nil {
 		t.Fatalf("Error while making storage factory: %v", err)
 	}
-	resourceConfig, err := factory.NewConfig(resource, nil)
+	resourceConfig, err := factory.NewConfig(resource, internalExampleFor(resource))
 	if err != nil {
 		t.Fatalf("Error while finding storage destination: %v", err)
 	}
 	return resourceConfig, server
+}
+
+// internalExampleFor returns an instance of the internal type behind the
+// resource. The storage factory needs it to calculate the storage version, and
+// falls back to the group's preferred version when it is nil.
+func internalExampleFor(resource schema.GroupResource) runtime.Object {
+	internal := schema.GroupVersion{Group: resource.Group, Version: runtime.APIVersionInternal}
+	for gvk := range legacyscheme.Scheme.AllKnownTypes() {
+		if gvk.GroupVersion() != internal {
+			continue
+		}
+		if plural, _ := meta.UnsafeGuessKindToResource(gvk); plural.Resource != resource.Resource {
+			continue
+		}
+		example, err := legacyscheme.Scheme.New(gvk)
+		if err != nil {
+			return nil
+		}
+		return example
+	}
+	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/resource_encoding_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/resource_encoding_config.go
@@ -209,8 +209,15 @@ func emulatedStorageVersion(binaryVersionOfResource schema.GroupVersion, example
 		}
 	}
 
-	// Getting here means every version of this kind was introduced after
-	// the emulation version, so the resource should not be served at this
-	// emulation version at all.
+	// Getting here means every version of this kind was introduced after the
+	// emulation version, so the resource should not be served at this emulation
+	// version at all. It still gets built before RemoveUnavailableKinds prunes
+	// it, so fall back to the highest-priority version that has the kind.
+	// binaryVersionOfResource is the group's preferred version, which is not
+	// guaranteed to have it.
+	if len(versions) > 0 {
+		return versions[0], nil
+	}
+
 	return binaryVersionOfResource, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Empties the hardcoded storage version override list, since emulatedStorageVersion already picks the same version for all eleven pinned resources.

Two of them only worked because of the pin. When every version of a kind was introduced after the emulated version, emulatedStorageVersion fell back to the group's preferred version, which for LeaseCandidate and ResourcePoolStatusRequest does not contain the kind, so building their storage failed the codec check before RemoveUnavailableKinds could prune them. The first commit makes that fallback stay within the versions that actually have the kind.

The third commit fixes registrytest, which passed a nil example to NewConfig and so fell back to the group's preferred version instead of auto-calculating.

#### Which issue(s) this PR is related to:

Follow-up to https://github.com/kubernetes/kubernetes/pull/137375

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
