### PR TITLE
Refactor watch event dispatch metric stage breakdown

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -560,12 +560,13 @@ func (c *cacheWatcher) process(ctx context.Context, resourceVersion uint64) {
 }
 
 func (c *cacheWatcher) observeDispatchMetrics(event *watchCacheEvent, builtAt, sentAt time.Time) {
-	if event.Type == watch.Bookmark || sentAt.IsZero() || event.RecordTime.IsZero() {
+	if event.Type == watch.Bookmark || sentAt.IsZero() {
 		return
 	}
-	if !event.CacheReceived.IsZero() {
-		c.watcherMetrics.ObserveStage(metrics.StageStorageToCache, event.CacheReceived.Sub(event.RecordTime))
-	}
-	c.watcherMetrics.ObserveStage(metrics.StageCacheToWatcher, sentAt.Sub(builtAt))
-	c.watcherMetrics.ObserveStage(metrics.StageTotal, sentAt.Sub(event.RecordTime))
+	// The pre-fanout points are marked in processEvent; complete the per-watcher
+	// tail here then emit all stages.
+	tl := event.timeline
+	tl.MarkAt(metrics.PointEventBuilt, builtAt)
+	tl.MarkAt(metrics.PointSentToClient, sentAt)
+	c.watcherMetrics.ObserveTimeline(&tl)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -560,12 +560,18 @@ func (c *cacheWatcher) process(ctx context.Context, resourceVersion uint64) {
 }
 
 func (c *cacheWatcher) observeDispatchMetrics(event *watchCacheEvent, builtAt, sentAt time.Time) {
-	if event.Type == watch.Bookmark || sentAt.IsZero() || event.RecordTime.IsZero() {
+	if event.Type == watch.Bookmark || sentAt.IsZero() {
 		return
 	}
-	if !event.CacheReceived.IsZero() {
-		c.watcherMetrics.ObserveStage(metrics.StageStorageToCache, event.CacheReceived.Sub(event.RecordTime))
+	tl := event.timeline
+	tl.MarkAt(metrics.PointEventBuilt, builtAt)
+	tl.MarkAt(metrics.PointSentToClient, sentAt)
+
+	if !tl[metrics.PointStorageDecoded].IsZero() {
+		if !tl[metrics.PointCacheReceived].IsZero() {
+			c.watcherMetrics.ObserveStage(metrics.StageStorageToCache, tl[metrics.PointCacheReceived].Sub(tl[metrics.PointStorageDecoded]))
+		}
+		c.watcherMetrics.ObserveStage(metrics.StageTotal, sentAt.Sub(tl[metrics.PointStorageDecoded]))
 	}
 	c.watcherMetrics.ObserveStage(metrics.StageWatcherToClientHandler, sentAt.Sub(builtAt))
-	c.watcherMetrics.ObserveStage(metrics.StageTotal, sentAt.Sub(event.RecordTime))
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -563,15 +563,10 @@ func (c *cacheWatcher) observeDispatchMetrics(event *watchCacheEvent, builtAt, s
 	if event.Type == watch.Bookmark || sentAt.IsZero() {
 		return
 	}
+	// The pre-fanout points are marked in processEvent; complete the per-watcher
+	// tail here then emit all stages.
 	tl := event.timeline
 	tl.MarkAt(metrics.PointEventBuilt, builtAt)
 	tl.MarkAt(metrics.PointSentToClient, sentAt)
-
-	if !tl[metrics.PointStorageDecoded].IsZero() {
-		if !tl[metrics.PointCacheReceived].IsZero() {
-			c.watcherMetrics.ObserveStage(metrics.StageStorageToCache, tl[metrics.PointCacheReceived].Sub(tl[metrics.PointStorageDecoded]))
-		}
-		c.watcherMetrics.ObserveStage(metrics.StageTotal, sentAt.Sub(tl[metrics.PointStorageDecoded]))
-	}
-	c.watcherMetrics.ObserveStage(metrics.StageWatcherToClientHandler, sentAt.Sub(builtAt))
+	c.watcherMetrics.ObserveTimeline(&tl)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -573,13 +573,29 @@ func TestCacheWatcherDrainingNoBookmarkAfterResourceVersionSent(t *testing.T) {
 
 	// note that we can add three events even though the chanSize is two because
 	// one event has been popped off from the input chan
-	if !w.add(&watchCacheEvent{Object: makePod(5), ResourceVersion: 5, RecordTime: fakeClock.Now().Add(-2 * time.Second), CacheReceived: fakeClock.Now().Add(-1 * time.Second)}, time.NewTimer(1*time.Second)) {
+	if !w.add(&watchCacheEvent{
+		Object:          makePod(5),
+		ResourceVersion: 5,
+		RecordTime:      fakeClock.Now().Add(-2 * time.Second),
+		timeline: metrics.DispatchTimeline{
+			metrics.PointStorageDecoded: fakeClock.Now().Add(-2 * time.Second),
+			metrics.PointCacheReceived:  fakeClock.Now().Add(-1 * time.Second),
+		},
+	}, time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
 	}
 	if !w.nonblockingAdd(&watchCacheEvent{Type: watch.Bookmark, ResourceVersion: 10, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "10"}}}) {
 		t.Fatal("failed adding an even to the watcher")
 	}
-	if !w.add(&watchCacheEvent{Object: makePod(15), ResourceVersion: 15, RecordTime: fakeClock.Now().Add(-2 * time.Second), CacheReceived: fakeClock.Now().Add(-1 * time.Second)}, time.NewTimer(1*time.Second)) {
+	if !w.add(&watchCacheEvent{
+		Object:          makePod(15),
+		ResourceVersion: 15,
+		RecordTime:      fakeClock.Now().Add(-2 * time.Second),
+		timeline: metrics.DispatchTimeline{
+			metrics.PointStorageDecoded: fakeClock.Now().Add(-2 * time.Second),
+			metrics.PointCacheReceived:  fakeClock.Now().Add(-1 * time.Second),
+		},
+	}, time.NewTimer(1*time.Second)) {
 		t.Fatal("failed adding an even to the watcher")
 	}
 	if w.add(&watchCacheEvent{Object: makePod(20), ResourceVersion: 20}, time.NewTimer(1*time.Second)) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -33,35 +33,49 @@ const (
 	subsystem = "watch_cache"
 )
 
-// DispatchStage identifies a single stage of an event's lifecycle as it moves
-// through the watch cache dispatch pipeline. It is used as the "stage" label
-// value on the dispatchStageDuration metric.
-//
-// StageTotal is the end-to-end latency of a successfully delivered event.
-// The remaining stages measure individual segments of that path.
-type DispatchStage int
+// DispatchPoint identifies a point in a watch event's dispatch lifecycle. The
+// duration between two points forms a labeled "stage" of the dispatch_duration
+// metric.
+type DispatchPoint int
 
 const (
-	// StageTotal: end-to-end, etcd decode -> written to the result channel.
-	StageTotal DispatchStage = iota
+	// PointStorageDecoded: the event was decoded from the storage backend (etcd).
+	PointStorageDecoded DispatchPoint = iota
+	// PointCacheReceived: the event was first processed by the cacher's reflector loop.
+	PointCacheReceived
+	// PointEventBuilt: the outgoing watch.Event was built (filter + convert).
+	PointEventBuilt
+	// PointSentToClient: the watch.Event was written to the watcher's result channel.
+	PointSentToClient
 
-	// StageStorageToCache: event decoded from etcd -> event received by cacher.
-	// Captures the delay between when an event is decoded from the storage backend
-	// and when it is first processed by the cacher's reflector loop.
-	StageStorageToCache
-
-	// StageCacheToWatcher: watch.Event built -> written to watcher's result channel.
-	// Captures time spent blocked handing the event off to the client,
-	// i.e. downstream (result channel) backpressure.
-	StageCacheToWatcher
-
-	numDispatchStages
+	numDispatchPoints
 )
 
-var dispatchStageName = [numDispatchStages]string{
-	StageTotal:          "total",
-	StageStorageToCache: "storage_to_cache",
-	StageCacheToWatcher: "cache_to_watcher",
+// DispatchTimeline records the timestamp at which each DispatchPoint was reached
+// for a single event delivery. Points that occur before fan-out are shared and
+// carried on the event; per-watcher points are filled in on delivery.
+//
+// Because DispatchTimeline is an array value, callers sharing a timeline across
+// goroutines (such as during watch event fan-out) should copy it by value
+// (e.g. tl := event.timeline) before calling MarkAt to avoid data races on
+// shared event state.
+type DispatchTimeline [numDispatchPoints]time.Time
+
+// MarkAt records a (previously captured) timestamp for the given point. Callers
+// pass their own time source so that the injectable clock and cross-goroutine
+// timestamps are respected.
+func (tl *DispatchTimeline) MarkAt(p DispatchPoint, t time.Time) { tl[p] = t }
+
+// dispatchStages declares the labeled intervals emitted from a DispatchTimeline.
+// Adding a stage is a single entry here; "total" spans the whole delivery. The
+// additive stages need not partition "total" (only a subset of points may be set).
+var dispatchStages = []struct {
+	label    string
+	from, to DispatchPoint
+}{
+	{"storage_to_cache", PointStorageDecoded, PointCacheReceived},
+	{"cache_to_watcher", PointEventBuilt, PointSentToClient},
+	{"total", PointStorageDecoded, PointSentToClient},
 }
 
 /*
@@ -352,24 +366,29 @@ func RecordsWatchCacheCapacityChange(groupResource schema.GroupResource, old, ne
 // WatcherMetricsObservers holds pre-resolved (group, resource) observers for
 // every dispatch stage, so the hot path never touches the label map.
 type WatcherMetricsObservers struct {
-	stageDurations [numDispatchStages]compbasemetrics.ObserverMetric
+	// stageDurations is indexed by position in dispatchStages.
+	stageDurations []compbasemetrics.ObserverMetric
 }
 
 // NewWatcherMetricsObservers creates a pre-resolved metrics observer for watch connections.
 func NewWatcherMetricsObservers(groupResource schema.GroupResource) *WatcherMetricsObservers {
-	o := &WatcherMetricsObservers{}
-	for s := range numDispatchStages {
-		o.stageDurations[s] = DispatchStageDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchStageName[s])
+	o := &WatcherMetricsObservers{stageDurations: make([]compbasemetrics.ObserverMetric, len(dispatchStages))}
+	for i, s := range dispatchStages {
+		o.stageDurations[i] = DispatchStageDuration.WithLabelValues(groupResource.Group, groupResource.Resource, s.label)
 	}
 	return o
 }
 
-// ObserveStage records the duration spent in the given dispatch stage.
-func (d *WatcherMetricsObservers) ObserveStage(stage DispatchStage, duration time.Duration) {
-	if stage < 0 || stage >= numDispatchStages {
-		return
+// ObserveTimeline emits the duration of every dispatch stage whose two endpoints
+// are both set on the timeline; stages with a missing endpoint are skipped.
+func (d *WatcherMetricsObservers) ObserveTimeline(tl *DispatchTimeline) {
+	for i, stage := range dispatchStages {
+		from, to := tl[stage.from], tl[stage.to]
+		if from.IsZero() || to.IsZero() {
+			continue
+		}
+		observe(d.stageDurations[i], to.Sub(from))
 	}
-	observe(d.stageDurations[stage], duration)
 }
 
 func observe(m compbasemetrics.ObserverMetric, duration time.Duration) {
@@ -387,9 +406,9 @@ var noopObs noopObserver
 
 // NewNoopWatcherMetricsObservers returns a metrics observers struct that does nothing.
 func NewNoopWatcherMetricsObservers() *WatcherMetricsObservers {
-	o := &WatcherMetricsObservers{}
-	for s := range o.stageDurations {
-		o.stageDurations[s] = noopObs
+	o := &WatcherMetricsObservers{stageDurations: make([]compbasemetrics.ObserverMetric, len(dispatchStages))}
+	for i := range o.stageDurations {
+		o.stageDurations[i] = noopObs
 	}
 	return o
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -33,38 +33,9 @@ const (
 	subsystem = "watch_cache"
 )
 
-// DispatchStage identifies a single stage of an event's lifecycle as it moves
-// through the watch cache dispatch pipeline. It is used as the "stage" label
-// value on the dispatchStageDuration metric.
-//
-// StageTotal is the end-to-end latency of a successfully delivered event.
-// The remaining stages measure individual segments of that path.
-type DispatchStage int
-
-const (
-	// StageTotal: end-to-end, etcd decode -> written to the result channel.
-	StageTotal DispatchStage = iota
-
-	// StageStorageToCache: event decoded from etcd -> event received by cacher.
-	// Captures the delay between when an event is decoded from the storage backend
-	// and when it is first processed by the cacher's reflector loop.
-	StageStorageToCache
-
-	// StageWatcherToClientHandler: watch.Event built -> written to watcher's result channel.
-	// Captures time spent blocked handing the event off to the client,
-	// i.e. downstream (result channel) backpressure.
-	StageWatcherToClientHandler
-
-	numDispatchStages
-)
-
-var dispatchStageName = [numDispatchStages]string{
-	StageTotal:                  "total",
-	StageStorageToCache:         "storage_to_cache",
-	StageWatcherToClientHandler: "watcher_to_client_handler",
-}
-
-// DispatchPoint identifies a point in a watch event's dispatch lifecycle.
+// DispatchPoint identifies a point in a watch event's dispatch lifecycle. The
+// duration between two points forms a labeled "stage" of the dispatch_duration
+// metric.
 type DispatchPoint int
 
 const (
@@ -94,6 +65,18 @@ type DispatchTimeline [numDispatchPoints]time.Time
 // pass their own time source so that the injectable clock and cross-goroutine
 // timestamps are respected.
 func (tl *DispatchTimeline) MarkAt(p DispatchPoint, t time.Time) { tl[p] = t }
+
+// dispatchStages declares the labeled intervals emitted from a DispatchTimeline.
+// Adding a stage is a single entry here; "total" spans the whole delivery. The
+// additive stages need not partition "total" (only a subset of points may be set).
+var dispatchStages = []struct {
+	label    string
+	from, to DispatchPoint
+}{
+	{"storage_to_cache", PointStorageDecoded, PointCacheReceived},
+	{"watcher_to_client_handler", PointEventBuilt, PointSentToClient},
+	{"total", PointStorageDecoded, PointSentToClient},
+}
 
 /*
  * By default, all the following metrics are defined as falling under
@@ -383,24 +366,29 @@ func RecordsWatchCacheCapacityChange(groupResource schema.GroupResource, old, ne
 // WatcherMetricsObservers holds pre-resolved (group, resource) observers for
 // every dispatch stage, so the hot path never touches the label map.
 type WatcherMetricsObservers struct {
-	stageDurations [numDispatchStages]compbasemetrics.ObserverMetric
+	// stageDurations is indexed by position in dispatchStages.
+	stageDurations []compbasemetrics.ObserverMetric
 }
 
 // NewWatcherMetricsObservers creates a pre-resolved metrics observer for watch connections.
 func NewWatcherMetricsObservers(groupResource schema.GroupResource) *WatcherMetricsObservers {
-	o := &WatcherMetricsObservers{}
-	for s := range numDispatchStages {
-		o.stageDurations[s] = DispatchStageDuration.WithLabelValues(groupResource.Group, groupResource.Resource, dispatchStageName[s])
+	o := &WatcherMetricsObservers{stageDurations: make([]compbasemetrics.ObserverMetric, len(dispatchStages))}
+	for i, s := range dispatchStages {
+		o.stageDurations[i] = DispatchStageDuration.WithLabelValues(groupResource.Group, groupResource.Resource, s.label)
 	}
 	return o
 }
 
-// ObserveStage records the duration spent in the given dispatch stage.
-func (d *WatcherMetricsObservers) ObserveStage(stage DispatchStage, duration time.Duration) {
-	if stage < 0 || stage >= numDispatchStages {
-		return
+// ObserveTimeline emits the duration of every dispatch stage whose two endpoints
+// are both set on the timeline; stages with a missing endpoint are skipped.
+func (d *WatcherMetricsObservers) ObserveTimeline(tl *DispatchTimeline) {
+	for i, stage := range dispatchStages {
+		from, to := tl[stage.from], tl[stage.to]
+		if from.IsZero() || to.IsZero() {
+			continue
+		}
+		observe(d.stageDurations[i], to.Sub(from))
 	}
-	observe(d.stageDurations[stage], duration)
 }
 
 func observe(m compbasemetrics.ObserverMetric, duration time.Duration) {
@@ -418,9 +406,9 @@ var noopObs noopObserver
 
 // NewNoopWatcherMetricsObservers returns a metrics observers struct that does nothing.
 func NewNoopWatcherMetricsObservers() *WatcherMetricsObservers {
-	o := &WatcherMetricsObservers{}
-	for s := range o.stageDurations {
-		o.stageDurations[s] = noopObs
+	o := &WatcherMetricsObservers{stageDurations: make([]compbasemetrics.ObserverMetric, len(dispatchStages))}
+	for i := range o.stageDurations {
+		o.stageDurations[i] = noopObs
 	}
 	return o
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -64,6 +64,37 @@ var dispatchStageName = [numDispatchStages]string{
 	StageWatcherToClientHandler: "watcher_to_client_handler",
 }
 
+// DispatchPoint identifies a point in a watch event's dispatch lifecycle.
+type DispatchPoint int
+
+const (
+	// PointStorageDecoded: the event was decoded from the storage backend (etcd).
+	PointStorageDecoded DispatchPoint = iota
+	// PointCacheReceived: the event was first processed by the cacher's reflector loop.
+	PointCacheReceived
+	// PointEventBuilt: the outgoing watch.Event was built (filter + convert).
+	PointEventBuilt
+	// PointSentToClient: the watch.Event was written to the watcher's result channel.
+	PointSentToClient
+
+	numDispatchPoints
+)
+
+// DispatchTimeline records the timestamp at which each DispatchPoint was reached
+// for a single event delivery. Points that occur before fan-out are shared and
+// carried on the event; per-watcher points are filled in on delivery.
+//
+// Because DispatchTimeline is an array value, callers sharing a timeline across
+// goroutines (such as during watch event fan-out) should copy it by value
+// (e.g. tl := event.timeline) before calling MarkAt to avoid data races on
+// shared event state.
+type DispatchTimeline [numDispatchPoints]time.Time
+
+// MarkAt records a (previously captured) timestamp for the given point. Callers
+// pass their own time source so that the injectable clock and cross-goroutine
+// timestamps are respected.
+func (tl *DispatchTimeline) MarkAt(p DispatchPoint, t time.Time) { tl[p] = t }
+
 /*
  * By default, all the following metrics are defined as falling under
  * ALPHA stability level https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/1209-metrics-stability/kubernetes-control-plane-metrics-stability.md#stability-classes)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -68,8 +68,10 @@ type watchCacheEvent struct {
 	Key             string
 	ResourceVersion uint64
 	RecordTime      time.Time
-	// CacheReceived is the time the event was received by the cacher.
-	CacheReceived time.Time
+	// timeline carries the shared, pre-fan-out dispatch-lifecycle timestamps of
+	// this event (currently PointCacheReceived). Per-watcher points are filled in
+	// on delivery.
+	timeline metrics.DispatchTimeline
 }
 
 // watchCache implements a Store interface.
@@ -236,8 +238,9 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64) err
 		Key:             key,
 		ResourceVersion: resourceVersion,
 		RecordTime:      recordTime,
-		CacheReceived:   cacheReceived,
 	}
+	wcEvent.timeline.MarkAt(metrics.PointStorageDecoded, recordTime)
+	wcEvent.timeline.MarkAt(metrics.PointCacheReceived, cacheReceived)
 
 	// We can call w.storage.Get() outside of a critical section,
 	// because the w.storage itself is thread-safe and the only


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
This PR refactors `apiserver_watch_events_dispatch_duration_seconds` stage tracking by replacing the hardcoded `DispatchStage` enum with a timestamp array (`DispatchTimeline`) and a table-driven stage mapping (`dispatchStages`).

Adding future watch dispatch latency stages is now a one-line change in `dispatchStages`, without modifying `watchCacheEvent` struct fields or method signatures. 

Follow up to [this](https://github.com/kubernetes/kubernetes/pull/140851#discussion_r3632639662) comment

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
https://github.com/kubernetes/kubernetes/issues/138774

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
