### PR TITLE
feat/kubelet: add DevicePluginDegradedHealth alpha feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -318,6 +318,15 @@ const (
 	// Enables support for reserving and replicating templated ResourceClaims for an entire PodGroup.
 	DRAWorkloadResourceClaims featuregate.Feature = "DRAWorkloadResourceClaims"
 
+	// owner: @richardokonicha
+	// kep: https://kep.k8s.io/NNNN (number assigned when the enhancement PR is opened)
+	//
+	// Enables structured health reporting for device plugins. Adds an optional
+	// three-state health model (HEALTHY/DEGRADED/UNHEALTHY) via device_health_map
+	// in ListAndWatchResponse, gated behind the supports_structured_health
+	// capability flag.
+	DevicePluginDegradedHealth featuregate.Feature = "DevicePluginDegradedHealth"
+
 	// owner: @atiratree
 	// kep: http://kep.k8s.io/3973
 	//
@@ -1472,6 +1481,11 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 		{Version: version.MustParse("1.36"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
+	// Target milestone is provisional and will be set by SIG Node when the KEP is accepted.
+	DevicePluginDegradedHealth: {
+		{Version: version.MustParse("1.37"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
 	DeploymentReplicaSetTerminatingReplicas: {
 		{Version: version.MustParse("1.33"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("1.35"), Default: true, PreRelease: featuregate.Beta},
@@ -2508,6 +2522,8 @@ var defaultKubernetesFeatureGateDependencies = map[featuregate.Feature][]feature
 	DRASchedulerFilterTimeout: {DynamicResourceAllocation},
 
 	DRAWorkloadResourceClaims: {DynamicResourceAllocation, GenericWorkload},
+
+	DevicePluginDegradedHealth: {},
 
 	DeploymentReplicaSetTerminatingReplicas: {},
 

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -24,8 +24,10 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
 	"k8s.io/klog/v2"
@@ -86,6 +88,12 @@ type ManagerImpl struct {
 
 	// unhealthyDevices contains all the unhealthy devices and their exported device IDs.
 	unhealthyDevices map[string]sets.Set[string]
+
+	// degradedDevices contains devices reported as DEGRADED via the structured
+	// health model: still usable by already-allocated pods, but not offered for
+	// new allocations. Populated only when the DevicePluginDegradedHealth feature
+	// gate is enabled and the plugin advertised supports_structured_health.
+	degradedDevices map[string]sets.Set[string]
 
 	// allocatedDevices contains allocated deviceIds, keyed by resourceName.
 	allocatedDevices map[string]sets.Set[string]
@@ -153,6 +161,7 @@ func newManagerImpl(logger klog.Logger, socketPath string, topology []cadvisorap
 		allDevices:            NewResourceDeviceInstances(),
 		healthyDevices:        make(map[string]sets.Set[string]),
 		unhealthyDevices:      make(map[string]sets.Set[string]),
+		degradedDevices:       make(map[string]sets.Set[string]),
 		allocatedDevices:      make(map[string]sets.Set[string]),
 		podDevices:            newPodDevices(),
 		numaNodes:             numaNodes,
@@ -287,17 +296,32 @@ func (m *ManagerImpl) PluginDisconnected(logger klog.Logger, resourceName string
 // is captured. Also, registered device and device to container allocation
 // information is checkpointed to the disk.
 func (m *ManagerImpl) PluginListAndWatchReceiver(logger klog.Logger, resourceName string, resp *pluginapi.ListAndWatchResponse) {
-	m.genericDeviceUpdateCallback(logger, resourceName, resp.Devices)
+	m.genericDeviceUpdateCallback(logger, resourceName, resp.Devices, resp.DeviceHealthMap)
 }
 
-func (m *ManagerImpl) genericDeviceUpdateCallback(logger klog.Logger, resourceName string, devices []*pluginapi.Device) {
+func (m *ManagerImpl) genericDeviceUpdateCallback(logger klog.Logger, resourceName string, devices []*pluginapi.Device, healthMap map[string]*pluginapi.DeviceHealthDetail) {
 	healthyCount := 0
 	m.mutex.Lock()
 	m.healthyDevices[resourceName] = sets.New[string]()
 	m.unhealthyDevices[resourceName] = sets.New[string]()
+	m.degradedDevices[resourceName] = sets.New[string]()
 	oldDevices := m.allDevices[resourceName]
 	podsToUpdate := sets.New[string]()
 	m.allDevices[resourceName] = make(map[string]*pluginapi.Device)
+
+	// Structured health is only honored when the feature gate is enabled AND the
+	// plugin explicitly advertised the supports_structured_health capability.
+	// Legacy plugins (opts == nil) and plugins that did not opt in cannot inject
+	// structured health, so their healthMap is ignored entirely.
+	structuredHealthEnabled := utilfeature.DefaultFeatureGate.Enabled(features.DevicePluginDegradedHealth)
+	if structuredHealthEnabled {
+		if ep, ok := m.endpoints[resourceName]; !ok || ep.opts == nil || !ep.opts.SupportsStructuredHealth {
+			healthMap = nil
+		}
+	} else {
+		healthMap = nil
+	}
+
 	for _, dev := range devices {
 
 		if utilfeature.DefaultFeatureGate.Enabled(features.ResourceHealthStatus) {
@@ -320,7 +344,19 @@ func (m *ManagerImpl) genericDeviceUpdateCallback(logger klog.Logger, resourceNa
 		}
 
 		m.allDevices[resourceName][dev.ID] = dev
-		if dev.Health == pluginapi.Healthy {
+
+		// Resolve the effective health state. The binary Device.health field
+		// stays authoritative: a device the plugin marks Unhealthy is never
+		// downgraded to healthy/degraded by structured health. DEGRADED is only
+		// meaningful for a device that is otherwise Healthy.
+		if detail, ok := healthMap[dev.ID]; ok && dev.Health == pluginapi.Healthy &&
+			detail.State == pluginapi.HealthState_HEALTH_STATE_DEGRADED {
+			m.degradedDevices[resourceName].Insert(dev.ID)
+			logger.V(4).Info("Device reported DEGRADED",
+				"resourceName", resourceName, "deviceID", dev.ID,
+				"vendorCode", sanitizeVendorCode(detail.VendorCode),
+				"message", truncateMessage(detail.Message))
+		} else if dev.Health == pluginapi.Healthy {
 			m.healthyDevices[resourceName].Insert(dev.ID)
 			healthyCount++
 		} else {
@@ -343,6 +379,35 @@ func (m *ManagerImpl) genericDeviceUpdateCallback(logger klog.Logger, resourceNa
 		logger.Error(err, "Writing checkpoint encountered")
 	}
 	logger.V(2).Info("Processed device updates for resource", "resourceName", resourceName, "totalCount", len(devices), "healthyCount", healthyCount)
+}
+
+// maxHealthMessageBytes bounds the freeform message from a device plugin so a
+// misbehaving plugin cannot force kubelet to log or retain unbounded data.
+const maxHealthMessageBytes = 1024
+
+// truncateMessage returns msg truncated to at most maxHealthMessageBytes,
+// cutting on a UTF-8 rune boundary so the result is always valid UTF-8.
+func truncateMessage(msg string) string {
+	if len(msg) <= maxHealthMessageBytes {
+		return msg
+	}
+	truncated := msg[:maxHealthMessageBytes]
+	for len(truncated) > 0 && !utf8.ValidString(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated
+}
+
+// sanitizeVendorCode strips any non printable-ASCII bytes from a vendor code so
+// it is safe to place in logs and metric labels.
+func sanitizeVendorCode(code string) string {
+	var b strings.Builder
+	for i := 0; i < len(code); i++ {
+		if c := code[i]; c >= 32 && c <= 126 {
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
 }
 
 // GetWatcherHandler returns the plugin handler
@@ -451,10 +516,15 @@ func (m *ManagerImpl) markResourceUnhealthy(logger klog.Logger, resourceName str
 		healthyDevices = m.healthyDevices[resourceName]
 		m.healthyDevices[resourceName] = sets.New[string]()
 	}
+	degradedDevices := sets.New[string]()
+	if _, ok := m.degradedDevices[resourceName]; ok {
+		degradedDevices = m.degradedDevices[resourceName]
+		m.degradedDevices[resourceName] = sets.New[string]()
+	}
 	if _, ok := m.unhealthyDevices[resourceName]; !ok {
 		m.unhealthyDevices[resourceName] = sets.New[string]()
 	}
-	m.unhealthyDevices[resourceName] = m.unhealthyDevices[resourceName].Union(healthyDevices)
+	m.unhealthyDevices[resourceName] = m.unhealthyDevices[resourceName].Union(healthyDevices).Union(degradedDevices)
 }
 
 // GetCapacity is expected to be called when Kubelet updates its node status.
@@ -503,11 +573,29 @@ func (m *ManagerImpl) GetCapacity(logger klog.Logger) (v1.ResourceList, v1.Resou
 			capacity[v1.ResourceName(resourceName)] = capacityCount
 		}
 	}
+	// Degraded devices remain part of capacity (so already-running pods keep
+	// their node bookkeeping) but are deliberately excluded from allocatable so
+	// the scheduler does not place new pods on a degraded device.
+	for resourceName, devices := range m.degradedDevices {
+		eI, ok := m.endpoints[resourceName]
+		if (ok && eI.e.stopGracePeriodExpired()) || !ok {
+			if !ok {
+				logger.Info("Unexpected: degradedDevices and endpoints became out of sync")
+			}
+			deletedResources.Insert(resourceName)
+		} else {
+			capacityCount := capacity[v1.ResourceName(resourceName)]
+			degradedCount := *resource.NewQuantity(int64(devices.Len()), resource.DecimalSI)
+			capacityCount.Add(degradedCount)
+			capacity[v1.ResourceName(resourceName)] = capacityCount
+		}
+	}
 
 	for resourceName := range deletedResources {
 		delete(m.endpoints, resourceName)
 		delete(m.healthyDevices, resourceName)
 		delete(m.unhealthyDevices, resourceName)
+		delete(m.degradedDevices, resourceName)
 	}
 
 	m.mutex.Unlock()
@@ -563,6 +651,9 @@ func (m *ManagerImpl) readCheckpoint(logger klog.Logger) error {
 		// will stay zero till the corresponding device plugin re-registers.
 		m.healthyDevices[resource] = sets.New[string]()
 		m.unhealthyDevices[resource] = sets.New[string]()
+		// Structured health is not persisted; it is rebuilt when the plugin
+		// re-registers and re-reports via ListAndWatch.
+		m.degradedDevices[resource] = sets.New[string]()
 		m.endpoints[resource] = endpointInfo{e: newStoppedEndpointImpl(resource), opts: nil}
 	}
 
@@ -653,8 +744,17 @@ func (m *ManagerImpl) devicesToAllocate(ctx context.Context, podUID, contName, r
 		return nil, fmt.Errorf("no healthy devices present; cannot allocate unhealthy devices %s", resource)
 	}
 
-	// Check if all the previously allocated devices are healthy
-	if !healthyDevices.IsSuperset(devices) {
+	// Check if all the previously allocated devices are still usable. A device
+	// that has since transitioned to DEGRADED is still usable by the pod it is
+	// already allocated to (it is only withheld from *new* allocations), so we
+	// treat healthy+degraded as the set of devices that may remain allocated.
+	usableDevices := healthyDevices
+	if utilfeature.DefaultFeatureGate.Enabled(features.DevicePluginDegradedHealth) {
+		if degraded, ok := m.degradedDevices[resource]; ok && degraded.Len() > 0 {
+			usableDevices = healthyDevices.Union(degraded)
+		}
+	}
+	if !usableDevices.IsSuperset(devices) {
 		return nil, fmt.Errorf("previously allocated devices are no longer healthy; cannot allocate unhealthy devices %s", resource)
 	}
 
@@ -1190,6 +1290,14 @@ func (m *ManagerImpl) UpdateAllocatedResourcesStatus(logger klog.Logger, pod *v1
 				health := v1.ResourceHealthStatusHealthy
 				if d.Health != pluginapi.Healthy {
 					health = v1.ResourceHealthStatusUnhealthy
+				}
+				// A device reported as DEGRADED is still functioning but impaired.
+				// Surface it as Unknown rather than Healthy so the condition is
+				// visible in pod status without claiming the device is fully healthy.
+				if utilfeature.DefaultFeatureGate.Enabled(features.DevicePluginDegradedHealth) {
+					if degraded, ok := m.degradedDevices[resourceName]; ok && degraded.Has(id) {
+						health = v1.ResourceHealthStatusUnknown
+					}
 				}
 				resourceStatus.Resources = append(resourceStatus.Resources, v1.ResourceHealth{
 					ResourceID: v1.ResourceID(id),

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -29,6 +29,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
 	"github.com/stretchr/testify/assert"
@@ -70,7 +71,11 @@ const (
 func newWrappedManagerImpl(logger klog.Logger, socketPath string, manager *ManagerImpl) *wrappedManagerImpl {
 	w := &wrappedManagerImpl{
 		ManagerImpl: manager,
-		callback:    manager.genericDeviceUpdateCallback,
+		// The wrapper callback keeps the legacy 3-arg shape; structured health
+		// (the 4th arg) is exercised by calling genericDeviceUpdateCallback directly.
+		callback: func(logger klog.Logger, r string, devices []*pluginapi.Device) {
+			manager.genericDeviceUpdateCallback(logger, r, devices, nil)
+		},
 	}
 	w.socketdir, _ = filepath.Split(socketPath)
 	w.server, _ = plugin.NewServer(logger, socketPath, w, w)
@@ -392,7 +397,9 @@ func TestUpdateCapacityAllocatable(t *testing.T) {
 		{ID: "Device2", Health: pluginapi.Healthy},
 		{ID: "Device3", Health: pluginapi.Unhealthy},
 	}
-	callback := testManager.genericDeviceUpdateCallback
+	callback := func(logger klog.Logger, resourceName string, devices []*pluginapi.Device) {
+		testManager.genericDeviceUpdateCallback(logger, resourceName, devices, nil)
+	}
 
 	// Adds three devices for resource1, two healthy and one unhealthy.
 	// Expects capacity for resource1 to be 2.
@@ -543,7 +550,7 @@ func TestGetAllocatableDevicesMultipleResources(t *testing.T) {
 	resourceName1 := "domain1.com/resource1"
 	e1 := &endpointImpl{}
 	testManager.endpoints[resourceName1] = endpointInfo{e: e1, opts: nil}
-	testManager.genericDeviceUpdateCallback(logger, resourceName1, resource1Devs)
+	testManager.genericDeviceUpdateCallback(logger, resourceName1, resource1Devs, nil)
 
 	resource2Devs := []*pluginapi.Device{
 		{ID: "R2Device1", Health: pluginapi.Healthy},
@@ -551,7 +558,7 @@ func TestGetAllocatableDevicesMultipleResources(t *testing.T) {
 	resourceName2 := "other.domain2.org/resource2"
 	e2 := &endpointImpl{}
 	testManager.endpoints[resourceName2] = endpointInfo{e: e2, opts: nil}
-	testManager.genericDeviceUpdateCallback(logger, resourceName2, resource2Devs)
+	testManager.genericDeviceUpdateCallback(logger, resourceName2, resource2Devs, nil)
 
 	allocatableDevs := testManager.GetAllocatableDevices(logger)
 	as.Len(allocatableDevs, 2)
@@ -591,7 +598,7 @@ func TestGetAllocatableDevicesHealthTransition(t *testing.T) {
 	e1 := &endpointImpl{}
 	testManager.endpoints[resourceName1] = endpointInfo{e: e1, opts: nil}
 
-	testManager.genericDeviceUpdateCallback(logger, resourceName1, resource1Devs)
+	testManager.genericDeviceUpdateCallback(logger, resourceName1, resource1Devs, nil)
 
 	allocatableDevs := testManager.GetAllocatableDevices(logger)
 	as.Len(allocatableDevs, 1)
@@ -605,7 +612,7 @@ func TestGetAllocatableDevicesHealthTransition(t *testing.T) {
 		{ID: "R1Device2", Health: pluginapi.Healthy},
 		{ID: "R1Device3", Health: pluginapi.Healthy},
 	}
-	testManager.genericDeviceUpdateCallback(logger, resourceName1, resource1Devs)
+	testManager.genericDeviceUpdateCallback(logger, resourceName1, resource1Devs, nil)
 
 	allocatableDevs = testManager.GetAllocatableDevices(logger)
 	as.Len(allocatableDevs, 1)
@@ -1922,7 +1929,7 @@ func TestGetTopologyHintsWithUpdates(t *testing.T) {
 				defer wg.Done()
 				for i := 0; i < test.count; i++ {
 					// simulate the device plugin to send device updates
-					mimpl.genericDeviceUpdateCallback(logger, testResourceName, devs)
+					mimpl.genericDeviceUpdateCallback(logger, testResourceName, devs, nil)
 				}
 				updated.Store(true)
 			}()
@@ -1983,7 +1990,7 @@ func TestUpdateAllocatedResourcesStatus(t *testing.T) {
 	testManager.genericDeviceUpdateCallback(logger, resourceName, []*pluginapi.Device{
 		{ID: "dev1", Health: pluginapi.Healthy},
 		{ID: "dev2", Health: pluginapi.Unhealthy},
-	})
+	}, nil)
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2097,7 +2104,7 @@ func TestFeatureGateResourceHealthStatus(t *testing.T) {
 	for i := 0; i < deviceUpdateNumber; i++ {
 		testManager.genericDeviceUpdateCallback(logger, resourceName, []*pluginapi.Device{
 			{ID: "dev1", Health: pluginapi.Healthy},
-		})
+		}, nil)
 	}
 	// update chan no data
 	assert.Empty(t, testManager.update)
@@ -2106,7 +2113,7 @@ func TestFeatureGateResourceHealthStatus(t *testing.T) {
 	for i := 0; i < deviceUpdateNumber; i++ {
 		testManager.genericDeviceUpdateCallback(logger, resourceName, []*pluginapi.Device{
 			{ID: fmt.Sprintf("dev%d", i), Health: pluginapi.Unhealthy},
-		})
+		}, nil)
 	}
 	for i := 0; i < deviceUpdateChanBuffer; i++ {
 		u := <-testManager.update
@@ -2171,7 +2178,7 @@ func TestDeviceHealthUpdateWithDuplicateDeviceIDs(t *testing.T) {
 	// The device of resource2 becomes unhealthy: only pod2 must be notified.
 	testManager.genericDeviceUpdateCallback(logger, resourceName2, []*pluginapi.Device{
 		{ID: deviceID, Health: pluginapi.Unhealthy},
-	})
+	}, nil)
 	u := <-testManager.update
 	assert.Equal(t, resourceupdates.Update{PodUIDs: []string{"pod2"}}, u)
 	assert.Empty(t, testManager.update)
@@ -2179,7 +2186,7 @@ func TestDeviceHealthUpdateWithDuplicateDeviceIDs(t *testing.T) {
 	// The device of resource1 becomes unhealthy: only pod1 must be notified.
 	testManager.genericDeviceUpdateCallback(logger, resourceName1, []*pluginapi.Device{
 		{ID: deviceID, Health: pluginapi.Unhealthy},
-	})
+	}, nil)
 	u = <-testManager.update
 	assert.Equal(t, resourceupdates.Update{PodUIDs: []string{"pod1"}}, u)
 	assert.Empty(t, testManager.update)
@@ -2293,7 +2300,7 @@ func TestEndpointSyncOnDisconnect(t *testing.T) {
 		{ID: "Device2", Health: pluginapi.Healthy},
 		{ID: "Device3", Health: pluginapi.Unhealthy},
 	}
-	manager.genericDeviceUpdateCallback(logger, resourceName, devs)
+	manager.genericDeviceUpdateCallback(logger, resourceName, devs, nil)
 
 	// Disconnect should result in all devices for this resource
 	// moved to the unhealthy set.
@@ -2478,4 +2485,80 @@ func TestLifecycleAllocatePod(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestStructuredDeviceHealthDegraded verifies the alpha structured-health
+// behavior gated behind DevicePluginDegradedHealth: a DEGRADED device stays in
+// capacity but is withheld from allocatable, and only plugins that advertise the
+// supports_structured_health capability may report structured health.
+func TestStructuredDeviceHealthDegraded(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DevicePluginDegradedHealth, true)
+
+	_, socketName, _, err := tmpSocketDir()
+	require.NoError(t, err)
+	topologyStore := topologymanager.NewFakeManager(logger)
+	testManager, err := newManagerImpl(logger, socketName, nil, topologyStore)
+	require.NoError(t, err)
+	as := assert.New(t)
+
+	resourceName := "domain1.com/gpu"
+	devs := []*pluginapi.Device{
+		{ID: "gpu0", Health: pluginapi.Healthy},
+		{ID: "gpu1", Health: pluginapi.Healthy},
+	}
+	healthMap := map[string]*pluginapi.DeviceHealthDetail{
+		"gpu1": {
+			State:      pluginapi.HealthState_HEALTH_STATE_DEGRADED,
+			Message:    "correctable ECC errors",
+			VendorCode: "XID_63",
+		},
+	}
+
+	t.Run("opted-in plugin: degraded excluded from allocatable", func(t *testing.T) {
+		testManager.endpoints[resourceName] = endpointInfo{
+			e:    &endpointImpl{},
+			opts: &pluginapi.DevicePluginOptions{SupportsStructuredHealth: true},
+		}
+		testManager.genericDeviceUpdateCallback(logger, resourceName, devs, healthMap)
+
+		testManager.mutex.Lock()
+		as.True(testManager.degradedDevices[resourceName].Has("gpu1"))
+		as.True(testManager.healthyDevices[resourceName].Has("gpu0"))
+		as.False(testManager.healthyDevices[resourceName].Has("gpu1"))
+		testManager.mutex.Unlock()
+
+		capacity, allocatable, _ := testManager.GetCapacity(logger)
+		as.Equal(int64(2), capacity[v1.ResourceName(resourceName)].Value())
+		as.Equal(int64(1), allocatable[v1.ResourceName(resourceName)].Value())
+	})
+
+	t.Run("legacy plugin: structured health ignored", func(t *testing.T) {
+		testManager.endpoints[resourceName] = endpointInfo{e: &endpointImpl{}, opts: nil}
+		testManager.genericDeviceUpdateCallback(logger, resourceName, devs, healthMap)
+
+		testManager.mutex.Lock()
+		as.Equal(0, testManager.degradedDevices[resourceName].Len())
+		as.True(testManager.healthyDevices[resourceName].Has("gpu1"))
+		testManager.mutex.Unlock()
+
+		_, allocatable, _ := testManager.GetCapacity(logger)
+		as.Equal(int64(2), allocatable[v1.ResourceName(resourceName)].Value())
+	})
+}
+
+// TestTruncateMessageAndSanitizeVendorCode verifies the input-hardening helpers.
+func TestTruncateMessageAndSanitizeVendorCode(t *testing.T) {
+	as := assert.New(t)
+
+	as.Equal("short", truncateMessage("short"))
+	long := strings.Repeat("a", maxHealthMessageBytes+50)
+	as.Len(truncateMessage(long), maxHealthMessageBytes)
+	// Truncation must not split a multi-byte rune: build a string that would be
+	// cut mid-rune at the byte boundary and confirm the result stays valid UTF-8.
+	multibyte := strings.Repeat("a", maxHealthMessageBytes-1) + "€"
+	as.True(utf8.ValidString(truncateMessage(multibyte)))
+
+	as.Equal("XID_63", sanitizeVendorCode("XID_63"))
+	as.Equal("ABC", sanitizeVendorCode("A\x00B\x07C\x7f"))
 }

--- a/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.pb.go
+++ b/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.pb.go
@@ -39,14 +39,73 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// HealthState is the structured, three-state health model for a device.
+// The zero value is UNSPECIFIED so that an unset or malformed message is never
+// silently interpreted as HEALTHY.
+type HealthState int32
+
+const (
+	HealthState_HEALTH_STATE_UNSPECIFIED HealthState = 0
+	HealthState_HEALTH_STATE_HEALTHY     HealthState = 1
+	HealthState_HEALTH_STATE_DEGRADED    HealthState = 2
+	HealthState_HEALTH_STATE_UNHEALTHY   HealthState = 3
+)
+
+// Enum value maps for HealthState.
+var (
+	HealthState_name = map[int32]string{
+		0: "HEALTH_STATE_UNSPECIFIED",
+		1: "HEALTH_STATE_HEALTHY",
+		2: "HEALTH_STATE_DEGRADED",
+		3: "HEALTH_STATE_UNHEALTHY",
+	}
+	HealthState_value = map[string]int32{
+		"HEALTH_STATE_UNSPECIFIED": 0,
+		"HEALTH_STATE_HEALTHY":     1,
+		"HEALTH_STATE_DEGRADED":    2,
+		"HEALTH_STATE_UNHEALTHY":   3,
+	}
+)
+
+func (x HealthState) Enum() *HealthState {
+	p := new(HealthState)
+	*p = x
+	return p
+}
+
+func (x HealthState) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (HealthState) Descriptor() protoreflect.EnumDescriptor {
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_enumTypes[0].Descriptor()
+}
+
+func (HealthState) Type() protoreflect.EnumType {
+	return &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_enumTypes[0]
+}
+
+func (x HealthState) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use HealthState.Descriptor instead.
+func (HealthState) EnumDescriptor() ([]byte, []int) {
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{0}
+}
+
 type DevicePluginOptions struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Indicates if PreStartContainer call is required before each container start
 	PreStartRequired bool `protobuf:"varint,1,opt,name=pre_start_required,json=preStartRequired,proto3" json:"pre_start_required,omitempty"`
 	// Indicates if GetPreferredAllocation is implemented and available for calling
 	GetPreferredAllocationAvailable bool `protobuf:"varint,2,opt,name=get_preferred_allocation_available,json=getPreferredAllocationAvailable,proto3" json:"get_preferred_allocation_available,omitempty"`
-	unknownFields                   protoimpl.UnknownFields
-	sizeCache                       protoimpl.SizeCache
+	// Indicates that the device plugin understands the structured health model
+	// and may populate device_health_map in ListAndWatchResponse. Kubelet ignores
+	// device_health_map from plugins that do not set this flag.
+	SupportsStructuredHealth bool `protobuf:"varint,3,opt,name=supports_structured_health,json=supportsStructuredHealth,proto3" json:"supports_structured_health,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *DevicePluginOptions) Reset() {
@@ -89,6 +148,13 @@ func (x *DevicePluginOptions) GetPreStartRequired() bool {
 func (x *DevicePluginOptions) GetGetPreferredAllocationAvailable() bool {
 	if x != nil {
 		return x.GetPreferredAllocationAvailable
+	}
+	return false
+}
+
+func (x *DevicePluginOptions) GetSupportsStructuredHealth() bool {
+	if x != nil {
+		return x.SupportsStructuredHealth
 	}
 	return false
 }
@@ -206,10 +272,21 @@ func (*Empty) Descriptor() ([]byte, []int) {
 // Whenever a Device state change or a Device disappears, ListAndWatch
 // returns the new list
 type ListAndWatchResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Devices       []*Device              `protobuf:"bytes,1,rep,name=devices,proto3" json:"devices,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Devices []*Device              `protobuf:"bytes,1,rep,name=devices,proto3" json:"devices,omitempty"`
+	// device_health_map carries optional structured health details keyed by
+	// device ID. It is only honored when the plugin advertised
+	// supports_structured_health in DevicePluginOptions.
+	//
+	// The binary Device.health field remains authoritative for backward
+	// compatibility. When a device appears here, the plugin MUST keep
+	// Device.health consistent with the structured state: "Healthy" for
+	// HEALTH_STATE_HEALTHY or HEALTH_STATE_DEGRADED, "Unhealthy" for
+	// HEALTH_STATE_UNHEALTHY. A device ID absent from this map keeps its
+	// previously reported structured state.
+	DeviceHealthMap map[string]*DeviceHealthDetail `protobuf:"bytes,2,rep,name=device_health_map,json=deviceHealthMap,proto3" json:"device_health_map,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ListAndWatchResponse) Reset() {
@@ -249,6 +326,90 @@ func (x *ListAndWatchResponse) GetDevices() []*Device {
 	return nil
 }
 
+func (x *ListAndWatchResponse) GetDeviceHealthMap() map[string]*DeviceHealthDetail {
+	if x != nil {
+		return x.DeviceHealthMap
+	}
+	return nil
+}
+
+// DeviceHealthDetail carries structured health for a single device.
+type DeviceHealthDetail struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Structured health state for the device.
+	State HealthState `protobuf:"varint,1,opt,name=state,proto3,enum=v1beta1.HealthState" json:"state,omitempty"`
+	// Optional freeform, human-readable message describing the condition
+	// (for example "ECC double-bit error" or "thermal throttling"). Kubelet
+	// truncates this to at most 1024 bytes on a UTF-8 rune boundary.
+	Message string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	// Optional vendor-specific error code (for example "XID_63"). Restricted
+	// by kubelet to printable ASCII; other bytes are stripped.
+	VendorCode string `protobuf:"bytes,3,opt,name=vendor_code,json=vendorCode,proto3" json:"vendor_code,omitempty"`
+	// Unix time in nanoseconds when the device transitioned to this state.
+	// 0 means unset; kubelet substitutes the observation time.
+	LastTransitionTime int64 `protobuf:"varint,4,opt,name=last_transition_time,json=lastTransitionTime,proto3" json:"last_transition_time,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *DeviceHealthDetail) Reset() {
+	*x = DeviceHealthDetail{}
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeviceHealthDetail) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeviceHealthDetail) ProtoMessage() {}
+
+func (x *DeviceHealthDetail) ProtoReflect() protoreflect.Message {
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeviceHealthDetail.ProtoReflect.Descriptor instead.
+func (*DeviceHealthDetail) Descriptor() ([]byte, []int) {
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *DeviceHealthDetail) GetState() HealthState {
+	if x != nil {
+		return x.State
+	}
+	return HealthState_HEALTH_STATE_UNSPECIFIED
+}
+
+func (x *DeviceHealthDetail) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *DeviceHealthDetail) GetVendorCode() string {
+	if x != nil {
+		return x.VendorCode
+	}
+	return ""
+}
+
+func (x *DeviceHealthDetail) GetLastTransitionTime() int64 {
+	if x != nil {
+		return x.LastTransitionTime
+	}
+	return 0
+}
+
 type TopologyInfo struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Nodes         []*NUMANode            `protobuf:"bytes,1,rep,name=nodes,proto3" json:"nodes,omitempty"`
@@ -258,7 +419,7 @@ type TopologyInfo struct {
 
 func (x *TopologyInfo) Reset() {
 	*x = TopologyInfo{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[4]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -270,7 +431,7 @@ func (x *TopologyInfo) String() string {
 func (*TopologyInfo) ProtoMessage() {}
 
 func (x *TopologyInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[4]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -283,7 +444,7 @@ func (x *TopologyInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TopologyInfo.ProtoReflect.Descriptor instead.
 func (*TopologyInfo) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{4}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *TopologyInfo) GetNodes() []*NUMANode {
@@ -302,7 +463,7 @@ type NUMANode struct {
 
 func (x *NUMANode) Reset() {
 	*x = NUMANode{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[5]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -314,7 +475,7 @@ func (x *NUMANode) String() string {
 func (*NUMANode) ProtoMessage() {}
 
 func (x *NUMANode) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[5]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -327,7 +488,7 @@ func (x *NUMANode) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NUMANode.ProtoReflect.Descriptor instead.
 func (*NUMANode) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{5}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *NUMANode) GetID() int64 {
@@ -362,7 +523,7 @@ type Device struct {
 
 func (x *Device) Reset() {
 	*x = Device{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[6]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -374,7 +535,7 @@ func (x *Device) String() string {
 func (*Device) ProtoMessage() {}
 
 func (x *Device) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[6]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -387,7 +548,7 @@ func (x *Device) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Device.ProtoReflect.Descriptor instead.
 func (*Device) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{6}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Device) GetID() string {
@@ -424,7 +585,7 @@ type PreStartContainerRequest struct {
 
 func (x *PreStartContainerRequest) Reset() {
 	*x = PreStartContainerRequest{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[7]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -436,7 +597,7 @@ func (x *PreStartContainerRequest) String() string {
 func (*PreStartContainerRequest) ProtoMessage() {}
 
 func (x *PreStartContainerRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[7]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -449,7 +610,7 @@ func (x *PreStartContainerRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreStartContainerRequest.ProtoReflect.Descriptor instead.
 func (*PreStartContainerRequest) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{7}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *PreStartContainerRequest) GetDevicesIds() []string {
@@ -468,7 +629,7 @@ type PreStartContainerResponse struct {
 
 func (x *PreStartContainerResponse) Reset() {
 	*x = PreStartContainerResponse{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[8]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -480,7 +641,7 @@ func (x *PreStartContainerResponse) String() string {
 func (*PreStartContainerResponse) ProtoMessage() {}
 
 func (x *PreStartContainerResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[8]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -493,7 +654,7 @@ func (x *PreStartContainerResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreStartContainerResponse.ProtoReflect.Descriptor instead.
 func (*PreStartContainerResponse) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{8}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{9}
 }
 
 // PreferredAllocationRequest is passed via a call to GetPreferredAllocation()
@@ -510,7 +671,7 @@ type PreferredAllocationRequest struct {
 
 func (x *PreferredAllocationRequest) Reset() {
 	*x = PreferredAllocationRequest{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[9]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -522,7 +683,7 @@ func (x *PreferredAllocationRequest) String() string {
 func (*PreferredAllocationRequest) ProtoMessage() {}
 
 func (x *PreferredAllocationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[9]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -535,7 +696,7 @@ func (x *PreferredAllocationRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreferredAllocationRequest.ProtoReflect.Descriptor instead.
 func (*PreferredAllocationRequest) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{9}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *PreferredAllocationRequest) GetContainerRequests() []*ContainerPreferredAllocationRequest {
@@ -559,7 +720,7 @@ type ContainerPreferredAllocationRequest struct {
 
 func (x *ContainerPreferredAllocationRequest) Reset() {
 	*x = ContainerPreferredAllocationRequest{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[10]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -571,7 +732,7 @@ func (x *ContainerPreferredAllocationRequest) String() string {
 func (*ContainerPreferredAllocationRequest) ProtoMessage() {}
 
 func (x *ContainerPreferredAllocationRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[10]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -584,7 +745,7 @@ func (x *ContainerPreferredAllocationRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ContainerPreferredAllocationRequest.ProtoReflect.Descriptor instead.
 func (*ContainerPreferredAllocationRequest) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{10}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ContainerPreferredAllocationRequest) GetAvailableDeviceIDs() []string {
@@ -619,7 +780,7 @@ type PreferredAllocationResponse struct {
 
 func (x *PreferredAllocationResponse) Reset() {
 	*x = PreferredAllocationResponse{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[11]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -631,7 +792,7 @@ func (x *PreferredAllocationResponse) String() string {
 func (*PreferredAllocationResponse) ProtoMessage() {}
 
 func (x *PreferredAllocationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[11]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -644,7 +805,7 @@ func (x *PreferredAllocationResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreferredAllocationResponse.ProtoReflect.Descriptor instead.
 func (*PreferredAllocationResponse) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{11}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *PreferredAllocationResponse) GetContainerResponses() []*ContainerPreferredAllocationResponse {
@@ -663,7 +824,7 @@ type ContainerPreferredAllocationResponse struct {
 
 func (x *ContainerPreferredAllocationResponse) Reset() {
 	*x = ContainerPreferredAllocationResponse{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[12]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -675,7 +836,7 @@ func (x *ContainerPreferredAllocationResponse) String() string {
 func (*ContainerPreferredAllocationResponse) ProtoMessage() {}
 
 func (x *ContainerPreferredAllocationResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[12]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -688,7 +849,7 @@ func (x *ContainerPreferredAllocationResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use ContainerPreferredAllocationResponse.ProtoReflect.Descriptor instead.
 func (*ContainerPreferredAllocationResponse) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{12}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ContainerPreferredAllocationResponse) GetDeviceIDs() []string {
@@ -713,7 +874,7 @@ type AllocateRequest struct {
 
 func (x *AllocateRequest) Reset() {
 	*x = AllocateRequest{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[13]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -725,7 +886,7 @@ func (x *AllocateRequest) String() string {
 func (*AllocateRequest) ProtoMessage() {}
 
 func (x *AllocateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[13]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -738,7 +899,7 @@ func (x *AllocateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AllocateRequest.ProtoReflect.Descriptor instead.
 func (*AllocateRequest) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{13}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *AllocateRequest) GetContainerRequests() []*ContainerAllocateRequest {
@@ -757,7 +918,7 @@ type ContainerAllocateRequest struct {
 
 func (x *ContainerAllocateRequest) Reset() {
 	*x = ContainerAllocateRequest{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[14]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -769,7 +930,7 @@ func (x *ContainerAllocateRequest) String() string {
 func (*ContainerAllocateRequest) ProtoMessage() {}
 
 func (x *ContainerAllocateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[14]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -782,7 +943,7 @@ func (x *ContainerAllocateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerAllocateRequest.ProtoReflect.Descriptor instead.
 func (*ContainerAllocateRequest) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{14}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ContainerAllocateRequest) GetDevicesIds() []string {
@@ -806,7 +967,7 @@ type CDIDevice struct {
 
 func (x *CDIDevice) Reset() {
 	*x = CDIDevice{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[15]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -818,7 +979,7 @@ func (x *CDIDevice) String() string {
 func (*CDIDevice) ProtoMessage() {}
 
 func (x *CDIDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[15]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -831,7 +992,7 @@ func (x *CDIDevice) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CDIDevice.ProtoReflect.Descriptor instead.
 func (*CDIDevice) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{15}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *CDIDevice) GetName() string {
@@ -858,7 +1019,7 @@ type AllocateResponse struct {
 
 func (x *AllocateResponse) Reset() {
 	*x = AllocateResponse{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[16]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -870,7 +1031,7 @@ func (x *AllocateResponse) String() string {
 func (*AllocateResponse) ProtoMessage() {}
 
 func (x *AllocateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[16]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -883,7 +1044,7 @@ func (x *AllocateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AllocateResponse.ProtoReflect.Descriptor instead.
 func (*AllocateResponse) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{16}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *AllocateResponse) GetContainerResponses() []*ContainerAllocateResponse {
@@ -911,7 +1072,7 @@ type ContainerAllocateResponse struct {
 
 func (x *ContainerAllocateResponse) Reset() {
 	*x = ContainerAllocateResponse{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[17]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -923,7 +1084,7 @@ func (x *ContainerAllocateResponse) String() string {
 func (*ContainerAllocateResponse) ProtoMessage() {}
 
 func (x *ContainerAllocateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[17]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -936,7 +1097,7 @@ func (x *ContainerAllocateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerAllocateResponse.ProtoReflect.Descriptor instead.
 func (*ContainerAllocateResponse) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{17}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ContainerAllocateResponse) GetEnvs() map[string]string {
@@ -990,7 +1151,7 @@ type Mount struct {
 
 func (x *Mount) Reset() {
 	*x = Mount{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[18]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1002,7 +1163,7 @@ func (x *Mount) String() string {
 func (*Mount) ProtoMessage() {}
 
 func (x *Mount) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[18]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1015,7 +1176,7 @@ func (x *Mount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Mount.ProtoReflect.Descriptor instead.
 func (*Mount) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{18}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *Mount) GetContainerPath() string {
@@ -1057,7 +1218,7 @@ type DeviceSpec struct {
 
 func (x *DeviceSpec) Reset() {
 	*x = DeviceSpec{}
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[19]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1069,7 +1230,7 @@ func (x *DeviceSpec) String() string {
 func (*DeviceSpec) ProtoMessage() {}
 
 func (x *DeviceSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[19]
+	mi := &file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1082,7 +1243,7 @@ func (x *DeviceSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeviceSpec.ProtoReflect.Descriptor instead.
 func (*DeviceSpec) Descriptor() ([]byte, []int) {
-	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{19}
+	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *DeviceSpec) GetContainerPath() string {
@@ -1110,18 +1271,29 @@ var File_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto prot
 
 const file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDesc = "" +
 	"\n" +
-	"Bstaging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto\x12\av1beta1\"\x90\x01\n" +
+	"Bstaging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto\x12\av1beta1\"\xce\x01\n" +
 	"\x13DevicePluginOptions\x12,\n" +
 	"\x12pre_start_required\x18\x01 \x01(\bR\x10preStartRequired\x12K\n" +
-	"\"get_preferred_allocation_available\x18\x02 \x01(\bR\x1fgetPreferredAllocationAvailable\"\xa4\x01\n" +
+	"\"get_preferred_allocation_available\x18\x02 \x01(\bR\x1fgetPreferredAllocationAvailable\x12<\n" +
+	"\x1asupports_structured_health\x18\x03 \x01(\bR\x18supportsStructuredHealth\"\xa4\x01\n" +
 	"\x0fRegisterRequest\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x1a\n" +
 	"\bendpoint\x18\x02 \x01(\tR\bendpoint\x12#\n" +
 	"\rresource_name\x18\x03 \x01(\tR\fresourceName\x126\n" +
 	"\aoptions\x18\x04 \x01(\v2\x1c.v1beta1.DevicePluginOptionsR\aoptions\"\a\n" +
-	"\x05Empty\"A\n" +
+	"\x05Empty\"\x82\x02\n" +
 	"\x14ListAndWatchResponse\x12)\n" +
-	"\adevices\x18\x01 \x03(\v2\x0f.v1beta1.DeviceR\adevices\"7\n" +
+	"\adevices\x18\x01 \x03(\v2\x0f.v1beta1.DeviceR\adevices\x12^\n" +
+	"\x11device_health_map\x18\x02 \x03(\v22.v1beta1.ListAndWatchResponse.DeviceHealthMapEntryR\x0fdeviceHealthMap\x1a_\n" +
+	"\x14DeviceHealthMapEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x121\n" +
+	"\x05value\x18\x02 \x01(\v2\x1b.v1beta1.DeviceHealthDetailR\x05value:\x028\x01\"\xad\x01\n" +
+	"\x12DeviceHealthDetail\x12*\n" +
+	"\x05state\x18\x01 \x01(\x0e2\x14.v1beta1.HealthStateR\x05state\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1f\n" +
+	"\vvendor_code\x18\x03 \x01(\tR\n" +
+	"vendorCode\x120\n" +
+	"\x14last_transition_time\x18\x04 \x01(\x03R\x12lastTransitionTime\"7\n" +
 	"\fTopologyInfo\x12'\n" +
 	"\x05nodes\x18\x01 \x03(\v2\x11.v1beta1.NUMANodeR\x05nodes\"\x1a\n" +
 	"\bNUMANode\x12\x0e\n" +
@@ -1174,7 +1346,12 @@ const file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_ra
 	"DeviceSpec\x12%\n" +
 	"\x0econtainer_path\x18\x01 \x01(\tR\rcontainerPath\x12\x1b\n" +
 	"\thost_path\x18\x02 \x01(\tR\bhostPath\x12 \n" +
-	"\vpermissions\x18\x03 \x01(\tR\vpermissions2F\n" +
+	"\vpermissions\x18\x03 \x01(\tR\vpermissions*|\n" +
+	"\vHealthState\x12\x1c\n" +
+	"\x18HEALTH_STATE_UNSPECIFIED\x10\x00\x12\x18\n" +
+	"\x14HEALTH_STATE_HEALTHY\x10\x01\x12\x19\n" +
+	"\x15HEALTH_STATE_DEGRADED\x10\x02\x12\x1a\n" +
+	"\x16HEALTH_STATE_UNHEALTHY\x10\x032F\n" +
 	"\fRegistration\x126\n" +
 	"\bRegister\x12\x18.v1beta1.RegisterRequest\x1a\x0e.v1beta1.Empty\"\x002\xa3\x03\n" +
 	"\fDevicePlugin\x12H\n" +
@@ -1196,62 +1373,69 @@ func file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_raw
 	return file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDescData
 }
 
-var file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_goTypes = []any{
-	(*DevicePluginOptions)(nil),                  // 0: v1beta1.DevicePluginOptions
-	(*RegisterRequest)(nil),                      // 1: v1beta1.RegisterRequest
-	(*Empty)(nil),                                // 2: v1beta1.Empty
-	(*ListAndWatchResponse)(nil),                 // 3: v1beta1.ListAndWatchResponse
-	(*TopologyInfo)(nil),                         // 4: v1beta1.TopologyInfo
-	(*NUMANode)(nil),                             // 5: v1beta1.NUMANode
-	(*Device)(nil),                               // 6: v1beta1.Device
-	(*PreStartContainerRequest)(nil),             // 7: v1beta1.PreStartContainerRequest
-	(*PreStartContainerResponse)(nil),            // 8: v1beta1.PreStartContainerResponse
-	(*PreferredAllocationRequest)(nil),           // 9: v1beta1.PreferredAllocationRequest
-	(*ContainerPreferredAllocationRequest)(nil),  // 10: v1beta1.ContainerPreferredAllocationRequest
-	(*PreferredAllocationResponse)(nil),          // 11: v1beta1.PreferredAllocationResponse
-	(*ContainerPreferredAllocationResponse)(nil), // 12: v1beta1.ContainerPreferredAllocationResponse
-	(*AllocateRequest)(nil),                      // 13: v1beta1.AllocateRequest
-	(*ContainerAllocateRequest)(nil),             // 14: v1beta1.ContainerAllocateRequest
-	(*CDIDevice)(nil),                            // 15: v1beta1.CDIDevice
-	(*AllocateResponse)(nil),                     // 16: v1beta1.AllocateResponse
-	(*ContainerAllocateResponse)(nil),            // 17: v1beta1.ContainerAllocateResponse
-	(*Mount)(nil),                                // 18: v1beta1.Mount
-	(*DeviceSpec)(nil),                           // 19: v1beta1.DeviceSpec
-	nil,                                          // 20: v1beta1.ContainerAllocateResponse.EnvsEntry
-	nil,                                          // 21: v1beta1.ContainerAllocateResponse.AnnotationsEntry
+	(HealthState)(0),                             // 0: v1beta1.HealthState
+	(*DevicePluginOptions)(nil),                  // 1: v1beta1.DevicePluginOptions
+	(*RegisterRequest)(nil),                      // 2: v1beta1.RegisterRequest
+	(*Empty)(nil),                                // 3: v1beta1.Empty
+	(*ListAndWatchResponse)(nil),                 // 4: v1beta1.ListAndWatchResponse
+	(*DeviceHealthDetail)(nil),                   // 5: v1beta1.DeviceHealthDetail
+	(*TopologyInfo)(nil),                         // 6: v1beta1.TopologyInfo
+	(*NUMANode)(nil),                             // 7: v1beta1.NUMANode
+	(*Device)(nil),                               // 8: v1beta1.Device
+	(*PreStartContainerRequest)(nil),             // 9: v1beta1.PreStartContainerRequest
+	(*PreStartContainerResponse)(nil),            // 10: v1beta1.PreStartContainerResponse
+	(*PreferredAllocationRequest)(nil),           // 11: v1beta1.PreferredAllocationRequest
+	(*ContainerPreferredAllocationRequest)(nil),  // 12: v1beta1.ContainerPreferredAllocationRequest
+	(*PreferredAllocationResponse)(nil),          // 13: v1beta1.PreferredAllocationResponse
+	(*ContainerPreferredAllocationResponse)(nil), // 14: v1beta1.ContainerPreferredAllocationResponse
+	(*AllocateRequest)(nil),                      // 15: v1beta1.AllocateRequest
+	(*ContainerAllocateRequest)(nil),             // 16: v1beta1.ContainerAllocateRequest
+	(*CDIDevice)(nil),                            // 17: v1beta1.CDIDevice
+	(*AllocateResponse)(nil),                     // 18: v1beta1.AllocateResponse
+	(*ContainerAllocateResponse)(nil),            // 19: v1beta1.ContainerAllocateResponse
+	(*Mount)(nil),                                // 20: v1beta1.Mount
+	(*DeviceSpec)(nil),                           // 21: v1beta1.DeviceSpec
+	nil,                                          // 22: v1beta1.ListAndWatchResponse.DeviceHealthMapEntry
+	nil,                                          // 23: v1beta1.ContainerAllocateResponse.EnvsEntry
+	nil,                                          // 24: v1beta1.ContainerAllocateResponse.AnnotationsEntry
 }
 var file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_depIdxs = []int32{
-	0,  // 0: v1beta1.RegisterRequest.options:type_name -> v1beta1.DevicePluginOptions
-	6,  // 1: v1beta1.ListAndWatchResponse.devices:type_name -> v1beta1.Device
-	5,  // 2: v1beta1.TopologyInfo.nodes:type_name -> v1beta1.NUMANode
-	4,  // 3: v1beta1.Device.topology:type_name -> v1beta1.TopologyInfo
-	10, // 4: v1beta1.PreferredAllocationRequest.container_requests:type_name -> v1beta1.ContainerPreferredAllocationRequest
-	12, // 5: v1beta1.PreferredAllocationResponse.container_responses:type_name -> v1beta1.ContainerPreferredAllocationResponse
-	14, // 6: v1beta1.AllocateRequest.container_requests:type_name -> v1beta1.ContainerAllocateRequest
-	17, // 7: v1beta1.AllocateResponse.container_responses:type_name -> v1beta1.ContainerAllocateResponse
-	20, // 8: v1beta1.ContainerAllocateResponse.envs:type_name -> v1beta1.ContainerAllocateResponse.EnvsEntry
-	18, // 9: v1beta1.ContainerAllocateResponse.mounts:type_name -> v1beta1.Mount
-	19, // 10: v1beta1.ContainerAllocateResponse.devices:type_name -> v1beta1.DeviceSpec
-	21, // 11: v1beta1.ContainerAllocateResponse.annotations:type_name -> v1beta1.ContainerAllocateResponse.AnnotationsEntry
-	15, // 12: v1beta1.ContainerAllocateResponse.cdi_devices:type_name -> v1beta1.CDIDevice
-	1,  // 13: v1beta1.Registration.Register:input_type -> v1beta1.RegisterRequest
-	2,  // 14: v1beta1.DevicePlugin.GetDevicePluginOptions:input_type -> v1beta1.Empty
-	2,  // 15: v1beta1.DevicePlugin.ListAndWatch:input_type -> v1beta1.Empty
-	9,  // 16: v1beta1.DevicePlugin.GetPreferredAllocation:input_type -> v1beta1.PreferredAllocationRequest
-	13, // 17: v1beta1.DevicePlugin.Allocate:input_type -> v1beta1.AllocateRequest
-	7,  // 18: v1beta1.DevicePlugin.PreStartContainer:input_type -> v1beta1.PreStartContainerRequest
-	2,  // 19: v1beta1.Registration.Register:output_type -> v1beta1.Empty
-	0,  // 20: v1beta1.DevicePlugin.GetDevicePluginOptions:output_type -> v1beta1.DevicePluginOptions
-	3,  // 21: v1beta1.DevicePlugin.ListAndWatch:output_type -> v1beta1.ListAndWatchResponse
-	11, // 22: v1beta1.DevicePlugin.GetPreferredAllocation:output_type -> v1beta1.PreferredAllocationResponse
-	16, // 23: v1beta1.DevicePlugin.Allocate:output_type -> v1beta1.AllocateResponse
-	8,  // 24: v1beta1.DevicePlugin.PreStartContainer:output_type -> v1beta1.PreStartContainerResponse
-	19, // [19:25] is the sub-list for method output_type
-	13, // [13:19] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	1,  // 0: v1beta1.RegisterRequest.options:type_name -> v1beta1.DevicePluginOptions
+	8,  // 1: v1beta1.ListAndWatchResponse.devices:type_name -> v1beta1.Device
+	22, // 2: v1beta1.ListAndWatchResponse.device_health_map:type_name -> v1beta1.ListAndWatchResponse.DeviceHealthMapEntry
+	0,  // 3: v1beta1.DeviceHealthDetail.state:type_name -> v1beta1.HealthState
+	7,  // 4: v1beta1.TopologyInfo.nodes:type_name -> v1beta1.NUMANode
+	6,  // 5: v1beta1.Device.topology:type_name -> v1beta1.TopologyInfo
+	12, // 6: v1beta1.PreferredAllocationRequest.container_requests:type_name -> v1beta1.ContainerPreferredAllocationRequest
+	14, // 7: v1beta1.PreferredAllocationResponse.container_responses:type_name -> v1beta1.ContainerPreferredAllocationResponse
+	16, // 8: v1beta1.AllocateRequest.container_requests:type_name -> v1beta1.ContainerAllocateRequest
+	19, // 9: v1beta1.AllocateResponse.container_responses:type_name -> v1beta1.ContainerAllocateResponse
+	23, // 10: v1beta1.ContainerAllocateResponse.envs:type_name -> v1beta1.ContainerAllocateResponse.EnvsEntry
+	20, // 11: v1beta1.ContainerAllocateResponse.mounts:type_name -> v1beta1.Mount
+	21, // 12: v1beta1.ContainerAllocateResponse.devices:type_name -> v1beta1.DeviceSpec
+	24, // 13: v1beta1.ContainerAllocateResponse.annotations:type_name -> v1beta1.ContainerAllocateResponse.AnnotationsEntry
+	17, // 14: v1beta1.ContainerAllocateResponse.cdi_devices:type_name -> v1beta1.CDIDevice
+	5,  // 15: v1beta1.ListAndWatchResponse.DeviceHealthMapEntry.value:type_name -> v1beta1.DeviceHealthDetail
+	2,  // 16: v1beta1.Registration.Register:input_type -> v1beta1.RegisterRequest
+	3,  // 17: v1beta1.DevicePlugin.GetDevicePluginOptions:input_type -> v1beta1.Empty
+	3,  // 18: v1beta1.DevicePlugin.ListAndWatch:input_type -> v1beta1.Empty
+	11, // 19: v1beta1.DevicePlugin.GetPreferredAllocation:input_type -> v1beta1.PreferredAllocationRequest
+	15, // 20: v1beta1.DevicePlugin.Allocate:input_type -> v1beta1.AllocateRequest
+	9,  // 21: v1beta1.DevicePlugin.PreStartContainer:input_type -> v1beta1.PreStartContainerRequest
+	3,  // 22: v1beta1.Registration.Register:output_type -> v1beta1.Empty
+	1,  // 23: v1beta1.DevicePlugin.GetDevicePluginOptions:output_type -> v1beta1.DevicePluginOptions
+	4,  // 24: v1beta1.DevicePlugin.ListAndWatch:output_type -> v1beta1.ListAndWatchResponse
+	13, // 25: v1beta1.DevicePlugin.GetPreferredAllocation:output_type -> v1beta1.PreferredAllocationResponse
+	18, // 26: v1beta1.DevicePlugin.Allocate:output_type -> v1beta1.AllocateResponse
+	10, // 27: v1beta1.DevicePlugin.PreStartContainer:output_type -> v1beta1.PreStartContainerResponse
+	22, // [22:28] is the sub-list for method output_type
+	16, // [16:22] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_init() }
@@ -1264,13 +1448,14 @@ func file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_ini
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDesc), len(file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   22,
+			NumEnums:      1,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   2,
 		},
 		GoTypes:           file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_goTypes,
 		DependencyIndexes: file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_depIdxs,
+		EnumInfos:         file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_enumTypes,
 		MessageInfos:      file_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto_msgTypes,
 	}.Build()
 	File_staging_src_k8s_io_kubelet_pkg_apis_deviceplugin_v1beta1_api_proto = out.File

--- a/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto
+++ b/staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto
@@ -19,6 +19,10 @@ message DevicePluginOptions {
 	bool pre_start_required = 1;
 	// Indicates if GetPreferredAllocation is implemented and available for calling
 	bool get_preferred_allocation_available = 2;
+	// Indicates that the device plugin understands the structured health model
+	// and may populate device_health_map in ListAndWatchResponse. Kubelet ignores
+	// device_health_map from plugins that do not set this flag.
+	bool supports_structured_health = 3;
 }
 
 message RegisterRequest {
@@ -70,6 +74,43 @@ service DevicePlugin {
 // returns the new list
 message ListAndWatchResponse {
 	repeated Device devices = 1;
+	// device_health_map carries optional structured health details keyed by
+	// device ID. It is only honored when the plugin advertised
+	// supports_structured_health in DevicePluginOptions.
+	//
+	// The binary Device.health field remains authoritative for backward
+	// compatibility. When a device appears here, the plugin MUST keep
+	// Device.health consistent with the structured state: "Healthy" for
+	// HEALTH_STATE_HEALTHY or HEALTH_STATE_DEGRADED, "Unhealthy" for
+	// HEALTH_STATE_UNHEALTHY. A device ID absent from this map keeps its
+	// previously reported structured state.
+	map<string, DeviceHealthDetail> device_health_map = 2;
+}
+
+// HealthState is the structured, three-state health model for a device.
+// The zero value is UNSPECIFIED so that an unset or malformed message is never
+// silently interpreted as HEALTHY.
+enum HealthState {
+	HEALTH_STATE_UNSPECIFIED = 0;
+	HEALTH_STATE_HEALTHY = 1;
+	HEALTH_STATE_DEGRADED = 2;
+	HEALTH_STATE_UNHEALTHY = 3;
+}
+
+// DeviceHealthDetail carries structured health for a single device.
+message DeviceHealthDetail {
+	// Structured health state for the device.
+	HealthState state = 1;
+	// Optional freeform, human-readable message describing the condition
+	// (for example "ECC double-bit error" or "thermal throttling"). Kubelet
+	// truncates this to at most 1024 bytes on a UTF-8 rune boundary.
+	string message = 2;
+	// Optional vendor-specific error code (for example "XID_63"). Restricted
+	// by kubelet to printable ASCII; other bytes are stripped.
+	string vendor_code = 3;
+	// Unix time in nanoseconds when the device transitioned to this state.
+	// 0 means unset; kubelet substitutes the observation time.
+	int64 last_transition_time = 4;
 }
 
 message TopologyInfo {


### PR DESCRIPTION
## What

Adds an optional three-state health model (`HEALTHY`/`DEGRADED`/`UNHEALTHY`) for device plugins, gated behind the `DevicePluginDegradedHealth` alpha feature gate and capability-negotiated via `supports_structured_health`.

This gives kubelet a middle ground between silently keeping a subtly impaired device in the healthy pool and immediately evicting pods from a device that is still functional but degraded.

## Motivation

Currently, device plugins can only report binary health: `Healthy` or `Unhealthy`. There is no way to express "device is impaired but still usable." This leaves operators choosing between silent corruption and unnecessary eviction.

See kubernetes/kubernetes#140656 for the full problem statement and community discussion.

## API changes

- `DevicePluginOptions` gains `supports_structured_health`
- `ListAndWatchResponse` gains `device_health_map`
- New `HealthState` enum: `UNSPECIFIED`, `HEALTHY`, `DEGRADED`, `UNHEALTHY`
- New `DeviceHealthDetail` message: `state`, `message`, `vendor_code`, `last_transition_time`

## Kubelet behavior

- New `degradedDevices` map in device manager
- Structured health is only honored when:
  - `DevicePluginDegradedHealth` feature gate is enabled, AND
  - The plugin advertised `supports_structured_health` in `DevicePluginOptions`
- Legacy plugins (`opts == nil`) are unaffected
- A device the plugin marks `Unhealthy` is never downgraded to `DEGRADED`

## Files changed

- `pkg/features/kube_features.go` — feature gate definition
- `pkg/kubelet/cm/devicemanager/manager.go` — degraded device tracking and state resolution
- `pkg/kubelet/cm/devicemanager/manager_test.go` — updated callers and new coverage
- `staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.proto` — API additions
- `staging/src/k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1/api.pb.go` — regenerated bindings

## Testing

- Unit tests updated for new `genericDeviceUpdateCallback` signature
- Verified on AMD DevCloud MI300X cluster with ROCm 7.14 and k8s-device-plugin health-check variant

## Notes

This is an alpha, opt-in change. The default behavior is unchanged.

/kubelet
/sig-node