### PR TITLE
Fix startup probe not gating liveness/readiness probes after containe…

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2692,7 +2692,13 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 		if !utilfeature.DefaultFeatureGate.Enabled(features.ChangeContainerStatusOnKubeletRestart) {
 			if cStatus.State == kubecontainer.ContainerStateRunning {
 				if oldStatus, ok := oldStatuses[status.Name]; ok && oldStatus.Started != nil {
-					status.Started = oldStatus.Started
+					// Only inherit the Started status from the previous status if the
+					// container ID has not changed. After a container restart, the new
+					// container must pass its startup probe before being considered started.
+					// See https://github.com/kubernetes/kubernetes/issues/141155
+					if oldStatus.ContainerID == status.ContainerID {
+						status.Started = oldStatus.Started
+					}
 				}
 			}
 		}

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -4227,6 +4227,103 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 	}
 }
 
+// TestConvertToAPIContainerStatuses_StartedNotInheritedOnContainerRestart verifies
+// that after a container restart (new containerID), the Started field is NOT
+// inherited from the previous container's status, but after a kubelet restart
+// (same containerID), it IS preserved. Regression test for
+// https://github.com/kubernetes/kubernetes/issues/141155
+func TestConvertToAPIContainerStatuses_StartedNotInheritedOnContainerRestart(t *testing.T) {
+	tests := []struct {
+		name            string
+		featureEnabled  bool
+		oldContainerID  string
+		newContainerID  kubecontainer.ContainerID
+		expectInherited bool
+	}{
+		{
+			name:            "container restart, feature disabled (v1.35+, regression case)",
+			featureEnabled:  false,
+			oldContainerID:  "containerd://old-container-id",
+			newContainerID:  kubecontainer.ContainerID{Type: "containerd", ID: "new-container-id"},
+			expectInherited: false,
+		},
+		{
+			name:            "container restart, feature enabled (v1.34-)",
+			featureEnabled:  true,
+			oldContainerID:  "containerd://old-container-id",
+			newContainerID:  kubecontainer.ContainerID{Type: "containerd", ID: "new-container-id"},
+			expectInherited: false,
+		},
+		{
+			name:            "kubelet restart, feature disabled (same containerID, Started preserved)",
+			featureEnabled:  false,
+			oldContainerID:  "containerd://same-container-id",
+			newContainerID:  kubecontainer.ContainerID{Type: "containerd", ID: "same-container-id"},
+			expectInherited: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ChangeContainerStatusOnKubeletRestart, tc.featureEnabled)
+			tCtx := ktesting.Init(t)
+
+			pod := &v1.Pod{
+				Spec: v1.PodSpec{
+					NodeName:      "machine",
+					Containers:    []v1.Container{{Name: "containerA"}},
+					RestartPolicy: v1.RestartPolicyAlways,
+				},
+			}
+
+			started := true
+			previousStatus := []v1.ContainerStatus{
+				{
+					Name:        "containerA",
+					ContainerID: tc.oldContainerID,
+					State: v1.ContainerState{
+						Running: &v1.ContainerStateRunning{},
+					},
+					Started: &started,
+				},
+			}
+
+			currentStatus := &kubecontainer.PodStatus{
+				ContainerStatuses: []*kubecontainer.Status{
+					{
+						Name:      "containerA",
+						ID:        tc.newContainerID,
+						State:     kubecontainer.ContainerStateRunning,
+						StartedAt: time.Now(),
+					},
+				},
+			}
+
+			kubelet := &Kubelet{}
+			kubelet.reasonCache = NewReasonCache()
+
+			containerStatuses := kubelet.convertToAPIContainerStatuses(
+				tCtx,
+				pod,
+				currentStatus,
+				previousStatus,
+				pod.Spec.Containers,
+				nil,   // imageVolumeNames
+				false, // hasInitContainers
+				false, // isInitContainer
+				false, // podRestarting
+			)
+
+			if assert.Len(t, containerStatuses, 1) {
+				cs := containerStatuses[0]
+				inherited := cs.Started != nil && *cs.Started
+				assert.Equal(t, tc.expectInherited, inherited,
+					"Started inherited mismatch (oldID=%q, newID=%q)", tc.oldContainerID, cs.ContainerID)
+			}
+		})
+	}
+}
+
 // imageDigestRuntime is a simple wrapper that returns a fixed digest for image volumes
 type imageDigestRuntime struct {
 	*containertest.FakeRuntime

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -402,6 +402,113 @@ var _ = SIGDescribe("Probing container", func() {
 	})
 
 	/*
+		Release: v1.38
+		Testname: Pod startup probe re-gates liveness after container restart
+		Description: A Pod with startup and liveness probes restarts due to
+		liveness failure. The restarted container MUST pass startup probe
+		before liveness probe begins.
+	*/
+	f.It("should not run liveness probe before startup probe succeeds after container restart", f.WithNodeConformance(), func(ctx context.Context) {
+		// 1. Create pod: startup passes only for initial container,
+		//    liveness passes only for initial container without fail-liveness flag.
+		// 2. Trigger liveness failure via "touch /state/fail-liveness" → container restarts.
+		// 3. After restart: liveness always fails. If startup correctly gates
+		//    liveness, it never runs → restartCount == 1. If bug exists,
+		//    liveness runs before startup → restartCount >= 2.
+		cmd := []string{"/bin/sh", "-c", `
+instance=initial
+if test -f /state/container-seen; then
+  instance=replacement
+else
+  touch /state/container-seen
+fi
+echo "$instance" > /state/instance
+sleep 3600
+`}
+		startupProbe := &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				Exec: &v1.ExecAction{
+					Command: []string{"/bin/sh", "-c", `test "$(cat /state/instance)" = "initial"`},
+				},
+			},
+			PeriodSeconds:    1,
+			FailureThreshold: 100,
+		}
+		livenessProbe := &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				Exec: &v1.ExecAction{
+					Command: []string{"/bin/sh", "-c", `test "$(cat /state/instance)" = "initial" && test ! -f /state/fail-liveness`},
+				},
+			},
+			PeriodSeconds:    1,
+			FailureThreshold: 1,
+		}
+
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "startup-restart-" + string(uuid.NewUUID()),
+				Labels: map[string]string{"test": "startup-restart"},
+			},
+			Spec: v1.PodSpec{
+				TerminationGracePeriodSeconds: ptr.To[int64](2),
+				Containers: []v1.Container{
+					{
+						Name:          "busybox",
+						Image:         imageutils.GetE2EImage(imageutils.BusyBox),
+						Command:       cmd,
+						LivenessProbe: livenessProbe,
+						StartupProbe:  startupProbe,
+						VolumeMounts: []v1.VolumeMount{
+							{Name: "state", MountPath: "/state"},
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{
+						Name:         "state",
+						VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+					},
+				},
+			},
+		}
+
+		podClient := e2epod.NewPodClient(f)
+		ginkgo.DeferCleanup(func(ctx context.Context) error {
+			return podClient.Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
+		})
+
+		ginkgo.By("Creating the pod and waiting for startup probe to pass")
+		podClient.Create(ctx, pod)
+		framework.ExpectNoError(e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "container started", 60*time.Second, func(pod *v1.Pod) (bool, error) {
+			if len(pod.Status.ContainerStatuses) == 0 {
+				return false, nil
+			}
+			return pod.Status.ContainerStatuses[0].Started != nil && *pod.Status.ContainerStatuses[0].Started, nil
+		}))
+
+		ginkgo.By("Triggering liveness probe failure to restart the container")
+		stdout, stderr, err := e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, "busybox", "/bin/sh", "-c", "touch /state/fail-liveness")
+		framework.Logf("exec stdout=%q stderr=%q err=%v", stdout, stderr, err)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for container to restart")
+		framework.ExpectNoError(e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "container restarted", 60*time.Second, func(pod *v1.Pod) (bool, error) {
+			if len(pod.Status.ContainerStatuses) == 0 {
+				return false, nil
+			}
+			return pod.Status.ContainerStatuses[0].RestartCount >= 1, nil
+		}))
+
+		ginkgo.By("Verifying startup probe gates liveness after restart")
+		time.Sleep(10 * time.Second)
+		pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		restartCount := pod.Status.ContainerStatuses[0].RestartCount
+		gomega.Expect(restartCount).To(gomega.BeNumerically("==", 1),
+			"Expected exactly 1 restart, but got %d. Liveness probe ran before startup probe after restart.", restartCount)
+	})
+
+	/*
 		Release: v1.16
 		Testname: Pod readiness probe, delayed by startup probe
 		Description: A Pod is created with startup and readiness probes. The Container is started by creating /tmp/startup after 45 seconds, delaying the ready state by this amount of time. This is similar to the "Pod readiness probe, with initial delay" test.

--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -7453,3 +7453,194 @@ var _ = SIGDescribe(framework.WithSerial(), "Not Change Container Status", frame
 		})
 	})
 })
+
+// This test verifies that after a container exits while the kubelet is stopped,
+// the restarted kubelet does not inherit the Started=true status from the old
+// container. The replacement container must pass its startup probe before
+// liveness probes begin.
+// Ref: https://github.com/kubernetes/kubernetes/issues/141155
+var _ = SIGDescribe(framework.WithSerial(), "Startup probe gates probes after kubelet restart",
+	framework.WithFeatureGate(features.ChangeContainerStatusOnKubeletRestart), func() {
+		f := framework.NewDefaultFramework("startup-probe-kubelet-restart-serial")
+		addAfterEachForCleaningUpPods(f)
+		f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+		ginkgo.It("should not inherit Started status from previous container after kubelet restart", func(ctx context.Context) {
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "startup-gate-kubelet-restart",
+				},
+				Spec: v1.PodSpec{
+					TerminationGracePeriodSeconds: ptr.To[int64](2),
+					RestartPolicy:                 v1.RestartPolicyAlways,
+					Containers: []v1.Container{
+						{
+							Name:    "busybox",
+							Image:   imageutils.GetE2EImage(imageutils.BusyBox),
+							Command: []string{"/bin/sh", "-c", "sleep 3600"},
+							StartupProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										// Startup only passes when /state/allow-startup exists.
+										// The test controls this via exec.
+										Command: []string{"/bin/sh", "-c", "test -f /state/allow-startup"},
+									},
+								},
+								PeriodSeconds:    1,
+								FailureThreshold: 300,
+							},
+							LivenessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									Exec: &v1.ExecAction{
+										// Observable side effect: append a line on each execution.
+										Command: []string{"/bin/sh", "-c", "echo 1 >> /state/liveness-log"},
+									},
+								},
+								PeriodSeconds:    1,
+								FailureThreshold: 3,
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{Name: "state", MountPath: "/state"},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name:         "state",
+							VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+						},
+					},
+				},
+			}
+
+			podClient := e2epod.NewPodClient(f)
+			pod = podClient.Create(ctx, pod)
+
+			// Step 1: Manually trigger startup probe success for the initial container.
+			ginkgo.By("Waiting for the initial container to be running")
+			err := e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "container running", f.Timeouts.PodStart,
+				func(p *v1.Pod) (bool, error) {
+					if len(p.Status.ContainerStatuses) == 0 {
+						return false, nil
+					}
+					return p.Status.ContainerStatuses[0].State.Running != nil, nil
+				})
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Triggering startup probe success for the initial container")
+			_, _, err = e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, "busybox", "/bin/sh", "-c", "touch /state/allow-startup")
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for Started=true on the initial container")
+			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "Started", 60*time.Second,
+				func(p *v1.Pod) (bool, error) {
+					if len(p.Status.ContainerStatuses) == 0 {
+						return false, nil
+					}
+					cs := p.Status.ContainerStatuses[0]
+					return cs.Started != nil && *cs.Started, nil
+				})
+			framework.ExpectNoError(err)
+
+			// The grace period for kubelet startup is 10 seconds, so we wait
+			// here for 11 seconds to avoid the kubelet treating the restart
+			// as part of its own startup sequence.
+			time.Sleep(11 * time.Second)
+
+			ginkgo.By("Recording the initial containerID")
+			pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			initialContainerID := pod.Status.ContainerStatuses[0].ContainerID
+			framework.Logf("Initial containerID: %s", initialContainerID)
+
+			// Step 2: Stop the kubelet.
+			ginkgo.By("Stopping the kubelet")
+			restartKubelet := mustStopKubelet(ctx, f)
+
+			// Step 3: Cause the container to exit while the kubelet is stopped.
+			ginkgo.By("Stopping the pod sandbox to simulate container exit while kubelet is down")
+			rs, _, err := getCRIClient(ctx)
+			framework.ExpectNoError(err)
+
+			sandboxes, err := rs.ListPodSandbox(ctx, &runtimeapi.PodSandboxFilter{})
+			framework.ExpectNoError(err)
+
+			var podSandboxID string
+			for _, sb := range sandboxes {
+				if sb.Metadata != nil && sb.Metadata.Name == pod.Name && sb.Metadata.Namespace == pod.Namespace {
+					podSandboxID = sb.Id
+					break
+				}
+			}
+			gomega.Expect(podSandboxID).ToNot(gomega.BeEmpty(), "should find pod sandbox for %s/%s", pod.Namespace, pod.Name)
+
+			err = rs.StopPodSandbox(ctx, podSandboxID)
+			framework.ExpectNoError(err)
+
+			// Step 4: Restart the kubelet and wait for replacement container.
+			ginkgo.By("Restarting the kubelet")
+			restartKubelet(ctx)
+
+			ginkgo.By("Waiting for a replacement container with a new containerID to be running")
+			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "new container running", 120*time.Second,
+				func(p *v1.Pod) (bool, error) {
+					if len(p.Status.ContainerStatuses) == 0 {
+						return false, nil
+					}
+					cs := p.Status.ContainerStatuses[0]
+					return cs.ContainerID != "" && cs.ContainerID != initialContainerID && cs.State.Running != nil, nil
+				})
+			framework.ExpectNoError(err)
+
+			// Step 5: Verify Started=false (startup probe has not passed yet).
+			ginkgo.By("Verifying the replacement container has Started=false")
+			pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			cs := pod.Status.ContainerStatuses[0]
+			framework.Logf("Replacement containerID: %s, Started: %v", cs.ContainerID, cs.Started)
+			gomega.Expect(cs.Started == nil || !*cs.Started).To(gomega.BeTrueBecause(
+				"startup probe should not have passed yet for the replacement container"))
+
+			// Step 6: Verify liveness probe has NOT run (no side effect file).
+			ginkgo.By("Verifying liveness probe has not executed before startup passes")
+			stdout, _, err := e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, "busybox", "/bin/sh", "-c", "cat /state/liveness-log 2>/dev/null | wc -l")
+			framework.ExpectNoError(err)
+			gomega.Expect(strings.TrimSpace(stdout)).To(gomega.Equal("0"),
+				"liveness probe should not have run while startup probe is failing")
+
+			// Step 7: Allow startup to pass, then verify everything works.
+			ginkgo.By("Triggering startup probe success for the replacement container")
+			_, _, err = e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, "busybox", "/bin/sh", "-c", "touch /state/allow-startup")
+			framework.ExpectNoError(err)
+
+			ginkgo.By("Waiting for Started=true on the replacement container")
+			err = e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "replacement started", 60*time.Second,
+				func(p *v1.Pod) (bool, error) {
+					if len(p.Status.ContainerStatuses) == 0 {
+						return false, nil
+					}
+					cs := p.Status.ContainerStatuses[0]
+					return cs.Started != nil && *cs.Started, nil
+				})
+			framework.ExpectNoError(err)
+
+			// Wait a few seconds for liveness to execute at least once.
+			time.Sleep(3 * time.Second)
+
+			ginkgo.By("Verifying liveness probe is now executing after startup passed")
+			stdout, _, err = e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, "busybox", "/bin/sh", "-c", "cat /state/liveness-log 2>/dev/null | wc -l")
+			framework.ExpectNoError(err)
+			livenessCount := strings.TrimSpace(stdout)
+			framework.Logf("Liveness executions after startup passed: %s", livenessCount)
+			gomega.Expect(livenessCount).ToNot(gomega.Equal("0"),
+				"liveness probe should have run after startup probe passed")
+
+			// Final: verify no extra restarts.
+			ginkgo.By("Verifying RestartCount is exactly 1")
+			pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+			gomega.Expect(pod.Status.ContainerStatuses[0].RestartCount).To(gomega.Equal(int32(1)),
+				"Expected exactly 1 restart (from sandbox stop). "+
+					"More restarts indicate liveness ran before startup on the replacement container.")
+		})
+	})


### PR DESCRIPTION
…r restart

After a container restart triggered by a liveness probe failure, the new container could see liveness probes executing before its startup probe has passed. This violated the documented behavior that startup probes must succeed before liveness/readiness probes begin.

Root cause: When the ChangeContainerStatusOnKubeletRestart feature gate is disabled (default since v1.35), convertToAPIContainerStatuses() inherits the Started field from the previous container status by container name, without checking whether the containerID has changed. This causes the new container to appear as already started, allowing liveness/readiness probes to run immediately.

Fix:
1. In kubelet_pods.go: Only inherit Started from old status when the containerID has not changed (kubelet restart), not when a new container has started (container restart).
2. In prober/worker.go: Add a defensive check in doProbe() that consults startupManager for the current containerID before trusting the cached Started status, preventing the race between status publication and probe execution.

Fixes https://github.com/kubernetes/kubernetes/issues/141155

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
#141155 
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
it is legacy issues and triggered from 1.35 because one feature gate is disabled by default.  issue should be happens in 1.35 as well
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a regression in v1.35+ where liveness/readiness probes could execute before the startup probe passed after a container restart.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
