### PR TITLE
Add regression test for Scale(MinInt32).infScale() sign edge case

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package resource
 
 import (
+	"math"
 	"testing"
+
+	inf "gopkg.in/inf.v0"
 )
 
 func TestInt64AmountAsInt64(t *testing.T) {
@@ -199,6 +202,31 @@ func TestInt64AmountAsScaledInt64(t *testing.T) {
 			}
 			if ok != test.ok {
 				t.Errorf("%v: expected ok: %t, got ok: %t", test.name, test.ok, ok)
+			}
+		})
+	}
+}
+
+func TestScaleInfScale(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		scale  Scale
+		result inf.Scale
+	}{
+		{"positive scale flips sign", 3, -3},
+		{"negative scale flips sign", -3, 3},
+		{"zero", 0, 0},
+		{"MinInt32+1 flips sign", math.MinInt32 + 1, math.MaxInt32},
+		// Scale is an int32, and infScale returns inf.Scale(-s). Negating
+		// math.MinInt32 does not fit in an int32, so the sign is not flipped
+		// and the value stays math.MinInt32. This is the same int-negation
+		// edge case as -mostNegative for int64. This asserts the current
+		// (unflipped) behavior; reachable via NewScaledQuantity(x, math.MinInt32).
+		{"MinInt32 does not flip sign", math.MinInt32, math.MinInt32},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.scale.infScale(); got != test.result {
+				t.Errorf("%s: Scale(%d).infScale() = %d, want %d", test.name, test.scale, got, test.result)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
@@ -19,6 +19,8 @@ package resource
 import (
 	"math"
 	"testing"
+
+	inf "gopkg.in/inf.v0"
 )
 
 func TestInt64AmountAsInt64(t *testing.T) {
@@ -249,6 +251,32 @@ func TestScaleCanAlignInfScale(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := tc.a.canAlignInfScale(tc.b); got != tc.want {
 				t.Fatalf("Scale(%d).canAlignInfScale(%d) = %t, want %t", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestScaleInfScale(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		scale  Scale
+		result inf.Scale
+	}{
+		{"positive scale flips sign", 3, -3},
+		{"negative scale flips sign", -3, 3},
+		{"zero", 0, 0},
+		{"MinInt32+1 flips sign", math.MinInt32 + 1, math.MaxInt32},
+		// Scale is an int32 and infScale returns inf.Scale(-s). Negating
+		// math.MinInt32 does not fit in an int32, so the sign is not flipped
+		// and the value stays math.MinInt32 - the same int-negation edge as
+		// -mostNegative for int64. This asserts that behavior of infScale
+		// directly (it is exercised on the inf.Dec path, e.g. ScaledValue on
+		// a Dec-backed Quantity; the int64 backend does not call it).
+		{"MinInt32 does not flip sign", math.MinInt32, math.MinInt32},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.scale.infScale(); got != test.result {
+				t.Errorf("%s: Scale(%d).infScale() = %d, want %d", test.name, test.scale, got, test.result)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind flake

**What this PR does / why we need it:**

`Scale` is an `int32`, and `infScale()` returns `inf.Scale(-s)`. When
`s == math.MinInt32`, `-math.MinInt32` does not fit in an int32, so
`Scale(math.MinInt32).infScale()` comes back as `MinInt32` instead of the
positive counterpart — the sign is not flipped. This scale is reachable via
`NewScaledQuantity(x, math.MinInt32)`. It is the same family of integer
sign-negation edge cases already covered for int64 (`-mostNegative`).

This PR adds a focused, arch-independent regression test that documents the
current behavior of `infScale()` around the `math.MinInt32` boundary,
including the neighboring `math.MinInt32 + 1` case where the sign flips
normally. No production code is changed.

**Which issue(s) this PR fixes:**

Follow-up to the apimachinery arithmetic-edge-case burndown in #141166,
adding the promised row plus regression test.

**Special notes for your reviewer:**

Test-only; scoped to `pkg/api/resource`. This is purely the integer
sign-negation edge case — it deliberately does not touch any large-magnitude
/ extreme-exponent parse path.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```
