### PR TITLE
Fix/pod level resources aliasing

### DIFF
--- a/staging/src/k8s.io/component-helpers/resource/helpers.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers.go
@@ -175,7 +175,12 @@ func PodRequests(pod *v1.Pod, opts PodResourcesOptions) v1.ResourceList {
 func applyPodLevelResources(result, effectiveResources v1.ResourceList) {
 	for resourceName, quantity := range effectiveResources {
 		if IsSupportedPodLevelResource(resourceName) {
-			result[resourceName] = quantity
+			// DeepCopy is required because a Quantity holds a *inf.Dec for values
+			// that do not fit the int64 fast path (for example 1.5Gi). Storing the
+			// value directly would make the returned list share that pointer with
+			// pod.Spec.Resources, so later arithmetic on the result - such as the
+			// pod overhead accumulation below - would mutate the caller's Pod.
+			result[resourceName] = quantity.DeepCopy()
 		}
 	}
 }

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -4799,7 +4799,7 @@ func TestPodResourcesAreStableAcrossCalls(t *testing.T) {
 	expectedRequests := PodRequests(pod, PodResourcesOptions{})
 	expectedLimits := PodLimits(pod, PodResourcesOptions{})
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		if got := PodRequests(pod, PodResourcesOptions{}); !equality.Semantic.DeepEqual(expectedRequests, got) {
 			t.Errorf("PodRequests drifted on call %d: %s", i+2, diff.Diff(expectedRequests, got))
 		}

--- a/staging/src/k8s.io/component-helpers/resource/helpers_test.go
+++ b/staging/src/k8s.io/component-helpers/resource/helpers_test.go
@@ -4709,3 +4709,125 @@ func TestResizeConditionsAndSupportedResources(t *testing.T) {
 		t.Errorf("expected SupportedPodLevelResources to contain CPU")
 	}
 }
+
+// TestPodResourcesDoNotMutatePod verifies that the pod resource accessors leave the
+// Pod they are given untouched. Pod-level quantities that do not fit the int64 fast
+// path (1.5Gi, for example) are backed by a *inf.Dec, so storing one in the result
+// without a DeepCopy makes the returned list share that pointer with
+// pod.Spec.Resources. Any later arithmetic on the result - such as accumulating pod
+// overhead - then writes through into the caller's Pod, which is commonly an object
+// owned by a shared informer cache.
+func TestPodResourcesDoNotMutatePod(t *testing.T) {
+	podWithPodLevelResources := func(requests, limits v1.ResourceList, overhead v1.ResourceList) *v1.Pod {
+		return &v1.Pod{
+			Spec: v1.PodSpec{
+				Resources: &v1.ResourceRequirements{Requests: requests, Limits: limits},
+				Overhead:  overhead,
+				Containers: []v1.Container{{
+					Name: "container-1",
+					Resources: v1.ResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceMemory: resource.MustParse("256Mi")},
+						Limits:   v1.ResourceList{v1.ResourceMemory: resource.MustParse("256Mi")},
+					},
+				}},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name string
+		pod  *v1.Pod
+	}{
+		{
+			name: "pod-level requests with overhead",
+			pod: podWithPodLevelResources(
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("1.5Gi")},
+				nil,
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("100Mi")},
+			),
+		},
+		{
+			name: "pod-level limits with overhead",
+			pod: podWithPodLevelResources(
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("1.5Gi")},
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("1.5Gi")},
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("100Mi")},
+			),
+		},
+		{
+			name: "pod-level requests without overhead",
+			pod: podWithPodLevelResources(
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("0.5Gi")},
+				nil,
+				nil,
+			),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expected := tc.pod.DeepCopy()
+
+			PodRequests(tc.pod, PodResourcesOptions{})
+			if !equality.Semantic.DeepEqual(expected, tc.pod) {
+				t.Errorf("PodRequests mutated the pod: %s", diff.Diff(expected, tc.pod))
+			}
+
+			PodLimits(tc.pod, PodResourcesOptions{})
+			if !equality.Semantic.DeepEqual(expected, tc.pod) {
+				t.Errorf("PodLimits mutated the pod: %s", diff.Diff(expected, tc.pod))
+			}
+		})
+	}
+}
+
+// TestPodResourcesAreStableAcrossCalls verifies that the accessors are idempotent.
+// If the returned list aliased pod.Spec.Resources, each call would accumulate pod
+// overhead into the Pod and the reported totals would drift upwards over time.
+func TestPodResourcesAreStableAcrossCalls(t *testing.T) {
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Resources: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceMemory: resource.MustParse("1.5Gi")},
+				Limits:   v1.ResourceList{v1.ResourceMemory: resource.MustParse("1.5Gi")},
+			},
+			Overhead:   v1.ResourceList{v1.ResourceMemory: resource.MustParse("100Mi")},
+			Containers: []v1.Container{{Name: "container-1"}},
+		},
+	}
+
+	expectedRequests := PodRequests(pod, PodResourcesOptions{})
+	expectedLimits := PodLimits(pod, PodResourcesOptions{})
+
+	for i := 0; i < 3; i++ {
+		if got := PodRequests(pod, PodResourcesOptions{}); !equality.Semantic.DeepEqual(expectedRequests, got) {
+			t.Errorf("PodRequests drifted on call %d: %s", i+2, diff.Diff(expectedRequests, got))
+		}
+		if got := PodLimits(pod, PodResourcesOptions{}); !equality.Semantic.DeepEqual(expectedLimits, got) {
+			t.Errorf("PodLimits drifted on call %d: %s", i+2, diff.Diff(expectedLimits, got))
+		}
+	}
+}
+
+// TestPodRequestsResultIsNotAliased verifies that mutating the returned ResourceList
+// cannot reach back into the Pod.
+func TestPodRequestsResultIsNotAliased(t *testing.T) {
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Resources: &v1.ResourceRequirements{
+				Requests: v1.ResourceList{v1.ResourceMemory: resource.MustParse("1.5Gi")},
+			},
+			Containers: []v1.Container{{Name: "container-1"}},
+		},
+	}
+	expected := pod.DeepCopy()
+
+	reqs := PodRequests(pod, PodResourcesOptions{})
+	memory := reqs[v1.ResourceMemory]
+	memory.Add(resource.MustParse("1Gi"))
+	reqs[v1.ResourceMemory] = memory
+
+	if !equality.Semantic.DeepEqual(expected, pod) {
+		t.Errorf("mutating the PodRequests result mutated the pod: %s", diff.Diff(expected, pod))
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`applyPodLevelResources` stored a `resource.Quantity` taken from `pod.Spec.Resources` into the
result map without `DeepCopy()`. A `Quantity` carries a `*inf.Dec` for values that do not fit the
int64 fast path, so the `ResourceList` returned by `PodRequests`/`PodLimits` shared that pointer
with the Pod. The pod overhead accumulation later in both functions calls `Quantity.Add`, which
mutates the shared `inf.Dec` in place and therefore writes into the caller's Pod.

Values on the `inf.Dec` path are ordinary: any BinarySI quantity with a fractional mantissa
(`1.5Gi`, `0.5Gi`, `1.5Mi`) takes it, because `ParseQuantity` sets `precision = -1` for that case.

Because the accessors are not idempotent, the error compounds on every call:

```
call 1: PodRequests=1636Mi   pod.Spec.Requests=1636Mi
call 5: PodRequests=2036Mi   pod.Spec.Requests=2036Mi
```

Every other helper in the file (`addResourceList`, `maxResourceList`, `max`) already deep-copies;
this one was the outlier. The fix is a single `quantity.DeepCopy()`.

#### Which issue(s) this PR is related to:

Fixes #141241

#### Special notes for your reviewer:

`PodLevelResources` is Beta and on by default since 1.34, and these accessors are called by the
scheduler and kubelet on Pods owned by shared informer caches, where mutation is not permitted.

Three tests are added:
- `TestPodResourcesDoNotMutatePod` - the Pod is unchanged after each accessor.
- `TestPodResourcesAreStableAcrossCalls` - repeated calls return the same value.
- `TestPodRequestsResultIsNotAliased` - mutating the returned list cannot reach the Pod.

Reverting the one-line fix makes all three fail, e.g.
`pod.Spec.Resources.Limits[memory] mutated by PodLimits: 1536Mi -> 1636Mi`.

Suites run green: `component-helpers/...`, `pkg/api/v1/resource/...`,
`pkg/scheduler/framework/...`, `pkg/quota/...`, `pkg/kubelet/cm/...`, `pkg/kubelet/eviction/...`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where computing a Pod's resource requests or limits could mutate the Pod object when pod-level resources were set. Repeated calls caused the reported requests and limits to drift upwards by the pod overhead each time.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
