### PR TITLE
core: add +k8s:update=NoUnset to Node.Spec.PodCIDRs

### DIFF
--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -966,7 +966,38 @@ func Validate_NodeSpec(
 	obj, oldObj *corev1.NodeSpec) (errs field.ErrorList) {
 
 	// field corev1.NodeSpec.PodCIDR has no validation
-	// field corev1.NodeSpec.PodCIDRs has no validation
+
+	{ // field corev1.NodeSpec.PodCIDRs
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj []string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.ValSliceUpdate(ctx, op, fldPath, obj, oldObj, nil, validate.NoUnset).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *corev1.NodeSpec) []string {
+				return oldObj.PodCIDRs
+			})
+		errs = append(errs, fn(fldPath.Child("podCIDRs"), obj.PodCIDRs, oldVal, oldObj != nil)...)
+	}
 
 	{ // field corev1.NodeSpec.ProviderID
 		fn := func(

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -974,7 +974,7 @@ func Validate_NodeSpec(
 			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update {
-				if equality.Semantic.DeepEqual(obj, oldObj) {
+				if validate.SemanticDeepEqual(obj, oldObj) {
 					return nil
 				}
 			}

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -7685,15 +7685,13 @@ func ValidateNodeUpdate(node, oldNode *core.Node) field.ErrorList {
 
 	// Allow the controller manager to assign a CIDR to a node if it doesn't have one.
 	if len(oldNode.Spec.PodCIDRs) > 0 {
-		// compare the entire slice
-		if len(oldNode.Spec.PodCIDRs) != len(node.Spec.PodCIDRs) {
+		if len(node.Spec.PodCIDRs) == 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "podCIDRs"), nil, "field cannot be cleared once set").WithOrigin("update").MarkCoveredByDeclarative())
+		} else if !apiequality.Semantic.DeepEqual(oldNode.Spec.PodCIDRs, node.Spec.PodCIDRs) {
+			// Modification of an already-assigned podCIDRs is not expressible with
+			// +k8s:update yet: NoModify is rejected on list fields, and the
+			// per-item form does not correlate changed values in a listType=set.
 			allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "podCIDRs"), "node updates may not change podCIDR except from \"\" to valid"))
-		} else {
-			for idx, value := range oldNode.Spec.PodCIDRs {
-				if value != node.Spec.PodCIDRs[idx] {
-					allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "podCIDRs"), "node updates may not change podCIDR except from \"\" to valid"))
-				}
-			}
 		}
 	}
 

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -3129,8 +3129,8 @@ message NodeSpec {
   // +optional
   // +patchStrategy=merge
   // +listType=set
-  // +k8s:alpha(since: "1.37")=+k8s:optional
-  // +k8s:alpha(since: "1.37")=+k8s:update=NoUnset
+  // +k8s:alpha(since: "1.38")=+k8s:optional
+  // +k8s:alpha(since: "1.38")=+k8s:update=NoUnset
   repeated string podCIDRs = 7;
 
   // ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -3129,6 +3129,8 @@ message NodeSpec {
   // +optional
   // +patchStrategy=merge
   // +listType=set
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:update=NoUnset
   repeated string podCIDRs = 7;
 
   // ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -6919,6 +6919,8 @@ type NodeSpec struct {
 	// +optional
 	// +patchStrategy=merge
 	// +listType=set
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:update=NoUnset
 	PodCIDRs []string `json:"podCIDRs,omitempty" protobuf:"bytes,7,opt,name=podCIDRs" patchStrategy:"merge"`
 
 	// ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -6919,8 +6919,8 @@ type NodeSpec struct {
 	// +optional
 	// +patchStrategy=merge
 	// +listType=set
-	// +k8s:alpha(since: "1.37")=+k8s:optional
-	// +k8s:alpha(since: "1.37")=+k8s:update=NoUnset
+	// +k8s:alpha(since: "1.38")=+k8s:optional
+	// +k8s:alpha(since: "1.38")=+k8s:update=NoUnset
 	PodCIDRs []string `json:"podCIDRs,omitempty" protobuf:"bytes,7,opt,name=podCIDRs" patchStrategy:"merge"`
 
 	// ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>

--- a/test/declarative_validation/core/node/declarative_validation_test.go
+++ b/test/declarative_validation/core/node/declarative_validation_test.go
@@ -197,6 +197,51 @@ func testDeclarativeValidateNodeUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "providerID"), nil, "field cannot be cleared once set").WithOrigin("update").MarkAlpha(),
 			},
 		},
+		"no change with podCIDRs": {
+			old: mkValidNode(func(n *core.Node) {
+				n.Spec.PodCIDRs = []string{"10.0.0.0/24"}
+			}),
+			update: mkValidNode(func(n *core.Node) {
+				n.Spec.PodCIDRs = []string{"10.0.0.0/24"}
+			}),
+		},
+		"set podCIDRs from empty": {
+			old: mkValidNode(),
+			update: mkValidNode(func(n *core.Node) {
+				n.Spec.PodCIDRs = []string{"10.0.0.0/24"}
+			}),
+		},
+		"clear podCIDRs": {
+			old: mkValidNode(func(n *core.Node) {
+				n.Spec.PodCIDRs = []string{"10.0.0.0/24"}
+			}),
+			update: mkValidNode(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podCIDRs"), nil, "field cannot be cleared once set").WithOrigin("update").MarkAlpha(),
+			},
+		},
+		// Modification of an assigned podCIDRs is still hand-written only:
+		// +k8s:update=NoModify is rejected on list fields.
+		"modify podCIDRs": {
+			old: mkValidNode(func(n *core.Node) {
+				n.Spec.PodCIDRs = []string{"10.0.0.0/24"}
+			}),
+			update: mkValidNode(func(n *core.Node) {
+				n.Spec.PodCIDRs = []string{"10.0.1.0/24"}
+			}),
+			expectedErrs: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "podCIDRs"), "node updates may not change podCIDR except from \"\" to valid").MarkFromImperative(),
+			},
+		},
+		"clear dual-stack podCIDRs": {
+			old: mkValidNode(func(n *core.Node) {
+				n.Spec.PodCIDRs = []string{"10.0.0.0/24", "fd00::/64"}
+			}),
+			update: mkValidNode(),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "podCIDRs"), nil, "field cannot be cleared once set").WithOrigin("update").MarkAlpha(),
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/test/declarative_validation/core/node/declarative_validation_test.go
+++ b/test/declarative_validation/core/node/declarative_validation_test.go
@@ -242,6 +242,19 @@ func testDeclarativeValidateNodeUpdate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "podCIDRs"), nil, "field cannot be cleared once set").WithOrigin("update").MarkAlpha(),
 			},
 		},
+		// A reorder is a modification too: the 0th entry must match podCIDR, so
+		// swapping the pair changes which CIDR is primary.
+		"reorder dual-stack podCIDRs": {
+			old: mkValidNode(func(n *core.Node) {
+				n.Spec.PodCIDRs = []string{"10.0.0.0/24", "fd00::/64"}
+			}),
+			update: mkValidNode(func(n *core.Node) {
+				n.Spec.PodCIDRs = []string{"fd00::/64", "10.0.0.0/24"}
+			}),
+			expectedErrs: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "podCIDRs"), "node updates may not change podCIDR except from \"\" to valid").MarkFromImperative(),
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/test/declarative_validation/core/node/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/node/zz_generated.validations.v1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.podCIDRs": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"spec.podPreemptionPolicy": {
 				{ErrorType: "FieldValueForbidden"},
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change
/sig api-machinery
/area api-validation

#### What this PR does / why we need it:

Migrates the "podCIDRs cannot be cleared" half of `Node.Spec.PodCIDRs` immutability to declarative validation, using `+k8s:update=NoUnset`. Same set-once shape as `Node.Spec.ProviderID` directly below it, which was migrated the same way in 1.36.

Only half of the rule is expressible today. `+k8s:update=NoModify` is rejected by validation-gen on list fields:

```
failed to generate validations: field k8s.io/api/core/v1.NodeSpec.podCIDRs: tag "k8s:alpha":
tag "k8s:update": +k8s:update=NoModify is not supported on list or map fields,
use +k8s:eachVal=+k8s:update=NoModify for per-item immutability
```

and the per-item form doesn't help here: `podCIDRs` is `+listType=set`, so a changed value correlates as a remove plus an add rather than a modification. `NoAddItem`/`NoRemoveItem` would also reject the initial assignment, which is explicitly allowed — the controller manager assigns the CIDR after the node registers.

So the modify branch stays hand-written, with a comment saying why, and `test/declarative_validation/core/node` has a `modify podCIDRs` case asserting it is still imperative-only. The remaining branch can be migrated once list-level `NoModify` is supported.

`podCIDR` (singular) needs no tag: it does not exist on the internal type, and `pkg/apis/core/v1/conversion.go` reconciles it against `podCIDRs` on the way in. Declarative validation runs on the versioned object produced by internal→versioned conversion, so the two can never disagree by the time it runs.

Part of #136785, under KEP-5073.

#### Does this PR introduce a user-facing change?

Clearing an already-assigned `node.spec.podCIDRs` now reports `field cannot be cleared once set` instead of `node updates may not change podCIDR except from "" to valid`. This matches the wording the `providerID` migration introduced in the same struct. Changing (rather than clearing) `podCIDRs` is unaffected.

```release-note
Clearing `node.spec.podCIDRs` on update now reports "field cannot be cleared once set" instead of "node updates may not change podCIDR except from \"\" to valid".
```

#### Additional documentation

```docs
KEP-5073: https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/5073-declarative-validation
```
