### PR TITLE
Use errors.As for unwrapping in ErrorToAPIStatus and storage.isErrCode

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status.go
@@ -17,6 +17,7 @@ limitations under the License.
 package responsewriters
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -25,15 +26,15 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 )
 
-// statusError is an object that can be converted into an metav1.Status
+// statusError is an object that can be converted into a metav1.Status
 type statusError interface {
 	Status() metav1.Status
 }
 
-// ErrorToAPIStatus converts an error to an metav1.Status object.
+// ErrorToAPIStatus converts an error to a metav1.Status object.
 func ErrorToAPIStatus(err error) *metav1.Status {
-	switch t := err.(type) {
-	case statusError:
+	var t statusError
+	if errors.As(err, &t) {
 		status := t.Status()
 		if len(status.Status) == 0 {
 			status.Status = metav1.StatusFailure
@@ -57,27 +58,26 @@ func ErrorToAPIStatus(err error) *metav1.Status {
 		status.APIVersion = "v1"
 		//TODO: check for invalid responses
 		return &status
-	default:
-		status := http.StatusInternalServerError
-		switch {
-		//TODO: replace me with NewConflictErr
-		case storage.IsConflict(err):
-			status = http.StatusConflict
-		}
-		// Log errors that were not converted to an error status
-		// by REST storage - these typically indicate programmer
-		// error by not using pkg/api/errors, or unexpected failure
-		// cases.
-		runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %#+v: %v", err, err))
-		return &metav1.Status{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Status",
-				APIVersion: "v1",
-			},
-			Status:  metav1.StatusFailure,
-			Code:    int32(status),
-			Reason:  metav1.StatusReasonUnknown,
-			Message: err.Error(),
-		}
+	}
+
+	status := http.StatusInternalServerError
+	//TODO: replace me with NewConflictErr
+	if storage.IsConflict(err) {
+		status = http.StatusConflict
+	}
+	// Log errors that were not converted to an error status
+	// by REST storage - these typically indicate programmer
+	// error by not using pkg/api/errors, or unexpected failure
+	// cases.
+	runtime.HandleError(fmt.Errorf("apiserver received an error that is not an metav1.Status: %w (type %T)", err, err))
+	return &metav1.Status{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Status",
+			APIVersion: "v1",
+		},
+		Status:  metav1.StatusFailure,
+		Code:    int32(status),
+		Reason:  metav1.StatusReasonUnknown,
+		Message: err.Error(),
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/status_test.go
@@ -18,6 +18,7 @@ package responsewriters
 
 import (
 	stderrs "errors"
+	"fmt"
 	"net/http"
 	"reflect"
 	"testing"
@@ -37,6 +38,35 @@ func TestBadStatusErrorToAPIStatus(t *testing.T) {
 	}
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("%s: Expected %#v, Got %#v", actual, expected, actual)
+	}
+}
+
+func TestWrappedStatusErrorToAPIStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want metav1.Status
+	}{
+		{
+			name: "wrapped NotFound",
+			err:  fmt.Errorf("additional context: %w", errors.NewNotFound(schema.GroupResource{Resource: "pods"}, "test")),
+			want: metav1.Status{
+				TypeMeta: metav1.TypeMeta{Kind: "Status", APIVersion: "v1"},
+				Status:   metav1.StatusFailure,
+				Code:     http.StatusNotFound,
+				Reason:   metav1.StatusReasonNotFound,
+				Message:  `pods "test" not found`,
+				Details:  &metav1.StatusDetails{Kind: "pods", Name: "test"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := ErrorToAPIStatus(tc.err)
+			if !reflect.DeepEqual(actual, &tc.want) {
+				t.Errorf("Expected %#v, Got %#v", tc.want, *actual)
+			}
+		})
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/errors.go
@@ -171,11 +171,9 @@ func IsCorruptObject(err error) bool {
 }
 
 func isErrCode(err error, code int) bool {
-	if err == nil {
-		return false
-	}
-	if e, ok := err.(*StorageError); ok {
-		return e.Code == code
+	var storageErr *StorageError
+	if errors.As(err, &storageErr) {
+		return storageErr.Code == code
 	}
 	return false
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/errors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/errors_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsErrCodeWithWrappedErrors(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		check  func(error) bool
+		expect bool
+	}{
+		{
+			name:   "wrapped NotFound",
+			err:    fmt.Errorf("context: %w", NewKeyNotFoundError("/foo", 0)),
+			check:  IsNotFound,
+			expect: true,
+		},
+		{
+			name:   "wrapped Conflict",
+			err:    fmt.Errorf("context: %w", NewResourceVersionConflictsError("/foo", 1)),
+			check:  IsConflict,
+			expect: true,
+		},
+		{
+			name:   "wrapped KeyExists",
+			err:    fmt.Errorf("context: %w", NewKeyExistsError("/foo", 0)),
+			check:  IsExist,
+			expect: true,
+		},
+		{
+			name:   "wrapped error with wrong code does not match",
+			err:    fmt.Errorf("context: %w", NewKeyNotFoundError("/foo", 0)),
+			check:  IsConflict,
+			expect: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.check(tc.err); got != tc.expect {
+				t.Errorf("got %v, want %v", got, tc.expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Replace direct type assertions with `errors.As` so that wrapped errors are correctly identified. This makes `ErrorToAPIStatus` find `statusError` implementations inside error chains, and makes `storage.IsConflict`, `IsNotFound`, and related helpers recognize wrapped `StorageErrors`.

This is convenient for anybody using these helper functions outside Kubernetes as well.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A
