### PR TITLE
Remove expired TestPolicyAdmissionV1beta1 integration test

### DIFF
--- a/test/integration/apiserver/cel/admission_policy_test.go
+++ b/test/integration/apiserver/cel/admission_policy_test.go
@@ -30,10 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
 	admissionregistrationv1apis "k8s.io/kubernetes/pkg/apis/admissionregistration/v1"
@@ -406,33 +403,16 @@ func createV1ValidatingPolicyAndBinding(ctx ktesting.TContext, client clientset.
 
 // This test shows that policy intercepts all requests for all resources,
 // subresources, verbs, and input versions of policy/binding.
-// The test emulates v1.33 as that was the last version before v1beta1 resource was removed.
-// Remove this test once v1.33 cannot be emulated in v1.37.
-//
-// This test tries to mirror very closely the same test for webhook admission
-// test/integration/apiserver/admissionwebhook/admission_test.go testWebhookAdmission
-func TestPolicyAdmissionV1beta1(t *testing.T) {
-	featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse(vapV1beta1LastEmulatableVersion))
-	testPolicyAdmission(t, true)
-}
-
-// This test shows that policy intercepts all requests for all resources,
-// subresources, verbs, and input versions of policy/binding.
 //
 // This test tries to mirror very closely the same test for webhook admission
 // test/integration/apiserver/admissionwebhook/admission_test.go testWebhookAdmission
 func TestPolicyAdmission(t *testing.T) {
-	testPolicyAdmission(t, false)
+	testPolicyAdmission(t)
 }
 
-func testPolicyAdmission(t *testing.T, supportV1Beta1 bool) {
+func testPolicyAdmission(t *testing.T) {
 	tCtx := ktesting.Init(t)
-	supportedVersions := []string{}
-	if supportV1Beta1 {
-		supportedVersions = append(supportedVersions, "v1beta1")
-	} else {
-		supportedVersions = append(supportedVersions, "v1")
-	}
+	supportedVersions := []string{"v1"}
 
 	holder := &policyExpectationHolder{
 		supportedVersions: supportedVersions,
@@ -562,14 +542,8 @@ func testPolicyAdmission(t *testing.T, supportV1Beta1 bool) {
 		holder.gvrToConvertedGVK[metaGVR] = schema.GroupVersionKind{Group: resourcesByGVR[convertedGVR].Group, Version: resourcesByGVR[convertedGVR].Version, Kind: resourcesByGVR[convertedGVR].Kind}
 	}
 
-	if supportV1Beta1 {
-		if err := createV1beta1ValidatingPolicyAndBinding(tCtx, client, convertedV1beta1Rules); err != nil {
-			t.Fatal(err)
-		}
-	} else {
-		if err := createV1ValidatingPolicyAndBinding(tCtx, client, convertedV1Rules); err != nil {
-			t.Fatal(err)
-		}
+	if err := createV1ValidatingPolicyAndBinding(tCtx, client, convertedV1Rules); err != nil {
+		t.Fatal(err)
 	}
 
 	testConfigmap := corev1.ConfigMap{
@@ -618,15 +592,14 @@ func testPolicyAdmission(t *testing.T, supportV1Beta1 bool) {
 						holder.reset(t)
 						testFunc := getTestFunc(gvr, verb)
 						testFunc(&testContext{
-							t:                     t,
-							emulateV1beta1Version: supportV1Beta1,
-							admissionHolder:       holder,
-							client:                dynamicClient,
-							clientset:             client,
-							verb:                  verb,
-							gvr:                   gvr,
-							resource:              resource,
-							resources:             resourcesByGVR,
+							t:               t,
+							admissionHolder: holder,
+							client:          dynamicClient,
+							clientset:       client,
+							verb:            verb,
+							gvr:             gvr,
+							resource:        resource,
+							resources:       resourcesByGVR,
 						})
 						holder.verify(t)
 					})

--- a/test/integration/apiserver/cel/admission_policy_test.go
+++ b/test/integration/apiserver/cel/admission_policy_test.go
@@ -34,7 +34,6 @@ import (
 	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
 	admissionregistrationv1apis "k8s.io/kubernetes/pkg/apis/admissionregistration/v1"
-	admissionregistrationv1beta1apis "k8s.io/kubernetes/pkg/apis/admissionregistration/v1beta1"
 	"k8s.io/kubernetes/test/integration/etcd"
 	"k8s.io/kubernetes/test/integration/framework"
 	"k8s.io/kubernetes/test/utils/ktesting"
@@ -46,7 +45,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 )
 
 const (
@@ -165,123 +163,6 @@ var testSpec admissionregistration.ValidatingAdmissionPolicy = admissionregistra
 			},
 		},
 	},
-}
-
-func createV1beta1ValidatingPolicyAndBinding(ctx ktesting.TContext, client clientset.Interface, convertedRules []admissionregistrationv1beta1.NamedRuleWithOperations) error {
-	denyAction := admissionregistrationv1beta1.DenyAction
-	exact := admissionregistrationv1beta1.Exact
-	equivalent := admissionregistrationv1beta1.Equivalent
-
-	var outSpec admissionregistrationv1beta1.ValidatingAdmissionPolicy
-	if err := admissionregistrationv1beta1apis.Convert_admissionregistration_ValidatingAdmissionPolicy_To_v1beta1_ValidatingAdmissionPolicy(&testSpec, &outSpec, nil); err != nil {
-		return err
-	}
-
-	exactPolicyTemplate := outSpec.DeepCopy()
-	convertedPolicyTemplate := outSpec.DeepCopy()
-
-	exactPolicyTemplate.SetName("test-policy-v1beta1")
-	exactPolicyTemplate.Spec.MatchConstraints = &admissionregistrationv1beta1.MatchResources{
-		ResourceRules: []admissionregistrationv1beta1.NamedRuleWithOperations{
-			{
-				RuleWithOperations: admissionregistrationv1.RuleWithOperations{
-					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},
-					Rule:       admissionregistrationv1.Rule{APIGroups: []string{"*"}, APIVersions: []string{"*"}, Resources: []string{"*/*"}},
-				},
-			},
-		},
-		MatchPolicy: &exact,
-	}
-
-	convertedPolicyTemplate.SetName("test-policy-v1beta1-convert")
-	convertedPolicyTemplate.Spec.MatchConstraints = &admissionregistrationv1beta1.MatchResources{
-		ResourceRules: convertedRules,
-		MatchPolicy:   &equivalent,
-	}
-
-	exactPolicy, err := client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Create(ctx, exactPolicyTemplate, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-
-	convertPolicy, err := client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicies().Create(ctx, convertedPolicyTemplate, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-
-	// Create a param that holds the options for this
-	configuration, err := client.CoreV1().ConfigMaps("default").Create(ctx, &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-policy-v1beta1-param",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"skipMatch": "yes",
-			},
-		},
-		Data: map[string]string{
-			"version": "v1beta1",
-			"phase":   validation,
-			"convert": "false",
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-
-	configurationConvert, err := client.CoreV1().ConfigMaps("default").Create(ctx, &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-policy-v1beta1-convert-param",
-			Namespace: "default",
-			Annotations: map[string]string{
-				"skipMatch": "yes",
-			},
-		},
-		Data: map[string]string{
-			"version": "v1beta1",
-			"phase":   validation,
-			"convert": "true",
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-
-	_, err = client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicyBindings().Create(ctx, &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-policy-v1beta1-binding",
-		},
-		Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingSpec{
-			PolicyName:        exactPolicy.GetName(),
-			ValidationActions: []admissionregistrationv1beta1.ValidationAction{admissionregistrationv1beta1.Warn},
-			ParamRef: &admissionregistrationv1beta1.ParamRef{
-				Name:                    configuration.GetName(),
-				Namespace:               configuration.GetNamespace(),
-				ParameterNotFoundAction: &denyAction,
-			},
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-	_, err = client.AdmissionregistrationV1beta1().ValidatingAdmissionPolicyBindings().Create(ctx, &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-policy-v1beta1-convert-binding",
-		},
-		Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingSpec{
-			PolicyName:        convertPolicy.GetName(),
-			ValidationActions: []admissionregistrationv1beta1.ValidationAction{admissionregistrationv1beta1.Warn},
-			ParamRef: &admissionregistrationv1beta1.ParamRef{
-				Name:                    configurationConvert.GetName(),
-				Namespace:               configurationConvert.GetNamespace(),
-				ParameterNotFoundAction: &denyAction,
-			},
-		},
-	}, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func createV1ValidatingPolicyAndBinding(ctx ktesting.TContext, client clientset.Interface, convertedRules []admissionregistrationv1.NamedRuleWithOperations) error {
@@ -511,7 +392,6 @@ func testPolicyAdmission(t *testing.T) {
 	// Note: this only works because there are no overlapping resource names in-process that are not co-located
 	convertedResources := map[string]schema.GroupVersionResource{}
 	// build the webhook rules enumerating the specific group/version/resources we want
-	convertedV1beta1Rules := []admissionregistrationv1beta1.NamedRuleWithOperations{}
 	convertedV1Rules := []admissionregistrationv1.NamedRuleWithOperations{}
 	for _, gvr := range gvrsToTest {
 		metaGVR := metav1.GroupVersionResource{Group: gvr.Group, Version: gvr.Version, Resource: gvr.Resource}
@@ -523,12 +403,6 @@ func testPolicyAdmission(t *testing.T) {
 			convertedGVR = gvr
 			convertedResources[gvr.Resource] = gvr
 			// add an admission rule indicating we can receive this version
-			convertedV1beta1Rules = append(convertedV1beta1Rules, admissionregistrationv1beta1.NamedRuleWithOperations{
-				RuleWithOperations: admissionregistrationv1.RuleWithOperations{
-					Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.OperationAll},
-					Rule:       admissionregistrationv1beta1.Rule{APIGroups: []string{gvr.Group}, APIVersions: []string{gvr.Version}, Resources: []string{gvr.Resource}},
-				},
-			})
 			convertedV1Rules = append(convertedV1Rules, admissionregistrationv1.NamedRuleWithOperations{
 				RuleWithOperations: admissionregistrationv1.RuleWithOperations{
 					Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.OperationAll},

--- a/test/integration/apiserver/cel/admission_test_util.go
+++ b/test/integration/apiserver/cel/admission_test_util.go
@@ -56,12 +56,6 @@ const (
 
 	mutation   = "mutation"
 	validation = "validation"
-
-	// Last emulatable version for VAP v1beta1. VAP v1beta1 has been
-	// removed in 1.34+ but since clusters may still emulate 1.33,
-	// we must still keep testing this emulation scenario.
-	// Remove in v1.37
-	vapV1beta1LastEmulatableVersion = "1.33"
 )
 
 // DIFF: Added interface to replace direct *holder usage in testContext to be
@@ -75,7 +69,6 @@ type admissionTestExpectationHolder interface {
 type testContext struct {
 	t *testing.T
 
-	emulateV1beta1Version bool
 	// DIFF: Changed from *holder to interface
 	admissionHolder admissionTestExpectationHolder
 
@@ -461,17 +454,10 @@ func getTestFunc(gvr schema.GroupVersionResource, verb string) testFunc {
 	return unimplemented
 }
 
-func getStubObj(gvr schema.GroupVersionResource, resource metav1.APIResource, emulateV1Beta1Version bool) (*unstructured.Unstructured, error) {
+func getStubObj(gvr schema.GroupVersionResource, resource metav1.APIResource) (*unstructured.Unstructured, error) {
 	stub := ""
-	if emulateV1Beta1Version {
-		// This should be removed once TestPolicyAdmissionV1beta1 is removed in v1.37
-		if data, ok := etcd.GetEtcdStorageDataForNamespaceServedAt(testNamespace, vapV1beta1LastEmulatableVersion, false)[gvr]; ok {
-			stub = data.Stub
-		}
-	} else {
-		if data, ok := etcd.GetEtcdStorageDataForNamespace(testNamespace)[gvr]; ok {
-			stub = data.Stub
-		}
+	if data, ok := etcd.GetEtcdStorageDataForNamespace(testNamespace)[gvr]; ok {
+		stub = data.Stub
 	}
 	if data, ok := stubDataOverrides[gvr]; ok {
 		stub = data
@@ -487,8 +473,8 @@ func getStubObj(gvr schema.GroupVersionResource, resource metav1.APIResource, em
 	return stubObj, nil
 }
 
-func createOrGetResource(client dynamic.Interface, gvr schema.GroupVersionResource, resource metav1.APIResource, emulateV1Beta1Version bool) (*unstructured.Unstructured, error) {
-	stubObj, err := getStubObj(gvr, resource, emulateV1Beta1Version)
+func createOrGetResource(client dynamic.Interface, gvr schema.GroupVersionResource, resource metav1.APIResource) (*unstructured.Unstructured, error) {
+	stubObj, err := getStubObj(gvr, resource)
 	if err != nil {
 		return nil, err
 	}
@@ -532,7 +518,7 @@ func shouldTestResourceVerb(gvr schema.GroupVersionResource, resource metav1.API
 //
 
 func testResourceCreate(c *testContext) {
-	stubObj, err := getStubObj(c.gvr, c.resource, c.emulateV1beta1Version)
+	stubObj, err := getStubObj(c.gvr, c.resource)
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -551,7 +537,7 @@ func testResourceCreate(c *testContext) {
 
 func testResourceUpdate(c *testContext) {
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		obj, err := createOrGetResource(c.client, c.gvr, c.resource, c.emulateV1beta1Version)
+		obj, err := createOrGetResource(c.client, c.gvr, c.resource)
 		if err != nil {
 			return err
 		}
@@ -566,7 +552,7 @@ func testResourceUpdate(c *testContext) {
 }
 
 func testResourcePatch(c *testContext) {
-	obj, err := createOrGetResource(c.client, c.gvr, c.resource, c.emulateV1beta1Version)
+	obj, err := createOrGetResource(c.client, c.gvr, c.resource)
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -586,7 +572,7 @@ func testResourcePatch(c *testContext) {
 
 func testResourceDelete(c *testContext) {
 	// Verify that an immediate delete triggers the webhook and populates the admisssionRequest.oldObject.
-	obj, err := createOrGetResource(c.client, c.gvr, c.resource, c.emulateV1beta1Version)
+	obj, err := createOrGetResource(c.client, c.gvr, c.resource)
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -619,7 +605,7 @@ func testResourceDelete(c *testContext) {
 	}
 
 	// Verify that an update-on-delete triggers the webhook and populates the admisssionRequest.oldObject.
-	obj, err = createOrGetResource(c.client, c.gvr, c.resource, c.emulateV1beta1Version)
+	obj, err = createOrGetResource(c.client, c.gvr, c.resource)
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -697,7 +683,7 @@ func testResourceDelete(c *testContext) {
 }
 
 func testResourceDeletecollection(c *testContext) {
-	obj, err := createOrGetResource(c.client, c.gvr, c.resource, c.emulateV1beta1Version)
+	obj, err := createOrGetResource(c.client, c.gvr, c.resource)
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -757,7 +743,7 @@ func getParentGVR(gvr schema.GroupVersionResource) schema.GroupVersionResource {
 
 func testTokenCreate(c *testContext) {
 	saGVR := gvr("", "v1", "serviceaccounts")
-	sa, err := createOrGetResource(c.client, saGVR, c.resources[saGVR], c.emulateV1beta1Version)
+	sa, err := createOrGetResource(c.client, saGVR, c.resources[saGVR])
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -780,7 +766,7 @@ func testSubresourceUpdate(c *testContext) {
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		parentGVR := getParentGVR(c.gvr)
 		parentResource := c.resources[parentGVR]
-		obj, err := createOrGetResource(c.client, parentGVR, parentResource, c.emulateV1beta1Version)
+		obj, err := createOrGetResource(c.client, parentGVR, parentResource)
 		if err != nil {
 			return err
 		}
@@ -821,7 +807,7 @@ func testSubresourceUpdate(c *testContext) {
 func testSubresourcePatch(c *testContext) {
 	parentGVR := getParentGVR(c.gvr)
 	parentResource := c.resources[parentGVR]
-	obj, err := createOrGetResource(c.client, parentGVR, parentResource, c.emulateV1beta1Version)
+	obj, err := createOrGetResource(c.client, parentGVR, parentResource)
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -861,7 +847,7 @@ func unimplemented(c *testContext) {
 // - removes finalizer from namespace
 // - ensures admission is called on final delete once finalizers are removed
 func testNamespaceDelete(c *testContext) {
-	obj, err := createOrGetResource(c.client, c.gvr, c.resource, c.emulateV1beta1Version)
+	obj, err := createOrGetResource(c.client, c.gvr, c.resource)
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -905,7 +891,7 @@ func testNamespaceDelete(c *testContext) {
 // - creates a rollback object and posts it
 func testDeploymentRollback(c *testContext) {
 	deploymentGVR := gvr("apps", "v1", "deployments")
-	obj, err := createOrGetResource(c.client, deploymentGVR, c.resources[deploymentGVR], c.emulateV1beta1Version)
+	obj, err := createOrGetResource(c.client, deploymentGVR, c.resources[deploymentGVR])
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -954,7 +940,7 @@ func testDeploymentRollback(c *testContext) {
 // testPodConnectSubresource verifies connect subresources
 func testPodConnectSubresource(c *testContext) {
 	podGVR := gvr("", "v1", "pods")
-	pod, err := createOrGetResource(c.client, podGVR, c.resources[podGVR], c.emulateV1beta1Version)
+	pod, err := createOrGetResource(c.client, podGVR, c.resources[podGVR])
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -989,7 +975,7 @@ func testPodConnectSubresource(c *testContext) {
 // testPodBindingEviction verifies pod binding and eviction admission
 func testPodBindingEviction(c *testContext) {
 	podGVR := gvr("", "v1", "pods")
-	pod, err := createOrGetResource(c.client, podGVR, c.resources[podGVR], c.emulateV1beta1Version)
+	pod, err := createOrGetResource(c.client, podGVR, c.resources[podGVR])
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -1042,7 +1028,7 @@ func testPodBindingEviction(c *testContext) {
 func testSubresourceProxy(c *testContext) {
 	parentGVR := getParentGVR(c.gvr)
 	parentResource := c.resources[parentGVR]
-	obj, err := createOrGetResource(c.client, parentGVR, parentResource, c.emulateV1beta1Version)
+	obj, err := createOrGetResource(c.client, parentGVR, parentResource)
 	if err != nil {
 		c.t.Error(err)
 		return


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`TestPolicyAdmissionV1beta1` carried the expiry condition "Remove this test once v1.33 cannot be emulated in v1.37", and that condition is now met: the emulation floor is `binaryVersion.SubtractMinor(3)`, so a 1.37 binary rejects `--emulated-version=kube=1.33`. The test only still ran because it bypassed the flag and called `SetFeatureGateEmulationVersionDuringTest` directly, which does not range-check. This removes the test and the `supportV1Beta1` / `emulateV1beta1Version` plumbing that existed only to serve it.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```