### PR TITLE
Handle MinInt64 negation overflow in Quantity.Neg and Sub

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"math"
 	"math/big"
 	"strconv"
 
@@ -31,6 +32,26 @@ type Scale int32
 // infScale adapts a Scale value to an inf.Scale value.
 func (s Scale) infScale() inf.Scale {
 	return inf.Scale(-s) // inf.Scale is upside-down
+}
+
+// canInfScale reports whether infScale is faithful for s. Scale is int32 and
+// infScale negates it, so math.MinInt32 is the one scale whose negation
+// overflows back to itself and cannot be represented as an inf.Scale.
+func (s Scale) canInfScale() bool {
+	return s != math.MinInt32
+}
+
+// canAlignInfScale reports whether a subtraction between scales s and other can
+// be represented on the inf.Dec fallback: both scales must be representable as
+// an inf.Scale, and their alignment delta must fit in int32 so aligning the two
+// operands there does not overflow. The delta is computed in int64 here so the
+// check itself does not overflow. It does not bound the cost of that alignment.
+func (s Scale) canAlignInfScale(other Scale) bool {
+	if !s.canInfScale() || !other.canInfScale() {
+		return false
+	}
+	delta := int64(s) - int64(other)
+	return delta >= -int64(math.MaxInt32) && delta <= int64(math.MaxInt32)
 }
 
 const (
@@ -198,8 +219,18 @@ func (a *int64Amount) Add(b int64Amount) bool {
 	return true
 }
 
-// Sub removes the value of b from the current amount, or returns false if underflow would result.
+// Sub removes b from a. It returns false without mutating a when this
+// subtraction cannot be performed safely on the int64 fast path and the caller
+// can represent the operands and their alignment in the decimal fallback.
 func (a *int64Amount) Sub(b int64Amount) bool {
+	if b.value == mostNegative && a.scale.canAlignInfScale(b.scale) {
+		// -b.value overflows int64, so leave a unchanged and let the caller fall
+		// back to inf.Dec. That fallback aligns both operands, so it is only
+		// correct when both scales and their alignment delta can be represented
+		// there; anything else stays on the int64 path and keeps its existing
+		// wrapped result.
+		return false
+	}
 	return a.Add(int64Amount{value: -b.value, scale: b.scale})
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"math"
 	"testing"
 )
 
@@ -85,6 +86,27 @@ func TestInt64AmountAdd(t *testing.T) {
 			if c != test.b {
 				t.Errorf("%v: overflow addition mutated source: %d", test, c)
 			}
+		}
+	}
+}
+
+func TestInt64AmountSubMostNegative(t *testing.T) {
+	// Sub can't form -mostNegative in an int64, so it declines the fast path and
+	// leaves the receiver untouched for Quantity.Sub to fall back from.
+	for _, test := range []struct {
+		name string
+		a    int64Amount
+		b    int64Amount
+	}{
+		{"unscaled", int64Amount{value: 1, scale: 0}, int64Amount{value: mostNegative, scale: 0}},
+		{"scaled", int64Amount{value: 1, scale: Milli}, int64Amount{value: mostNegative, scale: Milli}},
+	} {
+		got := test.a
+		if got.Sub(test.b) {
+			t.Errorf("%s: Sub(%v) = true, want false", test.name, test.b)
+		}
+		if got != test.a {
+			t.Errorf("%s: Sub(%v) mutated receiver to %v, want %v", test.name, test.b, got, test.a)
 		}
 	}
 }
@@ -199,6 +221,34 @@ func TestInt64AmountAsScaledInt64(t *testing.T) {
 			}
 			if ok != test.ok {
 				t.Errorf("%v: expected ok: %t, got ok: %t", test.name, test.ok, ok)
+			}
+		})
+	}
+}
+
+// TestScaleCanAlignInfScale locks the boundaries of the guard that gates the
+// decimal fallback in Sub: both operands must be representable, and their
+// alignment delta must fit int32. Directly pinning it here guards against the
+// range check being narrowed to one side, the bound flipping to a strict
+// comparison, or the delta regressing to int32 arithmetic.
+func TestScaleCanAlignInfScale(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a    Scale
+		b    Scale
+		want bool
+	}{
+		{"same-scale", 0, 0, true},
+		{"positive-max-delta", Scale(math.MaxInt32), 0, true},
+		{"negative-max-delta", 0, Scale(math.MaxInt32), true},
+		{"positive-delta-overflow", Scale(math.MaxInt32), -1, false},
+		{"negative-delta-overflow", -1, Scale(math.MaxInt32), false},
+		{"receiver-min-int32", Scale(math.MinInt32), 0, false},
+		{"other-min-int32", 0, Scale(math.MinInt32), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.a.canAlignInfScale(tc.b); got != tc.want {
+				t.Fatalf("Scale(%d).canAlignInfScale(%d) = %t, want %t", tc.a, tc.b, got, tc.want)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -614,6 +614,14 @@ func (q *Quantity) Sub(y Quantity) {
 	if q.IsZero() {
 		q.Format = y.Format
 	}
+	if q.d.Dec == nil && y.d.Dec == nil && q.i.value == 0 && y.i.value == mostNegative {
+		// 0 - y is exactly -y. Negating a copy of y keeps y's own scale and avoids
+		// aligning it against a scale-0 zero in the inf.Dec fallback, which builds
+		// 10^scale and overflows inf.Dec at the most negative scale.
+		q.i = y.i
+		q.Neg()
+		return
+	}
 	if q.d.Dec == nil && y.d.Dec == nil && q.i.Sub(y.i) {
 		return
 	}
@@ -652,8 +660,13 @@ func (q *Quantity) CmpInt64(y int64) int {
 func (q *Quantity) Neg() {
 	q.s = ""
 	if q.d.Dec == nil {
-		q.i.value = -q.i.value
-		return
+		// -mostNegative overflows int64 and switches to inf.Dec, unless its scale
+		// can't be represented there, in which case it keeps the wrapped result.
+		if q.i.value != mostNegative || !q.i.scale.canInfScale() {
+			q.i.value = -q.i.value
+			return
+		}
+		q.ToDec()
 	}
 	q.d.Dec.Neg(q.d.Dec)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
@@ -29,8 +29,6 @@ import (
 // split by assertion shape, not one fix per row (a row may carry TODOs from
 // several fixes):
 //   - accessorCases: a quantity read through every accessor.
-//   - mutationCases: Neg/Sub of MinInt64, checked by value (Cmp/String); the
-//     accessor overflow of the result belongs to two-to-63-parsed.
 //   - parseErrorCases: input that parses today but should be rejected.
 //   - archSplitCases: ToDec rows whose int64 accessors are arch-dependent
 //     (golang/go#45588: MinInt64 amd64, MaxInt64 arm64), so they are guarded.
@@ -423,47 +421,6 @@ func quantityAccessorCases() []accessorCase {
 	}
 }
 
-// mutationCase pins the wrong Quantity that Neg/Sub of MinInt64 produce today.
-// -MinInt64 overflows int64 back to MinInt64, so the result stays negative. We
-// check by value (Cmp/String), not accessor; the accessor overflow of the fixed
-// +2^63 is two-to-63-parsed's job.
-type mutationCase struct {
-	name       string
-	load       func() Quantity
-	wantEqual  string // what the result Cmp-equals today
-	wantSign   int
-	wantString string
-	fixedEqual string // what a fixed operation should equal
-	issue      string
-}
-
-func quantityMutationCases() []mutationCase {
-	return []mutationCase{
-		{
-			name:       "neg-of-min-int64",
-			load:       func() Quantity { q := NewQuantity(math.MinInt64, DecimalSI); q.Neg(); return *q },
-			wantEqual:  "-9223372036854775808",
-			wantSign:   -1,
-			wantString: "-9223372036854775808",
-			fixedEqual: "9223372036854775808",
-			issue:      "Neg of MinInt64 overflows int64 back to MinInt64 instead of +2^63 (#141166)",
-		},
-		{
-			name: "zero-sub-min-int64",
-			load: func() Quantity {
-				q := NewQuantity(0, DecimalSI)
-				q.Sub(*NewQuantity(math.MinInt64, DecimalSI))
-				return *q
-			},
-			wantEqual:  "-9223372036854775808",
-			wantSign:   -1,
-			wantString: "-9223372036854775808",
-			fixedEqual: "9223372036854775808",
-			issue:      "0 - MinInt64 overflows int64 back to MinInt64 instead of +2^63 (#141166)",
-		},
-	}
-}
-
 // parseErrorCase covers input ParseQuantity accepts today but should reject.
 type parseErrorCase struct {
 	name  string
@@ -570,24 +527,6 @@ func assertAccessors(t *testing.T, tc accessorCase) {
 func TestQuantityAccessorBaseline(t *testing.T) {
 	for _, tc := range quantityAccessorCases() {
 		assertAccessors(t, tc)
-	}
-}
-
-func TestQuantityMutationBaseline(t *testing.T) {
-	for _, tc := range quantityMutationCases() {
-		t.Run(tc.name, func(t *testing.T) {
-			q := tc.load()
-			cur := MustParse(tc.wantEqual)
-			if c := q.Cmp(cur); c != 0 {
-				t.Errorf("Cmp(%s) = %d, want 0 (pinned to today's wrong result; the fixed operation should equal %s: %s)", tc.wantEqual, c, tc.fixedEqual, tc.issue)
-			}
-			if got := q.Sign(); got != tc.wantSign {
-				t.Errorf("Sign() = %d, want %d (pinned to today; %s)", got, tc.wantSign, tc.issue)
-			}
-			if got := q.String(); got != tc.wantString {
-				t.Errorf("String() = %q, want %q (pinned to today; fixed operation gives %q)", got, tc.wantString, tc.fixedEqual)
-			}
-		})
 	}
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -1165,6 +1165,222 @@ func TestNeg(t *testing.T) {
 	}
 }
 
+func TestNegAndSubAtMostNegative(t *testing.T) {
+	// -mostNegative is 2^63, which doesn't fit in an int64, so Neg and Sub have to
+	// switch to inf.Dec instead of wrapping back to mostNegative.
+	want := MustParse("9223372036854775808") // 2^63
+
+	check := func(name string, got Quantity) {
+		t.Helper()
+		// AsInt64 must run before Cmp: Cmp promotes got to the Dec backend in place
+		// (via AsDec), after which AsInt64 always returns ok=false and can no longer
+		// catch a result the fix should have moved off the int64 backend.
+		if v, ok := got.AsInt64(); ok {
+			t.Errorf("%s: AsInt64() = (%d, true), want ok=false because 2^63 does not fit int64", name, v)
+		}
+		if got.Sign() != 1 {
+			t.Errorf("%s: Sign() = %d, want 1", name, got.Sign())
+		}
+		if got.String() != "9223372036854775808" {
+			t.Errorf("%s: String() = %q, want 9223372036854775808", name, got.String())
+		}
+		if got.Cmp(want) != 0 {
+			t.Errorf("%s = %s, want 9223372036854775808", name, got.String())
+		}
+	}
+
+	neg := intQuantity(mostNegative, 0, DecimalSI)
+	neg.Neg()
+	check("intQuantity(mostNegative).Neg()", neg)
+
+	sub := Quantity{Format: DecimalSI} // zero
+	sub.Sub(intQuantity(mostNegative, 0, DecimalSI))
+	check("zero.Sub(intQuantity(mostNegative))", sub)
+
+	// The zero minuend above hits Add's zero shortcut on the old code; a non-zero
+	// one hit its regular add path, so cover that too. 1 - mostNegative is 2^63+1.
+	oneSub := intQuantity(1, 0, DecimalSI)
+	oneSub.Sub(intQuantity(mostNegative, 0, DecimalSI))
+	// AsInt64 before Cmp again: 2^63+1 does not fit an int64, and on the old code the
+	// wrong int64-backed result reported otherwise.
+	if v, ok := oneSub.AsInt64(); ok {
+		t.Errorf("1 - mostNegative: AsInt64() = (%d, true), want ok=false because 2^63+1 does not fit int64", v)
+	}
+	if w := MustParse("9223372036854775809"); oneSub.Cmp(w) != 0 || oneSub.String() != "9223372036854775809" {
+		t.Errorf("1 - mostNegative = %s, want 9223372036854775809", oneSub.String())
+	}
+
+	// mostNegative+1 negates to mostPositive, which still fits an int64, so it must
+	// stay on the fast path rather than be promoted to inf.Dec.
+	neighbor := intQuantity(mostNegative+1, 0, DecimalSI)
+	neighbor.Neg()
+	if v, ok := neighbor.AsInt64(); !ok || v != mostPositive {
+		t.Errorf("intQuantity(mostNegative+1).Neg().AsInt64() = (%d, %t), want (%d, true)", v, ok, int64(mostPositive))
+	}
+
+	// The subtrahend boundary is symmetric: mostNegative+1 does not trip Sub's guard,
+	// so it stays on the int64 fast path. 0 - (mostNegative+1) is mostPositive, which
+	// fits, and must not be promoted to inf.Dec.
+	subNeighbor := Quantity{Format: DecimalSI}
+	subNeighbor.Sub(intQuantity(mostNegative+1, 0, DecimalSI))
+	if v, ok := subNeighbor.AsInt64(); !ok || v != mostPositive {
+		t.Errorf("zero.Sub(intQuantity(mostNegative+1)).AsInt64() = (%d, %t), want (%d, true)", v, ok, int64(mostPositive))
+	}
+
+	// Switching to inf.Dec has to keep the scale, not just the mantissa.
+	scaled := intQuantity(mostNegative, Milli, DecimalSI)
+	scaled.Neg()
+	if got := scaled.String(); got != "9223372036854775808m" {
+		t.Errorf("intQuantity(mostNegative, Milli).Neg() = %q, want 9223372036854775808m", got)
+	}
+
+	// Sub takes the same inf.Dec fallback for a scaled subtrahend and keeps the scale.
+	scaledSub := intQuantity(1, Milli, DecimalSI)
+	scaledSub.Sub(intQuantity(mostNegative, Milli, DecimalSI))
+	if got := scaledSub.String(); got != "9223372036854775809m" {
+		t.Errorf("intQuantity(1, Milli).Sub(intQuantity(mostNegative, Milli)) = %q, want 9223372036854775809m", got)
+	}
+
+	// A plain zero receiver takes the 0 - y == -y shortcut, so the scale comes from
+	// the subtrahend. AsInt64 is not asserted here: it returns ok=false on both the
+	// old code (negative scale) and the fixed code (Dec backend), so it can't tell
+	// them apart. String and Sign can.
+	zeroScaledSub := Quantity{Format: DecimalSI}
+	zeroScaledSub.Sub(*NewScaledQuantity(mostNegative, Milli))
+	if got := zeroScaledSub.String(); got != "9223372036854775808m" {
+		t.Errorf("zero.Sub(NewScaledQuantity(mostNegative, Milli)) = %q, want 9223372036854775808m", got)
+	}
+	if zeroScaledSub.Sign() != 1 {
+		t.Errorf("zero.Sub(NewScaledQuantity(mostNegative, Milli)): Sign() = %d, want 1", zeroScaledSub.Sign())
+	}
+}
+
+func TestMostNegativeAtUnrepresentableScaleStaysInt64(t *testing.T) {
+	// Scale(math.MinInt32) can't be negated into an inf.Scale, so Neg and Sub keep a
+	// mostNegative value on the int64 backend instead of promoting it; the decimal
+	// fallback would rescale that scale and panic. This only pins that the still-open
+	// boundary is not made worse, it does not claim the wrapped value is correct.
+	minScale := Scale(math.MinInt32)
+
+	t.Run("Neg", func(t *testing.T) {
+		q := intQuantity(mostNegative, minScale, DecimalSI)
+		q.Neg()
+		if q.d.Dec != nil {
+			t.Fatal("Neg promoted the unrepresentable scale to inf.Dec")
+		}
+		if q.i.value != mostNegative || q.i.scale != minScale {
+			t.Fatalf("Neg changed the int64 amount to {value:%d, scale:%d}", q.i.value, q.i.scale)
+		}
+	})
+
+	t.Run("zeroSub", func(t *testing.T) {
+		q := Quantity{Format: DecimalSI}
+		q.Sub(intQuantity(mostNegative, minScale, DecimalSI))
+		if q.d.Dec != nil {
+			t.Fatal("zero Sub promoted the unrepresentable scale to inf.Dec")
+		}
+		if q.i.value != mostNegative || q.i.scale != minScale {
+			t.Fatalf("zero Sub changed the int64 amount to {value:%d, scale:%d}", q.i.value, q.i.scale)
+		}
+	})
+
+	t.Run("nonZeroSub", func(t *testing.T) {
+		q := intQuantity(5, minScale, DecimalSI)
+		q.Sub(intQuantity(mostNegative, minScale, DecimalSI))
+		if q.d.Dec != nil {
+			t.Fatal("non-zero Sub promoted the unrepresentable scale to inf.Dec")
+		}
+		// The value and scale keep their existing wrapped int64 behavior, so this
+		// pins that the PR does not make the unresolved boundary worse rather than
+		// only checking that it did not promote.
+		if want := (int64Amount{value: mostNegative + 5, scale: minScale}); q.i != want {
+			t.Fatalf("non-zero Sub result = %#v, want %#v", q.i, want)
+		}
+	})
+
+	t.Run("receiverAtMinScaleMinusNormalMostNegative", func(t *testing.T) {
+		// The guard must look at the receiver's scale too. A mostNegative
+		// subtrahend at a normal scale would otherwise force the inf.Dec fallback,
+		// which promotes this MinInt32-scale receiver and panics in the rescale.
+		q := intQuantity(5, minScale, DecimalSI)
+		q.Sub(intQuantity(mostNegative, 0, DecimalSI))
+		if q.d.Dec != nil {
+			t.Fatal("Sub promoted a MinInt32-scale receiver to inf.Dec")
+		}
+	})
+
+	t.Run("unalignableScaleDeltaStaysInt64", func(t *testing.T) {
+		// Both scales are representable on their own, but their alignment delta
+		// (MaxInt32+1) is not. Forcing the inf.Dec fallback here would overflow
+		// the rescale exponent and panic, so this stays on the int64 path.
+		q := intQuantity(1, Scale(math.MaxInt32), DecimalSI)
+		q.Sub(intQuantity(mostNegative, -1, DecimalSI))
+		if q.d.Dec != nil {
+			t.Fatal("Sub promoted an unalignable scale pair to inf.Dec")
+		}
+	})
+}
+
+func TestZeroSubMostNegativePreservesScale(t *testing.T) {
+	// 0 - mostNegative at a large scale must not rescale: the shortcut negates a copy
+	// of the subtrahend, keeping its scale, so no 10^scale alignment is built. A scale
+	// of 100 is observable without a time or memory probe, a rescale to 0 would change
+	// the backend scale checked below.
+	q := Quantity{Format: DecimalSI}
+	q.Sub(*NewScaledQuantity(mostNegative, 100))
+
+	if q.d.Dec == nil {
+		t.Fatal("result stayed on the int64 backend, want inf.Dec")
+	}
+	if got, want := q.d.Dec.Scale(), inf.Scale(-100); got != want {
+		t.Fatalf("result scale = %d, want %d", got, want)
+	}
+	wantUnscaled := new(big.Int).Neg(big.NewInt(mostNegative)) // 2^63
+	if got := q.d.Dec.UnscaledBig(); got.Cmp(wantUnscaled) != 0 {
+		t.Fatalf("result unscaled = %s, want %s", got, wantUnscaled)
+	}
+}
+
+func TestSubMostNegativeCrossScale(t *testing.T) {
+	// A positive minuend at a higher scale reaches the inf.Dec fallback and must not
+	// wrap: 10 - mostNegative is 2^63+10. The existing same-scale cases don't cover
+	// the cross-scale add path.
+	q := intQuantity(1, 1, DecimalSI) // 10
+	q.Sub(intQuantity(mostNegative, 0, DecimalSI))
+
+	if got, want := q.String(), "9223372036854775818"; got != want {
+		t.Fatalf("10 - mostNegative = %s, want %s", got, want)
+	}
+	if v, ok := q.AsInt64(); ok {
+		t.Fatalf("AsInt64() = (%d, true), want ok=false because 2^63+10 does not fit int64", v)
+	}
+}
+
+func TestZeroSubMostNegativeInheritsFormat(t *testing.T) {
+	// The zero receiver adopts the subtrahend's format, and the result is still on the
+	// Dec backend, so pin both together. 2^63 is 8Ei in BinarySI. This asserts the
+	// canonical rendering only, not a round trip: ParseQuantity caps 8Ei back to
+	// MaxInt64, which is tracked separately in #140674.
+	q := Quantity{Format: DecimalSI}
+	q.Sub(intQuantity(mostNegative, 0, BinarySI))
+
+	if q.Format != BinarySI {
+		t.Fatalf("Format = %v, want BinarySI", q.Format)
+	}
+	if got, want := q.String(), "8Ei"; got != want {
+		t.Fatalf("String() = %s, want %s", got, want)
+	}
+	if v, ok := q.AsInt64(); ok {
+		t.Fatalf("AsInt64() = (%d, true), want ok=false", v)
+	}
+	// Pin the arithmetic value directly. "8Ei" is the canonical BinarySI spelling
+	// of 2^63 but does not round-trip (ParseQuantity caps it to MaxInt64, #140674),
+	// so the value, not that spelling, is what this test relies on for correctness.
+	if got := q.Cmp(MustParse("9223372036854775808")); got != 0 {
+		t.Fatalf("Cmp(2^63) = %d, want 0", got)
+	}
+}
+
 func TestAdd(t *testing.T) {
 	tests := []struct {
 		a        Quantity


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`Quantity.Neg()` negates the int64 backend with `q.i.value = -q.i.value`, and `int64Amount.Sub` negates its operand with `-b.value` before handing it to the overflow-safe `Add`. In two's complement, negating `math.MinInt64` gives back `math.MinInt64`, so that raw negation quietly does nothing. `NewQuantity(math.MinInt64, DecimalSI).Neg()` therefore left its receiver at `MinInt64`, and subtracting that value from a zero quantity added `MinInt64` instead of `+2^63` (a positive minuend that stayed on the int64 fast path produced a correspondingly wrapped difference). Because the value stayed on the int64 backend, `AsInt64()` then returned `(MinInt64, true)`, reporting an exact int64 for a value that isn't one.

`Quantity.Add` and `Quantity.Mul` already treat failure of their int64 fast paths as the signal to promote to `inf.Dec`. `Neg` and `Sub` were the remaining paths that negated a raw int64 operand before that check.

This adds the guard in both. `Neg` switches to the `inf.Dec` backend when the value is `mostNegative`. `int64Amount.Sub` declines its int64 fast path for a `mostNegative` subtrahend, returning false without mutating the receiver, so `Quantity.Sub` takes its existing `inf.Dec` fallback. `inf.Dec` holds `2^63` exactly, so the results are now correct, and since they land on the Dec backend `AsInt64()` returns `ok=false` for them.

An int64-backed zero receiver subtracting `mostNegative` takes a `0 - y == -y` shortcut: it negates a copy of the subtrahend rather than aligning it against a scale-0 zero in the fallback, which keeps `y`'s own scale and format. A Dec-backed zero receiver still takes the existing fallback.

This does not change the unchecked `Value()`, `MilliValue()`, or `ScaledValue()` accessors. For a Dec-backed `2^63` they still project through int64 and can wrap (`Value()` returns `-2^63`); that int64-projection overflow is a separate, still-open item under #141166. For the scale combinations fixed here, the internal value, `Cmp`, and `Sign` are exact; `String` canonicalization outside the existing suffix range is unchanged and tracked separately in #140459.

The change is scoped to the `mostNegative` coefficient. Every other coefficient keeps the existing int64 path (for example `mostNegative+1` negates to `mostPositive` without promotion). Not every scale can be promoted to the decimal backend: some extreme scale combinations cannot be represented or aligned there. A `canAlignInfScale` guard gates the promotion on both operand scales and their alignment delta, so `Neg` keeps a `mostNegative` value at such a scale on the int64 path and `int64Amount.Sub` only forces the fallback when the scales are supported. Unsupported extreme-scale combinations are not newly routed through this fallback; that underlying extreme-scale behavior is tracked separately, as is the pure constructor value `NewScaledQuantity(x, Scale(math.MinInt32))`.

#### Which issue(s) this PR fixes:

Part of #141166 (the `resource.Quantity` int64 overflow burndown). This is the "bound negative overflow at `MinInt64` and fix the `Neg`/`Sub` gaps" item.

#### Special notes for your reviewer:

`TestNegAndSubAtMostNegative` fails on master (the result comes back as `-9223372036854775808`) and passes with the fix. It covers a zero and a non-zero minuend (the two failed through different paths on the old code), the `mostNegative+1` boundary that must stay on the int64 path, and scaled `Neg` and `Sub` cases so the promotion keeps the scale. `TestInt64AmountSubMostNegative` pins the low-level no-mutation contract that `Quantity.Sub`'s fallback depends on.

`TestScaleCanAlignInfScale` pins the boundaries of the `canAlignInfScale` guard directly: both `±math.MaxInt32` deltas, one step past each side, and `math.MinInt32` on either operand. `TestMostNegativeAtUnrepresentableScaleStaysInt64` pins that `Neg` and both a zero and a non-zero `Sub` stay on the int64 backend for a scale the decimal backend cannot represent, rather than being forced through the fallback. `TestZeroSubMostNegativePreservesScale` checks the zero-receiver shortcut keeps the subtrahend's scale. `TestSubMostNegativeCrossScale` covers a positive minuend at a higher scale (`10 - MinInt64`), which reaches a different old-code branch than the same-scale cases. `TestZeroSubMostNegativeInheritsFormat` pins the format inheritance and the exact `2^63` value on the Dec backend.

The `2^63` result canonicalizes to `9223372036854775808` in `DecimalSI`, so that test asserts `String()` directly. In `BinarySI` its canonical spelling is `8Ei`, which does not round-trip (parsing caps it to `MaxInt64`, tracked in #140674), so that test pins the value with `Cmp` rather than relying on the spelling.

On merge order: #141170 pins today's wrong results as a baseline, so its two `MinInt64` mutation cases (`neg-of-min-int64`, `zero-sub-min-int64`) become resolved once this fix lands. Per the tracker's baseline-first ordering I am holding this PR; when #141170 merges I will rebase and remove those two resolved baseline rows (not merely flip their expected values, since their fields and messages describe "today's wrong result") before removing the hold.

#### Does this PR introduce a user-facing change?

```release-note
`resource.Quantity`: for int64-backed quantities whose scales, and for subtraction whose scale alignment, fit the decimal backend's scale range, `Neg()` of `math.MinInt64` and `Sub()` with a `math.MinInt64` subtrahend now promote to the decimal backend instead of overflowing while negating the int64 operand. The exact value is preserved (for example, `-math.MinInt64` becomes `2^63`) and `AsInt64()` returns `ok=false` for the decimal-backed result. Unsupported extreme-scale combinations retain their pre-existing behavior. The unchecked `Value()`, `MilliValue()`, and `ScaledValue()` overflow behavior is unchanged and tracked separately.
```
