### PR TITLE
Add UID tie-breaker to PodsByCreationTime sort

### DIFF
--- a/pkg/kubelet/util/sliceutils/sliceutils.go
+++ b/pkg/kubelet/util/sliceutils/sliceutils.go
@@ -34,6 +34,9 @@ func (s PodsByCreationTime) Swap(i, j int) {
 }
 
 func (s PodsByCreationTime) Less(i, j int) bool {
+	if s[i].CreationTimestamp.Equal(&s[j].CreationTimestamp) {
+		return s[i].UID < s[j].UID
+	}
 	return s[i].CreationTimestamp.Before(&s[j].CreationTimestamp)
 }
 

--- a/pkg/kubelet/util/sliceutils/sliceutils_test.go
+++ b/pkg/kubelet/util/sliceutils/sliceutils_test.go
@@ -26,13 +26,15 @@ import (
 )
 
 func buildPodsByCreationTime() PodsByCreationTime {
+	baseTime := time.Now()
 	return []*v1.Pod{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo1",
 				Namespace: v1.NamespaceDefault,
+				UID:       "uid-1",
 				CreationTimestamp: metav1.Time{
-					Time: time.Now(),
+					Time: baseTime,
 				},
 			},
 		},
@@ -40,8 +42,9 @@ func buildPodsByCreationTime() PodsByCreationTime {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo2",
 				Namespace: v1.NamespaceDefault,
+				UID:       "uid-2",
 				CreationTimestamp: metav1.Time{
-					Time: time.Now().Add(time.Hour * 1),
+					Time: baseTime.Add(time.Hour * 1),
 				},
 			},
 		},
@@ -49,8 +52,9 @@ func buildPodsByCreationTime() PodsByCreationTime {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo3",
 				Namespace: v1.NamespaceDefault,
+				UID:       "uid-3",
 				CreationTimestamp: metav1.Time{
-					Time: time.Now().Add(time.Hour * 2),
+					Time: baseTime.Add(time.Hour * 2),
 				},
 			},
 		},
@@ -103,7 +107,7 @@ func TestPodsByCreationTimeLess(t *testing.T) {
 		j    int
 		er   bool
 	}{
-		// ascending order
+		// ascending order by creation time
 		{buildPodsByCreationTime(), 0, 2, true},
 		{buildPodsByCreationTime(), 1, 0, false},
 	}
@@ -112,6 +116,69 @@ func TestPodsByCreationTimeLess(t *testing.T) {
 		r := fooTest.pods.Less(fooTest.i, fooTest.j)
 		if r != fooTest.er {
 			t.Errorf("returned %t but expected %t for the foo=%s", r, fooTest.er, fooTest.pods)
+		}
+	}
+}
+
+func TestPodsByCreationTimeTieBreaker(t *testing.T) {
+	// Test that when CreationTimestamp is equal, UID is used as tie-breaker
+	baseTime := time.Now()
+	podsWithSameTime := PodsByCreationTime{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-z",
+				Namespace: v1.NamespaceDefault,
+				UID:       "uid-z",
+				CreationTimestamp: metav1.Time{
+					Time: baseTime,
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-a",
+				Namespace: v1.NamespaceDefault,
+				UID:       "uid-a",
+				CreationTimestamp: metav1.Time{
+					Time: baseTime,
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-m",
+				Namespace: v1.NamespaceDefault,
+				UID:       "uid-m",
+				CreationTimestamp: metav1.Time{
+					Time: baseTime,
+				},
+			},
+		},
+	}
+
+	fooTests := []struct {
+		pods PodsByCreationTime
+		i    int
+		j    int
+		er   bool
+	}{
+		// When timestamps are equal, UID comparison determines order
+		// uid-a < uid-m < uid-z
+		{podsWithSameTime, 0, 1, false}, // uid-z < uid-a? No
+		{podsWithSameTime, 1, 0, true},  // uid-a < uid-z? Yes
+		{podsWithSameTime, 1, 2, true},  // uid-a < uid-m? Yes
+		{podsWithSameTime, 2, 1, false}, // uid-m < uid-a? No
+		{podsWithSameTime, 0, 2, false}, // uid-z < uid-m? No
+		{podsWithSameTime, 2, 0, true},  // uid-m < uid-z? Yes
+	}
+
+	for _, fooTest := range fooTests {
+		r := fooTest.pods.Less(fooTest.i, fooTest.j)
+		if r != fooTest.er {
+			t.Errorf("returned %t but expected %t for pods: %v vs %v (UID: %s vs %s)",
+				r, fooTest.er,
+				fooTest.pods[fooTest.i].Name, fooTest.pods[fooTest.j].Name,
+				fooTest.pods[fooTest.i].UID, fooTest.pods[fooTest.j].UID)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Ensure deterministic ordering of pods with identical CreationTimestamp by using pod UID as a tie-breaker. When pods have the same creation time (which can occur during batch creation or on systems with coarse clock resolution), they are now consistently ordered by UID instead of having undefined behavior.

This is particularly important during kubelet restart when pods are re-admitted through HandlePodAdditions, as it ensures predictable ordering for resource allocation decisions.

#### Which issue(s) this PR is related to:

Fixes #141210

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
