### PR TITLE
Automated cherry pick of #141012: Sync supported service account token algorithms to test image

### DIFF
--- a/pkg/serviceaccount/externaljwt/plugin/plugin.go
+++ b/pkg/serviceaccount/externaljwt/plugin/plugin.go
@@ -174,9 +174,11 @@ func (p *Plugin) validateJWTHeader(ctx context.Context, response *externaljwtv1.
 		return fmt.Errorf("key id longer than 1 kb")
 	}
 	switch header.Algorithm {
-	// IMPORTANT: If this function is updated to support additional algorithms,
-	// JWTTokenGenerator, signerFromRSAPrivateKey, signerFromECDSAPrivateKey in
-	// kubernetes/pkg/serviceaccount/jwt.go must also be updated to support the same Algorithms.
+	// IMPORTANT: The algorithms listed below must be kept in sync with:
+	// - pkg/serviceaccount/externaljwt/plugin/plugin.go validateJWTHeader
+	// - pkg/serviceaccount/jwt.go signerFromRSAPrivateKey
+	// - pkg/serviceaccount/jwt.go signerFromECDSAPrivateKey
+	// - test/images/agnhost/openidmetadata/openidmetadata.go validate SupportedSigningAlgs
 	case "RS256", "ES256", "ES384", "ES512":
 		// OK
 	default:

--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -117,10 +117,11 @@ func signerFromRSAPrivateKey(keyPair *rsa.PrivateKey) (jose.Signer, error) {
 		return nil, fmt.Errorf("failed to derive keyID: %v", err)
 	}
 
-	// IMPORTANT: If this function is updated to support additional key sizes,
-	// algorithmForPublicKey in serviceaccount/openidmetadata.go and
-	// validateJWTHeader in externaljwt/pkg/plugin/plugin.go must also
-	// be updated to support the same key sizes. Today we only support RS256.
+	// IMPORTANT: The RSA algorithms listed below must be kept in sync with:
+	// - pkg/serviceaccount/externaljwt/plugin/plugin.go validateJWTHeader
+	// - pkg/serviceaccount/jwt.go signerFromRSAPrivateKey
+	// - pkg/serviceaccount/jwt.go signerFromECDSAPrivateKey
+	// - test/images/agnhost/openidmetadata/openidmetadata.go validate SupportedSigningAlgs
 
 	// Wrap the RSA keypair in a JOSE JWK with the designated key ID.
 	privateJWK := &jose.JSONWebKey{
@@ -148,9 +149,11 @@ func signerFromRSAPrivateKey(keyPair *rsa.PrivateKey) (jose.Signer, error) {
 func signerFromECDSAPrivateKey(keyPair *ecdsa.PrivateKey) (jose.Signer, error) {
 	var alg jose.SignatureAlgorithm
 
-	// IMPORTANT: If this function is updated to support additional algorithms,
-	// validateJWTHeader in externaljwt/pkg/plugin/plugin.go must also be updated
-	// to support the same Algorithms. Today we only support "ES256", "ES384", "ES512".
+	// IMPORTANT: The EC algorithms listed below must be kept in sync with:
+	// - pkg/serviceaccount/externaljwt/plugin/plugin.go validateJWTHeader
+	// - pkg/serviceaccount/jwt.go signerFromRSAPrivateKey
+	// - pkg/serviceaccount/jwt.go signerFromECDSAPrivateKey
+	// - test/images/agnhost/openidmetadata/openidmetadata.go validate SupportedSigningAlgs
 
 	switch keyPair.Curve {
 	case elliptic.P256():

--- a/test/images/agnhost/openidmetadata/openidmetadata.go
+++ b/test/images/agnhost/openidmetadata/openidmetadata.go
@@ -123,9 +123,15 @@ func validate(ctx context.Context, raw string) error {
 	}
 	log.Printf("OK: Constructed OIDC provider for issuer %v", unsafeClaims.Issuer)
 
+	// IMPORTANT: The algorithms listed below must be kept in sync with:
+	// - pkg/serviceaccount/externaljwt/plugin/plugin.go validateJWTHeader
+	// - pkg/serviceaccount/jwt.go signerFromRSAPrivateKey
+	// - pkg/serviceaccount/jwt.go signerFromECDSAPrivateKey
+	// - test/images/agnhost/openidmetadata/openidmetadata.go validate SupportedSigningAlgs
+
 	validTok, err := iss.Verifier(&oidc.Config{
 		ClientID:             audience,
-		SupportedSigningAlgs: []string{oidc.RS256, oidc.ES256},
+		SupportedSigningAlgs: []string{oidc.RS256, oidc.ES256, oidc.ES384, oidc.ES512},
 	}).Verify(ctx, raw)
 	if err != nil {
 		return err


### PR DESCRIPTION
Cherry pick of #141012 on release-1.35.

#141012: Sync supported service account token algorithms to test image

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup
/kind failing-test


```release-note
NONE
```