### PR TITLE
kubelet: rollback in-memory pod allocation on checkpoint write failure

### DIFF
--- a/pkg/kubelet/allocation/allocation_manager.go
+++ b/pkg/kubelet/allocation/allocation_manager.go
@@ -18,6 +18,7 @@ package allocation
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -580,8 +581,9 @@ func (m *manager) AddPod(ctx context.Context, activePods []*v1.Pod, pod *v1.Pod)
 	if ok && utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScaling) {
 		// Checkpoint the resource values at which the Pod has been admitted or resized.
 		if err := m.SetAllocatedResources(logger, pod); err != nil {
-			// TODO(vinaykul,InPlacePodVerticalScaling): Can we recover from this in some way? Investigate
+			m.RemovePod(logger, pod.UID)
 			logger.Error(err, "SetPodAllocation failed", "pod", klog.KObj(pod))
+			return false, lifecycle.UnexpectedAdmissionError, fmt.Sprintf("failed to checkpoint pod allocation: %v", err)
 		}
 	}
 

--- a/pkg/kubelet/allocation/allocation_manager_test.go
+++ b/pkg/kubelet/allocation/allocation_manager_test.go
@@ -19,6 +19,7 @@ package allocation
 import (
 	"context"
 	"fmt"
+	"os"
 	goruntime "runtime"
 	"strings"
 	"testing"
@@ -3691,4 +3692,91 @@ func setupNonAllocatedCapacityTest(t *testing.T) (Manager, *v1.Pod, *v1.Pod, klo
 	})
 
 	return allocationManager, runningPod, pendingPod, logger
+}
+
+
+// TestAddPodCheckpointFailure verifies that AddPod fails admission and rolls back
+// the in-memory allocation when the checkpoint write fails, preventing state desynchronization.
+func TestAddPodCheckpointFailure(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScaling, true)
+	logger, _ := ktesting.NewTestContext(t)
+
+	checkpointDir, err := os.MkdirTemp("", "allocation_manager_checkpoint_test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(checkpointDir)
+	})
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       "test-pod-uid",
+			Name:      "test-pod",
+			Namespace: "default",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name: "c1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("100m"),
+							v1.ResourceMemory: resource.MustParse("128Mi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	activePods := []*v1.Pod{pod}
+
+	// Build a manager with a real checkpoint state so we can trigger a checkpoint failure.
+	allocatedState, err := state.NewStateCheckpoint(logger, checkpointDir, "test_checkpoint")
+	require.NoError(t, err)
+
+	// Inject failing checkpoint manager into the underlying state.
+	// Since state.State hides internal fields, we test stateCheckpoint failure via state interface.
+	statusManager := status.NewManager(&fake.Clientset{}, kubepod.NewBasicPodManager(), &statustest.FakePodDeletionSafetyProvider{}, kubeletutil.NewPodStartupLatencyTracker())
+	m := &manager{
+		allocated:      allocatedState,
+		admitHandlers:  lifecycle.PodAdmitHandlers{},
+		sourcesReady:   config.NewSourcesReady(func(_ sets.Set[string]) bool { return true }),
+		ticker:         time.NewTicker(initialRetryDelay),
+		triggerPodSync: func(_ context.Context, _ *v1.Pod) {},
+		getActivePods:  func() []*v1.Pod { return activePods },
+		getPodByUID: func(uid types.UID) (*v1.Pod, bool) {
+			for _, p := range activePods {
+				if p.UID == uid {
+					return p, true
+				}
+			}
+			return nil, false
+		},
+		statusManager: statusManager,
+		recorder:      record.NewFakeRecorder(10),
+	}
+
+	// Create a failing state wrapper
+	m.allocated = &failingState{
+		State: allocatedState,
+	}
+
+	ok, reason, message := m.AddPod(context.Background(), activePods, pod)
+
+	// Admission must fail: a checkpoint write failure must not silently allow the pod.
+	assert.False(t, ok, "AddPod must return false when checkpoint write fails")
+	assert.NotEmpty(t, reason, "AddPod must return a non-empty reason on checkpoint failure")
+	assert.NotEmpty(t, message, "AddPod must return a non-empty message on checkpoint failure")
+
+	// The in-memory allocation must have been rolled back.
+	_, found := m.allocated.GetPodResourceInfo(pod.UID)
+	assert.False(t, found, "pod allocation must not remain in cache after checkpoint write failure")
+}
+
+type failingState struct {
+	state.State
+}
+
+func (f *failingState) SetPodResourceInfo(logger klog.Logger, podUID types.UID, resourceInfo state.PodResourceInfo) error {
+	_ = f.State.SetPodResourceInfo(logger, podUID, resourceInfo)
+	return fmt.Errorf("injected checkpoint write failure")
 }

--- a/pkg/kubelet/allocation/state/state_checkpoint.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint.go
@@ -141,26 +141,73 @@ func (sc *stateCheckpoint) GetPodResourceInfo(podUID types.UID) (PodResourceInfo
 	return sc.cache.GetPodResourceInfo(podUID)
 }
 
-// SetContainerResoruces sets resources information for a pod's container
+
+func (sc *stateCheckpoint) getPodResourceInfoCopy(podUID types.UID) (PodResourceInfo, bool) {
+	oldInfo, oldFound := sc.cache.GetPodResourceInfo(podUID)
+	if !oldFound {
+		return PodResourceInfo{}, false
+	}
+	newInfo := PodResourceInfo{
+		ContainerResources: make(map[string]v1.ResourceRequirements, len(oldInfo.ContainerResources)),
+		PodLevelResources:  oldInfo.PodLevelResources.DeepCopy(),
+	}
+	for k, v := range oldInfo.ContainerResources {
+		newInfo.ContainerResources[k] = *v.DeepCopy()
+	}
+	if oldInfo.EmptyDirVolumeLimits != nil {
+		newInfo.EmptyDirVolumeLimits = make(map[string]*resource.Quantity, len(oldInfo.EmptyDirVolumeLimits))
+		for k, v := range oldInfo.EmptyDirVolumeLimits {
+			if v != nil {
+				q := v.DeepCopy()
+				newInfo.EmptyDirVolumeLimits[k] = &q
+			} else {
+				newInfo.EmptyDirVolumeLimits[k] = nil
+			}
+		}
+	}
+	return newInfo, true
+}
+
+// revertPodResourceInfo restores the in-memory cache to the previous state for a pod
+// when a checkpoint write fails, preventing a split-brain between memory and disk.
+func (sc *stateCheckpoint) revertPodResourceInfo(logger klog.Logger, podUID types.UID, oldInfo PodResourceInfo, oldFound bool) {
+	if oldFound {
+		_ = sc.cache.SetPodResourceInfo(logger, podUID, oldInfo)
+	} else {
+		_ = sc.cache.RemovePod(logger, podUID)
+	}
+}
+
+// SetContainerResources sets resources information for a pod's container
 func (sc *stateCheckpoint) SetContainerResources(logger klog.Logger, podUID types.UID, containerName string, resources v1.ResourceRequirements) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
+	oldInfo, oldFound := sc.getPodResourceInfoCopy(podUID)
 	err := sc.cache.SetContainerResources(logger, podUID, containerName, resources)
 	if err != nil {
 		return err
 	}
-	return sc.storeState(logger)
+	if err := sc.storeState(logger); err != nil {
+		sc.revertPodResourceInfo(logger, podUID, oldInfo, oldFound)
+		return err
+	}
+	return nil
 }
 
 // SetPodLevelResources sets resources information for a pod's resources at pod-level.
 func (sc *stateCheckpoint) SetPodLevelResources(logger klog.Logger, podUID types.UID, resInfo *v1.ResourceRequirements) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
+	oldInfo, oldFound := sc.getPodResourceInfoCopy(podUID)
 	err := sc.cache.SetPodLevelResources(logger, podUID, resInfo)
 	if err != nil {
 		return err
 	}
-	return sc.storeState(logger)
+	if err := sc.storeState(logger); err != nil {
+		sc.revertPodResourceInfo(logger, podUID, oldInfo, oldFound)
+		return err
+	}
+	return nil
 }
 
 // SetEmptyDirVolumeLimit sets the size limit for a pod's emptyDir volume.
@@ -168,22 +215,32 @@ func (sc *stateCheckpoint) SetEmptyDirVolumeLimit(podUID types.UID, volumeName s
 	logger := klog.TODO()
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
+	oldInfo, oldFound := sc.getPodResourceInfoCopy(podUID)
 	err := sc.cache.SetEmptyDirVolumeLimit(podUID, volumeName, limit)
 	if err != nil {
 		return err
 	}
-	return sc.storeState(logger)
+	if err := sc.storeState(logger); err != nil {
+		sc.revertPodResourceInfo(logger, podUID, oldInfo, oldFound)
+		return err
+	}
+	return nil
 }
 
 // SetPodResourceInfo sets pod resource information
 func (sc *stateCheckpoint) SetPodResourceInfo(logger klog.Logger, podUID types.UID, resourceInfo PodResourceInfo) error {
 	sc.mux.Lock()
 	defer sc.mux.Unlock()
+	oldInfo, oldFound := sc.getPodResourceInfoCopy(podUID)
 	err := sc.cache.SetPodResourceInfo(logger, podUID, resourceInfo)
 	if err != nil {
 		return err
 	}
-	return sc.storeState(logger)
+	if err := sc.storeState(logger); err != nil {
+		sc.revertPodResourceInfo(logger, podUID, oldInfo, oldFound)
+		return err
+	}
+	return nil
 }
 
 // Delete deletes resource information for specified pod

--- a/pkg/kubelet/allocation/state/state_checkpoint_test.go
+++ b/pkg/kubelet/allocation/state/state_checkpoint_test.go
@@ -26,6 +26,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 )
@@ -317,4 +318,118 @@ func Test_stateCheckpoint_formatUpgraded(t *testing.T) {
 	actualPodResourceAllocation = sc.cache.GetPodResourceInfoMap()
 
 	require.Equal(t, expectedPodResourceAllocation, actualPodResourceAllocation, "pod resource allocation info is not equal")
+}
+
+type failCheckpointManager struct {
+	checkpointmanager.CheckpointManager
+}
+
+func (f *failCheckpointManager) CreateCheckpoint(checkpointName string, checkpoint checkpointmanager.Checkpoint) error {
+	return fmt.Errorf("injected checkpoint write failure")
+}
+
+// Test_stateCheckpoint_rollbackOnStoreFailure verifies that when storeState fails,
+// Set* methods revert the in-memory cache to its previous state, preventing a split-brain between memory and disk.
+func Test_stateCheckpoint_rollbackOnStoreFailure(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	podUID := types.UID("pod-1")
+	containerName := "c1"
+	initialResources := v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("100m"),
+			v1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+	}
+	updatedResources := v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceCPU:    resource.MustParse("500m"),
+			v1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+
+	t.Run("SetPodResourceInfo reverts cache on storeState failure", func(t *testing.T) {
+		testDir := getTestDir(t)
+		scState, err := NewStateCheckpoint(logger, testDir, testCheckpoint)
+		require.NoError(t, err)
+		sc := scState.(*stateCheckpoint)
+
+		// Set initial state that is successfully persisted.
+		initialInfo := PodResourceInfo{
+			ContainerResources: map[string]v1.ResourceRequirements{
+				containerName: initialResources,
+			},
+		}
+		require.NoError(t, sc.SetPodResourceInfo(logger, podUID, initialInfo))
+
+		// Inject failing checkpoint manager.
+		sc.checkpointManager = &failCheckpointManager{CheckpointManager: sc.checkpointManager}
+
+		// Attempt to update; expect failure.
+		updatedInfo := PodResourceInfo{
+			ContainerResources: map[string]v1.ResourceRequirements{
+				containerName: updatedResources,
+			},
+		}
+		err = sc.SetPodResourceInfo(logger, podUID, updatedInfo)
+		require.Error(t, err, "expected SetPodResourceInfo to fail when storeState fails")
+
+		// In-memory cache must reflect the original state, not the failed update.
+		inMemory, found := sc.GetPodResourceInfo(podUID)
+		require.True(t, found)
+		require.Equal(t, initialInfo, inMemory, "cache must be reverted to pre-update state on storeState failure")
+	})
+
+	t.Run("SetContainerResources reverts cache on storeState failure", func(t *testing.T) {
+		testDir := getTestDir(t)
+		scState, err := NewStateCheckpoint(logger, testDir, testCheckpoint)
+		require.NoError(t, err)
+		sc := scState.(*stateCheckpoint)
+
+		// Persist initial state.
+		initialInfo := PodResourceInfo{
+			ContainerResources: map[string]v1.ResourceRequirements{
+				containerName: initialResources,
+			},
+		}
+		require.NoError(t, sc.SetPodResourceInfo(logger, podUID, initialInfo))
+
+		// Inject failing checkpoint manager.
+		sc.checkpointManager = &failCheckpointManager{CheckpointManager: sc.checkpointManager}
+
+		err = sc.SetContainerResources(logger, podUID, containerName, updatedResources)
+		require.Error(t, err)
+
+		inMemory, found := sc.GetPodResourceInfo(podUID)
+		require.True(t, found)
+		require.Equal(t, initialResources, inMemory.ContainerResources[containerName], "container resources must be reverted on storeState failure")
+	})
+
+	t.Run("SetPodResourceInfo for new pod removes entry on storeState failure", func(t *testing.T) {
+		testDir := getTestDir(t)
+		scState, err := NewStateCheckpoint(logger, testDir, testCheckpoint)
+		require.NoError(t, err)
+		sc := scState.(*stateCheckpoint)
+
+		// Persist initial state for another pod so the checkpoint file already exists.
+		require.NoError(t, sc.SetPodResourceInfo(logger, "other-pod", PodResourceInfo{
+			ContainerResources: map[string]v1.ResourceRequirements{
+				containerName: initialResources,
+			},
+		}))
+
+		// Inject failing checkpoint manager.
+		sc.checkpointManager = &failCheckpointManager{CheckpointManager: sc.checkpointManager}
+
+		// Attempt to add a brand-new pod entry; should fail and be removed from cache.
+		err = sc.SetPodResourceInfo(logger, "new-pod", PodResourceInfo{
+			ContainerResources: map[string]v1.ResourceRequirements{
+				containerName: updatedResources,
+			},
+		})
+		require.Error(t, err)
+
+		_, found := sc.GetPodResourceInfo("new-pod")
+		require.False(t, found, "new pod entry must be removed from cache on storeState failure")
+	})
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When the Kubelet allocation manager attempts to persist a pod's resource allocation during admission, failures in writing the checkpoint to disk (such as a read-only filesystem, I/O errors, or disk full) were handled as "best-effort" (log only) and did not fail admission. This allowed Kubelet's in-memory state to consider the pod admitted, while Kubelet's disk state lacked the checkpoint. Upon Kubelet restart, the state was lost, leading to leaked in-memory allocations ("ghost pod" resource leaks) and unexpected admission starvation on subsequent pods.

This PR refactors the allocation state checkpointing to be transactional:
1. `AddPod` now fails admission and returns a `UnexpectedAdmissionError` if `SetAllocatedResources` fails.
2. If `SetAllocatedResources` fails admission, the in-memory pod allocation is rolled back via `RemovePod` to prevent state desynchronization.
3. The underlying `stateCheckpoint`'s methods (`SetContainerResources`, `SetPodLevelResources`, `SetEmptyDirVolumeLimit`, and `SetPodResourceInfo`) are refactored to preserve the original state and atomically revert the in-memory cache to its previous state if the checkpoint write (`storeState`) fails.
4. Unit tests are added to verify that the cache is properly rolled back upon checkpoint manager failures.

#### Which issue(s) this PR is related to:

Fixes #141206

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Fix Kubelet resource allocation desynchronization by failing pod admission and reverting in-memory resource allocations if writing the allocation checkpoint to disk fails.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None
