### PR TITLE
kubelet: prevent strict CPU reservation from emptying shared pool

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -724,8 +724,13 @@ func (p *staticPolicy) allocateCPUs(logger klog.Logger, s state.State, numCPUs i
 	result.CPUs = result.CPUs.Union(remainingCPUs)
 	result.Aligned = p.topology.CheckAlignment(result.CPUs)
 
+	updatedDefaultCPUSet := s.GetDefaultCPUSet().Difference(result.CPUs)
+	if p.options.StrictCPUReservation && updatedDefaultCPUSet.IsEmpty() {
+		return topology.EmptyAllocation(), fmt.Errorf("exclusive CPU allocation would empty the shared CPU pool")
+	}
+
 	// Remove allocated CPUs from the shared CPUSet.
-	s.SetDefaultCPUSet(s.GetDefaultCPUSet().Difference(result.CPUs))
+	s.SetDefaultCPUSet(updatedDefaultCPUSet)
 
 	logger.Info("AllocateCPUs", "result", result.String())
 	return result, nil

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -693,6 +693,32 @@ func TestStaticPolicyAdd(t *testing.T) {
 	}
 }
 
+func TestStaticPolicyStrictCPUReservationPreservesSharedPool(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	reservedCPUs := cpuset.New(0)
+	policy, err := NewStaticPolicy(
+		logger,
+		topoSingleSocketHT,
+		reservedCPUs.Size(),
+		reservedCPUs,
+		topologymanager.NewFakeManager(logger),
+		map[string]string{StrictCPUReservationOption: "true"},
+	)
+	require.NoError(t, err)
+
+	defaultCPUSet := cpuset.New(1, 2, 3, 4, 5, 6, 7)
+	st := &mockState{
+		assignments:   state.ContainerCPUAssignments{},
+		defaultCPUSet: defaultCPUSet,
+	}
+	pod := makePod("fakePod", "fakeContainer", "7000m", "7000m")
+
+	err = policy.Allocate(logger, st, pod, &pod.Spec.Containers[0], lifecycle.AddOperation)
+	require.EqualError(t, err, "exclusive CPU allocation would empty the shared CPU pool")
+	require.Empty(t, st.assignments)
+	require.Equal(t, defaultCPUSet, st.defaultCPUSet)
+}
+
 func runStaticPolicyTestCase(t *testing.T, testCase staticPolicyTest) {
 	logger, _ := ktesting.NewTestContext(t)
 	tm := topologymanager.NewFakeManager(logger)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

When `strict-cpu-reservation` is enabled, reject an exclusive CPU allocation if it would empty the node shared CPU pool.

An empty default CPUSet cannot be enforced safely: shared containers can keep or inherit an overlapping affinity, and the resulting checkpoint is rejected after kubelet restart. The check runs before CPU Manager state is changed.

#### Which issue(s) this PR is related to:

Fixes #141196

#### Special notes for your reviewer:

KEP-4540 discusses shared workload starvation when the shared pool reaches zero. In practice, an empty cpuset is not a usable enforcement state. This PR rejects the final exclusive allocation instead of creating that state.

#### Does this PR introduce a user-facing change?

```release-note
With the static CPU Manager policy and `strict-cpu-reservation`, kubelet now rejects exclusive CPU allocations that would empty the shared CPU pool.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/b175ab3f86ee0cb30f7557df699f52f8eee8ef67/keps/sig-node/4540-strict-cpu-reservation
```