### PR TITLE
Fix/quantity large magnitude serialization

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -451,12 +451,27 @@ func (q *Quantity) CanonicalizeBytes(out []byte) (result, suffix []byte) {
 	switch format {
 	case DecimalExponent, DecimalSI:
 		number, exponent := q.AsCanonicalBytes(out)
-		suffix, _ := quantitySuffixer.constructBytes(10, exponent, format)
+		suffix, ok := quantitySuffixer.constructBytes(10, exponent, format)
+		if !ok {
+			// The magnitude is outside the range covered by the decimal SI
+			// suffixes (which stop at E, 10^18). Returning the mantissa without a
+			// suffix would silently change the value, so fall back to the
+			// exponent form, which can represent any magnitude.
+			suffix, _ = quantitySuffixer.constructBytes(10, exponent, DecimalExponent)
+		}
 		return number, suffix
 	default:
 		// format must be BinarySI
 		number, exponent := rounded.AsCanonicalBase1024Bytes(out)
-		suffix, _ := quantitySuffixer.constructBytes(2, exponent*10, format)
+		suffix, ok := quantitySuffixer.constructBytes(2, exponent*10, format)
+		if !ok {
+			// The magnitude is outside the range covered by the binary suffixes
+			// (which stop at Ei, 2^60). Fall back to the decimal exponent form
+			// rather than emitting a mantissa whose scale has been dropped.
+			decNumber, decExponent := q.AsCanonicalBytes(out)
+			decSuffix, _ := quantitySuffixer.constructBytes(10, decExponent, DecimalExponent)
+			return decNumber, decSuffix
+		}
 		return number, suffix
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -2033,3 +2033,81 @@ func TestQuantityPtrEqual(t *testing.T) {
 		})
 	}
 }
+
+// TestQuantityStringBeyondSuffixRange covers magnitudes for which no SI suffix
+// exists: the decimal suffixes stop at E (10^18) and the binary ones at Ei (2^60).
+// Emitting the canonical mantissa without a suffix in those cases dropped the scale
+// entirely, so 10^21 serialized as "1".
+func TestQuantityStringBeyondSuffixRange(t *testing.T) {
+	table := []struct {
+		in     string
+		format Format
+		expect string
+	}{
+		// Within the suffix range, the output must not change.
+		{"1000000000000000000", DecimalSI, "1E"},
+		{"100000000000000000000", DecimalSI, "100E"},
+		{"1152921504606846976", BinarySI, "1Ei"},
+
+		// Beyond the suffix range, fall back to the exponent form.
+		{"1000000000000000000000", DecimalSI, "1e21"},
+		{"10000000000000000000000", DecimalSI, "10e21"},
+		{"1000000000000000000000000", DecimalSI, "1e24"},
+		{"-1000000000000000000000", DecimalSI, "-1e21"},
+
+		// Already-exponent input keeps its format.
+		{"1e21", DecimalExponent, "1e21"},
+
+		// Beyond Ei the binary form falls back to the decimal representation.
+		{"1180591620717411303424", BinarySI, "1180591620717411303424"},
+	}
+
+	for _, item := range table {
+		q, err := ParseQuantity(item.in)
+		if err != nil {
+			t.Errorf("%v: unexpected parse error: %v", item.in, err)
+			continue
+		}
+		q.Format = item.format
+
+		got := q.String()
+		if got != item.expect {
+			t.Errorf("%v (%v): expected %v, got %v", item.in, item.format, item.expect, got)
+		}
+
+		// The serialized form must parse back to the same value. This is the
+		// property that the missing suffix violated.
+		parsed, err := ParseQuantity(got)
+		if err != nil {
+			t.Errorf("%v: serialized form %q does not parse: %v", item.in, got, err)
+			continue
+		}
+		if q.Cmp(parsed) != 0 {
+			t.Errorf("%v: serialized as %q which is %v, not %v", item.in, got, parsed.AsDec(), q.AsDec())
+		}
+	}
+}
+
+// TestQuantityMarshalJSONBeyondSuffixRange guards the API serialization path, which
+// is where the dropped scale actually reached stored objects.
+func TestQuantityMarshalJSONBeyondSuffixRange(t *testing.T) {
+	const in = "1000000000000000000000"
+
+	q, err := ParseQuantity(in)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	data, err := q.MarshalJSON()
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+
+	var out Quantity
+	if err := out.UnmarshalJSON(data); err != nil {
+		t.Fatalf("unexpected unmarshal error for %s: %v", data, err)
+	}
+	if q.Cmp(out) != 0 {
+		t.Errorf("JSON round trip changed the value: %v became %s which is %v", q.AsDec(), data, out.AsDec())
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`CanonicalizeBytes` discarded the `ok` result of `quantitySuffixer.constructBytes`. That call is a
map lookup returning `(nil, false)` when no suffix exists for the magnitude - decimal SI stops at
`E` (10^18), binary at `Ei` (2^60). On a miss the mantissa was emitted with no suffix, which
silently drops the scale:

```
1e18  -> "1E"     ok
1e20  -> "100E"   ok
1e21  -> "1"      wrong
1e22  -> "10"     wrong
1e24  -> "1"      wrong   (1e21 and 1e24 both serialize to "1")
2^70  -> "1"      wrong   (BinarySI)
```

`MarshalJSON` goes through the same path, so this reaches stored objects: a PVC requesting
`1000000000000000000000` serialized as `"storage":"1"`. The cached-string optimisation does not
mask it, because the `inf.Dec` parse path never populates `q.s`.

This checks `ok` and falls back to the exponent form, which can represent any magnitude.

#### Which issue(s) this PR is related to:

Fixes #141249.

#### Special notes for your reviewer:

- **Values within the suffix range are byte-for-byte unchanged.** The test table pins `1E`,
  `100E` and `1Ei` specifically to guard that. Only `inf.Dec`-backed values can reach the
  fallback, since an int64-backed quantity cannot exceed exponent 18.
- **This does not implement capping.** The type's doc comment says quantities above 2^63-1 "will
  be capped or rounded up", but capping was never implemented in `ParseQuantity`. Adding it would
  be a larger behavioural change needing API review, so this PR only makes serialization lossless.
  Happy to take the capping route instead if sig-api-machinery prefers it.
- New output for out-of-range values is the exponent form (`1e21`), which parses back to the same
  value. Previously such values round-tripped to a wrong value, so nothing that worked before
  changes behaviour.
- The BinarySI fallback uses distinct names (`decNumber`/`decExponent`/`decSuffix`) rather than
  shadowing the outer variables.

Two tests are added: `TestQuantityStringBeyondSuffixRange` (table covering in-range and
out-of-range, decimal and binary, negative values, plus a re-parse assertion) and
`TestQuantityMarshalJSONBeyondSuffixRange` (the API serialization path). Reverting the fix
produces `1000000000000000000000 (DecimalSI): expected 1e21, got 1`.

Suites run green: `apimachinery/pkg/api/...`, `apimachinery/pkg/runtime/...`,
`component-helpers/resource/...`, `pkg/api/v1/resource/...`, `pkg/apis/core/...`, `pkg/quota/...`,
`apiserver/pkg/quota/...`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed resource.Quantity silently dropping the scale when serializing values too large for an SI suffix (10^21 and above, or above Ei for binary format), which turned a value such as 10^21 into "1". Those quantities are now serialized using the exponent form and round-trip correctly.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
