### PR TITLE
e2e: respect driver min size in group snapshot tests

### DIFF
--- a/test/e2e/storage/framework/volume_resource.go
+++ b/test/e2e/storage/framework/volume_resource.go
@@ -99,7 +99,7 @@ func CreateVolumeResourceWithAccessModes(ctx context.Context, driver TestDriver,
 			driverVolumeSizeRange := dDriver.GetDriverInfo().SupportedSizeRange
 			claimSize, err := storageutils.GetSizeRangesIntersection(testVolumeSizeRange, driverVolumeSizeRange)
 			framework.ExpectNoError(err, "determine intersection of test size range %+v and driver size range %+v", testVolumeSizeRange, driverVolumeSizeRange)
-			framework.Logf("Using claimSize:%s, test suite supported size:%v, driver(%s) supported size:%v ", claimSize, testVolumeSizeRange, dDriver.GetDriverInfo().Name, testVolumeSizeRange)
+			framework.Logf("Using claimSize:%s, test suite supported size:%v, driver(%s) supported size:%v ", claimSize, testVolumeSizeRange, dDriver.GetDriverInfo().Name, driverVolumeSizeRange)
 			r.Sc = dDriver.GetDynamicProvisionStorageClass(ctx, r.Config, pattern.FsType)
 
 			if pattern.BindingMode != "" {

--- a/test/e2e/storage/testsuites/volume_group_snapshottable.go
+++ b/test/e2e/storage/testsuites/volume_group_snapshottable.go
@@ -49,6 +49,7 @@ type volumeGroupSnapshottableTest struct {
 	volumeResources []*storageframework.VolumeResource
 	snapshots       []*storageframework.VolumeGroupSnapshotResource
 	numReplicas     int
+	claimSize       string
 }
 
 // VolumeGroupSnapshottableTestSuite represents a test suite for testing volume group snapshot functionality.
@@ -122,12 +123,18 @@ func (s *VolumeGroupSnapshottableTestSuite) DefineTests(driver storageframework.
 				cs = f.ClientSet
 				config := driver.PrepareTest(ctx, f)
 
+				testVolumeSizeRange := s.GetTestSuiteInfo().SupportedSizeRange
+				driverVolumeSizeRange := driver.GetDriverInfo().SupportedSizeRange
+				claimSize, err := utils.GetSizeRangesIntersection(testVolumeSizeRange, driverVolumeSizeRange)
+				framework.ExpectNoError(err, "determine intersection of test size range %+v and driver size range %+v", testVolumeSizeRange, driverVolumeSizeRange)
+
 				groupTest = &volumeGroupSnapshottableTest{
 					config:          config,
 					volumeResources: []*storageframework.VolumeResource{},
 					snapshots:       []*storageframework.VolumeGroupSnapshotResource{},
 					pods:            []*v1.Pod{},
 					numReplicas:     3,
+					claimSize:       claimSize,
 				}
 			}
 
@@ -192,7 +199,7 @@ func (s *VolumeGroupSnapshottableTestSuite) DefineTests(driver storageframework.
 									},
 									Resources: v1.VolumeResourceRequirements{
 										Requests: v1.ResourceList{
-											v1.ResourceStorage: resource.MustParse(s.GetTestSuiteInfo().SupportedSizeRange.Min),
+											v1.ResourceStorage: resource.MustParse(groupTest.claimSize),
 										},
 									},
 									StorageClassName: &volumeResource.Sc.Name,
@@ -303,7 +310,7 @@ func (s *VolumeGroupSnapshottableTestSuite) DefineTests(driver storageframework.
 					gomega.Expect(volumeSnapshotInfoList).ShouldNot(gomega.BeNil(), "failed to get group snapshot handle list")
 					gomega.Expect(volumeSnapshotInfoList).Should(gomega.HaveLen(groupTest.numReplicas), "failed to verify snapshot handle list length")
 				}
-				claimSize := s.GetTestSuiteInfo().SupportedSizeRange.Min
+				claimSize := groupTest.claimSize
 
 				ginkgo.By("creating restored PVCs from snapshots")
 				restoredPVCs := []*v1.PersistentVolumeClaim{}

--- a/test/e2e/storage/testsuites/volume_group_snapshottable_stress.go
+++ b/test/e2e/storage/testsuites/volume_group_snapshottable_stress.go
@@ -147,6 +147,11 @@ func (t *volumeGroupSnapshottableStressTestSuite) DefineTests(driver storagefram
 		volumeResource := storageframework.CreateVolumeResource(ctx, driver, stressTest.config, pattern, t.GetTestSuiteInfo().SupportedSizeRange)
 		stressTest.volumeResources = append(stressTest.volumeResources, volumeResource)
 
+		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
+		driverVolumeSizeRange := driverInfo.SupportedSizeRange
+		claimSize, err := storageutils.GetSizeRangesIntersection(testVolumeSizeRange, driverVolumeSizeRange)
+		framework.ExpectNoError(err, "determine intersection of test size range %+v and driver size range %+v", testVolumeSizeRange, driverVolumeSizeRange)
+
 		// Create StatefulSet with volumeClaimTemplates
 		// StatefulSet name must be ≤52 chars so the auto-generated controller-revision-hash
 		// label (format: "<name>-<10-char-hash>") stays within Kubernetes' 63-byte label limit.
@@ -205,7 +210,7 @@ func (t *volumeGroupSnapshottableStressTestSuite) DefineTests(driver storagefram
 							},
 							Resources: v1.VolumeResourceRequirements{
 								Requests: v1.ResourceList{
-									v1.ResourceStorage: resource.MustParse(t.GetTestSuiteInfo().SupportedSizeRange.Min),
+									v1.ResourceStorage: resource.MustParse(claimSize),
 								},
 							},
 							StorageClassName: &volumeResource.Sc.Name,
@@ -215,7 +220,6 @@ func (t *volumeGroupSnapshottableStressTestSuite) DefineTests(driver storagefram
 			},
 		}
 
-		var err error
 		stressTest.statefulSet, err = cs.AppsV1().StatefulSets(f.Namespace.Name).Create(ctx, statefulSet, metav1.CreateOptions{})
 		framework.ExpectNoError(err, "failed to create StatefulSet")
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The e2e test suite for group snapshots did not respect the minimum volume size for drivers, leading to test failures on drivers that require a minimum volume size larger than the 1Mi default size.

To fix this issue, we reuse the existing utilities to first calculate the shared minimal volume size of test suite and storage
driver.

While at it, we fix the CreateVolumeResource function logging the wrong size ranges for the size calculation.

#### Which issue(s) this PR is related to:

n/a

#### Special notes for your reviewer:

n/a

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
