### PR TITLE
Fix/dra watch stop exits loop

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
@@ -360,7 +360,10 @@ func (w *watchSomething[NP, N, OP]) run() {
 		select {
 		case w.resultChan <- e:
 		case <-w.stopChan:
-			break
+			// Return rather than break: a break would only leave the select and
+			// the loop would keep draining the upstream watch. Returning runs the
+			// deferred close(w.resultChan), which is what consumers wait for.
+			return
 		}
 	}
 }

--- a/staging/src/k8s.io/dynamic-resource-allocation/client/generic_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/generic_test.go
@@ -47,7 +47,7 @@ func TestWatchSomethingStopTerminatesRun(t *testing.T) {
 	const queued = 5
 
 	upstream := &stalledWatch{ch: make(chan watch.Event, queued)}
-	for i := 0; i < queued; i++ {
+	for range queued {
 		upstream.ch <- watch.Event{
 			Type:   watch.Added,
 			Object: &resourcev1.ResourceSlice{ObjectMeta: metav1.ObjectMeta{Name: "slice"}},

--- a/staging/src/k8s.io/dynamic-resource-allocation/client/generic_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/generic_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	resourcev1 "k8s.io/api/resource/v1"
+	resourcev1beta1 "k8s.io/api/resource/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// stalledWatch is an upstream watch whose result channel stays open after Stop.
+// The wrapper must terminate on its own stopChan instead of relying on the
+// upstream closing its channel.
+type stalledWatch struct {
+	ch chan watch.Event
+}
+
+func (s *stalledWatch) Stop() {}
+
+func (s *stalledWatch) ResultChan() <-chan watch.Event { return s.ch }
+
+// TestWatchSomethingStopTerminatesRun verifies that stopping the watch makes run
+// return, which closes the result channel that consumers of watch.Interface wait
+// for. A plain break inside the select would only leave the select, leaving run to
+// spin on the upstream watch, converting and discarding events nobody can receive.
+func TestWatchSomethingStopTerminatesRun(t *testing.T) {
+	const queued = 5
+
+	upstream := &stalledWatch{ch: make(chan watch.Event, queued)}
+	for i := 0; i < queued; i++ {
+		upstream.ch <- watch.Event{
+			Type:   watch.Added,
+			Object: &resourcev1.ResourceSlice{ObjectMeta: metav1.ObjectMeta{Name: "slice"}},
+		}
+	}
+
+	w := &watchSomething[*resourcev1.ResourceSlice, resourcev1.ResourceSlice, *resourcev1beta1.ResourceSlice]{
+		upstream:   upstream,
+		resultChan: make(chan watch.Event),
+		stopChan:   make(chan struct{}),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w.run()
+	}()
+
+	// The consumer never reads from w.ResultChan. Wait until run has taken the
+	// first event off the upstream channel and blocked trying to deliver it, so
+	// that the remaining count below is deterministic.
+	ctx := context.Background()
+	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond, wait.ForeverTestTimeout, true, func(context.Context) (bool, error) {
+		return len(upstream.ch) == queued-1, nil
+	}); err != nil {
+		t.Fatalf("timed out waiting for the watch to start delivering: %v", err)
+	}
+
+	w.Stop()
+
+	select {
+	case <-done:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("run did not return after Stop")
+	}
+
+	if _, open := <-w.ResultChan(); open {
+		t.Error("expected the result channel to be closed after Stop")
+	}
+
+	if remaining := len(upstream.ch); remaining != queued-1 {
+		t.Errorf("expected the upstream watch to still hold %d events after Stop, it holds %d", queued-1, remaining)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In `watchSomething.run`, the `<-w.stopChan` case of the `select` used a naked `break`, which
leaves the `select` rather than the enclosing `for`. The intent is clear from the surrounding
comment ("This must not get blocked when the consumer stops reading, hence the stopChan"), but the
loop instead kept pulling from the upstream watch, converting and discarding events, and never
reached the deferred `close(w.resultChan)` that `watch.Interface` consumers wait for.

Changed to `return`, which runs both deferred calls.

#### Which issue(s) this PR is related to:

Fixes #141243.

#### Special notes for your reviewer:

In practice this is usually masked: `Stop()` calls `w.upstream.Stop()` first, and a well-behaved
`watch.Interface` closes its channel, which ends the loop through the `!ok` branch instead. I could
not demonstrate a hang with a real client-go watch, so this is a latent defect rather than an
active outage - please grade it accordingly. It still matters because the wrapper should not
depend on upstream behaviour for its own termination.

The new test (`generic_test.go`) uses an upstream whose channel stays open after `Stop()` and
asserts both that `run` returns and that queued upstream events are not drained. Reverting the fix
makes it fail with `run did not return after Stop` after the full timeout. Runs clean under
`-race`.

The new file uses the yearless copyright header required by `hack/boilerplate` for files created
after 2025; `hack/verify-boilerplate.sh` passes.

A repo-wide scan found this as the only `break`-inside-`select`-inside-`for` in `pkg/`, `cmd/`,
`plugin/` and `staging/`, so no other call sites need the same treatment.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the DRA converting watch client not terminating when stopped, which left its result channel open and kept draining the upstream watch.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
