### PR TITLE
Fix: missing Prometheus registration that silently hides exec-plugin policy audit metric

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -5995,8 +5995,7 @@
   type: Counter
   stabilityLevel: ALPHA
   labels:
-  - allowed
-  - denied
+  - status
   componentEndpoints:
   - component: cloud-controller-manager
     endpoint: /metrics

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -173,7 +173,7 @@ var (
 				"and allowlist (if any), partitioned by whether or not the policy " +
 				"permits the plugin",
 		},
-		[]string{"allowed", "denied"},
+		[]string{"status"},
 	)
 
 	transportCacheEntries = k8smetrics.NewGauge(
@@ -254,6 +254,7 @@ func init() {
 			legacyregistry.RawMustRegister(execPluginCertTTL)
 			legacyregistry.MustRegister(execPluginCertRotation)
 			legacyregistry.MustRegister(execPluginCalls)
+			legacyregistry.MustRegister(execPluginPolicyCalls)
 			legacyregistry.MustRegister(transportCacheEntries)
 			legacyregistry.MustRegister(transportCacheCalls)
 			legacyregistry.MustRegister(transportCAReloads)

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
@@ -85,6 +85,21 @@ func TestClientGOMetrics(t *testing.T) {
 				`,
 		},
 		{
+			description: "Number of exec plugin policy checks",
+			name:        "rest_client_exec_plugin_policy_call_total",
+			metric:      execPluginPolicyCalls,
+			update: func() {
+				metrics.ExecPluginPolicyCalls.Increment("allowed")
+				metrics.ExecPluginPolicyCalls.Increment("denied")
+			},
+			want: `
+			            # HELP rest_client_exec_plugin_policy_call_total [ALPHA] Number of comparisons of an exec plugin to the plugin policy and allowlist (if any), partitioned by whether or not the policy permits the plugin
+			            # TYPE rest_client_exec_plugin_policy_call_total counter
+			            rest_client_exec_plugin_policy_call_total{status="allowed"} 1
+			            rest_client_exec_plugin_policy_call_total{status="denied"} 1
+				`,
+		},
+		{
 			description: "Number of calls to get a new transport",
 			name:        "rest_client_transport_create_calls_total",
 			metric:      transportCacheCalls,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes the `execPluginPolicyCalls` metric so it is exposed to Prometheus and does not panic when incremented.

These two changes must ship together:

- Register `execPluginPolicyCalls` with `legacyregistry`, so Prometheus can scrape it.
- Change the metric definition from two label keys (`allowed`, `denied`) to one `status` label, matching `policyAdapter.Increment(status)` and `WithLabelValues(status)`.

The adapter increments the metric with one label value. With the previous two-label definition, registering the metric alone would cause `WithLabelValues(status)` to panic on its first increment because Prometheus requires one value per declared label key. Before registration, component-base's lazy metric initialization made this cardinality mismatch a silent no-op, which is why the bug went unnoticed.

After this fix, the metric is emitted as:

```
rest_client_exec_plugin_policy_call_total{status="allowed"} N
rest_client_exec_plugin_policy_call_total{status="denied"} N
```

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Register the exec-plugin policy audit Prometheus metric and correct its status label.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
