### PR TITLE
Migrate ResourceQuota.Spec.Scopes to declarative validation

### DIFF
--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -1888,8 +1888,73 @@ func Validate_ResourceQuota(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field corev1.ResourceQuota.Spec has no validation
+	{ // field corev1.ResourceQuota.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *corev1.ResourceQuotaSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_ResourceQuotaSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *corev1.ResourceQuota) *corev1.ResourceQuotaSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
+
 	// field corev1.ResourceQuota.Status has no validation
+	return errs
+}
+
+// Validate_ResourceQuotaSpec validates an instance of ResourceQuotaSpec according
+// to declarative validation rules in the API schema.
+func Validate_ResourceQuotaSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *corev1.ResourceQuotaSpec) (errs field.ErrorList) {
+
+	// field corev1.ResourceQuotaSpec.Hard has no validation
+
+	{ // field corev1.ResourceQuotaSpec.Scopes
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj []corev1.ResourceQuotaScope,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *corev1.ResourceQuotaSpec) []corev1.ResourceQuotaScope {
+				return oldObj.Scopes
+			})
+		errs = append(errs, fn(fldPath.Child("scopes"), obj.Scopes, oldVal, oldObj != nil)...)
+	}
+
+	// field corev1.ResourceQuotaSpec.ScopeSelector has no validation
 	return errs
 }
 

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -8569,7 +8569,7 @@ func ValidateResourceQuotaUpdate(newResourceQuota, oldResourceQuota *core.Resour
 		oldScopes.Insert(string(scope))
 	}
 	if !oldScopes.Equal(newScopes) {
-		allErrs = append(allErrs, field.Invalid(fldPath, newResourceQuota.Spec.Scopes, fieldImmutableErrorMsg))
+		allErrs = append(allErrs, field.Invalid(fldPath, newResourceQuota.Spec.Scopes, fieldImmutableErrorMsg).WithOrigin("immutable").MarkCoveredByDeclarative())
 	}
 
 	return allErrs

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -5876,6 +5876,8 @@ message ResourceQuotaSpec {
   // If not specified, the quota matches all objects.
   // +optional
   // +listType=atomic
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:immutable
   repeated string scopes = 2;
 
   // scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -8182,6 +8182,8 @@ type ResourceQuotaSpec struct {
 	// If not specified, the quota matches all objects.
 	// +optional
 	// +listType=atomic
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:immutable
 	Scopes []ResourceQuotaScope `json:"scopes,omitempty" protobuf:"bytes,2,rep,name=scopes,casttype=ResourceQuotaScope"`
 	// scopeSelector is also a collection of filters like scopes that must match each object tracked by a quota
 	// but expressed using ScopeSelectorOperator in combination with possible values.

--- a/test/declarative_validation/core/resourcequota/declarative_validation_test.go
+++ b/test/declarative_validation/core/resourcequota/declarative_validation_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	core "k8s.io/kubernetes/pkg/apis/core"
 	registry "k8s.io/kubernetes/pkg/registry/core/resourcequota"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
@@ -69,14 +71,63 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 
 	updateObj := mkValidResourceQuota()
 	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+
+	testCases := map[string]struct {
+		oldObj       core.ResourceQuota
+		updateObj    core.ResourceQuota
+		expectedErrs field.ErrorList
+	}{
+		"valid update": {
+			oldObj:    mkValidResourceQuota(tweakScopes(core.ResourceQuotaScopeBestEffort)),
+			updateObj: mkValidResourceQuota(tweakScopes(core.ResourceQuotaScopeBestEffort)),
+		},
+		"scopes changed": {
+			oldObj:    mkValidResourceQuota(tweakScopes(core.ResourceQuotaScopeBestEffort)),
+			updateObj: mkValidResourceQuota(tweakScopes(core.ResourceQuotaScopeNotBestEffort)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("scopes"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"scopes set from unset": {
+			oldObj:    mkValidResourceQuota(),
+			updateObj: mkValidResourceQuota(tweakScopes(core.ResourceQuotaScopeBestEffort)),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("scopes"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+		"scopes unset from set": {
+			oldObj:    mkValidResourceQuota(tweakScopes(core.ResourceQuotaScopeBestEffort)),
+			updateObj: mkValidResourceQuota(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec").Child("scopes"), nil, "").WithOrigin("immutable").MarkAlpha(),
+			},
+		},
+	}
+	for k, tc := range testCases {
+		t.Run(k, func(t *testing.T) {
+			tc.oldObj.ResourceVersion = "1"
+			tc.updateObj.ResourceVersion = "2"
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, &tc.updateObj, &tc.oldObj, registry.Strategy, tc.expectedErrs)
+		})
+	}
 }
 
-func mkValidResourceQuota() core.ResourceQuota {
-	return core.ResourceQuota{
+func mkValidResourceQuota(tweaks ...func(*core.ResourceQuota)) core.ResourceQuota {
+	obj := core.ResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "valid-obj",
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: core.ResourceQuotaSpec{},
+	}
+	for _, tweak := range tweaks {
+		tweak(&obj)
+	}
+	return obj
+}
+
+func tweakScopes(scopes ...core.ResourceQuotaScope) func(*core.ResourceQuota) {
+	return func(obj *core.ResourceQuota) {
+		obj.Spec.Scopes = scopes
 	}
 }

--- a/test/declarative_validation/core/resourcequota/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/resourcequota/zz_generated.validations.v1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.scopes": {
+				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
+			},
 		},
 	)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

Migrates the immutability validation of `ResourceQuota.Spec.Scopes` to declarative validation, following the pattern of previous migrations from the tracking issue:

- Adds `+k8s:alpha(since: "1.37")=+k8s:optional` and `+k8s:alpha(since: "1.37")=+k8s:immutable` to the versioned type.
- Regenerates `zz_generated.validations.go` and the coverage fixture.
- Marks the handwritten check in `ValidateResourceQuotaUpdate` with `.WithOrigin("immutable").MarkCoveredByDeclarative()`.
- Adds equivalence test cases (changed, set from unset, unset from set) to `test/declarative_validation/core/resourcequota`, all passing under both DeclarativeValidationBeta gate states.

#### Which issue(s) this PR is related to:

Part of #136785

#### Special notes for your reviewer:

One semantic difference worth flagging: the handwritten check compares old and new scopes as sets (order-insensitive), while the declarative `+k8s:immutable` rule uses deep equality (order-sensitive). An update that only reorders `spec.scopes` is accepted by handwritten validation but would be flagged by the declarative rule, showing up as a mismatch metric while the rule is in alpha shadow mode. I kept `+k8s:immutable` since a reorder-only update of quota scopes seems degenerate in practice, but happy to adjust if you would rather handle the set semantics differently.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
