### PR TITLE
Fix premature poll success in TestRecreateStatefulSetUpdate

### DIFF
--- a/test/integration/statefulset/statefulset_test.go
+++ b/test/integration/statefulset/statefulset_test.go
@@ -848,7 +848,7 @@ func TestRecreateStatefulSetUpdate(t *testing.T) {
 	}
 
 	newImage := "new-image"
-	updateSTS(t, stsClient, sts.Name, func(sts *appsv1.StatefulSet) {
+	updatedSTS := updateSTS(t, stsClient, sts.Name, func(sts *appsv1.StatefulSet) {
 		sts.Spec.Template.Spec.Containers[0].Image = newImage
 	})
 
@@ -881,8 +881,10 @@ func TestRecreateStatefulSetUpdate(t *testing.T) {
 			setPodsReadyCondition(t, c, &pendingPods, v1.ConditionTrue, time.Now())
 		}
 
-		return ss.Status.ReadyReplicas == *ss.Spec.Replicas &&
-			ss.Status.CurrentRevision == ss.Status.UpdateRevision, nil
+		return ss.Status.ObservedGeneration >= updatedSTS.Generation &&
+			ss.Status.ReadyReplicas == *ss.Spec.Replicas &&
+			ss.Status.CurrentRevision == ss.Status.UpdateRevision &&
+			ss.Status.CurrentRevision != oldCurrentRevision, nil
 	}); err != nil {
 		t.Fatalf("Timed out waiting for recreate update to complete: %v", err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

The poll condition was satisfied by the status before the update happened, before the controller observed the spec change, the StatefulSet still reported all replicas ready and `CurrentRevision` == `UpdateRevision`, so the poll could succeed immediately.
    
Require `Status.ObservedGeneration` to reach the updated generation and `CurrentRevision` to differ from the pre-update revision, so the poll only succeeds once the controller has observed the update and completed the recreate rollout.

#### Which issue(s) this PR is related to:
Fixes #141250

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
