### PR TITLE
Accept flexible fractional-second precision when parsing MicroTime

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time.go
@@ -122,12 +122,12 @@ func (t *MicroTime) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	pt, err := time.Parse(RFC3339Micro, str)
+	pt, err := time.Parse(time.RFC3339, str)
 	if err != nil {
 		return err
 	}
 
-	t.Time = pt.Local()
+	t.Time = pt.Truncate(time.Microsecond).Local()
 	return nil
 }
 
@@ -141,12 +141,12 @@ func (t *MicroTime) UnmarshalCBOR(b []byte) error {
 		return nil
 	}
 
-	parsed, err := time.Parse(RFC3339Micro, *s)
+	parsed, err := time.Parse(time.RFC3339, *s)
 	if err != nil {
 		return err
 	}
 
-	t.Time = parsed.Local()
+	t.Time = parsed.Truncate(time.Microsecond).Local()
 	return nil
 }
 
@@ -162,12 +162,12 @@ func (t *MicroTime) UnmarshalQueryParameter(str string) error {
 		return nil
 	}
 
-	pt, err := time.Parse(RFC3339Micro, str)
+	pt, err := time.Parse(time.RFC3339, str)
 	if err != nil {
 		return err
 	}
 
-	t.Time = pt.Local()
+	t.Time = pt.Truncate(time.Microsecond).Local()
 	return nil
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/micro_time_test.go
@@ -150,7 +150,7 @@ func TestMicroTimeUnmarshalCBOR(t *testing.T) {
 		{name: "null", in: []byte{0xf6}, out: MicroTime{}}, // null
 		{name: "valid", in: []byte("\x58\x1b1998-05-05T05:05:05.000000Z"), out: MicroTime{Time: Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},                                    // '1998-05-05T05:05:05.000000Z'
 		{name: "invalid cbor type", in: []byte{0x07}, out: MicroTime{}, errMessage: "cbor: cannot unmarshal positive integer into Go value of type string"},                                // 7
-		{name: "malformed timestamp", in: []byte("\x45hello"), out: MicroTime{}, errMessage: `parsing time "hello" as "2006-01-02T15:04:05.000000Z07:00": cannot parse "hello" as "2006"`}, // 'hello'
+		{name: "malformed timestamp", in: []byte("\x45hello"), out: MicroTime{}, errMessage: `parsing time "hello" as "2006-01-02T15:04:05Z07:00": cannot parse "hello" as "2006"`}, // 'hello'
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var got MicroTime
@@ -397,6 +397,43 @@ func TestMicroTimeRoundtripCBOR(t *testing.T) {
 				t.Logf("failed to produce diagnostic encoding of 0x%x: %v", b, err)
 			}
 			t.Errorf("expected equal: %v, %v (cbor was '%s')", initial, final, diag)
+		}
+	}
+}
+
+func TestMicroTimeUnmarshalJSONFlexiblePrecision(t *testing.T) {
+	// MicroTime must accept any valid RFC3339 instant, like Time, not only the
+	// canonical 6-digit form. Regression for MicroTime rejecting millisecond
+	// (JavaScript Date.toISOString()), second, and nanosecond precision.
+	for _, tc := range []struct {
+		in   string
+		want string // canonical microsecond marshal
+	}{
+		{`"2024-01-02T03:04:05Z"`, `"2024-01-02T03:04:05.000000Z"`},
+		{`"2024-01-02T03:04:05.123Z"`, `"2024-01-02T03:04:05.123000Z"`},
+		{`"2024-01-02T03:04:05.123456Z"`, `"2024-01-02T03:04:05.123456Z"`},
+		{`"2024-01-02T03:04:05.123456789Z"`, `"2024-01-02T03:04:05.123456Z"`},
+	} {
+		var mt MicroTime
+		if err := json.Unmarshal([]byte(tc.in), &mt); err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.in, err)
+			continue
+		}
+		var tm Time
+		if err := json.Unmarshal([]byte(tc.in), &tm); err != nil {
+			t.Errorf("%s: Time rejected an input MicroTime accepted: %v", tc.in, err)
+		}
+		got, err := json.Marshal(mt)
+		if err != nil {
+			t.Errorf("%s: marshal error: %v", tc.in, err)
+			continue
+		}
+		if string(got) != tc.want {
+			t.Errorf("%s: got %s, want %s", tc.in, got, tc.want)
+		}
+		var rt MicroTime
+		if err := json.Unmarshal(got, &rt); err != nil || !rt.Equal(&mt) {
+			t.Errorf("%s: round-trip failed: %s err=%v", tc.in, got, err)
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`metav1.MicroTime` parsed JSON/CBOR/query values with the fixed-width layout `RFC3339Micro` (`2006-01-02T15:04:05.000000Z07:00`), which matches only exactly six fractional-second digits. As a result it **rejected** valid RFC3339 timestamps that its sibling `metav1.Time` accepts:

- millisecond precision — `2024-01-02T03:04:05.123Z` (JavaScript `Date.prototype.toISOString()` is always millisecond precision)
- whole seconds — `2024-01-02T03:04:05Z`
- nanosecond precision — `2024-01-02T03:04:05.123456789Z`

`MicroTime` is the type of fields clients set directly, including the **required** `events.k8s.io/v1` `Event.eventTime` and `coordination.k8s.io/v1` `Lease.spec.acquireTime`/`renewTime`. Because the value is decoded before validation runs, a request carrying any of these in non-6-digit form is rejected outright — in practice a JavaScript/TypeScript client emitting `toISOString()` cannot create an Event or write a Lease via JSON at all.

This parses with `time.RFC3339` — the same layout `metav1.Time` uses, which tolerates any fractional-second width — and truncates to microsecond precision so the stored value matches the type's precision and round-trips. `MarshalJSON`/`MarshalCBOR`/`MarshalQueryParameter` continue to emit the canonical `RFC3339Micro` form, so serialized output is unchanged.

Added a regression test covering millisecond, whole-second, nanosecond, and canonical 6-digit inputs (asserting `Time` accepts the same set), and updated the CBOR malformed-input test's expected parse-error string for the new layout.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Parsing tolerance now matches `metav1.Time` (both use `time.RFC3339`); this is parity with the sibling type, not stricter RFC3339 validation. No previously accepted `MicroTime` input is rejected — only the parse-error message text changes.

**Does this PR introduce a user-facing change?**

```release-note
`metav1.MicroTime` now accepts any valid RFC3339 timestamp on decode (millisecond, whole-second, and nanosecond precision), matching `metav1.Time`, instead of requiring exactly six fractional-second digits. Clients that emit non-microsecond precision (for example JavaScript `Date.toISOString()`) can now set MicroTime fields such as `Event.eventTime` and `Lease.spec.renewTime`. Values are normalized to microsecond precision; serialized output is unchanged.
```
