### PR TITLE
Update leaderelection.go

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -167,7 +167,7 @@ type LeaderElectionConfig struct {
 
 // LeaderCallbacks are callbacks that are triggered during certain
 // lifecycle events of the LeaderElector. These are invoked asynchronously.
-//
+// These must be concurrent safe.
 // possible future callbacks:
 //   - OnChallenge()
 type LeaderCallbacks struct {


### PR DESCRIPTION
This PR updates the docs to mention that LeaderElection Callbacks must be concurrent safe as they as can run concurrently