### PR TITLE
Rename "cache_to_watcher" to "watcher_to_client_handler" in watch event dispatch duration metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -566,6 +566,6 @@ func (c *cacheWatcher) observeDispatchMetrics(event *watchCacheEvent, builtAt, s
 	if !event.CacheReceived.IsZero() {
 		c.watcherMetrics.ObserveStage(metrics.StageStorageToCache, event.CacheReceived.Sub(event.RecordTime))
 	}
-	c.watcherMetrics.ObserveStage(metrics.StageCacheToWatcher, sentAt.Sub(builtAt))
+	c.watcherMetrics.ObserveStage(metrics.StageWatcherToClientHandler, sentAt.Sub(builtAt))
 	c.watcherMetrics.ObserveStage(metrics.StageTotal, sentAt.Sub(event.RecordTime))
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -620,15 +620,15 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 	expected := `
 # HELP apiserver_watch_events_dispatch_duration_seconds [ALPHA] Histogram of watch event dispatch latency broken by resource type and pipeline stage. The 'total' stage is the end-to-end latency of a delivered event.
 # TYPE apiserver_watch_events_dispatch_duration_seconds histogram
-apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="cache_to_watcher",le="+Inf"} 2
-apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="cache_to_watcher"} 0
-apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="cache_to_watcher"} 2
 apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="storage_to_cache",le="+Inf"} 2
 apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="storage_to_cache"} 2
 apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="storage_to_cache"} 2
 apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="total",le="+Inf"} 2
 apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="total"} 4
 apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="total"} 2
+apiserver_watch_events_dispatch_duration_seconds_bucket{group="",resource="pods",stage="watcher_to_client_handler",le="+Inf"} 2
+apiserver_watch_events_dispatch_duration_seconds_sum{group="",resource="pods",stage="watcher_to_client_handler"} 0
+apiserver_watch_events_dispatch_duration_seconds_count{group="",resource="pods",stage="watcher_to_client_handler"} 2
 `
 	if err := testutil.GatherAndCompare(gatherWithoutBuckets(registry), strings.NewReader(expected), "apiserver_watch_events_dispatch_duration_seconds"); err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -50,18 +50,18 @@ const (
 	// and when it is first processed by the cacher's reflector loop.
 	StageStorageToCache
 
-	// StageCacheToWatcher: watch.Event built -> written to watcher's result channel.
+	// StageWatcherToClientHandler: watch.Event built -> written to watcher's result channel.
 	// Captures time spent blocked handing the event off to the client,
 	// i.e. downstream (result channel) backpressure.
-	StageCacheToWatcher
+	StageWatcherToClientHandler
 
 	numDispatchStages
 )
 
 var dispatchStageName = [numDispatchStages]string{
-	StageTotal:          "total",
-	StageStorageToCache: "storage_to_cache",
-	StageCacheToWatcher: "cache_to_watcher",
+	StageTotal:                  "total",
+	StageStorageToCache:         "storage_to_cache",
+	StageWatcherToClientHandler: "watcher_to_client_handler",
 }
 
 /*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR renames the apiserver_watch_events_dispatch_duration_seconds metric stage "cache_to_watcher" to "watcher_to_client_handler". 

The previous "cache_to_watcher" was misleading because it implied a span starting at cache ingestion, but it actually measures `sentAt.Sub(builtAt)`, which starts after the cacheWatcher goroutine pops the event from input, evaluates filters, and converts it to a `watch.Event`

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/kubernetes/issues/138774

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Rename the label "cache_to_watcher" in apiserver_watch_events_dispatch_duration_seconds ALPHA metric to "watcher_to_client_handler"
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
