### PR TITLE
[WIP] node e2e: check the hugepage reporting identity on one sample

### DIFF
--- a/test/e2e_node/hugepages_reporting_test.go
+++ b/test/e2e_node/hugepages_reporting_test.go
@@ -19,6 +19,7 @@ package e2enode
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -43,22 +44,33 @@ var _ = SIGDescribe("HugepageAwareMemoryReporting", framework.WithSlow(), framew
 	hugepageCount := 32 // 32 x 2Mi = 64Mi
 	hugepages := map[string]int{hugepagesResourceName2Mi: hugepageCount}
 	expectedHugepageBytes := uint64(hugepageCount) * 2 * 1024 * 1024
-	margin := uint64(50 * 1024 * 1024)
+	// The kubelet computes memory.available as the node capacity minus the
+	// working set, from one cgroup sample, and subtracts the hugepage capacity
+	// when the HugepageAwareEviction gate is enabled. Each test checks that
+	// identity on a single /stats/summary sample. A before and after comparison
+	// across the kubelet restart flakes on the memory the restart itself moves.
+	// identityEpsilon only absorbs skew between the node capacity and the root
+	// cgroup limit, and stays far below the 64Mi reservation.
+	identityEpsilon := uint64(16 * 1024 * 1024)
 
-	getAvailableMemory := func(ctx context.Context) uint64 {
-		var available uint64
+	// getMemorySample returns AvailableBytes and WorkingSetBytes from one
+	// /stats/summary response, so both come from the same cgroup sample.
+	getMemorySample := func(ctx context.Context) (uint64, uint64) {
+		var available, workingSet uint64
 		gomega.Eventually(ctx, func() error {
 			summary, err := getNodeSummary(ctx)
 			if err != nil {
 				return err
 			}
-			if summary == nil || summary.Node.Memory == nil || summary.Node.Memory.AvailableBytes == nil {
+			if summary == nil || summary.Node.Memory == nil ||
+				summary.Node.Memory.AvailableBytes == nil || summary.Node.Memory.WorkingSetBytes == nil {
 				return fmt.Errorf("memory stats not yet available")
 			}
 			available = *summary.Node.Memory.AvailableBytes
+			workingSet = *summary.Node.Memory.WorkingSetBytes
 			return nil
 		}).WithTimeout(time.Minute).WithPolling(2 * time.Second).Should(gomega.Succeed())
-		return available
+		return available, workingSet
 	}
 
 	getNodeMemoryCapacity := func(ctx context.Context) int64 {
@@ -66,6 +78,22 @@ var _ = SIGDescribe("HugepageAwareMemoryReporting", framework.WithSlow(), framew
 		framework.ExpectNoError(err)
 		cap := node.Status.Capacity[v1.ResourceMemory]
 		return cap.Value()
+	}
+
+	// getNodeHugepageCapacity returns the sum of all hugepages-* resources in
+	// the node capacity. The kubelet subtracts this same sum, so the identity
+	// must include hugepages the node already had, for example preallocated
+	// 1Gi pages, not only the 2Mi pages this test sets.
+	getNodeHugepageCapacity := func(ctx context.Context) uint64 {
+		node, err := f.ClientSet.CoreV1().Nodes().Get(ctx, framework.TestContext.NodeName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		var total uint64
+		for name, quantity := range node.Status.Capacity {
+			if strings.HasPrefix(string(name), v1.ResourceHugePagesPrefix) {
+				total += uint64(quantity.Value())
+			}
+		}
+		return total
 	}
 
 	ginkgo.Context("with feature gate enabled", func() {
@@ -82,7 +110,6 @@ var _ = SIGDescribe("HugepageAwareMemoryReporting", framework.WithSlow(), framew
 			}
 
 			capacityBefore := getNodeMemoryCapacity(ctx)
-			availableBefore := getAvailableMemory(ctx)
 
 			ginkgo.By(fmt.Sprintf("Allocating %d x 2Mi hugepages", hugepageCount))
 			setHugepages(ctx, hugepages)
@@ -96,19 +123,18 @@ var _ = SIGDescribe("HugepageAwareMemoryReporting", framework.WithSlow(), framew
 			gomega.Expect(capacityAfter).To(gomega.Equal(capacityBefore),
 				"node memory capacity must not change")
 
-			availableAfter := getAvailableMemory(ctx)
+			hugepageBytes := getNodeHugepageCapacity(ctx)
+			gomega.Expect(hugepageBytes).To(gomega.BeNumerically(">=", expectedHugepageBytes),
+				"node capacity must report at least the hugepage reservation")
 
-			drop := uint64(0)
-			if availableBefore > availableAfter {
-				drop = availableBefore - availableAfter
-			}
+			available, workingSet := getMemorySample(ctx)
 
-			framework.Logf("enabled: availableBefore=%d availableAfter=%d drop=%d hugepages=%d",
-				availableBefore, availableAfter, drop, expectedHugepageBytes)
+			framework.Logf("enabled: capacity=%d available=%d workingSet=%d hugepages=%d",
+				capacityAfter, available, workingSet, hugepageBytes)
 
-			gomega.Expect(drop).To(
-				gomega.BeNumerically(">=", expectedHugepageBytes-margin),
-				"memory.available should decrease by at least the hugepage reservation")
+			gomega.Expect(available+workingSet+hugepageBytes).To(
+				gomega.BeNumerically("~", capacityAfter, identityEpsilon),
+				"memory.available should decrease by the hugepage reservation")
 		})
 	})
 
@@ -125,8 +151,6 @@ var _ = SIGDescribe("HugepageAwareMemoryReporting", framework.WithSlow(), framew
 				e2eskipper.Skipf("skipping: 2Mi hugepages not supported on this node")
 			}
 
-			availableBefore := getAvailableMemory(ctx)
-
 			ginkgo.By(fmt.Sprintf("Allocating %d x 2Mi hugepages", hugepageCount))
 			setHugepages(ctx, hugepages)
 			defer releaseHugepages(ctx, hugepages)
@@ -135,21 +159,16 @@ var _ = SIGDescribe("HugepageAwareMemoryReporting", framework.WithSlow(), framew
 			restartKubelet(ctx, true)
 			waitForHugepages(f, ctx, hugepages)
 
-			availableAfter := getAvailableMemory(ctx)
+			capacity := getNodeMemoryCapacity(ctx)
+			available, workingSet := getMemorySample(ctx)
 
-			framework.Logf("disabled: availableBefore=%d availableAfter=%d hugepages=%d",
-				availableBefore, availableAfter, expectedHugepageBytes)
+			framework.Logf("disabled: capacity=%d available=%d workingSet=%d hugepages=%d",
+				capacity, available, workingSet, expectedHugepageBytes)
 
-			// With the feature gate disabled, hugepage reservation is NOT subtracted
-			// from memory.available. The cgroup-based calculation still counts hugepage
-			// memory as available, so the drop should be much smaller than the
-			// hugepage reservation.
-			drop := uint64(0)
-			if availableBefore > availableAfter {
-				drop = availableBefore - availableAfter
-			}
-			gomega.Expect(drop).To(
-				gomega.BeNumerically("<", expectedHugepageBytes-margin),
+			// With the feature gate disabled, the hugepage reservation is NOT
+			// subtracted from memory.available.
+			gomega.Expect(available+workingSet).To(
+				gomega.BeNumerically("~", capacity, identityEpsilon),
 				"memory.available should NOT decrease by the hugepage reservation when feature gate is disabled")
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/sig node

#### What this PR does / why we need it:

The test `HugepageAwareMemoryReporting ... with feature gate disabled should include hugepage capacity in memory.available` fails about half of all runs of `ci-kubernetes-node-kubelet-containerd-hugepages`. It failed 115 of 216 runs between its merge on 2026-06-29 (#138127) and 2026-08-04, and it flaked from its first day. The failure is in the test's arithmetic, not in the feature.

**Why the test fails.** The test reserves 64Mi of hugepages, restarts the kubelet, and compares the node's memory.available before and after. The gate disabled case asserts that the drop stays under `reservation - margin`, which is 64Mi - 50Mi = 14Mi. That gives memory.available a 14Mi budget for everything a kubelet restart moves. The measured values from 216 CI runs show the movement is bimodal: either 0 to 5Mi (all passes) or 40 to 52Mi (all failures), with nothing in between. The variable is named `margin`, but the subtraction inverts it: a bigger margin makes the check stricter.

**The feature works in every measured run.** With the gate enabled, the drop is the 64Mi reservation plus the same movement (minimum 62.7Mi, median 72.9Mi). With the gate disabled, the drop is the movement alone, always far below the reservation. Only the threshold is wrong.

**The fix: check the kubelet's arithmetic on one sample instead of across a restart.** The kubelet computes memory.available as the root cgroup limit minus the working set, from one cgroup sample (`pkg/kubelet/stats/helper.go`). The limit equals the node's reported memory capacity. With the gate enabled, `adjustForHugePages` subtracts the sum of the node capacity's `hugepages-*` resources (`pkg/kubelet/server/stats/summary.go`). Every term is visible in one /stats/summary response plus the node object. The test now asserts the identity on a single sample:

- gate disabled: available + workingSet = capacity, within 16Mi
- gate enabled: available + workingSet + hugepageCapacity = capacity, within 16Mi

The available and workingSet values come from the same summary response, so the kubelet derived them from the same cgroup sample. The 16Mi epsilon only absorbs skew between the node capacity and the root cgroup limit. The two identities differ by the full 64Mi reservation, four times the epsilon, so the gate on and gate off cases cannot be confused. The restart itself must stay: the kubelet reads the feature gate and discovers the hugepage allocation only at startup. It now serves as setup and leaves the measurement. The `margin` variable and the before and after comparison are gone. The new check also removes a weakness of the old gate enabled case, which passed on restart movement alone (it only required a 14Mi drop).

**Validation on real nodes.** We built this branch and ran the two tests repeatedly on GCE instances of three images. Every run that reached the tests passed both:

| OS (image) | Kernel / filesystem / runtime | Runs | Specs |
|---|---|---|---|
| Ubuntu 24.04 GKE (ubuntu-gke-2404-1-34 v20260803, the image of the flaking job) | 6.8-gke, ext4, containerd | 3 of 3 | 6 of 6 |
| COS 129 (cos-129-19506-299-82, with the CI userdata) | 6.12.94, containerd | 3 of 3 | 6 of 6 |
| Fedora CoreOS 44.20260707.3.1 | 7.1.3, XFS, CRI-O 1.36 | 2 of 2 that booted | 4 of 4 |

Each pass also proves the epsilon: a residual above 16Mi fails the assertion, and no run showed one on any of the three platforms.

#### Which issue(s) this PR fixes:

Fixes #140644
Fixes #141173

#### Special notes for your reviewer:

- The change touches only test/e2e_node/hugepages_reporting_test.go.
- The optional presubmit `pull-kubernetes-node-kubelet-serial-hugepages` runs this test on the same image config as the periodic. The general serial and slow presubmits skip it, because the test is [Slow] and [Disruptive]. The validation above ran on live instances of the same images before this PR existed.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
