### PR TITLE
Use Service informer for NodePort repair

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -1542,6 +1542,18 @@
   componentEndpoints:
   - component: kube-apiserver
     endpoint: /metrics
+- name: leak_cleanup_deferred_total
+  subsystem: nodeport_repair
+  namespace: apiserver
+  help: 'Number of repair loop runs that deferred leaked port cleanup because the
+    Service informer was not proven up to date, broken down by reason: stale, error'
+  type: Counter
+  stabilityLevel: ALPHA
+  labels:
+  - reason
+  componentEndpoints:
+  - component: kube-apiserver
+    endpoint: /metrics
 - name: port_errors_total
   subsystem: nodeport_repair
   namespace: apiserver

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -107,7 +107,8 @@ type legacyProvider struct {
 	serviceNodePortAllocator         *portallocator.PortAllocator
 	authorizer                       authorizer.UnconditionalAuthorizer
 
-	startServiceNodePortsRepair, startServiceClusterIPRepair func(onFirstSuccess func(), stopCh chan struct{})
+	startServiceNodePortsRepair func(onFirstSuccess func(), stopCh chan struct{}, initialServiceCacheDeadline time.Time)
+	startServiceClusterIPRepair func(onFirstSuccess func(), stopCh chan struct{})
 }
 
 func New(c Config, authorizer authorizer.UnconditionalAuthorizer) (*legacyProvider, error) {
@@ -130,7 +131,7 @@ func New(c Config, authorizer authorizer.UnconditionalAuthorizer) (*legacyProvid
 	if err != nil {
 		return nil, err
 	}
-	p.startServiceNodePortsRepair = portallocatorcontroller.NewRepair(c.Services.IPRepairInterval, client.CoreV1(), client.EventsV1(), c.Services.NodePortRange, rangeRegistries.nodePort).RunUntil
+	p.startServiceNodePortsRepair = portallocatorcontroller.NewRepair(c.Services.IPRepairInterval, client.CoreV1(), c.Informers.Core().V1().Services(), client.EventsV1(), c.Services.NodePortRange, rangeRegistries.nodePort).RunUntil
 
 	// create service cluster ip repair controller
 	if !utilfeature.DefaultFeatureGate.Enabled(features.MultiCIDRServiceAllocator) {
@@ -519,11 +520,18 @@ func (p *legacyProvider) PostStartHook() (string, genericapiserver.PostStartHook
 		// Additionally, we ensure that we don't wait for it for longer
 		// than 1 minute for backward compatibility of failing the whole
 		// apiserver if we can't repair them.
+		const startupTimeout = time.Minute
+		startupTimer := time.NewTimer(startupTimeout)
+		defer startupTimer.Stop()
+		// Reserve half the startup window for completing the repair after a
+		// freshness timeout. This deadline also includes time spent syncing the
+		// informer and reading allocations; retries must not extend it.
+		serviceCacheDeadline := time.Now().Add(startupTimeout / 2)
 		wg := sync.WaitGroup{}
 		wg.Add(2)
 		runner := async.NewRunner(
 			func(stopCh chan struct{}) { p.startServiceClusterIPRepair(wg.Done, stopCh) },
-			func(stopCh chan struct{}) { p.startServiceNodePortsRepair(wg.Done, stopCh) },
+			func(stopCh chan struct{}) { p.startServiceNodePortsRepair(wg.Done, stopCh, serviceCacheDeadline) },
 		)
 		runner.Start()
 		go func() {
@@ -545,7 +553,7 @@ func (p *legacyProvider) PostStartHook() (string, genericapiserver.PostStartHook
 		case <-context.Done():
 			return goerrors.New("unable to perform initial IP and Port allocation check (context cancelled)")
 
-		case <-time.After(time.Minute):
+		case <-startupTimer.C:
 			return goerrors.New("unable to perform initial IP and Port allocation check (timeout)")
 		}
 

--- a/pkg/registry/core/service/portallocator/controller/metrics.go
+++ b/pkg/registry/core/service/portallocator/controller/metrics.go
@@ -53,6 +53,19 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
+	// nodePortRepairLeakCleanupDeferred indicates the number of repair loop runs that kept
+	// apparently leaked ports allocated because the Service informer could not be proven
+	// to be up to date with storage, broken down by reason: stale, error.
+	nodePortRepairLeakCleanupDeferred = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "leak_cleanup_deferred_total",
+			Help:           "Number of repair loop runs that deferred leaked port cleanup because the Service informer was not proven up to date, broken down by reason: stale, error",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"reason"},
+	)
 )
 
 var registerMetricsOnce sync.Once
@@ -61,5 +74,6 @@ func registerMetrics() {
 	registerMetricsOnce.Do(func() {
 		legacyregistry.MustRegister(nodePortRepairPortErrors)
 		legacyregistry.MustRegister(nodePortRepairReconcileErrors)
+		legacyregistry.MustRegister(nodePortRepairLeakCleanupDeferred)
 	})
 }

--- a/pkg/registry/core/service/portallocator/controller/repair.go
+++ b/pkg/registry/core/service/portallocator/controller/repair.go
@@ -25,12 +25,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	eventsv1client "k8s.io/client-go/kubernetes/typed/events/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
@@ -41,11 +46,16 @@ import (
 
 // See ipallocator/controller/repair.go; this is a copy for ports.
 type Repair struct {
-	interval      time.Duration
-	serviceClient corev1client.ServicesGetter
-	portRange     net.PortRange
-	alloc         rangeallocation.RangeRegistry
-	leaks         map[int]int // counter per leaked port
+	interval       time.Duration
+	serviceClient  corev1client.ServicesGetter
+	serviceLister  corelisters.ServiceLister
+	serviceStore   cache.Store
+	servicesSynced cache.InformerSynced
+	portRange      net.PortRange
+	alloc          rangeallocation.RangeRegistry
+	leaks          map[int]int // counter per leaked port
+
+	serviceCacheDeadline time.Time
 
 	broadcaster events.EventBroadcaster
 	recorder    events.EventRecorder
@@ -57,42 +67,59 @@ const numRepairsBeforeLeakCleanup = 3
 
 // NewRepair creates a controller that periodically ensures that all ports are uniquely allocated across the cluster
 // and generates informational warnings for a cluster that is not in sync.
-func NewRepair(interval time.Duration, serviceClient corev1client.ServicesGetter, eventClient eventsv1client.EventsV1Interface, portRange net.PortRange, alloc rangeallocation.RangeRegistry) *Repair {
+// Services are read from the informer; serviceClient is used to check the
+// collection's resource version, or to list Services when the informer store
+// does not track its resource version.
+func NewRepair(interval time.Duration, serviceClient corev1client.ServicesGetter, serviceInformer coreinformers.ServiceInformer, eventClient eventsv1client.EventsV1Interface, portRange net.PortRange, alloc rangeallocation.RangeRegistry) *Repair {
 	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: eventClient})
 	recorder := eventBroadcaster.NewRecorder(legacyscheme.Scheme, "portallocator-repair-controller")
 
 	registerMetrics()
 
 	return &Repair{
-		interval:      interval,
-		serviceClient: serviceClient,
-		portRange:     portRange,
-		alloc:         alloc,
-		leaks:         map[int]int{},
-		broadcaster:   eventBroadcaster,
-		recorder:      recorder,
+		interval:       interval,
+		serviceClient:  serviceClient,
+		serviceLister:  serviceInformer.Lister(),
+		serviceStore:   serviceInformer.Informer().GetStore(),
+		servicesSynced: serviceInformer.Informer().HasSynced,
+		portRange:      portRange,
+		alloc:          alloc,
+		leaks:          map[int]int{},
+		broadcaster:    eventBroadcaster,
+		recorder:       recorder,
 	}
 }
 
-// RunUntil starts the controller until the provided ch is closed.
-func (c *Repair) RunUntil(onFirstSuccess func(), stopCh chan struct{}) {
+// RunUntil starts the controller until stopCh is closed. initialServiceCacheDeadline
+// limits freshness checks until the first successful repair, so waiting for the
+// informer does not consume the caller's entire startup budget.
+func (c *Repair) RunUntil(onFirstSuccess func(), stopCh chan struct{}, initialServiceCacheDeadline time.Time) {
+	c.serviceCacheDeadline = initialServiceCacheDeadline
 	c.broadcaster.StartRecordingToSink(stopCh)
 	defer c.broadcaster.Shutdown()
 
+	if !cache.WaitForNamedCacheSync("portallocator-repair-controller", stopCh, c.servicesSynced) {
+		return
+	}
+
+	ctx := wait.ContextForChannel(stopCh)
 	var once sync.Once
 	wait.Until(func() {
-		if err := c.runOnce(); err != nil {
+		if err := c.runOnce(ctx); err != nil {
 			runtime.HandleError(err)
 			return
 		}
-		once.Do(onFirstSuccess)
+		once.Do(func() {
+			c.serviceCacheDeadline = time.Time{}
+			onFirstSuccess()
+		})
 	}, c.interval, stopCh)
 }
 
 // runOnce verifies the state of the port allocations and returns an error if an unrecoverable problem occurs.
-func (c *Repair) runOnce() error {
+func (c *Repair) runOnce(ctx context.Context) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		err := c.doRunOnce()
+		err := c.doRunOnce(ctx)
 		if err != nil {
 			nodePortRepairReconcileErrors.Inc()
 		}
@@ -101,7 +128,7 @@ func (c *Repair) runOnce() error {
 }
 
 // doRunOnce verifies the state of the port allocations and returns an error if an unrecoverable problem occurs.
-func (c *Repair) doRunOnce() error {
+func (c *Repair) doRunOnce(ctx context.Context) error {
 	// TODO: (per smarterclayton) if Get() or ListServices() is a weak consistency read,
 	// or if they are executed against different leaders,
 	// the ordering guarantee required to ensure no port is allocated twice is violated.
@@ -113,7 +140,7 @@ func (c *Repair) doRunOnce() error {
 	// important when we start apiserver and etcd at the same time.
 	var snapshot *api.RangeAllocation
 	var err error
-	err = wait.PollUntilContextTimeout(context.Background(), time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		snapshot, err = c.alloc.Get()
 		if err != nil {
 			runtime.HandleError(fmt.Errorf("unable to refresh the port allocations: %w", err))
@@ -134,14 +161,41 @@ func (c *Repair) doRunOnce() error {
 		return fmt.Errorf("unable to rebuild allocator from snapshot: %v", err)
 	}
 
-	// We explicitly send no resource version, since the resource version
-	// of 'snapshot' is from a different collection, it's not comparable to
-	// the service collection. The caching layer keeps per-collection RVs,
-	// and this is proper, since in theory the collections could be hosted
-	// in separate etcd (or even non-etcd) instances.
-	list, err := c.serviceClient.Services(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("unable to refresh the port block: %v", err)
+	// Before releasing unused ports, check that the informer has observed the
+	// Services in storage. The allocation snapshot's resource version cannot
+	// be used for this check because it belongs to a different collection.
+	var list []*corev1.Service
+	complete := true
+	cacheRV := c.serviceStore.LastStoreSyncResourceVersion()
+	if cacheRV == "" {
+		// Without AtomicFIFO, the store does not track its resource version,
+		// so read Services directly to safely detect unused ports.
+		svcList, err := c.serviceClient.Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to refresh the port block: %w", err)
+		}
+		for i := range svcList.Items {
+			list = append(list, &svcList.Items[i])
+		}
+	} else {
+		// Bound periodic freshness checks by the repair interval. During startup,
+		// also honor the caller's deadline, shared across cache sync and retries,
+		// to leave time for persisting allocations and reporting first success.
+		deadline := time.Now().Add(c.interval)
+		if !c.serviceCacheDeadline.IsZero() && c.serviceCacheDeadline.Before(deadline) {
+			deadline = c.serviceCacheDeadline
+		}
+		readCtx, cancel := context.WithDeadline(ctx, deadline)
+		complete = c.serviceCacheIsFresh(readCtx)
+		cancel()
+		list, err = c.serviceLister.List(labels.Everything())
+		if err != nil {
+			return fmt.Errorf("unable to refresh the port block: %w", err)
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	rebuilt, err := portallocator.NewInMemory(c.portRange)
@@ -149,8 +203,7 @@ func (c *Repair) doRunOnce() error {
 		return fmt.Errorf("unable to create port allocator: %v", err)
 	}
 	// Check every Service's ports, and rebuild the state as we think it should be.
-	for i := range list.Items {
-		svc := &list.Items[i]
+	for _, svc := range list {
 		ports := collectServiceNodePorts(svc)
 		if len(ports) == 0 {
 			continue
@@ -194,6 +247,14 @@ func (c *Repair) doRunOnce() error {
 
 	// Check for ports that are left in the old set.  They appear to have been leaked.
 	stored.ForEach(func(port int) {
+		if !complete {
+			// If the informer is stale, these ports may still be in use. Keep
+			// them allocated and do not advance their leak cleanup counters.
+			if err := rebuilt.Allocate(port); err != nil {
+				runtime.HandleError(fmt.Errorf("the node port %d may have leaked, but can not be allocated: %w", port, err))
+			}
+			return
+		}
 		count, found := c.leaks[port]
 		switch {
 		case !found:
@@ -227,6 +288,35 @@ func (c *Repair) doRunOnce() error {
 		return fmt.Errorf("unable to persist the updated port allocations: %v", err)
 	}
 	return nil
+}
+
+// serviceCacheIsFresh gets the current Service collection resource version from
+// a live LIST and waits for the informer store to reach it. It returns false if
+// the request or comparison fails, or the context is canceled before the store
+// catches up. The caller must read the allocation snapshot before this check
+// and list Services from the informer afterwards to avoid releasing ports whose
+// Services have not reached the cache yet.
+func (c *Repair) serviceCacheIsFresh(ctx context.Context) bool {
+	live, err := c.serviceClient.Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{Limit: 1})
+	if err != nil {
+		nodePortRepairLeakCleanupDeferred.WithLabelValues("error").Inc()
+		runtime.HandleError(fmt.Errorf("unable to read the current services resource version, deferring leak cleanup: %w", err))
+		return false
+	}
+	err = wait.PollUntilContextCancel(ctx, 10*time.Millisecond, true, func(context.Context) (bool, error) {
+		cmp, err := resourceversion.CompareResourceVersion(c.serviceStore.LastStoreSyncResourceVersion(), live.ResourceVersion)
+		return cmp >= 0, err
+	})
+	if err != nil {
+		reason := "error"
+		if ctx.Err() != nil {
+			reason = "stale"
+		}
+		nodePortRepairLeakCleanupDeferred.WithLabelValues(reason).Inc()
+		runtime.HandleError(fmt.Errorf("service informer did not reach resource version %s (cache at %s), deferring leak cleanup: %w", live.ResourceVersion, c.serviceStore.LastStoreSyncResourceVersion(), err))
+		return false
+	}
+	return true
 }
 
 // collectServiceNodePorts returns nodePorts specified in the Service.

--- a/pkg/registry/core/service/portallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/portallocator/controller/repair_test.go
@@ -17,16 +17,30 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/component-base/metrics/testutil"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/core/service/portallocator"
@@ -40,6 +54,7 @@ type mockRangeRegistry struct {
 	updateCalled bool
 	updated      *api.RangeAllocation
 	updateErr    error
+	updateErrors []error
 }
 
 func (r *mockRangeRegistry) Get() (*api.RangeAllocation, error) {
@@ -50,7 +65,108 @@ func (r *mockRangeRegistry) Get() (*api.RangeAllocation, error) {
 func (r *mockRangeRegistry) CreateOrUpdate(alloc *api.RangeAllocation) error {
 	r.updateCalled = true
 	r.updated = alloc
+	if len(r.updateErrors) > 0 {
+		err := r.updateErrors[0]
+		r.updateErrors = r.updateErrors[1:]
+		return err
+	}
 	return r.updateErr
+}
+
+func newTestRepair(t *testing.T, fakeClient *fake.Clientset, portRange net.PortRange, registry *mockRangeRegistry) *testRepair {
+	t.Helper()
+
+	// The fake tracker never stamps resource versions on objects, so the
+	// informer's own store RV is not meaningful here. Both sides of the
+	// freshness comparison are driven explicitly by the test instead.
+	tr := &testRepair{
+		cacheRV: &testRV{rv: "10"},
+		liveRV:  &testRV{rv: "10"},
+	}
+	defaultReaction := clienttesting.ObjectReaction(fakeClient.Tracker())
+	fakeClient.PrependReactor("list", "services", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if err := tr.liveRV.getErr(); err != nil {
+			return true, nil, err
+		}
+		handled, obj, err := defaultReaction(action)
+		if list, ok := obj.(*corev1.ServiceList); ok && err == nil {
+			list.ResourceVersion = tr.liveRV.get()
+			// Only the freshness probe uses Limit=1; every other list reads storage.
+			if action.(clienttesting.ListActionImpl).GetListOptions().Limit != 1 {
+				list.Items = append(list.Items, tr.storageOnly()...)
+			}
+		}
+		return handled, obj, err
+	})
+
+	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
+	serviceInformer := informerFactory.Core().V1().Services()
+	tr.Repair = NewRepair(100*time.Millisecond, fakeClient.CoreV1(), serviceInformer, fakeClient.EventsV1(), portRange, registry)
+	tr.Repair.serviceStore = &cache.FakeCustomStore{LastStoreSyncResourceVersionFunc: tr.cacheRV.get}
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	informerFactory.Start(stopCh)
+	if !cache.WaitForCacheSync(stopCh, tr.servicesSynced) {
+		t.Fatal("failed to sync Service informer cache")
+	}
+
+	return tr
+}
+
+// testRepair exposes the two resource versions the freshness check compares:
+// cacheRV is what the informer store reports, liveRV is what a LIST returns.
+// Services added with addToStorageOnly are returned by LISTs against storage
+// but never reach the informer, standing in for a lagging cache.
+type testRepair struct {
+	*Repair
+	cacheRV *testRV
+	liveRV  *testRV
+
+	mu          sync.Mutex
+	storageSvcs []corev1.Service
+}
+
+func (r *testRepair) addToStorageOnly(svc corev1.Service) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.storageSvcs = append(r.storageSvcs, svc)
+}
+
+func (r *testRepair) storageOnly() []corev1.Service {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]corev1.Service(nil), r.storageSvcs...)
+}
+
+type testRV struct {
+	mu  sync.Mutex
+	rv  string
+	err error
+}
+
+func (r *testRV) set(rv string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.rv = rv
+}
+
+func (r *testRV) setErr(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.err = err
+}
+
+func (r *testRV) get() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.rv
+}
+
+func (r *testRV) getErr() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
 }
 
 func TestRepair(t *testing.T) {
@@ -60,9 +176,9 @@ func TestRepair(t *testing.T) {
 		item: &api.RangeAllocation{Range: "100-200"},
 	}
 	pr, _ := net.ParsePortRange(registry.item.Range)
-	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), *pr, registry)
+	r := newTestRepair(t, fakeClient, *pr, registry)
 
-	if err := r.runOnce(); err != nil {
+	if err := r.runOnce(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if !registry.updateCalled || registry.updated == nil || registry.updated.Range != pr.String() || registry.updated != registry.item {
@@ -80,8 +196,8 @@ func TestRepair(t *testing.T) {
 		item:      &api.RangeAllocation{Range: "100-200"},
 		updateErr: fmt.Errorf("test error"),
 	}
-	r = NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), *pr, registry)
-	if err := r.runOnce(); !strings.Contains(err.Error(), ": test error") {
+	r = newTestRepair(t, fakeClient, *pr, registry)
+	if err := r.runOnce(context.Background()); !strings.Contains(err.Error(), ": test error") {
 		t.Fatal(err)
 	}
 	repairErrors, err = testutil.GetCounterMetricValue(nodePortRepairReconcileErrors)
@@ -120,10 +236,10 @@ func TestRepairLeak(t *testing.T) {
 		},
 	}
 
-	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), *pr, registry)
+	r := newTestRepair(t, fakeClient, *pr, registry)
 	// Run through the "leak detection holdoff" loops.
 	for i := 0; i < (numRepairsBeforeLeakCleanup - 1); i++ {
-		if err := r.runOnce(); err != nil {
+		if err := r.runOnce(context.Background()); err != nil {
 			t.Fatal(err)
 		}
 		after, err := portallocator.NewFromSnapshot(registry.updated)
@@ -135,7 +251,7 @@ func TestRepairLeak(t *testing.T) {
 		}
 	}
 	// Run one more time to actually remove the leak.
-	if err := r.runOnce(); err != nil {
+	if err := r.runOnce(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	after, err := portallocator.NewFromSnapshot(registry.updated)
@@ -153,6 +269,215 @@ func TestRepairLeak(t *testing.T) {
 		unknown:    0,
 	}
 	expectMetrics(t, em)
+}
+
+// leakedRegistry returns a registry whose stored bitmap has the given ports
+// allocated, with no Service referencing them.
+func leakedRegistry(t *testing.T, pr net.PortRange, ports ...int) *mockRangeRegistry {
+	t.Helper()
+	previous, err := portallocator.NewInMemory(pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, port := range ports {
+		if err := previous.Allocate(port); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var dst api.RangeAllocation
+	if err := previous.Snapshot(&dst); err != nil {
+		t.Fatal(err)
+	}
+	return &mockRangeRegistry{
+		item: &api.RangeAllocation{
+			ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"},
+			Range:      dst.Range,
+			Data:       dst.Data,
+		},
+	}
+}
+
+func updatedHas(t *testing.T, registry *mockRangeRegistry, port int) bool {
+	t.Helper()
+	after, err := portallocator.NewFromSnapshot(registry.updated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return after.Has(port)
+}
+
+func expectDeferred(t *testing.T, reason string, want float64) {
+	t.Helper()
+	got, err := testutil.GetCounterMetricValue(nodePortRepairLeakCleanupDeferred.WithLabelValues(reason))
+	if err != nil {
+		t.Fatalf("failed to get %s value: %v", nodePortRepairLeakCleanupDeferred.Name, err)
+	}
+	if got != want {
+		t.Fatalf("expected %s{reason=%q} == %v, got %v", nodePortRepairLeakCleanupDeferred.Name, reason, want, got)
+	}
+}
+
+// A port with no Service in the informer is only released once the informer
+// is proven to have caught up with storage; until then the run still succeeds
+// but the leak countdown must not even start.
+func TestRepairLeakDeferredUntilCacheFresh(t *testing.T) {
+	pr, _ := net.ParsePortRange("100-200")
+	runs := numRepairsBeforeLeakCleanup + 1
+
+	testCases := []struct {
+		name   string
+		reason string
+		setup  func(r *testRepair)
+	}{
+		{
+			name:   "informer behind storage",
+			reason: "stale",
+			setup: func(r *testRepair) {
+				r.cacheRV.set("10")
+				r.liveRV.set("20")
+			},
+		},
+		{
+			name:   "live read fails",
+			reason: "error",
+			setup:  func(r *testRepair) { r.liveRV.setErr(fmt.Errorf("storage is (re)initializing")) },
+		},
+		{
+			name:   "resource versions are not comparable",
+			reason: "error",
+			setup:  func(r *testRepair) { r.cacheRV.set("not-a-number") },
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearMetrics()
+			registry := leakedRegistry(t, *pr, 111)
+			r := newTestRepair(t, fake.NewSimpleClientset(), *pr, registry)
+			tc.setup(r)
+
+			for i := range runs {
+				if err := r.runOnce(context.Background()); err != nil {
+					t.Fatalf("run %d: %v", i, err)
+				}
+				if !updatedHas(t, registry, 111) {
+					t.Fatalf("run %d: port released while the informer was not proven fresh", i)
+				}
+				if len(r.leaks) != 0 {
+					t.Fatalf("run %d: leak countdown started while the informer was not proven fresh: %v", i, r.leaks)
+				}
+			}
+			expectDeferred(t, tc.reason, float64(runs))
+			expectMetrics(t, testMetrics{})
+		})
+	}
+}
+
+// Once the informer catches up the normal holdoff applies from scratch: runs
+// spent stale must not have consumed any of it.
+func TestRepairLeakReleasedAfterCacheCatchesUp(t *testing.T) {
+	clearMetrics()
+	pr, _ := net.ParsePortRange("100-200")
+	registry := leakedRegistry(t, *pr, 111)
+	r := newTestRepair(t, fake.NewSimpleClientset(), *pr, registry)
+
+	r.cacheRV.set("10")
+	r.liveRV.set("20")
+	for range numRepairsBeforeLeakCleanup + 1 {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if !updatedHas(t, registry, 111) {
+		t.Fatal("port released while stale")
+	}
+
+	r.cacheRV.set("20")
+	for i := range numRepairsBeforeLeakCleanup - 1 {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		if !updatedHas(t, registry, 111) {
+			t.Fatalf("fresh run %d: port released before the holdoff expired", i)
+		}
+	}
+	if err := r.runOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if updatedHas(t, registry, 111) {
+		t.Fatal("port still allocated after the holdoff expired on a fresh informer")
+	}
+	expectDeferred(t, "stale", float64(numRepairsBeforeLeakCleanup+1))
+	expectMetrics(t, testMetrics{leak: 1})
+}
+
+// Staleness only gates releasing ports; repairing missing allocations for
+// Services the informer does see must proceed regardless.
+func TestRepairStaleCacheStillRepairsAllocations(t *testing.T) {
+	clearMetrics()
+	pr, _ := net.ParsePortRange("100-200")
+	registry := leakedRegistry(t, *pr, 122)
+	fakeClient := fake.NewSimpleClientset(&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "one"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{NodePort: 111}}},
+	})
+	r := newTestRepair(t, fakeClient, *pr, registry)
+	r.cacheRV.set("10")
+	r.liveRV.set("20")
+
+	if err := r.runOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !updatedHas(t, registry, 111) {
+		t.Error("missing allocation for a visible Service was not repaired")
+	}
+	if !updatedHas(t, registry, 122) {
+		t.Error("apparently leaked port released while stale")
+	}
+	expectDeferred(t, "stale", 1)
+	expectMetrics(t, testMetrics{repair: 1})
+}
+
+// Without a store resource version (client-go AtomicFIFO disabled) staleness
+// cannot be measured, so the loop lists storage as before and never consults
+// the informer: a Service the informer never saw is still repaired, and a
+// genuine leak is still released after the usual holdoff.
+func TestRepairWithoutStoreResourceVersionReadsStorage(t *testing.T) {
+	clearMetrics()
+	pr, _ := net.ParsePortRange("100-200")
+	registry := leakedRegistry(t, *pr, 122)
+	r := newTestRepair(t, fake.NewSimpleClientset(), *pr, registry)
+	r.cacheRV.set("")
+	r.addToStorageOnly(corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "one"},
+		Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{NodePort: 111}}},
+	})
+
+	for i := range numRepairsBeforeLeakCleanup - 1 {
+		if err := r.runOnce(context.Background()); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+		if !updatedHas(t, registry, 111) {
+			t.Fatalf("run %d: Service present only in storage was not repaired; lister used instead of storage", i)
+		}
+		if !updatedHas(t, registry, 122) {
+			t.Fatalf("run %d: leaked port released before the holdoff expired", i)
+		}
+	}
+	if err := r.runOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !updatedHas(t, registry, 111) {
+		t.Error("Service present only in storage was not repaired; lister used instead of storage")
+	}
+	if updatedHas(t, registry, 122) {
+		t.Error("leaked port still allocated after the holdoff expired")
+	}
+	for _, reason := range []string{"stale", "error"} {
+		expectDeferred(t, reason, 0)
+	}
+	// The mock registry returns the snapshot the loop writes into, so the
+	// repaired port is already stored on the following runs.
+	expectMetrics(t, testMetrics{repair: 1, leak: 1})
 }
 
 func TestRepairWithExisting(t *testing.T) {
@@ -217,8 +542,8 @@ func TestRepairWithExisting(t *testing.T) {
 			Data:  dst.Data,
 		},
 	}
-	r := NewRepair(0, fakeClient.CoreV1(), fakeClient.EventsV1(), *pr, registry)
-	if err := r.runOnce(); err != nil {
+	r := newTestRepair(t, fakeClient, *pr, registry)
+	if err := r.runOnce(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	after, err := portallocator.NewFromSnapshot(registry.updated)
@@ -343,6 +668,7 @@ func TestCollectServiceNodePorts(t *testing.T) {
 func clearMetrics() {
 	nodePortRepairPortErrors.Reset()
 	nodePortRepairReconcileErrors.Reset()
+	nodePortRepairLeakCleanupDeferred.Reset()
 }
 
 type testMetrics struct {
@@ -384,5 +710,205 @@ func expectMetrics(t *testing.T, em testMetrics) {
 	}
 	if m != em {
 		t.Fatalf("metrics error: expected %v, received %v", em, m)
+	}
+}
+
+// A fixed barrier must remain attainable when writes continue after the probe.
+func TestRepairCacheCatchesUpDuringRun(t *testing.T) {
+	clearMetrics()
+	pr, _ := net.ParsePortRange("100-200")
+	registry := leakedRegistry(t, *pr, 111)
+	client := fake.NewSimpleClientset()
+	r := newTestRepair(t, client, *pr, registry)
+	r.cacheRV.set("10")
+	r.liveRV.set("20")
+	probed := make(chan struct{})
+	client.PrependReactor("list", "services", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		if action.(clienttesting.ListActionImpl).GetListOptions().Limit != 1 {
+			return false, nil, nil
+		}
+		close(probed)
+		return true, &corev1.ServiceList{ListMeta: metav1.ListMeta{ResourceVersion: "20"}}, nil
+	})
+	done := make(chan error, 1)
+	go func() { done <- r.runOnce(context.Background()) }()
+	select {
+	case <-probed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("repair did not probe the Service collection")
+	}
+	// Storage moves ahead, but the cache need only reach the captured barrier.
+	r.liveRV.set("30")
+	r.cacheRV.set("20")
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("repair did not finish after the cache reached the barrier")
+	}
+	if _, found := r.leaks[111]; !found {
+		t.Fatal("fresh cache did not advance leak detection")
+	}
+	expectDeferred(t, "stale", 0)
+}
+
+// A stalled freshness request must not block periodic repairs indefinitely.
+func TestRepairWithStalledFreshnessRequest(t *testing.T) {
+	clearMetrics()
+	pr, _ := net.ParsePortRange("100-200")
+	registry := leakedRegistry(t, *pr, 111)
+	r := newTestRepair(t, fake.NewSimpleClientset(), *pr, registry)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	defer server.Close()
+	client, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.serviceClient = client.CoreV1()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := r.runOnce(ctx); err != nil {
+		t.Fatalf("repair did not finish within one repair interval: %v", err)
+	}
+	if !updatedHas(t, registry, 111) {
+		t.Fatal("stalled freshness check released a port")
+	}
+	if len(r.leaks) != 0 {
+		t.Fatal("stalled freshness check advanced leak detection")
+	}
+	expectDeferred(t, "error", 1)
+}
+
+func TestRepairStaleCachePreservesLeakCountdown(t *testing.T) {
+	clearMetrics()
+	pr, _ := net.ParsePortRange("100-200")
+	registry := leakedRegistry(t, *pr, 111)
+	r := newTestRepair(t, fake.NewSimpleClientset(), *pr, registry)
+	if err := r.runOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	remaining := r.leaks[111]
+	r.liveRV.set("20")
+	if err := r.runOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !updatedHas(t, registry, 111) || r.leaks[111] != remaining {
+		t.Fatal("stale cache released a port or changed its existing leak countdown")
+	}
+}
+
+func TestRepairCanceledWhileCacheIsStale(t *testing.T) {
+	clearMetrics()
+	pr, _ := net.ParsePortRange("100-200")
+	registry := leakedRegistry(t, *pr, 111)
+	client := fake.NewSimpleClientset()
+	r := newTestRepair(t, client, *pr, registry)
+	r.interval = time.Hour
+	r.liveRV.set("20")
+	probed := make(chan struct{})
+	client.PrependReactor("list", "services", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		close(probed)
+		return false, nil, nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- r.runOnce(ctx) }()
+	select {
+	case <-probed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("repair did not probe the Service collection")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("repair did not stop after context cancellation")
+	}
+	if registry.updateCalled || len(r.leaks) != 0 {
+		t.Fatal("canceled repair changed allocations or leak cleanup counters")
+	}
+}
+
+// Freshness failures must not prevent the first repair from using the informer
+// and reporting success within the caller's startup window.
+func TestRepairFirstSuccessWithUnavailableFreshness(t *testing.T) {
+	for _, scenario := range []string{"stale cache", "request fails", "request stalls", "cache sync uses freshness budget", "conflict retry"} {
+		t.Run(scenario, func(t *testing.T) {
+			clearMetrics()
+			pr, _ := net.ParsePortRange("100-200")
+			registry := leakedRegistry(t, *pr, 122)
+			fakeClient := fake.NewSimpleClientset(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "one", Name: "one"},
+				Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{NodePort: 111}}},
+			})
+			r := newTestRepair(t, fakeClient, *pr, registry)
+			r.interval = time.Hour
+			r.leaks[122] = 1
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.URL.Query().Get("limit") != "1" {
+					t.Error("initial repair issued a full Service LIST instead of using the informer")
+					http.Error(w, "full LIST is unavailable", http.StatusTooManyRequests)
+					return
+				}
+				switch scenario {
+				case "request fails":
+					http.Error(w, "Service storage unavailable", http.StatusServiceUnavailable)
+				case "request stalls":
+					<-req.Context().Done()
+				default:
+					w.Header().Set("Content-Type", "application/json")
+					// The freshness deadline may cancel the request during the write.
+					_, _ = fmt.Fprint(w, `{"apiVersion":"v1","kind":"ServiceList","metadata":{"resourceVersion":"20"},"items":[]}`)
+				}
+			}))
+			defer server.Close()
+			client, err := kubernetes.NewForConfig(&rest.Config{Host: server.URL})
+			if err != nil {
+				t.Fatal(err)
+			}
+			r.serviceClient = client.CoreV1()
+			deadline := time.Now().Add(100 * time.Millisecond)
+			if scenario == "cache sync uses freshness budget" {
+				r.servicesSynced = func() bool { return time.Now().After(deadline) }
+			}
+			if scenario == "conflict retry" {
+				registry.updateErrors = []error{apierrors.NewConflict(schema.GroupResource{Resource: "servicenodeportallocations"}, "nodeports", fmt.Errorf("allocation changed"))}
+			}
+			func() {
+				stop := make(chan struct{})
+				done := make(chan struct{})
+				success := make(chan struct{})
+				go func() {
+					defer close(done)
+					r.RunUntil(func() { close(success) }, stop, deadline)
+				}()
+				defer func() { close(stop); <-done }()
+				select {
+				case <-success:
+				case <-time.After(5 * time.Second):
+					t.Fatal("initial repair did not finish after the freshness deadline")
+				}
+			}()
+			if !updatedHas(t, registry, 111) {
+				t.Fatal("initial repair did not allocate the port of a Service visible in the informer")
+			}
+			if !updatedHas(t, registry, 122) || r.leaks[122] != 1 {
+				t.Fatal("initial repair released a port or advanced leak cleanup without a fresh cache")
+			}
+			if !r.serviceCacheDeadline.IsZero() {
+				t.Fatal("successful initial repair retained the startup freshness deadline")
+			}
+			if len(registry.updateErrors) != 0 {
+				t.Fatal("initial repair did not attempt to persist allocations")
+			}
+		})
 	}
 }

--- a/test/integration/network/services_resourceversion_test.go
+++ b/test/integration/network/services_resourceversion_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/resourceversion"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientfeatures "k8s.io/client-go/features"
+	clientfeaturestesting "k8s.io/client-go/features/testing"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+// TestServiceListResourceVersionContract pins the two properties the NodePort
+// repair loop relies on before it releases a port that no Service in its
+// informer references:
+//
+//  1. A LIST of Services with resourceVersion="" returns a collection
+//     resourceVersion at least as new as every Service write that completed
+//     before the request, even when Limit truncates the response to one item.
+//  2. Once the informer store's LastStoreSyncResourceVersion is at least that
+//     resourceVersion, the lister reflects every such write: created Services
+//     are present and deleted Services are gone.
+//
+// The watch cache computes the collection resourceVersion differently from
+// the etcd path, so both are exercised.
+func TestServiceListResourceVersionContract(t *testing.T) {
+	// LastStoreSyncResourceVersion is only reported with AtomicFIFO on.
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.AtomicFIFO, true)
+
+	testcases := []struct {
+		name   string
+		create int
+		delete int
+		limit  int64
+	}{
+		{name: "single-service", create: 1, limit: 1},
+		{name: "burst-larger-than-page", create: 25, limit: 1},
+		{name: "unpaginated", create: 5, limit: 0},
+		{name: "deletes", create: 6, delete: 4, limit: 1},
+	}
+
+	for _, watchCache := range []bool{true, false} {
+		t.Run(fmt.Sprintf("watchCache=%t", watchCache), func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			client, _, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{
+				ModifyServerRunOptions: func(opts *options.ServerRunOptions) {
+					opts.Etcd.EnableWatchCache = watchCache
+				},
+			})
+			defer tearDownFn()
+
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			serviceInformer := informerFactory.Core().V1().Services()
+			store := serviceInformer.Informer().GetStore()
+			lister := serviceInformer.Lister()
+			informerFactory.Start(tCtx.Done())
+			if !cache.WaitForCacheSync(tCtx.Done(), serviceInformer.Informer().HasSynced) {
+				t.Fatal("failed to sync Service informer")
+			}
+			if store.LastStoreSyncResourceVersion() == "" {
+				t.Fatal("informer store reports no resource version after sync")
+			}
+
+			for _, tc := range testcases {
+				t.Run(tc.name, func(t *testing.T) {
+					ns := framework.CreateNamespaceOrDie(client, "svc-rv-"+tc.name, t)
+					defer framework.DeleteNamespaceOrDie(client, ns, t)
+
+					var maxWriteRV string
+					created := make([]string, 0, tc.create)
+					for i := 0; i < tc.create; i++ {
+						svc, err := client.CoreV1().Services(ns.Name).Create(tCtx, newClusterIPService(fmt.Sprintf("svc-%d", i)), metav1.CreateOptions{})
+						if err != nil {
+							t.Fatalf("failed to create service: %v", err)
+						}
+						created = append(created, svc.Name)
+						maxWriteRV = maxResourceVersion(t, maxWriteRV, svc.ResourceVersion)
+					}
+					deleted := created[:tc.delete]
+					remaining := created[tc.delete:]
+					for _, name := range deleted {
+						if err := client.CoreV1().Services(ns.Name).Delete(tCtx, name, metav1.DeleteOptions{}); err != nil {
+							t.Fatalf("failed to delete service %s: %v", name, err)
+						}
+					}
+
+					// Every write above completed before this request was issued.
+					list, err := client.CoreV1().Services(metav1.NamespaceAll).List(tCtx, metav1.ListOptions{Limit: tc.limit})
+					if err != nil {
+						t.Fatalf("failed to list services: %v", err)
+					}
+					if tc.limit > 0 && int64(len(list.Items)) > tc.limit {
+						t.Fatalf("expected at most %d items, got %d", tc.limit, len(list.Items))
+					}
+					if cmp := compareResourceVersion(t, list.ResourceVersion, maxWriteRV); cmp < 0 {
+						t.Fatalf("collection resourceVersion %s is older than a Service write %s that completed before the list", list.ResourceVersion, maxWriteRV)
+					}
+
+					// The store only advances on Service events or bookmarks; issue one
+					// more write so the test does not wait on the bookmark interval.
+					if _, err := client.CoreV1().Services(ns.Name).Create(tCtx, newClusterIPService("nudge"), metav1.CreateOptions{}); err != nil {
+						t.Fatalf("failed to create nudge service: %v", err)
+					}
+					if err := wait.PollUntilContextTimeout(tCtx, 50*time.Millisecond, wait.ForeverTestTimeout, true, func(context.Context) (bool, error) {
+						return compareResourceVersion(t, store.LastStoreSyncResourceVersion(), list.ResourceVersion) >= 0, nil
+					}); err != nil {
+						t.Fatalf("informer store never reached the collection resourceVersion %s (last seen %s): %v", list.ResourceVersion, store.LastStoreSyncResourceVersion(), err)
+					}
+
+					// The lister is now at least as new as the collection was, so it must
+					// reflect every write that completed before the list.
+					for _, name := range remaining {
+						if _, err := lister.Services(ns.Name).Get(name); err != nil {
+							t.Errorf("service %s/%s was created before the list but is missing from the lister at store resourceVersion %s: %v", ns.Name, name, store.LastStoreSyncResourceVersion(), err)
+						}
+					}
+					for _, name := range deleted {
+						if _, err := lister.Services(ns.Name).Get(name); !apierrors.IsNotFound(err) {
+							t.Errorf("service %s/%s was deleted before the list but is still in the lister at store resourceVersion %s (err=%v)", ns.Name, name, store.LastStoreSyncResourceVersion(), err)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func newClusterIPService(name string) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.ServiceSpec{
+			Type:  v1.ServiceTypeClusterIP,
+			Ports: []v1.ServicePort{{Port: 80}},
+		},
+	}
+}
+
+func compareResourceVersion(t *testing.T, a, b string) int {
+	t.Helper()
+	cmp, err := resourceversion.CompareResourceVersion(a, b)
+	if err != nil {
+		t.Fatalf("resource versions %q and %q are not comparable: %v", a, b, err)
+	}
+	return cmp
+}
+
+func maxResourceVersion(t *testing.T, current, candidate string) string {
+	t.Helper()
+	if current == "" || compareResourceVersion(t, candidate, current) > 0 {
+		return candidate
+	}
+	return current
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

During kube-apiserver startup, the NodePort allocation repair controller reads
the allocation snapshot and issues an unpaginated LIST request for all Services.
If the Services watch cache is still initializing, the request can return `TooManyRequests`.

The client retries may be exhausted before the cache is ready. The controller
then waits three minutes before retrying, while the post-start hook times out
after one minute.

Use the shared Service informer for the initial reconciliation. Wait for its
cache to sync, then read Services from the lister.


#### Which issue(s) this PR fixes:

Fixes #141220

#### Special notes for your reviewer:

none

#### Does this PR introduce a user-facing change?

```release-note
Fixed kube-apiserver startup failures caused by transient Service watch cache initialization errors during NodePort allocation repair.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
none
```
