### PR TITLE
Use Sign() to reject negative quantities in validateBasicResource

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -8240,8 +8240,16 @@ func ValidateConfigMapUpdate(newCfg, oldCfg *core.ConfigMap) field.ErrorList {
 }
 
 func validateBasicResource(quantity resource.Quantity, fldPath *field.Path) field.ErrorList {
-	if quantity.Value() < 0 {
-		return field.ErrorList{field.Invalid(fldPath, quantity.Value(), "must be a valid resource quantity")}
+	// Sign() rather than Value(): the check only cares about the sign, and Value()
+	// does not report it reliably. It overflows to a positive number for negative
+	// quantities such as -9.5Gi, and falls back to zero when its conversion fails,
+	// as for -1e30 -- both of which pass a "Value() < 0" test. Sign() is correct
+	// for every quantity, and does not depend on how overflow is handled.
+	//
+	// String() rather than Value() in the error for the same reason: the reported
+	// value would otherwise be the overflowed one rather than what was submitted.
+	if quantity.Sign() < 0 {
+		return field.ErrorList{field.Invalid(fldPath, quantity.String(), "must be a valid resource quantity")}
 	}
 	return field.ErrorList{}
 }

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -32959,6 +32959,7 @@ func TestValidateBasicResource(t *testing.T) {
 		{name: "positive", quantity: "1Gi"},
 		{name: "positive, above MaxInt64", quantity: "1000E"},
 		{name: "positive, far above MaxInt64", quantity: "1e30"},
+		{name: "positive, Value() wraps negative", quantity: "9223372036854775808"},
 
 		{name: "negative", quantity: "-1Gi", wantErr: true},
 		{name: "negative, Value() overflows positive", quantity: "-9.5Gi", wantErr: true},

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -32945,3 +32945,55 @@ func TestValidatePodBinding(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateBasicResource(t *testing.T) {
+	// Value() is not a reliable way to ask for the sign of a quantity: it overflows
+	// to a positive number for some negative values and falls back to zero for
+	// others. Every negative case below passes a "Value() < 0" check.
+	cases := []struct {
+		name     string
+		quantity string
+		wantErr  bool
+	}{
+		{name: "zero", quantity: "0"},
+		{name: "positive", quantity: "1Gi"},
+		{name: "positive, above MaxInt64", quantity: "1000E"},
+		{name: "positive, far above MaxInt64", quantity: "1e30"},
+
+		{name: "negative", quantity: "-1Gi", wantErr: true},
+		{name: "negative, Value() overflows positive", quantity: "-9.5Gi", wantErr: true},
+		{name: "negative, Value() overflows positive with more digits", quantity: "-9.5000000001Gi", wantErr: true},
+		{name: "negative, Value() falls back to zero", quantity: "-1e30", wantErr: true},
+		{name: "negative, suffixed, Value() falls back to zero", quantity: "-100E", wantErr: true},
+		{name: "negative, at the int64 boundary", quantity: "-9223372036854775808", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := resource.MustParse(tc.quantity)
+			errs := validateBasicResource(q, field.NewPath("resources").Key("storage"))
+
+			if tc.wantErr && len(errs) == 0 {
+				t.Errorf("%s: expected an error, got none (Value() reports %d)", tc.quantity, q.Value())
+			}
+			if !tc.wantErr && len(errs) != 0 {
+				t.Errorf("%s: expected no error, got %v", tc.quantity, errs)
+			}
+			// The quantity belongs in the error, not the overflowed integer. String()
+			// canonicalizes, so compare by value rather than by spelling.
+			if tc.wantErr && len(errs) == 1 {
+				reported, ok := errs[0].BadValue.(string)
+				if !ok {
+					t.Fatalf("%s: error reports %T, want the quantity as a string", tc.quantity, errs[0].BadValue)
+				}
+				got, err := resource.ParseQuantity(reported)
+				if err != nil {
+					t.Fatalf("%s: error reports %q, which is not a quantity: %v", tc.quantity, reported, err)
+				}
+				if got.Cmp(q) != 0 {
+					t.Errorf("%s: error reports %q, want a quantity equal to the one submitted", tc.quantity, reported)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`validateBasicResource` rejects negative quantities by asking `quantity.Value() < 0`, but `Value()` does not report the sign reliably. It overflows to a positive number for some negative quantities, and falls back to zero when its internal conversion fails. Both of those pass the check:

```
MustParse("-9.5Gi")            Sign() = -1   Value() =  8246196746   accepted
MustParse("-9.5000000001Gi")   Sign() = -1   Value() =  8246196746   accepted
MustParse("-1e30")             Sign() = -1   Value() =           0   accepted
MustParse("-100E")             Sign() = -1   Value() =           0   accepted
MustParse("-1000E")            Sign() = -1   Value() =           0   accepted
```

The function is called for `PersistentVolumeSpec.Capacity`, `PersistentVolumeClaimStatus.Capacity` and `PersistentVolumeClaimStatus.AllocatedResources`. On the PV `spec.capacity` and PVC `allocatedResources` paths a second, exact `Cmp`-based check (`ValidatePositiveQuantityValue` / `ValidateNonnegativeQuantity`) already rejects negatives, so the only path where `validateBasicResource` is the sole sign guard is PVC `status.capacity` — that is where a negative overflow quantity is accepted today and is rejected after this change. (Verified by running the validators; thanks @thc1006 for the correction.)

The change also removes a spurious rejection in the other direction: a positive whose `Value()` wraps negative — `9223372036854775808` (2^63) has `Value() = -2^63`, `Sign() = +1` — was falsely rejected on all three paths by `Value() < 0`, and is now accepted.

`Sign()` answers exactly what the check is asking and does not depend on how overflow is handled, so this is independent of the accessor work tracked in #141166 and does not touch `resource.Quantity` itself.

The error's reported value moves from `Value()` to `String()` for the same reason: it would otherwise show the overflowed integer instead of the quantity that was submitted. `String()` canonicalizes, so `-9.5Gi` is reported as `-9728Mi`; the test compares by value rather than by spelling.

The function had no test of its own; this adds a table test covering the negatives above, the boundary case, and ordinary positive values including ones above `MaxInt64`. Every negative case in it passes on master.

**Which issue(s) this PR is related to**:

Part of #141166

**Special notes for your reviewer**:

@jpbetz, @thc1006 — this is the `Sign()` change discussed in https://github.com/kubernetes/kubernetes/issues/141166#issuecomment-5183613627. Sequencing is yours; it does not modify any quantity function, so it should not conflict with the tests PR landing first.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed `PersistentVolumeClaim` `status.capacity` accepting a negative quantity whose `Value()` overflows (for example `-9.5Gi` or `-1e30`), and stopped a positive capacity whose `Value()` wraps negative (for example `9223372036854775808`) from being wrongly rejected.
```

