### PR TITLE
Split Pod update with a changed UID into delete and add

### DIFF
--- a/pkg/scheduler/backend/queue/nominator.go
+++ b/pkg/scheduler/backend/queue/nominator.go
@@ -94,6 +94,23 @@ func (npm *nominator) addNominatedPodUnlocked(logger klog.Logger, pi fwk.PodInfo
 			logger.V(4).Info("Pod doesn't exist in podLister, aborted adding it to the nominator", "pod", klog.KObj(pi.GetPod()))
 			return
 		}
+		if updatedPod.UID != pi.GetPod().UID {
+			// The Pod was deleted and recreated under the same name while this instance was
+			// being scheduled. The caller that gets here is Scheduler.unreserveAndForget, which
+			// restores the nomination that Assume had removed, working off the Pod snapshot
+			// taken at Pop. It runs before the failure handler and outside the requeue path, so
+			// neither the UID check in handleSchedulingFailure nor the one in
+			// AddUnschedulablePodIfNotPresent can stop it, and this is the last place that can.
+			//
+			// Recording the nomination here would be permanent. The nominator is keyed by UID
+			// and every cleanup path is driven by an event, but every future event for this
+			// namespace/name carries the new UID. It would not stay harmless either, because
+			// nominatedPodToInfo resolves a nomination by namespace/name, so the entry would
+			// pull in the recreated Pod and keep the node accounted for against it in every
+			// Filter run for as long as the scheduler is up.
+			logger.V(4).Info("Pod was recreated with a different UID, aborted adding the previous instance to the nominator", "pod", klog.KObj(pi.GetPod()), "staleUID", pi.GetPod().UID, "currentUID", updatedPod.UID)
+			return
+		}
 		if updatedPod.Spec.NodeName != "" {
 			logger.V(4).Info("Pod is already scheduled to a node, aborted adding it to the nominator", "pod", klog.KObj(pi.GetPod()), "node", updatedPod.Spec.NodeName)
 			return

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -28,6 +28,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -887,6 +888,23 @@ func (p *PriorityQueue) addPod(ctx context.Context, pod *v1.Pod) {
 	// Furthermore, this must be called before moveToActiveQ to prevent a potential data race,
 	// where an active scheduler loop could pop and process the pod before its nomination is recorded.
 	p.nominator.addNominatedPod(logger, pInfo.PodInfo, nil)
+	// An Add event means that this namespace/name slot now belongs to pInfo.Pod.UID, so any
+	// leftover of the previous occupant has to go. This matters for a Pod that was deleted
+	// while it was in flight: Delete could not see it, its failure handler requeued it anyway
+	// because podSuperseded deliberately ignores a NotFound, and no further event will ever
+	// carry its UID. moveToActiveQ evicts such a leftover from unschedulableEntities and the
+	// activeQ heap replaces it, but neither touches the backoffQ, even though moveToActiveQ
+	// documents that the entity has to be removed from there first. Without this, the leftover
+	// stays in the backoffQ next to the live Pod in the activeQ, and flushBackoffQCompleted
+	// later overwrites the live entry with the dead one through heap.AddOrUpdate.
+	//
+	// This runs before the pod group branch below, so that a name reused by a group member
+	// clears the leftover as well. Queue keys are prefixed with the entity type, so a delete by
+	// a Pod key can never remove a queued PodGroup.
+	if stale := p.backoffQ.delete(pInfo); stale != nil {
+		logger.V(3).Info("Evicted a stale entry from the backoffQ on add of the Pod that owns its key", "pod", klog.KObj(pod))
+		decreaseUnschedulableReasonMetric(stale)
+	}
 	if p.isPodGroupMember(pod) {
 		p.addPodGroupMember(logger, pInfo)
 		return
@@ -1083,6 +1101,21 @@ func (p *PriorityQueue) AddUnschedulablePodIfNotPresent(logger klog.Logger, pInf
 	}()
 
 	pod := pInfo.Pod
+
+	// pInfo is a snapshot taken when this Pod was popped. While the attempt was running, the
+	// Pod may have been deleted and recreated under the same name with a different UID; the
+	// informer collapses that into a single update event, which Scheduler.updatePod splits
+	// into deletePod(old) and addPod(new). Requeueing the stale instance would park a dead Pod
+	// in the live Pod's namespace/name slot, and the live Pod's own requeue would then fail
+	// with "already present" and be dropped from the queue by the deferred Done above.
+	//
+	// The three checks below cannot catch this. They are keyed by type/namespace/name and find
+	// nothing once the recreated Pod has been popped, and for pod group members they can never
+	// match a Pod at all, because the queued entity is keyed by the PodGroup.
+	if p.podSuperseded(logger, pod) {
+		return ErrPodSuperseded
+	}
+
 	if p.unschedulableEntities.get(pInfo) != nil {
 		return fmt.Errorf("Pod %v is already present in unschedulable queue", klog.KObj(pod))
 	}
@@ -1530,6 +1563,40 @@ func (p *PriorityQueue) deletePodGroupMember(logger klog.Logger, pod *v1.Pod) {
 	if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
 		p.activeQ.broadcast()
 	}
+}
+
+// ErrPodSuperseded is returned by AddUnschedulablePodIfNotPresent when the Pod that finished
+// this scheduling attempt is no longer the Pod that owns its namespace/name.
+var ErrPodSuperseded = errors.New("pod was recreated during its scheduling attempt")
+
+// podSuperseded reports whether pod has been replaced by a Pod with the same namespace/name
+// and a different UID.
+//
+// Callers MUST hold p.lock; that is what makes the check race-free. client-go writes the
+// informer indexer before dispatching the notification that later drives Add and Delete on
+// this queue, and both of those take p.lock. So a read taken under p.lock is at least as
+// fresh as every queue mutation that has already been applied. Either the informer has
+// already run, and this read sees the new UID, or it has not, and Delete will remove
+// whatever we insert. The equivalent check in handleSchedulingFailure holds no lock and
+// works off a read taken earlier in the function, so it gives neither guarantee.
+//
+// A NotFound is deliberately not treated as superseded, which keeps today's behaviour for a
+// Pod that was plainly deleted. Its stale entry is either evicted by a later Add that reuses
+// the name, or picked up by the unschedulable leftover flush, attempted once more and then
+// dropped by the failure handler, which sees the NotFound itself. That costs one wasted
+// scheduling cycle; rejecting on NotFound here would be the complete fix.
+func (p *PriorityQueue) podSuperseded(logger klog.Logger, pod *v1.Pod) bool {
+	if p.podLister == nil {
+		// Only unit tests build the queue without a lister.
+		return false
+	}
+	livePod, err := p.podLister.Pods(pod.Namespace).Get(pod.Name)
+	if err != nil || livePod.UID == pod.UID {
+		return false
+	}
+	logger.V(2).Info("Pod was recreated with a different UID while it was being scheduled, not requeueing the previous instance",
+		"pod", klog.KObj(pod), "staleUID", pod.UID, "currentUID", livePod.UID)
+	return true
 }
 
 // deletePod removes an individual pod from the queue.

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -19,6 +19,7 @@ package queue
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -271,6 +272,67 @@ func TestPriorityQueue_Add(t *testing.T) {
 				t.Errorf("Expected medPod and unschedPod to be still present in nominatedPods: %v", q.nominator.nominatedPods["node1"])
 			}
 		})
+	}
+}
+
+// A Pod that is deleted while its scheduling attempt is running can still be requeued, because
+// the queue deliberately treats a NotFound from the pod lister as "no information". If the name
+// is reused afterwards, the Add of the new Pod has to evict that leftover. moveToActiveQ only
+// evicts an entity with the same key from unschedulableEntities, even though it documents that
+// the entity has to be removed from the backoffQ first, so without an explicit eviction the
+// dead entry stays in the backoffQ next to the live Pod in the activeQ.
+func TestPriorityQueue_Add_EvictsStaleBackoffEntry(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	const rejectorPlugin = "fakePlugin"
+	oldPod := st.MakePod().Name("foo").Namespace("ns").UID("old-uid").Obj()
+	recreatedPod := st.MakePod().Name("foo").Namespace("ns").UID("new-uid").Obj()
+
+	metrics.UnschedulableReason(rejectorPlugin, oldPod.Spec.SchedulerName).Set(0)
+
+	c := testingclock.NewFakeClock(time.Now())
+	q := NewTestQueue(ctx, newDefaultQueueSort(), WithClock(c))
+
+	q.Add(ctx, oldPod)
+	if _, err := q.Pop(logger); err != nil {
+		t.Fatalf("Pop failed: %v", err)
+	}
+	// The Pod is deleted while it is in flight, which the queue cannot observe, and its failure
+	// handler requeues it anyway. A cluster event during the same scheduling cycle routes the
+	// requeue to the backoffQ rather than to unschedulableEntities.
+	q.MoveAllToActiveOrBackoffQueue(logger, framework.EventUnschedulableTimeout, nil, nil, nil)
+	if err := q.AddUnschedulablePodIfNotPresent(logger, newQueuedPodInfoForLookup(oldPod, rejectorPlugin), q.SchedulingCycle()); err != nil {
+		t.Fatalf("unexpected error from AddUnschedulablePodIfNotPresent: %v", err)
+	}
+	if !q.backoffQ.has(newQueuedPodInfoForLookup(oldPod)) {
+		t.Fatalf("Expected the deleted pod to be in the backoffQ")
+	}
+	if val, _ := testutil.GetGaugeMetricValue(metrics.UnschedulableReason(rejectorPlugin, oldPod.Spec.SchedulerName)); val != 1 {
+		t.Fatalf("Expected the unschedulable reason metric to be 1, got %v", val)
+	}
+
+	// The name is reused by a new Pod.
+	q.Add(ctx, recreatedPod)
+
+	if q.backoffQ.has(newQueuedPodInfoForLookup(recreatedPod)) {
+		t.Errorf("Expected the stale entry to be evicted from the backoffQ")
+	}
+	if val, _ := testutil.GetGaugeMetricValue(metrics.UnschedulableReason(rejectorPlugin, oldPod.Spec.SchedulerName)); val != 0 {
+		t.Errorf("Expected the unschedulable reason metric of the evicted entry to be dropped, got %v", val)
+	}
+
+	// Completing the backoff must not resurrect the stale entry. moveToActiveQ would push it
+	// into the activeQ heap, which is keyed by namespace/name, and overwrite the live Pod.
+	c.Step(2 * time.Minute)
+	q.flushBackoffQCompleted(logger)
+	popped, err := q.Pop(logger)
+	if err != nil {
+		t.Fatalf("Pop failed: %v", err)
+	}
+	if got := popped.(*framework.QueuedPodInfo).Pod.UID; got != recreatedPod.UID {
+		t.Errorf("Popped pod UID = %v, want %v", got, recreatedPod.UID)
 	}
 }
 
@@ -1315,6 +1377,184 @@ func TestPriorityQueue_AddUnschedulablePodIfNotPresent(t *testing.T) {
 	// unschedulablePodInfo is inserted to unschedulable pod pool because no events happened during scheduling.
 	if diff := cmp.Diff(unschedulablePodInfo.Pod, getUnschedulablePod(q, unschedulablePodInfo.Pod)); diff != "" {
 		t.Errorf("Unexpected pod in unschedulableEntities (-want, +got):\n%s", diff)
+	}
+}
+
+// A Pod can be deleted and recreated under the same name while its scheduling attempt is still
+// running. The informer collapses that into a single update event, which Scheduler.updatePod
+// splits into a delete and an add, and the scheduling goroutine can pop the recreated Pod
+// before the failure handler of the previous instance requeues it. The namespace/name slot is
+// empty at that point, so the checks in AddUnschedulablePodIfNotPresent find nothing and would
+// admit the dead Pod into the live Pod's slot, after which the live Pod's own requeue fails
+// with "already present" and it is dropped from the queue for good.
+func TestPriorityQueue_AddUnschedulablePodIfNotPresent_PodRecreated(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	oldPod := st.MakePod().Name("foo").Namespace("ns").UID("old-uid").Obj()
+	recreatedPod := st.MakePod().Name("foo").Namespace("ns").UID("new-uid").Obj()
+
+	// The informer indexer already holds the recreated Pod, because client-go writes the store
+	// before it dispatches the notification that drives Delete and Add on this queue.
+	q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), []runtime.Object{recreatedPod}, WithClock(testingclock.NewFakeClock(time.Now())))
+
+	q.Add(ctx, oldPod)
+	if _, err := q.Pop(logger); err != nil {
+		t.Fatalf("Pop failed: %v", err)
+	}
+	// Scheduler.updatePod splits the collapsed update event. Delete is a no-op for a Pod that
+	// is in flight, and Add puts the recreated Pod into the activeQ.
+	q.Delete(logger, oldPod)
+	q.Add(ctx, recreatedPod)
+	// The scheduling goroutine pops the recreated Pod while the previous instance is still
+	// unwinding on the binding goroutine.
+	if _, err := q.Pop(logger); err != nil {
+		t.Fatalf("Pop of the recreated pod failed: %v", err)
+	}
+
+	err := q.AddUnschedulablePodIfNotPresent(logger, newQueuedPodInfoForLookup(oldPod, "plugin"), q.SchedulingCycle())
+	if !errors.Is(err, ErrPodSuperseded) {
+		t.Errorf("AddUnschedulablePodIfNotPresent() error = %v, want %v", err, ErrPodSuperseded)
+	}
+	if pInfo, ok := q.GetPod(oldPod.Name, oldPod.Namespace, nil); ok {
+		t.Errorf("Expected the previous instance not to be requeued, but the queue holds pod UID %v", pInfo.Pod.UID)
+	}
+
+	// The recreated Pod must still be able to come back from its own failed attempt.
+	if err := q.AddUnschedulablePodIfNotPresent(logger, newQueuedPodInfoForLookup(recreatedPod, "plugin"), q.SchedulingCycle()); err != nil {
+		t.Fatalf("unexpected error from AddUnschedulablePodIfNotPresent: %v", err)
+	}
+	pInfo, ok := q.GetPod(recreatedPod.Name, recreatedPod.Namespace, nil)
+	if !ok {
+		t.Fatalf("Failed to get pod %s/%s from queue", recreatedPod.Namespace, recreatedPod.Name)
+	}
+	if pInfo.Pod.UID != recreatedPod.UID {
+		t.Errorf("Queue holds pod UID %v, want %v", pInfo.Pod.UID, recreatedPod.UID)
+	}
+}
+
+// TestPriorityQueue_AddUnschedulablePodIfNotPresent_Superseded pins down when a requeue is
+// rejected because the Pod that owns the namespace/name slot changed, and - just as important -
+// when it must still be accepted.
+func TestPriorityQueue_AddUnschedulablePodIfNotPresent_Superseded(t *testing.T) {
+	pod := st.MakePod().Name("foo").Namespace("ns").UID("old-uid").Obj()
+	recreatedPod := st.MakePod().Name("foo").Namespace("ns").UID("new-uid").Obj()
+
+	tests := []struct {
+		name       string
+		objs       []runtime.Object
+		plugins    []string
+		doneBefore bool
+		wantErr    error
+		wantQueued bool
+	}{
+		{
+			name:       "pod was recreated under the same name",
+			objs:       []runtime.Object{recreatedPod},
+			plugins:    []string{"fooPlugin"},
+			wantErr:    ErrPodSuperseded,
+			wantQueued: false,
+		},
+		{
+			// Control: the ordinary case must keep working.
+			name:       "pod is still the one that owns its name",
+			objs:       []runtime.Object{pod},
+			plugins:    []string{"fooPlugin"},
+			wantQueued: true,
+		},
+		{
+			// podSuperseded deliberately treats a NotFound as "no information", so a Pod that
+			// was deleted while in flight is still requeued, exactly as before this check
+			// existed. Every queue test built on an empty informer relies on this.
+			name:       "pod was deleted and not recreated",
+			objs:       nil,
+			plugins:    []string{"fooPlugin"},
+			wantQueued: true,
+		},
+		{
+			// Done is called before PreBind runs, so a PreBind or Bind failure legitimately
+			// requeues a Pod that is no longer in inFlightPods. Gating the requeue on in-flight
+			// membership instead of on the Pod's identity would silently drop those retries.
+			name:       "binding failure requeues a pod that is no longer in flight",
+			objs:       []runtime.Object{pod},
+			doneBefore: true,
+			wantQueued: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), tt.objs, WithClock(testingclock.NewFakeClock(time.Now())))
+
+			q.Add(ctx, pod)
+			if _, err := q.Pop(logger); err != nil {
+				t.Fatalf("Pop failed: %v", err)
+			}
+			if tt.doneBefore {
+				q.Done(pod.UID)
+			}
+
+			err := q.AddUnschedulablePodIfNotPresent(logger, newQueuedPodInfoForLookup(pod, tt.plugins...), q.SchedulingCycle())
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Errorf("AddUnschedulablePodIfNotPresent() error = %v, want %v", err, tt.wantErr)
+				}
+			} else if err != nil {
+				t.Errorf("AddUnschedulablePodIfNotPresent() error = %v, want nil", err)
+			}
+
+			pInfo, ok := q.GetPod(pod.Name, pod.Namespace, nil)
+			if ok != tt.wantQueued {
+				t.Fatalf("Pod queued = %v, want %v", ok, tt.wantQueued)
+			}
+			if ok && pInfo.Pod.UID != pod.UID {
+				t.Errorf("Queue holds pod UID %v, want %v", pInfo.Pod.UID, pod.UID)
+			}
+		})
+	}
+}
+
+// For a pod group member the three name-keyed checks in AddUnschedulablePodIfNotPresent are
+// structurally dead: they look up pod/namespace/name while the only queued entity is keyed
+// podgroup/namespace/podgroupname. Nothing but the identity check stops a stale instance from
+// overwriting the live one in the group's member state, which would wedge the whole gang.
+func TestPriorityQueue_AddUnschedulablePodIfNotPresent_PodGroupMemberRecreated(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.GenericWorkload, true)
+	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	const podGroupName = "pg1"
+	oldPod := withPodGroupName(st.MakePod().Name("foo").Namespace("ns").UID("old-uid").Obj(), podGroupName)
+	recreatedPod := withPodGroupName(st.MakePod().Name("foo").Namespace("ns").UID("new-uid").Obj(), podGroupName)
+
+	q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), []runtime.Object{recreatedPod}, WithClock(testingclock.NewFakeClock(time.Now())))
+	q.AddPodGroup(logger, st.MakePodGroup().Name(podGroupName).Namespace(oldPod.Namespace).Priority(midPriority).Obj())
+
+	q.Add(ctx, oldPod)
+	if _, err := q.Pop(logger); err != nil {
+		t.Fatalf("Pop failed: %v", err)
+	}
+	// Scheduler.updatePod splits the collapsed update event into a delete and an add.
+	q.Delete(logger, oldPod)
+	q.Add(ctx, recreatedPod)
+
+	err := q.AddUnschedulablePodIfNotPresent(logger, newQueuedPodInfoForLookup(oldPod, "plugin"), q.SchedulingCycle())
+	if !errors.Is(err, ErrPodSuperseded) {
+		t.Errorf("AddUnschedulablePodIfNotPresent() error = %v, want %v", err, ErrPodSuperseded)
+	}
+
+	pInfo, ok := q.GetPod(recreatedPod.Name, recreatedPod.Namespace, recreatedPod.Spec.SchedulingGroup)
+	if !ok {
+		t.Fatalf("Failed to get pod %s/%s from queue", recreatedPod.Namespace, recreatedPod.Name)
+	}
+	if pInfo.Pod.UID != recreatedPod.UID {
+		t.Errorf("Pod group member has UID %v, want the live pod %v", pInfo.Pod.UID, recreatedPod.UID)
 	}
 }
 
@@ -2890,10 +3130,11 @@ func TestPriorityQueue_NominatedPodsForNode(t *testing.T) {
 
 func TestPriorityQueue_NominatedPodDeleted(t *testing.T) {
 	tests := []struct {
-		name      string
-		podInfo   *framework.PodInfo
-		deletePod bool
-		wantLen   int
+		name        string
+		podInfo     *framework.PodInfo
+		deletePod   bool
+		recreatePod bool
+		wantLen     int
 	}{
 		{
 			name:    "alive pod gets added into PodNominator",
@@ -2905,6 +3146,17 @@ func TestPriorityQueue_NominatedPodDeleted(t *testing.T) {
 			podInfo:   highPriNominatedPodInfo,
 			deletePod: true,
 			wantLen:   0,
+		},
+		{
+			// Scheduler.unreserveAndForget restores the nomination that Assume removed, working
+			// off the Pod snapshot taken at Pop, so it can hand us an instance that no longer
+			// exists. The nominator is keyed by UID and every cleanup path is driven by an
+			// event, but every future event for this name carries the new UID, so such an entry
+			// would never be reclaimed.
+			name:        "recreated pod shouldn't be added into PodNominator",
+			podInfo:     highPriNominatedPodInfo,
+			recreatePod: true,
+			wantLen:     0,
 		},
 		{
 			name:    "pod without .status.nominatedPodName specified shouldn't be added into PodNominator",
@@ -2930,6 +3182,12 @@ func TestPriorityQueue_NominatedPodDeleted(t *testing.T) {
 			if tt.deletePod {
 				// Simulate that the test pod gets deleted physically.
 				informerFactory.Core().V1().Pods().Informer().GetStore().Delete(tt.podInfo.Pod)
+			}
+			if tt.recreatePod {
+				// Simulate that the test pod gets deleted and recreated under the same name.
+				recreated := tt.podInfo.Pod.DeepCopy()
+				recreated.UID = tt.podInfo.Pod.UID + "-recreated"
+				informerFactory.Core().V1().Pods().Informer().GetStore().Update(recreated)
 			}
 
 			q.AddNominatedPod(logger, tt.podInfo, nil)

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -3187,7 +3187,10 @@ func TestPriorityQueue_NominatedPodDeleted(t *testing.T) {
 				// Simulate that the test pod gets deleted and recreated under the same name.
 				recreated := tt.podInfo.Pod.DeepCopy()
 				recreated.UID = tt.podInfo.Pod.UID + "-recreated"
-				informerFactory.Core().V1().Pods().Informer().GetStore().Update(recreated)
+				err := informerFactory.Core().V1().Pods().Informer().GetStore().Update(recreated)
+				if err != nil {
+					t.Fatalf("unexpected error from update api call: %v", err)
+				}
 			}
 
 			q.AddNominatedPod(logger, tt.podInfo, nil)

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -156,6 +156,20 @@ func (sched *Scheduler) updatePod(oldObj, newObj interface{}) {
 		return
 	}
 
+	// The informer identifies objects by namespace/name; ObjectMeta.UID is not part
+	// of that identity. If a Pod is deleted and recreated under the same name while
+	// the watch is broken, the relist that follows reconciles by name only, so the
+	// deletion is never detected and both objects arrive as a single update event.
+	// This is documented behavior of SharedInformer, which leaves the detection to
+	// the consumer. Split the event back into the delete and the add that actually
+	// happened, so that the recreated Pod is routed to the cache or to the
+	// scheduling queue depending on whether it is already assigned to a node.
+	if oldPod.UID != newPod.UID {
+		sched.deletePod(oldPod)
+		sched.addPod(newPod)
+		return
+	}
+
 	if assignedPod(oldPod) {
 		if utilfeature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingSchedulerPreemption) && responsibleForPod(newPod, sched.Profiles) {
 			oldDeferred := resource.IsPodResizeDeferred(oldPod)

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -165,6 +165,7 @@ func (sched *Scheduler) updatePod(oldObj, newObj interface{}) {
 	// happened, so that the recreated Pod is routed to the cache or to the
 	// scheduling queue depending on whether it is already assigned to a node.
 	if oldPod.UID != newPod.UID {
+		logger.V(4).Info("Pod was recreated with a different UID, splitting into delete and add events", "pod", klog.KObj(newPod), "oldUID", oldPod.UID, "newUID", newPod.UID)
 		sched.deletePod(oldPod)
 		sched.addPod(newPod)
 		return

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -927,12 +927,20 @@ func TestUpdatePod(t *testing.T) {
 
 	scheduledPodOtherNode := st.MakePod().Name("pod1").Namespace("ns1").UID("pod1").Node("node2").SchedulerName("supported-scheduler").Obj()
 
+	// Pods sharing the name of the fixtures above, but with a different UID. They
+	// stand for a Pod that was deleted and recreated under the same name, which the
+	// informer can deliver as a single update event instead of a delete and an add.
+	recreatedPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod2").ResourceVersion("2").SchedulerName("supported-scheduler").Obj()
+	recreatedScheduledPod := st.MakePod().Name("pod1").Namespace("ns1").UID("pod2").ResourceVersion("2").Node("node1").SchedulerName("supported-scheduler").Obj()
+	recreatedScheduledPodOtherNode := st.MakePod().Name("pod1").Namespace("ns1").UID("pod2").ResourceVersion("2").Node("node2").SchedulerName("supported-scheduler").Obj()
+
 	unscheduledPodGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 	unscheduledPodGroupMemberWithLabels := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 	scheduledPodGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Node("node1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 	scheduledPodGroupMemberWithLabels := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Labels(map[string]string{"foo": "bar"}).ResourceVersion("2").Node("node1").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 	scheduledPodGroupMemberWithOtherNode := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Node("node2").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 	podGroupMemberWithDeletionTimestamp := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod1").Terminating().ResourceVersion("2").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
+	recreatedUnscheduledPodGroupMember := st.MakePod().Name("pod1").Namespace("ns1").UID("pgpod2").ResourceVersion("2").SchedulerName("supported-scheduler").PodGroupName("pg1").Obj()
 
 	tests := []struct {
 		name                             string
@@ -942,6 +950,7 @@ func TestUpdatePod(t *testing.T) {
 		genericWorkloadEnabled           bool
 		waitingOnPermit                  bool
 		expectInQueue                    *v1.Pod
+		expectInActiveQ                  bool
 		expectInCache                    *v1.Pod
 		expectInPodGroupStateUnscheduled bool
 		expectInPodGroupStateAssumed     bool
@@ -1017,6 +1026,40 @@ func TestUpdatePod(t *testing.T) {
 			newPod:          podWithDeletionTimestamp,
 			waitingOnPermit: true,
 			expectInCache:   scheduledPod,
+		},
+		{
+			name:            "recreated pod with a different UID, not scheduled yet",
+			oldPod:          scheduledPod,
+			newPod:          recreatedPod,
+			expectInQueue:   recreatedPod,
+			expectInActiveQ: true,
+		},
+		{
+			name:          "recreated pod with a different UID, scheduled to a different node",
+			oldPod:        scheduledPod,
+			newPod:        recreatedScheduledPodOtherNode,
+			expectInCache: recreatedScheduledPodOtherNode,
+		},
+		{
+			name:          "recreated pod with a different UID, scheduled to the same node",
+			oldPod:        scheduledPod,
+			newPod:        recreatedScheduledPod,
+			expectInCache: recreatedScheduledPod,
+		},
+		{
+			name:            "recreated unscheduled pod with a different UID",
+			oldPod:          pod,
+			newPod:          recreatedPod,
+			expectInQueue:   recreatedPod,
+			expectInActiveQ: true,
+		},
+		{
+			name:                             "recreated unscheduled pod group member with a different UID",
+			oldPod:                           unscheduledPodGroupMember,
+			newPod:                           recreatedUnscheduledPodGroupMember,
+			genericWorkloadEnabled:           true,
+			expectInQueue:                    recreatedUnscheduledPodGroupMember,
+			expectInPodGroupStateUnscheduled: true,
 		},
 		{
 			name:          "update pod group member with GenericWorkload disabled",
@@ -1160,6 +1203,12 @@ func TestUpdatePod(t *testing.T) {
 				}
 			}
 
+			if tt.oldPod.UID != tt.newPod.UID {
+				if oldCached, err := sched.Cache.GetPod(tt.oldPod); err == nil {
+					t.Errorf("Expected pod UID %v to be evicted from cache, but it is still there", oldCached.UID)
+				}
+			}
+
 			qPod, ok := sched.SchedulingQueue.GetPod(tt.newPod.Name, tt.newPod.Namespace, tt.newPod.Spec.SchedulingGroup)
 			if tt.expectInQueue != nil {
 				if !ok {
@@ -1169,6 +1218,18 @@ func TestUpdatePod(t *testing.T) {
 				}
 			} else if ok {
 				t.Errorf("Expected pod not to be in scheduling queue")
+			}
+			if tt.expectInActiveQ {
+				var found bool
+				for _, p := range sched.SchedulingQueue.PodsInActiveQ() {
+					if p.UID == tt.newPod.UID {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Expected pod %v to be in activeQ", tt.newPod.UID)
+				}
 			}
 			pod, err := sched.Cache.GetPod(tt.newPod)
 			if tt.expectInCache != nil {
@@ -1196,6 +1257,10 @@ func TestUpdatePod(t *testing.T) {
 
 			if err != nil {
 				t.Fatalf("Expected pod group state to exist, got error: %v", err)
+			}
+
+			if tt.oldPod.UID != tt.newPod.UID && pgs.AllPods().Has(tt.oldPod.UID) {
+				t.Errorf("Expected pod UID %v to be dropped from the pod group state, but it is still there", tt.oldPod.UID)
 			}
 
 			if inUnscheduled := pgs.UnscheduledPods()[tt.newPod.Name] != nil; inUnscheduled != tt.expectInPodGroupStateUnscheduled {

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -1054,6 +1054,15 @@ func TestUpdatePod(t *testing.T) {
 			expectInActiveQ: true,
 		},
 		{
+			name:            "recreated pod with a different UID while the previous one waits on permit",
+			oldPod:          pod,
+			assumedPod:      scheduledPod,
+			newPod:          recreatedPod,
+			waitingOnPermit: true,
+			expectInQueue:   recreatedPod,
+			expectInActiveQ: true,
+		},
+		{
 			name:                             "recreated unscheduled pod group member with a different UID",
 			oldPod:                           unscheduledPodGroupMember,
 			newPod:                           recreatedUnscheduledPodGroupMember,
@@ -1203,7 +1212,10 @@ func TestUpdatePod(t *testing.T) {
 				}
 			}
 
-			if tt.oldPod.UID != tt.newPod.UID {
+			// A Pod that was rejected on Permit is deliberately left in the cache by
+			// handleAssumedPodDeletion: its binding cycle unwinds through
+			// handleBindingCycleError on the binding goroutine, which this test does not run.
+			if tt.oldPod.UID != tt.newPod.UID && !tt.waitingOnPermit {
 				if oldCached, err := sched.Cache.GetPod(tt.oldPod); err == nil {
 					t.Errorf("Expected pod UID %v to be evicted from cache, but it is still there", oldCached.UID)
 				}

--- a/pkg/scheduler/framework/api_calls/pod_status_patch.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch.go
@@ -110,8 +110,10 @@ func (psuc *PodStatusPatchCall) Execute(ctx context.Context, client clientset.In
 		return nil
 	}
 
-	// It's safe to run PatchPodStatus even on outdated pod object.
-	err := util.PatchPodStatus(ctx, client, psuc.podRef.Name, psuc.podRef.Namespace, psuc.podStatus, podStatusCopy)
+	// It's safe to run PatchPodStatus even on outdated pod object: the uid is sent as a
+	// precondition, so the patch cannot land on a pod that took over this pod's name
+	// between the call being queued and executed.
+	err := util.PatchPodStatus(ctx, client, psuc.podRef.Name, psuc.podRef.Namespace, psuc.podUID, psuc.podStatus, podStatusCopy)
 	if err != nil {
 		logger.Error(err, "Failed to patch pod status", "pod", psuc.podRef)
 		return err

--- a/pkg/scheduler/framework/api_calls/pod_status_patch_test.go
+++ b/pkg/scheduler/framework/api_calls/pod_status_patch_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apicalls
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -400,8 +401,10 @@ func TestPodStatusPatchCall_Execute(t *testing.T) {
 	t.Run("Successful patch", func(t *testing.T) {
 		client := fake.NewClientset()
 		patched := false
+		var patchData string
 		client.PrependReactor("patch", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
 			patched = true
+			patchData = string(action.(clienttesting.PatchAction).GetPatch())
 			return true, nil, nil
 		})
 
@@ -412,6 +415,11 @@ func TestPodStatusPatchCall_Execute(t *testing.T) {
 		}
 		if !patched {
 			t.Error("Expected patch API to be called")
+		}
+		// The call is executed long after it was queued, so the pod uid has to travel
+		// with it as a precondition.
+		if wantPrefix := `{"metadata":{"uid":"uid"},`; !strings.HasPrefix(patchData, wantPrefix) {
+			t.Errorf("Expected patch to start with %v, got %v", wantPrefix, patchData)
 		}
 		if !call.executed {
 			t.Error("Expected 'executed' flag to be set during execution")

--- a/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/extendeddynamicresources.go
@@ -579,7 +579,7 @@ func (pl *DynamicResources) patchPodExtendedResourceClaimStatus(
 		RequestMappings:   cer,
 		ResourceClaimName: claim.Name,
 	}
-	err := schedutil.PatchPodStatus(ctx, pl.clientset, pod.Name, pod.Namespace, &pod.Status, podStatusCopy)
+	err := schedutil.PatchPodStatus(ctx, pl.clientset, pod.Name, pod.Namespace, pod.UID, &pod.Status, podStatusCopy)
 	if err != nil {
 		return fmt.Errorf("update pod %s/%s ExtendedResourceClaimStatus: %w", pod.Namespace, pod.Name, err)
 	}

--- a/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
@@ -628,7 +628,7 @@ func (pl *DynamicResources) patchNodeAllocatableResourceClaimStatus(ctx context.
 	targetStatus := pod.Status.DeepCopy()
 
 	targetStatus.NodeAllocatableResourceClaimStatuses = nodeAllocatableClaimStatus
-	if err := schedutil.PatchPodStatus(ctx, pl.clientset, pod.Name, pod.Namespace, baseStatus, targetStatus); err != nil {
+	if err := schedutil.PatchPodStatus(ctx, pl.clientset, pod.Name, pod.Namespace, pod.UID, baseStatus, targetStatus); err != nil {
 		return statusError(logger, fmt.Errorf("updating pod %s/%s NodeAllocatableResourceClaimStatuses: %w", pod.Namespace, pod.Name, err))
 	}
 	logger.V(5).Info("Patched pod status with NodeAllocatableResourceClaimStatuses", "pod", klog.KObj(pod), "status", targetStatus.NodeAllocatableResourceClaimStatuses)

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -133,12 +133,15 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 			newStatus := victim.Status.DeepCopy()
 			updated := apipod.UpdatePodCondition(newStatus, condition)
 			if updated {
-				if err := util.PatchPodStatus(ctx, fh.ClientSet(), victim.Name, victim.Namespace, &victim.Status, newStatus); err != nil {
-					if !apierrors.IsNotFound(err) {
+				if err := util.PatchPodStatus(ctx, fh.ClientSet(), victim.Name, victim.Namespace, victim.UID, &victim.Status, newStatus); err != nil {
+					// The patch carries the victim's uid as a precondition, so a victim that
+					// was recreated under the same name is rejected as invalid. Like a
+					// deleted victim, it means the pod we picked is no longer there.
+					if !apierrors.IsNotFound(err) && !apierrors.IsInvalid(err) {
 						logger.Error(err, "Could not add DisruptionTarget condition due to preemption", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim))
 						return false, err
 					}
-					logger.V(2).Info("Victim Pod is already deleted", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim), "node", c.Name())
+					logger.V(2).Info("Victim Pod is already deleted or was recreated", "preemptor", klog.KObj(preemptor), "victim", klog.KObj(victim), "node", c.Name())
 					return false, nil
 				}
 			}
@@ -432,7 +435,7 @@ func clearNominatedNodeName(ctx context.Context, cs clientset.Interface, apiCach
 			}
 			podStatusCopy := p.Status.DeepCopy()
 			podStatusCopy.NominatedNodeName = ""
-			if err := util.PatchPodStatus(ctx, cs, p.Name, p.Namespace, &p.Status, podStatusCopy); err != nil {
+			if err := util.PatchPodStatus(ctx, cs, p.Name, p.Namespace, p.UID, &p.Status, podStatusCopy); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
@@ -270,6 +271,13 @@ func TestPrepareCandidate(t *testing.T) {
 				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
 				Obj()
 
+		// The status patch carries the victim's uid as a precondition, so a victim that
+		// was recreated under the same name is rejected as invalid.
+		invalidVictim1 = st.MakePod().Name("invalid-victim").UID("victim1").
+				Node(node1Name).SchedulerName(defaultSchedulerName).Priority(midPriority).
+				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
+				Obj()
+
 		failVictim = st.MakePod().Name("fail-victim").UID("victim1").
 				Node(node1Name).SchedulerName(defaultSchedulerName).Priority(midPriority).
 				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
@@ -436,6 +444,22 @@ func TestPrepareCandidate(t *testing.T) {
 				victims: &extenderv1.Victims{
 					Pods: []*v1.Pod{
 						notFoundVictim1,
+					},
+				},
+			},
+			preemptor:             preemptor,
+			testPods:              []*v1.Pod{},
+			nodeNames:             []string{node1Name},
+			expectedStatus:        nil,
+			expectedPreemptingMap: sets.New(types.UID("preemptor")),
+		},
+		{
+			name: "one victim, but victim was recreated before the status patch",
+			candidate: &candidate{
+				name: node1Name,
+				victims: &extenderv1.Victims{
+					Pods: []*v1.Pod{
+						invalidVictim1,
 					},
 				},
 			},
@@ -713,6 +737,12 @@ func TestPrepareCandidate(t *testing.T) {
 						// fake clientset does not return an error for not-found pods, so we simulate it here.
 						if action.(clienttesting.PatchAction).GetName() == "not-found-victim" {
 							return true, nil, apierrors.NewNotFound(v1.Resource("pods"), "not-found-victim")
+						}
+						// The fake clientset does not enforce the uid precondition either, so
+						// simulate what a real API server returns for a victim that is gone.
+						if action.(clienttesting.PatchAction).GetName() == "invalid-victim" {
+							return true, nil, apierrors.NewInvalid(v1.SchemeGroupVersion.WithKind("Pod").GroupKind(), "invalid-victim",
+								field.ErrorList{field.Invalid(field.NewPath("metadata").Child("uid"), "victim1", "field is immutable")})
 						}
 						return true, nil, nil
 					})
@@ -1360,7 +1390,7 @@ func TestRemoveNominatedNodeName(t *testing.T) {
 			name:                     "Should make patch request to clear node name",
 			currentNominatedNodeName: "node1",
 			expectPatchRequest:       true,
-			expectedPatchData:        `{"status":{"nominatedNodeName":null}}`,
+			expectedPatchData:        `{"metadata":{"uid":"foo-uid"},"status":{"nominatedNodeName":null}}`,
 		},
 		{
 			name:                     "Should not make patch request if nominated node is already cleared",
@@ -1387,7 +1417,7 @@ func TestRemoveNominatedNodeName(t *testing.T) {
 				})
 
 				pod := &v1.Pod{
-					ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+					ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "foo-uid"},
 					Status:     v1.PodStatus{NominatedNodeName: test.currentNominatedNodeName},
 				}
 

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -1315,5 +1315,5 @@ func updatePod(ctx context.Context, client clientset.Interface, apiCacher fwk.AP
 	if nnnNeedsUpdate {
 		podStatusCopy.NominatedNodeName = nominatingInfo.NominatedNodeName
 	}
-	return util.PatchPodStatus(ctx, client, pod.Name, pod.Namespace, &pod.Status, podStatusCopy)
+	return util.PatchPodStatus(ctx, client, pod.Name, pod.Namespace, pod.UID, &pod.Status, podStatusCopy)
 }

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -39,6 +39,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
+	internalqueue "k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
@@ -1204,29 +1205,40 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk fram
 	if e != nil {
 		logger.Info("Pod doesn't exist in informer cache", "pod", klog.KObj(pod), "err", e)
 		// We need to call DonePod here because we don't call AddUnschedulablePodIfNotPresent in this case.
-	} else {
+	} else if cachedPod.UID != podInfo.Pod.UID {
+		// This is checked before the NodeName branch below, because everything that follows -
+		// the requeue, the nomination and the status patch - addresses the Pod by
+		// namespace/name only. A recreated Pod that is already bound would otherwise skip this
+		// check and get the previous instance's condition patched onto it.
+		logger.V(2).Info("Pod was recreated while handling scheduling failure. Skip requeueing and status updates.", "pod", klog.KObj(pod), "oldUID", podInfo.Pod.UID, "newUID", cachedPod.UID)
+		// Drop any nomination this instance still holds. The nominator is keyed by UID, so this
+		// cannot affect the recreated Pod, and no future event will ever carry the old UID.
+		sched.SchedulingQueue.DeleteNominatedPodIfExists(podInfo.Pod)
+		return
+	} else if len(cachedPod.Spec.NodeName) != 0 && !isDeferredResize {
 		// In the case of extender, the pod may have been bound successfully, but timed out returning its response to the scheduler.
 		// It could result in the live version to carry .spec.nodeName, and that's inconsistent with the internal-queued version.
 		// For deferred resize pods, being assigned to a node in the cache is expected and not an inconsistent extender binding timeout.
-		if len(cachedPod.Spec.NodeName) != 0 && !isDeferredResize {
-			logger.Info("Pod has been assigned to node. Abort adding it back to queue.", "pod", klog.KObj(pod), "node", cachedPod.Spec.NodeName)
-			// We need to call DonePod here because we don't call AddUnschedulablePodIfNotPresent in this case.
-		} else {
-			if cachedPod.UID != podInfo.Pod.UID {
-				logger.V(2).Info("Pod was recreated while handling scheduling failure. Skip requeueing and status updates.", "pod", klog.KObj(pod), "oldUID", podInfo.Pod.UID, "newUID", cachedPod.UID)
+		logger.Info("Pod has been assigned to node. Abort adding it back to queue.", "pod", klog.KObj(pod), "node", cachedPod.Spec.NodeName)
+		// We need to call DonePod here because we don't call AddUnschedulablePodIfNotPresent in this case.
+	} else {
+		// As <cachedPod> is from SharedInformer, we need to do a DeepCopy() here.
+		// ignore this err since apiserver doesn't properly validate affinity terms
+		// and we can't fix the validation for backwards compatibility.
+		podInfo.PodInfo, _ = framework.NewPodInfo(cachedPod.DeepCopy())
+		pod = podInfo.Pod
+		nominatedPodInfo = podInfo.PodInfo
+		if err := sched.SchedulingQueue.AddUnschedulablePodIfNotPresent(logger, podInfo, sched.SchedulingQueue.SchedulingCycle()); err != nil {
+			if errors.Is(err, internalqueue.ErrPodSuperseded) {
+				// The queue detected, under its own lock, that this Pod was superseded while
+				// the lister read above was in flight. Skip the nomination and the status
+				// patch below, because both address the Pod by namespace/name only.
+				calledDone = true
 				return
 			}
-			// As <cachedPod> is from SharedInformer, we need to do a DeepCopy() here.
-			// ignore this err since apiserver doesn't properly validate affinity terms
-			// and we can't fix the validation for backwards compatibility.
-			podInfo.PodInfo, _ = framework.NewPodInfo(cachedPod.DeepCopy())
-			pod = podInfo.Pod
-			nominatedPodInfo = podInfo.PodInfo
-			if err := sched.SchedulingQueue.AddUnschedulablePodIfNotPresent(logger, podInfo, sched.SchedulingQueue.SchedulingCycle()); err != nil {
-				utilruntime.HandleErrorWithContext(ctx, err, "Error occurred")
-			}
-			calledDone = true
+			utilruntime.HandleErrorWithContext(ctx, err, "Error occurred")
 		}
+		calledDone = true
 	}
 
 	// Deferred resize pods are already bound to and running on their assigned node. The scheduler only

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -2634,7 +2634,7 @@ func TestUpdatePodStatus(t *testing.T) {
 				Message:            "newMessage",
 			},
 			expectPatchRequest:       true,
-			expectedPatchDataPattern: `{"status":{"conditions":\[{"lastProbeTime":"2020-05-13T01:01:01Z","lastTransitionTime":".*","message":"newMessage","reason":"newReason","status":"newStatus","type":"newType"}]}}`,
+			expectedPatchDataPattern: `{"metadata":{"uid":"foo-uid"},"status":{"conditions":\[{"lastProbeTime":"2020-05-13T01:01:01Z","lastTransitionTime":".*","message":"newMessage","reason":"newReason","status":"newStatus","type":"newType"}]}}`,
 		},
 		{
 			name: "Should make patch request to add a new pod condition when there is already one with another type",
@@ -2657,7 +2657,7 @@ func TestUpdatePodStatus(t *testing.T) {
 				Message:            "newMessage",
 			},
 			expectPatchRequest:       true,
-			expectedPatchDataPattern: `{"status":{"\$setElementOrder/conditions":\[{"type":"someOtherType"},{"type":"newType"}],"conditions":\[{"lastProbeTime":"2020-05-13T01:01:01Z","lastTransitionTime":".*","message":"newMessage","reason":"newReason","status":"newStatus","type":"newType"}]}}`,
+			expectedPatchDataPattern: `{"metadata":{"uid":"foo-uid"},"status":{"\$setElementOrder/conditions":\[{"type":"someOtherType"},{"type":"newType"}],"conditions":\[{"lastProbeTime":"2020-05-13T01:01:01Z","lastTransitionTime":".*","message":"newMessage","reason":"newReason","status":"newStatus","type":"newType"}]}}`,
 		},
 		{
 			name: "Should make patch request to update an existing pod condition",
@@ -2680,7 +2680,7 @@ func TestUpdatePodStatus(t *testing.T) {
 				Message:            "newMessage",
 			},
 			expectPatchRequest:       true,
-			expectedPatchDataPattern: `{"status":{"\$setElementOrder/conditions":\[{"type":"currentType"}],"conditions":\[{"lastProbeTime":"2020-05-13T01:01:01Z","lastTransitionTime":".*","message":"newMessage","reason":"newReason","status":"newStatus","type":"currentType"}]}}`,
+			expectedPatchDataPattern: `{"metadata":{"uid":"foo-uid"},"status":{"\$setElementOrder/conditions":\[{"type":"currentType"}],"conditions":\[{"lastProbeTime":"2020-05-13T01:01:01Z","lastTransitionTime":".*","message":"newMessage","reason":"newReason","status":"newStatus","type":"currentType"}]}}`,
 		},
 		{
 			name: "Should make patch request to update an existing pod condition, but the transition time should remain unchanged because the status is the same",
@@ -2703,7 +2703,7 @@ func TestUpdatePodStatus(t *testing.T) {
 				Message:            "newMessage",
 			},
 			expectPatchRequest:       true,
-			expectedPatchDataPattern: `{"status":{"\$setElementOrder/conditions":\[{"type":"currentType"}],"conditions":\[{"lastProbeTime":"2020-05-13T01:01:01Z","message":"newMessage","reason":"newReason","type":"currentType"}]}}`,
+			expectedPatchDataPattern: `{"metadata":{"uid":"foo-uid"},"status":{"\$setElementOrder/conditions":\[{"type":"currentType"}],"conditions":\[{"lastProbeTime":"2020-05-13T01:01:01Z","message":"newMessage","reason":"newReason","type":"currentType"}]}}`,
 		},
 		{
 			name: "Should not make patch request if pod condition already exists and is identical and nominated node name is not set",
@@ -2750,7 +2750,7 @@ func TestUpdatePodStatus(t *testing.T) {
 			},
 			newNominatingInfo:        &fwk.NominatingInfo{NominatingMode: fwk.ModeOverride, NominatedNodeName: "node1"},
 			expectPatchRequest:       true,
-			expectedPatchDataPattern: `{"status":{"nominatedNodeName":"node1"}}`,
+			expectedPatchDataPattern: `{"metadata":{"uid":"foo-uid"},"status":{"nominatedNodeName":"node1"}}`,
 		},
 		{
 			name: "Should not update nominated node name when nominatingInfo is nil",
@@ -2775,7 +2775,7 @@ func TestUpdatePodStatus(t *testing.T) {
 			currentNominatedNodeName: "existing-node",
 			newNominatingInfo:        nil,
 			expectPatchRequest:       true,
-			expectedPatchDataPattern: `{"status":{"\$setElementOrder/conditions":\[{"type":"currentType"}],"conditions":\[{"lastProbeTime":"2020-05-13T01:01:01Z","lastTransitionTime":".*","message":"newMessage","reason":"newReason","status":"newStatus","type":"currentType"}]}}`,
+			expectedPatchDataPattern: `{"metadata":{"uid":"foo-uid"},"status":{"\$setElementOrder/conditions":\[{"type":"currentType"}],"conditions":\[{"lastProbeTime":"2020-05-13T01:01:01Z","lastTransitionTime":".*","message":"newMessage","reason":"newReason","status":"newStatus","type":"currentType"}]}}`,
 		},
 		{
 			name: "Should not make patch request when nominatingInfo is nil and pod condition is unchanged",
@@ -2819,7 +2819,7 @@ func TestUpdatePodStatus(t *testing.T) {
 					return true, &v1.Pod{}, nil
 				})
 
-				pod := st.MakePod().Name("foo").NominatedNodeName(test.currentNominatedNodeName).Conditions(test.currentPodConditions).Obj()
+				pod := st.MakePod().Name("foo").UID("foo-uid").NominatedNodeName(test.currentNominatedNodeName).Conditions(test.currentPodConditions).Obj()
 
 				logger, ctx := ktesting.NewTestContext(t)
 				ctx, cancel := context.WithCancel(ctx)

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1326,14 +1326,23 @@ func TestSchedulerScheduleOne(t *testing.T) {
 	}
 }
 
-func TestHandleSchedulingFailureSkipsRecreatedPod(t *testing.T) {
-	logger, ctx := ktesting.NewTestContext(t)
+// unreserveAndForget restores the nomination that Assume had removed, working off the Pod
+// snapshot taken at Pop. It runs before the failure handler and outside the requeue path, so
+// neither the UID check in handleSchedulingFailure nor the one in
+// AddUnschedulablePodIfNotPresent can stop it from re-recording a nomination for a Pod that was
+// deleted and recreated meanwhile. Such an entry would be permanent, because the nominator is
+// keyed by UID and no future event for this name will ever carry the old one.
+func TestUnreserveAndForgetSkipsNominationForRecreatedPod(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	oldPod := st.MakePod().Name("foo").Namespace("ns").UID("old-uid").SchedulerName(testSchedulerName).Obj()
-	recreatedPod := oldPod.DeepCopy()
+	assumedPod := st.MakePod().Name("foo").Namespace("ns").UID("old-uid").Node("node1").NominatedNodeName("node1").SchedulerName(testSchedulerName).Obj()
+	// The replacement is still pending, so the nominator's existing liveness checks - the Pod
+	// exists, and it is not scheduled yet - both pass. Only the UID tells them apart.
+	recreatedPod := assumedPod.DeepCopy()
 	recreatedPod.UID = "new-uid"
+	recreatedPod.Spec.NodeName = ""
 
 	client := clientsetfake.NewClientset(recreatedPod)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
@@ -1356,47 +1365,126 @@ func TestHandleSchedulingFailureSkipsRecreatedPod(t *testing.T) {
 	ar := metrics.NewMetricsAsyncRecorder(10, time.Second, ctx.Done())
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory, internalqueue.WithMetricsRecorder(ar))
 	sched := &Scheduler{
-		client:          client,
-		SchedulingQueue: queue,
+		client:           client,
+		SchedulingQueue:  queue,
+		nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
 	}
 
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 
-	queue.Add(ctx, oldPod)
-	popped, err := queue.Pop(logger)
-	if err != nil {
-		t.Fatalf("Pop: %v", err)
-	}
-	if got := queue.InFlightPods(); !podListContainsPod(got, oldPod) {
-		t.Fatalf("expected popped pod to be in-flight before failure handling, got %v", got)
+	podInfo := mustNewPodInfo(t, assumedPod)
+	if err := sched.nodeInfoSnapshot.AssumePod(podInfo); err != nil {
+		t.Fatalf("AssumePod: %v", err)
 	}
 
-	nominatingInfo := &fwk.NominatingInfo{NominatingMode: fwk.ModeOverride, NominatedNodeName: "node1"}
-	poppedPod := popped.(*framework.QueuedPodInfo)
-	sched.handleSchedulingFailure(ctx, schedFramework, poppedPod, fwk.NewStatus(fwk.Unschedulable, "no fit"), nominatingInfo, time.Now())
+	state := framework.NewCycleState()
+	state.SetPodGroupSchedulingCycle(state)
 
-	if err := wait.PollUntilContextTimeout(ctx, time.Millisecond, wait.ForeverTestTimeout, false, func(context.Context) (bool, error) {
-		return len(queue.InFlightPods()) == 0, nil
-	}); err != nil {
-		t.Fatalf("in-flight pod was not cleared: %v", queue.InFlightPods())
+	if err := sched.unreserveAndForget(ctx, state, schedFramework, &framework.QueuedPodInfo{PodInfo: podInfo}, "node1"); err != nil {
+		t.Fatalf("unreserveAndForget: %v", err)
 	}
-	if got := queue.PodsInBackoffQ(); len(got) != 0 {
-		t.Fatalf("expected recreated pod to stay out of backoffQ, got %v", got)
-	}
-	if got := queue.UnschedulablePods(); len(got) != 0 {
-		t.Fatalf("expected recreated pod to stay out of unschedulablePods, got %v", got)
-	}
+
 	if got := queue.NominatedPodsForNode("node1"); len(got) != 0 {
-		t.Fatalf("expected recreated pod to stay out of nominated pods, got %v", got)
+		t.Errorf("expected the previous instance to stay out of the nominator, got %v", got)
+	}
+}
+
+func TestHandleSchedulingFailureSkipsRecreatedPod(t *testing.T) {
+	tests := []struct {
+		name           string
+		recreatedBound bool
+	}{
+		{
+			name: "recreated pod is still pending",
+		},
+		{
+			// The UID check used to be nested inside the else branch of the NodeName check, so
+			// a recreated Pod that had already been bound skipped it entirely. The failure
+			// handler then fell through to a namespace/name-addressed status patch and stamped
+			// the previous instance's PodScheduled=False onto the recreated Pod.
+			name:           "recreated pod is already bound",
+			recreatedBound: true,
+		},
 	}
 
-	updatedPod, err := client.CoreV1().Pods(recreatedPod.Namespace).Get(ctx, recreatedPod.Name, metav1.GetOptions{})
-	if err != nil {
-		t.Fatalf("Get pod: %v", err)
-	}
-	if diff := cmp.Diff(recreatedPod.Status, updatedPod.Status); diff != "" {
-		t.Fatalf("expected recreated pod status to remain unchanged (-want,+got):\n%s", diff)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			oldPod := st.MakePod().Name("foo").Namespace("ns").UID("old-uid").SchedulerName(testSchedulerName).Obj()
+			recreatedPod := oldPod.DeepCopy()
+			recreatedPod.UID = "new-uid"
+			if tt.recreatedBound {
+				recreatedPod.Spec.NodeName = "node1"
+			}
+
+			client := clientsetfake.NewClientset(recreatedPod)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
+
+			schedFramework, err := tf.NewFramework(ctx,
+				[]tf.RegisterPluginFunc{
+					tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+					tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				},
+				testSchedulerName,
+				frameworkruntime.WithClientSet(client),
+				frameworkruntime.WithEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, testSchedulerName)),
+				frameworkruntime.WithInformerFactory(informerFactory),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ar := metrics.NewMetricsAsyncRecorder(10, time.Second, ctx.Done())
+			queue := internalqueue.NewSchedulingQueue(nil, informerFactory, internalqueue.WithMetricsRecorder(ar))
+			sched := &Scheduler{
+				client:          client,
+				SchedulingQueue: queue,
+			}
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			queue.Add(ctx, oldPod)
+			popped, err := queue.Pop(logger)
+			if err != nil {
+				t.Fatalf("Pop: %v", err)
+			}
+			if got := queue.InFlightPods(); !podListContainsPod(got, oldPod) {
+				t.Fatalf("expected popped pod to be in-flight before failure handling, got %v", got)
+			}
+
+			nominatingInfo := &fwk.NominatingInfo{NominatingMode: fwk.ModeOverride, NominatedNodeName: "node1"}
+			poppedPod := popped.(*framework.QueuedPodInfo)
+			sched.handleSchedulingFailure(ctx, schedFramework, poppedPod, fwk.NewStatus(fwk.Unschedulable, "no fit"), nominatingInfo, time.Now())
+
+			if err := wait.PollUntilContextTimeout(ctx, time.Millisecond, wait.ForeverTestTimeout, false, func(context.Context) (bool, error) {
+				return len(queue.InFlightPods()) == 0, nil
+			}); err != nil {
+				t.Fatalf("in-flight pod was not cleared: %v", queue.InFlightPods())
+			}
+			if got := queue.PodsInBackoffQ(); len(got) != 0 {
+				t.Fatalf("expected recreated pod to stay out of backoffQ, got %v", got)
+			}
+			if got := queue.UnschedulablePods(); len(got) != 0 {
+				t.Fatalf("expected recreated pod to stay out of unschedulablePods, got %v", got)
+			}
+			if got := queue.NominatedPodsForNode("node1"); len(got) != 0 {
+				t.Fatalf("expected recreated pod to stay out of nominated pods, got %v", got)
+			}
+
+			updatedPod, err := client.CoreV1().Pods(recreatedPod.Namespace).Get(ctx, recreatedPod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("Get pod: %v", err)
+			}
+			if diff := cmp.Diff(recreatedPod.Status, updatedPod.Status); diff != "" {
+				t.Fatalf("expected recreated pod status to remain unchanged (-want,+got):\n%s", diff)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -118,9 +118,18 @@ func BindPod(ctx context.Context, cs kubernetes.Interface, binding *v1.Binding) 
 
 // PatchPodStatus calculates the delta bytes change from <old.Status> to <newStatus>,
 // and then submit a request to API server to patch the pod changes.
-func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, namespace string, oldStatus *v1.PodStatus, newStatus *v1.PodStatus) error {
+//
+// The pod uid is required and is sent as a precondition, so that a patch built for one
+// pod cannot be applied to a different pod that took over its name. A pod recreated
+// under the same name makes the API server reject the patch as Invalid, because
+// metadata.uid is immutable; a deleted pod keeps returning NotFound as before.
+func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, namespace string, uid types.UID, oldStatus *v1.PodStatus, newStatus *v1.PodStatus) error {
 	if newStatus == nil {
 		return nil
+	}
+
+	if uid == "" {
+		return fmt.Errorf("pod uid is required to patch the status of pod %q/%q", namespace, name)
 	}
 
 	if oldStatus == nil {
@@ -132,7 +141,9 @@ func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, n
 		return err
 	}
 
-	newData, err := json.Marshal(v1.Pod{Status: *newStatus})
+	// Only the new object carries the uid, so that it shows up in the patch as a
+	// precondition. Setting it on both sides would cancel it out of the delta.
+	newData, err := json.Marshal(v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: uid}, Status: *newStatus})
 	if err != nil {
 		return err
 	}
@@ -141,7 +152,9 @@ func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, n
 		return fmt.Errorf("failed to create merge patch for pod %q/%q: %w", namespace, name, err)
 	}
 
-	if "{}" == string(patchBytes) {
+	// The uid is always part of the patch, so an unchanged status reduces to the
+	// precondition alone rather than to an empty patch.
+	if fmt.Sprintf(`{"metadata":{"uid":%q}}`, uid) == string(patchBytes) {
 		return nil
 	}
 

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/net"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -184,6 +185,7 @@ func TestPatchPodStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pod1",
+					UID:       "pod1-uid",
 				},
 				Spec: v1.PodSpec{
 					ImagePullSecrets: []v1.LocalObjectReference{{Name: "foo"}},
@@ -208,6 +210,7 @@ func TestPatchPodStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pod1",
+					UID:       "pod1-uid",
 				},
 				Spec: v1.PodSpec{
 					// this will serialize to imagePullSecrets:[{}]
@@ -250,6 +253,7 @@ func TestPatchPodStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pod1",
+					UID:       "pod1-uid",
 				},
 				Spec: v1.PodSpec{
 					ImagePullSecrets: []v1.LocalObjectReference{{Name: "foo"}},
@@ -287,6 +291,7 @@ func TestPatchPodStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pod1",
+					UID:       "pod1-uid",
 				},
 				Spec: v1.PodSpec{
 					ImagePullSecrets: []v1.LocalObjectReference{{Name: "foo"}},
@@ -309,6 +314,7 @@ func TestPatchPodStatus(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pod1",
+					UID:       "pod1-uid",
 				},
 			},
 			statusToUpdate: v1.PodStatus{
@@ -339,7 +345,7 @@ func TestPatchPodStatus(t *testing.T) {
 			if tc.nilOldStatus {
 				oldStatus = nil
 			}
-			err = PatchPodStatus(ctx, client, tc.pod.Name, tc.pod.Namespace, oldStatus, &tc.statusToUpdate)
+			err = PatchPodStatus(ctx, client, tc.pod.Name, tc.pod.Namespace, tc.pod.UID, oldStatus, &tc.statusToUpdate)
 			if err != nil && tc.validateErr == nil {
 				// shouldn't be error
 				t.Fatal(err)
@@ -358,6 +364,86 @@ func TestPatchPodStatus(t *testing.T) {
 
 			if diff := cmp.Diff(tc.statusToUpdate, retrievedPod.Status); diff != "" {
 				t.Errorf("unexpected pod status (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestPatchPodStatusUIDPrecondition covers the uid precondition itself: that it reaches
+// the API server in the patch, that it is mandatory, and that it does not turn an
+// unchanged status into a write.
+func TestPatchPodStatusUIDPrecondition(t *testing.T) {
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod1", UID: "pod1-uid"},
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionFalse}},
+		},
+	}
+	updatedStatus := v1.PodStatus{
+		Conditions: []v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}},
+	}
+
+	tests := []struct {
+		name           string
+		uid            types.UID
+		statusToUpdate v1.PodStatus
+		wantErr        bool
+		// wantPatch is the exact patch expected to reach the API server. Empty means
+		// no patch request must be issued at all.
+		wantPatch string
+	}{
+		{
+			name:           "uid is sent as a precondition",
+			uid:            pod.UID,
+			statusToUpdate: updatedStatus,
+			wantPatch:      `{"metadata":{"uid":"pod1-uid"},"status":{"$setElementOrder/conditions":[{"type":"PodScheduled"}],"conditions":[{"status":"True","type":"PodScheduled"}]}}`,
+		},
+		{
+			name:           "unchanged status does not issue a patch",
+			uid:            pod.UID,
+			statusToUpdate: pod.Status,
+		},
+		{
+			name:           "empty uid is rejected",
+			uid:            "",
+			statusToUpdate: updatedStatus,
+			wantErr:        true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			client := clientsetfake.NewClientset()
+			if _, err := client.CoreV1().Pods(pod.Namespace).Create(ctx, &pod, metav1.CreateOptions{}); err != nil {
+				t.Fatal(err)
+			}
+
+			var gotPatches []string
+			client.PrependReactor("patch", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				gotPatches = append(gotPatches, string(action.(clienttesting.PatchAction).GetPatch()))
+				// Let the tracker apply the patch as usual.
+				return false, nil, nil
+			})
+
+			err := PatchPodStatus(ctx, client, pod.Name, pod.Namespace, tc.uid, &pod.Status, &tc.statusToUpdate)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error, got none")
+				}
+			} else if err != nil {
+				t.Fatal(err)
+			}
+
+			var wantPatches []string
+			if tc.wantPatch != "" {
+				wantPatches = []string{tc.wantPatch}
+			}
+			if diff := cmp.Diff(wantPatches, gotPatches); diff != "" {
+				t.Errorf("unexpected patch requests (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -1013,42 +1013,90 @@ func TestReplaceEvents(t *testing.T) {
 	// Test that both atomic and non-atomic replace have the same behavior
 	// in regards to events and store state.
 	for _, atomic := range []bool{false, true} {
-		source := fcache.NewFakeControllerSource()
-		t.Cleanup(func() {
-			source.Shutdown()
-		})
-		store := NewStore(DeletionHandlingMetaNamespaceKeyFunc)
-		fifoOptions := RealFIFOOptions{
-			AtomicEvents: atomic,
-		}
-		if !atomic {
-			fifoOptions.KnownObjects = store
-		}
-		fifo := NewRealFIFOWithOptions(fifoOptions)
-		recorder := newEventRecorder(store, DeletionHandlingMetaNamespaceKeyFunc)
-
-		cfg := &Config{
-			Queue:            fifo,
-			ListerWatcher:    source,
-			ObjectType:       &v1.Pod{},
-			FullResyncPeriod: 0,
-
-			Process: func(obj interface{}, isInInitialList bool) error {
-				if deltas, ok := obj.(Deltas); ok {
-					return processDeltas(fifo.logger, recorder, store, deltas, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
-				}
-				return errors.New("object given as Process argument is not Deltas")
-			},
-			ProcessBatch: func(deltaList []Delta, isInInitialList bool) error {
-				return processDeltasInBatch(fifo.logger, recorder, store, deltaList, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
-			},
-		}
-		c := New(cfg)
-		go c.RunWithContext(ctx)
-		if !WaitForCacheSync(ctx.Done(), c.HasSynced) {
-			t.Fatal("Timed out waiting for cache sync")
-		}
+		fifo, recorder, store := startReplaceEventsController(t, ctx, atomic)
 		testReplaceEvents(t, ctx, fifo, recorder, store, atomic)
+	}
+}
+
+// startReplaceEventsController wires a RealFIFO to a fresh store and event
+// recorder and runs a controller over them, so that a test can call Add and
+// Replace on the queue and observe the resulting handler calls.
+func startReplaceEventsController(t *testing.T, ctx context.Context, atomic bool) (*RealFIFO, *eventRecorder, Store) {
+	t.Helper()
+	source := fcache.NewFakeControllerSource()
+	t.Cleanup(func() {
+		source.Shutdown()
+	})
+	store := NewStore(DeletionHandlingMetaNamespaceKeyFunc)
+	fifoOptions := RealFIFOOptions{
+		AtomicEvents: atomic,
+	}
+	if !atomic {
+		fifoOptions.KnownObjects = store
+	}
+	fifo := NewRealFIFOWithOptions(fifoOptions)
+	recorder := newEventRecorder(store, DeletionHandlingMetaNamespaceKeyFunc)
+
+	cfg := &Config{
+		Queue:            fifo,
+		ListerWatcher:    source,
+		ObjectType:       &v1.Pod{},
+		FullResyncPeriod: 0,
+
+		Process: func(obj interface{}, isInInitialList bool) error {
+			if deltas, ok := obj.(Deltas); ok {
+				return processDeltas(fifo.logger, recorder, store, deltas, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
+			}
+			return errors.New("object given as Process argument is not Deltas")
+		},
+		ProcessBatch: func(deltaList []Delta, isInInitialList bool) error {
+			return processDeltasInBatch(fifo.logger, recorder, store, deltaList, isInInitialList, DeletionHandlingMetaNamespaceKeyFunc)
+		},
+	}
+	c := New(cfg)
+	go c.RunWithContext(ctx)
+	if !WaitForCacheSync(ctx.Done(), c.HasSynced) {
+		t.Fatal("Timed out waiting for cache sync")
+	}
+	return fifo, recorder, store
+}
+
+// TestReplaceEventsRecreatedObject pins the behavior an object is subject to
+// when it is deleted and recreated under the same name while the watch is
+// broken, and the reflector recovers with a full list.
+//
+// Deletions are detected by comparing sets of keys, and ObjectMeta.UID is not
+// part of a key. The recreated object's key is present both in the known
+// objects and in the replaced list, so no deletion is detected: the two
+// distinct objects are reported to the handler as a single update, with no
+// delete and no add. Consumers that care about object identity have to compare
+// ObjectMeta.UID themselves - see the contract documented on SharedInformer.
+func TestReplaceEventsRecreatedObject(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for _, atomic := range []bool{false, true} {
+		t.Run("atomic "+strconv.FormatBool(atomic), func(t *testing.T) {
+			fifo, recorder, store := startReplaceEventsController(t, ctx, atomic)
+
+			original := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default", UID: "uid-1", ResourceVersion: "1"}}
+			recreated := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", Namespace: "default", UID: "uid-2", ResourceVersion: "2"}}
+
+			require.NoError(t, fifo.Add(original), "failed to add")
+			require.NoError(t, recorder.waitForEventCount(ctx, 1, 5*time.Second), "failed to receive the initial add, got: %v", recorder.getHistory())
+			recorder.clearHistory()
+
+			// The object was deleted and recreated while the watch was down, so the
+			// list only ever sees the recreated one.
+			require.NoError(t, fifo.Replace([]interface{}{recreated}, "2"), "failed to replace")
+			require.NoError(t, recorder.waitForEventCount(ctx, 1, 5*time.Second), "failed to receive the replace event, got: %v", recorder.getHistory())
+
+			assert.Equal(t, []eventRecord{
+				{Action: "update", Key: "default/pod-1", EventRV: "2", StoreRV: "2", UID: "uid-2", OldUID: "uid-1"},
+			}, recorder.getHistory(), "expected a single update carrying both UIDs, with no delete and no add")
+			assert.Equal(t, []interface{}{recreated}, store.List())
+		})
 	}
 }
 
@@ -1433,6 +1481,11 @@ type eventRecord struct {
 	EventRV         string
 	StoreRV         string
 	IsInInitialList bool
+	// UID and OldUID are only set for objects that carry one. They exist so that
+	// tests can observe an update whose old and new object are different objects
+	// sharing a key, which is what a delete+recreate across a relist looks like.
+	UID    string
+	OldUID string
 }
 
 type eventRecorder struct {
@@ -1453,16 +1506,16 @@ func newEventRecorder(store Store, keyFunc KeyFunc) *eventRecorder {
 }
 
 func (m *eventRecorder) OnAdd(obj interface{}, isInInitialList bool) {
-	m.record("add", obj, isInInitialList)
+	m.record("add", nil, obj, isInInitialList)
 }
-func (m *eventRecorder) OnUpdate(_, obj interface{}) {
-	m.record("update", obj, false)
+func (m *eventRecorder) OnUpdate(old, obj interface{}) {
+	m.record("update", old, obj, false)
 }
 func (m *eventRecorder) OnDelete(obj interface{}) {
-	m.record("delete", obj, false)
+	m.record("delete", nil, obj, false)
 }
 
-func (m *eventRecorder) record(action string, obj interface{}, isInInitialList bool) {
+func (m *eventRecorder) record(action string, old, obj interface{}, isInInitialList bool) {
 	m.historyLock.Lock()
 	defer m.historyLock.Unlock()
 	key, _ := m.keyFunc(obj)
@@ -1472,8 +1525,17 @@ func (m *eventRecorder) record(action string, obj interface{}, isInInitialList b
 	}
 
 	eventRV := ""
+	uid := ""
 	if accessor, err := meta.Accessor(obj); err == nil {
 		eventRV = accessor.GetResourceVersion()
+		uid = string(accessor.GetUID())
+	}
+
+	oldUID := ""
+	if old != nil {
+		if accessor, err := meta.Accessor(old); err == nil {
+			oldUID = string(accessor.GetUID())
+		}
 	}
 
 	storeRV := ""
@@ -1489,6 +1551,8 @@ func (m *eventRecorder) record(action string, obj interface{}, isInInitialList b
 		EventRV:         eventRV,
 		StoreRV:         storeRV,
 		IsInInitialList: isInInitialList,
+		UID:             uid,
+		OldUID:          oldUID,
 	})
 	select {
 	case m.updateCh <- true:

--- a/test/integration/scheduler/patch_pod_status_test.go
+++ b/test/integration/scheduler/patch_pod_status_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
+	testutils "k8s.io/kubernetes/test/integration/util"
+)
+
+// TestPatchPodStatusUIDPrecondition verifies against a real API server that a status
+// patch built for one Pod cannot be applied to a different Pod that took over its name.
+//
+// A fake clientset cannot cover this: its tracker applies a strategic merge patch
+// without any immutability validation, so it happily rewrites metadata.uid.
+func TestPatchPodStatusUIDPrecondition(t *testing.T) {
+	testCtx := testutils.InitTestAPIServer(t, "patch-pod-status", nil)
+
+	ctx := testCtx.Ctx
+	cs := testCtx.ClientSet
+	ns := testCtx.NS.Name
+
+	newStatus := v1.PodStatus{
+		Conditions: []v1.PodCondition{{
+			Type:    v1.PodScheduled,
+			Status:  v1.ConditionFalse,
+			Reason:  v1.PodReasonUnschedulable,
+			Message: "patched by the test",
+		}},
+	}
+
+	createPod := func() *v1.Pod {
+		t.Helper()
+		pod, err := cs.CoreV1().Pods(ns).Create(ctx, &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: ns},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{{Name: "container", Image: "image"}},
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("Failed to create pod: %v", err)
+		}
+		return pod
+	}
+
+	original := createPod()
+	originalStatus := original.Status.DeepCopy()
+
+	// A patch aimed at the Pod that is actually there still works.
+	if err := schedutil.PatchPodStatus(ctx, cs, original.Name, ns, original.UID, originalStatus, &newStatus); err != nil {
+		t.Fatalf("Failed to patch the status of the live pod: %v", err)
+	}
+
+	if err := cs.CoreV1().Pods(ns).Delete(ctx, original.Name, *metav1.NewDeleteOptions(0)); err != nil {
+		t.Fatalf("Failed to delete pod: %v", err)
+	}
+	if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := cs.CoreV1().Pods(ns).Get(ctx, original.Name, metav1.GetOptions{})
+		return apierrors.IsNotFound(err), nil
+	}); err != nil {
+		t.Fatalf("Pod was not deleted: %v", err)
+	}
+
+	// A deleted Pod keeps reporting not-found: the precondition only ever fires against
+	// an object that is actually there.
+	err := schedutil.PatchPodStatus(ctx, cs, original.Name, ns, original.UID, originalStatus, &newStatus)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("Expected a not-found error when patching a deleted pod, got %v", err)
+	}
+
+	// Recreate under the same name. This is what the informer can report to the
+	// scheduler as a plain update of the original Pod.
+	recreated := createPod()
+	if recreated.UID == original.UID {
+		t.Fatalf("Recreated pod unexpectedly reuses uid %v", recreated.UID)
+	}
+
+	err = schedutil.PatchPodStatus(ctx, cs, original.Name, ns, original.UID, originalStatus, &newStatus)
+	if !apierrors.IsInvalid(err) {
+		t.Errorf("Expected an invalid error when patching a recreated pod with the previous uid, got %v", err)
+	}
+
+	live, err := cs.CoreV1().Pods(ns).Get(ctx, original.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get the recreated pod: %v", err)
+	}
+	if live.UID != recreated.UID {
+		t.Errorf("Recreated pod uid changed: got %v, want %v", live.UID, recreated.UID)
+	}
+	for _, condition := range live.Status.Conditions {
+		if condition.Message == "patched by the test" {
+			t.Errorf("Stale patch was applied to the recreated pod: %v", condition)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The SharedInformer identifies objects by `namespace/name`; `ObjectMeta.UID` is not part of an object's identity per its contract. When a Pod is deleted and recreated under the same name while the watch is disrupted, the reflector recovers with a full list, the deletion is not detected, and the two distinct Pods are delivered to handlers as a single `OnUpdate`.

`Scheduler.updatePod` branches only on `assignedPod(oldPod)`, assuming that an assigned old Pod implies an assigned new Pod. That holds for one object but not for two collapsed into one event, so the update reaches `cache.UpdatePod`, which sees a `NodeName` mismatch and terminates kube-scheduler.

The fix splits the collapsed event back into the delete and the add that actually happened, before the branch is chosen:

```go
if oldPod.UID != newPod.UID {
    sched.deletePod(oldPod)
    sched.addPod(newPod)
    return
}
```

#### Which issue(s) this PR is related to:
https://github.com/kubernetes/kubernetes/pull/141078/
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug where kube-scheduler could terminate when a Pod was deleted and recreated with the same name while the scheduler's watch was disrupted, causing the informer to report the two Pods as a single update event.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
