### PR TITLE
kubelet: filter foreign pods from API updates

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2635,6 +2635,16 @@ func (kl *Kubelet) deletePod(ctx context.Context, pod *v1.Pod) error {
 	return nil
 }
 
+func (kl *Kubelet) filterAPIPodsForThisNode(pods []*v1.Pod) []*v1.Pod {
+	filtered := make([]*v1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		if pod.Spec.NodeName == string(kl.nodeName) {
+			filtered = append(filtered, pod)
+		}
+	}
+	return filtered
+}
+
 // rejectPod records an event about the pod with the given reason and message,
 // and updates the pod to the failed phase in the status manager.
 func (kl *Kubelet) rejectPod(ctx context.Context, pod *v1.Pod, reason, message string) {
@@ -2753,6 +2763,9 @@ func (kl *Kubelet) syncLoopIteration(ctx context.Context, configCh <-chan kubety
 		if !open {
 			logger.Error(nil, "Update channel is closed, exiting the sync loop")
 			return false
+		}
+		if u.Source == kubetypes.ApiserverSource {
+			u.Pods = kl.filterAPIPodsForThisNode(u.Pods)
 		}
 
 		switch u.Op {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -581,6 +581,61 @@ func TestSyncLoopAbort(t *testing.T) {
 	kubelet.syncLoop(tCtx, ch, kubelet)
 }
 
+type recordingSyncHandler struct {
+	pods []*v1.Pod
+}
+
+func (h *recordingSyncHandler) HandlePodAdditions(_ context.Context, pods []*v1.Pod) {
+	h.pods = pods
+}
+
+func (h *recordingSyncHandler) HandlePodUpdates(context.Context, []*v1.Pod)   {}
+func (h *recordingSyncHandler) HandlePodRemoves(context.Context, []*v1.Pod)   {}
+func (h *recordingSyncHandler) HandlePodReconcile(context.Context, []*v1.Pod) {}
+func (h *recordingSyncHandler) HandlePodSyncs(context.Context, []*v1.Pod)     {}
+func (h *recordingSyncHandler) HandlePodCleanups(context.Context) error       { return nil }
+
+func TestSyncLoopIterationFiltersForeignAPIPods(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	defer testKubelet.Cleanup()
+	kubelet := testKubelet.kubelet
+
+	localPod := podWithUIDNameNsSpec("local", "local", "default", v1.PodSpec{NodeName: string(kubelet.nodeName)})
+	foreignPod := podWithUIDNameNsSpec("foreign", "foreign", "default", v1.PodSpec{NodeName: "other-node"})
+	unscheduledPod := podWithUIDNameNsSpec("unscheduled", "unscheduled", "default", v1.PodSpec{})
+
+	for _, tc := range []struct {
+		name     string
+		source   string
+		expected []*v1.Pod
+	}{
+		{
+			name:     "apiserver source excludes foreign and unscheduled pods",
+			source:   kubetypes.ApiserverSource,
+			expected: []*v1.Pod{localPod},
+		},
+		{
+			name:     "file source is not filtered",
+			source:   kubetypes.FileSource,
+			expected: []*v1.Pod{localPod, foreignPod, unscheduledPod},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configCh := make(chan kubetypes.PodUpdate, 1)
+			configCh <- kubetypes.PodUpdate{
+				Pods:   []*v1.Pod{localPod, foreignPod, unscheduledPod},
+				Op:     kubetypes.ADD,
+				Source: tc.source,
+			}
+			handler := &recordingSyncHandler{}
+
+			require.True(t, kubelet.syncLoopIteration(tCtx, configCh, handler, make(chan time.Time), make(chan time.Time), make(chan *pleg.PodLifecycleEvent)))
+			assert.Equal(t, tc.expected, handler.pods)
+		})
+	}
+}
+
 func TestSyncPodsStartPod(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Filters PodUpdates from the API server to retain only Pods whose `spec.nodeName` matches the local kubelet node. Kubelet normally receives only such Pods, but this guard prevents an unexpectedly broadened API update from reaching admission and status-update paths for a different node.

Static Pod updates from the file source remain unchanged.

#### Which issue(s) this PR is related to:

N/A

This is a defensive hardening change for an abnormal API-source update. The kubelet Pod reflector normally relists using a `spec.nodeName=<local-node>` field selector. If a request is malformed in transit, or an intermediary returns a response that does not honor that selector, kubelet can receive Pods assigned to other nodes. An `ADD` update passes those Pods into admission; a rejected Pod can then reach the status-update path. This change drops the unexpected Pods at the sync-loop boundary.

#### Special notes for your reviewer:

Adds a `syncLoopIteration` unit test covering local, foreign, and unscheduled Pods from the API source, plus an unchanged file-source update.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```