### PR TITLE
Optimize mutating webhook object serialization

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -28,6 +28,7 @@ import (
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -82,6 +83,10 @@ type versionedAttributeAccessor struct {
 	versionedAttr    *admission.VersionedAttributes
 	attr             admission.Attributes
 	objectInterfaces admission.ObjectInterfaces
+	// The serialized objects are reused by sequential webhooks that request the same GVK.
+	// versionedObjectJSON is invalidated after a mutation; both are invalidated after conversion.
+	versionedObjectJSON    []byte
+	versionedOldObjectJSON []byte
 }
 
 func (v *versionedAttributeAccessor) VersionedAttribute(gvk schema.GroupVersionKind) (*admission.VersionedAttributes, error) {
@@ -91,13 +96,58 @@ func (v *versionedAttributeAccessor) VersionedAttribute(gvk schema.GroupVersionK
 		if v.versionedAttr, err = admission.NewVersionedAttributes(v.attr, gvk, v.objectInterfaces); err != nil {
 			return nil, apierrors.NewInternalError(err)
 		}
-	} else {
+	} else if v.versionedAttr.VersionedKind != gvk {
 		// Subsequent call, convert existing versioned attributes to the requested version
 		if err := admission.ConvertVersionedAttributes(v.versionedAttr, gvk, v.objectInterfaces); err != nil {
 			return nil, apierrors.NewInternalError(err)
 		}
+		v.versionedObjectJSON = nil
+		v.versionedOldObjectJSON = nil
 	}
 	return v.versionedAttr, nil
+}
+
+func (v *versionedAttributeAccessor) serializedObjects() (objectJSON, oldObjectJSON []byte, err error) {
+	if v.versionedAttr.VersionedObject.Object() != nil && v.versionedObjectJSON == nil {
+		v.versionedObjectJSON, err = utiljson.Marshal(v.versionedAttr.VersionedObject.Object())
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	if v.versionedAttr.VersionedOldObject.Object() != nil && v.versionedOldObjectJSON == nil {
+		v.versionedOldObjectJSON, err = utiljson.Marshal(v.versionedAttr.VersionedOldObject.Object())
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return v.versionedObjectJSON, v.versionedOldObjectJSON, nil
+}
+
+func (v *versionedAttributeAccessor) updateObject(object runtime.Object) {
+	v.versionedAttr.UpdateObject(object)
+	v.versionedObjectJSON = nil
+}
+
+// setAdmissionReviewObjects replaces object-backed RawExtensions with their pre-serialized JSON.
+// The webhook client always uses JSON, so this preserves the wire format without re-marshaling the objects.
+func setAdmissionReviewObjects(request runtime.Object, objectJSON, oldObjectJSON []byte) error {
+	setRaw := func(dst *runtime.RawExtension, raw []byte) {
+		if raw != nil {
+			*dst = runtime.RawExtension{Raw: raw}
+		}
+	}
+
+	switch review := request.(type) {
+	case *admissionv1.AdmissionReview:
+		setRaw(&review.Request.Object, objectJSON)
+		setRaw(&review.Request.OldObject, oldObjectJSON)
+	case *admissionv1beta1.AdmissionReview:
+		setRaw(&review.Request.Object, objectJSON)
+		setRaw(&review.Request.OldObject, oldObjectJSON)
+	default:
+		return fmt.Errorf("unexpected admission review type %T", request)
+	}
+	return nil
 }
 
 var _ generic.Dispatcher = &mutatingDispatcher{}
@@ -163,7 +213,7 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr admission.Attrib
 		}
 
 		annotator := newWebhookAnnotator(versionedAttr, round, i, hook.Name, invocation.Webhook.GetConfigurationName())
-		changed, err := a.callAttrMutatingHook(ctx, hook, invocation, versionedAttr, annotator, o, round, i)
+		changed, err := a.callAttrMutatingHook(ctx, hook, invocation, v, annotator, o, round, i)
 		ignoreClientCallFailures := hook.FailurePolicy != nil && *hook.FailurePolicy == admissionregistrationv1.Ignore
 		rejected := false
 		if err != nil {
@@ -241,7 +291,8 @@ func (a *mutatingDispatcher) Dispatch(ctx context.Context, attr admission.Attrib
 
 // note that callAttrMutatingHook updates attr
 
-func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admissionregistrationv1.MutatingWebhook, invocation *generic.WebhookInvocation, attr *admission.VersionedAttributes, annotator *webhookAnnotator, o admission.ObjectInterfaces, round, idx int) (bool, error) {
+func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admissionregistrationv1.MutatingWebhook, invocation *generic.WebhookInvocation, attrAccessor *versionedAttributeAccessor, annotator *webhookAnnotator, o admission.ObjectInterfaces, round, idx int) (bool, error) {
+	attr := attrAccessor.versionedAttr
 	configurationName := invocation.Webhook.GetConfigurationName()
 	changed := false
 	defer func() { annotator.addMutationAnnotation(changed) }()
@@ -257,6 +308,13 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 	uid, request, response, err := webhookrequest.CreateAdmissionObjects(attr, invocation)
 	if err != nil {
 		return false, &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: fmt.Errorf("could not create admission objects: %w", err), Status: apierrors.NewBadRequest("error creating admission objects")}
+	}
+	objectJSON, oldObjectJSON, err := attrAccessor.serializedObjects()
+	if err != nil {
+		return false, &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: fmt.Errorf("could not serialize admission objects: %w", err), Status: apierrors.NewServiceUnavailable("error calling webhook")}
+	}
+	if err := setAdmissionReviewObjects(request, objectJSON, oldObjectJSON); err != nil {
+		return false, apierrors.NewInternalError(err)
 	}
 	// Make the webhook request
 	client, err := invocation.Webhook.GetRESTClient(a.cm)
@@ -352,11 +410,7 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 	switch result.PatchType {
 	// VerifyAdmissionResponse normalizes to v1 patch types, regardless of the AdmissionReview version used
 	case admissionv1.PatchTypeJSONPatch:
-		objJS, err := runtime.Encode(jsonSerializer, attr.VersionedObject.Object())
-		if err != nil {
-			return false, apierrors.NewInternalError(err)
-		}
-		patchedJS, err = patchObj.Apply(objJS)
+		patchedJS, err = patchObj.Apply(objectJSON)
 		if err != nil {
 			return false, apierrors.NewInternalError(err)
 		}
@@ -376,8 +430,6 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 		}
 	}
 
-	// TODO: if we have multiple mutating webhooks, we can remember the json
-	// instead of encoding and decoding for each one.
 	if newVersionedObject, _, err = jsonSerializer.Decode(patchedJS, nil, newVersionedObject); err != nil {
 		return false, apierrors.NewInternalError(err)
 	}
@@ -385,8 +437,8 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 	changed = !apiequality.Semantic.DeepEqual(attr.VersionedObject.Object(), newVersionedObject)
 	span.AddEvent("Patch applied")
 	annotator.addPatchAnnotation(patchObj, result.PatchType)
-	attr.UpdateObject(newVersionedObject)
-	o.GetObjectDefaulter().Default(attr.VersionedObject.Object())
+	o.GetObjectDefaulter().Default(newVersionedObject)
+	attrAccessor.updateObject(newVersionedObject)
 	return changed, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher_test.go
@@ -18,12 +18,232 @@ package mutating
 
 import (
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	serializerjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	utiljson "k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apiserver/pkg/admission"
 )
+
+type countingObject struct {
+	value        string
+	marshalCount *int
+}
+
+func (o *countingObject) MarshalJSON() ([]byte, error) {
+	(*o.marshalCount)++
+	return []byte(fmt.Sprintf(`{"value":%q}`, o.value)), nil
+}
+
+func (o *countingObject) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+
+func (o *countingObject) DeepCopyObject() runtime.Object {
+	copy := *o
+	return &copy
+}
+
+func TestSerializedObjectsAreCachedUntilObjectUpdate(t *testing.T) {
+	objectMarshalCount := 0
+	oldObjectMarshalCount := 0
+	accessor := &versionedAttributeAccessor{
+		versionedAttr: &admission.VersionedAttributes{
+			VersionedObject:    admission.NewLazyObject(&countingObject{value: "object", marshalCount: &objectMarshalCount}),
+			VersionedOldObject: admission.NewLazyObject(&countingObject{value: "old-object", marshalCount: &oldObjectMarshalCount}),
+		},
+	}
+
+	objectJSON, oldObjectJSON, err := accessor.serializedObjects()
+	if err != nil {
+		t.Fatalf("unexpected serialization error: %v", err)
+	}
+	secondObjectJSON, secondOldObjectJSON, err := accessor.serializedObjects()
+	if err != nil {
+		t.Fatalf("unexpected serialization error: %v", err)
+	}
+	if objectMarshalCount != 1 || oldObjectMarshalCount != 1 {
+		t.Fatalf("expected each object to be serialized once, got object=%d oldObject=%d", objectMarshalCount, oldObjectMarshalCount)
+	}
+	if string(objectJSON) != string(secondObjectJSON) || string(oldObjectJSON) != string(secondOldObjectJSON) {
+		t.Fatal("cached serialization changed between reads")
+	}
+
+	updatedObjectMarshalCount := 0
+	accessor.updateObject(&countingObject{value: "updated", marshalCount: &updatedObjectMarshalCount})
+	updatedObjectJSON, _, err := accessor.serializedObjects()
+	if err != nil {
+		t.Fatalf("unexpected serialization error after update: %v", err)
+	}
+	if updatedObjectMarshalCount != 1 {
+		t.Fatalf("expected updated object to be serialized once, got %d", updatedObjectMarshalCount)
+	}
+	if oldObjectMarshalCount != 1 {
+		t.Fatalf("expected immutable old object serialization to remain cached, got %d", oldObjectMarshalCount)
+	}
+	if got, want := string(updatedObjectJSON), `{"value":"updated"}`; got != want {
+		t.Fatalf("unexpected updated object JSON: got %s, want %s", got, want)
+	}
+}
+
+func TestSerializedObjectJSONMatchesWebhookPatchEncoding(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to register core types: %v", err)
+	}
+	serializer := serializerjson.NewSerializerWithOptions(serializerjson.DefaultMetaFactory, scheme, scheme, serializerjson.SerializerOptions{})
+
+	tests := []struct {
+		name   string
+		object runtime.Object
+	}{
+		{
+			name: "typed",
+			object: &corev1.Pod{
+				TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Labels: map[string]string{"a": "b"}},
+			},
+		},
+		{
+			name: "unstructured",
+			object: &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "example.com/v1",
+				"kind":       "Example",
+				"metadata": map[string]any{
+					"name":   "test",
+					"labels": map[string]any{"a": "b"},
+				},
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			accessor := &versionedAttributeAccessor{versionedAttr: &admission.VersionedAttributes{
+				VersionedObject: admission.NewLazyObject(test.object),
+			}}
+			got, _, err := accessor.serializedObjects()
+			if err != nil {
+				t.Fatalf("unexpected serialization error: %v", err)
+			}
+			want, err := runtime.Encode(serializer, test.object)
+			if err != nil {
+				t.Fatalf("unexpected webhook patch encoding error: %v", err)
+			}
+			assert.JSONEq(t, string(want), string(got))
+		})
+	}
+}
+
+func TestSetAdmissionReviewObjects(t *testing.T) {
+	objectJSON := []byte(`{"object":"cached"}`)
+	oldObjectJSON := []byte(`{"oldObject":"cached"}`)
+
+	tests := []struct {
+		name    string
+		request runtime.Object
+		verify  func(t *testing.T, request runtime.Object)
+	}{
+		{
+			name: "v1",
+			request: &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{
+				Object:    runtime.RawExtension{Object: &corev1.Pod{}},
+				OldObject: runtime.RawExtension{Object: &corev1.Pod{}},
+			}},
+			verify: func(t *testing.T, request runtime.Object) {
+				review := request.(*admissionv1.AdmissionReview)
+				assert.Equal(t, objectJSON, review.Request.Object.Raw)
+				assert.Nil(t, review.Request.Object.Object)
+				assert.Equal(t, oldObjectJSON, review.Request.OldObject.Raw)
+				assert.Nil(t, review.Request.OldObject.Object)
+			},
+		},
+		{
+			name: "v1beta1",
+			request: &admissionv1beta1.AdmissionReview{Request: &admissionv1beta1.AdmissionRequest{
+				Object:    runtime.RawExtension{Object: &corev1.Pod{}},
+				OldObject: runtime.RawExtension{Object: &corev1.Pod{}},
+			}},
+			verify: func(t *testing.T, request runtime.Object) {
+				review := request.(*admissionv1beta1.AdmissionReview)
+				assert.Equal(t, objectJSON, review.Request.Object.Raw)
+				assert.Nil(t, review.Request.Object.Object)
+				assert.Equal(t, oldObjectJSON, review.Request.OldObject.Raw)
+				assert.Nil(t, review.Request.OldObject.Object)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := setAdmissionReviewObjects(test.request, objectJSON, oldObjectJSON); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			test.verify(t, test.request)
+		})
+	}
+
+	if err := setAdmissionReviewObjects(&metav1.Status{}, objectJSON, oldObjectJSON); err == nil {
+		t.Fatal("expected an error for an unsupported admission review type")
+	}
+}
+
+func BenchmarkAdmissionReviewObjectSerialization(b *testing.B) {
+	labels := make(map[string]string, 1000)
+	for i := 0; i < 1000; i++ {
+		labels[fmt.Sprintf("label-%04d", i)] = fmt.Sprintf("value-%04d", i)
+	}
+	object := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "benchmark", Labels: labels}}
+	oldObject := object.DeepCopy()
+
+	b.Run("ten-webhooks/uncached", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			for range 10 {
+				review := &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{
+					Object:    runtime.RawExtension{Object: object},
+					OldObject: runtime.RawExtension{Object: oldObject},
+				}}
+				if _, err := utiljson.Marshal(review); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+
+	b.Run("ten-webhooks/cached", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			objectJSON, err := utiljson.Marshal(object)
+			if err != nil {
+				b.Fatal(err)
+			}
+			oldObjectJSON, err := utiljson.Marshal(oldObject)
+			if err != nil {
+				b.Fatal(err)
+			}
+			for range 10 {
+				review := &admissionv1.AdmissionReview{Request: &admissionv1.AdmissionRequest{
+					Object:    runtime.RawExtension{Raw: objectJSON},
+					OldObject: runtime.RawExtension{Raw: oldObjectJSON},
+				}}
+				if _, err := utiljson.Marshal(review); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}
+	})
+}
 
 func TestMutationAnnotationValue(t *testing.T) {
 	tcs := []struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig api-machinery

#### Which issue(s) this PR is related to:
N/A

#### What this PR does / why we need it:

Caches serialized objects during mutating webhook dispatch, and the cached JSONs are reused during the sequential webhook requests and JSON patches


#### Special notes for your reviewer:

Running on the synthetic benchmark with 10 webhooks, we achieve:
| Metric | Without cache | With cache | Percentage improvement |
| --- | --- | --- | --- |
| Serialization time | 7.93 ms | 2.97 ms | 62.55% |
| Allocated bytes | 2.62 MB | 0.78 MB | 70.23% |
| Allocations | 40093 | 4045 | 89.91% |

```release-note
NONE
```
