### PR TITLE
shrink watch cache hysteretically

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_history.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_history.go
@@ -35,6 +35,10 @@ const (
 
 	// defaultUpperBoundCapacity should be able to keep the required history.
 	defaultUpperBoundCapacity = 100 * 1024
+
+	// shrinkStreakThreshold is the number of consecutive events that have to
+	// qualify for shrinking (see resizeCacheLocked) before capacity is halved.
+	shrinkStreakThreshold = 2
 )
 
 func newWatchCacheHistory(config *ImmutableWatchCacheConfig, eventFreshDuration time.Duration) *watchCacheHistory {
@@ -100,6 +104,10 @@ type watchCacheHistory struct {
 
 	// eventFreshDuration defines the minimum watch history watchcache will store.
 	eventFreshDuration time.Duration
+
+	// shrinkStreak counts how many consecutive events qualified for shrinking
+	// the cache; capacity is halved only when it reaches shrinkStreakThreshold.
+	shrinkStreak int
 }
 
 // Assumes that lock is already held for write.
@@ -115,22 +123,47 @@ func (w *watchCacheHistory) updateCache(event *watchCacheEvent) {
 }
 
 // resizeCacheLocked resizes the cache if necessary:
-// - increases capacity by 2x if cache is full and all cached events occurred within last eventFreshDuration.
-// - decreases capacity by 2x when recent quarter of events occurred outside of eventFreshDuration(protect watchCache from flapping).
+//   - increases capacity by 2x if cache is full and all cached events occurred within last eventFreshDuration.
+//   - decreases capacity by 2x when, for shrinkStreakThreshold consecutive events, the cache is full and:
+//     a) the recent quarter of events spans more than eventFreshDuration, and
+//     b) the incoming event's arrival interval is not shorter than the average interval
+//     of the recent quarter (i.e. the event rate is not accelerating).
 func (w *watchCacheHistory) resizeCacheLocked(eventTime time.Time) {
-	if w.isCacheFullLocked() && eventTime.Sub(w.cache[w.startIndex%w.capacity].RecordTime) < w.eventFreshDuration {
+	if !w.isCacheFullLocked() {
+		w.shrinkStreak = 0
+		return
+	}
+
+	// increase capacity quickly
+	if eventTime.Sub(w.cache[w.startIndex%w.capacity].RecordTime) < w.eventFreshDuration {
 		capacity := min(w.capacity*2, w.upperBoundCapacity)
 		if capacity > w.capacity {
 			w.doCacheResizeLocked(capacity)
 		}
+		w.shrinkStreak = 0
 		return
 	}
-	if w.isCacheFullLocked() && eventTime.Sub(w.cache[(w.endIndex-w.capacity/4)%w.capacity].RecordTime) > w.eventFreshDuration {
-		capacity := max(w.capacity/2, w.lowerBoundCapacity)
-		if capacity < w.capacity {
-			w.doCacheResizeLocked(capacity)
-		}
+
+	// decrease capacity carefully and slowly
+	quarter := max(w.capacity/4, 1)
+	quarterSpan := eventTime.Sub(w.cache[(w.endIndex-quarter)%w.capacity].RecordTime)
+	arrivalGap := eventTime.Sub(w.cache[(w.endIndex-1)%w.capacity].RecordTime)
+	if quarterSpan <= w.eventFreshDuration || arrivalGap*time.Duration(quarter) < quarterSpan {
+		w.shrinkStreak = 0
 		return
+	}
+
+	// wait for shrinkStreakThreshold consecutive shrink signals
+	w.shrinkStreak++
+	if w.shrinkStreak < shrinkStreakThreshold {
+		return
+	}
+
+	// halve the capacity
+	w.shrinkStreak = 0
+	capacity := max(w.capacity/2, w.lowerBoundCapacity)
+	if capacity < w.capacity {
+		w.doCacheResizeLocked(capacity)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -699,7 +699,7 @@ func TestDynamicCache(t *testing.T) {
 		lowerBoundCapacity int
 		upperBoundCapacity int
 		interval           time.Duration
-		expectCapacity     int
+		expectCapacity     []int
 		expectStartIndex   int
 	}{
 		{
@@ -709,7 +709,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 5 / 2,
 			upperBoundCapacity: 5 * 2,
 			interval:           DefaultEventFreshDuration / 6,
-			expectCapacity:     10,
+			expectCapacity:     []int{10},
 			expectStartIndex:   0,
 		},
 		{
@@ -719,7 +719,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 5 / 2,
 			upperBoundCapacity: 5 * 2,
 			interval:           DefaultEventFreshDuration / 4,
-			expectCapacity:     5,
+			expectCapacity:     []int{5},
 			expectStartIndex:   0,
 		},
 		{
@@ -729,7 +729,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 5 / 2,
 			upperBoundCapacity: 5 * 2,
 			interval:           DefaultEventFreshDuration + time.Second,
-			expectCapacity:     2,
+			expectCapacity:     []int{5, 2},
 			expectStartIndex:   3,
 		},
 		{
@@ -739,7 +739,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 3,
 			upperBoundCapacity: 5 * 2,
 			interval:           DefaultEventFreshDuration + time.Second,
-			expectCapacity:     3,
+			expectCapacity:     []int{5, 3},
 			expectStartIndex:   2,
 		},
 		{
@@ -749,7 +749,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 5 / 2,
 			upperBoundCapacity: 8,
 			interval:           DefaultEventFreshDuration / 6,
-			expectCapacity:     8,
+			expectCapacity:     []int{8},
 			expectStartIndex:   0,
 		},
 		{
@@ -760,7 +760,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 5 / 2,
 			upperBoundCapacity: 5 * 2,
 			interval:           DefaultEventFreshDuration / 6,
-			expectCapacity:     10,
+			expectCapacity:     []int{10},
 			expectStartIndex:   3,
 		},
 		{
@@ -771,7 +771,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 5 / 2,
 			upperBoundCapacity: 5 * 2,
 			interval:           DefaultEventFreshDuration / 4,
-			expectCapacity:     5,
+			expectCapacity:     []int{5},
 			expectStartIndex:   3,
 		},
 		{
@@ -782,7 +782,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 5 / 2,
 			upperBoundCapacity: 5 * 2,
 			interval:           DefaultEventFreshDuration + time.Second,
-			expectCapacity:     2,
+			expectCapacity:     []int{5, 2},
 			expectStartIndex:   6,
 		},
 		{
@@ -793,7 +793,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 3,
 			upperBoundCapacity: 5 * 2,
 			interval:           DefaultEventFreshDuration + time.Second,
-			expectCapacity:     3,
+			expectCapacity:     []int{5, 3},
 			expectStartIndex:   5,
 		},
 		{
@@ -804,7 +804,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 5 / 2,
 			upperBoundCapacity: 8,
 			interval:           DefaultEventFreshDuration / 6,
-			expectCapacity:     8,
+			expectCapacity:     []int{8},
 			expectStartIndex:   3,
 		},
 		{
@@ -814,7 +814,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 8 / 2,
 			upperBoundCapacity: 8 * 2,
 			interval:           DefaultEventFreshDuration / 9,
-			expectCapacity:     16,
+			expectCapacity:     []int{16},
 			expectStartIndex:   0,
 		},
 		{
@@ -824,7 +824,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 8 / 2,
 			upperBoundCapacity: 8 * 2,
 			interval:           DefaultEventFreshDuration / 8,
-			expectCapacity:     8,
+			expectCapacity:     []int{8},
 			expectStartIndex:   0,
 		},
 		{
@@ -834,7 +834,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 8 / 2,
 			upperBoundCapacity: 8 * 2,
 			interval:           DefaultEventFreshDuration/2 + time.Second,
-			expectCapacity:     4,
+			expectCapacity:     []int{8, 4},
 			expectStartIndex:   4,
 		},
 		{
@@ -844,7 +844,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 7,
 			upperBoundCapacity: 8 * 2,
 			interval:           DefaultEventFreshDuration/2 + time.Second,
-			expectCapacity:     7,
+			expectCapacity:     []int{8, 7},
 			expectStartIndex:   1,
 		},
 		{
@@ -854,7 +854,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 8 / 2,
 			upperBoundCapacity: 10,
 			interval:           DefaultEventFreshDuration / 9,
-			expectCapacity:     10,
+			expectCapacity:     []int{10},
 			expectStartIndex:   0,
 		},
 		{
@@ -865,7 +865,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 8 / 2,
 			upperBoundCapacity: 8 * 2,
 			interval:           DefaultEventFreshDuration / 9,
-			expectCapacity:     16,
+			expectCapacity:     []int{16},
 			expectStartIndex:   3,
 		},
 		{
@@ -876,7 +876,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 8 / 2,
 			upperBoundCapacity: 8 * 2,
 			interval:           DefaultEventFreshDuration / 8,
-			expectCapacity:     8,
+			expectCapacity:     []int{8},
 			expectStartIndex:   3,
 		},
 		{
@@ -887,7 +887,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 8 / 2,
 			upperBoundCapacity: 8 * 2,
 			interval:           DefaultEventFreshDuration/2 + time.Second,
-			expectCapacity:     4,
+			expectCapacity:     []int{8, 4},
 			expectStartIndex:   7,
 		},
 		{
@@ -898,7 +898,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 7,
 			upperBoundCapacity: 8 * 2,
 			interval:           DefaultEventFreshDuration/2 + time.Second,
-			expectCapacity:     7,
+			expectCapacity:     []int{8, 7},
 			expectStartIndex:   4,
 		},
 		{
@@ -909,7 +909,7 @@ func TestDynamicCache(t *testing.T) {
 			lowerBoundCapacity: 8 / 2,
 			upperBoundCapacity: 10,
 			interval:           DefaultEventFreshDuration / 9,
-			expectCapacity:     10,
+			expectCapacity:     []int{10},
 			expectStartIndex:   3,
 		},
 	}
@@ -924,9 +924,11 @@ func TestDynamicCache(t *testing.T) {
 			store.history.upperBoundCapacity = test.upperBoundCapacity
 			loadEventWithDuration(store, test.eventCount, test.interval)
 			nextInterval := store.config.clock.Now().Add(time.Duration(test.interval.Nanoseconds() * int64(test.eventCount)))
-			store.history.resizeCacheLocked(nextInterval)
-			if store.history.capacity != test.expectCapacity {
-				t.Errorf("expect capacity %d, but get %d", test.expectCapacity, store.history.capacity)
+			for i, expectCapacity := range test.expectCapacity {
+				store.history.resizeCacheLocked(nextInterval)
+				if store.history.capacity != expectCapacity {
+					t.Errorf("resize call %d: expect capacity %d, but get %d", i+1, expectCapacity, store.history.capacity)
+				}
 			}
 
 			// check cache's startIndex, endIndex and all elements.
@@ -935,6 +937,78 @@ func TestDynamicCache(t *testing.T) {
 			}
 			if store.history.endIndex != test.startIndex+test.eventCount {
 				t.Errorf("expect endIndex %d get %d", test.startIndex+test.eventCount, store.history.endIndex)
+			}
+			if !checkCacheElements(store) {
+				t.Errorf("some elements locations in cache is wrong")
+			}
+		})
+	}
+}
+
+func TestDynamicCacheCapacitySequences(t *testing.T) {
+	const (
+		fast  = time.Second
+		slow  = DefaultEventFreshDuration/2 + time.Second
+		quiet = 10 * time.Minute
+		burst = time.Millisecond
+	)
+
+	tests := []struct {
+		name           string
+		capacity       int
+		gaps           []time.Duration
+		expectCapacity []int
+	}{
+		{
+			name:           "fresh traffic grows the cache once it is full",
+			capacity:       4,
+			gaps:           []time.Duration{fast, fast, fast, fast, fast, fast},
+			expectCapacity: []int{4, 4, 4, 4, 8, 8},
+		},
+		{
+			name:     "sustained slow traffic shrinks only on the 2nd consecutive signal",
+			capacity: 8,
+			gaps: []time.Duration{
+				slow, slow, slow, slow, slow, slow, slow, slow, // fill the cache
+				slow, // 1st shrink signal: streak starts, no shrink yet
+				slow, // 2nd consecutive signal: halve to 4
+				slow, // at capacity 4 the quarter spans a single slow gap (<eventFreshDuration): stable
+			},
+			expectCapacity: []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 4, 4},
+		},
+		{
+			name:     "burst after a quiet period does not shrink the cache",
+			capacity: 8,
+			gaps: []time.Duration{
+				fast, fast, fast, fast, fast, fast, fast, fast, // fill the cache
+				quiet,        // 1st shrink signal after the silence: streak starts
+				burst,        // burst arrives: resets the streak, do not halved the cache
+				burst, burst, // burst continues: quarter is fresh again, no shrink
+			},
+			expectCapacity: []int{8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if len(test.gaps) != len(test.expectCapacity) {
+				t.Fatalf("gaps and expectCapacity must have the same length")
+			}
+			store := newTestWatchCache(test.capacity, DefaultEventFreshDuration, &cache.Indexers{})
+			defer store.Stop()
+			store.history.lowerBoundCapacity = 2
+			store.history.upperBoundCapacity = 16
+
+			eventTime := store.config.clock.Now()
+			for i, gap := range test.gaps {
+				eventTime = eventTime.Add(gap)
+				store.history.updateCache(&watchCacheEvent{
+					Key:        fmt.Sprintf("event-%d", i),
+					RecordTime: eventTime,
+				})
+				if store.history.capacity != test.expectCapacity[i] {
+					t.Errorf("event %d (gap %v): expect capacity %d, but get %d", i, gap, test.expectCapacity[i], store.history.capacity)
+				}
 			}
 			if !checkCacheElements(store) {
 				t.Errorf("some elements locations in cache is wrong")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery


#### What this PR does / why we need it:
Do not shrink and then scale back watch cache in burst senario 

#### Which issue(s) this PR is related to:
fix https://github.com/kubernetes/kubernetes/issues/141192

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
