### PR TITLE
Remove internal network range from allocator error messages

### DIFF
--- a/pkg/registry/core/service/ipallocator/interfaces.go
+++ b/pkg/registry/core/service/ipallocator/interfaces.go
@@ -54,5 +54,5 @@ type ErrNotInRange struct {
 }
 
 func (e *ErrNotInRange) Error() string {
-	return fmt.Sprintf("the provided IP (%v) is not in the valid range. The range of valid IPs is %s", e.IP, e.ValidRange)
+	return fmt.Sprintf("provided IP %v is not in the valid range", e.IP)
 }

--- a/pkg/registry/core/service/portallocator/allocator.go
+++ b/pkg/registry/core/service/portallocator/allocator.go
@@ -49,7 +49,7 @@ type ErrNotInRange struct {
 }
 
 func (e *ErrNotInRange) Error() string {
-	return fmt.Sprintf("provided port is not in the valid range. The range of valid ports is %s", e.ValidPorts)
+	return "provided port is not in the valid range"
 }
 
 type PortAllocator struct {

--- a/pkg/registry/core/service/portallocator/storage/storage_test.go
+++ b/pkg/registry/core/service/portallocator/storage/storage_test.go
@@ -115,17 +115,17 @@ func TestAllocate(t *testing.T) {
 		{
 			name:   "Allocate invalid port: base port minus 1",
 			port:   basePortRange - 1,
-			errMsg: fmt.Sprintf("provided port is not in the valid range. The range of valid ports is %d-%d", basePortRange, basePortRange+sizePortRange-1),
+			errMsg: "provided port is not in the valid range",
 		},
 		{
 			name:   "Allocate invalid port: maximum port from the port range plus 1",
 			port:   basePortRange + sizePortRange,
-			errMsg: fmt.Sprintf("provided port is not in the valid range. The range of valid ports is %d-%d", basePortRange, basePortRange+sizePortRange-1),
+			errMsg: "provided port is not in the valid range",
 		},
 		{
 			name:   "Allocate invalid port",
 			port:   -2,
-			errMsg: fmt.Sprintf("provided port is not in the valid range. The range of valid ports is %d-%d", basePortRange, basePortRange+sizePortRange-1),
+			errMsg: "provided port is not in the valid range",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
What type of PR is this?
/kind bug
/sig network

What this PR does / why we need it:
Validation errors for out-of-range ClusterIPs and NodePorts included the exact --service-cluster-ip-range CIDR and port range boundaries in user-facing error messages. This allows low-privileged users (or compromised ServiceAccounts with only create permissions on services) to discover internal cluster network topology without having cluster-admin or describe cluster-info access.

 This PR strips the range details from the ErrNotInRange error messages in both the IP allocator and port allocator while keeping the rejected value visible so the user still knows which value was invalid.

Which issue(s) this PR is related to:
Fixes #141142

Special notes for your reviewer:
The ErrNotInRange struct fields (ValidRange, ValidPorts) are kept intact since the repair controllers type-assert on *ErrNotInRange. Only the Error() string output is changed. Cluster admins who need the actual range can access it through kubectl cluster-info dump or apiserver flags.

Does this PR introduce a user-facing change?
Yes: error messages users see now indicate that the value is out of range without exposing the cluster's configured boundaries.

 Additional documentation:
 N/A
