### PR TITLE
Fix kubectl describe showing memory in millibytes

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -1892,6 +1892,24 @@ func describeContainerCommand(container corev1.Container, w PrefixWriter) {
 	}
 }
 
+// isByteSizedResource returns true for resources measured in bytes.
+func isByteSizedResource(name corev1.ResourceName) bool {
+	return name == corev1.ResourceMemory ||
+		name == corev1.ResourceStorage ||
+		name == corev1.ResourceEphemeralStorage ||
+		kubectlresourcehelper.IsHugePageResourceName(name)
+}
+
+// formatResourceQuantity rounds fractional byte-sized quantities up to whole
+// bytes, so a value stored as "107374182400m" is shown as "107374183".
+func formatResourceQuantity(name corev1.ResourceName, quantity resource.Quantity) string {
+	if _, exact := quantity.AsScale(0); exact || !isByteSizedResource(name) {
+		return quantity.String()
+	}
+	rounded := resource.NewQuantity(quantity.Value(), quantity.Format)
+	return rounded.String()
+}
+
 func describeResources(resources *corev1.ResourceRequirements, w PrefixWriter, level int) {
 	if resources == nil {
 		return
@@ -1902,7 +1920,7 @@ func describeResources(resources *corev1.ResourceRequirements, w PrefixWriter, l
 	}
 	for _, name := range SortedResourceNames(resources.Limits) {
 		quantity := resources.Limits[name]
-		w.Write(level+1, "%s:\t%s\n", name, quantity.String())
+		w.Write(level+1, "%s:\t%s\n", name, formatResourceQuantity(name, quantity))
 	}
 
 	if len(resources.Requests) > 0 {
@@ -1910,7 +1928,7 @@ func describeResources(resources *corev1.ResourceRequirements, w PrefixWriter, l
 	}
 	for _, name := range SortedResourceNames(resources.Requests) {
 		quantity := resources.Requests[name]
-		w.Write(level+1, "%s:\t%s\n", name, quantity.String())
+		w.Write(level+1, "%s:\t%s\n", name, formatResourceQuantity(name, quantity))
 	}
 }
 
@@ -4073,7 +4091,8 @@ func describeNodeResource(nodeNonTerminatedPodsList *corev1.PodList, node *corev
 		fractionMemoryLimit := float64(memoryLimit.Value()) / float64(allocatable.Memory().Value()) * 100
 		w.Write(LEVEL_1, "%s\t%s\t\t%s (%d%%)\t%s (%d%%)\t%s (%d%%)\t%s (%d%%)\t%s\n", pod.Namespace, pod.Name,
 			cpuReq.String(), int64(fractionCpuReq), cpuLimit.String(), int64(fractionCpuLimit),
-			memoryReq.String(), int64(fractionMemoryReq), memoryLimit.String(), int64(fractionMemoryLimit), translateTimestampSince(pod.CreationTimestamp))
+			formatResourceQuantity(corev1.ResourceMemory, memoryReq), int64(fractionMemoryReq),
+			formatResourceQuantity(corev1.ResourceMemory, memoryLimit), int64(fractionMemoryLimit), translateTimestampSince(pod.CreationTimestamp))
 	}
 
 	w.Write(LEVEL_0, "Allocated resources:\n  (Total limits may be over 100 percent, i.e., overcommitted.)\n")
@@ -4103,9 +4122,13 @@ func describeNodeResource(nodeNonTerminatedPodsList *corev1.PodList, node *corev
 	w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
 		corev1.ResourceCPU, cpuReqs.String(), int64(fractionCpuReqs), cpuLimits.String(), int64(fractionCpuLimits))
 	w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
-		corev1.ResourceMemory, memoryReqs.String(), int64(fractionMemoryReqs), memoryLimits.String(), int64(fractionMemoryLimits))
+		corev1.ResourceMemory,
+		formatResourceQuantity(corev1.ResourceMemory, memoryReqs), int64(fractionMemoryReqs),
+		formatResourceQuantity(corev1.ResourceMemory, memoryLimits), int64(fractionMemoryLimits))
 	w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
-		corev1.ResourceEphemeralStorage, ephemeralstorageReqs.String(), int64(fractionEphemeralStorageReqs), ephemeralstorageLimits.String(), int64(fractionEphemeralStorageLimits))
+		corev1.ResourceEphemeralStorage,
+		formatResourceQuantity(corev1.ResourceEphemeralStorage, ephemeralstorageReqs), int64(fractionEphemeralStorageReqs),
+		formatResourceQuantity(corev1.ResourceEphemeralStorage, ephemeralstorageLimits), int64(fractionEphemeralStorageLimits))
 
 	extResources := make([]string, 0, len(allocatable))
 	hugePageResources := make([]string, 0, len(allocatable))
@@ -4129,7 +4152,9 @@ func describeNodeResource(nodeNonTerminatedPodsList *corev1.PodList, node *corev
 			fractionHugePageSizeLimits = float64(hugePageSizeLimits.Value()) / float64(hugePageSizeAllocable.Value()) * 100
 		}
 		w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
-			resource, hugePageSizeRequests.String(), int64(fractionHugePageSizeRequests), hugePageSizeLimits.String(), int64(fractionHugePageSizeLimits))
+			resource,
+			formatResourceQuantity(corev1.ResourceName(resource), hugePageSizeRequests), int64(fractionHugePageSizeRequests),
+			formatResourceQuantity(corev1.ResourceName(resource), hugePageSizeLimits), int64(fractionHugePageSizeLimits))
 	}
 
 	for _, ext := range extResources {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -1512,6 +1512,79 @@ func TestDescribeResources(t *testing.T) {
 	}
 }
 
+func TestFormatResourceQuantity(t *testing.T) {
+	testCases := []struct {
+		name     string
+		resource corev1.ResourceName
+		quantity string
+		expected string
+	}{
+		{
+			name:     "fractional memory",
+			resource: corev1.ResourceMemory,
+			quantity: "0.1Gi",
+			expected: "107374183",
+		},
+		{
+			name:     "millibyte memory",
+			resource: corev1.ResourceMemory,
+			quantity: "107374182400m",
+			expected: "107374183",
+		},
+		{
+			name:     "sub-byte memory",
+			resource: corev1.ResourceMemory,
+			quantity: "1m",
+			expected: "1",
+		},
+		{
+			name:     "whole memory",
+			resource: corev1.ResourceMemory,
+			quantity: "10Gi",
+			expected: "10Gi",
+		},
+		{
+			name:     "zero memory",
+			resource: corev1.ResourceMemory,
+			quantity: "0",
+			expected: "0",
+		},
+		{
+			name:     "fractional ephemeral storage",
+			resource: corev1.ResourceEphemeralStorage,
+			quantity: "0.1Gi",
+			expected: "107374183",
+		},
+		{
+			name:     "fractional hugepages",
+			resource: corev1.ResourceName("hugepages-2Mi"),
+			quantity: "0.1Gi",
+			expected: "107374183",
+		},
+		{
+			name:     "cpu millicores",
+			resource: corev1.ResourceCPU,
+			quantity: "100m",
+			expected: "100m",
+		},
+		{
+			name:     "fractional cpu",
+			resource: corev1.ResourceCPU,
+			quantity: "0.1",
+			expected: "100m",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := formatResourceQuantity(testCase.resource, resource.MustParse(testCase.quantity))
+			if got != testCase.expected {
+				t.Errorf("expected %q, got %q", testCase.expected, got)
+			}
+		})
+	}
+}
+
 func TestDescribeContainerPorts(t *testing.T) {
 	testCases := []struct {
 		name              string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`kubectl describe` could display memory and other byte-sized resources in millibytes, e.g. `107374182400m` instead of a byte count.

This happens because a manifest value such as `memory: 0.1Gi` is not representable as a whole number of bytes — 10 does not divide a power of 2:

```
0.1 * 1024 * 1024 * 1024 * 1000 = 107374182400
```

The API server therefore stores the quantity as `107374182400m`. `describe` rendered quantities with `Quantity.String()`, which faithfully reproduced that millibyte form. A fractional byte has no physical meaning, so this is never useful to read.

This PR adds a `formatResourceQuantity` helper that rounds fractional byte-sized quantities up to the next whole byte, so `107374182400m` is displayed as `107374183`.

Implementation notes:

- `AsScale(0)` is used to detect whether a quantity is exact at whole-byte scale; only non-exact values are rewritten.
- Rounding goes through `Quantity.Value()` (which rounds fractional values up) and `resource.NewQuantity`, so the existing `resource.Quantity` canonicalization decides the suffix rather than reimplementing unit math. Values that are already whole keep their canonical suffix — `10Gi` still prints as `10Gi`.
- `MilliValue()` is deliberately avoided: it overflows `int64` above ~9.2 GB, which is well inside the range real memory limits occupy.
- The rounding is scoped to byte-sized resources (memory, storage, ephemeral-storage, hugepages) so valid CPU milli values such as `100m` are still printed unchanged.

Call sites updated in `staging/src/k8s.io/kubectl/pkg/describe/describe.go`:

- container `Limits`/`Requests` in `describeResources` (`kubectl describe pod`)
- the per-pod memory columns in the non-terminated pods table (`kubectl describe node`)
- the `Allocated resources` totals for memory and ephemeral-storage (`kubectl describe node`) — this is the output shown in the linked issue
- the hugepages rows in `Allocated resources`

Reproduced with the manifest from the issue (`cpu: 1m`, `memory: 0.1Gi`, limits `4`/`4Gi`) on a 4 CPU / 16Gi node.

Before:

```
Containers:
  pause:
    Requests:
      cpu:        1m
      memory:     107374182400m

Non-terminated Pods:          (1 in total)
  Namespace   Name   CPU Requests  CPU Limits  Memory Requests     Memory Limits
  ---------   ----   ------------  ----------  ---------------     -------------
  default     foo    1m (0%)       4 (100%)    107374182400m (0%)  4Gi (25%)

Allocated resources:
  Resource           Requests            Limits
  --------           --------            ------
  cpu                1m (0%)             4 (100%)
  memory             107374182400m (0%)  4Gi (25%)
```

After:

```
Containers:
  pause:
    Requests:
      cpu:        1m
      memory:     107374183

Non-terminated Pods:          (1 in total)
  Namespace   Name   CPU Requests  CPU Limits  Memory Requests  Memory Limits
  ---------   ----   ------------  ----------  ---------------  -------------
  default     foo    1m (0%)       4 (100%)    107374183 (0%)   4Gi (25%)

Allocated resources:
  Resource           Requests        Limits
  --------           --------        ------
  cpu                1m (0%)         4 (100%)
  memory             107374183 (0%)  4Gi (25%)
```

Note that `cpu: 1m` and the whole-byte `4Gi` / `16Gi` values are unchanged.

#### Which issue(s) this PR fixes

Fixes kubernetes/kubectl#1597

#### Does this PR introduce a user-facing change?

```release-note
Fixed `kubectl describe` displaying memory and other byte-sized resources in millibytes (for example `107374182400m`) when a fractional value such as `0.1Gi` was requested. Such quantities are now rounded up to whole bytes.
```
