### PR TITLE
Add release-1.37 publishing bot rules, drop release-1.33

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -11,6 +11,11 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/streaming
+  - name: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/streaming
   library: true
 - destination: apimachinery
   branches:
@@ -43,6 +48,14 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/apimachinery
+  - name: release-1.37
+    dependencies:
+    - repository: streaming
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/apimachinery
   library: true
@@ -90,6 +103,16 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/api
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/api
   library: true
@@ -169,6 +192,22 @@ rules:
       # assumes GO111MODULE=on
       go build -mod=mod ./...
       go test -mod=mod ./...
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/client-go
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod ./...
+      go test -mod=mod ./...
   library: true
 - destination: code-generator
   branches:
@@ -214,6 +253,16 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/code-generator
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/code-generator
 - destination: component-base
@@ -280,6 +329,20 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/component-base
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/component-base
   library: true
@@ -349,6 +412,20 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/component-helpers
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/component-helpers
   library: true
 - destination: kms
   branches:
@@ -390,6 +467,14 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/kms
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/kms
   library: true
@@ -477,6 +562,24 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/apiserver
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: kms
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/apiserver
   library: true
@@ -584,6 +687,28 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/kube-aggregator
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: apiserver
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: kms
+      branch: release-1.37
+    - repository: code-generator
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/kube-aggregator
 - destination: sample-apiserver
@@ -717,6 +842,33 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: apiserver
+      branch: release-1.37
+    - repository: code-generator
+      branch: release-1.37
+    - repository: kms
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/sample-apiserver
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
 - destination: sample-controller
   branches:
   - name: master
@@ -811,6 +963,27 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/sample-controller
+    required-packages:
+    - k8s.io/code-generator
+    smoke-test: |
+      # assumes GO111MODULE=on
+      go build -mod=mod .
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: code-generator
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/sample-controller
     required-packages:
@@ -934,6 +1107,30 @@ rules:
       - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
     - k8s.io/code-generator
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: apiserver
+      branch: release-1.37
+    - repository: code-generator
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: kms
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/apiextensions-apiserver
+    required-packages:
+    - k8s.io/code-generator
 - destination: metrics
   branches:
   - name: master
@@ -1010,6 +1207,22 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/metrics
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: code-generator
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/metrics
   library: true
 - destination: cli-runtime
   branches:
@@ -1075,6 +1288,20 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/cli-runtime
+  - name: release-1.37
+    dependencies:
+    - repository: api
+      branch: release-1.37
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/cli-runtime
   library: true
@@ -1154,6 +1381,22 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
+  - name: release-1.37
+    dependencies:
+    - repository: api
+      branch: release-1.37
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: cli-runtime
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/sample-cli-plugin
 - destination: kube-proxy
   branches:
   - name: master
@@ -1230,6 +1473,22 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/kube-proxy
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/kube-proxy
   library: true
 - destination: cri-api
   branches:
@@ -1256,6 +1515,11 @@ rules:
   - name: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/cri-api
+  - name: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/cri-api
   library: true
@@ -1341,6 +1605,22 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/cri-client
+  - name: release-1.37
+    dependencies:
+    - repository: api
+      branch: release-1.37
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: cri-api
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/cri-client
   library: true
 - destination: cri-streaming
   branches:
@@ -1362,6 +1642,16 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/cri-streaming
+  - name: release-1.37
+    dependencies:
+    - repository: cri-api
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/cri-streaming
   library: true
@@ -1459,6 +1749,22 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/kubelet
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/kubelet
   library: true
 - destination: controller-manager
   branches:
@@ -1554,6 +1860,26 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/controller-manager
+  - name: release-1.37
+    dependencies:
+    - repository: api
+      branch: release-1.37
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: apiserver
+      branch: release-1.37
+    - repository: kms
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/controller-manager
   library: true
@@ -1671,6 +1997,30 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/cloud-provider
+  - name: release-1.37
+    dependencies:
+    - repository: api
+      branch: release-1.37
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: apiserver
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: controller-manager
+      branch: release-1.37
+    - repository: component-helpers
+      branch: release-1.37
+    - repository: kms
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/cloud-provider
   library: true
@@ -1800,6 +2150,32 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/kube-controller-manager
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: apiserver
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: controller-manager
+      branch: release-1.37
+    - repository: cloud-provider
+      branch: release-1.37
+    - repository: component-helpers
+      branch: release-1.37
+    - repository: kms
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/kube-controller-manager
   library: true
 - destination: cluster-bootstrap
   branches:
@@ -1855,6 +2231,18 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/cluster-bootstrap
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
   library: true
@@ -1914,6 +2302,18 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/csi-translation-lib
+  - name: release-1.37
+    dependencies:
+    - repository: api
+      branch: release-1.37
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/csi-translation-lib
   library: true
 - destination: mount-utils
   branches:
@@ -1940,6 +2340,11 @@ rules:
   - name: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/mount-utils
+  - name: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/mount-utils
   library: true
@@ -2059,6 +2464,30 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/kubectl
+  - name: release-1.37
+    dependencies:
+    - repository: api
+      branch: release-1.37
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: cli-runtime
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: code-generator
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: component-helpers
+      branch: release-1.37
+    - repository: metrics
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/kubectl
   library: true
 - destination: pod-security-admission
   branches:
@@ -2154,6 +2583,26 @@ rules:
       branch: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/pod-security-admission
+  - name: release-1.37
+    dependencies:
+    - repository: api
+      branch: release-1.37
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: apiserver
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: kms
+      branch: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/pod-security-admission
   library: true
@@ -2279,6 +2728,30 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: apiserver
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: component-helpers
+      branch: release-1.37
+    - repository: kms
+      branch: release-1.37
+    - repository: kubelet
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/dynamic-resource-allocation
 - destination: kube-scheduler
   branches:
   - name: master
@@ -2395,6 +2868,32 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/kube-scheduler
+  - name: release-1.37
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    - repository: api
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: apiserver
+      branch: release-1.37
+    - repository: component-helpers
+      branch: release-1.37
+    - repository: dynamic-resource-allocation
+      branch: release-1.37
+    - repository: kms
+      branch: release-1.37
+    - repository: kubelet
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/kube-scheduler
   library: true
 - destination: endpointslice
   branches:
@@ -2472,6 +2971,22 @@ rules:
       branch: release-1.36
       dirs:
       - staging/src/k8s.io/endpointslice
+  - name: release-1.37
+    dependencies:
+    - repository: api
+      branch: release-1.37
+    - repository: apimachinery
+      branch: release-1.37
+    - repository: streaming
+      branch: release-1.37
+    - repository: client-go
+      branch: release-1.37
+    - repository: component-base
+      branch: release-1.37
+    source:
+      branch: release-1.37
+      dirs:
+      - staging/src/k8s.io/endpointslice
 - destination: externaljwt
   branches:
   - name: master
@@ -2497,6 +3012,11 @@ rules:
   - name: release-1.36
     source:
       branch: release-1.36
+      dirs:
+      - staging/src/k8s.io/externaljwt
+  - name: release-1.37
+    source:
+      branch: release-1.37
       dirs:
       - staging/src/k8s.io/externaljwt
 recursive-delete-patterns:

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -27,11 +27,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/apimachinery
-  - name: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/apimachinery
   - name: release-1.34
     source:
       branch: release-1.34
@@ -69,14 +64,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/api
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/api
   - name: release-1.34
@@ -128,20 +115,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/client-go
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod ./...
-      go test -mod=mod ./...
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/client-go
     smoke-test: |
@@ -221,14 +194,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/code-generator
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/code-generator
   - name: release-1.34
     dependencies:
     - repository: apimachinery
@@ -279,18 +244,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/component-base
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/component-base
   - name: release-1.34
@@ -362,18 +315,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/component-helpers
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/component-helpers
   - name: release-1.34
     dependencies:
     - repository: apimachinery
@@ -437,14 +378,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kms
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/kms
   - name: release-1.34
     dependencies:
     - repository: apimachinery
@@ -496,22 +429,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/apiserver
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: kms
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/apiserver
   - name: release-1.34
@@ -605,26 +522,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kube-aggregator
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: apiserver
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: kms
-      branch: release-1.33
-    - repository: code-generator
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/kube-aggregator
   - name: release-1.34
@@ -733,31 +630,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/sample-apiserver
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: apiserver
-      branch: release-1.33
-    - repository: code-generator
-      branch: release-1.33
-    - repository: kms
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/sample-apiserver
     required-packages:
@@ -892,25 +764,6 @@ rules:
     smoke-test: |
       # assumes GO111MODULE=on
       go build -mod=mod .
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: code-generator
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/sample-controller
-    required-packages:
-    - k8s.io/code-generator
-    smoke-test: |
-      # assumes GO111MODULE=on
-      go build -mod=mod .
   - name: release-1.34
     dependencies:
     - repository: apimachinery
@@ -1013,28 +866,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/apiextensions-apiserver
-    required-packages:
-    - k8s.io/code-generator
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: apiserver
-      branch: release-1.33
-    - repository: code-generator
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: kms
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/apiextensions-apiserver
     required-packages:
@@ -1149,20 +980,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/metrics
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: code-generator
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/metrics
   - name: release-1.34
     dependencies:
     - repository: apimachinery
@@ -1240,18 +1057,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cli-runtime
-  - name: release-1.33
-    dependencies:
-    - repository: api
-      branch: release-1.33
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/cli-runtime
   - name: release-1.34
     dependencies:
     - repository: api
@@ -1321,20 +1126,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/sample-cli-plugin
-  - name: release-1.33
-    dependencies:
-    - repository: api
-      branch: release-1.33
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: cli-runtime
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/sample-cli-plugin
   - name: release-1.34
@@ -1415,20 +1206,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-proxy
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/kube-proxy
   - name: release-1.34
     dependencies:
     - repository: apimachinery
@@ -1497,11 +1274,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cri-api
-  - name: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/cri-api
   - name: release-1.34
     source:
       branch: release-1.34
@@ -1539,22 +1311,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/cri-client
-  - name: release-1.33
-    dependencies:
-    - repository: api
-      branch: release-1.33
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: cri-api
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/cri-client
   - name: release-1.34
@@ -1673,26 +1429,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kubelet
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: apiserver
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: cri-api
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: kms
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/kubelet
   - name: release-1.34
     dependencies:
     - repository: apimachinery
@@ -1786,24 +1522,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/controller-manager
-  - name: release-1.33
-    dependencies:
-    - repository: api
-      branch: release-1.33
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: apiserver
-      branch: release-1.33
-    - repository: kms
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/controller-manager
   - name: release-1.34
@@ -1907,28 +1625,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/cloud-provider
-  - name: release-1.33
-    dependencies:
-    - repository: api
-      branch: release-1.33
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: apiserver
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: controller-manager
-      branch: release-1.33
-    - repository: component-helpers
-      branch: release-1.33
-    - repository: kms
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/cloud-provider
   - name: release-1.34
@@ -2052,30 +1748,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-controller-manager
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: apiserver
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: controller-manager
-      branch: release-1.33
-    - repository: cloud-provider
-      branch: release-1.33
-    - repository: component-helpers
-      branch: release-1.33
-    - repository: kms
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/kube-controller-manager
   - name: release-1.34
     dependencies:
     - repository: apimachinery
@@ -2191,16 +1863,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/cluster-bootstrap
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/cluster-bootstrap
   - name: release-1.34
     dependencies:
     - repository: apimachinery
@@ -2260,16 +1922,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/csi-translation-lib
-  - name: release-1.33
-    dependencies:
-    - repository: api
-      branch: release-1.33
-    - repository: apimachinery
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/csi-translation-lib
   - name: release-1.34
     dependencies:
     - repository: api
@@ -2322,11 +1974,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/mount-utils
-  - name: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/mount-utils
   - name: release-1.34
     source:
       branch: release-1.34
@@ -2372,28 +2019,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/kubectl
-  - name: release-1.33
-    dependencies:
-    - repository: api
-      branch: release-1.33
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: cli-runtime
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: code-generator
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: component-helpers
-      branch: release-1.33
-    - repository: metrics
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/kubectl
   - name: release-1.34
@@ -2511,24 +2136,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/pod-security-admission
-  - name: release-1.33
-    dependencies:
-    - repository: api
-      branch: release-1.33
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: apiserver
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: kms
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/pod-security-admission
   - name: release-1.34
     dependencies:
     - repository: api
@@ -2630,30 +2237,6 @@ rules:
       branch: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/dynamic-resource-allocation
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: apiserver
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: cri-api
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: component-helpers
-      branch: release-1.33
-    - repository: kms
-      branch: release-1.33
-    - repository: kubelet
-      branch: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/dynamic-resource-allocation
   - name: release-1.34
@@ -2780,30 +2363,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/kube-scheduler
-  - name: release-1.33
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    - repository: api
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: apiserver
-      branch: release-1.33
-    - repository: component-helpers
-      branch: release-1.33
-    - repository: dynamic-resource-allocation
-      branch: release-1.33
-    - repository: kms
-      branch: release-1.33
-    - repository: kubelet
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/kube-scheduler
   - name: release-1.34
     dependencies:
     - repository: apimachinery
@@ -2913,20 +2472,6 @@ rules:
       branch: master
       dirs:
       - staging/src/k8s.io/endpointslice
-  - name: release-1.33
-    dependencies:
-    - repository: api
-      branch: release-1.33
-    - repository: apimachinery
-      branch: release-1.33
-    - repository: client-go
-      branch: release-1.33
-    - repository: component-base
-      branch: release-1.33
-    source:
-      branch: release-1.33
-      dirs:
-      - staging/src/k8s.io/endpointslice
   - name: release-1.34
     dependencies:
     - repository: api
@@ -2992,11 +2537,6 @@ rules:
   - name: master
     source:
       branch: master
-      dirs:
-      - staging/src/k8s.io/externaljwt
-  - name: release-1.33
-    source:
-      branch: release-1.33
       dirs:
       - staging/src/k8s.io/externaljwt
   - name: release-1.34


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The release-1.37 branch is cut, so the publishing bot needs rules for it. The first commit adds the release-1.37 rules for every staging repository. It was generated with the upstream tool:

```
go run k8s.io/publishing-bot/cmd/update-rules@latest -branch=release-1.37 --rules=./staging/publishing/rules.yaml -o ./staging/publishing/rules.yaml
```

The tool drops the comments above `default-go-version`, so I added them back by hand.

The second commit removes the release-1.33 rules, because release-1.33 is EOL. It only deletes lines.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`hack/verify-publishing-bot.sh` passes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
