### PR TITLE
Populate UnschedulablePlugins for PlacementFeasible rejection

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -778,6 +778,9 @@ func (p *PriorityQueue) runPreEnqueuePlugin(ctx context.Context, pl fwk.PreEnque
 	if !pInfo.UnschedulablePlugins.Has(pl.Name()) && !pInfo.PendingPlugins.Has(pl.Name()) {
 		metrics.UnschedulableReason(pl.Name(), pod.Spec.SchedulerName).Inc()
 	}
+	if pInfo.UnschedulablePlugins == nil {
+		pInfo.UnschedulablePlugins = sets.New[string]()
+	}
 	pInfo.UnschedulablePlugins.Insert(pl.Name())
 	pInfo.GatingPlugin = pl.Name()
 	pInfo.GatingPluginEvents = p.pluginToEventsMap[pInfo.GatingPlugin]

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -2178,7 +2178,7 @@ func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placeme
 		if plStatus.IsError() {
 			return fwk.AsStatus(fmt.Errorf("running PlacementFeasible plugin: %w", plStatus.AsError())).WithPlugin(pl.Name())
 		}
-		return fwk.AsStatus(fmt.Errorf("unexpected status from PlacementFeasible plugin: %v", plStatus.Code())).WithPlugin(pl.Name())
+		return fwk.AsStatus(fmt.Errorf("unexpected status code (%v) from PlacementFeasible plugin: %v", plStatus.Code(), plStatus.Message())).WithPlugin(pl.Name())
 	}
 
 	return status

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -1226,7 +1226,7 @@ func TestRunPlacementFeasiblePlugins(t *testing.T) {
 				{name: "p1", status: fwk.NewStatus(fwk.Skip, "error")},
 				{name: "p2", status: nil},
 			},
-			expectedStatus: fwk.AsStatus(fmt.Errorf("unexpected status from PlacementFeasible plugin: Skip")).WithPlugin("p1"),
+			expectedStatus: fwk.AsStatus(fmt.Errorf("unexpected status code (Skip) from PlacementFeasible plugin: error")).WithPlugin("p1"),
 			expectedCalled: []bool{true, false},
 		},
 	}

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -612,8 +612,8 @@ type QueueingParams struct {
 	// It shouldn't be updated once initialized. It's used to record the e2e scheduling
 	// latency for an entity.
 	InitialAttemptTimestamp *time.Time
-	// UnschedulablePlugins records the plugin names that the entity failed with Unschedulable or UnschedulableAndUnresolvable status
-	// at specific extension points: PreFilter, Filter, Reserve, or Permit (WaitOnPermit).
+	// UnschedulablePlugins records the plugin names that the entity failed with Wait, Unschedulable or UnschedulableAndUnresolvable status
+	// at specific extension points: PreFilter, Filter, Reserve, Permit (WaitOnPermit) or PlacementFeasible.
 	// If entities are rejected at other extension points,
 	// they're assumed to be unexpected errors (e.g., temporal network issue, plugin implementation issue, etc)
 	// and retried soon after a backoff period.

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1188,11 +1188,16 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk fram
 
 	if err == ErrNoNodesAvailable {
 		logger.V(2).Info("Unable to schedule pod; no nodes are registered to the cluster; waiting", "pod", klog.KObj(pod))
-	} else if fitError, ok := err.(*framework.FitError); ok { // Inject UnschedulablePlugins to PodInfo, which will be used later for moving Pods between queues efficiently.
+	} else if fitError, ok := errors.AsType[*framework.FitError](err); ok { // Inject UnschedulablePlugins to PodInfo, which will be used later for moving Pods between queues efficiently.
 		podInfo.UnschedulablePlugins = fitError.Diagnosis.UnschedulablePlugins
 		podInfo.PendingPlugins = fitError.Diagnosis.PendingPlugins
 		logger.V(2).Info("Unable to schedule pod; no fit; waiting", "pod", klog.KObj(pod), "err", errMsg)
-	} else if errors.Is(err, errPodGroupUnschedulable) {
+	} else if fitError, ok := errors.AsType[*podGroupFitError](err); ok {
+		// Clone the plugin sets to ensure other readers of the same podGroupFitError
+		// won't modify them afterwards.
+		podInfo.UnschedulablePlugins = fitError.unschedulablePlugins.Clone()
+		podInfo.PendingPlugins = fitError.pendingPlugins.Clone()
+		errMsg = fmt.Sprintf("parent pod group is unschedulable: %s", errMsg)
 		logger.V(2).Info("Unable to schedule pod belonging to a pod group; waiting", "pod", klog.KObj(pod), "err", errMsg)
 	} else {
 		utilruntime.HandleErrorWithContext(ctx, err, "Error scheduling pod; retrying", "pod", klog.KObj(pod))

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -41,42 +41,6 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// revertFns is an aggregator of functions that undo the in-memory changes (such
-// as assuming pods and calls to Reserve plugins) performed during the pod group
-// scheduling algorithm simulation.
-//
-// These functions are executed:
-//   - After the whole root is processed in the scheduling algorithm, to clean up the
-//     simulation state.
-//   - On failure in (composite) pod group algorithm, to immediately roll back partial
-//     modifications.
-//   - After each candidate placement is considered in the placement scheduling algorithm,
-//     to reset the state before evaluating the next candidate placement.
-type revertFns []func()
-
-// append registers additional revert functions.
-func (r *revertFns) append(other revertFns) {
-	*r = append(*r, other...)
-}
-
-// revert executes the underlying reverting functions in reverse order of their registration
-// (Last In, First Out). Reverting in LIFO order ensures that sequential operations are unwound
-// correctly, preserving state integrity since later operations might depend on the side-effects
-// established by earlier ones (similar to how deferred execution works in Go).
-func (r *revertFns) revert() {
-	if r == nil {
-		return
-	}
-	for i := len(*r) - 1; i >= 0; i-- {
-		(*r)[i]()
-		(*r)[i] = nil // allow GC
-	}
-	*r = nil
-}
-
-// errPodGroupUnschedulable is used to describe that the pod group is unschedulable.
-var errPodGroupUnschedulable = fmt.Errorf("pod group is unschedulable")
-
 // scheduleOnePodGroup does the entire workload-aware scheduling workflow for a single pod group.
 func (sched *Scheduler) scheduleOnePodGroup(ctx context.Context, podGroupInfo *framework.QueuedPodGroupInfo) {
 	logger := klog.FromContext(ctx)
@@ -382,15 +346,6 @@ func (sched *Scheduler) updateUnscheduledPods(pgi *framework.PodGroupInfo, queue
 	}
 }
 
-// podSchedulingContext holds the precomputed data needed to handle the pod scheduling.
-// Each scheduling attempt in the same pod group scheduling cycle for the same pod
-// should use a new podSchedulingContext.
-type podSchedulingContext struct {
-	logger         klog.Logger
-	state          *framework.CycleState
-	podsToActivate *framework.PodsToActivate
-}
-
 // initPodSchedulingContext initializes the scheduling context of a single pod for pod group scheduling cycle.
 func initPodSchedulingContext(ctx context.Context, pod *v1.Pod, placementCycleState *framework.CycleState) *podSchedulingContext {
 	logger := klog.FromContext(ctx)
@@ -473,7 +428,8 @@ func (sched *Scheduler) runRootSchedulingAlgorithm(ctx context.Context, schedFwk
 		revertFns = childRevertFns
 		if rootResult.status.IsSuccess() && !rootResult.anyScheduled {
 			// The framework requires at least 1 pod to be scheduled in order to return a success status.
-			rootResult.status = fwk.NewStatus(fwk.Unschedulable).WithError(errPodGroupUnschedulable)
+			fitError := newPodGroupFitError(fwk.NewStatus(fwk.Unschedulable, "no pods were schedulable"))
+			rootResult.status = fwk.NewStatus(fwk.Unschedulable).WithError(fitError)
 		}
 		return result
 	}
@@ -482,69 +438,10 @@ func (sched *Scheduler) runRootSchedulingAlgorithm(ctx context.Context, schedFwk
 
 	if result.status.IsSuccess() && !result.anyScheduled {
 		// The framework requires at least 1 pod to be scheduled in order to return a success status.
-		result.status = fwk.NewStatus(fwk.Unschedulable).WithError(errPodGroupUnschedulable)
+		fitError := newPodGroupFitError(fwk.NewStatus(fwk.Unschedulable, "no pods were schedulable"))
+		result.status = fwk.NewStatus(fwk.Unschedulable).WithError(fitError)
 	}
 	return map[fwk.EntityKey]*podGroupAlgorithmResult{pgKey(result.podGroupInfo): result}
-}
-
-// algorithmResult stores the scheduling result and status for a scheduling attempt of a single pod.
-type algorithmResult struct {
-	// podInfo is the pod info for the pod the result applies to.
-	podInfo *framework.QueuedPodInfo
-	// scheduleResult is a scheduling algorithm result.
-	scheduleResult ScheduleResult
-	// podCtx is a specific pod scheduling context used for the scheduling algorithm.
-	podCtx *podSchedulingContext
-	// schedulingDuration is a pod scheduling duration used for metrics recording.
-	schedulingDuration time.Duration
-	// status is a scheduling algorithm status.
-	status *fwk.Status
-}
-
-func (ar *algorithmResult) GetPod() *v1.Pod {
-	return ar.podInfo.Pod
-}
-
-func (ar *algorithmResult) GetPodInfo() fwk.PodInfo {
-	return ar.podInfo
-}
-
-func (ar *algorithmResult) GetNodeName() string {
-	return ar.scheduleResult.SuggestedHost
-}
-
-func (ar *algorithmResult) GetCycleState() fwk.CycleState {
-	return ar.podCtx.state
-}
-
-// podGroupAlgorithmResult stores the scheduling pod scheduling results for a pod group
-// and any information needed to act on these results.
-type podGroupAlgorithmResult struct {
-	// podGroupInfo is the leaf pod group this result applies to.
-	podGroupInfo *framework.PodGroupInfo
-	// podResults is the list of scheduling results for each pod in the group.
-	// Only in the case of a pod group-wide Unschedulable or Error status can it contain fewer pods.
-	podResults []algorithmResult
-	// status is the final status of the pod group algorithm.
-	//
-	// Success code indicates that the pod group is schedulable and does not require any preemption.
-	// Its feasible pods should be moved to the binding cycle.
-	// This should only be set when the pod group is feasible and `waitingOnPreemption` is false.
-	//
-	// Unschedulable code indicates that the pod group is unschedulable,
-	// and all its pods should be moved back to the scheduling queue as unschedulable.
-	// Result with `waitingOnPreemption` set to true should have the Unschedulable status.
-	//
-	// Error code means that pod group scheduling failed due to an unexpected error,
-	// and no pods will be scheduled this attempt.
-	status *fwk.Status
-	// waitingOnPreemption indicates whether this pod group requires or is waiting for preemption to complete.
-	// This can only be set to true when the status is Unschedulable.
-	waitingOnPreemption bool
-	// placementCycleState is the state with which this placement was processed.
-	placementCycleState fwk.PlacementCycleState
-	// anyScheduled indicates if at least one pod was scheduled in this pod group during this cycle.
-	anyScheduled bool
 }
 
 // podGroupSchedulingDefaultAlgorithm runs the default algorithm for scheduling a pod group.
@@ -566,7 +463,7 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 	result = &podGroupAlgorithmResult{
 		podGroupInfo:        podGroupInfo,
 		podResults:          make([]algorithmResult, 0, len(queuedPodInfos)),
-		status:              fwk.NewStatus(fwk.Unschedulable).WithError(errPodGroupUnschedulable),
+		status:              fwk.NewStatus(fwk.Unschedulable),
 		waitingOnPreemption: false,
 		placementCycleState: placementCycleState,
 	}
@@ -586,18 +483,11 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 		Remaining: len(podGroupInfo.GetUnscheduledPods()),
 		Scheduled: podGroupState.ScheduledPodsCount(),
 	}
-	placementFeasibleStatus := schedFwk.RunPlacementFeasiblePlugins(ctx, placementCycleState, podGroupInfo, placementProgress)
+	proceed, placementFeasibleStatus := podGroupPotentiallyFeasible(ctx, schedFwk, placementCycleState, podGroupInfo, placementProgress)
 	result.status = placementFeasibleStatus
-	if placementFeasibleStatus.IsError() {
-		// Do not evaluate any pods if PlacementFeasible plugins return error or unexpected status.
-		result.status = fwk.AsStatus(fmt.Errorf("failed to evaluate placement feasibility: %w", placementFeasibleStatus.AsError()))
-		return result, nil
-	}
-	if placementFeasibleStatus.Code() == fwk.Unschedulable {
-		// Unschedulable from PlacementFeasible plugins indicates that the pod group
-		// cannot meet its constraints, even if we succeed in scheduling all the pods.
+	if !proceed {
+		// PlacementFeasible plugins said not to proceed to the subsequent pods.
 		// Exit early from the pod group algorithm.
-		result.status = fwk.NewStatus(fwk.Unschedulable, result.status.Reasons()...).WithError(errPodGroupUnschedulable)
 		return result, nil
 	}
 
@@ -620,31 +510,43 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 		if podResult.status.IsSuccess() {
 			placementProgress.Scheduled++
 		}
-		placementFeasibleStatus := schedFwk.RunPlacementFeasiblePlugins(ctx, placementCycleState, podGroupInfo, placementProgress)
-		if placementFeasibleStatus.IsError() {
-			// Stop evaluating the rest of the pods if PlacementFeasible plugins return error or unexpected status.
-			result.status = fwk.AsStatus(fmt.Errorf("failed to evaluate placement feasibility: %w", placementFeasibleStatus.AsError()))
-			break
-		}
-
+		proceed, placementFeasibleStatus := podGroupPotentiallyFeasible(ctx, schedFwk, placementCycleState, podGroupInfo, placementProgress)
 		result.status = placementFeasibleStatus
-
-		// Unschedulable from PlacementFeasible plugins indicates that the pod group
-		// cannot meet its constraints regardless of how many more pods we check.
-		// We can stop the scheduling loop early.
-		if placementFeasibleStatus.Code() == fwk.Unschedulable {
+		if !proceed {
+			// PlacementFeasible plugins said not to proceed to the subsequent pods.
+			// We can stop the scheduling loop early.
 			break
 		}
-
 		anyScheduled = anyScheduled || podResult.status.IsSuccess()
-	}
-
-	if result.status.IsWait() {
-		result.status = fwk.NewStatus(fwk.Unschedulable, result.status.Reasons()...).WithError(errPodGroupUnschedulable)
 	}
 
 	result.anyScheduled = anyScheduled
 	return result, revertFns
+}
+
+// podGroupPotentiallyFeasible runs placement feasible plugins and returns a status indicating whether
+// the (composite) pod group can meet its constraints based on the placement progress.
+// It returns true when the scheduling should proceed, false otherwise.
+// Returned status is modified to be fine to be copied directly to the podGroupAlgorithmResult.
+func podGroupPotentiallyFeasible(ctx context.Context, schedFwk framework.Framework, placementCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, placementProgress framework.PlacementProgress) (bool, *fwk.Status) {
+	status := schedFwk.RunPlacementFeasiblePlugins(ctx, placementCycleState, podGroupInfo, placementProgress)
+	switch status.Code() {
+	case fwk.Error:
+		// Do not evaluate more children if PlacementFeasible plugins return error or unexpected status.
+		return false, fwk.AsStatus(fmt.Errorf("failed to evaluate placement feasibility: %w", status.AsError()))
+	case fwk.Unschedulable:
+		// Unschedulable from PlacementFeasible plugins indicates that the (composite) pod group
+		// cannot meet its constraints, even if we succeed in scheduling all the children.
+		fitError := newPodGroupFitError(status)
+		return false, fwk.NewStatus(fwk.Unschedulable).WithError(fitError)
+	case fwk.Wait:
+		// Wait status indicates the scheduling should proceed,
+		// while at the same time, if it's a terminal status, the outcome should be Unschedulable.
+		fitError := newPodGroupFitError(status)
+		return true, fwk.NewStatus(fwk.Unschedulable).WithError(fitError)
+	default:
+		return true, status
+	}
 }
 
 // podGroupPodSchedulingAlgorithm runs a scheduling algorithm for individual pod from a pod group.
@@ -750,14 +652,21 @@ func completeCompositePodGroupAlgorithmResult(ctx context.Context, rootPodGroupI
 func completeCompositePodGroupAlgorithmResultMap(ctx context.Context, podGroupInfo *framework.PodGroupInfo, pgResults map[fwk.EntityKey]*podGroupAlgorithmResult, parentResult *podGroupAlgorithmResult) {
 	key := pgKey(podGroupInfo)
 	result, ok := pgResults[key]
-	// When a parent composite pod group fails, any child that previously succeeded during its own evaluation
-	// must be invalidated with the parent's failure status to prevent its pods from proceeding to binding.
-	if !ok || (!parentResult.status.IsSuccess() && result.status.IsSuccess()) {
+	if !ok {
+		// In case the pod group wasn't processed, create the result and set its status to parent.
 		result = &podGroupAlgorithmResult{
 			podGroupInfo: podGroupInfo,
-			status:       parentResult.status,
+			status:       parentResult.status.Clone(),
 		}
 		pgResults[key] = result
+	} else if !parentResult.status.IsSuccess() && result.status.IsSuccess() {
+		// When a parent composite pod group fails, any child that previously succeeded during its own evaluation
+		// must be invalidated with the parent's failure status to prevent its pods from proceeding to binding.
+		// Preserve the old result, but just overwrite the status.
+		result.status = parentResult.status.Clone()
+	} else if parentResult.status.IsError() && !result.status.IsError() {
+		// In case of an error, overwrite the status with an error.
+		result.status = parentResult.status.Clone()
 	}
 	if podGroupInfo.CompositePodGroup != nil {
 		for _, child := range podGroupInfo.GetChildGroups() {
@@ -772,6 +681,12 @@ func completeCompositePodGroupAlgorithmResultMap(ctx context.Context, podGroupIn
 // errors, and preemption states are propagated down the hierarchy (including composite groups)
 // to prevent invalid bindings and ensure accurate root-level metrics.
 func applyPodGroupPostFilterResult(completePGResults map[fwk.EntityKey]*podGroupAlgorithmResult, pgPostFilterResult *fwk.PodGroupPostFilterResult, status *fwk.Status) {
+	if status.IsError() {
+		for _, pgResult := range completePGResults {
+			pgResult.status = status.Clone()
+		}
+		return
+	}
 	if status.IsSuccess() {
 		// Post-filter plugins successfully identified preemption candidates.
 		// Mark all pod groups in the hierarchy as waiting on preemption.
@@ -790,14 +705,12 @@ func applyPodGroupPostFilterResult(completePGResults map[fwk.EntityKey]*podGroup
 			}
 		}
 	}
-	if status.IsError() {
-		for _, pgResult := range completePGResults {
-			pgResult.status = status
-		}
-	} else {
-		for _, pgResult := range completePGResults {
-			pgResult.status.AppendReason(status.String())
-		}
+	msg := status.Message()
+	if msg == "" {
+		return
+	}
+	for _, pgResult := range completePGResults {
+		pgResult.status.AppendReason(msg)
 	}
 }
 
@@ -862,12 +775,11 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 				case podGroupResult.status.IsRejected():
 					if podGroupResult.waitingOnPreemption {
 						// Pod has to come back to the scheduling queue as unschedulable, waiting for preemption to complete.
-						sched.FailureHandler(ctx, schedFwk, pInfo, podGroupResult.status, podResult.scheduleResult.nominatingInfo, podSchedulingStart)
+						sched.FailureHandler(ctx, schedFwk, pInfo, podGroupResult.status.Clone(), podResult.scheduleResult.nominatingInfo, podSchedulingStart)
 					} else {
 						// Pod group is unschedulable, so the pod has to be marked as unschedulable.
 						// Its rejection status is set to the pod group's status message.
-						status := fwk.NewStatus(fwk.Unschedulable, podGroupResult.status.Message()).WithError(errPodGroupUnschedulable)
-						sched.FailureHandler(ctx, schedFwk, pInfo, status, clearNominatedNode, podSchedulingStart)
+						sched.FailureHandler(ctx, schedFwk, pInfo, podGroupResult.status.Clone(), clearNominatedNode, podSchedulingStart)
 					}
 					unschedulablePods++
 				default:
@@ -913,7 +825,7 @@ func (sched *Scheduler) submitPodGroupAlgorithmResult(ctx context.Context, sched
 				Type:    schedulingapi.PodGroupInitiallyScheduled,
 				Status:  metav1.ConditionFalse,
 				Reason:  schedulingapi.PodGroupReasonSchedulerError,
-				Message: podGroupResult.status.AsError().Error(),
+				Message: podGroupResult.status.Message(),
 			}
 			utilruntime.HandleErrorWithContext(ctx, podGroupResult.status.AsError(), "Error scheduling pod group", "podGroup", klog.KObj(pgi), "errorPods", len(queuedPodInfos))
 		}
@@ -1038,7 +950,8 @@ func (sched *Scheduler) podGroupSchedulingPlacementAlgorithm(ctx context.Context
 	if len(successfulResults) == 0 {
 		// We need to send events and set the status for pods in case all simulations were infeasible.
 		// The selection of which simulation we report is arbitrary for now, but may change in the future.
-		anyResult.status = fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("0/%d placements are available, first placement status: %v", len(placements), anyResult.status.AsError())).WithError(errPodGroupUnschedulable)
+		fitError := newPodGroupPlacementFitError(anyResult.status, len(placements))
+		anyResult.status = fwk.NewStatus(fwk.Unschedulable).WithError(fitError)
 		return anyResult, nil
 	}
 
@@ -1122,6 +1035,10 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 		placementRevertFns.revert()
 
 		if result.status.IsError() {
+			// It is critical to copy the entire subtreeResult into results.
+			// If omitted, the pod results are reconstructed later using the generic parent error
+			// (*podGroupFitError) rather than their original *framework.FitError.
+			maps.Copy(results, subtreeResult)
 			return result, nil
 		}
 
@@ -1138,10 +1055,11 @@ func (sched *Scheduler) compositePodGroupSchedulingPlacementAlgorithm(ctx contex
 		// We need to send events and set the status for pods in case all simulations were infeasible.
 		// The selection of which simulation we report is arbitrary for now, but may change in the future.
 		anyResultRoot := anyResultSubtree[pgKey(podGroupInfo)]
-		anyResultRoot.status = fwk.NewStatus(fwk.Unschedulable, fmt.Sprintf("0/%d placements are available, first placement status: %v", len(placements), anyResultRoot.status.AsError())).WithError(errPodGroupUnschedulable)
+		fitError := newPodGroupPlacementFitError(anyResultRoot.status, len(placements))
+		anyResultRoot.status = fwk.NewStatus(fwk.Unschedulable).WithError(fitError)
 		// It is critical to copy the entire anyResultSubtree into results.
 		// If omitted, the pod results are reconstructed later using the generic parent error
-		// (errPodGroupUnschedulable) rather than their original *framework.FitError.
+		// (*podGroupFitError) rather than their original *framework.FitError.
 		// Losing the FitError means we lose the UnschedulablePlugins for each pod,
 		// which breaks the QueueingHints.
 		maps.Copy(results, anyResultSubtree)
@@ -1331,18 +1249,22 @@ func (sched *Scheduler) compositePodGroupSchedulingDefaultAlgorithm(ctx context.
 		}
 	}()
 
+	// Run PlacementFeasible plugins to check if the composite pod group can meet its constraints
+	// before even attempting to schedule any children.
 	placementProgress := framework.PlacementProgress{
 		Remaining: len(podGroupInfo.Children),
 	}
-	placementFeasibleStatus := schedFwk.RunPlacementFeasiblePlugins(ctx, placementCycleState, podGroupInfo, placementProgress)
-
-	if placementFeasibleStatus.Code() == fwk.Unschedulable || placementFeasibleStatus.Code() == fwk.Error {
+	proceed, placementFeasibleStatus := podGroupPotentiallyFeasible(ctx, schedFwk, placementCycleState, podGroupInfo, placementProgress)
+	if !proceed {
+		// PlacementFeasible plugins said not to proceed to the subsequent children.
+		// Exit early from the pod group algorithm.
 		return &podGroupAlgorithmResult{
 			podGroupInfo:        podGroupInfo,
 			status:              placementFeasibleStatus,
 			placementCycleState: placementCycleState,
 		}, revertFns
 	}
+
 	anyScheduled := false
 	for _, childPGInfo := range podGroupInfo.GetChildGroups() {
 		childPodGroupState := framework.NewCycleState()
@@ -1361,15 +1283,14 @@ func (sched *Scheduler) compositePodGroupSchedulingDefaultAlgorithm(ctx context.
 		if childResult.status.IsSuccess() {
 			placementProgress.Scheduled++
 		}
-		placementFeasibleStatus = schedFwk.RunPlacementFeasiblePlugins(ctx, placementCycleState, podGroupInfo, placementProgress)
-		if placementFeasibleStatus.Code() == fwk.Unschedulable || placementFeasibleStatus.Code() == fwk.Error {
+		proceed, placementFeasibleStatus = podGroupPotentiallyFeasible(ctx, schedFwk, placementCycleState, podGroupInfo, placementProgress)
+		if !proceed {
+			// PlacementFeasible plugins said not to proceed to the subsequent children.
+			// We can stop the scheduling loop early.
 			break
 		}
 	}
 
-	if placementFeasibleStatus.IsWait() {
-		placementFeasibleStatus = fwk.NewStatus(fwk.Unschedulable, placementFeasibleStatus.Reasons()...).WithError(errPodGroupUnschedulable)
-	}
 	return &podGroupAlgorithmResult{
 		podGroupInfo:        podGroupInfo,
 		status:              placementFeasibleStatus,

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -49,6 +49,7 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	schedulingapi "k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -191,7 +192,7 @@ func (mp *fakePlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, pl
 }
 
 func (mp *fakePlacementFeasiblePlugin) Permit(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
-	return fwk.NewStatus(fwk.Error, "unexpected call to permit"), 0
+	return nil, 0
 }
 
 func TestValidatePodGroup(t *testing.T) {
@@ -1624,6 +1625,38 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			},
 		},
 		{
+			name:   "All pods feasible, but podGroup unschedulable with podGroupFitError",
+			status: fwk.NewStatus(fwk.Unschedulable).WithError(newPodGroupFitError(fwk.NewStatus(fwk.Unschedulable, "not enough capacity for the gang"))),
+			podResultsByPodName: map[string]algorithmResult{
+				"p1": {scheduleResult: ScheduleResult{SuggestedHost: "node1"}, status: nil},
+				"p2": {scheduleResult: ScheduleResult{SuggestedHost: "node1"}, status: nil},
+				"p3": {scheduleResult: ScheduleResult{SuggestedHost: "node1"}, status: nil},
+			},
+			expectFailed: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupInitiallyScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "not enough capacity for the gang",
+			},
+		},
+		{
+			name:   "All pods feasible, but podGroup unschedulable with placement podGroupFitError",
+			status: fwk.NewStatus(fwk.Unschedulable).WithError(newPodGroupPlacementFitError(fwk.NewStatus(fwk.Unschedulable, "not enough capacity for the gang"), 2)),
+			podResultsByPodName: map[string]algorithmResult{
+				"p1": {scheduleResult: ScheduleResult{SuggestedHost: "node1"}, status: nil},
+				"p2": {scheduleResult: ScheduleResult{SuggestedHost: "node1"}, status: nil},
+				"p3": {scheduleResult: ScheduleResult{SuggestedHost: "node1"}, status: nil},
+			},
+			expectFailed: sets.New("p1", "p2", "p3"),
+			expectCondition: &metav1.Condition{
+				Type:    schedulingapi.PodGroupInitiallyScheduled,
+				Status:  metav1.ConditionFalse,
+				Reason:  schedulingapi.PodGroupReasonUnschedulable,
+				Message: "0/2 placements are available, first placement status: not enough capacity for the gang",
+			},
+		},
+		{
 			name: "One unschedulable",
 			podResultsByPodName: map[string]algorithmResult{
 				"p1": {scheduleResult: ScheduleResult{SuggestedHost: "node1"}, status: nil},
@@ -2611,7 +2644,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 						status: fwk.NewStatus(fwk.Unschedulable, "0/1 nodes are available:"),
 					},
 				},
-				status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status").WithError(errPodGroupUnschedulable),
+				status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status"),
 			},
 		},
 		"when all placements are infeasible, but pods are feasible, returns unschedulable": {
@@ -2651,7 +2684,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 						status: nil,
 					},
 				},
-				status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status").WithError(errPodGroupUnschedulable),
+				status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status"),
 			},
 		},
 		"filters out infeasible placements": {
@@ -3786,7 +3819,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 			},
 			expectedResults: map[string]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {
-					status: fwk.NewStatus(fwk.Unschedulable, "pod group is unschedulable"),
+					status: fwk.NewStatus(fwk.Unschedulable, "no pods were schedulable"),
 				},
 				childPGInfo1.GetKey(): {
 					podResults: []algorithmResult{
@@ -3803,6 +3836,80 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 							status:  fwk.NewStatus(fwk.Unschedulable, "0/1 nodes are available: 1 node1 rejected."),
 						},
 					},
+				},
+			},
+		},
+		"returns unschedulable if no pods got scheduled and placement feasible rejected pods": {
+			placementPlugin: fakePlacementPlugin{
+				generatePlacementsResult: defaultPlacementResults,
+				scorePlacementsResult: map[string]map[string]int64{
+					rootPGInfo.GetKey(): {
+						"placement1": 2,
+						"placement2": 1,
+					},
+					childPGInfo1.GetKey(): {
+						"placement1": 5,
+						"placement2": 1,
+						"placement3": 1,
+						"placement4": 1,
+					},
+					childPGInfo2.GetKey(): {
+						"placement1": 5,
+						"placement2": 1,
+						"placement3": 1,
+						"placement4": 1,
+					},
+				},
+				filterStatus: map[string]*fwk.Status{
+					nodes[0].Name: fwk.NewStatus(fwk.Unschedulable, "node1 rejected"),
+					nodes[1].Name: fwk.NewStatus(fwk.Unschedulable, "node2 rejected"),
+					nodes[2].Name: fwk.NewStatus(fwk.Unschedulable, "node3 rejected"),
+					nodes[3].Name: fwk.NewStatus(fwk.Unschedulable, "node4 rejected"),
+				},
+			},
+			placementFeasibleStatuses: [][]fwk.Code{
+				// cpg, p1
+				{fwk.Wait, fwk.Wait, fwk.Unschedulable},
+				// pg1, p1
+				{fwk.Wait, fwk.Unschedulable},
+				// pg1, p2
+				{fwk.Wait, fwk.Unschedulable},
+				// pg2, p1
+				{fwk.Wait, fwk.Unschedulable},
+				// pg2, p2
+				{fwk.Wait, fwk.Unschedulable},
+				// cpg, p2
+				{fwk.Wait, fwk.Wait, fwk.Unschedulable},
+				// pg1, p3
+				{fwk.Wait, fwk.Unschedulable},
+				// pg1, p4
+				{fwk.Wait, fwk.Unschedulable},
+				// pg2, p3
+				{fwk.Wait, fwk.Unschedulable},
+				// pg2, p4
+				{fwk.Wait, fwk.Unschedulable},
+			},
+			expectedResults: map[string]podGroupAlgorithmResult{
+				rootPGInfo.GetKey(): {
+					status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status"),
+				},
+				childPGInfo1.GetKey(): {
+					podResults: []algorithmResult{
+						{
+							podInfo: queuedPodInfo1,
+							status:  fwk.NewStatus(fwk.Unschedulable, "0/1 nodes are available: 1 node1 rejected."),
+						},
+					},
+					status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status"),
+				},
+				childPGInfo2.GetKey(): {
+					podResults: []algorithmResult{
+						{
+							podInfo: queuedPodInfo2,
+							status:  fwk.NewStatus(fwk.Unschedulable, "0/1 nodes are available: 1 node1 rejected."),
+						},
+					},
+					status: fwk.NewStatus(fwk.Unschedulable, "0/2 placements are available, first placement status: injected placementFeasible status"),
 				},
 			},
 		},
@@ -3870,10 +3977,38 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				generatePlacementsStatus: map[string]*fwk.Status{
 					childPGInfo2.GetKey(): fwk.AsStatus(fmt.Errorf("injected error")),
 				},
+				scorePlacementsResult: map[string]map[string]int64{
+					rootPGInfo.GetKey(): {
+						"placement1": 1,
+					},
+					childPGInfo1.GetKey(): {
+						"placement1": 2,
+						"placement2": 1,
+					},
+					childPGInfo2.GetKey(): {
+						"placement1": 2,
+						"placement2": 1,
+					},
+				},
 			},
 			expectedResults: map[string]podGroupAlgorithmResult{
 				rootPGInfo.GetKey(): {
 					status: fwk.NewStatus(fwk.Error, "composite pod group evaluation failed due to child error: injected error"),
+				},
+				childPGInfo1.GetKey(): {
+					podResults: []algorithmResult{
+						{
+							podInfo: queuedPodInfo1,
+							scheduleResult: ScheduleResult{
+								SuggestedHost:  nodes[0].Name,
+								EvaluatedNodes: 1,
+								FeasibleNodes:  1,
+							},
+						},
+					},
+				},
+				childPGInfo2.GetKey(): {
+					status: fwk.AsStatus(fmt.Errorf("injected error")),
 				},
 			},
 		},
@@ -3972,16 +4107,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 					ScheduleResult{},
 					fwk.Status{},
 					framework.PodInfo{}),
-				cmp.FilterPath(func(p cmp.Path) bool {
-					if len(p) < 2 {
-						return false
-					}
-					step, ok := p[len(p)-1].(cmp.StructField)
-					if !ok {
-						return false
-					}
-					return (strings.HasSuffix(p[len(p)-2].Type().String(), "podGroupAlgorithmResult") && (step.Name() == "podGroupInfo" || step.Name() == "placementCycleState" || step.Name() == "revertFn" || step.Name() == "anyScheduled"))
-				}, cmp.Ignore()),
+				cmpopts.IgnoreFields(podGroupAlgorithmResult{}, "podGroupInfo", "placementCycleState", "anyScheduled"),
 				cmpopts.IgnoreFields(algorithmResult{}, "podCtx", "schedulingDuration"),
 				statusCmpOpt,
 			}
@@ -5981,5 +6107,1223 @@ func buildHierarchicalQueuedPodGroupInfo(
 	return &framework.QueuedPodGroupInfo{
 		PodGroupInfo:   rootInfo,
 		QueuedPodInfos: queuedPodInfos,
+	}
+}
+
+func TestPodGroupPotentiallyFeasible(t *testing.T) {
+	tests := []struct {
+		name               string
+		injectedStatus     fwk.Code
+		expectedProceed    bool
+		expectedStatusCode fwk.Code
+	}{
+		{
+			name:               "PlacementFeasible returns Success",
+			injectedStatus:     fwk.Success,
+			expectedProceed:    true,
+			expectedStatusCode: fwk.Success,
+		},
+		{
+			name:               "PlacementFeasible returns Wait",
+			injectedStatus:     fwk.Wait,
+			expectedProceed:    true,
+			expectedStatusCode: fwk.Unschedulable,
+		},
+		{
+			name:               "PlacementFeasible returns Unschedulable",
+			injectedStatus:     fwk.Unschedulable,
+			expectedProceed:    false,
+			expectedStatusCode: fwk.Unschedulable,
+		},
+		{
+			name:               "PlacementFeasible returns Error",
+			injectedStatus:     fwk.Error,
+			expectedProceed:    false,
+			expectedStatusCode: fwk.Error,
+		},
+		{
+			name:               "PlacementFeasible returns UnschedulableAndUnresolvable (unsupported code)",
+			injectedStatus:     fwk.UnschedulableAndUnresolvable,
+			expectedProceed:    false,
+			expectedStatusCode: fwk.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+
+			_, ctx := ktesting.NewTestContext(t)
+			placementFeasiblePlugin := &fakePlacementFeasiblePlugin{
+				placementFeasibleStatuses: [][]fwk.Code{{tt.injectedStatus}},
+			}
+			registry := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					return placementFeasiblePlugin, nil
+				}),
+			}
+			schedFwk, err := tf.NewFramework(ctx, registry, "test-scheduler")
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			placementCycleState := framework.NewCycleState()
+			podGroupInfo := &framework.PodGroupInfo{
+				UnscheduledPods: []*v1.Pod{
+					st.MakePod().Name("pod").UID("pod").PodGroupName("pg").Obj(),
+				},
+				PodGroup: st.MakePodGroup().Name("pg").Obj(),
+			}
+			placementProgress := framework.PlacementProgress{
+				Remaining: 1,
+				Scheduled: 0,
+			}
+
+			proceed, status := podGroupPotentiallyFeasible(ctx, schedFwk, placementCycleState, podGroupInfo, placementProgress)
+			if proceed != tt.expectedProceed {
+				t.Errorf("Expected proceed: %v, got: %v", tt.expectedProceed, proceed)
+			}
+			if status.Code() != tt.expectedStatusCode {
+				t.Errorf("Expected status code: %v, got: %v", tt.expectedStatusCode, status.Code())
+			}
+		})
+	}
+}
+
+func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
+	testNode := st.MakeNode().Name("node1").UID("node1").Obj()
+
+	p1 := st.MakePod().Name("p1").Namespace("default").UID("p1").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+	p2 := st.MakePod().Name("p2").Namespace("default").UID("p2").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+	p3 := st.MakePod().Name("p3").Namespace("default").UID("p3").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
+	p4 := st.MakePod().Name("p4").Namespace("default").UID("p4").PodGroupName("pg2").SchedulerName("test-scheduler").Obj()
+	p5 := st.MakePod().Name("p5").Namespace("default").UID("p5").PodGroupName("pg3").SchedulerName("test-scheduler").Obj()
+	pg1Pods := []*v1.Pod{p1, p2, p3}
+	pg2Pods := []*v1.Pod{p4}
+	pg3Pods := []*v1.Pod{p5}
+
+	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
+	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
+	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
+	qInfo4 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p4}}
+	qInfo5 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p5}}
+
+	pg1 := st.MakePodGroup().Name("pg").Namespace("default").Obj()
+	pg2 := st.MakePodGroup().Name("pg2").Namespace("default").ParentCompositePodGroup("cpg").Obj()
+	pg3 := st.MakePodGroup().Name("pg3").Namespace("default").ParentCompositePodGroup("cpg").Obj()
+	cpg := st.MakeCompositePodGroup().Name("cpg").Namespace("default").Obj()
+
+	podGroupInfo := &framework.QueuedPodGroupInfo{
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
+			fwk.PodGroupKey("default", "pg"): {qInfo1, qInfo2, qInfo3},
+		},
+		PodGroupInfo: &framework.PodGroupInfo{
+			Name:            "pg",
+			Namespace:       "default",
+			Type:            fwk.PodGroupKeyType,
+			UnscheduledPods: pg1Pods,
+			PodGroup:        pg1,
+		},
+	}
+
+	compositePodGroupInfo := &framework.QueuedPodGroupInfo{
+		QueuedPodInfos: map[fwk.EntityKey][]*framework.QueuedPodInfo{
+			fwk.PodGroupKey("default", "pg2"): {qInfo4},
+			fwk.PodGroupKey("default", "pg3"): {qInfo5},
+		},
+		PodGroupInfo: &framework.PodGroupInfo{
+			Name:              "cpg",
+			Namespace:         "default",
+			Type:              fwk.CompositePodGroupKeyType,
+			CompositePodGroup: cpg,
+			Children: []*framework.PodGroupInfo{
+				{
+					Name:            "pg2",
+					Namespace:       "default",
+					Type:            fwk.PodGroupKeyType,
+					UnscheduledPods: pg2Pods,
+					PodGroup:        pg2,
+				},
+				{
+					Name:            "pg3",
+					Namespace:       "default",
+					Type:            fwk.PodGroupKeyType,
+					UnscheduledPods: pg3Pods,
+					PodGroup:        pg3,
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                         string
+		tasEnabled                   []bool
+		cpgEnabled                   []bool
+		compositePodGroups           []*schedulingv1alpha3.CompositePodGroup
+		podGroups                    []*schedulingv1beta1.PodGroup
+		pods                         []*v1.Pod
+		podGroupInfo                 *framework.QueuedPodGroupInfo
+		plugin                       *fakePodGroupPlugin
+		podGroupFeasibleStatuses     [][]fwk.Code
+		expectedFailedPodConditions  map[string]*v1.PodCondition
+		expectedUnschedulablePlugins map[*v1.Pod]sets.Set[string]
+		expectedBindings             sets.Set[string]
+	}{
+		{
+			name:         "All pods feasible",
+			tasEnabled:   []bool{true, false},
+			cpgEnabled:   []bool{true, false},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": nil,
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Success,
+			}},
+			expectedBindings: sets.New("p1", "p2", "p3"),
+		},
+		{
+			name:         "No pods schedulable",
+			tasEnabled:   []bool{true, false},
+			cpgEnabled:   []bool{true, false},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": fwk.NewStatus(fwk.Unschedulable, "node1 capacity exceeded"),
+					"p2": fwk.NewStatus(fwk.Unschedulable, "node2 capacity exceeded"),
+					"p3": fwk.NewStatus(fwk.Unschedulable, "node3 capacity exceeded"),
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Success,
+				fwk.Success,
+				fwk.Success,
+				fwk.Success,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p1": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node1 capacity exceeded.",
+				},
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node2 capacity exceeded.",
+				},
+				"p3": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node3 capacity exceeded.",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p1: sets.New("FakePodGroupPlugin"),
+				p2: sets.New("FakePodGroupPlugin"),
+				p3: sets.New("FakePodGroupPlugin"),
+			},
+		},
+		{
+			name:         "One pod unschedulable, with placement context",
+			tasEnabled:   []bool{true},
+			cpgEnabled:   []bool{true},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": fwk.NewStatus(fwk.Unschedulable, "node capacity exceeded"),
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Unschedulable,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p1": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: 0/1 placements are available, first placement status: injected placementFeasible status",
+				},
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node capacity exceeded.",
+				},
+				"p3": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: 0/1 placements are available, first placement status: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p1: sets.New("GangScheduling"),
+				p2: sets.New("FakePodGroupPlugin"),
+				p3: sets.New("GangScheduling"),
+			},
+		},
+		{
+			name:         "One pod unschedulable, without placement context",
+			tasEnabled:   []bool{false},
+			cpgEnabled:   []bool{false},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": fwk.NewStatus(fwk.Unschedulable, "node capacity exceeded"),
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Unschedulable,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p1": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: injected placementFeasible status",
+				},
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node capacity exceeded.",
+				},
+				"p3": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p1: sets.New("GangScheduling"),
+				p2: sets.New("FakePodGroupPlugin"),
+				p3: sets.New("GangScheduling"),
+			},
+		},
+		{
+			name:         "One pod unschedulable, causing loop to break earlier, with placement context",
+			tasEnabled:   []bool{true},
+			cpgEnabled:   []bool{true},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": fwk.NewStatus(fwk.Unschedulable, "node capacity exceeded"),
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Unschedulable,
+				fwk.Unschedulable,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p1": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: 0/1 placements are available, first placement status: injected placementFeasible status",
+				},
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node capacity exceeded.",
+				},
+				"p3": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: 0/1 placements are available, first placement status: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p1: sets.New("GangScheduling"),
+				p2: sets.New("FakePodGroupPlugin"),
+				p3: sets.New("GangScheduling"),
+			},
+		},
+		{
+			name:         "One pod unschedulable, causing loop to break earlier, without placement context",
+			tasEnabled:   []bool{false},
+			cpgEnabled:   []bool{false},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": fwk.NewStatus(fwk.Unschedulable, "node capacity exceeded"),
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Unschedulable,
+				fwk.Unschedulable,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p1": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: injected placementFeasible status",
+				},
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node capacity exceeded.",
+				},
+				"p3": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p1: sets.New("GangScheduling"),
+				p2: sets.New("FakePodGroupPlugin"),
+				p3: sets.New("GangScheduling"),
+			},
+		},
+		{
+			name:         "One pod unschedulable, but others feasible",
+			tasEnabled:   []bool{true, false},
+			cpgEnabled:   []bool{true, false},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": fwk.NewStatus(fwk.Unschedulable, "node capacity exceeded"),
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Success,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node capacity exceeded.",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p2: sets.New("FakePodGroupPlugin"),
+			},
+			expectedBindings: sets.New("p1", "p3"),
+		},
+		{
+			name:         "One pod returns error, with success pods",
+			tasEnabled:   []bool{true, false},
+			cpgEnabled:   []bool{true, false},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": fwk.NewStatus(fwk.Error, "filter internal error"),
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Wait,
+				fwk.Success,
+				fwk.Success,
+				fwk.Success,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p1": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to schedule other pod from a pod group: running \"FakePodGroupPlugin\" filter plugin: filter internal error",
+				},
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "running \"FakePodGroupPlugin\" filter plugin: filter internal error",
+				},
+				"p3": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to schedule other pod from a pod group: running \"FakePodGroupPlugin\" filter plugin: filter internal error",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p1: sets.New[string](),
+				p2: sets.New[string](),
+				p3: sets.New[string](),
+			},
+		},
+		{
+			name:         "One pod returns error, with unschedulable pods",
+			tasEnabled:   []bool{true, false},
+			cpgEnabled:   []bool{true, false},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": fwk.NewStatus(fwk.Unschedulable, "node1 capacity exceeded"),
+					"p2": fwk.NewStatus(fwk.Error, "filter internal error"),
+					"p3": fwk.NewStatus(fwk.Unschedulable, "node3 capacity exceeded"),
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Unschedulable,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p1": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to schedule other pod from a pod group: running \"FakePodGroupPlugin\" filter plugin: filter internal error",
+				},
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "running \"FakePodGroupPlugin\" filter plugin: filter internal error",
+				},
+				"p3": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to schedule other pod from a pod group: running \"FakePodGroupPlugin\" filter plugin: filter internal error",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p1: sets.New[string](),
+				p2: sets.New[string](),
+				p3: sets.New[string](),
+			},
+		},
+		{
+			name:         "Pods feasible, but PlacementFeasible errors",
+			tasEnabled:   []bool{true, false},
+			cpgEnabled:   []bool{true, false},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": fwk.NewStatus(fwk.Unschedulable, "node1 capacity exceeded"),
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Wait,
+				fwk.Success,
+				fwk.Success,
+				fwk.Error,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p1": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to evaluate placement feasibility: running PlacementFeasible plugin: injected placementFeasible status",
+				},
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to evaluate placement feasibility: running PlacementFeasible plugin: injected placementFeasible status",
+				},
+				"p3": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to evaluate placement feasibility: running PlacementFeasible plugin: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p1: sets.New[string](),
+				p2: sets.New[string](),
+				p3: sets.New[string](),
+			},
+		},
+		{
+			name:         "Unschedulable pods, but PlacementFeasible errors",
+			tasEnabled:   []bool{true, false},
+			cpgEnabled:   []bool{true, false},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": fwk.NewStatus(fwk.Unschedulable, "node1 capacity exceeded"),
+					"p2": fwk.NewStatus(fwk.Unschedulable, "node2 capacity exceeded"),
+					"p3": fwk.NewStatus(fwk.Unschedulable, "node3 capacity exceeded"),
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Wait,
+				fwk.Error,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p1": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to evaluate placement feasibility: running PlacementFeasible plugin: injected placementFeasible status",
+				},
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to evaluate placement feasibility: running PlacementFeasible plugin: injected placementFeasible status",
+				},
+				"p3": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to evaluate placement feasibility: running PlacementFeasible plugin: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p1: sets.New[string](),
+				p2: sets.New[string](),
+				p3: sets.New[string](),
+			},
+		},
+		{
+			name:         "PlacementFeasible returns Unschedulable on first step, with placement context",
+			tasEnabled:   []bool{true},
+			cpgEnabled:   []bool{true},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": nil,
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Unschedulable,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p1": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: 0/1 placements are available, first placement status: injected placementFeasible status",
+				},
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: 0/1 placements are available, first placement status: injected placementFeasible status",
+				},
+				"p3": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: 0/1 placements are available, first placement status: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p1: sets.New("GangScheduling"),
+				p2: sets.New("GangScheduling"),
+				p3: sets.New("GangScheduling"),
+			},
+		},
+		{
+			name:         "PlacementFeasible returns Unschedulable on first step, without placement context",
+			tasEnabled:   []bool{false},
+			cpgEnabled:   []bool{false},
+			podGroups:    []*schedulingv1beta1.PodGroup{pg1},
+			pods:         pg1Pods,
+			podGroupInfo: podGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p1": nil,
+					"p2": nil,
+					"p3": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{{
+				fwk.Unschedulable,
+			}},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p1": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: injected placementFeasible status",
+				},
+				"p2": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: injected placementFeasible status",
+				},
+				"p3": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p1: sets.New("GangScheduling"),
+				p2: sets.New("GangScheduling"),
+				p3: sets.New("GangScheduling"),
+			},
+		},
+		{
+			name:               "CPG: All pods feasible",
+			tasEnabled:         []bool{true},
+			cpgEnabled:         []bool{true},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{cpg},
+			podGroups:          []*schedulingv1beta1.PodGroup{pg2, pg3},
+			pods:               []*v1.Pod{p4, p5},
+			podGroupInfo:       compositePodGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p4": nil,
+					"p5": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{
+				{fwk.Wait, fwk.Success, fwk.Success},
+				{fwk.Wait, fwk.Success},
+				{fwk.Wait, fwk.Success},
+			},
+			expectedBindings: sets.New("p4", "p5"),
+		},
+		{
+			name:               "CPG: No pods schedulable",
+			tasEnabled:         []bool{true},
+			cpgEnabled:         []bool{true},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{cpg},
+			podGroups:          []*schedulingv1beta1.PodGroup{pg2, pg3},
+			pods:               []*v1.Pod{p4, p5},
+			podGroupInfo:       compositePodGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p4": fwk.NewStatus(fwk.Unschedulable, "node1 capacity exceeded"),
+					"p5": fwk.NewStatus(fwk.Unschedulable, "node2 capacity exceeded"),
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{
+				{fwk.Success, fwk.Success, fwk.Success},
+				{fwk.Success, fwk.Success},
+				{fwk.Success, fwk.Success},
+			},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p4": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node1 capacity exceeded.",
+				},
+				"p5": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node2 capacity exceeded.",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p4: sets.New("FakePodGroupPlugin"),
+				p5: sets.New("FakePodGroupPlugin"),
+			},
+		},
+		{
+			name:               "CPG: One pod unschedulable",
+			tasEnabled:         []bool{true},
+			cpgEnabled:         []bool{true},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{cpg},
+			podGroups:          []*schedulingv1beta1.PodGroup{pg2, pg3},
+			pods:               []*v1.Pod{p4, p5},
+			podGroupInfo:       compositePodGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p4": fwk.NewStatus(fwk.Unschedulable, "node capacity exceeded"),
+					"p5": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{
+				{fwk.Wait, fwk.Wait, fwk.Unschedulable},
+				{fwk.Wait, fwk.Unschedulable},
+				{fwk.Wait, fwk.Success},
+			},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p4": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node capacity exceeded.",
+				},
+				"p5": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: 0/1 placements are available, first placement status: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p4: sets.New("FakePodGroupPlugin"),
+				p5: sets.New("GangScheduling"),
+			},
+		},
+		{
+			name:               "CPG: One pod unschedulable, causing loop to break earlier",
+			tasEnabled:         []bool{true},
+			cpgEnabled:         []bool{true},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{cpg},
+			podGroups:          []*schedulingv1beta1.PodGroup{pg2, pg3},
+			pods:               []*v1.Pod{p4, p5},
+			podGroupInfo:       compositePodGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p4": fwk.NewStatus(fwk.Unschedulable, "node capacity exceeded"),
+					"p5": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{
+				{fwk.Wait, fwk.Unschedulable, fwk.Unschedulable},
+				{fwk.Wait, fwk.Unschedulable},
+				{fwk.Wait, fwk.Success},
+			},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p4": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node capacity exceeded.",
+				},
+				"p5": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: 0/1 placements are available, first placement status: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p4: sets.New("FakePodGroupPlugin"),
+				p5: sets.New("GangScheduling"),
+			},
+		},
+		{
+			name:               "CPG: One pod unschedulable, but others feasible",
+			tasEnabled:         []bool{true},
+			cpgEnabled:         []bool{true},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{cpg},
+			podGroups:          []*schedulingv1beta1.PodGroup{pg2, pg3},
+			pods:               []*v1.Pod{p4, p5},
+			podGroupInfo:       compositePodGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p4": fwk.NewStatus(fwk.Unschedulable, "node capacity exceeded"),
+					"p5": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{
+				{fwk.Wait, fwk.Wait, fwk.Success},
+				{fwk.Wait, fwk.Unschedulable},
+				{fwk.Wait, fwk.Success},
+			},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p4": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "0/1 nodes are available: 1 node capacity exceeded.",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p4: sets.New("FakePodGroupPlugin"),
+			},
+			expectedBindings: sets.New("p5"),
+		},
+		{
+			name:               "CPG: One pod returns error, with success pods",
+			tasEnabled:         []bool{true},
+			cpgEnabled:         []bool{true},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{cpg},
+			podGroups:          []*schedulingv1beta1.PodGroup{pg2, pg3},
+			pods:               []*v1.Pod{p4, p5},
+			podGroupInfo:       compositePodGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p4": nil,
+					"p5": fwk.NewStatus(fwk.Error, "filter internal error"),
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{
+				{fwk.Wait, fwk.Success, fwk.Success},
+				{fwk.Wait, fwk.Success},
+				{fwk.Wait, fwk.Success},
+			},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p4": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "composite pod group evaluation failed due to child error: failed to schedule other pod from a pod group: running \"FakePodGroupPlugin\" filter plugin: filter internal error",
+				},
+				"p5": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "running \"FakePodGroupPlugin\" filter plugin: filter internal error",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p4: sets.New[string](),
+				p5: sets.New[string](),
+			},
+		},
+		{
+			name:               "CPG: One pod returns error, with unschedulable pods",
+			tasEnabled:         []bool{true},
+			cpgEnabled:         []bool{true},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{cpg},
+			podGroups:          []*schedulingv1beta1.PodGroup{pg2, pg3},
+			pods:               []*v1.Pod{p4, p5},
+			podGroupInfo:       compositePodGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p4": fwk.NewStatus(fwk.Unschedulable, "node capacity exceeded"),
+					"p5": fwk.NewStatus(fwk.Error, "filter internal error"),
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{
+				{fwk.Wait, fwk.Wait, fwk.Unschedulable},
+				{fwk.Wait, fwk.Unschedulable},
+				{fwk.Wait, fwk.Success},
+			},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p4": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "composite pod group evaluation failed due to child error: failed to schedule other pod from a pod group: running \"FakePodGroupPlugin\" filter plugin: filter internal error",
+				},
+				"p5": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "running \"FakePodGroupPlugin\" filter plugin: filter internal error",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p4: sets.New[string](),
+				p5: sets.New[string](),
+			},
+		},
+		{
+			name:               "CPG: Pods feasible, but PlacementFeasible errors",
+			tasEnabled:         []bool{true},
+			cpgEnabled:         []bool{true},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{cpg},
+			podGroups:          []*schedulingv1beta1.PodGroup{pg2, pg3},
+			pods:               []*v1.Pod{p4, p5},
+			podGroupInfo:       compositePodGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p4": nil,
+					"p5": fwk.NewStatus(fwk.Unschedulable, "node capacity exceeded"),
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{
+				{fwk.Wait, fwk.Success, fwk.Error},
+				{fwk.Wait, fwk.Success},
+				{fwk.Wait, fwk.Unschedulable},
+			},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p4": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to evaluate placement feasibility: running PlacementFeasible plugin: injected placementFeasible status",
+				},
+				"p5": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to evaluate placement feasibility: running PlacementFeasible plugin: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p4: sets.New[string](),
+				p5: sets.New[string](),
+			},
+		},
+		{
+			name:               "CPG: Unschedulable pods, but PlacementFeasible errors",
+			tasEnabled:         []bool{true},
+			cpgEnabled:         []bool{true},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{cpg},
+			podGroups:          []*schedulingv1beta1.PodGroup{pg2, pg3},
+			pods:               []*v1.Pod{p4, p5},
+			podGroupInfo:       compositePodGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p4": fwk.NewStatus(fwk.Unschedulable, "node1 capacity exceeded"),
+					"p5": fwk.NewStatus(fwk.Unschedulable, "node2 capacity exceeded"),
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{
+				{fwk.Wait, fwk.Wait, fwk.Error},
+				{fwk.Wait, fwk.Unschedulable},
+				{fwk.Wait, fwk.Unschedulable},
+			},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p4": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to evaluate placement feasibility: running PlacementFeasible plugin: injected placementFeasible status",
+				},
+				"p5": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonSchedulerError,
+					Message: "failed to evaluate placement feasibility: running PlacementFeasible plugin: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p4: sets.New[string](),
+				p5: sets.New[string](),
+			},
+		},
+		{
+			name:               "CPG: PlacementFeasible returns Unschedulable on first step, with placement context",
+			tasEnabled:         []bool{true},
+			cpgEnabled:         []bool{true},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{cpg},
+			podGroups:          []*schedulingv1beta1.PodGroup{pg2, pg3},
+			pods:               []*v1.Pod{p4, p5},
+			podGroupInfo:       compositePodGroupInfo,
+			plugin: &fakePodGroupPlugin{
+				filterStatus: map[string]*fwk.Status{
+					"p4": nil,
+					"p5": nil,
+				},
+			},
+			podGroupFeasibleStatuses: [][]fwk.Code{
+				{fwk.Unschedulable},
+			},
+			expectedFailedPodConditions: map[string]*v1.PodCondition{
+				"p4": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: 0/1 placements are available, first placement status: injected placementFeasible status",
+				},
+				"p5": {
+					Type:    v1.PodScheduled,
+					Status:  v1.ConditionFalse,
+					Reason:  v1.PodReasonUnschedulable,
+					Message: "parent pod group is unschedulable: 0/1 placements are available, first placement status: injected placementFeasible status",
+				},
+			},
+			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
+				p4: sets.New("GangScheduling"),
+				p5: sets.New("GangScheduling"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		for _, tasEnabled := range tt.tasEnabled {
+			for _, cpgEnabled := range tt.cpgEnabled {
+				if !tasEnabled && cpgEnabled {
+					// Cannot happen, skip.
+					continue
+				}
+				t.Run(fmt.Sprintf("%s (TAS enabled: %v, CPG enabled: %v)", tt.name, tasEnabled, cpgEnabled), func(t *testing.T) {
+					featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+						features.GenericWorkload:                 true,
+						features.TopologyAwareWorkloadScheduling: tasEnabled,
+						features.CompositePodGroup:               cpgEnabled,
+					})
+
+					logger, ctx := ktesting.NewTestContext(t)
+					ctx, cancel := context.WithCancel(ctx)
+					defer cancel()
+
+					objs := []runtime.Object{testNode}
+					for _, cpg := range tt.compositePodGroups {
+						objs = append(objs, cpg)
+					}
+					for _, pg := range tt.podGroups {
+						objs = append(objs, pg)
+					}
+					for _, p := range tt.pods {
+						objs = append(objs, p)
+					}
+					client := clientsetfake.NewClientset(objs...)
+
+					informerFactory := informers.NewSharedInformerFactory(client, 0)
+					queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
+					snapshot := internalcache.NewEmptySnapshot()
+
+					placementFeasiblePlugin := &fakePlacementFeasiblePlugin{
+						placementFeasibleStatuses: tt.podGroupFeasibleStatuses,
+					}
+
+					registry := []tf.RegisterPluginFunc{
+						tf.RegisterFilterPlugin(tt.plugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+							return tt.plugin, nil
+						}),
+						tf.RegisterPostFilterPlugin(tt.plugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+							return tt.plugin, nil
+						}),
+						tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+							return placementFeasiblePlugin, nil
+						}),
+						tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+						tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+					}
+
+					schedFwk, err := tf.NewFramework(ctx, registry, "test-scheduler",
+						frameworkruntime.WithInformerFactory(informerFactory),
+						frameworkruntime.WithSnapshotSharedLister(snapshot),
+						frameworkruntime.WithPodNominator(queue),
+						frameworkruntime.WithClientSet(client),
+						frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+						frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+						frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
+					)
+					if err != nil {
+						t.Fatalf("Failed to create new framework: %v", err)
+					}
+
+					cache := internalcache.New(ctx, nil, true, cpgEnabled)
+					cache.AddNode(logger, testNode)
+					for _, cpg := range tt.compositePodGroups {
+						cache.AddCompositePodGroup(logger, cpg)
+					}
+					for _, pg := range tt.podGroups {
+						cache.AddPodGroup(pg)
+					}
+					for _, p := range tt.pods {
+						cache.AddPodGroupMember(p)
+					}
+
+					sched := &Scheduler{
+						Profiles:         profile.Map{"test-scheduler": schedFwk},
+						SchedulingQueue:  queue,
+						Cache:            cache,
+						client:           client,
+						nodeInfoSnapshot: snapshot,
+					}
+					sched.SchedulePod = sched.schedulePod
+					sched.FailureHandler = sched.handleSchedulingFailure
+
+					bindChan := make(chan string, len(tt.pods))
+					client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+						if action.GetSubresource() != "binding" {
+							return false, nil, nil
+						}
+						binding := action.(clienttesting.CreateAction).GetObject().(*v1.Binding)
+						bindChan <- binding.Name
+						return true, binding, nil
+					})
+
+					informerFactory.Start(ctx.Done())
+					informerFactory.WaitForCacheSync(ctx.Done())
+
+					if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
+						t.Fatalf("Failed to update snapshot: %v", err)
+					}
+
+					sched.podGroupCycle(ctx, schedFwk, framework.NewCycleState(), tt.podGroupInfo, time.Now())
+
+					boundPods := sets.New[string]()
+					for i := 0; i < len(tt.expectedBindings); i++ {
+						select {
+						case podName := <-bindChan:
+							boundPods.Insert(podName)
+						case <-time.After(5 * time.Second):
+							t.Fatalf("Timed out waiting for expected bindings")
+						}
+					}
+					if diff := cmp.Diff(tt.expectedBindings, boundPods); diff != "" {
+						t.Errorf("Unexpected bound pods (-want, +got):\n%s", diff)
+					}
+
+					for podName, expectedCond := range tt.expectedFailedPodConditions {
+						updatedPod, err := client.CoreV1().Pods("default").Get(ctx, podName, metav1.GetOptions{})
+						if err != nil {
+							t.Fatalf("Failed to get pod %s: %v", podName, err)
+						}
+						_, gotCond := podutil.GetPodCondition(&updatedPod.Status, expectedCond.Type)
+						if diff := cmp.Diff(expectedCond, gotCond, cmpopts.IgnoreFields(v1.PodCondition{}, "LastTransitionTime", "LastProbeTime")); diff != "" {
+							t.Errorf("Unexpected pod %s condition (-want, +got):\n%s", podName, diff)
+						}
+					}
+
+					for pod, expectedPlugins := range tt.expectedUnschedulablePlugins {
+						pInfo, ok := queue.GetPod(pod.Name, pod.Namespace, pod.Spec.SchedulingGroup)
+						if !ok {
+							t.Fatalf("Failed to get pod %s from queue", pod.Name)
+						}
+						if diff := cmp.Diff(expectedPlugins, pInfo.UnschedulablePlugins); diff != "" {
+							t.Errorf("Unexpected pod %s unschedulablePlugins (-want, +got):\n%s", pod.Name, diff)
+						}
+					}
+				})
+			}
+		}
 	}
 }

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1493,6 +1493,127 @@ func TestHandleSchedulingFailureForDeferredResizePod(t *testing.T) {
 	}
 }
 
+func TestHandleSchedulingFailure_PodGroupFitErrorCloned(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	pg := st.MakePodGroup().Name("pg1").Namespace("ns").MinCount(2).Obj()
+	pod1 := st.MakePod().Name("pod1").Namespace("ns").UID("uid1").PodGroupName("pg1").SchedulerName(testSchedulerName).Obj()
+	pod2 := st.MakePod().Name("pod2").Namespace("ns").UID("uid2").PodGroupName("pg1").SchedulerName(testSchedulerName).Obj()
+
+	client := clientsetfake.NewClientset(pod1, pod2)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+	schedFramework, err := tf.NewFramework(ctx,
+		[]tf.RegisterPluginFunc{
+			tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+			tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+		},
+		testSchedulerName,
+		frameworkruntime.WithClientSet(client),
+		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+		frameworkruntime.WithInformerFactory(informerFactory),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ar := metrics.NewMetricsAsyncRecorder(10, time.Second, ctx.Done())
+	queue := internalqueue.NewSchedulingQueue(nil, informerFactory, internalqueue.WithMetricsRecorder(ar))
+	sched := &Scheduler{
+		client:          client,
+		SchedulingQueue: queue,
+	}
+
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
+	queue.AddPodGroup(logger, pg)
+	queue.Add(ctx, pod1)
+	queue.Add(ctx, pod2)
+
+	entity, err := queue.Pop(logger)
+	if err != nil {
+		t.Fatalf("Failed to pop pod group: %v", err)
+	}
+	pgInfo := entity.(*framework.QueuedPodGroupInfo)
+
+	var poppedPods []*framework.QueuedPodInfo
+	pgInfo.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+		poppedPods = append(poppedPods, pInfo)
+		return true
+	})
+	if len(poppedPods) != 2 {
+		t.Fatalf("Expected 2 popped pods, got %d", len(poppedPods))
+	}
+
+	fitError := &podGroupFitError{
+		status:               fwk.NewStatus(fwk.Unschedulable, "pod group unschedulable"),
+		unschedulablePlugins: sets.New("pluginA", "pluginB"),
+		pendingPlugins:       sets.New("pluginC"),
+	}
+	status := fwk.NewStatus(fwk.Unschedulable, "gang unschedulable").WithError(fitError)
+
+	for _, pInfo := range poppedPods {
+		sched.handleSchedulingFailure(ctx, schedFramework, pInfo, status.Clone(), nil, time.Now())
+	}
+
+	queuedPod1, ok := queue.GetPod(pod1.Name, pod1.Namespace, pod1.Spec.SchedulingGroup)
+	if !ok {
+		t.Fatalf("Failed to get pod1 from the queue")
+	}
+	queuedPod2, ok := queue.GetPod(pod2.Name, pod2.Namespace, pod2.Spec.SchedulingGroup)
+	if !ok {
+		t.Fatalf("Failed to get pod2 from the queue")
+	}
+
+	wantUnschedulable := sets.New("pluginA", "pluginB")
+	wantPending := sets.New("pluginC")
+
+	if diff := cmp.Diff(wantUnschedulable, queuedPod1.UnschedulablePlugins); diff != "" {
+		t.Fatalf("Unexpected unschedulablePlugins for pod1 (-want, +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(wantPending, queuedPod1.PendingPlugins); diff != "" {
+		t.Fatalf("Unexpected pendingPlugins for pod1 (-want, +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(wantUnschedulable, queuedPod2.UnschedulablePlugins); diff != "" {
+		t.Fatalf("Unexpected unschedulablePlugins for pod2 (-want, +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(wantPending, queuedPod2.PendingPlugins); diff != "" {
+		t.Fatalf("Unexpected pendingPlugins for pod2 (-want, +got):\n%s", diff)
+	}
+
+	// Verify mutations to each plugin sets don't propagate to others.
+	queuedPod1.UnschedulablePlugins.Insert("pluginPod1")
+	queuedPod1.PendingPlugins.Insert("pluginPod1")
+	queuedPod2.UnschedulablePlugins.Insert("pluginPod2")
+	queuedPod2.PendingPlugins.Insert("pluginPod2")
+	fitError.unschedulablePlugins.Insert("pluginFit")
+	fitError.pendingPlugins.Insert("pluginFit")
+
+	if diff := cmp.Diff(sets.New("pluginA", "pluginB", "pluginPod1"), queuedPod1.UnschedulablePlugins); diff != "" {
+		t.Fatalf("Unexpected unschedulablePlugins for pod1 (-want, +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(sets.New("pluginC", "pluginPod1"), queuedPod1.PendingPlugins); diff != "" {
+		t.Fatalf("Unexpected pendingPlugins for pod1 (-want, +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(sets.New("pluginA", "pluginB", "pluginPod2"), queuedPod2.UnschedulablePlugins); diff != "" {
+		t.Fatalf("Unexpected unschedulablePlugins for pod2 (-want, +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(sets.New("pluginC", "pluginPod2"), queuedPod2.PendingPlugins); diff != "" {
+		t.Fatalf("Unexpected pendingPlugins for pod2 (-want, +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(sets.New("pluginA", "pluginB", "pluginFit"), fitError.unschedulablePlugins); diff != "" {
+		t.Fatalf("Unexpected unschedulablePlugins for fitError (-want, +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(sets.New("pluginC", "pluginFit"), fitError.pendingPlugins); diff != "" {
+		t.Fatalf("Unexpected pendingPlugins for fitError (-want, +got):\n%s", diff)
+	}
+}
+
 type constSigPluginConfig struct {
 	name       string
 	signature  []fwk.SignFragment

--- a/pkg/scheduler/types.go
+++ b/pkg/scheduler/types.go
@@ -1,0 +1,197 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	fwk "k8s.io/kube-scheduler/framework"
+	"k8s.io/kubernetes/pkg/scheduler/framework"
+)
+
+// revertFns is an aggregator of functions that undo the in-memory changes (such
+// as assuming pods and calls to Reserve plugins) performed during the pod group
+// scheduling algorithm simulation.
+//
+// These functions are executed:
+//   - After the whole root is processed in the scheduling algorithm, to clean up the
+//     simulation state.
+//   - On failure in (composite) pod group algorithm, to immediately roll back partial
+//     modifications.
+//   - After each candidate placement is considered in the placement scheduling algorithm,
+//     to reset the state before evaluating the next candidate placement.
+type revertFns []func()
+
+// append registers additional revert functions.
+func (r *revertFns) append(other revertFns) {
+	*r = append(*r, other...)
+}
+
+// revert executes the underlying reverting functions in reverse order of their registration
+// (Last In, First Out). Reverting in LIFO order ensures that sequential operations are unwound
+// correctly, preserving state integrity since later operations might depend on the side-effects
+// established by earlier ones (similar to how deferred execution works in Go).
+func (r *revertFns) revert() {
+	if r == nil {
+		return
+	}
+	for i := len(*r) - 1; i >= 0; i-- {
+		(*r)[i]()
+		(*r)[i] = nil // allow GC
+	}
+	*r = nil
+}
+
+// podSchedulingContext holds the precomputed data needed to handle the pod scheduling.
+// Each scheduling attempt in the same pod group scheduling cycle for the same pod
+// should use a new podSchedulingContext.
+type podSchedulingContext struct {
+	logger         klog.Logger
+	state          *framework.CycleState
+	podsToActivate *framework.PodsToActivate
+}
+
+// algorithmResult stores the scheduling result and status for a scheduling attempt of a single pod.
+type algorithmResult struct {
+	// podInfo is the pod info for the pod the result applies to.
+	podInfo *framework.QueuedPodInfo
+	// scheduleResult is a scheduling algorithm result.
+	scheduleResult ScheduleResult
+	// podCtx is a specific pod scheduling context used for the scheduling algorithm.
+	podCtx *podSchedulingContext
+	// schedulingDuration is a pod scheduling duration used for metrics recording.
+	schedulingDuration time.Duration
+	// status is a scheduling algorithm status.
+	status *fwk.Status
+}
+
+func (ar *algorithmResult) GetPod() *v1.Pod {
+	return ar.podInfo.Pod
+}
+
+func (ar *algorithmResult) GetPodInfo() fwk.PodInfo {
+	return ar.podInfo
+}
+
+func (ar *algorithmResult) GetNodeName() string {
+	return ar.scheduleResult.SuggestedHost
+}
+
+func (ar *algorithmResult) GetCycleState() fwk.CycleState {
+	return ar.podCtx.state
+}
+
+// podGroupAlgorithmResult stores the scheduling pod scheduling results for a pod group
+// and any information needed to act on these results.
+type podGroupAlgorithmResult struct {
+	// podGroupInfo is the leaf pod group this result applies to.
+	podGroupInfo *framework.PodGroupInfo
+	// podResults is the list of scheduling results for each pod in the group.
+	// Only in the case of a pod group-wide Unschedulable or Error status can it contain fewer pods.
+	podResults []algorithmResult
+	// status is the final status of the pod group algorithm.
+	//
+	// Success code indicates that the pod group is schedulable and does not require any preemption.
+	// Its feasible pods should be moved to the binding cycle.
+	// This should only be set when the pod group is feasible and `waitingOnPreemption` is false.
+	//
+	// Unschedulable code indicates that the pod group is unschedulable,
+	// and all its pods should be moved back to the scheduling queue as unschedulable.
+	// Result with `waitingOnPreemption` set to true should have the Unschedulable status.
+	//
+	// Error code means that pod group scheduling failed due to an unexpected error,
+	// and no pods will be scheduled this attempt.
+	status *fwk.Status
+	// waitingOnPreemption indicates whether this pod group requires or is waiting for preemption to complete.
+	// This can only be set to true when the status is Unschedulable.
+	waitingOnPreemption bool
+	// placementCycleState is the state with which this placement was processed.
+	placementCycleState fwk.PlacementCycleState
+	// anyScheduled indicates if at least one pod was scheduled in this pod group during this cycle.
+	anyScheduled bool
+}
+
+// podGroupFitError describes a fit error for a PodGroup or CompositePodGroup
+type podGroupFitError struct {
+	// status is a PodGroup rejection status.
+	status *fwk.Status
+	// numPlacements is the number of generated placements.
+	numPlacements int
+	// unschedulablePlugins are plugins that returned Wait, Unschedulable or UnschedulableAndUnresolvable status.
+	unschedulablePlugins sets.Set[string]
+	// pendingPlugins are plugins that returned Pending status.
+	pendingPlugins sets.Set[string]
+}
+
+// newPodGroupFitError creates a new PodGroupFitError without placement context.
+func newPodGroupFitError(s *fwk.Status) *podGroupFitError {
+	return newPodGroupPlacementFitError(s, 0)
+}
+
+// newPodGroupPlacementFitError creates a new PodGroupFitError within placement algorithm.
+func newPodGroupPlacementFitError(s *fwk.Status, numPlacements int) *podGroupFitError {
+	fe := &podGroupFitError{
+		status:        s,
+		numPlacements: numPlacements,
+	}
+	fe.addPluginStatus(s)
+	return fe
+}
+
+// addPluginStatus updates the fit error with plugin status.
+func (fe *podGroupFitError) addPluginStatus(s *fwk.Status) {
+	if fitError, ok := errors.AsType[*podGroupFitError](s.AsError()); ok {
+		// If the status holds podGroupFitError, it means that it already contains
+		// the unschedulablePlugins and pendingPlugins inside.
+		fe.unschedulablePlugins = fe.unschedulablePlugins.Union(fitError.unschedulablePlugins)
+		fe.pendingPlugins = fe.pendingPlugins.Union(fitError.pendingPlugins)
+		return
+	}
+	if s.Plugin() == "" {
+		return
+	}
+	if s.IsRejected() || s.IsWait() {
+		if fe.unschedulablePlugins == nil {
+			fe.unschedulablePlugins = sets.New[string]()
+		}
+		fe.unschedulablePlugins.Insert(s.Plugin())
+	}
+	if s.Code() == fwk.Pending {
+		if fe.pendingPlugins == nil {
+			fe.pendingPlugins = sets.New[string]()
+		}
+		fe.pendingPlugins.Insert(s.Plugin())
+	}
+}
+
+// Error returns the error message for the fit error.
+// In case of non-placement algorithm's error, it will not contain any placement context.
+func (fe *podGroupFitError) Error() string {
+	reason := fe.status.Message()
+	if err := fe.status.AsError(); err != nil {
+		reason = err.Error()
+	}
+	if fe.numPlacements == 0 {
+		return reason
+	}
+	return fmt.Sprintf("0/%d placements are available, first placement status: %s", fe.numPlacements, reason)
+}

--- a/staging/src/k8s.io/kube-scheduler/framework/types.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/types.go
@@ -372,18 +372,18 @@ type QueuedEntityInfo interface {
 	// It shouldn't be updated once initialized. It's used to record the e2e scheduling
 	// latency for an entity.
 	GetInitialAttemptTimestamp() *time.Time
-	// GetUnschedulablePlugins records the plugin names that the entity failed with Unschedulable or UnschedulableAndUnresolvable status
-	// at specific extension points: PreFilter, Filter, Reserve, or Permit (WaitOnPermit).
+	// GetUnschedulablePlugins returns the plugin names that the entity failed with Wait, Unschedulable or UnschedulableAndUnresolvable status
+	// at specific extension points: PreFilter, Filter, Reserve, Permit (WaitOnPermit) or PlacementFeasible.
 	// If entities are rejected at other extension points,
 	// they're assumed to be unexpected errors (e.g., temporal network issue, plugin implementation issue, etc)
 	// and retried soon after a backoff period.
 	// That is because such failures could be solved regardless of incoming cluster events (registered in EventsToRegister).
 	GetUnschedulablePlugins() sets.Set[string]
-	// GetPendingPlugins records the plugin names that the entity failed with Pending status.
+	// GetPendingPlugins returns the plugin names that the entity failed with Pending status.
 	GetPendingPlugins() sets.Set[string]
-	// GetGatingPlugin records the plugin name that gated the entity at PreEnqueue.
+	// GetGatingPlugin returns the plugin name that gated the entity at PreEnqueue.
 	GetGatingPlugin() string
-	// GetGatingPluginEvents records the events registered by the plugin that gated the entity at PreEnqueue.
+	// GetGatingPluginEvents returns the events registered by the plugin that gated the entity at PreEnqueue.
 	// We have it as a cache purpose to avoid re-computing which event(s) might ungate the entity.
 	GetGatingPluginEvents() []ClusterEvent
 }

--- a/test/integration/dra/pod_group.go
+++ b/test/integration/dra/pod_group.go
@@ -208,7 +208,7 @@ func testPodGroup(tCtx ktesting.TContext) {
 		pod1.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": "worker-1"}
 		pod1 = createPod(tCtx, namespace, "-1", pod1, claimObj)
 
-		expectPodUnschedulable(tCtx, pod0, "pod group is unschedulable, minCount (2) cannot be satisfied")
+		expectPodUnschedulable(tCtx, pod0, "parent pod group is unschedulable: minCount (2) cannot be satisfied")
 		expectPodUnschedulable(tCtx, pod1, "1 resourceclaim not available on the node")
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR correctly populates UnschedulablePlugins of member pods, when the pod group is rejected by a PlacementFeasible plugin, by introducing a `podGroupFitError` concept similar to already-existing `FitError` for pods.

Moreover, this PR refactors the code, so that the PodGroups and CompositePodGroups code paths for PlacementFeasible plugins are more unified, and fixes smaller issues related to non-cloning the state where needed.

This PR also moves the type definitions from `schedule_one_podgroup.go` to a new `types.go`, so that the former doesn't grow even more.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Generative AI was used in the PR preparation. Changes were carefully reviewed before pushing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed logic around PlacementFeasible status propagation so that the unschedulable plugins for a pod are correctly stored. PodGroup statuses were improved to be more readable.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
