### PR TITLE
Clarify /flagz and /configz documentation in zpages

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/flagz/api/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/flagz/api/v1alpha1/types.go
@@ -32,6 +32,10 @@ type Flagz struct {
 	// Flags contains the command-line flags and their values.
 	// The keys are the flag names and the values are the flag values,
 	// possibly with confidential values redacted.
+	// Values reflect the flag layer only: the value a flag was explicitly
+	// set to, or its default when unset. They do not necessarily match the
+	// component's resolved runtime configuration, which may come from
+	// configuration files and is exposed by /configz where implemented.
 	// +optional
 	Flags map[string]string `json:"flags,omitempty"`
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/flagz/api/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/flagz/api/v1beta1/types.go
@@ -32,6 +32,10 @@ type Flagz struct {
 	// Flags contains the command-line flags and their values.
 	// The keys are the flag names and the values are the flag values,
 	// possibly with confidential values redacted.
+	// Values reflect the flag layer only: the value a flag was explicitly
+	// set to, or its default when unset. They do not necessarily match the
+	// component's resolved runtime configuration, which may come from
+	// configuration files and is exposed by /configz where implemented.
 	// +optional
 	Flags map[string]string `json:"flags,omitempty"`
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/flagz/flagz.go
@@ -14,6 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package flagz implements the /flagz endpoint, which exposes the
+// command-line flag layer of a component: the value each flag was
+// explicitly set to, or the flag's default value when it was not set.
+//
+// /flagz does not reflect the component's resolved (effective) runtime
+// configuration. Settings that come from configuration files or other
+// non-flag sources are not visible here; where implemented, the resolved
+// configuration is exposed by the /configz endpoint instead. The two
+// endpoints are complementary views and neither is a superset of the
+// other. Endpoint availability also differs by component: not every
+// component serves both (for example, kube-apiserver does not expose
+// /configz).
 package flagz
 
 import (

--- a/staging/src/k8s.io/component-base/configz/configz.go
+++ b/staging/src/k8s.io/component-base/configz/configz.go
@@ -16,6 +16,15 @@ limitations under the License.
 
 // Package configz serves ComponentConfig objects from running components.
 //
+// The /configz endpoint reflects the component's resolved (effective)
+// configuration as registered by the component, typically the merged
+// result of defaults, configuration files, and command-line overrides.
+// This differs from the /flagz endpoint, which reports only the
+// command-line flag layer (explicitly set flag values, or flag defaults
+// when unset). The two endpoints are complementary and neither is a
+// superset of the other. Not every component implements /configz (for
+// example, kube-apiserver does not register one).
+//
 // Each component that wants to serve its ComponentConfig creates a Config
 // object, and the program should call InstallHandler once. e.g.,
 //


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This PR clarifies package and API type documentation for the `/flagz` and `/configz` endpoints.

- `/flagz` reflects the command-line flag layer (explicitly set values, or defaults when unset).
- `/configz` reflects a component’s resolved (effective) configuration, where implemented.

The docs now explicitly state that these endpoints are **complementary**, not supersets of one another, and that availability differs by component (for example, `kube-apiserver` does not expose `/configz`).

This is a comment-only/documentation-only change with no behavior changes.

#### Which issue(s) this PR is related to:

Ref: kubernetes/kubernetes#140083

#### Special notes for your reviewer:

Docs clarification only; no functional or runtime impact.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs, usage docs, etc.:

```docs
N/A
```