### PR TITLE
Strict cpu exhaustion fix

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -64,7 +64,7 @@ dependencies:
 
   # etcd
   - name: "etcd"
-    version: 3.7.0
+    version: 3.7.1
     refPaths:
     - path: cluster/gce/manifests/etcd.manifest
       match: etcd_docker_tag|etcd_version

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -18,7 +18,7 @@
     {
     "name": "etcd-container",
     {{security_context}}
-    "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.7.0-0') }}",
+        "image": "{{ pillar.get('etcd_docker_repository', 'registry.k8s.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.7.1-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -43,7 +43,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.7.0') }}"
+        "value": "{{ pillar.get('etcd_version', '3.7.1') }}"
       },
       {
         "name": "DO_NOT_MOVE_BINARIES",

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,8 +170,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.7.0-0
-export ETCD_VERSION=3.7.0
+export ETCD_IMAGE=3.7.1-0
+export ETCD_VERSION=3.7.1
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -327,7 +327,7 @@ const (
 	MinExternalEtcdVersion = "3.5.24-0"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.7.0-0"
+	DefaultEtcdVersion = "3.7.1-0"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
@@ -509,9 +509,9 @@ var (
 	// an etcd version even if the map is not yet updated before a release. The user will
 	// get a warning in that case, so ideally the map should be updated for each release.
 	SupportedEtcdVersion = map[uint8]string{
-		34: "3.7.0-0",
-		35: "3.7.0-0",
-		36: "3.7.0-0",
+		34: "3.7.1-0",
+		35: "3.7.1-0",
+		36: "3.7.1-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.7.0}
+ETCD_VERSION=${ETCD_VERSION:-3.7.1}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 # This is intentionally not called ETCD_LOG_LEVEL:

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -724,8 +724,13 @@ func (p *staticPolicy) allocateCPUs(logger klog.Logger, s state.State, numCPUs i
 	result.CPUs = result.CPUs.Union(remainingCPUs)
 	result.Aligned = p.topology.CheckAlignment(result.CPUs)
 
+	updatedDefaultCPUSet := s.GetDefaultCPUSet().Difference(result.CPUs)
+	if p.options.StrictCPUReservation && updatedDefaultCPUSet.IsEmpty() {
+		return topology.EmptyAllocation(), fmt.Errorf("refusing to allocate %d exclusive CPUs because it would leave the shared CPU pool empty", numCPUs)
+	}
+
 	// Remove allocated CPUs from the shared CPUSet.
-	s.SetDefaultCPUSet(s.GetDefaultCPUSet().Difference(result.CPUs))
+	s.SetDefaultCPUSet(updatedDefaultCPUSet)
 
 	logger.Info("AllocateCPUs", "result", result.String())
 	return result, nil

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -753,6 +753,34 @@ func runStaticPolicyTestCaseWithFeatureGate(t *testing.T, testCase staticPolicyT
 	runStaticPolicyTestCase(t, testCase)
 }
 
+func TestStaticPolicyAllocatePreservesSharedCPU(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	policy, err := NewStaticPolicy(
+		logger,
+		topoSingleSocketHT,
+		1,
+		cpuset.New(0),
+		topologymanager.NewFakeManager(logger),
+		map[string]string{StrictCPUReservationOption: "true"},
+	)
+	require.NoError(t, err)
+
+	sharedCPUs := cpuset.New(1, 2, 3, 4, 5, 6, 7)
+	sharedCPUCount := sharedCPUs.Size()
+	st := &mockState{
+		assignments:   state.ContainerCPUAssignments{},
+		defaultCPUSet: sharedCPUs,
+	}
+	pod := makePod("testPod", "testContainer", "7000m", "7000m")
+	container := &pod.Spec.Containers[0]
+
+	err = policy.Allocate(logger, st, pod, container, lifecycle.AddOperation)
+	require.EqualError(t, err, fmt.Sprintf("refusing to allocate %d exclusive CPUs because it would leave the shared CPU pool empty", sharedCPUCount))
+	require.True(t, st.GetDefaultCPUSet().Equals(sharedCPUs), "default CPUSet changed after rejected allocation")
+	_, assigned := st.GetCPUSet(string(pod.UID), container.Name)
+	require.False(t, assigned, "container received CPUs after rejected allocation")
+}
+
 func TestStaticPolicyAllocateRecordsBaseline(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.InPlacePodVerticalScalingExclusiveCPUs, true)
 

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/deployment.yaml
@@ -26,4 +26,4 @@ spec:
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]
       - name: etcd
-        image: registry.k8s.io/etcd:v3.7.0
+        image: registry.k8s.io/etcd:v3.7.1

--- a/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: etcd
-        image: registry.k8s.io/etcd:3.7.0-0
+        image: registry.k8s.io/etcd:3.7.1-0
         imagePullPolicy: Always
         ports:
         - containerPort: 2380

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -217,7 +217,7 @@ func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}
 	configs[BusyBox] = Config{list.PromoterE2eRegistry, "busybox", "1.37.0-2"}
 	configs[DistrolessIptables] = Config{list.BuildImageRegistry, "distroless-iptables", "v0.9.6"}
-	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.7.0-0"}
+	configs[Etcd] = Config{list.GcEtcdRegistry, "etcd", "3.7.1-0"}
 	configs[InvalidRegistryImage] = Config{list.InvalidRegistry, "alpine", "3.1"}
 	configs[IpcUtils] = Config{list.PromoterE2eRegistry, "ipc-utils", "1.4"}
 	configs[GlibcDnsTesting] = Config{list.PromoterE2eRegistry, "glibc-dns-testing", "2.1.1"}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/141196

This change fixes strict-cpu-reservation bug in CPUManager to prevent exclusive CPU allocations from exhausting shared pool

/kind bug

```release-note
NONE
```
