### PR TITLE
fix BenchmarkRatcheting set locked feature gate CRDValidationRatcheting

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/ratcheting_test.go
@@ -1953,6 +1953,7 @@ func BenchmarkRatcheting(b *testing.B) {
 			name = "RatchetingDisabled"
 		}
 		b.Run(name, func(b *testing.B) {
+			featuregatetesting.SetFeatureGateEmulationVersionDuringTest(b, utilfeature.DefaultFeatureGate, version.MustParse("1.32"))
 			featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.CRDValidationRatcheting, ratchetingEnabled)
 			b.ResetTimer()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

```
W0806 14:24:08.260527  603760 feature_gate.go:352] Setting GA feature gate CRDValidationRatcheting=true. It will be removed in a future release.
goos: linux
goarch: amd64
pkg: k8s.io/apiextensions-apiserver/test/integration
cpu: AMD EPYC Processor (with IBPB)
BenchmarkRatcheting/RatchetingEnabled/ValidXValid-8                    2         808490111 ns/op
BenchmarkRatcheting/RatchetingEnabled/ValidXInvalid-8                  3         401178629 ns/op
BenchmarkRatcheting/RatchetingEnabled/InvalidXInvalid-8               10         105862086 ns/op
BenchmarkRatcheting/RatchetingDisabled/ValidXValid-8                   2         786537178 ns/op
BenchmarkRatcheting/RatchetingDisabled/ValidXInvalid-8                 3         385179090 ns/op
BenchmarkRatcheting/RatchetingDisabled/InvalidXInvalid-8               9         112963992 ns/op
--- FAIL: BenchmarkRatcheting/RatchetingDisabled
    ratcheting_test.go:1957: error setting CRDValidationRatcheting=false: cannot set feature gate CRDValidationRatcheting to false, feature is locked to true. Feature CRDValidationRatcheting is locked at version 1.34. Try adding SetFeatureGateEmulationVersionDuringTest(t, gate, version.MustParse("1.32")) at the beginning of your test.
    ratcheting_test.go:1957: error restoring CRDValidationRatcheting=true: feature:CRDValidationRatcheting was explicitly set, but not in enabled map
--- FAIL: BenchmarkRatcheting
FAIL
exit status 1
FAIL    k8s.io/apiextensions-apiserver/test/integration 13.193s
FAIL
```


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
