### PR TITLE
DRA ResourceSlice: reject multi-term per-device nodeSelector

### DIFF
--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1114,10 +1114,10 @@ func validateDevice(device resource.Device, oldDevice *resource.Device, fldPath 
 			setFields = append(setFields, "`nodeSelector`")
 			allErrs = append(allErrs, corevalidation.ValidateNodeSelector(device.NodeSelector, false, fldPath.Child("nodeSelector"))...)
 			// Per-device nodeSelector has the same single-term contract as the slice-level selector:
-			// the allocator's createNodeSelector merges a single term and hard-errors on more than one,
-			// which aborts the scheduling cycle. Enforce it here as the slice-level check already does.
-			// This check is new, so ratchet it like Capacity and Taints above: only enforce it on create
-			// or when the selector changes, so an existing slice with multiple terms can still be updated.
+			// the allocator can only combine a single term, so more than one is unsupported. Enforce it
+			// here as the slice-level check already does. This check is new, so ratchet it like Capacity
+			// and Taints above: only enforce it on create or when the selector changes, so an existing
+			// slice with multiple terms can still be updated.
 			if oldDevice == nil || !apiequality.Semantic.DeepEqual(oldDevice.NodeSelector, device.NodeSelector) {
 				if len(device.NodeSelector.NodeSelectorTerms) != 1 {
 					allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeSelector", "nodeSelectorTerms"), device.NodeSelector.NodeSelectorTerms, "must have exactly one node selector term"))

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1113,6 +1113,16 @@ func validateDevice(device resource.Device, oldDevice *resource.Device, fldPath 
 		if device.NodeSelector != nil {
 			setFields = append(setFields, "`nodeSelector`")
 			allErrs = append(allErrs, corevalidation.ValidateNodeSelector(device.NodeSelector, false, fldPath.Child("nodeSelector"))...)
+			// Per-device nodeSelector has the same single-term contract as the slice-level selector:
+			// the allocator's createNodeSelector merges a single term and hard-errors on more than one,
+			// which aborts the scheduling cycle. Enforce it here as the slice-level check already does.
+			// This check is new, so ratchet it like Capacity and Taints above: only enforce it on create
+			// or when the selector changes, so an existing slice with multiple terms can still be updated.
+			if oldDevice == nil || !apiequality.Semantic.DeepEqual(oldDevice.NodeSelector, device.NodeSelector) {
+				if len(device.NodeSelector.NodeSelectorTerms) != 1 {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeSelector", "nodeSelectorTerms"), device.NodeSelector.NodeSelectorTerms, "must have exactly one node selector term"))
+				}
+			}
 		}
 		if device.AllNodes != nil {
 			if *device.AllNodes {

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1113,6 +1113,14 @@ func validateDevice(device resource.Device, oldDevice *resource.Device, fldPath 
 		if device.NodeSelector != nil {
 			setFields = append(setFields, "`nodeSelector`")
 			allErrs = append(allErrs, corevalidation.ValidateNodeSelector(device.NodeSelector, false, fldPath.Child("nodeSelector"))...)
+			// The allocator combines only a single term, so a per-device selector must have
+			// exactly one, matching the slice-level check. Ratcheted like Capacity and Taints
+			// above so an existing multi-term slice can still be updated.
+			if oldDevice == nil || !apiequality.Semantic.DeepEqual(oldDevice.NodeSelector, device.NodeSelector) {
+				if len(device.NodeSelector.NodeSelectorTerms) != 1 {
+					allErrs = append(allErrs, field.Invalid(fldPath.Child("nodeSelector", "nodeSelectorTerms"), device.NodeSelector.NodeSelectorTerms, "must have exactly one node selector term"))
+				}
+			}
 		}
 		if device.AllNodes != nil {
 			if *device.AllNodes {

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -236,6 +236,11 @@ func TestValidateResourceSlice(t *testing.T) {
 		VersionValues: []string{"1.0.0"},
 	}
 
+	twoTermNodeSelectorTerms := []core.NodeSelectorTerm{
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"a"}}}},
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"b"}}}},
+	}
+
 	scenarios := map[string]struct {
 		slice                                        *resourceapi.ResourceSlice
 		wantFailures                                 field.ErrorList
@@ -1352,6 +1357,29 @@ func TestValidateResourceSlice(t *testing.T) {
 				return slice
 			}(),
 		},
+		"device-node-selector-with-multiple-terms": {
+			wantFailures: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "devices").Index(0).Child("nodeSelector", "nodeSelectorTerms"), twoTermNodeSelectorTerms, "must have exactly one node selector term"),
+			},
+			slice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSlice(goodName, goodName, driverName, 1)
+				slice.Spec.PerDeviceNodeSelection = ptr.To(true)
+				slice.Spec.NodeName = nil
+				slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: twoTermNodeSelectorTerms}
+				return slice
+			}(),
+		},
+		"valid-device-node-selector-single-term": {
+			slice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSlice(goodName, goodName, driverName, 1)
+				slice.Spec.PerDeviceNodeSelection = ptr.To(true)
+				slice.Spec.NodeName = nil
+				slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: []core.NodeSelectorTerm{
+					{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"a"}}}},
+				}}
+				return slice
+			}(),
+		},
 		"missing-name-shared-counters": {
 			wantFailures: field.ErrorList{
 				field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "").MarkCoveredByDeclarative(),
@@ -2058,6 +2086,25 @@ func TestValidateResourceSliceUpdate(t *testing.T) {
 		},
 	}
 
+	singleNodeSelectorTerm := []core.NodeSelectorTerm{
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"a"}}}},
+	}
+	multipleNodeSelectorTerms := []core.NodeSelectorTerm{
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"a"}}}},
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"b"}}}},
+	}
+	differentMultipleNodeSelectorTerms := []core.NodeSelectorTerm{
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"a"}}}},
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"c"}}}},
+	}
+	perDeviceSliceWithNodeSelector := func(terms []core.NodeSelectorTerm) *resourceapi.ResourceSlice {
+		slice := testResourceSlice(name, name, name, 1)
+		slice.Spec.NodeName = nil
+		slice.Spec.PerDeviceNodeSelection = ptr.To(true)
+		slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: terms}
+		return slice
+	}
+
 	scenarios := map[string]struct {
 		consumableCapacityFeatureGate      bool
 		fractionalCapacityRangeFeatureGate bool
@@ -2152,6 +2199,41 @@ func TestValidateResourceSliceUpdate(t *testing.T) {
 				device := slice.Spec.Devices[0].DeepCopy()
 				device.Name += "-other"
 				slice.Spec.Devices = append(slice.Spec.Devices, *device)
+				return slice
+			},
+		},
+		"valid-ratcheted-device-node-selector-with-multiple-terms": {
+			// Grandfathered: an existing device selector with multiple terms stays valid across an
+			// update that does not change the selector.
+			oldResourceSlice: perDeviceSliceWithNodeSelector(multipleNodeSelectorTerms),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].Attributes["foo"] = resourceapi.DeviceAttribute{StringValue: ptr.To("bar")}
+				return slice
+			},
+		},
+		"invalid-update-device-node-selector-to-multiple-terms": {
+			wantFailures:     field.ErrorList{field.Invalid(field.NewPath("spec", "devices").Index(0).Child("nodeSelector", "nodeSelectorTerms"), multipleNodeSelectorTerms, "must have exactly one node selector term")},
+			oldResourceSlice: perDeviceSliceWithNodeSelector(singleNodeSelectorTerm),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: multipleNodeSelectorTerms}
+				return slice
+			},
+		},
+		"invalid-update-device-node-selector-to-different-multiple-terms": {
+			// Ratchet grandfathers only an unchanged value: changing one multi-term selector to a
+			// different multi-term selector is still rejected.
+			wantFailures:     field.ErrorList{field.Invalid(field.NewPath("spec", "devices").Index(0).Child("nodeSelector", "nodeSelectorTerms"), differentMultipleNodeSelectorTerms, "must have exactly one node selector term")},
+			oldResourceSlice: perDeviceSliceWithNodeSelector(multipleNodeSelectorTerms),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: differentMultipleNodeSelectorTerms}
+				return slice
+			},
+		},
+		"valid-update-device-node-selector-multiple-to-single-term": {
+			// The repair path: an existing multi-term selector can be fixed down to a single term.
+			oldResourceSlice: perDeviceSliceWithNodeSelector(multipleNodeSelectorTerms),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: singleNodeSelectorTerm}
 				return slice
 			},
 		},

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -236,6 +236,11 @@ func TestValidateResourceSlice(t *testing.T) {
 		VersionValues: []string{"1.0.0"},
 	}
 
+	twoTermNodeSelectorTerms := []core.NodeSelectorTerm{
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"a"}}}},
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"b"}}}},
+	}
+
 	scenarios := map[string]struct {
 		slice                                        *resourceapi.ResourceSlice
 		wantFailures                                 field.ErrorList
@@ -1352,6 +1357,29 @@ func TestValidateResourceSlice(t *testing.T) {
 				return slice
 			}(),
 		},
+		"device-node-selector-with-multiple-terms": {
+			wantFailures: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "devices").Index(0).Child("nodeSelector", "nodeSelectorTerms"), twoTermNodeSelectorTerms, "must have exactly one node selector term"),
+			},
+			slice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSlice(goodName, goodName, driverName, 1)
+				slice.Spec.PerDeviceNodeSelection = ptr.To(true)
+				slice.Spec.NodeName = nil
+				slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: twoTermNodeSelectorTerms}
+				return slice
+			}(),
+		},
+		"valid-device-node-selector-single-term": {
+			slice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSlice(goodName, goodName, driverName, 1)
+				slice.Spec.PerDeviceNodeSelection = ptr.To(true)
+				slice.Spec.NodeName = nil
+				slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: []core.NodeSelectorTerm{
+					{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"a"}}}},
+				}}
+				return slice
+			}(),
+		},
 		"missing-name-shared-counters": {
 			wantFailures: field.ErrorList{
 				field.Required(field.NewPath("spec", "sharedCounters").Index(0).Child("name"), "").MarkCoveredByDeclarative(),
@@ -2058,6 +2086,25 @@ func TestValidateResourceSliceUpdate(t *testing.T) {
 		},
 	}
 
+	singleNodeSelectorTerm := []core.NodeSelectorTerm{
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"a"}}}},
+	}
+	multipleNodeSelectorTerms := []core.NodeSelectorTerm{
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"a"}}}},
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"b"}}}},
+	}
+	differentMultipleNodeSelectorTerms := []core.NodeSelectorTerm{
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"a"}}}},
+		{MatchExpressions: []core.NodeSelectorRequirement{{Key: "topology.example.com/rack", Operator: core.NodeSelectorOpIn, Values: []string{"c"}}}},
+	}
+	perDeviceSliceWithNodeSelector := func(terms []core.NodeSelectorTerm) *resourceapi.ResourceSlice {
+		slice := testResourceSlice(name, name, name, 1)
+		slice.Spec.NodeName = nil
+		slice.Spec.PerDeviceNodeSelection = ptr.To(true)
+		slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: terms}
+		return slice
+	}
+
 	scenarios := map[string]struct {
 		consumableCapacityFeatureGate      bool
 		fractionalCapacityRangeFeatureGate bool
@@ -2152,6 +2199,71 @@ func TestValidateResourceSliceUpdate(t *testing.T) {
 				device := slice.Spec.Devices[0].DeepCopy()
 				device.Name += "-other"
 				slice.Spec.Devices = append(slice.Spec.Devices, *device)
+				return slice
+			},
+		},
+		"valid-ratcheted-device-node-selector-with-multiple-terms": {
+			// Grandfathered: an existing device selector with multiple terms stays valid across an
+			// update that does not change the selector.
+			oldResourceSlice: perDeviceSliceWithNodeSelector(multipleNodeSelectorTerms),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].Attributes["foo"] = resourceapi.DeviceAttribute{StringValue: ptr.To("bar")}
+				return slice
+			},
+		},
+		"valid-ratcheted-device-node-selector-after-device-reordering": {
+			// The old device is looked up by name, so reordering the devices must not make the
+			// unchanged multi-term selector look like a new device and lose the grandfathering.
+			oldResourceSlice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSlice(name, name, name, 2)
+				slice.Spec.NodeName = nil
+				slice.Spec.PerDeviceNodeSelection = ptr.To(true)
+				slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: singleNodeSelectorTerm}
+				slice.Spec.Devices[1].NodeSelector = &core.NodeSelector{NodeSelectorTerms: multipleNodeSelectorTerms}
+				return slice
+			}(),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0], slice.Spec.Devices[1] = slice.Spec.Devices[1], slice.Spec.Devices[0]
+				slice.Spec.Devices[0].Attributes["foo"] = resourceapi.DeviceAttribute{StringValue: ptr.To("bar")}
+				return slice
+			},
+		},
+		"invalid-new-device-with-multiple-term-node-selector": {
+			// Grandfathering is keyed on the device name, so a device added by an update is
+			// rejected even though the existing device keeps its multi-term selector.
+			wantFailures:     field.ErrorList{field.Invalid(field.NewPath("spec", "devices").Index(1).Child("nodeSelector", "nodeSelectorTerms"), multipleNodeSelectorTerms, "must have exactly one node selector term")},
+			oldResourceSlice: perDeviceSliceWithNodeSelector(multipleNodeSelectorTerms),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices = append(slice.Spec.Devices, resourceapi.Device{
+					Name:         "device-1",
+					NodeSelector: &core.NodeSelector{NodeSelectorTerms: multipleNodeSelectorTerms},
+				})
+				return slice
+			},
+		},
+		"invalid-update-device-node-selector-to-multiple-terms": {
+			wantFailures:     field.ErrorList{field.Invalid(field.NewPath("spec", "devices").Index(0).Child("nodeSelector", "nodeSelectorTerms"), multipleNodeSelectorTerms, "must have exactly one node selector term")},
+			oldResourceSlice: perDeviceSliceWithNodeSelector(singleNodeSelectorTerm),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: multipleNodeSelectorTerms}
+				return slice
+			},
+		},
+		"invalid-update-device-node-selector-to-different-multiple-terms": {
+			// Ratchet grandfathers only an unchanged value: changing one multi-term selector to a
+			// different multi-term selector is still rejected.
+			wantFailures:     field.ErrorList{field.Invalid(field.NewPath("spec", "devices").Index(0).Child("nodeSelector", "nodeSelectorTerms"), differentMultipleNodeSelectorTerms, "must have exactly one node selector term")},
+			oldResourceSlice: perDeviceSliceWithNodeSelector(multipleNodeSelectorTerms),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: differentMultipleNodeSelectorTerms}
+				return slice
+			},
+		},
+		"valid-update-device-node-selector-multiple-to-single-term": {
+			// The repair path: an existing multi-term selector can be fixed down to a single term.
+			oldResourceSlice: perDeviceSliceWithNodeSelector(multipleNodeSelectorTerms),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].NodeSelector = &core.NodeSelector{NodeSelectorTerms: singleNodeSelectorTerm}
 				return slice
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Both node selector fields on a `ResourceSlice` are documented as single-term selectors: `ResourceSliceSpec.NodeSelector` and `Device.NodeSelector` each say "Must use exactly one term." The slice-level field enforces that contract in validation, but the per-device field does not.

`validateDevice` only runs `ValidateNodeSelector` on `device.NodeSelector`, which requires at least one valid term but does not cap the count. A per-device selector with two or more valid terms therefore passes API validation, while the equivalent slice-level selector is rejected.

The allocator relies on the single-term invariant that validation was supposed to guarantee. When `createNodeSelector` processes a selector with more than one term, it returns a hard error:

```go
default:
    // This shouldn't occur, validation must prevent creation of such slices.
    return nil, fmt.Errorf("unsupported ResourceSlice.NodeSelector with %d terms", len(nodeSelector.NodeSelectorTerms))
```

The caller wraps that error with `%w` but not with `ErrFailedAllocationOnNode`, so the DynamicResources Filter plugin treats it as a framework error rather than a per-node rejection. A framework error from Filter cancels the remaining node search and aborts the scheduling cycle, and it recurs on retry while the malformed slice stays in place.

This PR closes the validation gap. `validateDevice` now rejects a per-device `nodeSelector` whose `nodeSelectorTerms` length is not exactly one, with the same error the slice-level check already produces. The check is ratcheted the way `validateDevice` already ratchets `capacity` and `taints`, so a slice that already carries a multi-term selector can still be updated as long as the selector itself does not change.

#### Which issue(s) this PR is related to:

Fixes #141212

#### Special notes for your reviewer:

The new check mirrors the slice-level constraint in `validateResourceSliceSpec` (the "must have exactly one node selector term" error), so the two paths now agree.

I ratcheted it rather than validating unconditionally because the constraint is being added to a field that previously accepted multiple terms, so a slice with a persisted multi-term selector could otherwise start failing on an unrelated update. `validateDevice` already uses `oldDevice == nil || !apiequality.Semantic.DeepEqual(...)` for `capacity` and `taints` for the same reason.

The allocator side, wrapping the `createNodeSelector` error with `ErrFailedAllocationOnNode` so an already-persisted malformed slice degrades to a per-node rejection instead of a cycle abort, is a separate and larger change across the stable, incubating, and experimental allocator variants, so it is not included here. It is tracked in #141214 so the gap is not lost when this closes #141212.

Tests: `TestValidateResourceSlice` gains a create case that rejects a two-term device selector plus a control that accepts a single-term one. `TestValidateResourceSliceUpdate` covers the ratchet: an unchanged multi-term selector is grandfathered, a single-to-multi change and a multi-to-different-multi change are both rejected, and a multi-to-single repair is allowed. Every rejection case fails without the validation change and passes with it.

#### Does this PR introduce a user-facing change?

```release-note
ResourceSlice validation now rejects a newly created or modified per-device `nodeSelector` with more than one node selector term, matching the documented single-term constraint that the slice-level `nodeSelector` already enforces. An update that leaves a previously stored multi-term selector unchanged is still allowed.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. AI-assisted tools were used during implementation, test planning, and review; I reviewed and validated the final change.
