### PR TITLE
apimachinery: fix managedfields.ExtractInto nil panic when fieldset leaves are absent from live object

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/extract.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/extract.go
@@ -72,7 +72,11 @@ func ExtractInto(object runtime.Object, objectType typed.ParseableType, fieldMan
 	u := typedObj.ExtractItems(fieldset.Leaves()).AsValue().Unstructured()
 	m, ok := u.(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("unable to convert managed fields for %s to unstructured, expected map, got %T", fieldManager, u)
+		if u == nil {
+			m = map[string]interface{}{}
+		} else {
+			return fmt.Errorf("unable to convert managed fields for %s to unstructured, expected map, got %T", fieldManager, u)
+		}
 	}
 
 	// set the type meta manually if it doesn't exist to avoid missing kind errors

--- a/staging/src/k8s.io/apimachinery/pkg/util/managedfields/extract_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/managedfields/extract_test.go
@@ -118,6 +118,36 @@ func TestExtractInto(t *testing.T) {
 			expectedOut:  map[string]interface{}{"status": map[string]interface{}{"replicas": int64(1)}},
 			subresource:  "status",
 		},
+		{
+			name:    "unstructured, manager owns fields absent from live object",
+			obj:     &unstructured.Unstructured{Object: map[string]interface{}{"spec": map[string]interface{}{"paused": true}}},
+			objType: parser.Type("io.k8s.api.apps.v1.Deployment"),
+			managedFields: []metav1.ManagedFieldsEntry{
+				applyFieldsEntry("mgr1", `{ "f:spec": { "f:replicas": {}}}`, ""),
+			},
+			fieldManager: "mgr1",
+			expectedOut:  map[string]interface{}{"spec": nil},
+		},
+		{
+			name:    "structured, manager owns fields absent from live object",
+			obj:     &fakeDeployment{Spec: fakeDeploymentSpec{Paused: true}},
+			objType: parser.Type("io.k8s.api.apps.v1.Deployment"),
+			managedFields: []metav1.ManagedFieldsEntry{
+				applyFieldsEntry("mgr1", `{ "f:spec": { "f:replicas": {}}}`, ""),
+			},
+			fieldManager: "mgr1",
+			expectedOut:  map[string]interface{}{"spec": map[string]interface{}{"replicas": nil}},
+		},
+		{
+			name:    "unstructured, manager owns only fields not present on live object",
+			obj:     &unstructured.Unstructured{Object: map[string]interface{}{}},
+			objType: parser.Type("io.k8s.api.apps.v1.Deployment"),
+			managedFields: []metav1.ManagedFieldsEntry{
+				applyFieldsEntry("mgr1", `{ "f:stringData": { "f:password": {}}}`, ""),
+			},
+			fieldManager: "mgr1",
+			expectedOut:  map[string]interface{}{},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## What

When a field manager owns fields that do not exist on the live object (e.g. `Secret.stringData`, which is converted to `data` by the API server and never appears on read-back), `ExtractInto` fails with:

```
unable to convert managed fields for <manager> to unstructured, expected map, got <nil>
```

The root cause: `typedObj.ExtractItems(fieldset.Leaves()).AsValue().Unstructured()` returns `nil` when all owned fields are absent from the live object. The type assertion `u.(map[string]interface{})` then fails.

This is inconsistent with `ExtractInto`'s documented behavior (lines 32-36): *"no error is returned, but applyConfiguration is left unpopulated"* when the manager owns nothing extractable.

## Fix

Treat a `nil` result from `Unstructured()` as an empty `map[string]interface{}`, which leaves `applyConfiguration` unpopulated — matching the documented behavior for the case where no managed fields are found at all.

## Testing

Added three test cases to `extract_test.go`:

1. **unstructured, manager owns fields absent from live object** — manager owns `f:spec.f:replicas` but the object only has `spec.paused`; extract returns `{"spec": nil}` (the struct path exists but leaf is absent)
2. **structured, manager owns fields absent from live object** — same scenario with a typed object; extract returns `{"spec": {"replicas": nil}}`
3. **unstructured, manager owns only fields not present on live object** — manager owns `f:stringData.f:password` on a Deployment (field doesn't exist at all); previously this was the bug case returning an error, now returns `{}`

Fixes #141153

/sig api-machinery

## Release Note

```release-note
BUG FIX: Fixed managedfields.ExtractInto returning an error when a field manager owns fields that are not present on the live object (e.g. Secret stringData). The function now correctly returns an empty applied configuration instead of failing with "expected map, got <nil>".
```