### PR TITLE
Fix/limitranger pod level hugepages

### DIFF
--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -32,13 +32,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
 	genericadmissioninitailizer "k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/utils/lru"
 
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -674,18 +674,18 @@ func podLimits(pod *api.Pod, opts podResourcesOptions) api.ResourceList {
 	return limits
 }
 
-var supportedPodLevelResources = sets.New(api.ResourceCPU, api.ResourceMemory)
-
-// isSupportedPodLevelResources checks if a given resource is supported by pod-level
+// isSupportedPodLevelResource checks if a given resource is supported by pod-level
 // resource management through the PodLevelResources feature. Returns true if
 // the resource is supported.
-// isSupportedPodLevelResource method exists in
-// staging/src/k8s.io/component-helpers/resource/helpers.go.
-// isSupportedPodLevelResource is added here to avoid conversion of v1.
-// Pod to api.Pod.
-// TODO(ndixita): Find alternatives to avoid duplicating the code.
+//
+// This delegates to the canonical implementation in component-helpers instead of
+// keeping a local copy. The predicate only needs a resource name, so the conversion
+// of v1.Pod to api.Pod that motivated the other duplicated helpers in this file does
+// not apply here. A local copy previously omitted hugepages, which made podRequests
+// and podLimits fall back to the aggregated container values and silently skip
+// pod-level LimitRange enforcement for hugepages.
 func isSupportedPodLevelResource(name api.ResourceName) bool {
-	return supportedPodLevelResources.Has(name)
+	return resourcehelper.IsSupportedPodLevelResource(corev1.ResourceName(name))
 }
 
 // addResourceList adds the resources in newList to list.

--- a/plugin/pkg/admission/limitranger/admission_test.go
+++ b/plugin/pkg/admission/limitranger/admission_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	resourcehelper "k8s.io/component-helpers/resource"
 	"k8s.io/kubernetes/pkg/features"
 
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -1059,5 +1060,88 @@ func TestLimitRanger_GetLimitRangesFixed22422(t *testing.T) {
 	}
 	if test1Count != 1 {
 		t.Errorf("Expected 1 limit range call, got %d", test1Count)
+	}
+}
+
+// TestIsSupportedPodLevelResourceMatchesCanonical guards against this package's
+// notion of a pod-level resource drifting from the canonical one in
+// component-helpers. A drift for hugepages previously caused podRequests and
+// podLimits to ignore the pod-level values.
+func TestIsSupportedPodLevelResourceMatchesCanonical(t *testing.T) {
+	resourceNames := []string{
+		"cpu",
+		"memory",
+		"hugepages-2Mi",
+		"hugepages-1Gi",
+		"ephemeral-storage",
+		"example.com/dongle",
+	}
+
+	for _, name := range resourceNames {
+		t.Run(name, func(t *testing.T) {
+			want := resourcehelper.IsSupportedPodLevelResource(corev1.ResourceName(name))
+			if got := isSupportedPodLevelResource(api.ResourceName(name)); got != want {
+				t.Errorf("isSupportedPodLevelResource(%q) = %v, component-helpers says %v", name, got, want)
+			}
+		})
+	}
+}
+
+// TestPodLimitFuncPodLevelHugepages verifies that a Pod-type LimitRange is enforced
+// against the pod-level hugepages values. Validation permits the pod-level value to
+// exceed the aggregated container value, so evaluating the container aggregate
+// instead would let a pod exceed the configured maximum.
+func TestPodLimitFuncPodLevelHugepages(t *testing.T) {
+	const hugepages = "hugepages-2Mi"
+
+	limitRange := corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{Name: "hugepages-max", Namespace: "test"},
+		Spec: corev1.LimitRangeSpec{
+			Limits: []corev1.LimitRangeItem{{
+				Type: corev1.LimitTypePod,
+				Max:  corev1.ResourceList{corev1.ResourceName(hugepages): resource.MustParse("4Gi")},
+			}},
+		},
+	}
+
+	hugepagesList := func(value string) api.ResourceList {
+		return api.ResourceList{api.ResourceName(hugepages): resource.MustParse(value)}
+	}
+
+	tests := []struct {
+		name        string
+		podLevel    string
+		expectError bool
+	}{
+		{
+			name:        "pod-level hugepages above the maximum is rejected",
+			podLevel:    "8Gi",
+			expectError: true,
+		},
+		{
+			name:        "pod-level hugepages within the maximum is accepted",
+			podLevel:    "4Gi",
+			expectError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodLevelResources, true)
+
+			// Containers declare less than the pod-level value on purpose: the
+			// aggregated container total stays within the maximum in every case.
+			containerResources := getResourceRequirements(hugepagesList("2Gi"), hugepagesList("2Gi"))
+			podResources := getResourceRequirements(hugepagesList(test.podLevel), hugepagesList(test.podLevel))
+			pod := validPodWithPodLevelResources("pod-level-hugepages", 1, containerResources, podResources)
+
+			err := PodValidateLimitFunc(&limitRange, &pod)
+			if test.expectError && err == nil {
+				t.Errorf("expected pod with pod-level %s=%s to be rejected by max 4Gi, got no error", hugepages, test.podLevel)
+			}
+			if !test.expectError && err != nil {
+				t.Errorf("expected pod with pod-level %s=%s to be accepted, got: %v", hugepages, test.podLevel, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION


#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

LimitRanger kept a private `isSupportedPodLevelResource` listing only cpu and memory, while the
canonical `resourcehelper.IsSupportedPodLevelResource` also matches the `hugepages-` prefix.
Because of the drift, `podRequests`/`podLimits` skipped the pod-level override for hugepages and
fell back to the aggregated container values.

Validation permits the pod-level value to exceed the container aggregate (it only rejects the
reverse), so a Pod could declare pod-level `hugepages-2Mi: 8Gi` with containers totalling `2Gi`
and be evaluated against `2Gi`. A `LimitRange` of type `Pod` with `max hugepages-2Mi: 4Gi`
admitted that Pod, while the identical value written at container level was correctly rejected.

This replaces the local copy with a call to the canonical helper. The comment justifying the
duplication ("avoid conversion of v1.Pod to api.Pod") does not apply here - the function takes
only a resource name - so delegating removes the drift permanently instead of re-syncing a copy
that can drift again.

#### Which issue(s) this PR is related to:

Fixes #141247.

#### Special notes for your reviewer:

This adds `k8s.io/component-helpers/resource` to the package's imports and drops the now-unused
`k8s.io/apimachinery/pkg/util/sets` import. `plugin/` already depends on other `component-helpers`
packages (e.g. `plugin/pkg/auth/authorizer/node/graph.go`), the root `.import-restrictions` only
forbids cAdvisor, and `hack/verify-imports.sh` passes.

The other duplicated helpers flagged by the same `TODO(ndixita)` comments (`podRequests`,
`podLimits`, `addResourceList`, `maxResourceList`) are deliberately left alone to keep this change
focused, but they are worth a follow-up audit for the same class of drift.

Two tests are added:
- `TestIsSupportedPodLevelResourceMatchesCanonical` - parity against component-helpers, so any
  future drift fails CI rather than silently disabling enforcement.
- `TestPodLimitFuncPodLevelHugepages` - end-to-end `PodValidateLimitFunc`, with both an
  over-limit and a within-limit case.

Reverting the fix makes both fail:
`expected pod with pod-level hugepages-2Mi=8Gi to be rejected by max 4Gi, got no error`.

All of `plugin/pkg/admission/...` runs green.

#### Does this PR introduce a user-facing change?

```release-note
Fixed LimitRange enforcement ignoring pod-level hugepages values. A Pod specifying hugepages through pod-level resources could exceed the maximum configured by a Pod-scoped LimitRange.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
