### PR TITLE
kube-proxy: return 503 for healthcheck of deleted service

### DIFF
--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -388,44 +388,48 @@ func testHandlerWithHealth(hcs *server, nsn types.NamespacedName, status int, en
 	tHandler(hcs, nsn, status, endpoints, kubeProxyHealthy, t)
 }
 
+func assertHandlerResponse(handler http.Handler, nsn types.NamespacedName, status int, endpoints int, kubeProxyHealthy bool, t *testing.T) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, "/healthz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp := httptest.NewRecorder()
+
+	handler.ServeHTTP(resp, req)
+
+	if resp.Code != status {
+		t.Errorf("expected status code %v, got %v", status, resp.Code)
+	}
+	var payload hcPayload
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Service.Name != nsn.Name || payload.Service.Namespace != nsn.Namespace {
+		t.Errorf("expected payload name %q, got %v", nsn.String(), payload.Service)
+	}
+	if payload.LocalEndpoints != endpoints {
+		t.Errorf("expected %d endpoints, got %d", endpoints, payload.LocalEndpoints)
+	}
+	if payload.ServiceProxyHealthy != kubeProxyHealthy {
+		t.Errorf("expected %v kubeProxyHealthy, got %v", kubeProxyHealthy, payload.ServiceProxyHealthy)
+	}
+	if !cmp.Equal(resp.Header()["Content-Type"], []string{"application/json"}) {
+		t.Errorf("expected 'Content-Type: application/json' response header, got: %v", resp.Header()["Content-Type"])
+	}
+	if !cmp.Equal(resp.Header()["X-Content-Type-Options"], []string{"nosniff"}) {
+		t.Errorf("expected 'X-Content-Type-Options: nosniff' response header, got: %v", resp.Header()["X-Content-Type-Options"])
+	}
+	if !cmp.Equal(resp.Header()["X-Load-Balancing-Endpoint-Weight"], []string{strconv.Itoa(endpoints)}) {
+		t.Errorf("expected 'X-Load-Balancing-Endpoint-Weight: %d' response header, got: %v", endpoints, resp.Header()["X-Load-Balancing-Endpoint-Weight"])
+	}
+}
+
 func tHandler(hcs *server, nsn types.NamespacedName, status int, endpoints int, kubeProxyHealthy bool, t *testing.T) {
 	instance := hcs.services[nsn]
 	for _, h := range instance.httpServers {
-		handler := h.(*fakeHTTPServer).handler
-
-		req, err := http.NewRequest("GET", "/healthz", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp := httptest.NewRecorder()
-
-		handler.ServeHTTP(resp, req)
-
-		if resp.Code != status {
-			t.Errorf("expected status code %v, got %v", status, resp.Code)
-		}
-		var payload hcPayload
-		if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
-			t.Fatal(err)
-		}
-		if payload.Service.Name != nsn.Name || payload.Service.Namespace != nsn.Namespace {
-			t.Errorf("expected payload name %q, got %v", nsn.String(), payload.Service)
-		}
-		if payload.LocalEndpoints != endpoints {
-			t.Errorf("expected %d endpoints, got %d", endpoints, payload.LocalEndpoints)
-		}
-		if payload.ServiceProxyHealthy != kubeProxyHealthy {
-			t.Errorf("expected %v kubeProxyHealthy, got %v", kubeProxyHealthy, payload.ServiceProxyHealthy)
-		}
-		if !cmp.Equal(resp.Header()["Content-Type"], []string{"application/json"}) {
-			t.Errorf("expected 'Content-Type: application/json' respose header, got: %v", resp.Header()["Content-Type"])
-		}
-		if !cmp.Equal(resp.Header()["X-Content-Type-Options"], []string{"nosniff"}) {
-			t.Errorf("expected 'X-Content-Type-Options: nosniff' respose header, got: %v", resp.Header()["X-Content-Type-Options"])
-		}
-		if !cmp.Equal(resp.Header()["X-Load-Balancing-Endpoint-Weight"], []string{strconv.Itoa(endpoints)}) {
-			t.Errorf("expected 'X-Load-Balancing-Endpoint-Weight: %d' respose header, got: %v", endpoints, resp.Header()["X-Load-Balancing-Endpoint-Weight"])
-		}
+		assertHandlerResponse(h.(*fakeHTTPServer).handler, nsn, status, endpoints, kubeProxyHealthy, t)
 	}
 }
 
@@ -1011,4 +1015,41 @@ func TestServerWithSelectiveListeningAddress(t *testing.T) {
 	}
 	// test the handler
 	testHandler(hcs, nsn, http.StatusServiceUnavailable, 0, t)
+}
+
+func TestHealthcheckDeletedServiceResponse(t *testing.T) {
+	listener := newFakeListener()
+	httpFactory := newFakeHTTPServerFactory()
+	nodePortAddresses := proxyutil.NewNodePortAddresses(v1.IPv4Protocol, []string{})
+	proxyChecker := &fakeProxyHealthChecker{true}
+
+	hcsi := newServiceHealthServer("hostname", nil, listener, httpFactory, nodePortAddresses, proxyChecker, v1.IPv4Protocol)
+	hcs := hcsi.(*server)
+
+	nsn := mknsn("ns1", "svc")
+	if err := hcs.SyncServices(map[types.NamespacedName]uint16{nsn: 9376}); err != nil {
+		t.Fatal(err)
+	}
+	if err := hcs.SyncEndpoints(map[types.NamespacedName]int{nsn: 3}); err != nil {
+		t.Fatal(err)
+	}
+	testHandler(hcs, nsn, http.StatusOK, 3, t)
+
+	// An in-flight handler outlives the services map entry; a deleted service
+	// must return 503, not Go's implicit 200 OK.
+	var orphanedHandler http.Handler
+	for _, h := range hcs.services[nsn].httpServers {
+		orphanedHandler = h.(*fakeHTTPServer).handler
+	}
+	if orphanedHandler == nil {
+		t.Fatal("expected non-nil handler before deletion")
+	}
+
+	if err := hcs.SyncServices(nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(hcs.services) != 0 {
+		t.Errorf("expected 0 services after deletion, got %d", len(hcs.services))
+	}
+	assertHandlerResponse(orphanedHandler, nsn, http.StatusServiceUnavailable, 0, true, t)
 }

--- a/pkg/proxy/healthcheck/service_health.go
+++ b/pkg/proxy/healthcheck/service_health.go
@@ -241,13 +241,16 @@ var _ http.Handler = hcHandler{}
 func (h hcHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	h.hcs.lock.RLock()
 	svc, ok := h.hcs.services[h.name]
-	if !ok || svc == nil {
-		h.hcs.lock.RUnlock()
-		klog.ErrorS(nil, "Received request for closed healthcheck", "service", h.name)
-		return
+	count := 0
+	if ok && svc != nil {
+		count = svc.endpoints
 	}
-	count := svc.endpoints
 	h.hcs.lock.RUnlock()
+
+	if !ok || svc == nil {
+		klog.ErrorS(nil, "Received request for closed healthcheck", "service", h.name)
+	}
+
 	kubeProxyHealthy := h.hcs.healthzServer.Health().Healthy
 
 	resp.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig network
/area kube-proxy

#### What this PR does / why we need it:

Services with `externalTrafficPolicy: Local` expose a health check node port that external load balancers probe to decide whether a node has local endpoints. `ServeHTTP` returns without calling `WriteHeader` when the service
has been deleted from the `services` map, so Go's `net/http` sends an implicit `200 OK`. The fix removes the early return so the deleted-service case falls through to the normal path with `count = 0`, producing `503`, consistent with a service that has no endpoints.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The race window is narrow: `closeAll()` closes the listener and active connections before the map entry is removed, meaning only in-flight requests are affected. I have no evidence this is reproducible in practice, but I also have zero evidence it won't happen since the unit-test shows it could. It's worth fixing regardless: returning an implicit `200` OK for a deleted service is semantically wrong. The fix makes it consistent with the no-endpoints case and bulletproofs us against future refactors that might widen the race window.

#### Does this PR introduce a user-facing change?

```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
