### PR TITLE
Update CoreDNS ito 1.14.6

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -31,7 +31,7 @@ dependencies:
 
   # CoreDNS
   - name: "coredns-kube-up"
-    version: 1.13.1
+    version: 1.14.6
     refPaths:
     - path: cluster/addons/dns/coredns/coredns.yaml.base
       match: registry.k8s.io/coredns
@@ -41,7 +41,7 @@ dependencies:
       match: registry.k8s.io/coredns
 
   - name: "coredns-kubeadm"
-    version: 1.13.1
+    version: 1.14.6
     refPaths:
     - path: cmd/kubeadm/app/constants/constants.go
       match: CoreDNSVersion =

--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -133,7 +133,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.13.1
+        image: registry.k8s.io/coredns/coredns:v1.14.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -133,7 +133,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.13.1
+        image: registry.k8s.io/coredns/coredns:v1.14.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -133,7 +133,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: registry.k8s.io/coredns/coredns:v1.13.1
+        image: registry.k8s.io/coredns/coredns:v1.14.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -369,7 +369,7 @@ const (
 	CoreDNSImageName = "coredns"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
-	CoreDNSVersion = "v1.13.1"
+	CoreDNSVersion = "v1.14.6"
 
 	// ClusterConfigurationKind is the string kind value for the ClusterConfiguration struct
 	ClusterConfigurationKind = "ClusterConfiguration"

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/blang/semver/v4 v4.0.0
 	github.com/container-storage-interface/spec v1.9.0
-	github.com/coredns/corefile-migration v1.0.29
+	github.com/coredns/corefile-migration v1.0.34
 	github.com/coreos/go-oidc v2.3.0+incompatible
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.6

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/containerd/typeurl/v2 v2.2.3 h1:yNA/94zxWdvYACdYO8zofhrTVuQY73fFU1y++
 github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
 github.com/coredns/caddy v1.1.1 h1:2eYKZT7i6yxIfGP3qLJoJ7HAsDJqYB+X68g4NYjSrE0=
 github.com/coredns/caddy v1.1.1/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
-github.com/coredns/corefile-migration v1.0.29 h1:g4cPYMXXDDs9uLE2gFYrJaPBuUAR07eEMGyh9JBE13w=
-github.com/coredns/corefile-migration v1.0.29/go.mod h1:56DPqONc3njpVPsdilEnfijCwNGC3/kTJLl7i7SPavY=
+github.com/coredns/corefile-migration v1.0.34 h1:Evzog/Av6/EQVy/xEAVZo2wsYAWMirIlunDfXxLg5Hk=
+github.com/coredns/corefile-migration v1.0.34/go.mod h1:56DPqONc3njpVPsdilEnfijCwNGC3/kTJLl7i7SPavY=
 github.com/coreos/go-oidc v2.3.0+incompatible h1:+5vEsrgprdLjjQ9FzIKAzQz1wwPD+83hQRfUIPh7rO0=
 github.com/coreos/go-oidc v2.3.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=

--- a/vendor/github.com/coredns/corefile-migration/migration/versions.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/versions.go
@@ -30,7 +30,49 @@ type release struct {
 
 // Versions holds a map of plugin/option migrations per CoreDNS release (since 1.1.4)
 var Versions = map[string]release{
+	"1.14.6": {
+		priorVersion:   "1.14.4",
+		dockerImageSHA: "900f9c109f7a33545d3c811516e8376df9019147b750f5ce3e254468769176ea",
+		plugins:        plugins_1_14_0,
+	},
+	"1.14.4": {
+		nextVersion:    "1.14.6",
+		priorVersion:   "1.14.3",
+		dockerImageSHA: "3e98f280fd601b37411c5fb7075fd9f337833c480f1644970b727ae0af067782",
+		plugins:        plugins_1_14_0,
+	},
+	"1.14.3": {
+		nextVersion:    "1.14.4",
+		priorVersion:   "1.14.2",
+		dockerImageSHA: "b21d26b915e10acb5bc78715c1e8b6047ab2675389b2bcc18b3a6499d90e74c0",
+		plugins:        plugins_1_14_0,
+	},
+	"1.14.2": {
+		nextVersion:    "1.14.3",
+		priorVersion:   "1.14.1",
+		dockerImageSHA: "fd5079792b93909db3adefa91e41c3995455013394f0197c7346786ae19079fc",
+		plugins:        plugins_1_14_0,
+	},
+	"1.14.1": {
+		nextVersion:    "1.14.2",
+		priorVersion:   "1.14.0",
+		dockerImageSHA: "82b57287b29beb757c740dbbe68f2d4723da94715b563fffad5c13438b71b14a",
+		plugins:        plugins_1_14_0,
+	},
+	"1.14.0": {
+		nextVersion:    "1.14.1",
+		priorVersion:   "1.13.2",
+		dockerImageSHA: "4fbdd8fb53c5d1748aeb98f0799798fb073bb11128c13e8415aa254ad1ae0203",
+		plugins:        plugins_1_14_0,
+	},
+	"1.13.2": {
+		nextVersion:    "1.14.0",
+		priorVersion:   "1.13.1",
+		dockerImageSHA: "94caebb89dcfb9d2c4be45bfda34410a3e1092458fbbbc0284365c9e4c9a7818",
+		plugins:        plugins_1_13_0,
+	},
 	"1.13.1": {
+		nextVersion:    "1.13.2",
 		priorVersion:   "1.13.0",
 		dockerImageSHA: "9b9128672209474da07c91439bf15ed704ae05ad918dd6454e5b6ae14e35fee6",
 		plugins:        plugins_1_13_0,
@@ -806,9 +848,28 @@ var Versions = map[string]release{
     }
     prometheus :9153
     proxy . *
-    cache 30
-    reload
+	cache 30
+	reload
 }`},
+}
+
+var plugins_1_14_0 = map[string]plugin{
+	"errors":       plugins["errors"]["v3"],
+	"log":          plugins["log"]["v1"],
+	"health":       plugins["health"]["v1"],
+	"ready":        {},
+	"autopath":     {},
+	"kubernetes":   plugins["kubernetes"]["v8"],
+	"k8s_external": plugins["k8s_external"]["v2"],
+	"prometheus":   {},
+	"forward":      plugins["forward"]["v5"],
+	"cache":        plugins["cache"]["v4"],
+	"loop":         {},
+	"reload":       {},
+	"loadbalance":  {},
+	"hosts":        plugins["hosts"]["v1"],
+	"rewrite":      plugins["rewrite"]["v3"],
+	"transfer":     plugins["transfer"]["v1"],
 }
 
 var plugins_1_13_0 = map[string]plugin{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -100,7 +100,7 @@ github.com/containerd/typeurl/v2
 # github.com/coredns/caddy v1.1.1
 ## explicit; go 1.13
 github.com/coredns/caddy/caddyfile
-# github.com/coredns/corefile-migration v1.0.29
+# github.com/coredns/corefile-migration v1.0.34
 ## explicit; go 1.14
 github.com/coredns/corefile-migration/migration
 github.com/coredns/corefile-migration/migration/corefile


### PR DESCRIPTION
Fixes #141229 
Fixes https://github.com/kubernetes/kubernetes/issues/141229

Upgrades CoreDNS to 1.14.6 to fix the 49+ CVEs clusters are exposed to

/sig network
/area dns
/kind bug
/priority important-soon

```release-note
NONE
```
