### PR TITLE
test: create snapshot metadata resources in PrepareTest when CapSnapshotMetadata is enabled

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -376,6 +376,22 @@ func (h *hostpathCSIDriver) PrepareTest(ctx context.Context, f *framework.Framew
 		framework.Failf("deploying %s driver: %v", h.driverInfo.Name, err)
 	}
 
+	if h.driverInfo.Capabilities[storageframework.CapSnapshotMetadata] {
+		// Create snapshot metadata resources (CRD is already created by test runner script)
+		ginkgo.By("Creating snapshot metadata resources")
+		err = utils.CreateSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, driverns)
+		if err != nil {
+			framework.Failf("failed to create snapshot metadata resources: %v", err)
+		}
+		ginkgo.DeferCleanup(func(ctx context.Context) {
+			ginkgo.By("Cleaning up snapshot metadata resources")
+			err = utils.CleanupSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, driverns)
+			if err != nil {
+				framework.Logf("Warning: failed to cleanup snapshot metadata resources: %v", err)
+			}
+		})
+	}
+
 	cleanupFunc := generateDriverCleanupFunc(
 		f,
 		h.driverInfo.Name,

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -376,6 +376,12 @@ func (h *hostpathCSIDriver) PrepareTest(ctx context.Context, f *framework.Framew
 		framework.Failf("deploying %s driver: %v", h.driverInfo.Name, err)
 	}
 
+	if h.driverInfo.Capabilities[storageframework.CapSnapshotMetadata] {
+		if err := utils.CreateSnapshotMetadataTLSSecret(ctx, f, driverns); err != nil {
+			framework.Failf("creating snapshot metadata TLS secret: %v", err)
+		}
+	}
+
 	cleanupFunc := generateDriverCleanupFunc(
 		f,
 		h.driverInfo.Name,

--- a/test/e2e/storage/testsuites/snapshot-metadata.go
+++ b/test/e2e/storage/testsuites/snapshot-metadata.go
@@ -307,11 +307,6 @@ func (s *snapshotMetadataTestSuite) DefineTests(driver storageframework.TestDriv
 
 		config = smDriver.PrepareTest(ctx, f)
 
-		// Create snapshot metadata resources (CRD is already created by test runner script)
-		ginkgo.By("Creating snapshot metadata resources")
-		err = storageutils.CreateSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, config.DriverNamespace.Name)
-		framework.ExpectNoError(err, "Failed to create snapshot metadata resources")
-
 		pattern.VolMode = v1.PersistentVolumeBlock
 		volume = storageframework.CreateVolumeResource(ctx, smDriver, config, pattern, s.GetTestSuiteInfo().SupportedSizeRange)
 		testPVC = volume.Pvc
@@ -359,14 +354,6 @@ func (s *snapshotMetadataTestSuite) DefineTests(driver storageframework.TestDriv
 			backupClientPod = nil
 		}
 
-		// Cleanup snapshot metadata resources
-		if config != nil {
-			ginkgo.By("Cleaning up snapshot metadata resources")
-			err := storageutils.CleanupSnapshotMetadataResources(ctx, f, config.Driver.GetDriverInfo().Name, config.DriverNamespace.Name)
-			if err != nil {
-				framework.Logf("Warning: failed to cleanup snapshot metadata resources: %v", err)
-			}
-		}
 	})
 
 	ginkgo.It("should verify GetMetadataDelta", func(ctx context.Context) {

--- a/test/e2e/storage/utils/snapshot-metadata.go
+++ b/test/e2e/storage/utils/snapshot-metadata.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -145,7 +146,11 @@ func createTLSSecret(ctx context.Context, f *framework.Framework, driverNamespac
 
 	client := f.ClientSet.CoreV1().Secrets(driverNamespace)
 	if _, err := client.Create(ctx, tlsSecret, metav1.CreateOptions{}); err != nil {
-		return fmt.Errorf("failed to create or update TLS secret: %w", err)
+		if apierrors.IsAlreadyExists(err) {
+			framework.Logf("TLS secret already exists: %s", tlsSecret.Name)
+			return nil
+		}
+		return fmt.Errorf("failed to create TLS secret: %w", err)
 	}
 
 	framework.Logf("TLS secret created successfully: %s", tlsSecret.Name)
@@ -211,6 +216,28 @@ func createSnapshotMetdataServiceCR(ctx context.Context, f *framework.Framework,
 
 	if _, err := f.DynamicClient.Resource(gvr).Create(ctx, sms, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create SnapshotMetadataService: %w", err)
+	}
+
+	return nil
+}
+
+// CreateSnapshotMetadataTLSSecret creates only the TLS secret needed by the
+// csi-snapshot-metadata sidecar. Use this in PrepareTest when CapSnapshotMetadata
+// is enabled so the driver pod can mount the secret without requiring the full
+// set of snapshot metadata resources (Service, SnapshotMetadataService CR).
+func CreateSnapshotMetadataTLSSecret(ctx context.Context, f *framework.Framework, driverNamespace string) error {
+	caCert, caPrivateKey, err := generateCA()
+	if err != nil {
+		return fmt.Errorf("failed to generate CA certificate: %w", err)
+	}
+
+	serverCertBytes, serverKeyBytes, err := generateServerCert(driverNamespace, caCert, caPrivateKey)
+	if err != nil {
+		return fmt.Errorf("failed to generate server certificate: %w", err)
+	}
+
+	if err := createTLSSecret(ctx, f, driverNamespace, serverCertBytes, serverKeyBytes); err != nil {
+		return fmt.Errorf("failed to create TLS secret: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it

When `CSI_PROW_ENABLE_SNAPSHOT_METADATA=true`, the csi-hostpath driver's `PrepareTest()` keeps the `csi-snapshot-metadata` sidecar container and its `csi-snapshot-metadata-server-certs` volume in the StatefulSet. However, the TLS secret backing that volume is only created later by `CreateSnapshotMetadataResources()` during the snapshot metadata test's `init()`. This means any non-snapshot-metadata CSI test that uses the csi-hostpath driver (e.g., provisioning, expansion tests) will fail with `FailedMount` because the secret doesn't exist when the pod tries to start.

## Which issue(s) this PR fixes

Fixes a bug where enabling snapshot metadata via the env var breaks all other CSI hostpath tests.

## How to reproduce

1. Set up a KIND cluster with snapshot CRDs and snapshot controller installed
2. Build and run e2e tests with `CSI_PROW_ENABLE_SNAPSHOT_METADATA=true`
3. Run any non-snapshot-metadata test using the csi-hostpath driver:
   ```
   FOCUS='\[Driver: csi-hostpath\].*\[Testpattern: Dynamic PV (default fs)\].*volumes should store data'
   ```
4. The CSI hostpath pod will fail with:
   ```
   FailedMount: MountVolume.SetUp failed for volume "csi-snapshot-metadata-server-certs" :
   secret "csi-snapshot-metadata-server-certs" not found
   ```

## Root cause

The execution order in `PrepareTest()` is:
1. `CreateFromManifests()` deploys the StatefulSet **with** the `csi-snapshot-metadata` sidecar (because `CapSnapshotMetadata=true`)
2. The sidecar mounts the `csi-snapshot-metadata-server-certs` secret volume
3. The pod is scheduled and tries to mount the secret — but it doesn't exist
4. Pod hangs in `ContainerCreating` with `FailedMount`

The secret is only created in `CreateSnapshotMetadataResources()`, which is called during snapshot metadata test `init()` — but non-snapshot-metadata tests never call it.

## Why upstream CI doesn't catch this

The upstream job `pull-kubernetes-e2e-storage-kind-snapshot-metadata` uses `FOCUS=\[Feature:snapshotmetadata\]` to run **only** snapshot metadata tests. Those tests call `CreateSnapshotMetadataResources()` in their `init()`, which creates the secret. The bug only manifests when running snapshot metadata tests **alongside** other CSI tests in the same suite — as downstream consumers like OpenShift CI do.

## Fix

Move the `CreateSnapshotMetadataResources()` call (and its corresponding `CleanupSnapshotMetadataResources()` cleanup) from the snapshot metadata test suite's `init()` into `PrepareTest()` in `test/e2e/storage/drivers/csi.go`, guarded by `CapSnapshotMetadata`.

This ensures the TLS secret, Service, and SnapshotMetadataService CR are created immediately after the StatefulSet is deployed — regardless of which test suite is running — and cleaned up via `ginkgo.DeferCleanup` when the test finishes.

## Verified locally

Tested with KIND cluster (kindest/node:v1.33.1):
- **Without fix**: Test `[Testpattern: Dynamic PV (default fs)] volumes should store data` — `FailedMount` → PVC stuck `Pending` for 5 minutes → FAIL
- **With fix**: Resources created in `PrepareTest()` → pod starts → PVC binds in 10s → PASS (47s total)

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig storage
/area test
/cc @leonardoce @carlory