### PR TITLE
fix:volumeattachment could not be cleanup while controller-manager restart after volumeattachment created because of csidriver created delay

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -738,7 +738,7 @@ func (adc *attachDetachController) processVolumeAttachments(logger klog.Logger) 
 		}
 
 		if plugin == nil {
-			plugin, err = adc.volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+			plugin, err = volumeutil.FindDetachablePluginBySpec(volumeSpec, &adc.volumePluginMgr)
 			if err != nil || plugin == nil {
 				// Currently VA objects are created for CSI volumes only. nil plugin is unexpected, generate a warning
 				logger.Info("Skipping processing the volume on node, no attacher interface found", "node", klog.KRef("", string(nodeName)), "PV", klog.KRef("", *pvName), "err", err)

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -738,7 +738,7 @@ func (adc *attachDetachController) processVolumeAttachments(logger klog.Logger) 
 		}
 
 		if plugin == nil {
-			plugin, err = adc.volumePluginMgr.FindAttachablePluginBySpec(volumeSpec)
+			plugin, err = findDetachablePluginBySpec(volumeSpec, &adc.volumePluginMgr)
 			if err != nil || plugin == nil {
 				// Currently VA objects are created for CSI volumes only. nil plugin is unexpected, generate a warning
 				logger.Info("Skipping processing the volume on node, no attacher interface found", "node", klog.KRef("", string(nodeName)), "PV", klog.KRef("", *pvName), "err", err)
@@ -888,4 +888,26 @@ func (adc *attachDetachController) GetSubpather() subpath.Interface {
 
 func (adc *attachDetachController) GetCSIDriverLister() storagelistersv1.CSIDriverLister {
 	return adc.csiDriverLister
+}
+
+// findDetachablePluginBySpec is a variant of VolumePluginMgr.FindAttachablePluginByName() function.
+// The difference is that it bypass the CanAttach() check for CSI plugin, i.e. it assumes all CSI plugin supports detach.
+// The intention here is that a CSI plugin volume can end up in an Uncertain state,  so that a detach
+// operation will help it to detach no matter it actually has the ability to attach/detach.
+func findDetachablePluginBySpec(spec *volume.Spec, pm *volume.VolumePluginMgr) (volume.AttachableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginBySpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	if attachableVolumePlugin, ok := volumePlugin.(volume.AttachableVolumePlugin); ok {
+		if attachableVolumePlugin.GetPluginName() == "kubernetes.io/csi" {
+			return attachableVolumePlugin, nil
+		}
+		if canAttach, err := attachableVolumePlugin.CanAttach(spec); err != nil {
+			return nil, err
+		} else if canAttach {
+			return attachableVolumePlugin, nil
+		}
+	}
+	return nil, nil
 }

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -482,6 +482,7 @@ type vaTest struct {
 	vaNodeName             string
 	vaAttachStatus         bool
 	csiMigration           bool
+	csiPlugin              bool
 	expected_attaches      map[string][]string
 	expected_detaches      map[string][]string
 	expectedASWAttachState cache.AttachState
@@ -530,6 +531,18 @@ func Test_ADC_VolumeAttachmentRecovery(t *testing.T) {
 			csiMigration:           true,
 			expectedASWAttachState: cache.AttachStateUncertain,
 		},
+		{ // pod is scheduled, volume changes from attachable to non-attachable, attach status:false, verify volume is marked as uncertain
+			testName:               "Scheduled Pod with non-attachable PV",
+			volName:                "csi-driver1^vol-handle1",
+			podNodeName:            "mynode-1",
+			pvName:                 "pv1",
+			vaName:                 "va1",
+			vaNodeName:             "mynode-1",
+			vaAttachStatus:         false,
+			csiMigration:           false,
+			csiPlugin:              true,
+			expectedASWAttachState: cache.AttachStateUncertain,
+		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {
 			volumeAttachmentRecoveryTestCase(t, tc)
@@ -552,6 +565,7 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 	podInformer := informerFactory.Core().V1().Pods().Informer()
 	pvInformer := informerFactory.Core().V1().PersistentVolumes().Informer()
 	vaInformer := informerFactory.Storage().V1().VolumeAttachments().Informer()
+	csiDriverInformer := informerFactory.Storage().V1().CSIDrivers().Informer()
 
 	// Create the controller
 	var wg sync.WaitGroup
@@ -602,6 +616,14 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 		}
 		nodeInformer.GetIndexer().Add(&newNode)
 	}
+	if tc.csiPlugin {
+		newCsiDriver := controllervolumetesting.NewCSIDriver("csi-driver1", "csi-driver1", false)
+		_, err = adc.kubeClient.StorageV1().CSIDrivers().Create(tCtx, newCsiDriver, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Run failed with error. Failed to create a new csidriver: <%v>", err)
+		}
+		_ = csiDriverInformer.GetIndexer().Add(newCsiDriver)
+	}
 	// Create and add objects requested by the test
 	if tc.podName != "" {
 		newPod := controllervolumetesting.NewPodWithVolume(tc.podName, tc.volName, tc.podNodeName)
@@ -611,11 +633,14 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 		}
 		podInformer.GetIndexer().Add(newPod)
 	}
+
 	if tc.pvName != "" {
 		var newPv *v1.PersistentVolume
 		if tc.csiMigration {
 			// NewPV returns a GCEPersistentDisk volume, which is migrated.
 			newPv = controllervolumetesting.NewPV(tc.pvName, tc.volName)
+		} else if tc.csiPlugin {
+			newPv = controllervolumetesting.NewCSIPV(tc.pvName)
 		} else {
 			// Otherwise use NFS, which is not subject to migration.
 			newPv = controllervolumetesting.NewNFSPV(tc.pvName, tc.volName)
@@ -642,7 +667,8 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 		informerFactory.Core().V1().Pods().Informer().HasSynced,
 		informerFactory.Core().V1().Nodes().Informer().HasSynced,
 		informerFactory.Core().V1().PersistentVolumes().Informer().HasSynced,
-		informerFactory.Storage().V1().VolumeAttachments().Informer().HasSynced) {
+		informerFactory.Storage().V1().VolumeAttachments().Informer().HasSynced,
+		informerFactory.Storage().V1().CSIDrivers().Informer().HasSynced) {
 		t.Fatalf("Error waiting for the informer caches to sync")
 	}
 
@@ -666,6 +692,12 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 	})
 	if tc.csiMigration {
 		verifyExpectedVolumeState(t, adc, tc)
+	} else if tc.csiPlugin {
+		attachedState := adc.actualStateOfWorld.GetAttachState(
+			v1.UniqueVolumeName(csi.CSIPluginName+"/"+tc.volName), types.NodeName(tc.vaNodeName))
+		if attachedState != tc.expectedASWAttachState {
+			t.Fatalf("Expected attachedState %v, but it is %v", tc.expectedASWAttachState, attachedState)
+		}
 	} else {
 		// Verify if expected attaches and detaches have happened
 		testPlugin := plugins[0].(*controllervolumetesting.TestPlugin)

--- a/pkg/controller/volume/attachdetach/testing/testvolumespec.go
+++ b/pkg/controller/volume/attachdetach/testing/testvolumespec.go
@@ -60,6 +60,7 @@ func CreateTestClient(logger klog.Logger) *fake.Clientset {
 	var volumeAttachments *storagev1.VolumeAttachmentList
 	var pvs *v1.PersistentVolumeList
 	var nodes *v1.NodeList
+	var csidrivers *storagev1.CSIDriverList
 
 	fakeClient := &fake.Clientset{}
 
@@ -193,11 +194,34 @@ func CreateTestClient(logger klog.Logger) *fake.Clientset {
 		pvs.Items = append(pvs.Items, *pv)
 		return true, createAction.GetObject(), nil
 	})
-
+	csidrivers = &storagev1.CSIDriverList{}
+	fakeClient.AddReactor("list", "csidrivers", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		obj := &storagev1.CSIDriverList{}
+		obj.Items = append(obj.Items, csidrivers.Items...)
+		return true, obj, nil
+	})
+	fakeClient.AddReactor("create", "csidrivers", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+		createAction := action.(core.CreateAction)
+		csidriver := createAction.GetObject().(*storagev1.CSIDriver)
+		csidrivers.Items = append(csidrivers.Items, *csidriver)
+		return true, createAction.GetObject(), nil
+	})
 	fakeWatch := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	fakeClient.AddWatchReactor("*", core.DefaultWatchReactor(fakeWatch, nil))
 
 	return fakeClient
+}
+
+func NewCSIDriver(uid, name string, attachable bool) *storagev1.CSIDriver {
+	return &storagev1.CSIDriver{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  types.UID(uid),
+			Name: name,
+		},
+		Spec: storagev1.CSIDriverSpec{
+			AttachRequired: &attachable,
+		},
+	}
 }
 
 // NewPod returns a test pod object
@@ -286,6 +310,27 @@ func NewPV(pvName, volumeName string) *v1.PersistentVolume {
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
 					PDName: volumeName,
+				},
+			},
+		},
+	}
+}
+
+// Returns a persistentVolume object
+func NewCSIPV(pvName string) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:  types.UID(pvName),
+			Name: pvName,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:           "csi-driver1",
+					VolumeHandle:     "vol-handle1",
+					FSType:           "ext4",
+					ReadOnly:         false,
+					VolumeAttributes: map[string]string{"partition": ""},
 				},
 			},
 		},

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -355,7 +355,7 @@ func (og *operationGenerator) GenerateDetachVolumeFunc(
 	var err error
 
 	if volumeToDetach.VolumeSpec != nil {
-		attachableVolumePlugin, err = findDetachablePluginBySpec(volumeToDetach.VolumeSpec, og.volumePluginMgr)
+		attachableVolumePlugin, err = util.FindDetachablePluginBySpec(volumeToDetach.VolumeSpec, og.volumePluginMgr)
 		if err != nil || attachableVolumePlugin == nil {
 			return volumetypes.GeneratedOperations{}, volumeToDetach.GenerateErrorDetailed("DetachVolume.findDetachablePluginBySpec failed", err)
 		}
@@ -2205,28 +2205,6 @@ func isDeviceOpened(deviceToDetach AttachedVolume, hostUtil hostutil.HostUtils) 
 		}
 	}
 	return deviceOpened, nil
-}
-
-// findDetachablePluginBySpec is a variant of VolumePluginMgr.FindAttachablePluginByName() function.
-// The difference is that it bypass the CanAttach() check for CSI plugin, i.e. it assumes all CSI plugin supports detach.
-// The intention here is that a CSI plugin volume can end up in an Uncertain state,  so that a detach
-// operation will help it to detach no matter it actually has the ability to attach/detach.
-func findDetachablePluginBySpec(spec *volume.Spec, pm *volume.VolumePluginMgr) (volume.AttachableVolumePlugin, error) {
-	volumePlugin, err := pm.FindPluginBySpec(spec)
-	if err != nil {
-		return nil, err
-	}
-	if attachableVolumePlugin, ok := volumePlugin.(volume.AttachableVolumePlugin); ok {
-		if attachableVolumePlugin.GetPluginName() == "kubernetes.io/csi" {
-			return attachableVolumePlugin, nil
-		}
-		if canAttach, err := attachableVolumePlugin.CanAttach(spec); err != nil {
-			return nil, err
-		} else if canAttach {
-			return attachableVolumePlugin, nil
-		}
-	}
-	return nil, nil
 }
 
 func getMigratedStatusBySpec(spec *volume.Spec) bool {

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -701,3 +701,25 @@ func VolumeHealthConditionSetsEqual(a, b []v1.VolumeHealthCondition) bool {
 	}
 	return true
 }
+
+// FindDetachablePluginBySpec is a variant of VolumePluginMgr.FindAttachablePluginByName() function.
+// The difference is that it bypass the CanAttach() check for CSI plugin, i.e. it assumes all CSI plugin supports detach.
+// The intention here is that a CSI plugin volume can end up in an Uncertain state,  so that a detach
+// operation will help it to detach no matter it actually has the ability to attach/detach.
+func FindDetachablePluginBySpec(spec *volume.Spec, pm *volume.VolumePluginMgr) (volume.AttachableVolumePlugin, error) {
+	volumePlugin, err := pm.FindPluginBySpec(spec)
+	if err != nil {
+		return nil, err
+	}
+	if attachableVolumePlugin, ok := volumePlugin.(volume.AttachableVolumePlugin); ok {
+		if attachableVolumePlugin.GetPluginName() == "kubernetes.io/csi" {
+			return attachableVolumePlugin, nil
+		}
+		if canAttach, err := attachableVolumePlugin.CanAttach(spec); err != nil {
+			return nil, err
+		} else if canAttach {
+			return attachableVolumePlugin, nil
+		}
+	}
+	return nil, nil
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:

/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #141151
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #141151
#### Special notes for your reviewer:
@gnufied 
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
