### PR TITLE
client-go: support multiple leader election metrics providers

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/metrics.go
@@ -36,37 +36,35 @@ type LeaderMetric interface {
 	SlowpathExercised(name string)
 }
 
-type noopMetric struct{}
-
-func (noopMetric) On(name string)                {}
-func (noopMetric) Off(name string)               {}
-func (noopMetric) SlowpathExercised(name string) {}
-
-// defaultLeaderMetrics expects the caller to lock before setting any metrics.
 type defaultLeaderMetrics struct {
-	// leader's value indicates if the current process is the owner of name lease
-	leader LeaderMetric
+	leaders []LeaderMetric
 }
 
 func (m *defaultLeaderMetrics) leaderOn(name string) {
 	if m == nil {
 		return
 	}
-	m.leader.On(name)
+	for _, metric := range m.leaders {
+		metric.On(name)
+	}
 }
 
 func (m *defaultLeaderMetrics) leaderOff(name string) {
 	if m == nil {
 		return
 	}
-	m.leader.Off(name)
+	for _, metric := range m.leaders {
+		metric.Off(name)
+	}
 }
 
 func (m *defaultLeaderMetrics) slowpathExercised(name string) {
 	if m == nil {
 		return
 	}
-	m.leader.SlowpathExercised(name)
+	for _, metric := range m.leaders {
+		metric.SlowpathExercised(name)
+	}
 }
 
 type noMetrics struct{}
@@ -80,40 +78,40 @@ type MetricsProvider interface {
 	NewLeaderMetric() LeaderMetric
 }
 
-type noopMetricsProvider struct{}
-
-func (noopMetricsProvider) NewLeaderMetric() LeaderMetric {
-	return noopMetric{}
-}
-
-var globalMetricsFactory = leaderMetricsFactory{
-	metricsProvider: noopMetricsProvider{},
-}
+var globalMetricsFactory = leaderMetricsFactory{}
 
 type leaderMetricsFactory struct {
-	metricsProvider MetricsProvider
-
-	onlyOnce sync.Once
+	lock             sync.RWMutex
+	metricsProviders []MetricsProvider
 }
 
 func (f *leaderMetricsFactory) setProvider(mp MetricsProvider) {
-	f.onlyOnce.Do(func() {
-		f.metricsProvider = mp
-	})
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.metricsProviders = append(f.metricsProviders, mp)
 }
 
 func (f *leaderMetricsFactory) newLeaderMetrics() leaderMetricsAdapter {
-	mp := f.metricsProvider
-	if mp == (noopMetricsProvider{}) {
+	f.lock.RLock()
+	providers := append([]MetricsProvider(nil), f.metricsProviders...)
+	f.lock.RUnlock()
+
+	if len(providers) == 0 {
 		return noMetrics{}
 	}
+
+	leaders := make([]LeaderMetric, 0, len(providers))
+	for _, provider := range providers {
+		leaders = append(leaders, provider.NewLeaderMetric())
+	}
+
 	return &defaultLeaderMetrics{
-		leader: mp.NewLeaderMetric(),
+		leaders: leaders,
 	}
 }
 
-// SetProvider sets the metrics provider for all subsequently created work
-// queues. Only the first call has an effect.
+// SetProvider adds a metrics provider for all subsequently created leader
+// elections.
 func SetProvider(metricsProvider MetricsProvider) {
 	globalMetricsFactory.setProvider(metricsProvider)
 }

--- a/staging/src/k8s.io/client-go/tools/leaderelection/metrics_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/metrics_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+type countingLeaderMetric struct {
+	onCount       atomic.Int32
+	offCount      atomic.Int32
+	slowpathCount atomic.Int32
+}
+
+func (m *countingLeaderMetric) On(string) {
+	m.onCount.Add(1)
+}
+
+func (m *countingLeaderMetric) Off(string) {
+	m.offCount.Add(1)
+}
+
+func (m *countingLeaderMetric) SlowpathExercised(string) {
+	m.slowpathCount.Add(1)
+}
+
+type testMetricsProvider struct {
+	metric LeaderMetric
+}
+
+func (p testMetricsProvider) NewLeaderMetric() LeaderMetric {
+	return p.metric
+}
+
+func TestLeaderMetricsFactoryMultipleProviders(t *testing.T) {
+	factory := leaderMetricsFactory{}
+	first := &countingLeaderMetric{}
+	second := &countingLeaderMetric{}
+
+	factory.setProvider(testMetricsProvider{metric: first})
+	factory.setProvider(testMetricsProvider{metric: second})
+
+	metric := factory.newLeaderMetrics()
+	metric.leaderOn("test")
+	metric.leaderOff("test")
+	metric.slowpathExercised("test")
+
+	for name, provider := range map[string]*countingLeaderMetric{
+		"first":  first,
+		"second": second,
+	} {
+		if got := provider.onCount.Load(); got != 1 {
+			t.Errorf("%s provider On calls = %d, want 1", name, got)
+		}
+		if got := provider.offCount.Load(); got != 1 {
+			t.Errorf("%s provider Off calls = %d, want 1", name, got)
+		}
+		if got := provider.slowpathCount.Load(); got != 1 {
+			t.Errorf("%s provider SlowpathExercised calls = %d, want 1", name, got)
+		}
+	}
+}
+
+func TestLeaderMetricsFactoryProvidersApplyToSubsequentMetrics(t *testing.T) {
+	factory := leaderMetricsFactory{}
+	first := &countingLeaderMetric{}
+	second := &countingLeaderMetric{}
+
+	factory.setProvider(testMetricsProvider{metric: first})
+	beforeSecondProvider := factory.newLeaderMetrics()
+	factory.setProvider(testMetricsProvider{metric: second})
+	afterSecondProvider := factory.newLeaderMetrics()
+
+	beforeSecondProvider.leaderOn("test")
+	if got := first.onCount.Load(); got != 1 {
+		t.Fatalf("first provider On calls = %d, want 1", got)
+	}
+	if got := second.onCount.Load(); got != 0 {
+		t.Fatalf("second provider received calls from previously created metrics: got %d, want 0", got)
+	}
+
+	afterSecondProvider.leaderOn("test")
+	if got := first.onCount.Load(); got != 2 {
+		t.Errorf("first provider On calls = %d, want 2", got)
+	}
+	if got := second.onCount.Load(); got != 1 {
+		t.Errorf("second provider On calls = %d, want 1", got)
+	}
+}
+
+func TestLeaderMetricsFactoryConcurrentRegistration(t *testing.T) {
+	const providerCount = 32
+
+	factory := leaderMetricsFactory{}
+	providers := make([]*countingLeaderMetric, providerCount)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := range providers {
+		providers[i] = &countingLeaderMetric{}
+		wg.Add(1)
+		go func(metric *countingLeaderMetric) {
+			defer wg.Done()
+			<-start
+			factory.setProvider(testMetricsProvider{metric: metric})
+		}(providers[i])
+	}
+
+	close(start)
+	for i := 0; i < providerCount; i++ {
+		factory.newLeaderMetrics().leaderOn("test")
+	}
+	wg.Wait()
+
+	factory.newLeaderMetrics().leaderOn("test")
+	for i, provider := range providers {
+		if got := provider.onCount.Load(); got < 1 {
+			t.Errorf("provider %d On calls = %d, want at least 1", i, got)
+		}
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/metrics_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/metrics_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ func TestLeaderMetricsFactoryConcurrentRegistration(t *testing.T) {
 	}
 
 	close(start)
-	for i := 0; i < providerCount; i++ {
+	for range providerCount {
 		factory.newLeaderMetrics().leaderOn("test")
 	}
 	wg.Wait()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Leader-election metrics currently use `sync.Once`, so the first library that registers a provider silently prevents every other library from receiving metrics.

This change retains every registered leader-election metrics provider. Each newly created leader election receives an immutable snapshot and fans `On`, `Off`, and `SlowpathExercised` events out in registration order. Provider registration and snapshot creation are synchronized, while provider callbacks execute outside the factory lock.

#### Which issue(s) this PR is related to:

Part of #127739

#### Special notes for your reviewer:

This intentionally covers only the leader-election provider discussed in #127739; the other client-go metrics implementations can be evaluated separately.

Validation:

- `GOWORK=off go test ./tools/leaderelection -count=1`
- `GOWORK=off go test -race ./tools/leaderelection -run '^TestLeaderMetricsFactory' -count=1`
- `GOWORK=off go test -race -run TestLeaderMetricsFactory -count=20 ./tools/leaderelection`

This PR was written in part with the assistance of generative AI. I reviewed and understand the change; the validation above passed.

#### Does this PR introduce a user-facing change?

```release-note
client-go leader election metrics now support multiple registered providers for subsequently created leader elections.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
