### PR TITLE
kubelet: add node-level metrics to CRI stats path

### DIFF
--- a/pkg/kubelet/metrics/collectors/cri_metrics.go
+++ b/pkg/kubelet/metrics/collectors/cri_metrics.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	cadvisormetrics "github.com/google/cadvisor/lib/metrics"
 	"k8s.io/component-base/metrics"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
@@ -31,14 +32,24 @@ type criMetricsCollector struct {
 	// The descriptors structure will be populated by one call to ListMetricDescriptors from the runtime.
 	// They will be saved in this map, where the key is the Name and the value is the Desc.
 	descriptors             map[string]*metrics.Desc
+	labelKeys               map[string][]string
 	listPodSandboxMetricsFn func(context.Context) ([]*runtimeapi.PodSandboxMetrics, error)
+	nodeGatherer            *nodeMetricsGatherer
 }
 
 // Check if criMetricsCollector implements necessary interface
 var _ metrics.StableCollector = &criMetricsCollector{}
 
-// NewCRIMetricsCollector implements the metrics.Collector interface
-func NewCRIMetricsCollector(ctx context.Context, listPodSandboxMetricsFn func(context.Context) ([]*runtimeapi.PodSandboxMetrics, error), listMetricDescriptorsFn func(context.Context) ([]*runtimeapi.MetricDescriptor, error)) metrics.StableCollector {
+// NewCRIMetricsCollector creates a collector for CRI pod/container metrics.
+// If infoProvider is non-nil, it also collects node-level (root cgroup)
+// metrics from cAdvisor using the same CRI metric descriptors.
+func NewCRIMetricsCollector(
+	ctx context.Context,
+	listPodSandboxMetricsFn func(context.Context) ([]*runtimeapi.PodSandboxMetrics, error),
+	listMetricDescriptorsFn func(context.Context) ([]*runtimeapi.MetricDescriptor, error),
+	infoProvider nodeInfoProvider,
+	containerLabelsFunc cadvisormetrics.ContainerLabelsFunc,
+) metrics.StableCollector {
 	descs, err := listMetricDescriptorsFn(ctx)
 	if err != nil {
 		logger := klog.FromContext(ctx)
@@ -47,13 +58,22 @@ func NewCRIMetricsCollector(ctx context.Context, listPodSandboxMetricsFn func(co
 			listPodSandboxMetricsFn: listPodSandboxMetricsFn,
 		}
 	}
-	c := &criMetricsCollector{
-		listPodSandboxMetricsFn: listPodSandboxMetricsFn,
-		descriptors:             make(map[string]*metrics.Desc, len(descs)),
+
+	descriptors := make(map[string]*metrics.Desc, len(descs))
+	labelKeys := make(map[string][]string, len(descs))
+	for _, desc := range descs {
+		descriptors[desc.Name] = criDescToProm(desc)
+		labelKeys[desc.Name] = desc.LabelKeys
 	}
 
-	for _, desc := range descs {
-		c.descriptors[desc.Name] = criDescToProm(desc)
+	c := &criMetricsCollector{
+		descriptors:             descriptors,
+		labelKeys:               labelKeys,
+		listPodSandboxMetricsFn: listPodSandboxMetricsFn,
+	}
+
+	if infoProvider != nil {
+		c.nodeGatherer = newNodeMetricsGatherer(ctx, descriptors, labelKeys, infoProvider, containerLabelsFunc)
 	}
 
 	return c
@@ -94,6 +114,10 @@ func (c *criMetricsCollector) CollectWithStability(ch chan<- metrics.Metric) {
 				}
 			}
 		}
+	}
+
+	if c.nodeGatherer != nil {
+		c.nodeGatherer.collectNodeMetrics(ch)
 	}
 }
 

--- a/pkg/kubelet/metrics/collectors/cri_node_metrics.go
+++ b/pkg/kubelet/metrics/collectors/cri_node_metrics.go
@@ -1,0 +1,133 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"context"
+	"time"
+
+	cadvisorcontainer "github.com/google/cadvisor/lib/container"
+	cadvisormetrics "github.com/google/cadvisor/lib/metrics"
+	info "github.com/google/cadvisor/lib/model"
+	"k8s.io/component-base/metrics"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+// nodeInfoProvider is the interface for reading container and machine info
+// from cAdvisor. It mirrors the unexported cadvisormetrics.infoProvider.
+type nodeInfoProvider interface {
+	GetRequestedContainersInfo(string, info.RequestOptions) (map[string]*info.ContainerInfo, error)
+	GetVersionInfo() (*info.VersionInfo, error)
+	GetMachineInfo() (*info.MachineInfo, error)
+}
+
+// nodeMetricsGatherer reads root cgroup stats from cAdvisor via a private
+// PrometheusCollector, then relabels the output to match CRI descriptors.
+type nodeMetricsGatherer struct {
+	logger      klog.Logger
+	registry    metrics.KubeRegistry
+	descriptors map[string]*metrics.Desc
+	labelKeys   map[string][]string
+}
+
+func newNodeMetricsGatherer(
+	ctx context.Context,
+	descriptors map[string]*metrics.Desc,
+	labelKeys map[string][]string,
+	infoProvider nodeInfoProvider,
+	containerLabelsFunc cadvisormetrics.ContainerLabelsFunc,
+) *nodeMetricsGatherer {
+	nodeMetrics := cadvisorcontainer.MetricSet{
+		cadvisorcontainer.CpuUsageMetrics:     {},
+		cadvisorcontainer.MemoryUsageMetrics:  {},
+		cadvisorcontainer.NetworkUsageMetrics: {},
+	}
+
+	cadvisorCollector := cadvisormetrics.NewPrometheusCollector(
+		infoProvider,
+		containerLabelsFunc,
+		nodeMetrics,
+		clock.RealClock{},
+		info.RequestOptions{
+			IdType:    info.TypeName,
+			Count:     1,
+			Recursive: false,
+		},
+	)
+
+	registry := metrics.NewKubeRegistry()
+	registry.RawMustRegister(cadvisorCollector)
+
+	return &nodeMetricsGatherer{
+		logger:      klog.FromContext(ctx),
+		registry:    registry,
+		descriptors: descriptors,
+		labelKeys:   labelKeys,
+	}
+}
+
+// collectNodeMetrics gathers metrics from the private cAdvisor registry
+// and relabels them to match the CRI runtime's metric descriptors.
+func (g *nodeMetricsGatherer) collectNodeMetrics(ch chan<- metrics.Metric) {
+	families, err := g.registry.Gather()
+	if err != nil {
+		g.logger.Error(err, "Error gathering node metrics from cAdvisor")
+	}
+
+	for _, family := range families {
+		desc, ok := g.descriptors[family.GetName()]
+		if !ok {
+			continue
+		}
+		keys := g.labelKeys[family.GetName()]
+
+		for _, m := range family.GetMetric() {
+			cadvisorLabels := make(map[string]string, len(m.GetLabel()))
+			for _, lp := range m.GetLabel() {
+				cadvisorLabels[lp.GetName()] = lp.GetValue()
+			}
+
+			labelValues := make([]string, len(keys))
+			for i, key := range keys {
+				labelValues[i] = cadvisorLabels[key]
+			}
+
+			var valueType metrics.ValueType
+			var value float64
+			if c := m.GetCounter(); c != nil {
+				valueType = metrics.CounterValue
+				value = c.GetValue()
+			} else if gauge := m.GetGauge(); gauge != nil {
+				valueType = metrics.GaugeValue
+				value = gauge.GetValue()
+			} else {
+				continue
+			}
+
+			metric, err := metrics.NewConstMetric(desc, valueType, value, labelValues...)
+			if err != nil {
+				g.logger.Error(err, "Error creating node metric", "name", family.GetName())
+				continue
+			}
+			if ts := m.GetTimestampMs(); ts != 0 {
+				metric = metrics.NewLazyMetricWithTimestamp(time.UnixMilli(ts), metric)
+			}
+			ch <- metric
+		}
+	}
+}

--- a/pkg/kubelet/metrics/collectors/cri_node_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/cri_node_metrics_test.go
@@ -1,0 +1,288 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	info "github.com/google/cadvisor/lib/model"
+	"k8s.io/component-base/metrics/testutil"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+type fakeNodeInfoProvider struct {
+	info map[string]*info.ContainerInfo
+	err  error
+}
+
+func (f *fakeNodeInfoProvider) GetRequestedContainersInfo(containerName string, options info.RequestOptions) (map[string]*info.ContainerInfo, error) {
+	return f.info, f.err
+}
+
+func (f *fakeNodeInfoProvider) GetVersionInfo() (*info.VersionInfo, error) {
+	return &info.VersionInfo{}, nil
+}
+
+func (f *fakeNodeInfoProvider) GetMachineInfo() (*info.MachineInfo, error) {
+	return &info.MachineInfo{}, nil
+}
+
+func nodeContainerLabelsFunc(c *info.ContainerInfo) map[string]string {
+	return map[string]string{
+		"id":        c.Name,
+		"image":     "",
+		"namespace": "",
+		"pod":       "",
+		"container": "",
+	}
+}
+
+func fakeCRIDescriptors() []*runtimeapi.MetricDescriptor {
+	baseLabelKeys := []string{"pod", "namespace", "container", "id", "image"}
+	networkLabelKeys := append(append([]string{}, baseLabelKeys...), "interface")
+
+	return []*runtimeapi.MetricDescriptor{
+		{Name: "container_cpu_user_seconds_total", Help: "Cumulative user cpu time consumed in seconds.", LabelKeys: baseLabelKeys},
+		{Name: "container_cpu_system_seconds_total", Help: "Cumulative system cpu time consumed in seconds.", LabelKeys: baseLabelKeys},
+		{Name: "container_cpu_usage_seconds_total", Help: "Cumulative cpu time consumed in seconds.", LabelKeys: append(append([]string{}, baseLabelKeys...), "cpu")},
+		{Name: "container_memory_cache", Help: "Number of bytes of page cache memory.", LabelKeys: baseLabelKeys},
+		{Name: "container_memory_rss", Help: "Size of RSS in bytes.", LabelKeys: baseLabelKeys},
+		{Name: "container_memory_usage_bytes", Help: "Current memory usage in bytes, including all memory regardless of when it was accessed", LabelKeys: baseLabelKeys},
+		{Name: "container_memory_working_set_bytes", Help: "Current working set in bytes.", LabelKeys: baseLabelKeys},
+		{Name: "container_memory_failures_total", Help: "Cumulative count of memory allocation failures.", LabelKeys: append(append([]string{}, baseLabelKeys...), "failure_type", "scope")},
+		{Name: "container_network_receive_bytes_total", Help: "Cumulative count of bytes received", LabelKeys: networkLabelKeys},
+		{Name: "container_network_receive_packets_total", Help: "Cumulative count of packets received", LabelKeys: networkLabelKeys},
+		{Name: "container_network_receive_packets_dropped_total", Help: "Cumulative count of packets dropped while receiving", LabelKeys: networkLabelKeys},
+		{Name: "container_network_receive_errors_total", Help: "Cumulative count of errors encountered while receiving", LabelKeys: networkLabelKeys},
+		{Name: "container_network_transmit_bytes_total", Help: "Cumulative count of bytes transmitted", LabelKeys: networkLabelKeys},
+		{Name: "container_network_transmit_packets_total", Help: "Cumulative count of packets transmitted", LabelKeys: networkLabelKeys},
+		{Name: "container_network_transmit_packets_dropped_total", Help: "Cumulative count of packets dropped while transmitting", LabelKeys: networkLabelKeys},
+		{Name: "container_network_transmit_errors_total", Help: "Cumulative count of errors encountered while transmitting", LabelKeys: networkLabelKeys},
+	}
+}
+
+func newFakeListDescriptorsFn(descs []*runtimeapi.MetricDescriptor) func(context.Context) ([]*runtimeapi.MetricDescriptor, error) {
+	return func(ctx context.Context) ([]*runtimeapi.MetricDescriptor, error) {
+		return descs, nil
+	}
+}
+
+func emptyPodMetrics(ctx context.Context) ([]*runtimeapi.PodSandboxMetrics, error) {
+	return nil, nil
+}
+
+func rootContainerInfo() map[string]*info.ContainerInfo {
+	return map[string]*info.ContainerInfo{
+		"/": {
+			ContainerReference: info.ContainerReference{Name: "/"},
+			Spec: info.ContainerSpec{
+				HasCpu:     true,
+				HasMemory:  true,
+				HasNetwork: true,
+			},
+			Stats: []*info.ContainerStats{{
+				Timestamp: time.Unix(1700000000, 0),
+				Cpu: &info.CpuStats{
+					Usage: info.CpuUsage{
+						User:   5 * uint64(time.Second),
+						System: 3 * uint64(time.Second),
+						Total:  8 * uint64(time.Second),
+					},
+				},
+				Memory: &info.MemoryStats{
+					Usage:      1048576,
+					WorkingSet: 524288,
+					Cache:      262144,
+					RSS:        131072,
+					Failcnt:    42,
+					ContainerData: info.MemoryStatsMemoryData{
+						Pgfault:    100,
+						Pgmajfault: 5,
+					},
+					HierarchicalData: info.MemoryStatsMemoryData{
+						Pgfault:    200,
+						Pgmajfault: 10,
+					},
+				},
+				Network: &info.NetworkStats{
+					Interfaces: []info.InterfaceStats{
+						{Name: "eth0", RxBytes: 1000, RxPackets: 10, RxDropped: 1, RxErrors: 2, TxBytes: 2000, TxPackets: 20, TxDropped: 3, TxErrors: 4},
+					},
+				},
+			}},
+		},
+	}
+}
+
+func TestCRINodeMetricsCollector(t *testing.T) {
+	collector := NewCRIMetricsCollector(
+		context.TODO(),
+		emptyPodMetrics,
+		newFakeListDescriptorsFn(fakeCRIDescriptors()),
+		&fakeNodeInfoProvider{info: rootContainerInfo()},
+		nodeContainerLabelsFunc,
+	)
+
+	expected := `
+		# HELP container_cpu_user_seconds_total [INTERNAL] Cumulative user cpu time consumed in seconds.
+		# TYPE container_cpu_user_seconds_total counter
+		container_cpu_user_seconds_total{container="",id="/",image="",namespace="",pod=""} 5 1700000000000
+		# HELP container_cpu_system_seconds_total [INTERNAL] Cumulative system cpu time consumed in seconds.
+		# TYPE container_cpu_system_seconds_total counter
+		container_cpu_system_seconds_total{container="",id="/",image="",namespace="",pod=""} 3 1700000000000
+		# HELP container_cpu_usage_seconds_total [INTERNAL] Cumulative cpu time consumed in seconds.
+		# TYPE container_cpu_usage_seconds_total counter
+		container_cpu_usage_seconds_total{container="",cpu="total",id="/",image="",namespace="",pod=""} 8 1700000000000
+		# HELP container_memory_cache [INTERNAL] Number of bytes of page cache memory.
+		# TYPE container_memory_cache gauge
+		container_memory_cache{container="",id="/",image="",namespace="",pod=""} 262144 1700000000000
+		# HELP container_memory_rss [INTERNAL] Size of RSS in bytes.
+		# TYPE container_memory_rss gauge
+		container_memory_rss{container="",id="/",image="",namespace="",pod=""} 131072 1700000000000
+		# HELP container_memory_usage_bytes [INTERNAL] Current memory usage in bytes, including all memory regardless of when it was accessed
+		# TYPE container_memory_usage_bytes gauge
+		container_memory_usage_bytes{container="",id="/",image="",namespace="",pod=""} 1.048576e+06 1700000000000
+		# HELP container_memory_working_set_bytes [INTERNAL] Current working set in bytes.
+		# TYPE container_memory_working_set_bytes gauge
+		container_memory_working_set_bytes{container="",id="/",image="",namespace="",pod=""} 524288 1700000000000
+		# HELP container_memory_failures_total [INTERNAL] Cumulative count of memory allocation failures.
+		# TYPE container_memory_failures_total counter
+		container_memory_failures_total{container="",failure_type="pgfault",id="/",image="",namespace="",pod="",scope="container"} 100 1700000000000
+		container_memory_failures_total{container="",failure_type="pgfault",id="/",image="",namespace="",pod="",scope="hierarchy"} 200 1700000000000
+		container_memory_failures_total{container="",failure_type="pgmajfault",id="/",image="",namespace="",pod="",scope="container"} 5 1700000000000
+		container_memory_failures_total{container="",failure_type="pgmajfault",id="/",image="",namespace="",pod="",scope="hierarchy"} 10 1700000000000
+		# HELP container_network_receive_bytes_total [INTERNAL] Cumulative count of bytes received
+		# TYPE container_network_receive_bytes_total counter
+		container_network_receive_bytes_total{container="",id="/",image="",interface="eth0",namespace="",pod=""} 1000 1700000000000
+		# HELP container_network_receive_errors_total [INTERNAL] Cumulative count of errors encountered while receiving
+		# TYPE container_network_receive_errors_total counter
+		container_network_receive_errors_total{container="",id="/",image="",interface="eth0",namespace="",pod=""} 2 1700000000000
+		# HELP container_network_receive_packets_dropped_total [INTERNAL] Cumulative count of packets dropped while receiving
+		# TYPE container_network_receive_packets_dropped_total counter
+		container_network_receive_packets_dropped_total{container="",id="/",image="",interface="eth0",namespace="",pod=""} 1 1700000000000
+		# HELP container_network_receive_packets_total [INTERNAL] Cumulative count of packets received
+		# TYPE container_network_receive_packets_total counter
+		container_network_receive_packets_total{container="",id="/",image="",interface="eth0",namespace="",pod=""} 10 1700000000000
+		# HELP container_network_transmit_bytes_total [INTERNAL] Cumulative count of bytes transmitted
+		# TYPE container_network_transmit_bytes_total counter
+		container_network_transmit_bytes_total{container="",id="/",image="",interface="eth0",namespace="",pod=""} 2000 1700000000000
+		# HELP container_network_transmit_errors_total [INTERNAL] Cumulative count of errors encountered while transmitting
+		# TYPE container_network_transmit_errors_total counter
+		container_network_transmit_errors_total{container="",id="/",image="",interface="eth0",namespace="",pod=""} 4 1700000000000
+		# HELP container_network_transmit_packets_dropped_total [INTERNAL] Cumulative count of packets dropped while transmitting
+		# TYPE container_network_transmit_packets_dropped_total counter
+		container_network_transmit_packets_dropped_total{container="",id="/",image="",interface="eth0",namespace="",pod=""} 3 1700000000000
+		# HELP container_network_transmit_packets_total [INTERNAL] Cumulative count of packets transmitted
+		# TYPE container_network_transmit_packets_total counter
+		container_network_transmit_packets_total{container="",id="/",image="",interface="eth0",namespace="",pod=""} 20 1700000000000
+	`
+
+	if err := testutil.CustomCollectAndCompare(collector, strings.NewReader(expected)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCRINodeMetricsCollectorCAdvisorError(t *testing.T) {
+	collector := NewCRIMetricsCollector(
+		context.TODO(),
+		emptyPodMetrics,
+		newFakeListDescriptorsFn(fakeCRIDescriptors()),
+		&fakeNodeInfoProvider{err: fmt.Errorf("cadvisor unavailable")},
+		nodeContainerLabelsFunc,
+	)
+
+	if err := testutil.CustomCollectAndCompare(collector, strings.NewReader("")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCRINodeMetricsCollectorNoStats(t *testing.T) {
+	collector := NewCRIMetricsCollector(
+		context.TODO(),
+		emptyPodMetrics,
+		newFakeListDescriptorsFn(fakeCRIDescriptors()),
+		&fakeNodeInfoProvider{info: map[string]*info.ContainerInfo{
+			"/": {
+				ContainerReference: info.ContainerReference{Name: "/"},
+				Spec:               info.ContainerSpec{HasCpu: true, HasMemory: true, HasNetwork: true},
+			},
+		}},
+		nodeContainerLabelsFunc,
+	)
+
+	if err := testutil.CustomCollectAndCompare(collector, strings.NewReader("")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCRINodeMetricsCollectorListDescriptorsError(t *testing.T) {
+	collector := NewCRIMetricsCollector(
+		context.TODO(),
+		emptyPodMetrics,
+		func(ctx context.Context) ([]*runtimeapi.MetricDescriptor, error) {
+			return nil, fmt.Errorf("CRI runtime not ready")
+		},
+		&fakeNodeInfoProvider{info: rootContainerInfo()},
+		nodeContainerLabelsFunc,
+	)
+
+	if err := testutil.CustomCollectAndCompare(collector, strings.NewReader("")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCRINodeMetricsCoverCRIDescriptors(t *testing.T) {
+	descriptors := fakeCRIDescriptors()
+	descriptorNames := make(map[string]struct{}, len(descriptors))
+	for _, d := range descriptors {
+		descriptorNames[d.Name] = struct{}{}
+	}
+
+	collector := NewCRIMetricsCollector(
+		context.TODO(),
+		emptyPodMetrics,
+		newFakeListDescriptorsFn(descriptors),
+		&fakeNodeInfoProvider{info: rootContainerInfo()},
+		nodeContainerLabelsFunc,
+	)
+
+	registry := testutil.NewFakeKubeRegistry("1.37.0")
+	registry.CustomMustRegister(collector)
+	families, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+
+	gathered := make(map[string]struct{}, len(families))
+	for _, family := range families {
+		name := family.GetName()
+		if _, ok := descriptorNames[name]; !ok {
+			t.Errorf("node collector emitted metric %q not in CRI descriptors", name)
+		}
+		gathered[name] = struct{}{}
+	}
+
+	for _, d := range descriptors {
+		if _, ok := gathered[d.Name]; !ok {
+			t.Errorf("CRI descriptor %q has no node-level equivalent from cAdvisor", d.Name)
+		}
+	}
+}

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -534,7 +534,7 @@ func (s *Server) InstallAuthNotRequiredHandlers(ctx context.Context) {
 	r := compbasemetrics.NewKubeRegistry()
 	r.RawMustRegister(metrics.NewPrometheusMachineCollector(prometheusHostAdapter{s.host}, includedMetrics))
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodAndContainerStatsFromCRI) {
-		r.CustomRegister(collectors.NewCRIMetricsCollector(context.TODO(), s.host.ListPodSandboxMetrics, s.host.ListMetricDescriptors))
+		r.CustomMustRegister(collectors.NewCRIMetricsCollector(ctx, s.host.ListPodSandboxMetrics, s.host.ListMetricDescriptors, prometheusHostAdapter{s.host}, containerPrometheusLabelsFunc(s.host)))
 		servermetrics.SetMetricsProvider(servermetrics.CRIMetricsProvider)
 	} else {
 		cadvisorOpts := cadvisorapi.RequestOptions{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

When PodAndContainerStatsFromCRI is enabled, container metrics come from
the CRI runtime via ListPodSandboxMetrics, but node-level (root cgroup)
stats are missing. Integrate node metrics collection into the existing
CRI metrics collector so that a single StableCollector owns all CRI
metric descriptors.

A nodeMetricsGatherer helper runs a private cAdvisor PrometheusCollector
scoped to "/" (Recursive: false), gathers its output, filters it through
the CRI descriptor whitelist, and relabels metrics to match the CRI
label schema.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Collected metrics are limited to CPU, memory, and network, as these are
the only metric kinds that produce meaningful data for the root cgroup.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed missing node-level metrics on the /metrics/cadvisor endpoint when PodAndContainerStatsFromCRI is enabled.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-node/2371-cri-pod-container-stats
```

This PR was written in part with the assistance of generative AI.