### PR TITLE
Fix/field selector canonical ordering

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/fields/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/fields/selector.go
@@ -429,7 +429,6 @@ func splitTerm(term string) (lhs, op, rhs string, ok bool) {
 
 func parseSelector(selector string, fn TransformFunc) (Selector, error) {
 	parts := splitTerms(selector)
-	sort.StringSlice(parts).Sort()
 	var items []Selector
 	for _, part := range parts {
 		if part == "" {
@@ -454,6 +453,13 @@ func parseSelector(selector string, fn TransformFunc) (Selector, error) {
 			return nil, fmt.Errorf("invalid selector: '%s'; can't understand '%s'", selector, part)
 		}
 	}
+	// Order the terms by their serialized form rather than by the raw input text.
+	// The two are not the same string: "==" is emitted as "=" and values are
+	// re-escaped, so sorting the input did not guarantee sorted output and
+	// String() was not a fixed point. Parsing and re-serializing a selector such
+	// as "metadata.name==,metadata.name=0" kept swapping the two terms around.
+	sort.SliceStable(items, func(i, j int) bool { return items[i].String() < items[j].String() })
+
 	if len(items) == 1 {
 		return items[0].Transform(fn)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/fields/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/fields/selector_test.go
@@ -395,3 +395,46 @@ func TestTransform(t *testing.T) {
 	}
 
 }
+
+// TestSelectorStringIsIdempotent verifies that serializing a parsed selector
+// produces a canonical form: re-parsing that form and serializing it again must
+// return the same string. Terms used to be ordered by the raw input text, which
+// differs from the emitted text ("==" is emitted as "=", values are re-escaped),
+// so two terms could keep swapping places on every round trip.
+func TestSelectorStringIsIdempotent(t *testing.T) {
+	testCases := []string{
+		"",
+		"a=b",
+		"a=b,c=d",
+		"c=d,a=b",
+		"a!=b,a=c",
+		"metadata.name==,metadata.name=0",
+		"spec.nodeName==,spec.nodeName=0",
+		"a==b,a=0",
+		`a=b\,c,a=d`,
+		`a=b\\,a=c`,
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			parsed, err := ParseSelector(tc)
+			if err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+			first := parsed.String()
+
+			reparsed, err := ParseSelector(first)
+			if err != nil {
+				t.Fatalf("serialized form %q does not parse: %v", first, err)
+			}
+			if second := reparsed.String(); second != first {
+				t.Errorf("String() is not idempotent: %q serialized to %q, which serialized to %q", tc, first, second)
+			}
+
+			// The round trip must also preserve the terms themselves.
+			if !reflect.DeepEqual(parsed.Requirements(), reparsed.Requirements()) {
+				t.Errorf("round trip changed the requirements: %v became %v", parsed.Requirements(), reparsed.Requirements())
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`parseSelector` sorted the raw input terms before parsing them. The input text and the emitted
text are not the same string - `==` is emitted as `=` and values are re-escaped - so sorting the
input did not produce sorted output, and `String()` was not a fixed point:

```
"metadata.name==,metadata.name=0"
  -> "metadata.name=0,metadata.name="
  -> "metadata.name=,metadata.name=0"     (different)
```

The sort now runs on the parsed terms, keyed by their canonical `String()`.

#### Which issue(s) this PR is related to:

Fixes #141245.

#### Special notes for your reviewer:

- **The sort deliberately runs before `Transform`, not after.** My first attempt sorted the
  transformed terms and that broke the existing `TestTransform` case asserting a transform
  preserves term order (`"a=b,c=d"` with `a`->`e` yields `"e=f,c=d"`). That ordering is existing
  behaviour for `ParseAndTransformSelector`, so sorting pre-transform fixes the reported
  non-idempotency while leaving it intact.
- Term ordering in `String()` output can differ from before for selectors where the raw and
  canonical forms sort differently. Ordering stays deterministic, and semantics are unaffected
  since these are conjunctions.
- **Low severity.** I did not find a production code path that breaks because of the old
  behaviour, and it converged after one extra round trip rather than oscillating. Treat this as a
  correctness fix; happy for it to be deprioritised.

`TestSelectorStringIsIdempotent` is added, covering plain selectors, `!=`, escaped commas and
backslashes, and the two reordering cases; it also asserts the round trip preserves
`Requirements()`. Reverting the fix produces
`String() is not idempotent: "metadata.name==,metadata.name=0" serialized to "metadata.name=0,metadata.name=", which serialized to "metadata.name=,metadata.name=0"`.

Suites run green: `apimachinery/pkg/fields/...`, `apiserver/pkg/storage/...`,
`apiserver/pkg/endpoints/...`, `pkg/registry/core/pod/...`, `pkg/registry/core/service/...`,
`pkg/registry/resource/resourceslice/...`, `pkg/registry/authorization/...`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed field selectors not producing a canonical string: parsing and re-serializing certain selectors could keep reordering their terms.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
