### PR TITLE
Reject decimal exponents that do not fit the int32 scale

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
@@ -478,12 +478,11 @@ type parseErrorCase struct {
 func quantityParseErrorCases() []parseErrorCase {
 	return []parseErrorCase{
 		{
-			// exponent reduced mod 2^32 (4294967297 -> 1), so this parses to 1e1.
-			name:              "exponent-over-int32",
-			input:             "1e4294967297",
-			wantParseError:    false,
-			wantValueIfParsed: 10,
-			parseTODO:         "ParseQuantity should reject this; the int32 exponent overflow silently yields 1e1 (#141166)",
+			// #141203 rejects an exponent past the int32 scale instead of
+			// reducing it mod 2^32 (4294967297 -> 1, which parsed as 1e1).
+			name:           "exponent-over-int32",
+			input:          "1e4294967297",
+			wantParseError: true,
 		},
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -542,6 +542,10 @@ func TestQuantityParse(t *testing.T) {
 		"-3.01i",
 		"-3.01e-",
 
+		// an exponent outside the int32 scale is rejected rather than truncated
+		// to an unrelated value; 1e4294967297 would otherwise parse as 1e1
+		"1e4294967297",
+
 		// trailing whitespace is forbidden
 		" 1",
 		"1 ",
@@ -550,6 +554,32 @@ func TestQuantityParse(t *testing.T) {
 		_, err := ParseQuantity(item)
 		if err == nil {
 			t.Errorf("%v parsed unexpectedly", item)
+		}
+	}
+}
+
+func TestInterpretExponentInt32Bounds(t *testing.T) {
+	// interpret parses the exponent at 64 bits but stores it in an int32 scale
+	// that is later negated, so the usable range is [-MaxInt32, MaxInt32].
+	// Anything outside it is rejected, not truncated to an unrelated value.
+	cases := []struct {
+		suffix  string
+		wantExp int32
+		wantOK  bool
+	}{
+		{"e14", 14, true},
+		{"E2147483647", 2147483647, true},   // MaxInt32
+		{"E-2147483647", -2147483647, true}, // -MaxInt32
+		{"E2147483648", 0, false},           // MaxInt32 + 1
+		{"E-2147483648", 0, false},          // MinInt32; -MinInt32 overflows int32
+		{"E4294967297", 0, false},           // 2^32 + 1, truncates to 1 today
+		{"E6024865272343", 0, false},        // far past int32
+	}
+	for _, tc := range cases {
+		base, exp, format, ok := quantitySuffixer.interpret(suffix(tc.suffix))
+		if ok != tc.wantOK || (ok && (exp != tc.wantExp || base != 10 || format != DecimalExponent)) {
+			t.Errorf("interpret(%q) = (base=%d, exp=%d, %v, ok=%t), want exp=%d ok=%t",
+				tc.suffix, base, exp, format, ok, tc.wantExp, tc.wantOK)
 		}
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -560,8 +560,10 @@ func TestQuantityParse(t *testing.T) {
 
 func TestInterpretExponentInt32Bounds(t *testing.T) {
 	// interpret parses the exponent at 64 bits but stores it in an int32 scale
-	// that is later negated, so the usable range is [-MaxInt32, MaxInt32].
-	// Anything outside it is rejected, not truncated to an unrelated value.
+	// that is later negated, so it accepts [-MaxInt32, MaxInt32] and rejects
+	// anything past it, instead of narrowing it to an unrelated value. This
+	// checks interpret's suffix-layer bounds only, not what the rest of
+	// ParseQuantity does with an accepted exponent.
 	cases := []struct {
 		suffix  string
 		wantExp int32

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -542,6 +542,10 @@ func TestQuantityParse(t *testing.T) {
 		"-3.01i",
 		"-3.01e-",
 
+		// an exponent outside the int32 scale is rejected rather than truncated
+		// to an unrelated value; 1e4294967297 would otherwise parse as 1e1
+		"1e4294967297",
+
 		// trailing whitespace is forbidden
 		" 1",
 		"1 ",
@@ -550,6 +554,37 @@ func TestQuantityParse(t *testing.T) {
 		_, err := ParseQuantity(item)
 		if err == nil {
 			t.Errorf("%v parsed unexpectedly", item)
+		}
+	}
+}
+
+func TestInterpretExponentInt32Bounds(t *testing.T) {
+	// interpret parses the exponent at 64 bits but stores it in an int32 scale
+	// that is later negated, so it accepts [-MaxInt32, MaxInt32] and rejects
+	// anything past it, instead of narrowing it to an unrelated value. This
+	// checks interpret's suffix-layer bounds only, not what the rest of
+	// ParseQuantity does with an accepted exponent.
+	cases := []struct {
+		suffix  string
+		wantExp int32
+		wantOK  bool
+	}{
+		{"e14", 14, true},
+		{"E2147483647", 2147483647, true},   // MaxInt32
+		{"E-2147483647", -2147483647, true}, // -MaxInt32
+		{"E2147483648", 0, false},           // MaxInt32 + 1
+		{"E-2147483648", 0, false},          // MinInt32; -MinInt32 overflows int32
+		{"E4294967297", 0, false},           // 2^32 + 1, truncated to 1 today
+		{"E8589934592", 0, false},           // 2^33, truncated to 0 today
+		{"E9223372036854775807", 0, false},  // MaxInt64, truncated to -1 today
+		{"E9223372036854775808", 0, false},  // MaxInt64 + 1, past int64: ParseInt range error
+		{"E6024865272343", 0, false},        // far past int32
+	}
+	for _, tc := range cases {
+		base, exp, format, ok := quantitySuffixer.interpret(suffix(tc.suffix))
+		if ok != tc.wantOK || (ok && (exp != tc.wantExp || base != 10 || format != DecimalExponent)) {
+			t.Errorf("interpret(%q) = (base=%d, exp=%d, %v, ok=%t), want exp=%d ok=%t",
+				tc.suffix, base, exp, format, ok, tc.wantExp, tc.wantOK)
 		}
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/suffix.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"math"
 	"strconv"
 )
 
@@ -189,6 +190,12 @@ func (sh *suffixHandler) interpret(suffix suffix) (base, exponent int32, fmt For
 	if len(suffix) > 1 && (suffix[0] == 'E' || suffix[0] == 'e') {
 		parsed, err := strconv.ParseInt(string(suffix[1:]), 10, 64)
 		if err != nil {
+			return 0, 0, DecimalExponent, false
+		}
+		// The exponent becomes an int32 scale that is negated for the inf.Scale,
+		// and -MinInt32 overflows int32. Reject values outside that range rather
+		// than truncating them (1e4294967297 would otherwise parse as 1e1).
+		if parsed > math.MaxInt32 || parsed < -math.MaxInt32 {
 			return 0, 0, DecimalExponent, false
 		}
 		return 10, int32(parsed), DecimalExponent, true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it

`quantitySuffixer.interpret` parses a decimal suffix exponent at 64 bits with `strconv.ParseInt(..., 10, 64)`, then narrows it with `int32(parsed)`. When the exponent does not fit in an `int32`, that narrowing wraps it into an unrelated value instead of failing, and parsing keeps going as if nothing were wrong: `1e4294967297` is accepted and parses as `1e1`, because `4294967297` (`2^32 + 1`) truncates to `1`. The result looks like a valid quantity but means something entirely different from what the caller wrote.

This adds a bounds check in `interpret`: an exponent outside `[-MaxInt32, MaxInt32]` is rejected with a parse error instead of being narrowed. The lower bound stops at `-MaxInt32` rather than `MinInt32` because the exponent is later negated to build the `inf.Scale`, and `-MinInt32` does not fit an `int32` either, so accepting `MinInt32` would only push the same overflow one step downstream.

The change is deliberately narrow: it removes one specific silent reinterpretation at the suffix layer. It does not touch how an accepted exponent is later combined with the mantissa or rounded; tightening those later stages is separate work under the same tracker.

#### Which issue(s) this PR fixes

Part of the `resource.Quantity` int32-overflow burndown, #141166.

#### Special notes for your reviewer

`TestInterpretExponentInt32Bounds` pins the suffix-layer boundary: `MaxInt32` and `-MaxInt32` are accepted, and everything past them is rejected, including `MinInt32` and the `2^32 + 1` truncation. It drives `interpret` in isolation and asserts only what that function returns, so it is not an end-to-end statement about `ParseQuantity`. `TestQuantityParse` adds `1e4294967297` through the full parser. Both fail on master and pass with this change, and the rest of the `resource` suite stays green.

Earlier PRs identified the same narrowing and did not merge for process reasons (CLA, stale-bot). This PR uses the symmetric bound from #139412 (@alhudz); #131063 (@aiburegit) explored the same fix with a 32-bit parse. Credit to both.

This overlaps semantically with #141170, which currently pins `1e4294967297` as a not-yet-rejected case in its `parseErrorCases` baseline. Whichever of the two lands second should flip that expectation and drop the TODO, so the baseline does not go stale after a rebase.

/sig api-machinery

#### Does this PR introduce a user-facing change?

```release-note
Fixed quantity parsing to reject decimal exponents that are too large to represent as an internal scale, instead of silently narrowing them to an unrelated value (for example `1e4294967297` no longer parses as `1e1`).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. AI-assisted tools were used during implementation, test planning, and review; I reviewed and validated the final change.
