### PR TITLE
kubelet: clarify devicemanager test config readiness

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -334,7 +334,7 @@ func setupPluginManager(t *testing.T, pluginSocketName string, m Manager) plugin
 }
 
 func runPluginManager(ctx context.Context, pluginManager pluginmanager.PluginManager) {
-	// FIXME: Replace sets.Set[string] with sets.Set[string]
+	// In tests, treat kubelet config sources as always ready.
 	sourcesReady := config.NewSourcesReady(func(_ sets.Set[string]) bool { return true })
 	go pluginManager.Run(ctx, sourcesReady, wait.NeverStop)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replaces a misleading FIXME in the device manager test helper with a comment that describes the intended test behavior: kubelet config sources are treated as always ready. No production behavior changes.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Test-only comment clarification, scoped to `pkg/kubelet/cm/devicemanager/manager_test.go`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```