### PR TITLE
kubelet: cpumanager: Fix exclusive allocation metrics accounting

### DIFF
--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -439,6 +439,17 @@ func (p *staticPolicy) allocatePodForAdd(logger klog.Logger, s state.State, pod 
 	// Store the pod-level allocation in the state.
 	s.SetPodCPUSet(podUID, podAllocation.CPUs)
 
+	// From this point on the pod owns the whole bubble: if the partitioning
+	// below fails, every CPU taken from the default CPU set must go back to
+	// it, or the CPUs would leak out of the shared pool with no pod able to
+	// ever use them again.
+	defer func() {
+		if rerr != nil {
+			p.releasePodAllocation(logger, s, podUID, podAllocation.CPUs)
+			logger.Error(rerr, "Incomplete pod-level CPU allocation rolled back, released pod CPUs", "podCPUSet", podAllocation.CPUs)
+		}
+	}()
+
 	// 5. Partition the pod's allocation, handling init container CPU reuse correctly.
 	exclusiveCPUs := make(map[string]cpuset.CPUSet)
 	sidecarCPUs := cpuset.New()
@@ -509,6 +520,19 @@ func (p *staticPolicy) allocatePodForAdd(logger klog.Logger, s state.State, pod 
 	}
 
 	return nil
+}
+
+// releasePodAllocation releases every CPU resource the pod holds in the
+// state: the container assignments are dropped and the whole pod-level CPU
+// set goes back to the default CPU set, so a failed pod admission never
+// leaks CPUs out of the shared pool.
+func (p *staticPolicy) releasePodAllocation(logger klog.Logger, s state.State, podUID string, podCPUSet cpuset.CPUSet) {
+	for containerName := range s.GetCPUAssignments()[podUID] {
+		s.Delete(podUID, containerName)
+	}
+	s.SetDefaultCPUSet(s.GetDefaultCPUSet().Union(podCPUSet))
+	s.DeletePod(podUID)
+	p.updateMetricsOnRelease(logger, s, podCPUSet)
 }
 
 func podCPUAllocationToString(alloc map[string]cpuset.CPUSet) string {

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -127,6 +127,9 @@ type staticPolicy struct {
 	// we compute this value multiple time, and it's not supposed to change
 	// at runtime - the cpumanager can't deal with runtime topology changes anyway.
 	cpuGroupSize int
+	// sorted list of NUMA nodes known to the topology; computed once at initialization
+	// and reused for metric updates and deterministic topology hints generation.
+	numaNodes []int
 }
 
 // Ensure staticPolicy implements Policy interface
@@ -146,7 +149,8 @@ func NewStaticPolicy(logger klog.Logger, topology *topology.CPUTopology, numRese
 	}
 
 	cpuGroupSize := topology.CPUsPerCore()
-	logger.Info("created with configuration", "options", opts, "cpuGroupSize", cpuGroupSize)
+	numaNodes := topology.CPUDetails.NUMANodes().List()
+	logger.Info("created with configuration", "options", opts, "cpuGroupSize", cpuGroupSize, "numaNodes", numaNodes)
 
 	policy := &staticPolicy{
 		topology:     topology,
@@ -154,6 +158,7 @@ func NewStaticPolicy(logger klog.Logger, topology *topology.CPUTopology, numRese
 		cpusToReuse:  make(map[string]cpuset.CPUSet),
 		options:      opts,
 		cpuGroupSize: cpuGroupSize,
+		numaNodes:    numaNodes,
 	}
 
 	allCPUs := topology.CPUDetails.CPUs()
@@ -1027,11 +1032,11 @@ func (p *staticPolicy) getPodTopologyHintsForAdd(logger klog.Logger, s state.Sta
 // marking all others with 'Preferred: false'.
 func (p *staticPolicy) generateCPUTopologyHints(availableCPUs cpuset.CPUSet, reusableCPUs cpuset.CPUSet, request int) []topologymanager.TopologyHint {
 	// Initialize minAffinitySize to include all NUMA Nodes.
-	minAffinitySize := p.topology.CPUDetails.NUMANodes().Size()
+	minAffinitySize := len(p.numaNodes)
 
 	// Iterate through all combinations of numa nodes bitmask and build hints from them.
 	hints := []topologymanager.TopologyHint{}
-	bitmask.IterateBitMasks(p.topology.CPUDetails.NUMANodes().List(), func(mask bitmask.BitMask) {
+	bitmask.IterateBitMasks(p.numaNodes, func(mask bitmask.BitMask) {
 		// First, update minAffinitySize for the current request size.
 		cpusInMask := p.topology.CPUDetails.CPUsInNUMANodes(mask.GetBits()...).Size()
 		if cpusInMask >= request && mask.Count() < minAffinitySize {
@@ -1143,7 +1148,7 @@ func (p *staticPolicy) updateMetricsFromState(logger klog.Logger, s state.State)
 	metrics.CPUManagerSharedPoolSizeMilliCores.Set(float64(p.GetAvailableCPUs(s).Size() * 1000))
 	totalExclusiveCPUs := getTotalAssignedExclusiveCPUs(s)
 	metrics.CPUManagerExclusiveCPUsAllocationCount.Set(float64(totalExclusiveCPUs.Size()))
-	updateAllocationPerNUMAMetric(logger, p.topology, totalExclusiveCPUs)
+	updateAllocationPerNUMAMetric(logger, p.topology, totalExclusiveCPUs, p.numaNodes)
 }
 
 func (p *staticPolicy) updateMetricsOnAllocate(logger klog.Logger, s state.State, cpuAlloc topology.Allocation) {
@@ -1171,7 +1176,7 @@ func getTotalAssignedExclusiveCPUs(s state.State) cpuset.CPUSet {
 	return totalAssignedCPUs
 }
 
-func updateAllocationPerNUMAMetric(logger klog.Logger, topo *topology.CPUTopology, allocatedCPUs cpuset.CPUSet) {
+func updateAllocationPerNUMAMetric(logger klog.Logger, topo *topology.CPUTopology, allocatedCPUs cpuset.CPUSet, numaNodes []int) {
 	numaCount := make(map[int]int)
 
 	// Count CPUs allocated per NUMA node
@@ -1189,7 +1194,7 @@ func updateAllocationPerNUMAMetric(logger klog.Logger, topo *topology.CPUTopolog
 	// node with no allocated CPUs must be explicitly reset to zero, or the
 	// gauge would keep reporting the last non-zero value after all the CPUs
 	// of that node went back to the shared pool.
-	for _, numaNode := range topo.CPUDetails.NUMANodes().UnsortedList() {
+	for _, numaNode := range numaNodes {
 		metrics.CPUManagerAllocationPerNUMA.WithLabelValues(strconv.Itoa(numaNode)).Set(float64(numaCount[numaNode]))
 	}
 }

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -433,21 +433,24 @@ func (p *staticPolicy) allocatePodForAdd(logger klog.Logger, s state.State, pod 
 		logger.Error(err, "Unable to allocate CPUs for pod", "totalPodCPUs", totalPodCPUs)
 		return err
 	}
-	p.updateMetricsOnAllocate(logger, s, podAllocation)
 	logger.V(4).Info("Allocated pod-level CPU bubble", "allocation", podAllocation.CPUs)
 
 	// Store the pod-level allocation in the state.
 	s.SetPodCPUSet(podUID, podAllocation.CPUs)
+
+	// Update metrics after the pod-level allocation is set, as metrics recalculation requires it.
+	p.updateMetricsOnAllocate(logger, s, podAllocation)
 
 	// From this point on the pod owns the whole bubble: if the partitioning
 	// below fails, every CPU taken from the default CPU set must go back to
 	// it, or the CPUs would leak out of the shared pool with no pod able to
 	// ever use them again.
 	defer func() {
-		if rerr != nil {
-			p.releasePodAllocation(logger, s, podUID, podAllocation.CPUs)
-			logger.Error(rerr, "Incomplete pod-level CPU allocation rolled back, released pod CPUs", "podCPUSet", podAllocation.CPUs)
+		if rerr == nil {
+			return
 		}
+		p.releasePodAllocation(logger, s, podUID, podAllocation.CPUs)
+		logger.Error(rerr, "Incomplete pod-level CPU allocation rolled back, released pod CPUs", "podCPUSet", podAllocation.CPUs)
 	}()
 
 	// 5. Partition the pod's allocation, handling init container CPU reuse correctly.
@@ -532,7 +535,7 @@ func (p *staticPolicy) releasePodAllocation(logger klog.Logger, s state.State, p
 	}
 	s.SetDefaultCPUSet(s.GetDefaultCPUSet().Union(podCPUSet))
 	s.DeletePod(podUID)
-	p.updateMetricsOnRelease(logger, s, podCPUSet)
+	p.updateMetricsFromState(logger, s)
 }
 
 func podCPUAllocationToString(alloc map[string]cpuset.CPUSet) string {
@@ -698,7 +701,7 @@ func (p *staticPolicy) RemoveContainer(logger klog.Logger, s state.State, podUID
 				updatedCPUSets := s.GetDefaultCPUSet().Union(podCPUSet)
 				s.SetDefaultCPUSet(updatedCPUSets)
 				s.DeletePod(podUID) // Clean up all state for the pod.
-				p.updateMetricsOnRelease(logger, s, podCPUSet)
+				p.updateMetricsFromState(logger, s)
 				logger.Info("Released pod-level CPUs", "defaultCPUSet", updatedCPUSets)
 			}
 			// If other containers still exist, do not release any CPUs yet.
@@ -712,7 +715,7 @@ func (p *staticPolicy) RemoveContainer(logger klog.Logger, s state.State, podUID
 	toRelease = toRelease.Difference(cpusInUse)
 	updatedCPUs := s.GetDefaultCPUSet().Union(toRelease)
 	s.SetDefaultCPUSet(updatedCPUs)
-	p.updateMetricsOnRelease(logger, s, toRelease)
+	p.updateMetricsFromState(logger, s)
 	logger.Info("RemoveContainer end", "defaultCPUSet", updatedCPUs)
 	return nil
 }
@@ -1122,39 +1125,47 @@ func (p *staticPolicy) getAlignedCPUs(numaAffinity bitmask.BitMask, allocatableC
 }
 
 func (p *staticPolicy) initializeMetrics(logger klog.Logger, s state.State) {
-	metrics.CPUManagerSharedPoolSizeMilliCores.Set(float64(p.GetAvailableCPUs(s).Size() * 1000))
 	metrics.ContainerAlignedComputeResourcesFailure.WithLabelValues(metrics.AlignScopeContainer, metrics.AlignedPhysicalCPU).Add(0) // ensure the value exists
 	metrics.ContainerAlignedComputeResources.WithLabelValues(metrics.AlignScopeContainer, metrics.AlignedPhysicalCPU).Add(0)        // ensure the value exists
 	metrics.ContainerAlignedComputeResources.WithLabelValues(metrics.AlignScopeContainer, metrics.AlignedUncoreCache).Add(0)        // ensure the value exists
-	totalAssignedCPUs := getTotalAssignedExclusiveCPUs(s)
-	metrics.CPUManagerExclusiveCPUsAllocationCount.Set(float64(totalAssignedCPUs.Size()))
-	updateAllocationPerNUMAMetric(logger, p.topology, totalAssignedCPUs)
+	p.updateMetricsFromState(logger, s)
+}
+
+// updateMetricsFromState recomputes from the state the gauges tracking the
+// exclusive CPU allocations: the size of the shared CPU pool, the number of
+// exclusively allocated CPUs and their distribution across NUMA nodes.
+// Deriving the values from the state, rather than applying deltas on every
+// allocation and release, guarantees the gauges always match what has been
+// taken out of the default CPU set (a CPU reused from an init container is
+// counted once) and keeps them consistent across kubelet restarts. It must
+// be called only once the state mutation is complete.
+func (p *staticPolicy) updateMetricsFromState(logger klog.Logger, s state.State) {
+	metrics.CPUManagerSharedPoolSizeMilliCores.Set(float64(p.GetAvailableCPUs(s).Size() * 1000))
+	totalExclusiveCPUs := getTotalAssignedExclusiveCPUs(s)
+	metrics.CPUManagerExclusiveCPUsAllocationCount.Set(float64(totalExclusiveCPUs.Size()))
+	updateAllocationPerNUMAMetric(logger, p.topology, totalExclusiveCPUs)
 }
 
 func (p *staticPolicy) updateMetricsOnAllocate(logger klog.Logger, s state.State, cpuAlloc topology.Allocation) {
-	ncpus := cpuAlloc.CPUs.Size()
-	metrics.CPUManagerExclusiveCPUsAllocationCount.Add(float64(ncpus))
-	metrics.CPUManagerSharedPoolSizeMilliCores.Add(float64(-ncpus * 1000))
 	if cpuAlloc.Aligned.UncoreCache {
 		metrics.ContainerAlignedComputeResources.WithLabelValues(metrics.AlignScopeContainer, metrics.AlignedUncoreCache).Inc()
 	}
-	totalAssignedCPUs := getTotalAssignedExclusiveCPUs(s)
-	updateAllocationPerNUMAMetric(logger, p.topology, totalAssignedCPUs)
+	p.updateMetricsFromState(logger, s)
 }
 
-func (p *staticPolicy) updateMetricsOnRelease(logger klog.Logger, s state.State, cset cpuset.CPUSet) {
-	ncpus := cset.Size()
-	metrics.CPUManagerExclusiveCPUsAllocationCount.Add(float64(-ncpus))
-	metrics.CPUManagerSharedPoolSizeMilliCores.Add(float64(ncpus * 1000))
-	totalAssignedCPUs := getTotalAssignedExclusiveCPUs(s)
-	updateAllocationPerNUMAMetric(logger, p.topology, totalAssignedCPUs.Difference(cset))
-}
-
+// getTotalAssignedExclusiveCPUs returns the set of CPUs exclusively allocated on the node.
+// This is union of all CPU sets allocated for containers using exclusive CPUs and
+// pods using pod-level exclusive CPU sets (the "bubble" allocation for whole pod is used).
 func getTotalAssignedExclusiveCPUs(s state.State) cpuset.CPUSet {
 	totalAssignedCPUs := cpuset.New()
 	for _, assignment := range s.GetCPUAssignments() {
 		for _, cset := range assignment {
 			totalAssignedCPUs = totalAssignedCPUs.Union(cset)
+		}
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodLevelResourceManagers) {
+		for _, podEntry := range s.GetPodCPUAssignments() {
+			totalAssignedCPUs = totalAssignedCPUs.Union(podEntry.CPUSet)
 		}
 	}
 	return totalAssignedCPUs
@@ -1174,8 +1185,11 @@ func updateAllocationPerNUMAMetric(logger klog.Logger, topo *topology.CPUTopolog
 		numaCount[numaNode]++
 	}
 
-	// Update metric
-	for numaNode, count := range numaCount {
-		metrics.CPUManagerAllocationPerNUMA.WithLabelValues(strconv.Itoa(numaNode)).Set(float64(count))
+	// Update the metric for every NUMA node known to the topology: a NUMA
+	// node with no allocated CPUs must be explicitly reset to zero, or the
+	// gauge would keep reporting the last non-zero value after all the CPUs
+	// of that node went back to the shared pool.
+	for _, numaNode := range topo.CPUDetails.NUMANodes().UnsortedList() {
+		metrics.CPUManagerAllocationPerNUMA.WithLabelValues(strconv.Itoa(numaNode)).Set(float64(numaCount[numaNode]))
 	}
 }

--- a/pkg/kubelet/cm/cpumanager/policy_static_metrics_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_metrics_test.go
@@ -1,0 +1,703 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpumanager
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/klog/v2/ktesting"
+	pkgfeatures "k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
+	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"k8s.io/kubernetes/pkg/kubelet/metrics"
+	"k8s.io/utils/cpuset"
+)
+
+// mainTB adapts TestMain to the minimal interface the feature gate test
+// helpers need. The cleanups restoring the gates are collected instead of
+// being deferred to the end of a test, so they can be run as soon as the
+// metrics are registered.
+type mainTB struct {
+	cleanups []func()
+}
+
+func (tb *mainTB) Cleanup(f func())                  { tb.cleanups = append(tb.cleanups, f) }
+func (tb *mainTB) Helper()                           {}
+func (tb *mainTB) Name() string                      { return "TestMain" }
+func (tb *mainTB) Logf(format string, args ...any)   { log.Printf(format, args...) }
+func (tb *mainTB) Error(args ...any)                 { tb.Fatal(args...) }
+func (tb *mainTB) Errorf(format string, args ...any) { tb.Fatalf(format, args...) }
+func (tb *mainTB) Fatal(args ...any)                 { log.Fatal(args...) }
+func (tb *mainTB) Fatalf(format string, args ...any) { log.Fatalf(format, args...) }
+
+// restore runs the collected cleanups in reverse order, the way testing does.
+func (tb *mainTB) restore() {
+	for i := len(tb.cleanups) - 1; i >= 0; i-- {
+		tb.cleanups[i]()
+	}
+	tb.cleanups = nil
+}
+
+// TestMain makes sure every metric asserted on in this package exists before
+// any test runs.
+// metrics.Register is guarded by a sync.Once and registers the resource
+// manager metrics only when PodLevelResourceManagers is enabled.
+// So without this the first test calling metrics.Register decides which
+// metrics are registered and exist.
+// (an unregistered metric silently discards every update and always reads back zero)
+func TestMain(m *testing.M) {
+	tb := &mainTB{}
+	featuregatetesting.SetFeatureGatesDuringTest(tb, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		pkgfeatures.PodLevelResources:        true,
+		pkgfeatures.PodLevelResourceManagers: true,
+	})
+	metrics.Register()
+	tb.restore()
+
+	os.Exit(m.Run())
+}
+
+type cpuMetricsSnapshot struct {
+	exclusiveCPUs   float64
+	sharedPoolMilli float64
+	perNUMA         map[string]float64
+}
+
+// readCPUMetrics reads the per-NUMA gauge by gathering the registry rather
+// than through WithLabelValues, which would silently create a missing series:
+// a NUMA node absent from the snapshot means no series exists for it.
+func readCPUMetrics(t *testing.T) cpuMetricsSnapshot {
+	t.Helper()
+
+	exclusiveCPUs, err := testutil.GetGaugeMetricValue(metrics.CPUManagerExclusiveCPUsAllocationCount)
+	require.NoError(t, err)
+	sharedPoolMilli, err := testutil.GetGaugeMetricValue(metrics.CPUManagerSharedPoolSizeMilliCores)
+	require.NoError(t, err)
+
+	perNUMA := map[string]float64{}
+	families, err := legacyregistry.DefaultGatherer.Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != "kubelet_"+metrics.CPUManagerAllocationPerNUMAKey {
+			continue
+		}
+		for _, sample := range family.GetMetric() {
+			for _, label := range sample.GetLabel() {
+				if label.GetName() == metrics.AlignedNUMANode {
+					perNUMA[label.GetValue()] = sample.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+	return cpuMetricsSnapshot{exclusiveCPUs: exclusiveCPUs, sharedPoolMilli: sharedPoolMilli, perNUMA: perNUMA}
+}
+
+func assertCPUMetrics(t *testing.T, expected cpuMetricsSnapshot) {
+	t.Helper()
+	const delta = 0.001
+	got := readCPUMetrics(t)
+	require.InDelta(t, expected.exclusiveCPUs, got.exclusiveCPUs, delta, "exclusive CPU allocation count")
+	require.InDelta(t, expected.sharedPoolMilli, got.sharedPoolMilli, delta, "shared pool size millicores")
+	require.InDeltaMapValues(t, expected.perNUMA, got.perNUMA, delta, "allocation per NUMA node")
+}
+
+func newMetricsTestPolicy(t *testing.T, topo *topology.CPUTopology, numReservedCPUs int, reservedCPUs cpuset.CPUSet, hint *topologymanager.TopologyHint) *staticPolicy {
+	t.Helper()
+	metrics.Register()
+	metrics.CPUManagerAllocationPerNUMA.Reset()
+
+	logger, _ := ktesting.NewTestContext(t)
+	affinity := topologymanager.NewFakeManagerWithHint(logger, hint)
+	policy, err := NewStaticPolicy(logger, topo, numReservedCPUs, reservedCPUs, affinity, nil)
+	require.NoError(t, err)
+	return policy.(*staticPolicy)
+}
+
+func resetCPUMetrics() {
+	metrics.CPUManagerAllocationPerNUMA.Reset()
+	metrics.CPUManagerExclusiveCPUsAllocationCount.Set(-1)
+	metrics.CPUManagerSharedPoolSizeMilliCores.Set(-1)
+}
+
+func TestStaticPolicyMetricsInitialization(t *testing.T) {
+	testCases := []struct {
+		description                     string
+		podLevelResourceManagersEnabled bool
+		stAssignments                   state.ContainerCPUAssignments
+		stPodAssignments                state.PodCPUAssignments
+		stDefaultCPUSet                 cpuset.CPUSet
+		expected                        cpuMetricsSnapshot
+	}{
+		{
+			description:                     "empty state with PodLevelResourceManagers disabled",
+			podLevelResourceManagersEnabled: false,
+			stAssignments:                   state.ContainerCPUAssignments{},
+			stDefaultCPUSet:                 cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   0,
+				sharedPoolMilli: 11000,
+				perNUMA:         map[string]float64{"0": 0, "1": 0},
+			},
+		},
+		{
+			description:                     "empty state with PodLevelResourceManagers enabled",
+			podLevelResourceManagersEnabled: true,
+			stAssignments:                   state.ContainerCPUAssignments{},
+			stDefaultCPUSet:                 cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   0,
+				sharedPoolMilli: 11000,
+				perNUMA:         map[string]float64{"0": 0, "1": 0},
+			},
+		},
+		{
+			description:                     "container assignments with PodLevelResourceManagers disabled",
+			podLevelResourceManagersEnabled: false,
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{"cont": cpuset.New(2, 8)},
+				"podB": map[string]cpuset.CPUSet{"cont": cpuset.New(1, 7)},
+			},
+			stDefaultCPUSet: cpuset.New(0, 3, 4, 5, 6, 9, 10, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   4,
+				sharedPoolMilli: 7000,
+				perNUMA:         map[string]float64{"0": 2, "1": 2},
+			},
+		},
+		{
+			description:                     "container assignments with PodLevelResourceManagers enabled",
+			podLevelResourceManagersEnabled: true,
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{"cont": cpuset.New(2, 8)},
+				"podB": map[string]cpuset.CPUSet{"cont": cpuset.New(1, 7)},
+			},
+			stDefaultCPUSet: cpuset.New(0, 3, 4, 5, 6, 9, 10, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   4,
+				sharedPoolMilli: 7000,
+				perNUMA:         map[string]float64{"0": 2, "1": 2},
+			},
+		},
+		{
+			description:                     "overlapping assignments of an init container reused by an app container with PodLevelResourceManagers disabled",
+			podLevelResourceManagersEnabled: false,
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{
+					"init-cont": cpuset.New(2, 8),
+					"app-cont":  cpuset.New(2, 6, 8),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 3, 4, 5, 7, 9, 10, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   3,
+				sharedPoolMilli: 8000,
+				perNUMA:         map[string]float64{"0": 3, "1": 0},
+			},
+		},
+		{
+			description:                     "overlapping assignments of an init container reused by an app container with PodLevelResourceManagers enabled",
+			podLevelResourceManagersEnabled: true,
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{
+					"init-cont": cpuset.New(2, 8),
+					"app-cont":  cpuset.New(2, 6, 8),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 3, 4, 5, 7, 9, 10, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   3,
+				sharedPoolMilli: 8000,
+				perNUMA:         map[string]float64{"0": 3, "1": 0},
+			},
+		},
+		{
+			description:                     "one-shot init container reused by app containers running alongside a sidecar with PodLevelResourceManagers disabled",
+			podLevelResourceManagersEnabled: false,
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{
+					"init-cont":    cpuset.New(2, 8),
+					"sidecar-cont": cpuset.New(6),
+					"app-cont-1":   cpuset.New(2, 8),
+					"app-cont-2":   cpuset.New(4),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 3, 5, 7, 9, 10, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   4,
+				sharedPoolMilli: 7000,
+				perNUMA:         map[string]float64{"0": 4, "1": 0},
+			},
+		},
+		{
+			description:                     "one-shot init container reused by app containers running alongside a sidecar with PodLevelResourceManagers enabled",
+			podLevelResourceManagersEnabled: true,
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{
+					"init-cont":    cpuset.New(2, 8),
+					"sidecar-cont": cpuset.New(6),
+					"app-cont-1":   cpuset.New(2, 8),
+					"app-cont-2":   cpuset.New(4),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 1, 3, 5, 7, 9, 10, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   4,
+				sharedPoolMilli: 7000,
+				perNUMA:         map[string]float64{"0": 4, "1": 0},
+			},
+		},
+		{
+			description:                     "pod-level bubble spanning both NUMA nodes with all container assignments with PodLevelResourceManagers disabled",
+			podLevelResourceManagersEnabled: false,
+			stPodAssignments: state.PodCPUAssignments{
+				"podA": state.PodEntry{CPUSet: cpuset.New(1, 2, 3, 4, 6, 7, 8, 10)},
+			},
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{
+					"gu-cont":     cpuset.New(1, 7),
+					"shared-cont": cpuset.New(2, 3, 4, 6, 8, 10),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 5, 9, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   8,
+				sharedPoolMilli: 3000,
+				perNUMA:         map[string]float64{"0": 5, "1": 3},
+			},
+		},
+		{
+			description:                     "pod-level bubble spanning both NUMA nodes with all container assignments with PodLevelResourceManagers enabled",
+			podLevelResourceManagersEnabled: true,
+			stPodAssignments: state.PodCPUAssignments{
+				"podA": state.PodEntry{CPUSet: cpuset.New(1, 2, 3, 4, 6, 7, 8, 10)},
+			},
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{
+					"gu-cont":     cpuset.New(1, 7),
+					"shared-cont": cpuset.New(2, 3, 4, 6, 8, 10),
+				},
+			},
+			stDefaultCPUSet: cpuset.New(0, 5, 9, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   8,
+				sharedPoolMilli: 3000,
+				perNUMA:         map[string]float64{"0": 5, "1": 3},
+			},
+		},
+		{
+			description:                     "pod-level bubble spanning both NUMA nodes with partial container assignments with PodLevelResourceManagers disabled",
+			podLevelResourceManagersEnabled: false,
+			stPodAssignments: state.PodCPUAssignments{
+				"podA": state.PodEntry{CPUSet: cpuset.New(1, 2, 3, 4, 6, 7, 8, 10)},
+			},
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{"shared-cont": cpuset.New(2, 3, 4, 6, 8, 10)},
+			},
+			stDefaultCPUSet: cpuset.New(0, 5, 9, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   6,
+				sharedPoolMilli: 3000,
+				perNUMA:         map[string]float64{"0": 5, "1": 1},
+			},
+		},
+		{
+			description:                     "pod-level bubble spanning both NUMA nodes with partial container assignments with PodLevelResourceManagers enabled",
+			podLevelResourceManagersEnabled: true,
+			stPodAssignments: state.PodCPUAssignments{
+				"podA": state.PodEntry{CPUSet: cpuset.New(1, 2, 3, 4, 6, 7, 8, 10)},
+			},
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{"shared-cont": cpuset.New(2, 3, 4, 6, 8, 10)},
+			},
+			stDefaultCPUSet: cpuset.New(0, 5, 9, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   8,
+				sharedPoolMilli: 3000,
+				perNUMA:         map[string]float64{"0": 5, "1": 3},
+			},
+		},
+		{
+			description:                     "container assignments mixed with a pod-level bubble with PodLevelResourceManagers disabled",
+			podLevelResourceManagersEnabled: false,
+			stPodAssignments: state.PodCPUAssignments{
+				"podA": state.PodEntry{CPUSet: cpuset.New(1, 3, 7, 9)},
+			},
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{
+					"gu-cont":     cpuset.New(1, 7),
+					"shared-cont": cpuset.New(3, 9),
+				},
+				"podB": map[string]cpuset.CPUSet{"cont": cpuset.New(2, 8)},
+			},
+			stDefaultCPUSet: cpuset.New(0, 4, 5, 6, 10, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   6,
+				sharedPoolMilli: 5000,
+				perNUMA:         map[string]float64{"0": 2, "1": 4},
+			},
+		},
+		{
+			description:                     "container assignments mixed with a pod-level bubble with PodLevelResourceManagers enabled",
+			podLevelResourceManagersEnabled: true,
+			stPodAssignments: state.PodCPUAssignments{
+				"podA": state.PodEntry{CPUSet: cpuset.New(1, 3, 7, 9)},
+			},
+			stAssignments: state.ContainerCPUAssignments{
+				"podA": map[string]cpuset.CPUSet{
+					"gu-cont":     cpuset.New(1, 7),
+					"shared-cont": cpuset.New(3, 9),
+				},
+				"podB": map[string]cpuset.CPUSet{"cont": cpuset.New(2, 8)},
+			},
+			stDefaultCPUSet: cpuset.New(0, 4, 5, 6, 10, 11),
+			expected: cpuMetricsSnapshot{
+				exclusiveCPUs:   6,
+				sharedPoolMilli: 5000,
+				perNUMA:         map[string]float64{"0": 2, "1": 4},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.PodLevelResourceManagers, testCase.podLevelResourceManagersEnabled)
+			logger, _ := ktesting.NewTestContext(t)
+
+			p := newMetricsTestPolicy(t, topoDualSocketHT, 1, cpuset.New(0), nil)
+			st := &mockState{
+				assignments:    testCase.stAssignments,
+				podAssignments: testCase.stPodAssignments,
+				defaultCPUSet:  testCase.stDefaultCPUSet,
+			}
+
+			resetCPUMetrics()
+			p.initializeMetrics(logger, st)
+
+			assertCPUMetrics(t, testCase.expected)
+		})
+	}
+}
+
+func TestStaticPolicyMetricsContainerAllocation(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)
+	idle := cpuMetricsSnapshot{
+		exclusiveCPUs:   0,
+		sharedPoolMilli: 7000,
+		perNUMA:         map[string]float64{"0": 0},
+	}
+
+	setup := func(t *testing.T) (*staticPolicy, *mockState) {
+		p := newMetricsTestPolicy(t, topoSingleSocketHT, 1, cpuset.New(0), nil)
+		st := &mockState{assignments: state.ContainerCPUAssignments{}, defaultCPUSet: allCPUs}
+		require.NoError(t, p.Start(logger, st))
+		assertCPUMetrics(t, idle)
+		return p, st
+	}
+
+	t.Run("allocation and full release", func(t *testing.T) {
+		p, st := setup(t)
+		pod := makePod("podUID", "cont", "2", "2")
+
+		require.NoError(t, p.Allocate(logger, st, pod, &pod.Spec.Containers[0], lifecycle.AddOperation))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 2, sharedPoolMilli: 5000, perNUMA: map[string]float64{"0": 2}})
+
+		require.NoError(t, p.RemoveContainer(logger, st, "podUID", "cont"))
+		assertCPUMetrics(t, idle)
+	})
+
+	t.Run("init container CPU reuse counted once", func(t *testing.T) {
+		p, st := setup(t)
+		pod := makeMultiContainerPod(
+			[]struct{ request, limit string }{{"4000m", "4000m"}},
+			[]struct{ request, limit string }{{"2000m", "2000m"}})
+
+		require.NoError(t, p.Allocate(logger, st, pod, &pod.Spec.InitContainers[0], lifecycle.AddOperation))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 4, sharedPoolMilli: 3000, perNUMA: map[string]float64{"0": 4}})
+
+		// The app container reuses 2 CPUs of the init container, so the gauges must not change.
+		require.NoError(t, p.Allocate(logger, st, pod, &pod.Spec.Containers[0], lifecycle.AddOperation))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 4, sharedPoolMilli: 3000, perNUMA: map[string]float64{"0": 4}})
+
+		require.NoError(t, p.RemoveContainer(logger, st, "podUID", "initContainer-0"))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 2, sharedPoolMilli: 5000, perNUMA: map[string]float64{"0": 2}})
+
+		require.NoError(t, p.RemoveContainer(logger, st, "podUID", "appContainer-0"))
+		assertCPUMetrics(t, idle)
+	})
+
+	t.Run("allocation skipped for a container already present in the state", func(t *testing.T) {
+		p, st := setup(t)
+		pod := makePod("podUID", "cont", "2", "2")
+
+		require.NoError(t, p.Allocate(logger, st, pod, &pod.Spec.Containers[0], lifecycle.AddOperation))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 2, sharedPoolMilli: 5000, perNUMA: map[string]float64{"0": 2}})
+
+		require.NoError(t, p.Allocate(logger, st, pod, &pod.Spec.Containers[0], lifecycle.AddOperation))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 2, sharedPoolMilli: 5000, perNUMA: map[string]float64{"0": 2}})
+	})
+
+	t.Run("failed allocation leaves the metrics unchanged", func(t *testing.T) {
+		p, st := setup(t)
+		pod := makePod("podUID", "cont", "9", "9")
+
+		require.Error(t, p.Allocate(logger, st, pod, &pod.Spec.Containers[0], lifecycle.AddOperation))
+		assertCPUMetrics(t, idle)
+	})
+
+	t.Run("release of an unknown pod container leaves the metrics unchanged", func(t *testing.T) {
+		p, st := setup(t)
+
+		require.NoError(t, p.RemoveContainer(logger, st, "no-such-pod", "no-such-cont"))
+		assertCPUMetrics(t, idle)
+	})
+
+	t.Run("release of an unknown container leaves the metrics unchanged", func(t *testing.T) {
+		p, st := setup(t)
+
+		pod := makePod("podUID", "cont", "2", "2")
+
+		require.NoError(t, p.Allocate(logger, st, pod, &pod.Spec.Containers[0], lifecycle.AddOperation))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 2, sharedPoolMilli: 5000, perNUMA: map[string]float64{"0": 2}})
+
+		require.NoError(t, p.RemoveContainer(logger, st, "podUID", "no-such-container"))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 2, sharedPoolMilli: 5000, perNUMA: map[string]float64{"0": 2}})
+	})
+}
+
+func TestStaticPolicyMetricsPodLevelAllocation(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.PodLevelResources, true)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.PodLevelResourceManagers, true)
+
+	logger, _ := ktesting.NewTestContext(t)
+	hint := &topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true}
+	allCPUs := cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+	idle := cpuMetricsSnapshot{
+		exclusiveCPUs:   0,
+		sharedPoolMilli: 11000,
+		perNUMA:         map[string]float64{"0": 0, "1": 0},
+	}
+
+	setup := func(t *testing.T) (*staticPolicy, *mockState) {
+		p := newMetricsTestPolicy(t, topoDualSocketHT, 1, cpuset.New(0), hint)
+		st := &mockState{assignments: state.ContainerCPUAssignments{}, defaultCPUSet: allCPUs}
+		require.NoError(t, p.Start(logger, st))
+		assertCPUMetrics(t, idle)
+		return p, st
+	}
+
+	t.Run("whole bubble counted on allocation, released with the last container", func(t *testing.T) {
+		p, st := setup(t)
+		pod := makePodWithContainersAndPodLevelResources("plrm-pod", "4", "4", nil, []containerSpec{
+			{name: "gu-container", request: "2", limit: "2"},
+			{name: "shared-container"},
+		})
+
+		require.NoError(t, p.AllocatePod(logger, st, pod, lifecycle.AddOperation))
+		busy := cpuMetricsSnapshot{
+			exclusiveCPUs:   4,
+			sharedPoolMilli: 7000,
+			perNUMA:         map[string]float64{"0": 4, "1": 0},
+		}
+		assertCPUMetrics(t, busy)
+
+		require.NoError(t, p.RemoveContainer(logger, st, "plrm-pod", "gu-container"))
+		assertCPUMetrics(t, busy)
+
+		require.NoError(t, p.RemoveContainer(logger, st, "plrm-pod", "shared-container"))
+		assertCPUMetrics(t, idle)
+	})
+
+	t.Run("failed bubble partitioning rolls the allocation back", func(t *testing.T) {
+		p, st := setup(t)
+		// The containers request more exclusive CPUs than the pod-level
+		// budget, so partitioning the bubble must fail after the bubble has
+		// been allocated.
+		pod := makePodWithContainersAndPodLevelResources("rollback-pod", "3", "3", nil, []containerSpec{
+			{name: "gu-container-1", request: "2", limit: "2"},
+			{name: "gu-container-2", request: "2", limit: "2"},
+		})
+
+		require.Error(t, p.AllocatePod(logger, st, pod, lifecycle.AddOperation))
+
+		assertCPUMetrics(t, idle)
+		require.True(t, st.GetDefaultCPUSet().Equals(allCPUs), "default CPU set should be restored, got %s", st.GetDefaultCPUSet())
+		_, hasPodCPUSet := st.GetPodCPUSet("rollback-pod")
+		require.False(t, hasPodCPUSet, "pod-level CPU set should be removed")
+		require.Empty(t, st.GetCPUAssignments(), "container assignments should be removed")
+	})
+
+	t.Run("rollback releases the container assignments already present in the state", func(t *testing.T) {
+		p := newMetricsTestPolicy(t, topoDualSocketHT, 1, cpuset.New(0), hint)
+		bubble := cpuset.New(2, 4, 8, 10)
+		st := &mockState{
+			assignments: state.ContainerCPUAssignments{
+				"plrm-pod": {
+					"gu-container":     cpuset.New(2, 8),
+					"shared-container": cpuset.New(4, 10),
+				},
+			},
+			podAssignments: state.PodCPUAssignments{
+				"plrm-pod": state.PodEntry{CPUSet: bubble},
+			},
+			defaultCPUSet: allCPUs.Difference(bubble),
+		}
+		require.NoError(t, p.Start(logger, st))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 4, sharedPoolMilli: 7000, perNUMA: map[string]float64{"0": 4, "1": 0}})
+
+		p.releasePodAllocation(logger, st, "plrm-pod", bubble)
+
+		assertCPUMetrics(t, idle)
+		require.True(t, st.GetDefaultCPUSet().Equals(allCPUs), "default CPU set should be restored, got %s", st.GetDefaultCPUSet())
+		_, hasPodCPUSet := st.GetPodCPUSet("plrm-pod")
+		require.False(t, hasPodCPUSet, "pod-level CPU set should be removed")
+		require.Empty(t, st.GetCPUAssignments(), "container assignments should be removed")
+	})
+
+	t.Run("pod with non-integral pod-level CPUs leaves the metrics unchanged", func(t *testing.T) {
+		p, st := setup(t)
+		pod := makePodWithContainersAndPodLevelResources("shared-pod", "1500m", "1500m", nil, []containerSpec{
+			{name: "container"},
+		})
+
+		require.NoError(t, p.AllocatePod(logger, st, pod, lifecycle.AddOperation))
+		assertCPUMetrics(t, idle)
+	})
+
+	t.Run("pod with non-integral pod-level CPUs and an integral container", func(t *testing.T) {
+		p, st := setup(t)
+		pod := makePodWithContainersAndPodLevelResources("mixed-pod", "3500m", "3500m", nil, []containerSpec{
+			{name: "gu-container", request: "2", limit: "2"},
+			{name: "shared-container"},
+		})
+
+		// No bubble: non-integral pod-level CPUs make the pod ineligible for a pod-scope allocation.
+		require.NoError(t, p.AllocatePod(logger, st, pod, lifecycle.AddOperation))
+		assertCPUMetrics(t, idle)
+		_, hasPodCPUSet := st.GetPodCPUSet("mixed-pod")
+		require.False(t, hasPodCPUSet, "no pod-level CPU set should be allocated")
+
+		// The integral container still gets a node-scope exclusive allocation through the container-scope path.
+		require.NoError(t, p.Allocate(logger, st, pod, &pod.Spec.Containers[0], lifecycle.AddOperation))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 2, sharedPoolMilli: 9000, perNUMA: map[string]float64{"0": 2, "1": 0}})
+
+		require.NoError(t, p.Allocate(logger, st, pod, &pod.Spec.Containers[1], lifecycle.AddOperation))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 2, sharedPoolMilli: 9000, perNUMA: map[string]float64{"0": 2, "1": 0}})
+
+		require.NoError(t, p.RemoveContainer(logger, st, "mixed-pod", "gu-container"))
+		assertCPUMetrics(t, idle)
+	})
+}
+
+func TestStaticPolicyMetricsPerNUMA(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	hintNUMA0 := &topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true}
+	hintNUMA1 := &topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(1), Preferred: true}
+
+	p := newMetricsTestPolicy(t, topoDualSocketHT, 1, cpuset.New(0), hintNUMA0)
+	st := &mockState{assignments: state.ContainerCPUAssignments{}, defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)}
+	require.NoError(t, p.Start(logger, st))
+	idle := cpuMetricsSnapshot{
+		exclusiveCPUs:   0,
+		sharedPoolMilli: 11000,
+		perNUMA:         map[string]float64{"0": 0, "1": 0},
+	}
+	assertCPUMetrics(t, idle)
+
+	podA := makePod("podA", "contA", "2", "2")
+	require.NoError(t, p.Allocate(logger, st, podA, &podA.Spec.Containers[0], lifecycle.AddOperation))
+	assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 2, sharedPoolMilli: 9000, perNUMA: map[string]float64{"0": 2, "1": 0}})
+
+	p.affinity = topologymanager.NewFakeManagerWithHint(logger, hintNUMA1)
+	podB := makePod("podB", "contB", "2", "2")
+	require.NoError(t, p.Allocate(logger, st, podB, &podB.Spec.Containers[0], lifecycle.AddOperation))
+	assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 4, sharedPoolMilli: 7000, perNUMA: map[string]float64{"0": 2, "1": 2}})
+
+	// The NUMA node 0 series must drop to zero, not disappear or keep the last value.
+	require.NoError(t, p.RemoveContainer(logger, st, "podA", "contA"))
+	assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 2, sharedPoolMilli: 9000, perNUMA: map[string]float64{"0": 0, "1": 2}})
+
+	require.NoError(t, p.RemoveContainer(logger, st, "podB", "contB"))
+	assertCPUMetrics(t, idle)
+}
+
+func TestStaticPolicyMetricsRestartConsistency(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+
+	simulateRestart := func(t *testing.T, p *staticPolicy, st state.State) {
+		t.Helper()
+		resetCPUMetrics()
+		p.initializeMetrics(logger, st)
+	}
+
+	t.Run("container-scope allocations with init container reuse", func(t *testing.T) {
+		p := newMetricsTestPolicy(t, topoSingleSocketHT, 1, cpuset.New(0), nil)
+		st := &mockState{assignments: state.ContainerCPUAssignments{}, defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7)}
+		require.NoError(t, p.Start(logger, st))
+
+		pod := makeMultiContainerPod(
+			[]struct{ request, limit string }{{"4000m", "4000m"}},
+			[]struct{ request, limit string }{{"2000m", "2000m"}})
+		require.NoError(t, p.Allocate(logger, st, pod, &pod.Spec.InitContainers[0], lifecycle.AddOperation))
+		require.NoError(t, p.Allocate(logger, st, pod, &pod.Spec.Containers[0], lifecycle.AddOperation))
+		busy := readCPUMetrics(t)
+
+		simulateRestart(t, p, st)
+		assertCPUMetrics(t, busy)
+	})
+
+	t.Run("pod-level allocation partially released before the restart", func(t *testing.T) {
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.PodLevelResources, true)
+		featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, pkgfeatures.PodLevelResourceManagers, true)
+
+		hint := &topologymanager.TopologyHint{NUMANodeAffinity: newNUMAAffinity(0), Preferred: true}
+		p := newMetricsTestPolicy(t, topoDualSocketHT, 1, cpuset.New(0), hint)
+		st := &mockState{assignments: state.ContainerCPUAssignments{}, defaultCPUSet: cpuset.New(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)}
+		require.NoError(t, p.Start(logger, st))
+
+		pod := makePodWithContainersAndPodLevelResources("plrm-pod", "4", "4", nil, []containerSpec{
+			{name: "gu-container", request: "2", limit: "2"},
+			{name: "shared-container"},
+		})
+		require.NoError(t, p.AllocatePod(logger, st, pod, lifecycle.AddOperation))
+		busy := cpuMetricsSnapshot{
+			exclusiveCPUs:   4,
+			sharedPoolMilli: 7000,
+			perNUMA:         map[string]float64{"0": 4, "1": 0},
+		}
+		assertCPUMetrics(t, busy)
+
+		require.NoError(t, p.RemoveContainer(logger, st, "plrm-pod", "gu-container"))
+
+		// The whole bubble must still be accounted after the restart, even though some container assignments are gone.
+		simulateRestart(t, p, st)
+		assertCPUMetrics(t, busy)
+
+		require.NoError(t, p.RemoveContainer(logger, st, "plrm-pod", "shared-container"))
+		assertCPUMetrics(t, cpuMetricsSnapshot{exclusiveCPUs: 0, sharedPoolMilli: 11000, perNUMA: map[string]float64{"0": 0, "1": 0}})
+	})
+}

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -232,6 +232,45 @@ func TestStaticPolicyStart(t *testing.T) {
 	}
 }
 
+func TestStaticPolicyNUMANodesInitialization(t *testing.T) {
+	testCases := []struct {
+		description   string
+		topology      *topology.CPUTopology
+		expectedNUMAs []int
+	}{
+		{
+			description:   "single NUMA node",
+			topology:      topoSingleSocketHT,
+			expectedNUMAs: []int{0},
+		},
+		{
+			description:   "dual NUMA nodes",
+			topology:      topoDualSocketHT,
+			expectedNUMAs: []int{0, 1},
+		},
+		{
+			description:   "quad socket topology",
+			topology:      topoQuadSocketFourWayHT,
+			expectedNUMAs: []int{0, 1, 2, 3},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			policy, err := NewStaticPolicy(logger, tc.topology, 1, cpuset.New(0), topologymanager.NewFakeManagerWithHint(logger, nil), nil)
+			if err != nil {
+				t.Fatalf("NewStaticPolicy failed: %v", err)
+			}
+
+			p := policy.(*staticPolicy)
+			if !reflect.DeepEqual(p.numaNodes, tc.expectedNUMAs) {
+				t.Errorf("expected numaNodes %v, got %v", tc.expectedNUMAs, p.numaNodes)
+			}
+		})
+	}
+}
+
 func TestStaticPolicyAdd(t *testing.T) {
 	var largeTopoCPUids []int
 	var largeTopoSock0CPUids []int

--- a/pkg/kubelet/cm/cpumanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints_test.go
@@ -252,7 +252,8 @@ func TestGetTopologyHints(t *testing.T) {
 
 		m := manager{
 			policy: &staticPolicy{
-				topology: topology,
+				topology:  topology,
+				numaNodes: topology.CPUDetails.NUMANodes().List(),
 			},
 			state: &mockState{
 				assignments:   tc.assignments,
@@ -304,7 +305,8 @@ func TestGetPodTopologyHints(t *testing.T) {
 
 		m := manager{
 			policy: &staticPolicy{
-				topology: topology,
+				topology:  topology,
+				numaNodes: topology.CPUDetails.NUMANodes().List(),
 			},
 			state: &mockState{
 				assignments:   tc.assignments,
@@ -486,8 +488,9 @@ func TestGetPodTopologyHintsWithPolicyOptions(t *testing.T) {
 			policyOpt, _ := NewStaticPolicyOptions(testCase.policyOptions)
 			m := manager{
 				policy: &staticPolicy{
-					topology: testCase.topology,
-					options:  policyOpt,
+					topology:  testCase.topology,
+					options:   policyOpt,
+					numaNodes: testCase.topology.CPUDetails.NUMANodes().List(),
 				},
 				state: &mockState{
 					assignments:   testCase.assignments,
@@ -611,7 +614,8 @@ func TestTopologyHintsPodLevelResources(t *testing.T) {
 
 			m := manager{
 				policy: &staticPolicy{
-					topology: topology,
+					topology:  topology,
+					numaNodes: topology.CPUDetails.NUMANodes().List(),
 				},
 				state: &mockState{
 					assignments:   tc.assignments,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The static policy maintained the `CPUManagerExclusiveCPUsAllocationCount` and `CPUManagerSharedPoolSizeMilliCores` gauges by applying per-event deltas, and updated `CPUManagerAllocationPerNUMA` only for the NUMA nodes present in the current allocation. This drifted away from the actual allocation state in several scenarios

##### Failing scenarios

1. Init container CPU reuse was double counted (container scope). When an app container reuses the CPUs of a non-restartable init container, `allocateCPUs` returns the full allocation including the reused CPUs, which stay assigned to the init container too. The allocation path added the full size of both allocations, counting the reused CPUs twice. The release path correctly subtracted the sibling-adjusted sets, so after the pod was removed the gauge kept a permanent positive residue equal to the number of reused CPUs. The shared pool gauge had the mirrored problem: the allocation delta subtracted CPUs which had never been taken out of the default CPU set.
    
2. Fresh allocations and restarts disagreed. During a kubelet run the exclusive allocation gauge accumulated deltas with the duplicates described above, while after a restart `initializeMetrics` recomputed it as the union of the checkpointed assignments (no duplicates). The same node state could therefore report two different values before and after a kubelet restart.
    
3. Pod-level (pod scope) allocations could leak on partial failure. `allocatePodForAdd` updated the metrics and stored the pod-level CPU set, but a failure while partitioning the bubble among the containers (takeByTopology) returned an error without releasing anything: the bubble stayed out of the default CPU set, the gauge stayed inflated, and nothing could ever clean it up, because `RemoveContainer` returns early for a pod with no container assignments and `removeStaleState` only iterates over container assignments.
    
4. Pod-level releases could drift the gauge below the real value. `RemoveContainer` subtracts the whole pod-level CPU set when the last container assignment is removed, but after a kubelet restart `initializeMetrics` only accounted the union of the remaining container assignments, which is smaller than the bubble if some containers had already been removed before the restart. Releasing a pod which died while the kubelet was down then over-subtracted the difference.
    
5. `initializeMetrics` ignored the pod-level CPU sets. After a restart the gauge was seeded only from the container assignments, so the part of a pod-level bubble not covered by any container assignment was not counted, even though it is excluded from the default CPU set.
    
6. `CPUManagerAllocationPerNUMA` never dropped back to zero. The update loop only wrote the NUMA nodes present in the current allocation, so once the last exclusively allocated CPU of a node was released, the node kept reporting its last non-zero value forever. The metric was also fed only with the container assignments, making a pod-level bubble invisible at allocation time, because the container assignments are stored later than the pod-level CPU set.

##### The fix

Instead of patching every delta, derive all three gauges from the checkpointed state, which is the single source of truth for what has been taken out of the default CPU set:

* A new `updateMetricsFromState` helper recomputes, after every state mutation: the shared pool size from `GetAvailableCPUs` (default CPU set minus reserved), and the exclusively allocated CPUs as the union of all container assignments (a CPU reused from an init container is counted exactly once) and of all pod-level CPU sets (the whole bubble counts, however it is partitioned among the containers, since the container assignments are carved out of it). `initializeMetrics`, `updateMetricsOnAllocate` and ~~`updateMetricsOnRelease`~~ all reduce to this recomputation, so fresh allocations, releases and restarts can no longer disagree.
    
* `allocatePodForAdd` stores the pod-level CPU set before updating the metrics and rolls back on failure: a new `releasePodAllocation` helper drops the container assignments, returns the whole bubble to the default CPU set, deletes the pod-level entry and refreshes the gauges, so a failed pod admission no longer leaks CPUs or metric values.
    
* `updateAllocationPerNUMAMetric` now writes a value for every NUMA node known to the topology, explicitly resetting to zero the nodes with no exclusively allocated CPUs, and is fed with the same state-derived exclusive CPU set as the allocation count gauge, so pod-level bubbles are accounted as soon as they are allocated.
    
* `updateMetricsOnRelease` ~~loses its cpuset parameter: the released set was only used to apply the (now removed) deltas.~~ - was removed base on comment: https://github.com/kubernetes/kubernetes/pull/141261#discussion_r3760340188 [EDIT]

##### Tests

Add a new test file `pkg/kubelet/cm/cpumanager/policy_static_metrics_test.go` to implement tests for gauge metrics.
Tests cover regular scenarios and all failing scenarios testing:
* initialization from a checkpointed state, with the `PodLevelResourceManagers` feature gate both enabled and disabled
* container-scope allocation and release, including the CPUs an app container reuses from an init container
* pod-level allocation: the whole bubble, its release with the last container, and the rollback of a failed partitioning
* the per-NUMA distribution, including the nodes that must report zero
* the values reported before and after a kubelet restart, which have to match

#### Which issue(s) this PR is related to:

Fixes #141262

#### Special notes for your reviewer:

`metrics.Register` is guarded by a `sync.Once` and skips the resource manager metrics when `PodLevelResourceManagers` is disabled.
So the first test to call `metrics.Register` decides which metrics are registered and exist for the whole unit tests binary.
An unregistered metric silently reads back zero. As some of tests use feature gates and some not, the registered metrics state was dependent on order of tests executions.

To stabilize that `TestMain` function was added which registers metrics with both pod-level gates enabled.
This guarantees that all metrics will be registered.

#### Does this PR introduce a user-facing change?

```release-note
Fix drifts of CPUManager gauge metrics: `CPUManagerExclusiveCPUsAllocationCount`, `CPUManagerSharedPoolSizeMilliCores`, `CPUManagerAllocationPerNUMA` from true state. (#141262, @lukaszwojciechowski)
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
