### PR TITLE
Remove Permit support from GangScheduling plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -19,7 +19,6 @@ package gangscheduling
 import (
 	"context"
 	"fmt"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
@@ -37,9 +36,6 @@ import (
 const (
 	// Name is the name of the plugin used in the plugin registry and configurations.
 	Name = names.GangScheduling
-	// permitTimeoutDuration defines how long the gang pods should
-	// wait at the permit stage for a quorum before being rejected.
-	permitTimeoutDuration = 5 * time.Minute
 )
 
 // GangScheduling is a plugin that enforces "all-or-nothing" scheduling for pods
@@ -53,7 +49,6 @@ type GangScheduling struct {
 
 var _ fwk.EnqueueExtensions = &GangScheduling{}
 var _ fwk.PreEnqueuePlugin = &GangScheduling{}
-var _ fwk.PermitPlugin = &GangScheduling{}
 var _ framework.PlacementFeasiblePlugin = &GangScheduling{}
 
 // New initializes a new plugin and returns it.
@@ -349,138 +344,6 @@ func (pl *GangScheduling) isPGReady(snapshot fwk.PodGroupManager, namespace, pgN
 	}
 
 	return readinessCountFn(pgState) >= minCount
-}
-
-// Permit forces all pods in a gang to wait at this stage. Once the number of waiting (assumed) pods
-// reaches the gang's MinCount, all pods in the gang are permitted to proceed to binding simultaneously.
-func (pl *GangScheduling) Permit(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
-	if pod.Spec.SchedulingGroup == nil {
-		return nil, 0
-	}
-
-	logger := klog.FromContext(ctx)
-	namespace := pod.Namespace
-	schedulingGroup := pod.Spec.SchedulingGroup
-
-	var podGroup *schedulingapi.PodGroup
-	var err error
-	var snapshot fwk.PodGroupManager
-
-	if pl.isCompositePodGroupEnabled {
-		snapshot, err = pl.podGroupManager.BuildHierarchySnapshotFromPod(pod)
-		if err != nil {
-			return fwk.AsStatus(fmt.Errorf("failed to build hierarchy snapshot: %w", err)), 0
-		}
-		podGroup, err = snapshot.PodGroups().Get(namespace, *schedulingGroup.PodGroupName)
-	} else {
-		podGroup, err = pl.snapshotLister.PodGroups().Get(namespace, *schedulingGroup.PodGroupName)
-		snapshot = pl.podGroupManager
-	}
-
-	if err != nil {
-		return fwk.AsStatus(fmt.Errorf("failed to get podGroup %s/%s: %w", namespace, *schedulingGroup.PodGroupName, err)), 0
-	}
-
-	if pl.isCompositePodGroupEnabled && podGroup.Spec.ParentCompositePodGroupName != nil {
-		return pl.permitPodForHierarchy(logger, snapshot, pod, namespace, *podGroup.Spec.ParentCompositePodGroupName)
-	}
-
-	podGroupState, err := snapshot.PodGroupStates().Get(namespace, podGroup.Name)
-	if err != nil {
-		return fwk.AsStatus(err), 0
-	}
-
-	return pl.permitPodGroup(logger, pod, podGroup, podGroupState)
-}
-
-func (pl *GangScheduling) permitPodGroup(logger klog.Logger, pod *v1.Pod, podGroup *schedulingapi.PodGroup, podGroupState fwk.PodGroupState) (*fwk.Status, time.Duration) {
-	if podGroup.Spec.SchedulingPolicy.Gang == nil {
-		return nil, 0
-	}
-
-	scheduledPodsCount := podGroupState.ScheduledPodsCount()
-	if scheduledPodsCount < int(podGroup.Spec.SchedulingPolicy.Gang.MinCount) {
-		// Activate unscheduled pods from this pod group in case they were waiting for this pod to be scheduled.
-		unscheduledPods := podGroupState.UnscheduledPods()
-		pl.handle.Activate(logger, unscheduledPods)
-		logger.V(4).Info("Quorum is not met for a gang. Waiting for another pod to allow", "pod", klog.KObj(pod), "schedulingGroup", podGroup.Name, "activatedPods", len(unscheduledPods))
-		return fwk.NewStatus(fwk.Wait, "waiting for minCount pods from a gang to be scheduled"), permitTimeoutDuration
-	}
-
-	assumedPods := podGroupState.AssumedPods()
-	logger.V(4).Info("Quorum is met for a gang. Allowing other pods from a gang waiting on permit", "pod", klog.KObj(pod), "schedulingGroup", podGroup.Name, "allowedPods", len(assumedPods))
-
-	// The quorum is met. Allow this pod and signal all other waiting pods from the same gang to proceed.
-	for podUID := range assumedPods {
-		waitingPod := pl.handle.GetWaitingPod(podUID)
-		if waitingPod != nil {
-			waitingPod.Allow(Name)
-		}
-	}
-
-	return nil, 0
-}
-
-func (pl *GangScheduling) permitPodForHierarchy(logger klog.Logger, snapshot fwk.PodGroupManager, pod *v1.Pod, namespace string, startCPGName string) (*fwk.Status, time.Duration) {
-	cpgKey := fwk.CompositePodGroupKey(namespace, startCPGName)
-	rootKey, ok, err := snapshot.GetRootKeyForGroup(cpgKey)
-	if err != nil {
-		return fwk.AsStatus(err), 0
-	}
-	if !ok {
-		return fwk.AsStatus(fmt.Errorf("failed to build hierarchy snapshot: composite pod group object not found in state for %s", cpgKey.String())), 0
-	}
-
-	if !pl.isCPGTreeReady(snapshot, rootKey.Namespace, rootKey.Name, func(s fwk.PodGroupState) int { return s.ScheduledPodsCount() }) {
-		pl.activateUnscheduledPodsInHierarchy(logger, snapshot, rootKey.Namespace, rootKey.Name)
-		logger.V(4).Info("Quorum is not met for a CPG hierarchy. Waiting for another pod to allow", "pod", klog.KObj(pod), "rootCPG", rootKey.Name)
-		return fwk.NewStatus(fwk.Wait, fmt.Sprintf("waiting for composite pod group %q tree to meet quorum", rootKey.Name)), permitTimeoutDuration
-	}
-
-	pl.allowAssumedPodsInHierarchy(snapshot, rootKey.Namespace, rootKey.Name)
-	logger.V(4).Info("Quorum is met for a CPG hierarchy. Allowing other pods from the hierarchy waiting on permit", "pod", klog.KObj(pod), "rootCPG", rootKey.Name)
-	return nil, 0
-}
-
-func (pl *GangScheduling) activateUnscheduledPodsInHierarchy(logger klog.Logger, snapshot fwk.PodGroupManager, namespace, cpgName string) {
-	cpgState, err := snapshot.CompositePodGroupStates().Get(namespace, cpgName)
-	if err != nil {
-		return
-	}
-	for _, childKey := range cpgState.GetChildren() {
-		childType, _, childName := childKey.Type, childKey.Namespace, childKey.Name
-		if childType == fwk.CompositePodGroupKeyType {
-			pl.activateUnscheduledPodsInHierarchy(logger, snapshot, namespace, childName)
-		} else {
-			if pgState, err := snapshot.PodGroupStates().Get(namespace, childName); err == nil {
-				unscheduledPods := pgState.UnscheduledPods()
-				pl.handle.Activate(logger, unscheduledPods)
-			}
-		}
-	}
-}
-
-func (pl *GangScheduling) allowAssumedPodsInHierarchy(snapshot fwk.PodGroupManager, namespace, cpgName string) {
-	cpgState, err := snapshot.CompositePodGroupStates().Get(namespace, cpgName)
-	if err != nil {
-		return
-	}
-	for _, childKey := range cpgState.GetChildren() {
-		childType, _, childName := childKey.Type, childKey.Namespace, childKey.Name
-		if childType == fwk.CompositePodGroupKeyType {
-			pl.allowAssumedPodsInHierarchy(snapshot, namespace, childName)
-			continue
-		}
-		if pgState, err := snapshot.PodGroupStates().Get(namespace, childName); err == nil {
-			assumedPods := pgState.AssumedPods()
-			for podUID := range assumedPods {
-				waitingPod := pl.handle.GetWaitingPod(podUID)
-				if waitingPod != nil {
-					waitingPod.Allow(Name)
-				}
-			}
-		}
-	}
 }
 
 // PlacementFeasible is responsible for enforcing the gang's MinCount constraint in the pod group scheduling cycle.

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -27,7 +27,6 @@ import (
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -827,7 +826,7 @@ func (m *mockSharedLister) PodGroupStates() fwk.PodGroupStateLister {
 	return m.podGroupStateLister
 }
 
-func TestGangSchedulingFlow(t *testing.T) {
+func TestPreEnqueue(t *testing.T) {
 	gangPodGroup1 := st.MakePodGroup().Namespace("ns1").Name("pg1").WorkloadRef("t1", "gang-wl").MinCount(3).Obj()
 	gangPodGroup2 := st.MakePodGroup().Namespace("ns1").Name("pg2").WorkloadRef("t2", "gang-wl").MinCount(4).Obj()
 	basicPodGroup := st.MakePodGroup().Namespace("ns1").Name("pg3").WorkloadRef("1", "basic-wl").BasicPolicy().Obj()
@@ -897,372 +896,199 @@ func TestGangSchedulingFlow(t *testing.T) {
 	p2_1 := st.MakePod().Namespace("ns1").Name("p2_1").UID("p2_1").PodGroupName("pg-basic-2").Obj()
 
 	type testCase struct {
-		name                            string
-		pod                             *v1.Pod
-		initialPods                     []*v1.Pod
-		initialPodGroups                []*schedulingv1beta1.PodGroup
-		initialCompositePodGroups       []*schedulingv1alpha3.CompositePodGroup
-		podsWaitingOnPermit             []*v1.Pod
-		isDuringPodGroupSchedulingCycle bool
-		isCompositePodGroupEnabled      bool
-		wantPreEnqueueStatus            *fwk.Status
-		wantPermitStatus                *fwk.Status
-		wantActivatedPods               []*v1.Pod
-		wantAllowedPods                 []types.UID
+		name                       string
+		pod                        *v1.Pod
+		initialPods                []*v1.Pod
+		initialPodGroups           []*schedulingv1beta1.PodGroup
+		initialCompositePodGroups  []*schedulingv1alpha3.CompositePodGroup
+		isCompositePodGroupEnabled []bool
+		wantPreEnqueueStatus       *fwk.Status
 	}
 	baseTests := []testCase{
 		{
-			name:                       "non-gang pod succeeds immediately (CPG=false)",
-			pod:                        nonGangPod,
-			isCompositePodGroupEnabled: false,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
-			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           nil,
+			name:                 "non-gang pod succeeds immediately",
+			pod:                  nonGangPod,
+			initialPodGroups:     []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
+			wantPreEnqueueStatus: nil,
 		},
 		{
-			name:                       "non-gang pod succeeds immediately (CPG=true)",
-			pod:                        nonGangPod,
-			isCompositePodGroupEnabled: true,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
-			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           nil,
+			name:                 "basic policy pod succeeds immediately",
+			pod:                  basicPolicyPod,
+			initialPodGroups:     []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
+			wantPreEnqueueStatus: nil,
 		},
 		{
-			name:                       "basic policy pod succeeds immediately (CPG=false)",
-			pod:                        basicPolicyPod,
-			isCompositePodGroupEnabled: false,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
-			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           nil,
-		},
-		{
-			name:                       "basic policy pod succeeds immediately (CPG=true)",
-			pod:                        basicPolicyPod,
-			isCompositePodGroupEnabled: true,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
-			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           nil,
-		},
-		{
-			name:                       "gang pod fails PreEnqueue when pod group is not yet created (CPG=false)",
+			name:                       "gang pod fails PreEnqueue when pod group is not yet created",
 			pod:                        p1,
-			isCompositePodGroupEnabled: false,
+			isCompositePodGroupEnabled: []bool{false},
 			initialPods:                []*v1.Pod{p2, p3, p4, p5},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `waiting for pods's pod group "pg1" to appear in scheduling queue`),
 		},
 		{
-			name:                       "gang pod fails PreEnqueue when pod group is not yet created (CPG=true)",
+			name:                       "gang pod fails PreEnqueue when pod group is not yet created",
 			pod:                        p1,
-			isCompositePodGroupEnabled: true,
+			isCompositePodGroupEnabled: []bool{true},
 			initialPods:                []*v1.Pod{p2, p3, p4, p5},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "failed to build hierarchy snapshot: pod group object not found in state for podgroup/ns1/pg1"),
 		},
 		{
-			name:                       "gang pod fails PreEnqueue when quorum is not met (CPG=false)",
-			pod:                        p1,
-			isCompositePodGroupEnabled: false,
-			initialPods:                []*v1.Pod{p2, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
-			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
+			name:                 "gang pod fails PreEnqueue when quorum is not met",
+			pod:                  p1,
+			initialPods:          []*v1.Pod{p2, p4, p5},
+			initialPodGroups:     []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
+			wantPreEnqueueStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
 		},
 		{
-			name:                       "gang pod fails PreEnqueue when quorum is not met (CPG=true)",
-			pod:                        p1,
-			isCompositePodGroupEnabled: true,
-			initialPods:                []*v1.Pod{p2, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
-			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
+			name:                 "gang pod passes PreEnqueue",
+			pod:                  p1,
+			initialPods:          []*v1.Pod{p2, p3, p4, p5},
+			initialPodGroups:     []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
+			wantPreEnqueueStatus: nil,
 		},
 		{
-			name:                       "gang pod passes PreEnqueue, but waits at Permit (CPG=false)",
-			pod:                        p1,
-			isCompositePodGroupEnabled: false,
-			initialPods:                []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
-			podsWaitingOnPermit:        []*v1.Pod{p2, p4, p5},
-			wantPreEnqueueStatus:       nil,
-			wantActivatedPods:          []*v1.Pod{p3},
-			wantPermitStatus:           fwk.NewStatus(fwk.Wait, "waiting for minCount pods from a gang to be scheduled"),
-		},
-		{
-			name:                       "gang pod passes PreEnqueue, but waits at Permit (CPG=true)",
-			pod:                        p1,
-			isCompositePodGroupEnabled: true,
-			initialPods:                []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
-			podsWaitingOnPermit:        []*v1.Pod{p2, p4, p5},
-			wantPreEnqueueStatus:       nil,
-			wantActivatedPods:          []*v1.Pod{p3},
-			wantPermitStatus:           fwk.NewStatus(fwk.Wait, "waiting for minCount pods from a gang to be scheduled"),
-		},
-		{
-			name:                       "final gang pod arrives at Permit and allows all waiting pods from a gang (CPG=false)",
-			pod:                        p1,
-			isCompositePodGroupEnabled: false,
-			initialPods:                []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
-			podsWaitingOnPermit:        []*v1.Pod{p2, p3, p4, p5},
-			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           nil,
-			wantAllowedPods:            []types.UID{"p1", "p2", "p3"},
-		},
-		{
-			name:                       "final gang pod arrives at Permit and allows all waiting pods from a gang (CPG=true)",
-			pod:                        p1,
-			isCompositePodGroupEnabled: true,
-			initialPods:                []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
-			podsWaitingOnPermit:        []*v1.Pod{p2, p3, p4, p5},
-			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           nil,
-			wantAllowedPods:            []types.UID{"p1", "p2", "p3"},
-		},
-		{
-			name:                       "CPG Hierarchical Stage 1: No pods, tree not ready (CPG=true)",
+			name:                       "CPG Hierarchical Stage 1: No pods, tree not ready",
 			pod:                        p1CPG,
-			isCompositePodGroupEnabled: true,
+			isCompositePodGroupEnabled: []bool{true},
 			initialPods:                []*v1.Pod{},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for composite pod group \"cpg-root\" tree to meet quorum"),
 		},
 		{
-			name:                       "CPG Hierarchical Stage 1: No pods, tree not ready (CPG=false)",
+			name:                       "CPG Hierarchical Stage 1: No pods, ready, as CPGs are ignored",
 			pod:                        p1CPG,
-			isCompositePodGroupEnabled: false,
+			isCompositePodGroupEnabled: []bool{false},
 			initialPods:                []*v1.Pod{},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           nil,
 		},
 		{
-			name:                       "CPG Hierarchical Stage 2: Add p6, cpg-sub1 ready but root not ready (CPG=true)",
+			name:                       "CPG Hierarchical Stage 2: Add p6, cpg-sub1 ready but root not ready",
 			pod:                        p6CPG,
-			isCompositePodGroupEnabled: true,
+			isCompositePodGroupEnabled: []bool{true},
 			initialPods:                []*v1.Pod{p1CPG, p2CPG},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for composite pod group \"cpg-root\" tree to meet quorum"),
 		},
 		{
-			name:                       "CPG Hierarchical Stage 2: Add p6 (CPG=false)",
+			name:                       "CPG Hierarchical Stage 2: Add p6, already ready",
 			pod:                        p6CPG,
-			isCompositePodGroupEnabled: false,
+			isCompositePodGroupEnabled: []bool{false},
 			initialPods:                []*v1.Pod{p1CPG, p2CPG},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           nil,
 		},
 		{
-			name:                       "CPG Hierarchical Stage 3: Add p4, root becomes ready (CPG=true)",
+			name:                       "CPG Hierarchical Stage 3: Add p4, root becomes ready",
 			pod:                        p4CPG,
-			isCompositePodGroupEnabled: true,
-			initialPods:                []*v1.Pod{p1CPG, p2CPG, p6CPG},
-			podsWaitingOnPermit:        []*v1.Pod{p1CPG, p2CPG, p6CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
-			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
-			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           nil,
-		},
-		{
-			name:                       "CPG Hierarchical Stage 3: Add p4 (CPG=false)",
-			pod:                        p4CPG,
-			isCompositePodGroupEnabled: false,
+			isCompositePodGroupEnabled: []bool{true},
 			initialPods:                []*v1.Pod{p1CPG, p2CPG, p6CPG},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
 		},
 		{
-			name:                       "CPG Basic With Gang Stage 1: pg1 ready, root ready (CPG=true)",
+			name:                       "CPG Hierarchical Stage 3: Add p4, already ready",
+			pod:                        p4CPG,
+			isCompositePodGroupEnabled: []bool{false},
+			initialPods:                []*v1.Pod{p1CPG, p2CPG, p6CPG},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
+			wantPreEnqueueStatus:       nil,
+		},
+		{
+			name:                       "CPG Basic With Gang Stage 1: pg1 ready, root ready",
 			pod:                        p2_1,
-			isCompositePodGroupEnabled: true,
+			isCompositePodGroupEnabled: []bool{true},
 			initialPods:                []*v1.Pod{p1_1, p1_2},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgBasic1, pgBasic2},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgBasicRoot},
 			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           fwk.NewStatus(fwk.Wait, "waiting for composite pod group \"cpg-basic-root\" tree to meet quorum"),
 		},
 		{
-			name:                       "CPG Basic With Gang Stage 1: pg1 ready, root ready (CPG=false)",
+			name:                       "CPG Basic With Gang Stage 1: pg1 ready, root ready, pg2 not ready",
 			pod:                        p2_1,
-			isCompositePodGroupEnabled: false,
+			isCompositePodGroupEnabled: []bool{false},
 			initialPods:                []*v1.Pod{p1_1, p1_2},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgBasic1, pgBasic2},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgBasicRoot},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
-		},
-		{
-			name:                       "CPG Permit Wait: Hierarchical gang waits at permit if gang isn't fully scheduled (CPG=true)",
-			pod:                        p4CPG,
-			isCompositePodGroupEnabled: true,
-			initialPods:                []*v1.Pod{p1CPG, p2CPG, p6CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
-			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
-			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           fwk.NewStatus(fwk.Wait, "waiting for composite pod group \"cpg-root\" tree to meet quorum"),
-		},
-		{
-			name:                       "CPG Permit Wait: Hierarchical gang waits at permit if gang isn't fully scheduled (CPG=false)",
-			pod:                        p4CPG,
-			isCompositePodGroupEnabled: false,
-			initialPods:                []*v1.Pod{p1CPG, p2CPG, p6CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
-			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
-			wantPreEnqueueStatus:       nil,
-			wantPermitStatus:           nil,
 		},
 	}
 
 	for _, tt := range baseTests {
-		t.Run(tt.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
-			if tt.isCompositePodGroupEnabled {
-				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareWorkloadScheduling, true)
-			}
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CompositePodGroup, tt.isCompositePodGroupEnabled)
-			logger, ctx := ktesting.NewTestContext(t)
-			cache := internalcache.New(ctx, nil, true, tt.isCompositePodGroupEnabled)
+		isCompositePodGroupEnabled := []bool{true, false}
+		if len(tt.isCompositePodGroupEnabled) > 0 {
+			isCompositePodGroupEnabled = tt.isCompositePodGroupEnabled
+		}
+		for _, isCPGEnabled := range isCompositePodGroupEnabled {
+			t.Run(fmt.Sprintf("%s (CPG enabled: %v)", tt.name, isCPGEnabled), func(t *testing.T) {
+				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+					features.GenericWorkload:                 true,
+					features.TopologyAwareWorkloadScheduling: isCPGEnabled,
+					features.CompositePodGroup:               isCPGEnabled,
+				})
+				logger, ctx := ktesting.NewTestContext(t)
+				cache := internalcache.New(ctx, nil, true, isCPGEnabled)
 
-			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
-			podGroupInformer := informerFactory.Scheduling().V1beta1().PodGroups()
-			if tt.isCompositePodGroupEnabled {
-				informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
-			}
-			fakeActivator := &podActivatorMock{}
-			snapshot := internalcache.NewEmptySnapshot()
-			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
-				frameworkruntime.WithInformerFactory(informerFactory),
-				frameworkruntime.WithPodGroupManager(cache),
-				frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
-				frameworkruntime.WithPodActivator(fakeActivator),
-				frameworkruntime.WithSnapshotSharedLister(snapshot),
-			)
-			if err != nil {
-				t.Fatalf("Failed to create framework: %v", err)
-			}
-
-			// Populate informers and manager state for the test case.
-			for _, pg := range tt.initialPodGroups {
-				err := podGroupInformer.Informer().GetStore().Add(pg)
-				if err != nil {
-					t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
+				informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
+				podGroupInformer := informerFactory.Scheduling().V1beta1().PodGroups()
+				if isCPGEnabled {
+					informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
 				}
-				cache.AddPodGroup(pg)
-			}
-			if tt.isCompositePodGroupEnabled {
-				for _, cpg := range tt.initialCompositePodGroups {
-					err := informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer().GetStore().Add(cpg)
+				fakeActivator := &podActivatorMock{}
+				snapshot := internalcache.NewEmptySnapshot()
+				fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+					frameworkruntime.WithInformerFactory(informerFactory),
+					frameworkruntime.WithPodGroupManager(cache),
+					frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+					frameworkruntime.WithPodActivator(fakeActivator),
+					frameworkruntime.WithSnapshotSharedLister(snapshot),
+				)
+				if err != nil {
+					t.Fatalf("Failed to create framework: %v", err)
+				}
+
+				// Populate informers and manager state for the test case.
+				for _, pg := range tt.initialPodGroups {
+					err := podGroupInformer.Informer().GetStore().Add(pg)
 					if err != nil {
-						t.Fatalf("Failed to add cpg %s to store: %v", cpg.Name, err)
+						t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
 					}
-					cache.AddCompositePodGroup(logger, cpg)
+					cache.AddPodGroup(pg)
 				}
-			}
-
-			for _, p := range tt.initialPods {
-				cache.AddPodGroupMember(p)
-			}
-			cache.AddPodGroupMember(tt.pod)
-
-			p, err := New(ctx, nil, fh, feature.Features{EnableGenericWorkload: true, EnableCompositePodGroup: tt.isCompositePodGroupEnabled})
-			if err != nil {
-				t.Fatalf("Failed to create plugin: %v", err)
-			}
-			pl := p.(*GangScheduling)
-
-			gotPreEnqueueStatus := pl.PreEnqueue(ctx, tt.pod)
-			if diff := cmp.Diff(tt.wantPreEnqueueStatus, gotPreEnqueueStatus); diff != "" {
-				t.Fatalf("Unexpected PreEnqueue status (-want,+got):\n%s", diff)
-			}
-			if !gotPreEnqueueStatus.IsSuccess() {
-				// Pod is rejected.
-				return
-			}
-
-			if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
-				t.Fatalf("Failed to update snapshot: %v", err)
-			}
-
-			// Simulate that other pods have already hit Permit and are now waiting.
-			for _, p := range tt.podsWaitingOnPermit {
-				pod := p.DeepCopy()
-				pod.Spec.NodeName = "some-node"
-				if err := cache.AssumePod(logger, pod); err != nil {
-					t.Fatalf("Failed to assume pod %q: %v", pod.Name, err)
+				if isCPGEnabled {
+					for _, cpg := range tt.initialCompositePodGroups {
+						err := informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer().GetStore().Add(cpg)
+						if err != nil {
+							t.Fatalf("Failed to add cpg %s to store: %v", cpg.Name, err)
+						}
+						cache.AddCompositePodGroup(logger, cpg)
+					}
 				}
-				status, _ := pl.Permit(ctx, schedulerframework.NewCycleState(), pod, "some-node")
-				if status.Code() != fwk.Wait {
-					t.Fatalf("Expected Wait status while permitting a pod %q: %v", pod.Name, status)
+
+				for _, p := range tt.initialPods {
+					cache.AddPodGroupMember(p)
 				}
-			}
+				cache.AddPodGroupMember(tt.pod)
 
-			// Clear activated pods to assert those activated in tt.pod Permit.
-			fakeActivator.activatedPods = nil
-
-			cycleState := schedulerframework.NewCycleState()
-			if tt.isDuringPodGroupSchedulingCycle {
-				cycleState.SetPodGroupSchedulingCycle(cycleState)
-			}
-
-			pod := tt.pod.DeepCopy()
-			pod.Spec.NodeName = "some-node"
-
-			// In a pod group scheduling cycle, a snapshot is taken after all
-			// waiting pods are assumed, so that Permit can read from it.
-			if tt.isDuringPodGroupSchedulingCycle {
-				if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
-					t.Fatalf("Failed to update snapshot: %v", err)
-				}
-				podInfo, err := schedulerframework.NewPodInfo(pod)
+				p, err := New(ctx, nil, fh, feature.Features{EnableGenericWorkload: true, EnableCompositePodGroup: isCPGEnabled})
 				if err != nil {
-					t.Fatalf("Failed to create pod info for %q: %v", pod.Name, err)
+					t.Fatalf("Failed to create plugin: %v", err)
 				}
-				// Assume pod in the snapshot, as in a pod group scheduling cycle.
-				if err := snapshot.AssumePod(podInfo); err != nil {
-					t.Fatalf("Failed to assume pod %q in snapshot: %v", pod.Name, err)
-				}
-			} else {
-				// Assume pod in the cache, as in a pod-by-pod scheduling cycle, where Permit reads from cache.
-				if err := cache.AssumePod(logger, pod); err != nil {
-					t.Fatalf("Failed to assume pod %q in cache: %v", pod.Name, err)
-				}
-				if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
-					t.Fatalf("Failed to update snapshot: %v", err)
-				}
-			}
+				pl := p.(*GangScheduling)
 
-			gotPermitStatus, _ := pl.Permit(ctx, cycleState, pod, "some-node")
-			if diff := cmp.Diff(tt.wantPermitStatus, gotPermitStatus); diff != "" {
-				t.Fatalf("Unexpected Permit status (-want, +got):\n%s", diff)
-			}
-			if gotPermitStatus.Code() == fwk.Wait {
-				// Pod waits for others from a gang. Simulate its eventual forget.
-				if tt.isDuringPodGroupSchedulingCycle {
-					if err := snapshot.ForgetPod(logger, pod); err != nil {
-						t.Fatalf("Failed to forget pod %q from snapshot: %v", pod.Name, err)
-					}
-				} else {
-					if err := cache.ForgetPod(logger, pod); err != nil {
-						t.Fatalf("Failed to forget pod %q from cache: %v", pod.Name, err)
-					}
+				gotPreEnqueueStatus := pl.PreEnqueue(ctx, tt.pod)
+				if diff := cmp.Diff(tt.wantPreEnqueueStatus, gotPreEnqueueStatus); diff != "" {
+					t.Fatalf("Unexpected PreEnqueue status (-want,+got):\n%s", diff)
 				}
-				return
-			}
-
-			if diff := cmp.Diff(tt.wantActivatedPods, fakeActivator.activatedPods); diff != "" {
-				t.Errorf("Unexpected activated pods (-want, +got):\n%s", diff)
-			}
-			for _, p := range tt.wantAllowedPods {
-				if wp := fh.GetWaitingPod(p); wp != nil {
-					t.Errorf("Expected pod %q to be allowed", p)
-				}
-			}
-		})
+			})
+		}
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -25,7 +25,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
@@ -51,89 +50,54 @@ func init() {
 func Test_isSchedulableAfterPodAdded(t *testing.T) {
 	tests := []struct {
 		name                       string
+		isCompositePodGroupEnabled []bool
 		pod                        *v1.Pod
 		newPod                     *v1.Pod
 		pgs                        []*schedulingv1beta1.PodGroup
 		cpgs                       []*schedulingv1alpha3.CompositePodGroup
 		expectedHint               fwk.QueueingHint
-		isCompositePodGroupEnabled bool
 	}{
 		{
 			name:                       "add a newPod which matches the pod's scheduling group",
+			isCompositePodGroupEnabled: []bool{true, false},
 			pod:                        st.MakePod().Name("p").PodGroupName("pg").Obj(),
 			newPod:                     st.MakePod().PodGroupName("pg").Obj(),
 			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: true,
-		},
-		{
-			name:                       "add a newPod which matches the pod's scheduling group (CPG=false)",
-			pod:                        st.MakePod().Name("p").PodGroupName("pg").Obj(),
-			newPod:                     st.MakePod().PodGroupName("pg").Obj(),
-			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: false,
 		},
 		{
 			name:                       "add a newPod with NodeName set which matches the pod's scheduling group",
+			isCompositePodGroupEnabled: []bool{true, false},
 			pod:                        st.MakePod().Name("p").PodGroupName("pg").Obj(),
 			newPod:                     st.MakePod().PodGroupName("pg").Node("node1").Obj(),
 			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:                       "add a newPod with NodeName set which matches the pod's scheduling group (CPG=false)",
+			name:                       "add a newPod which doesn't match the pod's namespace",
+			isCompositePodGroupEnabled: []bool{true, false},
 			pod:                        st.MakePod().Name("p").PodGroupName("pg").Obj(),
-			newPod:                     st.MakePod().PodGroupName("pg").Node("node1").Obj(),
-			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name:   "add a newPod which doesn't match the pod's namespace",
-			pod:    st.MakePod().Name("p").PodGroupName("pg").Obj(),
-			newPod: st.MakePod().Namespace("foo").PodGroupName("pg").Obj(),
+			newPod:                     st.MakePod().Namespace("foo").PodGroupName("pg").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Name("pg").Obj(),
 				st.MakePodGroup().Namespace("foo").Name("pg").Obj(),
 			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:   "add a newPod which doesn't match the pod's namespace (CPG=false)",
-			pod:    st.MakePod().Name("p").PodGroupName("pg").Obj(),
-			newPod: st.MakePod().Namespace("foo").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg").Obj(),
-				st.MakePodGroup().Namespace("foo").Name("pg").Obj(),
-			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name:   "add a newPod which doesn't match the pod's pod group name",
-			pod:    st.MakePod().Name("p").PodGroupName("pg1").Obj(),
-			newPod: st.MakePod().PodGroupName("pg2").Obj(),
+			name:                       "add a newPod which doesn't match the pod's pod group name",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Name("p").PodGroupName("pg1").Obj(),
+			newPod:                     st.MakePod().PodGroupName("pg2").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Name("pg1").Obj(),
 				st.MakePodGroup().Name("pg2").Obj(),
 			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:   "add a newPod which doesn't match the pod's pod group name (CPG=false)",
-			pod:    st.MakePod().Name("p").PodGroupName("pg1").Obj(),
-			newPod: st.MakePod().PodGroupName("pg2").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").Obj(),
-				st.MakePodGroup().Name("pg2").Obj(),
-			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name:   "add a newPod which belongs to a different scheduling group but matches the root CPG",
-			pod:    st.MakePod().Name("p1").PodGroupName("pg1").Obj(),
-			newPod: st.MakePod().Name("p2").PodGroupName("pg2").Obj(),
+			name:                       "add a newPod which belongs to a different scheduling group but matches the root CPG",
+			isCompositePodGroupEnabled: []bool{true},
+			pod:                        st.MakePod().Name("p1").PodGroupName("pg1").Obj(),
+			newPod:                     st.MakePod().Name("p2").PodGroupName("pg2").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Obj(),
 				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Obj(),
@@ -141,13 +105,13 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Obj(),
 			},
-			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: true,
+			expectedHint: fwk.Queue,
 		},
 		{
-			name:   "add a newPod which belongs to a different scheduling group but matches the root CPG (CPG=false)",
-			pod:    st.MakePod().Name("p1").PodGroupName("pg1").Obj(),
-			newPod: st.MakePod().Name("p2").PodGroupName("pg2").Obj(),
+			name:                       "add a newPod which belongs to a different scheduling group but matches the root CPG, but CPG is ignored",
+			isCompositePodGroupEnabled: []bool{false},
+			pod:                        st.MakePod().Name("p1").PodGroupName("pg1").Obj(),
+			newPod:                     st.MakePod().Name("p2").PodGroupName("pg2").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Obj(),
 				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Obj(),
@@ -155,13 +119,13 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Obj(),
 			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:   "add a newPod which belongs to a different scheduling group and does not match the root CPG",
-			pod:    st.MakePod().Name("p1").PodGroupName("pg1").Obj(),
-			newPod: st.MakePod().Name("p2").PodGroupName("pg2").Obj(),
+			name:                       "add a newPod which belongs to a different scheduling group and does not match the root CPG",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Name("p1").PodGroupName("pg1").Obj(),
+			newPod:                     st.MakePod().Name("p2").PodGroupName("pg2").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root1").Obj(),
 				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root2").Obj(),
@@ -170,61 +134,51 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 				st.MakeCompositePodGroup().Name("cpg-root1").Obj(),
 				st.MakeCompositePodGroup().Name("cpg-root2").Obj(),
 			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
-		},
-		{
-			name:   "add a newPod which belongs to a different scheduling group and does not match the root CPG (CPG=false)",
-			pod:    st.MakePod().Name("p1").PodGroupName("pg1").Obj(),
-			newPod: st.MakePod().Name("p2").PodGroupName("pg2").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root1").Obj(),
-				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root2").Obj(),
-			},
-			cpgs: []*schedulingv1alpha3.CompositePodGroup{
-				st.MakeCompositePodGroup().Name("cpg-root1").Obj(),
-				st.MakeCompositePodGroup().Name("cpg-root2").Obj(),
-			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
+			expectedHint: fwk.QueueSkip,
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareWorkloadScheduling, true)
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CompositePodGroup, tc.isCompositePodGroupEnabled)
-			logger, ctx := ktesting.NewTestContext(t)
+		for _, isCPGEnabled := range tc.isCompositePodGroupEnabled {
+			t.Run(fmt.Sprintf("%s (CPG enabled: %v)", tc.name, isCPGEnabled), func(t *testing.T) {
+				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+					features.GenericWorkload:                 true,
+					features.TopologyAwareWorkloadScheduling: isCPGEnabled,
+					features.CompositePodGroup:               isCPGEnabled,
+				})
+				logger, ctx := ktesting.NewTestContext(t)
 
-			var objs []runtime.Object
-			for _, pg := range tc.pgs {
-				objs = append(objs, pg)
-			}
-			for _, cpg := range tc.cpgs {
-				objs = append(objs, cpg)
-			}
-			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
-
-			for _, pg := range tc.pgs {
-				if err := informerFactory.Scheduling().V1beta1().PodGroups().Informer().GetStore().Add(pg); err != nil {
-					t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
+				var objs []runtime.Object
+				for _, pg := range tc.pgs {
+					objs = append(objs, pg)
 				}
-			}
-			for _, cpg := range tc.cpgs {
-				if err := informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer().GetStore().Add(cpg); err != nil {
-					t.Fatalf("Failed to add cpg %s to store: %v", cpg.Name, err)
+				for _, cpg := range tc.cpgs {
+					objs = append(objs, cpg)
 				}
-			}
+				informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
 
-			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
-				frameworkruntime.WithInformerFactory(informerFactory),
-			)
-			if err != nil {
-				t.Fatalf("Failed to create framework: %v", err)
-			}
+				for _, pg := range tc.pgs {
+					if err := informerFactory.Scheduling().V1beta1().PodGroups().Informer().GetStore().Add(pg); err != nil {
+						t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
+					}
+				}
+				for _, cpg := range tc.cpgs {
+					if err := informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer().GetStore().Add(cpg); err != nil {
+						t.Fatalf("Failed to add cpg %s to store: %v", cpg.Name, err)
+					}
+				}
 
-			p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
-			if err == nil {
+				fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+					frameworkruntime.WithInformerFactory(informerFactory),
+				)
+				if err != nil {
+					t.Fatalf("Failed to create framework: %v", err)
+				}
+
+				p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
+				if err != nil {
+					t.Fatal(err)
+				}
+
 				pgMap := make(map[string]*schedulingv1beta1.PodGroup)
 				for _, pg := range tc.pgs {
 					pgMap[pg.Name] = pg
@@ -234,115 +188,86 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 					cpgMap[cpg.Name] = cpg
 				}
 				p.(*GangScheduling).podGroupManager = &mockPodGroupManager{pgs: pgMap, cpgs: cpgMap}
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			actualHint, err := p.(*GangScheduling).isSchedulableAfterPodAdded(logger, tc.pod, nil, tc.newPod)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
-				t.Errorf("unexpected QueueingHint (-want, +got):\n%s", diff)
-			}
-		})
+				actualHint, err := p.(*GangScheduling).isSchedulableAfterPodAdded(logger, tc.pod, nil, tc.newPod)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+					t.Errorf("unexpected QueueingHint (-want, +got):\n%s", diff)
+				}
+			})
+		}
 	}
 }
 
 func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 	tests := []struct {
 		name                       string
+		isCompositePodGroupEnabled []bool
 		pod                        *v1.Pod
 		newPodGroup                *schedulingv1beta1.PodGroup
 		pgs                        []*schedulingv1beta1.PodGroup
 		cpgs                       []*schedulingv1alpha3.CompositePodGroup
 		expectedHint               fwk.QueueingHint
-		isCompositePodGroupEnabled bool
 	}{
 		{
 			name:                       "add a pod group which matches the pod's pod group name",
+			isCompositePodGroupEnabled: []bool{true, false},
 			pod:                        st.MakePod().Name("p").PodGroupName("pg").Obj(),
 			newPodGroup:                st.MakePodGroup().Name("pg").MinCount(1).WorkloadRef("t", "w").Obj(),
 			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: true,
 		},
 		{
-			name:                       "add a pod group which matches the pod's pod group name (CPG=false)",
-			pod:                        st.MakePod().Name("p").PodGroupName("pg").Obj(),
-			newPodGroup:                st.MakePodGroup().Name("pg").MinCount(1).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name:        "add a pod group which doesn't match the pod's scheduling group name",
-			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
-			newPodGroup: st.MakePodGroup().Name("pg2").MinCount(1).WorkloadRef("t", "w").Obj(),
+			name:                       "add a pod group which doesn't match the pod's scheduling group name",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Name("p").PodGroupName("pg1").Obj(),
+			newPodGroup:                st.MakePodGroup().Name("pg2").MinCount(1).WorkloadRef("t", "w").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Name("pg1").Obj(),
 			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:        "add a pod group which doesn't match the pod's scheduling group name (CPG=false)",
-			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
-			newPodGroup: st.MakePodGroup().Name("pg2").MinCount(1).WorkloadRef("t", "w").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").Obj(),
-			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name:        "add a pod group which doesn't match the pod's scheduling group namespace",
-			pod:         st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			newPodGroup: st.MakePodGroup().Namespace("ns2").Name("pg").MinCount(1).WorkloadRef("t", "w").Obj(),
+			name:                       "add a pod group which doesn't match the pod's scheduling group namespace",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			newPodGroup:                st.MakePodGroup().Namespace("ns2").Name("pg").MinCount(1).WorkloadRef("t", "w").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Namespace("ns1").Name("pg").Obj(),
 			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:        "add a pod group which doesn't match the pod's scheduling group namespace (CPG=false)",
-			pod:         st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			newPodGroup: st.MakePodGroup().Namespace("ns2").Name("pg").MinCount(1).WorkloadRef("t", "w").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Namespace("ns1").Name("pg").Obj(),
-			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name:        "add a pod group which doesn't match the pod's scheduling group but matches the root CPG",
-			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
-			newPodGroup: st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").MinCount(1).Obj(),
+			name:                       "add a pod group which doesn't match the pod's scheduling group but matches the root CPG",
+			isCompositePodGroupEnabled: []bool{true},
+			pod:                        st.MakePod().Name("p").PodGroupName("pg1").Obj(),
+			newPodGroup:                st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").MinCount(1).Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Obj(),
 			},
-			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: true,
+			expectedHint: fwk.Queue,
 		},
 		{
-			name:        "add a pod group which doesn't match the pod's scheduling group but matches the root CPG (CPG=false)",
-			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
-			newPodGroup: st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").MinCount(1).Obj(),
+			name:                       "add a pod group which doesn't match the pod's scheduling group but matches the root CPG, but CPG is ignored",
+			isCompositePodGroupEnabled: []bool{false},
+			pod:                        st.MakePod().Name("p").PodGroupName("pg1").Obj(),
+			newPodGroup:                st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").MinCount(1).Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Obj(),
 			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:        "add a pod group which doesn't match the pod's scheduling group and doesn't match the root CPG",
-			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
-			newPodGroup: st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root2").MinCount(1).Obj(),
+			name:                       "add a pod group which doesn't match the pod's scheduling group and doesn't match the root CPG",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Name("p").PodGroupName("pg1").Obj(),
+			newPodGroup:                st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root2").MinCount(1).Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root1").Obj(),
 			},
@@ -350,60 +275,51 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 				st.MakeCompositePodGroup().Name("cpg-root1").Obj(),
 				st.MakeCompositePodGroup().Name("cpg-root2").Obj(),
 			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
-		},
-		{
-			name:        "add a pod group which doesn't match the pod's scheduling group and doesn't match the root CPG (CPG=false)",
-			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
-			newPodGroup: st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root2").MinCount(1).Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root1").Obj(),
-			},
-			cpgs: []*schedulingv1alpha3.CompositePodGroup{
-				st.MakeCompositePodGroup().Name("cpg-root1").Obj(),
-				st.MakeCompositePodGroup().Name("cpg-root2").Obj(),
-			},
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
+			expectedHint: fwk.QueueSkip,
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareWorkloadScheduling, true)
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CompositePodGroup, tc.isCompositePodGroupEnabled)
-			logger, ctx := ktesting.NewTestContext(t)
+		for _, isCPGEnabled := range tc.isCompositePodGroupEnabled {
+			t.Run(fmt.Sprintf("%s (CPG enabled: %v)", tc.name, isCPGEnabled), func(t *testing.T) {
+				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+					features.GenericWorkload:                 true,
+					features.TopologyAwareWorkloadScheduling: isCPGEnabled,
+					features.CompositePodGroup:               isCPGEnabled,
+				})
+				logger, ctx := ktesting.NewTestContext(t)
 
-			var objs []runtime.Object
-			for _, pg := range tc.pgs {
-				objs = append(objs, pg)
-			}
-			for _, cpg := range tc.cpgs {
-				objs = append(objs, cpg)
-			}
-			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
-
-			for _, pg := range tc.pgs {
-				if err := informerFactory.Scheduling().V1beta1().PodGroups().Informer().GetStore().Add(pg); err != nil {
-					t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
+				var objs []runtime.Object
+				for _, pg := range tc.pgs {
+					objs = append(objs, pg)
 				}
-			}
-			for _, cpg := range tc.cpgs {
-				if err := informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer().GetStore().Add(cpg); err != nil {
-					t.Fatalf("Failed to add cpg %s to store: %v", cpg.Name, err)
+				for _, cpg := range tc.cpgs {
+					objs = append(objs, cpg)
 				}
-			}
+				informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
 
-			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
-				frameworkruntime.WithInformerFactory(informerFactory),
-			)
-			if err != nil {
-				t.Fatalf("Failed to create framework: %v", err)
-			}
+				for _, pg := range tc.pgs {
+					if err := informerFactory.Scheduling().V1beta1().PodGroups().Informer().GetStore().Add(pg); err != nil {
+						t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
+					}
+				}
+				for _, cpg := range tc.cpgs {
+					if err := informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer().GetStore().Add(cpg); err != nil {
+						t.Fatalf("Failed to add cpg %s to store: %v", cpg.Name, err)
+					}
+				}
 
-			p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
-			if err == nil {
+				fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+					frameworkruntime.WithInformerFactory(informerFactory),
+				)
+				if err != nil {
+					t.Fatalf("Failed to create framework: %v", err)
+				}
+
+				p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
+				if err != nil {
+					t.Fatal(err)
+				}
+
 				pgMap := make(map[string]*schedulingv1beta1.PodGroup)
 				for _, pg := range tc.pgs {
 					pgMap[pg.Name] = pg
@@ -416,161 +332,100 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 					cpgMap[cpg.Name] = cpg
 				}
 				p.(*GangScheduling).podGroupManager = &mockPodGroupManager{pgs: pgMap, cpgs: cpgMap}
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			actualHint, err := p.(*GangScheduling).isSchedulableAfterPodGroupAdded(logger, tc.pod, nil, tc.newPodGroup)
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-			}
-			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
-				t.Errorf("Expected QueuingHint doesn't match (-want,+got):\n%s", diff)
-			}
-		})
+				actualHint, err := p.(*GangScheduling).isSchedulableAfterPodGroupAdded(logger, tc.pod, nil, tc.newPodGroup)
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+					t.Errorf("Expected QueuingHint doesn't match (-want,+got):\n%s", diff)
+				}
+			})
+		}
 	}
 }
 
 func Test_isSchedulableAfterPodGroupUpdated(t *testing.T) {
 	tests := []struct {
-		name                       string
-		pod                        *v1.Pod
-		oldPodGroup                *schedulingv1beta1.PodGroup
-		newPodGroup                *schedulingv1beta1.PodGroup
-		expectedHint               fwk.QueueingHint
-		expectErr                  bool
-		isCompositePodGroupEnabled bool
+		name         string
+		pod          *v1.Pod
+		oldPodGroup  *schedulingv1beta1.PodGroup
+		newPodGroup  *schedulingv1beta1.PodGroup
+		expectedHint fwk.QueueingHint
+		expectErr    bool
 	}{
 		{
-			name:                       "minCount decreased matches target pod",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: true,
+			name:         "minCount decreased matches target pod",
+			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			expectedHint: fwk.Queue,
 		},
 		{
-			name:                       "minCount decreased matches target pod (CPG=false)",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: false,
+			name:         "update Basic policy",
+			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().WorkloadRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().Obj(),
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:                       "update Basic policy",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
+			name:         "minCount increased matches target pod",
+			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:                       "update Basic policy (CPG=false)",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").BasicPolicy().Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
+			name:         "minCount unchanged matches target pod",
+			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:                       "minCount increased matches target pod",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
+			name:         "minCount decreased but pod group name doesn't match target pod",
+			pod:          st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg-other").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:                       "minCount increased matches target pod (CPG=false)",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
+			name:         "minCount decreased but pod group namespace doesn't match target pod",
+			pod:          st.MakePod().Namespace("ns-other").Name("p").PodGroupName("pg").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name:                       "minCount unchanged matches target pod",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
-		},
-		{
-			name:                       "minCount unchanged matches target pod (CPG=false)",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name:                       "minCount decreased but pod group name doesn't match target pod",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg-other").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
-		},
-		{
-			name:                       "minCount decreased but pod group name doesn't match target pod (CPG=false)",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg-other").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name:                       "minCount decreased but pod group namespace doesn't match target pod",
-			pod:                        st.MakePod().Namespace("ns-other").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
-		},
-		{
-			name:                       "minCount decreased but pod group namespace doesn't match target pod (CPG=false)",
-			pod:                        st.MakePod().Namespace("ns-other").Name("p").PodGroupName("pg").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name:                       "pod without a scheduling group is skipped",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
-		},
-		{
-			name:                       "pod without a scheduling group is skipped (CPG=false)",
-			pod:                        st.MakePod().Namespace("ns1").Name("p").Obj(),
-			oldPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
-			newPodGroup:                st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
+			name:         "pod without a scheduling group is skipped",
+			pod:          st.MakePod().Namespace("ns1").Name("p").Obj(),
+			oldPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(4).WorkloadRef("t", "w").Obj(),
+			newPodGroup:  st.MakePodGroup().Namespace("ns1").Name("pg").MinCount(3).WorkloadRef("t", "w").Obj(),
+			expectedHint: fwk.QueueSkip,
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareWorkloadScheduling, true)
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CompositePodGroup, tc.isCompositePodGroupEnabled)
-			logger, ctx := ktesting.NewTestContext(t)
+		for _, isCPGEnabled := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s (CPG enabled: %v)", tc.name, isCPGEnabled), func(t *testing.T) {
+				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+					features.GenericWorkload:                 true,
+					features.TopologyAwareWorkloadScheduling: isCPGEnabled,
+					features.CompositePodGroup:               isCPGEnabled,
+				})
+				logger, ctx := ktesting.NewTestContext(t)
 
-			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
-			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
-				frameworkruntime.WithInformerFactory(informerFactory),
-			)
-			if err != nil {
-				t.Fatalf("Failed to create framework: %v", err)
-			}
+				informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
+				fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+					frameworkruntime.WithInformerFactory(informerFactory),
+				)
+				if err != nil {
+					t.Fatalf("Failed to create framework: %v", err)
+				}
 
-			p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
-			if err == nil {
+				p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
+				if err != nil {
+					t.Fatal(err)
+				}
+
 				pgMap := make(map[string]*schedulingv1beta1.PodGroup)
 				if tc.oldPodGroup != nil {
 					pgMap[tc.oldPodGroup.Name] = tc.oldPodGroup
@@ -580,24 +435,21 @@ func Test_isSchedulableAfterPodGroupUpdated(t *testing.T) {
 				}
 				cpgMap := make(map[string]*schedulingv1alpha3.CompositePodGroup)
 				p.(*GangScheduling).podGroupManager = &mockPodGroupManager{pgs: pgMap, cpgs: cpgMap}
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			actualHint, err := p.(*GangScheduling).isSchedulableAfterPodGroupUpdated(logger, tc.pod, tc.oldPodGroup, tc.newPodGroup)
-			if tc.expectErr {
-				if err == nil {
-					t.Errorf("Expected error but got nil")
+				actualHint, err := p.(*GangScheduling).isSchedulableAfterPodGroupUpdated(logger, tc.pod, tc.oldPodGroup, tc.newPodGroup)
+				if tc.expectErr {
+					if err == nil {
+						t.Errorf("Expected error but got nil")
+					}
+					return
 				}
-				return
-			}
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-			}
-			if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
-				t.Errorf("Expected QueuingHint doesn't match (-want,+got):\n%s", diff)
-			}
-		})
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if diff := cmp.Diff(tc.expectedHint, actualHint); diff != "" {
+					t.Errorf("Expected QueuingHint doesn't match (-want,+got):\n%s", diff)
+				}
+			})
+		}
 	}
 }
 
@@ -614,85 +466,63 @@ func (pam *podActivatorMock) Activate(_ klog.Logger, pods map[string]*v1.Pod) {
 func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 	tests := []struct {
 		name                       string
+		isCompositePodGroupEnabled []bool
 		pod                        *v1.Pod
 		newCPG                     *schedulingv1alpha3.CompositePodGroup
 		cpgs                       []*schedulingv1alpha3.CompositePodGroup
 		pgs                        []*schedulingv1beta1.PodGroup
 		expectedHint               fwk.QueueingHint
-		isCompositePodGroupEnabled bool
 	}{
 		{
-			name: "add a CPG which matches the pod's root CPG",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			name:                       "add a CPG which matches the pod's root CPG",
+			isCompositePodGroupEnabled: []bool{true},
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
 			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
-			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: true,
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+			expectedHint: fwk.Queue,
 		},
 		{
-			name: "add a CPG which matches the pod's root CPG (CPG=false)",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			name:                       "add a CPG which matches the pod's root CPG, but CPG is ignored",
+			isCompositePodGroupEnabled: []bool{false},
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
 			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name: "add a CPG which matches the pod's root CPG",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
-			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name: "add a CPG which matches the pod's intermediate CPG but implies the same root",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			name:                       "add a CPG which matches the pod's intermediate CPG but implies the same root",
+			isCompositePodGroupEnabled: []bool{true},
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
 			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").Obj(),
-			expectedHint:               fwk.Queue,
-			isCompositePodGroupEnabled: true,
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").Obj(),
+			expectedHint: fwk.Queue,
 		},
 		{
-			name: "add a CPG which matches the pod's intermediate CPG but implies the same root (CPG=false)",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			name:                       "add a CPG which matches the pod's intermediate CPG but implies the same root, but CPG is ignored",
+			isCompositePodGroupEnabled: []bool{false},
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
 			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").Obj(),
+			expectedHint: fwk.QueueSkip,
 		},
 		{
-			name: "add a CPG which matches the pod's intermediate CPG but implies the same root",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub").Obj(),
-			},
-			cpgs: []*schedulingv1alpha3.CompositePodGroup{
-				st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
-			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-sub").ParentCompositePodGroup("cpg-root").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name: "add a CPG which does not match the pod's CPG hierarchy",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
+			name:                       "add a CPG which does not match the pod's CPG hierarchy",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
 			pgs: []*schedulingv1beta1.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-1").Obj(),
 			},
@@ -700,78 +530,55 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 				st.MakeCompositePodGroup().Namespace("default").Name("cpg-1").Obj(),
 				st.MakeCompositePodGroup().Namespace("default").Name("cpg-2").Obj(),
 			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-2").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: true,
-		},
-		{
-			name: "add a CPG which does not match the pod's CPG hierarchy (CPG=false)",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-1").Obj(),
-			},
-			cpgs: []*schedulingv1alpha3.CompositePodGroup{
-				st.MakeCompositePodGroup().Namespace("default").Name("cpg-1").Obj(),
-				st.MakeCompositePodGroup().Namespace("default").Name("cpg-2").Obj(),
-			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-2").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
-		},
-		{
-			name: "add a CPG which does not match the pod's CPG hierarchy",
-			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-1").Obj(),
-			},
-			cpgs: []*schedulingv1alpha3.CompositePodGroup{
-				st.MakeCompositePodGroup().Namespace("default").Name("cpg-1").Obj(),
-				st.MakeCompositePodGroup().Namespace("default").Name("cpg-2").Obj(),
-			},
-			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-2").Obj(),
-			expectedHint:               fwk.QueueSkip,
-			isCompositePodGroupEnabled: false,
+			newCPG:       st.MakeCompositePodGroup().Namespace("default").Name("cpg-2").Obj(),
+			expectedHint: fwk.QueueSkip,
 		},
 	}
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareWorkloadScheduling, true)
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CompositePodGroup, tc.isCompositePodGroupEnabled)
-			logger, ctx := ktesting.NewTestContext(t)
+		for _, isCPGEnabled := range tc.isCompositePodGroupEnabled {
+			t.Run(fmt.Sprintf("%s (CPG enabled: %v)", tc.name, isCPGEnabled), func(t *testing.T) {
+				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+					features.GenericWorkload:                 true,
+					features.TopologyAwareWorkloadScheduling: isCPGEnabled,
+					features.CompositePodGroup:               isCPGEnabled,
+				})
+				logger, ctx := ktesting.NewTestContext(t)
 
-			// Must create clientset with objects
-			var objs []runtime.Object
-			for _, pg := range tc.pgs {
-				objs = append(objs, pg)
-			}
-			for _, cpg := range tc.cpgs {
-				objs = append(objs, cpg)
-			}
-
-			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
-
-			// We need to wait for informers to sync
-			for _, pg := range tc.pgs {
-				if err := informerFactory.Scheduling().V1beta1().PodGroups().Informer().GetStore().Add(pg); err != nil {
-					t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
+				// Must create clientset with objects
+				var objs []runtime.Object
+				for _, pg := range tc.pgs {
+					objs = append(objs, pg)
 				}
-			}
-			for _, cpg := range tc.cpgs {
-				if err := informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer().GetStore().Add(cpg); err != nil {
-					t.Fatalf("Failed to add cpg %s to store: %v", cpg.Name, err)
+				for _, cpg := range tc.cpgs {
+					objs = append(objs, cpg)
 				}
-			}
 
-			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
-				frameworkruntime.WithInformerFactory(informerFactory),
-			)
-			if err != nil {
-				t.Fatalf("Failed to create framework: %v", err)
-			}
+				informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
 
-			p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
-			if err == nil {
+				// We need to wait for informers to sync
+				for _, pg := range tc.pgs {
+					if err := informerFactory.Scheduling().V1beta1().PodGroups().Informer().GetStore().Add(pg); err != nil {
+						t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
+					}
+				}
+				for _, cpg := range tc.cpgs {
+					if err := informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer().GetStore().Add(cpg); err != nil {
+						t.Fatalf("Failed to add cpg %s to store: %v", cpg.Name, err)
+					}
+				}
+
+				fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+					frameworkruntime.WithInformerFactory(informerFactory),
+				)
+				if err != nil {
+					t.Fatalf("Failed to create framework: %v", err)
+				}
+
+				p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
+				if err != nil {
+					t.Fatal(err)
+				}
+
 				pgMap := make(map[string]*schedulingv1beta1.PodGroup)
 				for _, pg := range tc.pgs {
 					pgMap[pg.Name] = pg
@@ -783,21 +590,18 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 				if tc.newCPG != nil {
 					cpgMap[tc.newCPG.Name] = tc.newCPG
 				}
-				p.(*GangScheduling).podGroupManager = &mockPodGroupManager{pgs: pgMap, cpgs: cpgMap}
-			}
-			if err != nil {
-				t.Fatal(err)
-			}
-			pl := p.(*GangScheduling)
+				pl := p.(*GangScheduling)
+				pl.podGroupManager = &mockPodGroupManager{pgs: pgMap, cpgs: cpgMap}
 
-			hint, err := pl.isSchedulableAfterCompositePodGroupAdded(logger, tc.pod, nil, tc.newCPG)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if hint != tc.expectedHint {
-				t.Errorf("expected hint %v, got %v", tc.expectedHint, hint)
-			}
-		})
+				hint, err := pl.isSchedulableAfterCompositePodGroupAdded(logger, tc.pod, nil, tc.newCPG)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if hint != tc.expectedHint {
+					t.Errorf("expected hint %v, got %v", tc.expectedHint, hint)
+				}
+			})
+		}
 	}
 }
 
@@ -842,58 +646,31 @@ func TestPreEnqueue(t *testing.T) {
 
 	nonGangPod := st.MakePod().Namespace("ns1").Name("non-gang").UID("non-gang").Obj()
 
-	cpgRoot := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "cpg-root"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			SchedulingPolicy: schedulingv1alpha3.CompositePodGroupSchedulingPolicy{Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: 2}},
-		},
-	}
-	cpgSub1 := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "cpg-sub1"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			ParentCompositePodGroupName: new("cpg-root"),
-			SchedulingPolicy:            schedulingv1alpha3.CompositePodGroupSchedulingPolicy{Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: 2}},
-		},
-	}
-	cpgSub2 := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "cpg-sub2"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			ParentCompositePodGroupName: new("cpg-root"),
-			SchedulingPolicy:            schedulingv1alpha3.CompositePodGroupSchedulingPolicy{Basic: &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}},
-		},
-	}
-	cpgSub3 := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "cpg-sub3"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			ParentCompositePodGroupName: new("cpg-root"),
-			SchedulingPolicy:            schedulingv1alpha3.CompositePodGroupSchedulingPolicy{Gang: &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: 2}},
-		},
-	}
+	cpgRoot := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-root").MinGroupCount(2).Obj()
+	cpgSub1 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-sub1").ParentCompositePodGroup("cpg-root").MinGroupCount(2).Obj()
+	cpgSub2 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-sub2").ParentCompositePodGroup("cpg-root").BasicPolicy().Obj()
+	cpgSub3 := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-sub3").ParentCompositePodGroup("cpg-root").MinGroupCount(2).Obj()
 
-	pg1 := st.MakePodGroup().Namespace("ns1").Name("pg1-cpg").ParentCompositePodGroup("cpg-sub1").MinCount(1).Obj()
-	pg2 := st.MakePodGroup().Namespace("ns1").Name("pg2-cpg").ParentCompositePodGroup("cpg-sub1").MinCount(1).Obj()
-	pg3 := st.MakePodGroup().Namespace("ns1").Name("pg3-cpg").ParentCompositePodGroup("cpg-sub1").MinCount(1).Obj()
-	pg4 := st.MakePodGroup().Namespace("ns1").Name("pg4-cpg").ParentCompositePodGroup("cpg-sub2").BasicPolicy().Obj()
-	pg5 := st.MakePodGroup().Namespace("ns1").Name("pg5-cpg").ParentCompositePodGroup("cpg-sub2").MinCount(1).Obj()
-	pg6 := st.MakePodGroup().Namespace("ns1").Name("pg6-cpg").ParentCompositePodGroup("cpg-sub3").MinCount(1).Obj()
-	pg7 := st.MakePodGroup().Namespace("ns1").Name("pg7-cpg").ParentCompositePodGroup("cpg-sub3").MinCount(1).Obj()
+	pg1CPG := st.MakePodGroup().Namespace("ns1").Name("pg1-cpg").ParentCompositePodGroup("cpg-sub1").MinCount(1).Obj()
+	pg2CPG := st.MakePodGroup().Namespace("ns1").Name("pg2-cpg").ParentCompositePodGroup("cpg-sub1").MinCount(1).Obj()
+	pg3CPG := st.MakePodGroup().Namespace("ns1").Name("pg3-cpg").ParentCompositePodGroup("cpg-sub1").MinCount(1).Obj()
+	pg4CPG := st.MakePodGroup().Namespace("ns1").Name("pg4-cpg").ParentCompositePodGroup("cpg-sub2").BasicPolicy().Obj()
+	pg5CPG := st.MakePodGroup().Namespace("ns1").Name("pg5-cpg").ParentCompositePodGroup("cpg-sub2").MinCount(1).Obj()
+	pg6CPG := st.MakePodGroup().Namespace("ns1").Name("pg6-cpg").ParentCompositePodGroup("cpg-sub3").MinCount(1).Obj()
+	pg7CPG := st.MakePodGroup().Namespace("ns1").Name("pg7-cpg").ParentCompositePodGroup("cpg-sub3").MinCount(1).Obj()
 
 	p1CPG := st.MakePod().Namespace("ns1").Name("p1-cpg").UID("p1-cpg").PodGroupName("pg1-cpg").Obj()
 	p2CPG := st.MakePod().Namespace("ns1").Name("p2-cpg").UID("p2-cpg").PodGroupName("pg2-cpg").Obj()
 	p4CPG := st.MakePod().Namespace("ns1").Name("p4-cpg").UID("p4-cpg").PodGroupName("pg4-cpg").Obj()
 	p6CPG := st.MakePod().Namespace("ns1").Name("p6-cpg").UID("p6-cpg").PodGroupName("pg6-cpg").Obj()
 
-	cpgBasicRoot := &schedulingv1alpha3.CompositePodGroup{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "ns1", Name: "cpg-basic-root"},
-		Spec: schedulingv1alpha3.CompositePodGroupSpec{
-			SchedulingPolicy: schedulingv1alpha3.CompositePodGroupSchedulingPolicy{Basic: &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}},
-		},
-	}
-	pgBasic1 := st.MakePodGroup().Namespace("ns1").Name("pg-basic-1").ParentCompositePodGroup("cpg-basic-root").MinCount(2).Obj()
-	pgBasic2 := st.MakePodGroup().Namespace("ns1").Name("pg-basic-2").ParentCompositePodGroup("cpg-basic-root").MinCount(2).Obj()
-	p1_1 := st.MakePod().Namespace("ns1").Name("p1_1").UID("p1_1").PodGroupName("pg-basic-1").Obj()
-	p1_2 := st.MakePod().Namespace("ns1").Name("p1_2").UID("p1_2").PodGroupName("pg-basic-1").Obj()
-	p2_1 := st.MakePod().Namespace("ns1").Name("p2_1").UID("p2_1").PodGroupName("pg-basic-2").Obj()
+	cpgBasicRoot := st.MakeCompositePodGroup().Namespace("ns1").Name("cpg-basic-root").BasicPolicy().Obj()
+
+	pgBasic1CPG := st.MakePodGroup().Namespace("ns1").Name("pg-basic-1").ParentCompositePodGroup("cpg-basic-root").MinCount(2).Obj()
+	pgBasic2CPG := st.MakePodGroup().Namespace("ns1").Name("pg-basic-2").ParentCompositePodGroup("cpg-basic-root").MinCount(2).Obj()
+	p1_1BasicCPG := st.MakePod().Namespace("ns1").Name("p1_1").UID("p1_1").PodGroupName("pg-basic-1").Obj()
+	p1_2BasicCPG := st.MakePod().Namespace("ns1").Name("p1_2").UID("p1_2").PodGroupName("pg-basic-1").Obj()
+	p2_1BasicCPG := st.MakePod().Namespace("ns1").Name("p2_1").UID("p2_1").PodGroupName("pg-basic-2").Obj()
 
 	type testCase struct {
 		name                       string
@@ -906,127 +683,127 @@ func TestPreEnqueue(t *testing.T) {
 	}
 	baseTests := []testCase{
 		{
-			name:                 "non-gang pod succeeds immediately",
-			pod:                  nonGangPod,
-			initialPodGroups:     []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
-			wantPreEnqueueStatus: nil,
+			name:                       "non-gang pod succeeds immediately",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        nonGangPod,
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
+			wantPreEnqueueStatus:       nil,
 		},
 		{
-			name:                 "basic policy pod succeeds immediately",
-			pod:                  basicPolicyPod,
-			initialPodGroups:     []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
-			wantPreEnqueueStatus: nil,
+			name:                       "basic policy pod succeeds immediately",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        basicPolicyPod,
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
+			wantPreEnqueueStatus:       nil,
 		},
 		{
 			name:                       "gang pod fails PreEnqueue when pod group is not yet created",
-			pod:                        p1,
 			isCompositePodGroupEnabled: []bool{false},
+			pod:                        p1,
 			initialPods:                []*v1.Pod{p2, p3, p4, p5},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `waiting for pods's pod group "pg1" to appear in scheduling queue`),
 		},
 		{
 			name:                       "gang pod fails PreEnqueue when pod group is not yet created",
-			pod:                        p1,
 			isCompositePodGroupEnabled: []bool{true},
+			pod:                        p1,
 			initialPods:                []*v1.Pod{p2, p3, p4, p5},
 			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "failed to build hierarchy snapshot: pod group object not found in state for podgroup/ns1/pg1"),
 		},
 		{
-			name:                 "gang pod fails PreEnqueue when quorum is not met",
-			pod:                  p1,
-			initialPods:          []*v1.Pod{p2, p4, p5},
-			initialPodGroups:     []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
-			wantPreEnqueueStatus: fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
+			name:                       "gang pod fails PreEnqueue when quorum is not met",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        p1,
+			initialPods:                []*v1.Pod{p2, p4, p5},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
+			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
 		},
 		{
-			name:                 "gang pod passes PreEnqueue",
-			pod:                  p1,
-			initialPods:          []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:     []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
-			wantPreEnqueueStatus: nil,
+			name:                       "gang pod passes PreEnqueue",
+			isCompositePodGroupEnabled: []bool{true, false},
+			pod:                        p1,
+			initialPods:                []*v1.Pod{p2, p3, p4, p5},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
+			wantPreEnqueueStatus:       nil,
 		},
 		{
 			name:                       "CPG Hierarchical Stage 1: No pods, tree not ready",
-			pod:                        p1CPG,
 			isCompositePodGroupEnabled: []bool{true},
+			pod:                        p1CPG,
 			initialPods:                []*v1.Pod{},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1CPG, pg2CPG, pg3CPG, pg4CPG, pg5CPG, pg6CPG, pg7CPG},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for composite pod group \"cpg-root\" tree to meet quorum"),
 		},
 		{
 			name:                       "CPG Hierarchical Stage 1: No pods, ready, as CPGs are ignored",
-			pod:                        p1CPG,
 			isCompositePodGroupEnabled: []bool{false},
+			pod:                        p1CPG,
 			initialPods:                []*v1.Pod{},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1CPG, pg2CPG, pg3CPG, pg4CPG, pg5CPG, pg6CPG, pg7CPG},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
 		},
 		{
 			name:                       "CPG Hierarchical Stage 2: Add p6, cpg-sub1 ready but root not ready",
-			pod:                        p6CPG,
 			isCompositePodGroupEnabled: []bool{true},
+			pod:                        p6CPG,
 			initialPods:                []*v1.Pod{p1CPG, p2CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1CPG, pg2CPG, pg3CPG, pg4CPG, pg5CPG, pg6CPG, pg7CPG},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for composite pod group \"cpg-root\" tree to meet quorum"),
 		},
 		{
 			name:                       "CPG Hierarchical Stage 2: Add p6, already ready",
-			pod:                        p6CPG,
 			isCompositePodGroupEnabled: []bool{false},
+			pod:                        p6CPG,
 			initialPods:                []*v1.Pod{p1CPG, p2CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1CPG, pg2CPG, pg3CPG, pg4CPG, pg5CPG, pg6CPG, pg7CPG},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
 		},
 		{
 			name:                       "CPG Hierarchical Stage 3: Add p4, root becomes ready",
-			pod:                        p4CPG,
 			isCompositePodGroupEnabled: []bool{true},
+			pod:                        p4CPG,
 			initialPods:                []*v1.Pod{p1CPG, p2CPG, p6CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1CPG, pg2CPG, pg3CPG, pg4CPG, pg5CPG, pg6CPG, pg7CPG},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
 		},
 		{
 			name:                       "CPG Hierarchical Stage 3: Add p4, already ready",
-			pod:                        p4CPG,
 			isCompositePodGroupEnabled: []bool{false},
+			pod:                        p4CPG,
 			initialPods:                []*v1.Pod{p1CPG, p2CPG, p6CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1CPG, pg2CPG, pg3CPG, pg4CPG, pg5CPG, pg6CPG, pg7CPG},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
 		},
 		{
 			name:                       "CPG Basic With Gang Stage 1: pg1 ready, root ready",
-			pod:                        p2_1,
 			isCompositePodGroupEnabled: []bool{true},
-			initialPods:                []*v1.Pod{p1_1, p1_2},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgBasic1, pgBasic2},
+			pod:                        p2_1BasicCPG,
+			initialPods:                []*v1.Pod{p1_1BasicCPG, p1_2BasicCPG},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgBasic1CPG, pgBasic2CPG},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgBasicRoot},
 			wantPreEnqueueStatus:       nil,
 		},
 		{
 			name:                       "CPG Basic With Gang Stage 1: pg1 ready, root ready, pg2 not ready",
-			pod:                        p2_1,
 			isCompositePodGroupEnabled: []bool{false},
-			initialPods:                []*v1.Pod{p1_1, p1_2},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgBasic1, pgBasic2},
+			pod:                        p2_1BasicCPG,
+			initialPods:                []*v1.Pod{p1_1BasicCPG, p1_2BasicCPG},
+			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgBasic1CPG, pgBasic2CPG},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgBasicRoot},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
 		},
 	}
 
 	for _, tt := range baseTests {
-		isCompositePodGroupEnabled := []bool{true, false}
-		if len(tt.isCompositePodGroupEnabled) > 0 {
-			isCompositePodGroupEnabled = tt.isCompositePodGroupEnabled
-		}
-		for _, isCPGEnabled := range isCompositePodGroupEnabled {
+		for _, isCPGEnabled := range tt.isCompositePodGroupEnabled {
 			t.Run(fmt.Sprintf("%s (CPG enabled: %v)", tt.name, isCPGEnabled), func(t *testing.T) {
 				featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 					features.GenericWorkload:                 true,
@@ -1095,8 +872,6 @@ func TestPreEnqueue(t *testing.T) {
 func TestPlacementFeasible(t *testing.T) {
 	tests := []struct {
 		name                  string
-		cpgFeatureGate        bool
-		isCPG                 bool
 		minCount              int32
 		childrenCount         int
 		unscheduledPods       []*v1.Pod
@@ -1105,9 +880,7 @@ func TestPlacementFeasible(t *testing.T) {
 		initialScheduledCount int
 	}{
 		{
-			name:                  "All pods succeed, minCount met at end (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "All pods succeed, minCount met at end",
 			minCount:              2,
 			childrenCount:         2,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
@@ -1116,31 +889,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 0,
 		},
 		{
-			name:                  "All pods succeed, minCount met at end (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              2,
-			childrenCount:         2,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success, fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Success},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "All pods succeed, minCount met at end (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              2,
-			childrenCount:         2,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success, fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Success},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "First pod fails, minCount not satisfiable (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "First pod fails, minCount not satisfiable",
 			minCount:              3,
 			childrenCount:         3,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
@@ -1149,31 +898,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 0,
 		},
 		{
-			name:                  "First pod fails, minCount not satisfiable (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              3,
-			childrenCount:         3,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Unschedulable},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "First pod fails, minCount not satisfiable (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              3,
-			childrenCount:         3,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Unschedulable},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "Second pod fails, minCount not satisfiable (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "Second pod fails, minCount not satisfiable",
 			minCount:              2,
 			childrenCount:         2,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
@@ -1182,31 +907,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 0,
 		},
 		{
-			name:                  "Second pod fails, minCount not satisfiable (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              2,
-			childrenCount:         2,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success, fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Unschedulable},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "Second pod fails, minCount not satisfiable (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              2,
-			childrenCount:         2,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success, fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Unschedulable},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "Non-gang pod group with 0 scheduled pods fails (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "Non-gang pod group with 0 scheduled pods fails",
 			minCount:              0,
 			childrenCount:         1,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
@@ -1215,42 +916,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 0,
 		},
 		{
-			name:                  "Non-gang pod group with 0 scheduled pods fails (isCPG=true, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 true,
-			minCount:              0,
-			childrenCount:         1,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Unschedulable},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "Non-gang pod group with 0 scheduled pods fails (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              0,
-			childrenCount:         1,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Unschedulable},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "Non-gang pod group with 0 scheduled pods fails (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              0,
-			childrenCount:         1,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Unschedulable},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "Non-gang pod group with succeeds once 1 pod is scheduled (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "Non-gang pod group with succeeds once 1 pod is scheduled",
 			minCount:              0,
 			childrenCount:         1,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
@@ -1259,42 +925,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 0,
 		},
 		{
-			name:                  "Non-gang pod group with succeeds once 1 pod is scheduled (isCPG=true, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 true,
-			minCount:              0,
-			childrenCount:         1,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Success},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "Non-gang pod group with succeeds once 1 pod is scheduled (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              0,
-			childrenCount:         1,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Success},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "Non-gang pod group with succeeds once 1 pod is scheduled (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              0,
-			childrenCount:         1,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Success},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "Non-gang pod group with 1 initially scheduled pod succeeds (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "Non-gang pod group with 1 initially scheduled pod succeeds",
 			minCount:              0,
 			childrenCount:         1,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
@@ -1303,42 +934,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 1,
 		},
 		{
-			name:                  "Non-gang pod group with 1 initially scheduled pod succeeds (isCPG=true, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 true,
-			minCount:              0,
-			childrenCount:         1,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Success},
-			initialScheduledCount: 1,
-		},
-		{
-			name:                  "Non-gang pod group with 1 initially scheduled pod succeeds (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              0,
-			childrenCount:         1,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Success},
-			initialScheduledCount: 1,
-		},
-		{
-			name:                  "Non-gang pod group with 1 initially scheduled pod succeeds (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              0,
-			childrenCount:         1,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Success},
-			initialScheduledCount: 1,
-		},
-		{
-			name:                  "More than minCount pods, all succeed (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "More than minCount pods, all succeed",
 			minCount:              2,
 			childrenCount:         3,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
@@ -1347,31 +943,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 0,
 		},
 		{
-			name:                  "More than minCount pods, all succeed (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              2,
-			childrenCount:         3,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success, fwk.Success, fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Success, fwk.Success},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "More than minCount pods, all succeed (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              2,
-			childrenCount:         3,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success, fwk.Success, fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Success, fwk.Success},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "More than minCount pods, first fails (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "More than minCount pods, first fails",
 			minCount:              2,
 			childrenCount:         3,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
@@ -1380,31 +952,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 0,
 		},
 		{
-			name:                  "More than minCount pods, first fails (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              2,
-			childrenCount:         3,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable, fwk.Success, fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Wait, fwk.Success},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "More than minCount pods, first fails (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              2,
-			childrenCount:         3,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable, fwk.Success, fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Wait, fwk.Success},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "More than minCount pods, minCount not satisfiable (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "More than minCount pods, minCount not satisfiable",
 			minCount:              2,
 			childrenCount:         3,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
@@ -1413,31 +961,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 0,
 		},
 		{
-			name:                  "More than minCount pods, minCount not satisfiable (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              2,
-			childrenCount:         3,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable, fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Unschedulable},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "More than minCount pods, minCount not satisfiable (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              2,
-			childrenCount:         3,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj(), st.MakePod().Name("p3").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable, fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Unschedulable},
-			initialScheduledCount: 0,
-		},
-		{
-			name:                  "1 pod scheduled, 2 unscheduled pods succeed, minCount 3 met (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "1 pod scheduled, 2 unscheduled pods succeed, minCount 3 met",
 			minCount:              3,
 			childrenCount:         2,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
@@ -1446,31 +970,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 1,
 		},
 		{
-			name:                  "1 pod scheduled, 2 unscheduled pods succeed, minCount 3 met (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              3,
-			childrenCount:         2,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success, fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Success},
-			initialScheduledCount: 1,
-		},
-		{
-			name:                  "1 pod scheduled, 2 unscheduled pods succeed, minCount 3 met (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              3,
-			childrenCount:         2,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success, fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Wait, fwk.Success},
-			initialScheduledCount: 1,
-		},
-		{
-			name:                  "minCount already met by scheduled pods (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "minCount already met by scheduled pods",
 			minCount:              2,
 			childrenCount:         1,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
@@ -1479,31 +979,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 2,
 		},
 		{
-			name:                  "minCount already met by scheduled pods (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              2,
-			childrenCount:         1,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Success},
-			initialScheduledCount: 2,
-		},
-		{
-			name:                  "minCount already met by scheduled pods (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              2,
-			childrenCount:         1,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Success},
-			initialScheduledCount: 2,
-		},
-		{
-			name:                  "1 pod scheduled, minCount 3, first unscheduled fails, not enough remaining (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
+			name:                  "1 pod scheduled, minCount 3, first unscheduled fails, not enough remaining",
 			minCount:              3,
 			childrenCount:         2,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
@@ -1512,53 +988,7 @@ func TestPlacementFeasible(t *testing.T) {
 			initialScheduledCount: 1,
 		},
 		{
-			name:                  "1 pod scheduled, minCount 3, first unscheduled fails, not enough remaining (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              3,
-			childrenCount:         2,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Unschedulable},
-			initialScheduledCount: 1,
-		},
-		{
-			name:                  "1 pod scheduled, minCount 3, first unscheduled fails, not enough remaining (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
-			minCount:              3,
-			childrenCount:         2,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
-			podStatuses:           []fwk.Code{fwk.Unschedulable},
-			expectedStatuses:      []fwk.Code{fwk.Unschedulable},
-			initialScheduledCount: 1,
-		},
-		{
-			name:                  "1 pod scheduled, minCount 4, first unscheduled succeeds, not enough remaining (isCPG=false, cpgFeatureGate=false)",
-			cpgFeatureGate:        false,
-			isCPG:                 false,
-			minCount:              4,
-			childrenCount:         2,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Unschedulable},
-			initialScheduledCount: 1,
-		},
-		{
-			name:                  "1 pod scheduled, minCount 4, first unscheduled succeeds, not enough remaining (isCPG=false, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 false,
-			minCount:              4,
-			childrenCount:         2,
-			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
-			podStatuses:           []fwk.Code{fwk.Success},
-			expectedStatuses:      []fwk.Code{fwk.Unschedulable},
-			initialScheduledCount: 1,
-		},
-		{
-			name:                  "1 pod scheduled, minCount 4, first unscheduled succeeds, not enough remaining (isCPG=true, cpgFeatureGate=true)",
-			cpgFeatureGate:        true,
-			isCPG:                 true,
+			name:                  "1 pod scheduled, minCount 4, first unscheduled succeeds, not enough remaining",
 			minCount:              4,
 			childrenCount:         2,
 			unscheduledPods:       []*v1.Pod{st.MakePod().Name("p1").Obj(), st.MakePod().Name("p2").Obj()},
@@ -1569,98 +999,103 @@ func TestPlacementFeasible(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
-			if tc.cpgFeatureGate {
-				featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareWorkloadScheduling, true)
-			}
-			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CompositePodGroup, tc.cpgFeatureGate)
-			_, ctx := ktesting.NewTestContext(t)
-
-			pgName := "test-pg"
-			namespace := "default"
-
-			pgInfo := &testPodGroupInfo{
-				namespace:       namespace,
-				name:            pgName,
-				unscheduledPods: tc.unscheduledPods,
-			}
-
-			var objs []runtime.Object
-
-			if tc.isCPG {
-				cpg := &schedulingv1alpha3.CompositePodGroup{
-					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pgName},
-					Spec:       schedulingv1alpha3.CompositePodGroupSpec{},
+		for _, isCPGEnabled := range []bool{true, false} {
+			for _, isCPG := range []bool{true, false} {
+				if !isCPGEnabled && isCPG {
+					// Cannot happen, skip
+					continue
 				}
-				if tc.minCount > 0 {
-					cpg.Spec.SchedulingPolicy.Gang = &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: tc.minCount}
-				} else {
-					cpg.Spec.SchedulingPolicy.Basic = &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}
-				}
-				pgInfo.groupType = fwk.CompositePodGroupKeyType
-				pgInfo.cpg = cpg
-				objs = append(objs, cpg)
-			} else {
-				pg := st.MakePodGroup().Namespace(namespace).Name(pgName).ParentCompositePodGroup("cpg-root").Obj()
-				if tc.minCount > 0 {
-					pg.Spec.SchedulingPolicy.Gang = &schedulingv1beta1.GangSchedulingPolicy{MinCount: tc.minCount}
-				} else {
-					pg.Spec.SchedulingPolicy.Basic = &schedulingv1beta1.BasicSchedulingPolicy{}
-				}
-				pgInfo.groupType = fwk.PodGroupKeyType
-				pgInfo.podGroup = pg
-				objs = append(objs, pg)
+				t.Run(fmt.Sprintf("%s (isCPG: %v, CPG enabled: %v)", tc.name, isCPG, isCPGEnabled), func(t *testing.T) {
+					featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+						features.GenericWorkload:                 true,
+						features.TopologyAwareWorkloadScheduling: isCPGEnabled,
+						features.CompositePodGroup:               isCPGEnabled,
+					})
+					_, ctx := ktesting.NewTestContext(t)
+
+					pgName := "test-pg"
+					namespace := "default"
+
+					pgInfo := &testPodGroupInfo{
+						namespace:       namespace,
+						name:            pgName,
+						unscheduledPods: tc.unscheduledPods,
+					}
+
+					var objs []runtime.Object
+
+					if isCPG {
+						cpg := st.MakeCompositePodGroup().Namespace(namespace).Name(pgName).Obj()
+						if tc.minCount > 0 {
+							cpg.Spec.SchedulingPolicy.Gang = &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: tc.minCount}
+						} else {
+							cpg.Spec.SchedulingPolicy.Basic = &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}
+						}
+						pgInfo.groupType = fwk.CompositePodGroupKeyType
+						pgInfo.cpg = cpg
+						objs = append(objs, cpg)
+					} else {
+						pg := st.MakePodGroup().Namespace(namespace).Name(pgName).ParentCompositePodGroup("cpg-root").Obj()
+						if tc.minCount > 0 {
+							pg.Spec.SchedulingPolicy.Gang = &schedulingv1beta1.GangSchedulingPolicy{MinCount: tc.minCount}
+						} else {
+							pg.Spec.SchedulingPolicy.Basic = &schedulingv1beta1.BasicSchedulingPolicy{}
+						}
+						pgInfo.groupType = fwk.PodGroupKeyType
+						pgInfo.podGroup = pg
+						objs = append(objs, pg)
+					}
+
+					informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
+					informerFactory.Scheduling().V1beta1().PodGroups().Informer()
+					if isCPGEnabled {
+						informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
+					}
+					informerFactory.StartWithContext(ctx)
+					informerFactory.WaitForCacheSyncWithContext(ctx)
+
+					fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
+						frameworkruntime.WithInformerFactory(informerFactory),
+					)
+					if err != nil {
+						t.Fatalf("Failed to create framework: %v", err)
+					}
+
+					p, err := New(ctx, nil, fh, feature.Features{EnableGenericWorkload: true, EnableCompositePodGroup: isCPGEnabled})
+					if err != nil {
+						t.Fatalf("Failed to create plugin: %v", err)
+					}
+					pl := p.(*GangScheduling)
+
+					mockState := &mockPodGroupState{scheduledPodsCount: tc.initialScheduledCount}
+					mockLister := &mockSharedLister{
+						podGroupStateLister: &mockPodGroupStateLister{state: mockState},
+					}
+					pl.snapshotLister = mockLister
+
+					cycleState := schedulerframework.NewCycleState()
+					cycleState.SetPodGroupSchedulingCycle(cycleState)
+
+					scheduled := tc.initialScheduledCount
+					for i, code := range tc.podStatuses {
+						if code == fwk.Success {
+							scheduled++
+							mockState.scheduledPodsCount++
+						}
+
+						args := schedulerframework.PlacementProgress{
+							Remaining: tc.childrenCount - (i + 1),
+							Scheduled: scheduled,
+						}
+						gotStatus := pl.PlacementFeasible(ctx, cycleState, pgInfo, args)
+
+						if gotCode := gotStatus.Code(); gotCode != tc.expectedStatuses[i] {
+							t.Errorf("Step %d: expected status %v, got %v", i, tc.expectedStatuses[i], gotCode)
+						}
+					}
+				})
 			}
-
-			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
-			informerFactory.Scheduling().V1beta1().PodGroups().Informer()
-			if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) {
-				informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
-			}
-			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSyncWithContext(ctx)
-
-			fh, err := frameworkruntime.NewFramework(ctx, nil, nil,
-				frameworkruntime.WithInformerFactory(informerFactory),
-			)
-			if err != nil {
-				t.Fatalf("Failed to create framework: %v", err)
-			}
-
-			p, err := New(ctx, nil, fh, feature.Features{EnableGenericWorkload: true, EnableCompositePodGroup: tc.cpgFeatureGate})
-			if err != nil {
-				t.Fatalf("Failed to create plugin: %v", err)
-			}
-			pl := p.(*GangScheduling)
-
-			mockState := &mockPodGroupState{scheduledPodsCount: tc.initialScheduledCount}
-			mockLister := &mockSharedLister{
-				podGroupStateLister: &mockPodGroupStateLister{state: mockState},
-			}
-			pl.snapshotLister = mockLister
-
-			cycleState := schedulerframework.NewCycleState()
-			cycleState.SetPodGroupSchedulingCycle(cycleState)
-
-			scheduled := tc.initialScheduledCount
-			for i, code := range tc.podStatuses {
-				if code == fwk.Success {
-					scheduled++
-					mockState.scheduledPodsCount++
-				}
-
-				args := schedulerframework.PlacementProgress{
-					Remaining: tc.childrenCount - (i + 1),
-					Scheduled: scheduled,
-				}
-				gotStatus := pl.PlacementFeasible(ctx, cycleState, pgInfo, args)
-
-				if gotCode := gotStatus.Code(); gotCode != tc.expectedStatuses[i] {
-					t.Errorf("Step %d: expected status %v, got %v", i, tc.expectedStatuses[i], gotCode)
-				}
-			}
-		})
+		}
 	}
 }
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -4202,8 +4202,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				tf.RegisterFilterPlugin(placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 					return &placementPlugin, nil
 				}),
-				tf.RegisterPermitPlugin(gangscheduling.Name, gangPluginFactory),
-				tf.RegisterPluginAsExtensions(gangscheduling.Name, gangPluginFactory, "PlacementFeasible"),
+				tf.RegisterPreEnqueuePlugin(gangscheduling.Name, gangPluginFactory),
 			}
 
 			for i, placementScorePluginData := range tt.pluginData {
@@ -4991,8 +4990,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 		}),
 		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPermitPlugin(gangscheduling.Name, gangPluginFactory),
-		tf.RegisterPluginAsExtensions(gangscheduling.Name, gangPluginFactory, "PlacementFeasible"),
+		tf.RegisterPreEnqueuePlugin(gangscheduling.Name, gangPluginFactory),
 	}
 
 	clientObjs := []runtime.Object{testNode, rootCPG, cpgSub1, cpgSub2, cpgSub3, pg1, pg2, pg3, pg4, pg5, pg6, pg7}
@@ -5228,8 +5226,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 		}),
 		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPermitPlugin(gangscheduling.Name, gangPluginFactory),
-		tf.RegisterPluginAsExtensions(gangscheduling.Name, gangPluginFactory, "PlacementFeasible"),
+		tf.RegisterPreEnqueuePlugin(gangscheduling.Name, gangPluginFactory),
 	}
 
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
@@ -5455,8 +5452,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 		}),
 		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPermitPlugin(gangscheduling.Name, gangPluginFactory),
-		tf.RegisterPluginAsExtensions(gangscheduling.Name, gangPluginFactory, "PlacementFeasible"),
+		tf.RegisterPreEnqueuePlugin(gangscheduling.Name, gangPluginFactory),
 	}
 
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)

--- a/pkg/scheduler/testing/framework/framework_helpers.go
+++ b/pkg/scheduler/testing/framework/framework_helpers.go
@@ -53,6 +53,11 @@ func RegisterQueueSortPlugin(pluginName string, pluginNewFunc runtime.PluginFact
 	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "QueueSort")
 }
 
+// RegisterPreEnqueuePlugin returns a function to register a PreEnqueue Plugin to a given registry.
+func RegisterPreEnqueuePlugin(pluginName string, pluginNewFunc runtime.PluginFactory) RegisterPluginFunc {
+	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "PreEnqueue")
+}
+
 // RegisterPreFilterPlugin returns a function to register a PreFilter Plugin to a given registry.
 func RegisterPreFilterPlugin(pluginName string, pluginNewFunc runtime.PluginFactory) RegisterPluginFunc {
 	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "PreFilter")
@@ -145,6 +150,8 @@ func getPluginSetByExtension(plugins *schedulerapi.Plugins, extension string) *s
 	switch extension {
 	case "QueueSort":
 		return &plugins.QueueSort
+	case "PreEnqueue":
+		return &plugins.PreEnqueue
 	case "Filter":
 		return &plugins.Filter
 	case "PostFilter":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR removes the Permit extension point implementation from the GangScheduling plugin.

Following the introduction of the PlacementFeasible extension point in v1.37, Permit support was temporarily kept as a safeguard due to lack of time to evaluate its usefulness. After evaluation, removing Permit simplifies the scheduling flow, improves performance, and reduces code maintenance without impacting any flow.

The primary benefit of Permit was providing a final synchronization right before the binding cycle. However, its practical usefulness is minimal:

- Failure scenarios prior to binding are rare and indicate underlying bugs rather than the real-life behavior, which are: binding order being different than scheduling order, failure of Assume on cache or failure of Reserve.

- Pods can still fail during later stages (such as PreBind or Bind). As a result, the Permit phase does not fully guarantee that a PodGroup will not deploy partially.

Ultimately, if group-level synchronization is needed in the future, it should be addressed via a dedicated PodGroupPermit extension point rather than per-pod Permit checks.

This PR also refactors the gang scheduling tests to simplify them. This step was sent as a second commit to decouple it from Permit removal.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

First commit removes the Permit support. Second commit refactors the gang scheduling tests.

Generative AI was used in the PR preparation. Changes were carefully reviewed before pushing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Removed Permit extension point implementation from GangScheduling plugin. Similar functionality is already covered by the PlacementFeasible, making the Permit redundant.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/4671
```
