### PR TITLE
Do not rely on Quantity.Value() overflow to detect sign or unset limits

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -597,7 +597,11 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 	thresholdsMap := make(map[string]*resource.Quantity)
 	for _, container := range pod.Spec.Containers {
 		ephemeralLimit := container.Resources.Limits.StorageEphemeral()
-		if ephemeralLimit != nil && ephemeralLimit.Value() != 0 {
+		// Use IsZero rather than Value to test whether a limit is set. Value can
+		// overflow an int64 and returns 0 when it does, so a large but valid limit
+		// such as "100E" would otherwise be mistaken for an unset limit and never
+		// enforced. The comparison below uses Cmp, which is overflow-safe.
+		if ephemeralLimit != nil && !ephemeralLimit.IsZero() {
 			thresholdsMap[container.Name] = ephemeralLimit
 		}
 	}
@@ -606,7 +610,7 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 			continue
 		}
 		ephemeralLimit := container.Resources.Limits.StorageEphemeral()
-		if ephemeralLimit != nil && ephemeralLimit.Value() != 0 {
+		if ephemeralLimit != nil && !ephemeralLimit.IsZero() {
 			thresholdsMap[container.Name] = ephemeralLimit
 		}
 	}

--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -315,7 +315,10 @@ func (c *csiDriverClient) NodeExpandVolume(ctx context.Context, opts csiResizeOp
 		return opts.newSize, errors.New("missing volume path")
 	}
 
-	if opts.newSize.Value() < 0 {
+	// Use Sign rather than Value to test for a negative size. Value can overflow
+	// an int64, and on overflow it does not preserve the sign, so a negative
+	// quantity such as "-9.5Gi" reports a positive Value and slips past the check.
+	if opts.newSize.Sign() < 0 {
 		return opts.newSize, errors.New("size can not be less than 0")
 	}
 

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -848,6 +848,16 @@ func TestNodeExpandVolume(t *testing.T) {
 			newSize:    *resource.NewQuantity(-10, resource.DecimalSI),
 			mustFail:   true,
 		},
+		{
+			// Quantity.Value() overflows an int64 for this input and does not
+			// preserve the sign, reporting a positive 8246196746. A negative size
+			// must still be rejected.
+			name:       "with negative quantity whose Value overflows",
+			volID:      "vol-1234",
+			volumePath: "/foo/bar",
+			newSize:    resource.MustParse("-9.5Gi"),
+			mustFail:   true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This picks up the "Fix remaining callers relying on garbage to detect overflow: `csi_client.go`, kubelet" item from the Quantity int64 overflow burndown (#141166).

`Quantity.Value()` is `ScaledValue(0)` and can overflow an int64. On overflow it neither preserves the sign nor reports the failure, so any caller using it as a predicate silently gets the wrong answer. Reproduced on current master (`ec9448ceef1`):

```
-9.5Gi   Sign()=-1  Value()=  8246196746   Value()<0  -> false
-1e30    Sign()=-1  Value()=           0   Value()<0  -> false
-100E    Sign()=-1  Value()=           0   Value()<0  -> false
100E     Sign()= 1  Value()=           0   Value()!=0 -> false
1000E    Sign()= 1  Value()=           0   Value()!=0 -> false
```

Two callers used `Value()` that way:

- `pkg/volume/csi/csi_client.go` rejected negative expansion sizes with `newSize.Value() < 0`. A negative size whose `Value()` overflows was accepted rather than rejected.
- `pkg/kubelet/eviction/eviction_manager.go` tested `ephemeralLimit.Value() != 0` to decide whether a container ephemeral-storage limit was set. A limit large enough to overflow was treated as unset.

`Sign()` and `IsZero()` read the quantity's internal representation directly (`q.i.value` / `q.d.Dec`) and never route through `ScaledValue`, so they are unaffected by overflow and are equivalent to the previous checks for every value that does not overflow. This is the same approach taken for `validateBasicResource` in #141169, and matches the existing idiom already used in `pkg/kubelet/eviction/helpers.go` (`quantity.Sign() < 0`).

**Which issue(s) this PR fixes**:

Ref #141166

**Special notes for your reviewer**:

Scope is deliberately limited to call sites that use `Value()` as a *predicate* (sign / is-it-set). I did not touch call sites that do raw int64 math on the result, since those are the separate "move callers to the new accessors" item and depend on the accessor signature being settled first. Specifically left alone:

- `pkg/volume/emptydir/empty_dir.go` guards with `sizeLimit.Value() > 0` and then uses `sizeLimit.Value()` as the mount size. Switching only the guard would make a `100E` limit emit `size=0`, which is worse than the current behavior. This one needs the checked accessors.
- `pkg/kubelet/volumemanager/cache/desired_state_of_world.go` converts through `resource.NewQuantity(...Value(), ...)` and compares the raw int64s.

On testing:

- The csi change is a real behavior change and has a regression test. It fails on master with `expected an error` and passes with the fix.
- The eviction change is behavior-preserving today: a limit large enough to overflow `Value()` cannot be exceeded by real usage, and the comparison downstream already uses `Cmp`, which is overflow-safe. I did not add a test that cannot distinguish the two states. It is still worth making now, because the planned move to saturating accessors will have `Value()` return `MaxInt64` instead of `0` for these inputs, which would silently change what this call site decides. Happy to add coverage if you would rather have it pinned.

Verified locally: `go test ./pkg/volume/csi/ ./pkg/kubelet/eviction/` both pass, `gofmt` clean, `go vet` clean.

This PR was written in part with the assistance of generative AI.

/sig storage
/sig node
/cc @jpbetz

**Does this PR introduce a user-facing change?**:

```release-note
Fixed the kubelet rejecting a negative CSI volume expansion size. Sizes whose int64 conversion overflowed were previously accepted because the sign was lost.
```
