### PR TITLE
core/v1: add alpha declarative validation for PodSpec.ActiveDeadlineSeconds

### DIFF
--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -1291,7 +1291,41 @@ func Validate_PodSpec(
 	// field corev1.PodSpec.EphemeralContainers has no validation
 	// field corev1.PodSpec.RestartPolicy has no validation
 	// field corev1.PodSpec.TerminationGracePeriodSeconds has no validation
-	// field corev1.PodSpec.ActiveDeadlineSeconds has no validation
+
+	{ // field corev1.PodSpec.ActiveDeadlineSeconds
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int64,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 1).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			if e := validate.Maximum(ctx, op, fldPath, obj, oldObj, 2147483647).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *corev1.PodSpec) *int64 {
+				return oldObj.ActiveDeadlineSeconds
+			})
+		errs = append(errs, fn(fldPath.Child("activeDeadlineSeconds"), obj.ActiveDeadlineSeconds, oldVal, oldObj != nil)...)
+	}
+
 	// field corev1.PodSpec.DNSPolicy has no validation
 	// field corev1.PodSpec.NodeSelector has no validation
 	// field corev1.PodSpec.ServiceAccountName has no validation

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -4636,12 +4636,24 @@ type PodValidationOptions struct {
 
 // validatePodMetadataAndSpec tests if required fields in the pod.metadata and pod.spec are set,
 // and is called by ValidatePodCreate and ValidatePodUpdate.
+// validatePodMetadataAndSpec validates a Pod's ObjectMeta (create-path) together with its spec.
+// This should only be called from create-time validation; update paths should call
+// validatePodSpecOnly instead, since they already validate ObjectMeta via ValidateObjectMetaUpdate,
+// and re-running create-path ObjectMeta validation on update is redundant (see #140339).
 func validatePodMetadataAndSpec(pod *core.Pod, opts PodValidationOptions) field.ErrorList {
+	metaPath := field.NewPath("metadata")
+	allErrs := ValidateObjectMeta(&pod.ObjectMeta, true, ValidatePodName, metaPath)
+	allErrs = append(allErrs, validatePodSpecOnly(pod, opts)...)
+	return allErrs
+}
+
+// validatePodSpecOnly validates a Pod's spec and spec-related annotations, without
+// validating ObjectMeta. Safe to call from both create and update validation paths.
+func validatePodSpecOnly(pod *core.Pod, opts PodValidationOptions) field.ErrorList {
 	metaPath := field.NewPath("metadata")
 	specPath := field.NewPath("spec")
 
-	allErrs := ValidateObjectMeta(&pod.ObjectMeta, true, ValidatePodName, metaPath)
-	allErrs = append(allErrs, ValidatePodSpecificAnnotations(pod.ObjectMeta.Annotations, &pod.Spec, metaPath.Child("annotations"), opts)...)
+	allErrs := ValidatePodSpecificAnnotations(pod.ObjectMeta.Annotations, &pod.Spec, metaPath.Child("annotations"), opts)
 	allErrs = append(allErrs, ValidatePodSpec(&pod.Spec, &pod.ObjectMeta, specPath, opts)...)
 
 	// we do additional validation only pertinent for pods and not pod templates
@@ -4662,7 +4674,7 @@ func validatePodMetadataAndSpec(pod *core.Pod, opts PodValidationOptions) field.
 	}
 
 	if pod.Spec.TerminationGracePeriodSeconds != nil {
-		allErrs = append(allErrs, ValidateNonnegativeField(*pod.Spec.TerminationGracePeriodSeconds, specPath.Child("terminationGracePeriodSeconds"))...)
+		allErrs = append(allErrs, ValidateNonnegativeField(*pod.Spec.TerminationGracePeriodSeconds, specPath.Child("terminationGracePeriodSeconds")).MarkCoveredByDeclarative()...)
 	}
 
 	allErrs = append(allErrs, validateContainersOnlyForPod(pod.Spec.Containers, specPath.Child("containers"))...)
@@ -4831,8 +4843,10 @@ func ValidatePodSpec(spec *core.PodSpec, podMeta *metav1.ObjectMeta, fldPath *fi
 
 	if spec.ActiveDeadlineSeconds != nil {
 		value := *spec.ActiveDeadlineSeconds
-		if value < 1 || value > math.MaxInt32 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("activeDeadlineSeconds"), value, validation.InclusiveRangeError(1, math.MaxInt32)))
+		if value < 1 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("activeDeadlineSeconds"), value, validation.InclusiveRangeError(1, math.MaxInt32)).WithOrigin("minimum").MarkCoveredByDeclarative())
+		} else if value > math.MaxInt32 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("activeDeadlineSeconds"), value, validation.InclusiveRangeError(1, math.MaxInt32)).WithOrigin("maximum").MarkCoveredByDeclarative())
 		}
 	}
 
@@ -5859,7 +5873,7 @@ var updatablePodSpecFields = []string{
 func ValidatePodUpdate(newPod, oldPod *core.Pod, opts PodValidationOptions) field.ErrorList {
 	fldPath := field.NewPath("metadata")
 	allErrs := ValidateObjectMetaUpdate(&newPod.ObjectMeta, &oldPod.ObjectMeta, fldPath)
-	allErrs = append(allErrs, validatePodMetadataAndSpec(newPod, opts)...)
+	allErrs = append(allErrs, validatePodSpecOnly(newPod, opts)...)
 	allErrs = append(allErrs, ValidatePodSpecificAnnotationUpdates(newPod, oldPod, fldPath.Child("annotations"), opts)...)
 	specPath := field.NewPath("spec")
 
@@ -6456,7 +6470,7 @@ func ValidatePodEphemeralContainersUpdate(newPod, oldPod *core.Pod, opts PodVali
 	// Part 1: Validate newPod's spec and updates to metadata
 	fldPath := field.NewPath("metadata")
 	allErrs := ValidateObjectMetaUpdate(&newPod.ObjectMeta, &oldPod.ObjectMeta, fldPath)
-	allErrs = append(allErrs, validatePodMetadataAndSpec(newPod, opts)...)
+	allErrs = append(allErrs, validatePodSpecOnly(newPod, opts)...)
 	allErrs = append(allErrs, ValidatePodSpecificAnnotationUpdates(newPod, oldPod, fldPath.Child("annotations"), opts)...)
 
 	// static pods don't support ephemeral containers #113935
@@ -6492,7 +6506,7 @@ func ValidatePodResize(newPod, oldPod *core.Pod, opts PodValidationOptions) fiel
 	// Part 1: Validate newPod's spec and updates to metadata
 	fldPath := field.NewPath("metadata")
 	allErrs := ValidateObjectMetaUpdate(&newPod.ObjectMeta, &oldPod.ObjectMeta, fldPath)
-	allErrs = append(allErrs, validatePodMetadataAndSpec(newPod, opts)...)
+	allErrs = append(allErrs, validatePodSpecOnly(newPod, opts)...)
 
 	// static pods cannot be resized.
 	if _, ok := oldPod.Annotations[core.MirrorPodAnnotationKey]; ok {

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -4708,6 +4708,9 @@ message PodSpec {
   // StartTime before the system will actively try to mark it failed and kill associated containers.
   // Value must be a positive integer.
   // +optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:minimum=1
+  // +k8s:alpha(since: "1.37")=+k8s:maximum=2147483647
   optional int64 activeDeadlineSeconds = 5;
 
   // Set DNS policy for the pod.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4421,6 +4421,9 @@ type PodSpec struct {
 	// StartTime before the system will actively try to mark it failed and kill associated containers.
 	// Value must be a positive integer.
 	// +optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:minimum=1
+	// +k8s:alpha(since: "1.37")=+k8s:maximum=2147483647
 	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty" protobuf:"varint,5,opt,name=activeDeadlineSeconds"`
 	// Set DNS policy for the pod.
 	// Defaults to "ClusterFirst".

--- a/test/declarative_validation/apps/daemonset/declarative_validation_test.go
+++ b/test/declarative_validation/apps/daemonset/declarative_validation_test.go
@@ -99,6 +99,9 @@ func TestDeclarativeValidate(t *testing.T) {
 			baseObj.Spec.Template.Spec.EvictionResponders = responders
 			baseObj.Spec.Template.Spec.SchedulingGroup = schedulingGroup
 		})
+		poddeclarativevalidation.RunDeclarativeValidateActiveDeadlineSecondsForbiddenTestCases(t, ctx, registry.Strategy, field.NewPath("spec", "template", "spec"), mkDaemonSet(), func(baseObj *apps.DaemonSet, val *int64) {
+			baseObj.Spec.Template.Spec.ActiveDeadlineSeconds = val
+		})
 	}
 }
 

--- a/test/declarative_validation/apps/daemonset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/daemonset/zz_generated.validations.v1_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/apps/daemonset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/daemonset/zz_generated.validations.v1beta2_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/apps/deployment/declarative_validation_test.go
+++ b/test/declarative_validation/apps/deployment/declarative_validation_test.go
@@ -106,6 +106,9 @@ func TestDeclarativeValidate(t *testing.T) {
 			baseObj.Spec.Template.Spec.EvictionResponders = responders
 			baseObj.Spec.Template.Spec.SchedulingGroup = schedulingGroup
 		})
+		poddeclarativevalidation.RunDeclarativeValidateActiveDeadlineSecondsForbiddenTestCases(t, ctx, registry.Strategy, field.NewPath("spec", "template", "spec"), mkDeployment(), func(baseObj *apps.Deployment, val *int64) {
+			baseObj.Spec.Template.Spec.ActiveDeadlineSeconds = val
+		})
 	}
 }
 

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta1_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/deployment/zz_generated.validations.v1beta2_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/apps/replicaset/declarative_validation_test.go
+++ b/test/declarative_validation/apps/replicaset/declarative_validation_test.go
@@ -98,6 +98,9 @@ func TestDeclarativeValidate(t *testing.T) {
 			baseObj.Spec.Template.Spec.EvictionResponders = responders
 			baseObj.Spec.Template.Spec.SchedulingGroup = schedulingGroup
 		})
+		poddeclarativevalidation.RunDeclarativeValidateActiveDeadlineSecondsForbiddenTestCases(t, ctx, registry.Strategy, field.NewPath("spec", "template", "spec"), mkReplicaSet(), func(baseObj *apps.ReplicaSet, val *int64) {
+			baseObj.Spec.Template.Spec.ActiveDeadlineSeconds = val
+		})
 	}
 }
 

--- a/test/declarative_validation/apps/replicaset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/replicaset/zz_generated.validations.v1_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/apps/replicaset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/replicaset/zz_generated.validations.v1beta2_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/apps/statefulset/declarative_validation_test.go
+++ b/test/declarative_validation/apps/statefulset/declarative_validation_test.go
@@ -116,6 +116,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		baseObj.Spec.Template.Spec.EvictionResponders = responders
 		baseObj.Spec.Template.Spec.SchedulingGroup = schedulingGroup
 	})
+	poddeclarativevalidation.RunDeclarativeValidateActiveDeadlineSecondsForbiddenTestCases(t, ctx, registry.Strategy, field.NewPath("spec", "template", "spec"), new(mkValidStatefulSet()), func(baseObj *apps.StatefulSet, val *int64) {
+		baseObj.Spec.Template.Spec.ActiveDeadlineSeconds = val
+	})
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1_test.go
@@ -71,6 +71,10 @@ func init() {
 			"spec.serviceName": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta1_test.go
@@ -71,6 +71,10 @@ func init() {
 			"spec.serviceName": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/apps/statefulset/zz_generated.validations.v1beta2_test.go
@@ -71,6 +71,10 @@ func init() {
 			"spec.serviceName": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/batch/cronjob/declarative_validation_test.go
+++ b/test/declarative_validation/batch/cronjob/declarative_validation_test.go
@@ -434,6 +434,9 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 		baseObj.Spec.JobTemplate.Spec.Template.Spec.EvictionResponders = responders
 		baseObj.Spec.JobTemplate.Spec.Template.Spec.SchedulingGroup = schedulingGroup
 	})
+	poddeclarativevalidation.RunDeclarativeValidateActiveDeadlineSecondsTestCases(t, ctx, registry.Strategy, field.NewPath("spec", "jobTemplate", "spec", "template", "spec"), new(mkCronJob()), func(baseObj *batch.CronJob, val *int64) {
+		baseObj.Spec.JobTemplate.Spec.Template.Spec.ActiveDeadlineSeconds = val
+	})
 }
 
 func tweakJobSchedulingBasic() func(*batch.CronJob) {

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
@@ -107,6 +107,10 @@ func init() {
 			"spec.jobTemplate.spec.scheduling.schedulingPolicy.gang.minCount": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"spec.jobTemplate.spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.jobTemplate.spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
@@ -107,6 +107,10 @@ func init() {
 			"spec.jobTemplate.spec.scheduling.schedulingPolicy.gang.minCount": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"spec.jobTemplate.spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.jobTemplate.spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/batch/job/declarative_validation_test.go
+++ b/test/declarative_validation/batch/job/declarative_validation_test.go
@@ -253,6 +253,9 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		baseObj.Spec.Template.Spec.EvictionResponders = responders
 		baseObj.Spec.Template.Spec.SchedulingGroup = schedulingGroup
 	})
+	poddeclarativevalidation.RunDeclarativeValidateActiveDeadlineSecondsTestCases(t, ctx, registry.Strategy, field.NewPath("spec", "template", "spec"), new(mkJob()), func(baseObj *batch.Job, val *int64) {
+		baseObj.Spec.Template.Spec.ActiveDeadlineSeconds = val
+	})
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {

--- a/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
@@ -107,6 +107,10 @@ func init() {
 			"spec.scheduling.schedulingPolicy.gang.minCount": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/core/pod/active_deadline_seconds.go
+++ b/test/declarative_validation/core/pod/active_deadline_seconds.go
@@ -1,0 +1,136 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/utils/ptr"
+)
+
+// RunDeclarativeValidateActiveDeadlineSecondsTestCases exercises the shared
+// spec.activeDeadlineSeconds minimum/maximum declarative validation rules
+// across any type that embeds a PodSpec. This gives each embedding Kind
+// (e.g. ReplicationController, DaemonSet, Deployment, ...) coverage for the
+// rule without duplicating the same test cases in every package.
+func RunDeclarativeValidateActiveDeadlineSecondsTestCases[T runtime.Object](t *testing.T, ctx context.Context, strategy rest.RESTCreateStrategy, specPath *field.Path, baseObj T, setActiveDeadlineSeconds func(baseObj T, val *int64)) {
+	testCases := map[string]struct {
+		input        *int64
+		expectedErrs field.ErrorList
+	}{
+		"unset": {
+			input: nil,
+		},
+		"positive": {
+			input: ptr.To(int64(100)),
+		},
+		"max": {
+			input: ptr.To(int64(math.MaxInt32)),
+		},
+		"zero": {
+			input: ptr.To(int64(0)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"negative": {
+			input: ptr.To(int64(-1)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"over maximum": {
+			input: ptr.To(int64(math.MaxInt32 + 1)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("maximum").MarkAlpha(),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run("activeDeadlineSeconds: "+k, func(t *testing.T) {
+			obj := baseObj.DeepCopyObject().(T)
+			setActiveDeadlineSeconds(obj, tc.input)
+			apitesting.VerifyValidationEquivalence(t, ctx, obj, strategy, tc.expectedErrs)
+		})
+	}
+}
+
+// RunDeclarativeValidateActiveDeadlineSecondsForbiddenTestCases exercises the
+// hand-written (non-declarative) rule that forbids spec.activeDeadlineSeconds
+// on PodSpecs embedded in controllers with an always-restarting pod template
+// (e.g. ReplicationController, DaemonSet, ReplicaSet, StatefulSet). This rule
+// depends on a sibling field's value and isn't expressible as a declarative
+// tag today, so it stays purely imperative. The declarative minimum/maximum
+// shadow-validation still runs independently, so boundary-violating values
+// produce both the declarative error and the imperative Forbidden error.
+func RunDeclarativeValidateActiveDeadlineSecondsForbiddenTestCases[T runtime.Object](t *testing.T, ctx context.Context, strategy rest.RESTCreateStrategy, specPath *field.Path, baseObj T, setActiveDeadlineSeconds func(baseObj T, val *int64)) {
+	forbidden := field.Forbidden(specPath.Child("activeDeadlineSeconds"), "").MarkFromImperative()
+	testCases := map[string]struct {
+		input        *int64
+		expectedErrs field.ErrorList
+	}{
+		"unset": {
+			input: nil,
+		},
+		"positive": {
+			input: ptr.To(int64(100)),
+			expectedErrs: field.ErrorList{
+				forbidden,
+			},
+		},
+		"max": {
+			input: ptr.To(int64(math.MaxInt32)),
+			expectedErrs: field.ErrorList{
+				forbidden,
+			},
+		},
+		"zero": {
+			input: ptr.To(int64(0)),
+			expectedErrs: field.ErrorList{
+				forbidden,
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"negative": {
+			input: ptr.To(int64(-1)),
+			expectedErrs: field.ErrorList{
+				forbidden,
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"over maximum": {
+			input: ptr.To(int64(math.MaxInt32 + 1)),
+			expectedErrs: field.ErrorList{
+				forbidden,
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("maximum").MarkAlpha(),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run("activeDeadlineSeconds: "+k, func(t *testing.T) {
+			obj := baseObj.DeepCopyObject().(T)
+			setActiveDeadlineSeconds(obj, tc.input)
+			apitesting.VerifyValidationEquivalence(t, ctx, obj, strategy, tc.expectedErrs)
+		})
+	}
+}

--- a/test/declarative_validation/core/pod/active_deadline_seconds.go
+++ b/test/declarative_validation/core/pod/active_deadline_seconds.go
@@ -1,0 +1,136 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/registry/rest"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
+	"k8s.io/utils/ptr"
+)
+
+// RunDeclarativeValidateActiveDeadlineSecondsTestCases exercises the shared
+// spec.activeDeadlineSeconds minimum/maximum declarative validation rules
+// across any type that embeds a PodSpec. This gives each embedding Kind
+// (e.g. ReplicationController, DaemonSet, Deployment, ...) coverage for the
+// rule without duplicating the same test cases in every package.
+func RunDeclarativeValidateActiveDeadlineSecondsTestCases[T runtime.Object](t *testing.T, ctx context.Context, strategy rest.RESTCreateStrategy, specPath *field.Path, baseObj T, setActiveDeadlineSeconds func(baseObj T, val *int64)) {
+	testCases := map[string]struct {
+		input        *int64
+		expectedErrs field.ErrorList
+	}{
+		"unset": {
+			input: nil,
+		},
+		"positive": {
+			input: new(int64(100)),
+		},
+		"max": {
+			input: ptr.To(int64(math.MaxInt32)),
+		},
+		"zero": {
+			input: new(int64(0)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"negative": {
+			input: new(int64(-1)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"over maximum": {
+			input: ptr.To(int64(math.MaxInt32 + 1)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("maximum").MarkAlpha(),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run("activeDeadlineSeconds: "+k, func(t *testing.T) {
+			obj := baseObj.DeepCopyObject().(T)
+			setActiveDeadlineSeconds(obj, tc.input)
+			apitesting.VerifyValidationEquivalence(t, ctx, obj, strategy, tc.expectedErrs)
+		})
+	}
+}
+
+// RunDeclarativeValidateActiveDeadlineSecondsForbiddenTestCases exercises the
+// hand-written (non-declarative) rule that forbids spec.activeDeadlineSeconds
+// on PodSpecs embedded in controllers with an always-restarting pod template
+// (e.g. ReplicationController, DaemonSet, ReplicaSet, StatefulSet). This rule
+// depends on a sibling field's value and isn't expressible as a declarative
+// tag today, so it stays purely imperative. The declarative minimum/maximum
+// shadow-validation still runs independently, so boundary-violating values
+// produce both the declarative error and the imperative Forbidden error.
+func RunDeclarativeValidateActiveDeadlineSecondsForbiddenTestCases[T runtime.Object](t *testing.T, ctx context.Context, strategy rest.RESTCreateStrategy, specPath *field.Path, baseObj T, setActiveDeadlineSeconds func(baseObj T, val *int64)) {
+	forbidden := field.Forbidden(specPath.Child("activeDeadlineSeconds"), "").MarkFromImperative()
+	testCases := map[string]struct {
+		input        *int64
+		expectedErrs field.ErrorList
+	}{
+		"unset": {
+			input: nil,
+		},
+		"positive": {
+			input: new(int64(100)),
+			expectedErrs: field.ErrorList{
+				forbidden,
+			},
+		},
+		"max": {
+			input: ptr.To(int64(math.MaxInt32)),
+			expectedErrs: field.ErrorList{
+				forbidden,
+			},
+		},
+		"zero": {
+			input: new(int64(0)),
+			expectedErrs: field.ErrorList{
+				forbidden,
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"negative": {
+			input: new(int64(-1)),
+			expectedErrs: field.ErrorList{
+				forbidden,
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"over maximum": {
+			input: ptr.To(int64(math.MaxInt32 + 1)),
+			expectedErrs: field.ErrorList{
+				forbidden,
+				field.Invalid(specPath.Child("activeDeadlineSeconds"), nil, "").WithOrigin("maximum").MarkAlpha(),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run("activeDeadlineSeconds: "+k, func(t *testing.T) {
+			obj := baseObj.DeepCopyObject().(T)
+			setActiveDeadlineSeconds(obj, tc.input)
+			apitesting.VerifyValidationEquivalence(t, ctx, obj, strategy, tc.expectedErrs)
+		})
+	}
+}

--- a/test/declarative_validation/core/pod/declarative_validation_test.go
+++ b/test/declarative_validation/core/pod/declarative_validation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -74,6 +75,24 @@ func TestDeclarativeValidate(t *testing.T) {
 				)),
 				expectedErrs: field.ErrorList{
 					field.Invalid(field.NewPath("spec", "tolerations").Index(0).Child("key"), nil, "").WithOrigin("format=k8s-label-key").MarkAlpha(),
+				},
+			},
+			"invalid zero activeDeadlineSeconds": {
+				input: podtest.MakePod("foo", podtest.SetActiveDeadlineSeconds(0)),
+				expectedErrs: field.ErrorList{
+					field.Invalid(field.NewPath("spec", "activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+				},
+			},
+			"invalid negative activeDeadlineSeconds": {
+				input: podtest.MakePod("foo", podtest.SetActiveDeadlineSeconds(-1)),
+				expectedErrs: field.ErrorList{
+					field.Invalid(field.NewPath("spec", "activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+				},
+			},
+			"invalid activeDeadlineSeconds over maximum": {
+				input: podtest.MakePod("foo", podtest.SetActiveDeadlineSeconds(math.MaxInt32+1)),
+				expectedErrs: field.ErrorList{
+					field.Invalid(field.NewPath("spec", "activeDeadlineSeconds"), nil, "").WithOrigin("maximum").MarkAlpha(),
 				},
 			},
 		}

--- a/test/declarative_validation/core/pod/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/pod/zz_generated.validations.v1_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/core/podtemplate/declarative_validation_test.go
+++ b/test/declarative_validation/core/podtemplate/declarative_validation_test.go
@@ -80,6 +80,9 @@ func TestDeclarativeValidate(t *testing.T) {
 			baseObj.Template.Spec.EvictionResponders = responders
 			baseObj.Template.Spec.SchedulingGroup = schedulingGroup
 		})
+		poddeclarativevalidation.RunDeclarativeValidateActiveDeadlineSecondsTestCases(t, ctx, registry.Strategy, field.NewPath("template", "spec"), mkPodTemplate(), func(baseObj *api.PodTemplate, val *int64) {
+			baseObj.Template.Spec.ActiveDeadlineSeconds = val
+		})
 	}
 }
 

--- a/test/declarative_validation/core/podtemplate/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/podtemplate/zz_generated.validations.v1_test.go
@@ -61,6 +61,10 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/core/replicationcontroller/declarative_validation_test.go
+++ b/test/declarative_validation/core/replicationcontroller/declarative_validation_test.go
@@ -218,6 +218,9 @@ func TestDeclarativeValidate(t *testing.T) {
 		baseObj.Spec.Template.Spec.EvictionResponders = responders
 		baseObj.Spec.Template.Spec.SchedulingGroup = schedulingGroup
 	})
+	poddeclarativevalidation.RunDeclarativeValidateActiveDeadlineSecondsForbiddenTestCases(t, ctx, registry.Strategy, field.NewPath("spec", "template", "spec"), new(mkValidReplicationController()), func(baseObj *api.ReplicationController, val *int64) {
+		baseObj.Spec.Template.Spec.ActiveDeadlineSeconds = val
+	})
 }
 
 func TestDeclarativeValidateUpdate(t *testing.T) {

--- a/test/declarative_validation/core/replicationcontroller/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/replicationcontroller/zz_generated.validations.v1_test.go
@@ -71,6 +71,10 @@ func init() {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 				{ErrorType: "FieldValueRequired"},
 			},
+			"spec.template.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "maximum"},
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.template.spec.evictionResponders": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},


### PR DESCRIPTION
/kind feature
/sig api-machinery

This adds declarative validation for `spec.activeDeadlineSeconds` on PodSpec, gated alpha as of 1.37. While working on it I also found and fixed a redundant ObjectMeta validation call on the pod update paths, so that's included here too.

### What changed

`ActiveDeadlineSeconds` now has `+k8s:minimum=1` and `+k8s:maximum=2147483647` alpha markers in `types.go` (and the matching proto comment), with `zz_generated.validations.go` regenerated to match.

The existing hand-written range check in `ValidatePodSpec` is split into separate minimum and maximum branches, each tagged with `WithOrigin(...)` and `MarkCoveredByDeclarative()`, so the imperative and declarative validators don't both report the same error once the declarative path is active. `TerminationGracePeriodSeconds` had the same issue, so it got the same fix.

`validatePodMetadataAndSpec` is split into two functions. The original keeps its behavior (ObjectMeta validation plus spec validation) and is still used by `ValidatePodCreate`. A new `validatePodSpecOnly` does just the spec validation, and is now what `ValidatePodUpdate`, `ValidatePodEphemeralContainersUpdate`, and `ValidatePodResize` call instead. Those three update paths were previously calling the create-path ObjectMeta validator right after `ValidateObjectMetaUpdate` had already run, which is redundant and also runs checks (name/generateName) that don't apply on update. See #140339 for the earlier discussion on this.

### Tests

Added `test/declarative_validation/core/pod/active_deadline_seconds.go` with two shared table-driven helpers.

`RunDeclarativeValidateActiveDeadlineSecondsTestCases` covers the standard boundary cases (unset, positive, at max, zero, negative, over max) for types where the field is allowed.

`RunDeclarativeValidateActiveDeadlineSecondsForbiddenTestCases` covers the same cases for the always-restarting controller types (ReplicationController, DaemonSet, ReplicaSet, StatefulSet), where existing validation already forbids the field entirely. Since the two validators run independently, out-of-range values on these types now produce both the imperative `Forbidden` error and the declarative min/max error, and the tests check for both.

Both helpers are wired into the coverage tests for every PodSpec-embedding type: DaemonSet, Deployment, ReplicaSet, StatefulSet, CronJob, Job, ReplicationController, PodTemplate, and Pod. All generated coverage fixtures were regenerated to match.

### Why the ObjectMeta fix is in this PR

It's unrelated to the declarative validation work but small enough that I didn't think it needed its own PR. Happy to split it out if reviewers would rather keep this scoped to just `ActiveDeadlineSeconds`.

### Testing done

- `go build ./test/declarative_validation/...`
- `go test ./test/declarative_validation/...` and `go test ./pkg/apis/core/validation/...` both pass
- `hack/update-codegen.sh` followed by `git status` came back clean

### Special notes for reviewers

I used Claude (Anthropic) while preparing this PR, mainly to help review the diff before pushing and to help draft this description. All code changes are my own, I understand and can explain every change here, and all testing listed above was run and verified locally by me before submitting. No code(except comments) was generated wholesale by AI.

I'd also like a second opinion on where I placed `MarkCoveredByDeclarative()` on `ActiveDeadlineSeconds` and `TerminationGracePeriodSeconds`, specifically splitting the single range check into origin-tagged minimum/maximum branches. If there's a preferred pattern for this I'm happy to adjust.

```release-note
Add alpha declarative validation for PodSpec.activeDeadlineSeconds, gated behind the +k8s:alpha(since: "1.37") marker.
```