### PR TITLE
kube-proxy: clean stale conntrack for deleted UDP services

### DIFF
--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -43,7 +43,8 @@ import (
 // List existing conntrack entries and calculate the desired conntrack state
 // based on the current Services and Endpoints.
 func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
-	svcPortMap proxy.ServicePortMap, endpointsMap proxy.EndpointsMap) {
+	svcPortMap proxy.ServicePortMap, endpointsMap proxy.EndpointsMap,
+	deletedUDPServices proxy.ServicePortMap) {
 
 	start := time.Now()
 	klog.V(4).InfoS("Started to reconcile conntrack entries", "ipFamily", ipFamily)
@@ -63,6 +64,28 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 	serviceIPEndpoints := make(map[string]sets.Set[string])
 	// serviceNodePortEndpoints maps service NodePort to the set of serving endpoints  (Endpoint IP and Port).
 	serviceNodePortEndpoints := make(map[int]sets.Set[string])
+
+	// Deleted UDP services are no longer in svcPortMap, but may still have
+	// stale conntrack entries pointing to their frontend IPs. Process them
+	// with a forced empty endpoint set, skipping NodePort cleanup for the
+	// same reason as services without serving endpoints.
+	// Process deleted services first so current services overwrite empty endpoint
+	// sets if the same frontend IP:port is reused by a live service.
+	for _, svc := range deletedUDPServices {
+		if svc.Protocol() != v1.ProtocolUDP {
+			continue
+		}
+
+		endpoints := sets.New[string]()
+		portStr := strconv.Itoa(svc.Port())
+		serviceIPEndpoints[net.JoinHostPort(svc.ClusterIP().String(), portStr)] = endpoints
+		for _, loadBalancerIP := range svc.LoadBalancerVIPs() {
+			serviceIPEndpoints[net.JoinHostPort(loadBalancerIP.String(), portStr)] = endpoints
+		}
+		for _, externalIP := range svc.ExternalIPs() {
+			serviceIPEndpoints[net.JoinHostPort(externalIP.String(), portStr)] = endpoints
+		}
+	}
 
 	for svcName, svc := range svcPortMap {
 		// we are only interested in UDP services

--- a/pkg/proxy/conntrack/cleanup_test.go
+++ b/pkg/proxy/conntrack/cleanup_test.go
@@ -323,7 +323,7 @@ func TestCleanStaleEntries(t *testing.T) {
 	)
 
 	legacyregistry.MustRegister(metrics.ReconcileConntrackFlowsDeletedEntriesTotal)
-	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap)
+	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap, nil)
 	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
 
 	metricCount, err := testutil.GetCounterMetricValue(metrics.ReconcileConntrackFlowsDeletedEntriesTotal.WithLabelValues(string(testIPFamily)))
@@ -430,7 +430,7 @@ func TestPerformanceCleanStaleEntries(t *testing.T) {
 	fake := &fakeHandler{entries: flows}
 	ct := newConntracker(fake)
 
-	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap)
+	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap, nil)
 	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
 	if len(actualEntries) != expectedEntries {
 		t.Errorf("unexpected number of entries, got %d expected %d", len(actualEntries), expectedEntries)
@@ -547,7 +547,7 @@ func TestServiceWithoutEndpoints(t *testing.T) {
 		},
 	)
 
-	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap)
+	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap, nil)
 	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
 
 	require.Len(t, actualEntries, len(entriesAfterCleanup))
@@ -564,4 +564,475 @@ func TestServiceWithoutEndpoints(t *testing.T) {
 	if diff := cmp.Diff(entriesAfterCleanup, actualEntries); len(diff) > 0 {
 		t.Errorf("unexpected entries after cleanup: %s", diff)
 	}
+}
+
+func TestDeletedUDPServices(t *testing.T) {
+	sct := proxy.NewServiceChangeTracker(v1.IPv4Protocol, nil, nil)
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testServiceName,
+			Namespace: testServiceNamespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP:   testClusterIP,
+			ExternalIPs: []string{testExternalIP},
+			Ports: []v1.ServicePort{
+				{
+					Name:     "test-udp",
+					Port:     testServicePort,
+					NodePort: testServiceNodePort,
+					Protocol: v1.ProtocolUDP,
+				},
+			},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{
+					IP: testLoadBalancerIP,
+				}},
+			},
+		},
+	}
+
+	sct.Update(nil, svc)
+	svcPortMap := make(proxy.ServicePortMap)
+	_ = svcPortMap.Update(sct)
+
+	udpPortName := proxy.ServicePortName{
+		NamespacedName: types.NamespacedName{
+			Namespace: svc.Namespace,
+			Name:      svc.Name,
+		},
+		Port:     svc.Spec.Ports[0].Name,
+		Protocol: svc.Spec.Ports[0].Protocol,
+	}
+
+	// Capture the ServicePort data before deleting the service.
+	deletedSvc := svcPortMap[udpPortName]
+
+	sct.Update(svc, nil)
+	_ = svcPortMap.Update(sct)
+	if len(svcPortMap) != 0 {
+		t.Fatalf("expected svcPortMap to be empty after deletion, got %+v", svcPortMap)
+	}
+
+	deletedUDPServices := proxy.ServicePortMap{
+		udpPortName: deletedSvc,
+	}
+
+	flows := []*netlink.ConntrackFlow{}
+	var entriesAfterCleanup []*netlink.ConntrackFlow
+
+	// UDP flows to the deleted service's frontends are stale and must be
+	// cleared. Since the service is deleted, endpoints are forced empty and
+	// all flows to its frontends are removed.
+	for _, origDest := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
+		for _, dnatDest := range []string{testServingEndpointIP, testDeletedEndpointIP} {
+			flows = append(flows, generateConntrackEntry(origDest, testServicePort, dnatDest, testEndpointPort, unix.IPPROTO_UDP))
+		}
+	}
+
+	// UDP entries not directed to a service frontend are preserved.
+	entry := generateConntrackEntry(testExternalIP, testNonServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	// non-UDP entries must be preserved.
+	entry = generateConntrackEntry(testExternalIP, testServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_TCP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	// *:NodePort entries are matched on the destination port only, which with
+	// an empty endpoints set would also remove flows not owned by kube-proxy,
+	// so NodePort cleanup is skipped for deleted services and these entries
+	// must be preserved.
+	entry = generateConntrackEntry("", testServiceNodePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	ct := newConntracker(
+		&fakeHandler{
+			entries: flows,
+		},
+	)
+
+	CleanStaleEntries(ct, testIPFamily, svcPortMap, nil, deletedUDPServices)
+	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
+
+	require.Len(t, actualEntries, len(entriesAfterCleanup))
+
+	// sort the actual flows before comparison
+	sort.Slice(actualEntries, func(i, j int) bool {
+		return actualEntries[i].String() < actualEntries[j].String()
+	})
+	// sort the expected flows before comparison
+	sort.Slice(entriesAfterCleanup, func(i, j int) bool {
+		return entriesAfterCleanup[i].String() < entriesAfterCleanup[j].String()
+	})
+
+	if diff := cmp.Diff(entriesAfterCleanup, actualEntries); len(diff) > 0 {
+		t.Errorf("unexpected entries after cleanup: %s", diff)
+	}
+}
+
+func TestDeletedUDPServicesIPReuse(t *testing.T) {
+	sct := proxy.NewServiceChangeTracker(v1.IPv4Protocol, nil, nil)
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testServiceName,
+			Namespace: testServiceNamespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP:   testClusterIP,
+			ExternalIPs: []string{testExternalIP},
+			Ports: []v1.ServicePort{
+				{
+					Name:     "test-udp",
+					Port:     testServicePort,
+					NodePort: testServiceNodePort,
+					Protocol: v1.ProtocolUDP,
+				},
+			},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{
+					IP: testLoadBalancerIP,
+				}},
+			},
+		},
+	}
+
+	sct.Update(nil, svc)
+	svcPortMap := make(proxy.ServicePortMap)
+	_ = svcPortMap.Update(sct)
+
+	udpPortName := proxy.ServicePortName{
+		NamespacedName: types.NamespacedName{
+			Namespace: svc.Namespace,
+			Name:      svc.Name,
+		},
+		Port:     svc.Spec.Ports[0].Name,
+		Protocol: svc.Spec.Ports[0].Protocol,
+	}
+
+	// Capture the ServicePort data before deleting the service.
+	deletedSvc := svcPortMap[udpPortName]
+
+	sct.Update(svc, nil)
+	_ = svcPortMap.Update(sct)
+	if len(svcPortMap) != 0 {
+		t.Fatalf("expected svcPortMap to be empty after deletion, got %+v", svcPortMap)
+	}
+
+	deletedUDPServices := proxy.ServicePortMap{
+		udpPortName: deletedSvc,
+	}
+
+	// Create a second service that reuses the deleted service's frontend IPs.
+	reusedServiceName := "cleanup-test-reused"
+	svc2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      reusedServiceName,
+			Namespace: testServiceNamespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP:   testClusterIP,
+			ExternalIPs: []string{testExternalIP},
+			Ports: []v1.ServicePort{
+				{
+					Name:     "test-udp",
+					Port:     testServicePort,
+					NodePort: testServiceNodePort,
+					Protocol: v1.ProtocolUDP,
+				},
+			},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{
+					IP: testLoadBalancerIP,
+				}},
+			},
+		},
+	}
+
+	sct.Update(nil, svc2)
+	_ = svcPortMap.Update(sct)
+
+	udpPortName2 := proxy.ServicePortName{
+		NamespacedName: types.NamespacedName{
+			Namespace: svc2.Namespace,
+			Name:      svc2.Name,
+		},
+		Port:     svc2.Spec.Ports[0].Name,
+		Protocol: svc2.Spec.Ports[0].Protocol,
+	}
+	if svcPortMap[udpPortName2] == nil {
+		t.Fatalf("expected svcPortMap to contain reused service %q", udpPortName2.String())
+	}
+
+	ect := proxy.NewEndpointsChangeTracker(v1.IPv4Protocol, "test-worker", nil, nil)
+	eps := &discovery.EndpointSlice{
+		TypeMeta:    metav1.TypeMeta{},
+		AddressType: discovery.AddressTypeIPv4,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-0", reusedServiceName),
+			Namespace: testServiceNamespace,
+			Labels:    map[string]string{discovery.LabelServiceName: reusedServiceName},
+		},
+		Endpoints: []discovery.Endpoint{
+			{
+				Addresses:  []string{testServingEndpointIP},
+				Conditions: discovery.EndpointConditions{Serving: new(true)},
+			},
+		},
+		Ports: []discovery.EndpointPort{
+			{
+				Name:     new("test-udp"),
+				Port:     new(int32(testEndpointPort)),
+				Protocol: ptr.To(v1.ProtocolUDP),
+			},
+		},
+	}
+
+	ect.EndpointSliceUpdate(eps, false)
+	endpointsMap := make(proxy.EndpointsMap)
+	_ = endpointsMap.Update(ect)
+
+	flows := []*netlink.ConntrackFlow{}
+	var entriesAfterCleanup []*netlink.ConntrackFlow
+
+	// Flows to the reused frontend IPs that are DNATed to the current
+	// service's serving endpoint must be preserved.
+	for _, origDest := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
+		entry := generateConntrackEntry(origDest, testServicePort, testServingEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+		flows = append(flows, entry)
+		entriesAfterCleanup = append(entriesAfterCleanup, entry)
+	}
+
+	// Flows to the reused frontend IPs that are DNATed to a deleted endpoint
+	// must be cleared.
+	for _, origDest := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
+		flows = append(flows, generateConntrackEntry(origDest, testServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP))
+	}
+
+	// UDP entries not directed to a service frontend are preserved.
+	entry := generateConntrackEntry(testExternalIP, testNonServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	// non-UDP entries must be preserved.
+	entry = generateConntrackEntry(testExternalIP, testServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_TCP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	// *:NodePort entries are matched on the destination port only. The
+	// current service has serving endpoints, so only flows to a deleted
+	// endpoint are stale.
+	entry = generateConntrackEntry("", testServiceNodePort, testServingEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+	flows = append(flows, generateConntrackEntry("", testServiceNodePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP))
+
+	ct := newConntracker(
+		&fakeHandler{
+			entries: flows,
+		},
+	)
+
+	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap, deletedUDPServices)
+	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
+
+	require.Len(t, actualEntries, len(entriesAfterCleanup))
+
+	// sort the actual flows before comparison
+	sort.Slice(actualEntries, func(i, j int) bool {
+		return actualEntries[i].String() < actualEntries[j].String()
+	})
+	// sort the expected flows before comparison
+	sort.Slice(entriesAfterCleanup, func(i, j int) bool {
+		return entriesAfterCleanup[i].String() < entriesAfterCleanup[j].String()
+	})
+
+	if diff := cmp.Diff(entriesAfterCleanup, actualEntries); len(diff) > 0 {
+		t.Errorf("unexpected entries after cleanup: %s", diff)
+	}
+}
+
+func TestProcessServiceMapChange(t *testing.T) {
+	// Callback mimics the proxier's serviceMapChange method: it records UDP
+	// services that disappeared from the previous ServicePortMap but were not
+	// present in the current one.
+	makeCallback := func() (func(previous, current proxy.ServicePortMap), proxy.ServicePortMap) {
+		deletedUDPServices := make(proxy.ServicePortMap)
+		callback := func(previous, current proxy.ServicePortMap) {
+			for svcPortName, svc := range previous {
+				if _, ok := current[svcPortName]; ok {
+					continue
+				}
+				if svc.Protocol() != v1.ProtocolUDP {
+					continue
+				}
+				deletedUDPServices[svcPortName] = svc
+			}
+		}
+		return callback, deletedUDPServices
+	}
+
+	udpSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testServiceName,
+			Namespace: testServiceNamespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP:   testClusterIP,
+			ExternalIPs: []string{testExternalIP},
+			Ports: []v1.ServicePort{
+				{
+					Name:     "test-udp",
+					Port:     testServicePort,
+					NodePort: testServiceNodePort,
+					Protocol: v1.ProtocolUDP,
+				},
+			},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{
+					IP: testLoadBalancerIP,
+				}},
+			},
+		},
+	}
+
+	t.Run("udp deletion captured and used for cleanup", func(t *testing.T) {
+		callback, deletedUDPServices := makeCallback()
+		sct := proxy.NewServiceChangeTracker(v1.IPv4Protocol, nil, callback)
+
+		sct.Update(nil, udpSvc)
+		svcPortMap := make(proxy.ServicePortMap)
+		_ = svcPortMap.Update(sct)
+
+		udpPortName := proxy.ServicePortName{
+			NamespacedName: types.NamespacedName{
+				Namespace: udpSvc.Namespace,
+				Name:      udpSvc.Name,
+			},
+			Port:     udpSvc.Spec.Ports[0].Name,
+			Protocol: udpSvc.Spec.Ports[0].Protocol,
+		}
+
+		sct.Update(udpSvc, nil)
+		_ = svcPortMap.Update(sct)
+
+		require.Len(t, deletedUDPServices, 1)
+		captured, ok := deletedUDPServices[udpPortName]
+		require.True(t, ok)
+
+		require.Equal(t, testClusterIP, captured.ClusterIP().String())
+		require.Equal(t, testServicePort, captured.Port())
+		require.Equal(t, v1.ProtocolUDP, captured.Protocol())
+		externalIPs := make([]string, 0, len(captured.ExternalIPs()))
+		for _, ip := range captured.ExternalIPs() {
+			externalIPs = append(externalIPs, ip.String())
+		}
+		require.Equal(t, []string{testExternalIP}, externalIPs)
+		loadBalancerVIPs := make([]string, 0, len(captured.LoadBalancerVIPs()))
+		for _, ip := range captured.LoadBalancerVIPs() {
+			loadBalancerVIPs = append(loadBalancerVIPs, ip.String())
+		}
+		require.Equal(t, []string{testLoadBalancerIP}, loadBalancerVIPs)
+		require.Equal(t, testServiceNodePort, captured.NodePort())
+
+		// Conntrack flows to the deleted UDP service's frontends must be
+		// cleared when the captured map is passed to CleanStaleEntries.
+		flows := []*netlink.ConntrackFlow{}
+		var entriesAfterCleanup []*netlink.ConntrackFlow
+
+		for _, origDest := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
+			for _, dnatDest := range []string{testServingEndpointIP, testDeletedEndpointIP} {
+				flows = append(flows, generateConntrackEntry(origDest, testServicePort, dnatDest, testEndpointPort, unix.IPPROTO_UDP))
+			}
+		}
+
+		entry := generateConntrackEntry(testExternalIP, testNonServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+		flows = append(flows, entry)
+		entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+		entry = generateConntrackEntry(testExternalIP, testServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_TCP)
+		flows = append(flows, entry)
+		entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+		entry = generateConntrackEntry("", testServiceNodePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+		flows = append(flows, entry)
+		entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+		ct := newConntracker(
+			&fakeHandler{
+				entries: flows,
+			},
+		)
+
+		CleanStaleEntries(ct, testIPFamily, svcPortMap, nil, deletedUDPServices)
+		actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
+
+		require.Len(t, actualEntries, len(entriesAfterCleanup))
+
+		sort.Slice(actualEntries, func(i, j int) bool {
+			return actualEntries[i].String() < actualEntries[j].String()
+		})
+		sort.Slice(entriesAfterCleanup, func(i, j int) bool {
+			return entriesAfterCleanup[i].String() < entriesAfterCleanup[j].String()
+		})
+
+		if diff := cmp.Diff(entriesAfterCleanup, actualEntries); len(diff) > 0 {
+			t.Errorf("unexpected entries after cleanup: %s", diff)
+		}
+	})
+
+	t.Run("tcp deletion is not captured", func(t *testing.T) {
+		callback, deletedUDPServices := makeCallback()
+		sct := proxy.NewServiceChangeTracker(v1.IPv4Protocol, nil, callback)
+
+		tcpSvc := udpSvc.DeepCopy()
+		tcpSvc.Spec.Ports[0].Name = "test-tcp"
+		tcpSvc.Spec.Ports[0].Protocol = v1.ProtocolTCP
+
+		sct.Update(nil, tcpSvc)
+		svcPortMap := make(proxy.ServicePortMap)
+		_ = svcPortMap.Update(sct)
+
+		tcpPortName := proxy.ServicePortName{
+			NamespacedName: types.NamespacedName{
+				Namespace: tcpSvc.Namespace,
+				Name:      tcpSvc.Name,
+			},
+			Port:     tcpSvc.Spec.Ports[0].Name,
+			Protocol: tcpSvc.Spec.Ports[0].Protocol,
+		}
+
+		sct.Update(tcpSvc, nil)
+		_ = svcPortMap.Update(sct)
+
+		require.NotContains(t, deletedUDPServices, tcpPortName)
+		require.Empty(t, deletedUDPServices)
+	})
+
+	t.Run("udp update is not captured as deletion", func(t *testing.T) {
+		callback, deletedUDPServices := makeCallback()
+		sct := proxy.NewServiceChangeTracker(v1.IPv4Protocol, nil, callback)
+
+		sct.Update(nil, udpSvc)
+		svcPortMap := make(proxy.ServicePortMap)
+		_ = svcPortMap.Update(sct)
+
+		udpSvc2 := udpSvc.DeepCopy()
+		udpSvc2.Spec.Ports[0].Port = testServicePort + 1
+
+		sct.Update(udpSvc, udpSvc2)
+		_ = svcPortMap.Update(sct)
+
+		require.Empty(t, deletedUDPServices)
+	})
 }

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -135,10 +135,11 @@ type Proxier struct {
 	endpointsChanges *proxy.EndpointsChangeTracker
 	serviceChanges   *proxy.ServiceChangeTracker
 
-	mu             sync.Mutex // protects the following fields
-	svcPortMap     proxy.ServicePortMap
-	endpointsMap   proxy.EndpointsMap
-	topologyLabels map[string]string
+	mu                 sync.Mutex // protects the following fields
+	svcPortMap         proxy.ServicePortMap
+	endpointsMap       proxy.EndpointsMap
+	deletedUDPServices proxy.ServicePortMap
+	topologyLabels     map[string]string
 	// endpointSlicesSynced, and servicesSynced are set to true
 	// when corresponding objects are synced after startup. This is used to avoid
 	// updating iptables with some partial data after kube-proxy restart.
@@ -265,8 +266,8 @@ func NewProxier(ctx context.Context,
 	proxier := &Proxier{
 		ipFamily:                 ipFamily,
 		svcPortMap:               make(proxy.ServicePortMap),
-		serviceChanges:           proxy.NewServiceChangeTracker(ipFamily, newServiceInfo, nil),
 		endpointsMap:             make(proxy.EndpointsMap),
+		deletedUDPServices:       make(proxy.ServicePortMap),
 		endpointsChanges:         proxy.NewEndpointsChangeTracker(ipFamily, nodeName, newEndpointInfo, nil),
 		needFullSync:             true,
 		syncPeriod:               syncPeriod,
@@ -297,6 +298,8 @@ func NewProxier(ctx context.Context,
 			metrics.LocalhostNodePortAcceptedNFAcctCounter:     false,
 		},
 	}
+
+	proxier.serviceChanges = proxy.NewServiceChangeTracker(ipFamily, newServiceInfo, proxier.serviceMapChange)
 
 	logger.V(2).Info("Iptables sync params", "minSyncPeriod", minSyncPeriod, "syncPeriod", syncPeriod, "maxSyncPeriod", proxyutil.FullSyncPeriod)
 	// We pass syncPeriod to ipt.Monitor, which will call us only if it needs to.
@@ -617,6 +620,21 @@ func (proxier *Proxier) forceSyncProxyRules() {
 	proxier.mu.Unlock()
 
 	proxier.syncProxyRules()
+}
+
+// serviceMapChange is called by the ServiceChangeTracker when services change.
+// It captures deleted UDP services so their stale conntrack entries can be
+// cleaned up later in the same sync, even though they are no longer in svcPortMap.
+func (proxier *Proxier) serviceMapChange(previous, current proxy.ServicePortMap) {
+	for svcPortName, svc := range previous {
+		if _, ok := current[svcPortName]; ok {
+			continue
+		}
+		if svc.Protocol() != v1.ProtocolUDP {
+			continue
+		}
+		proxier.deletedUDPServices[svcPortName] = svc
+	}
 }
 
 // This is where all of the iptables-save/restore calls happen.
@@ -1420,9 +1438,10 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		proxier.logger.Error(err, "Error syncing healthcheck endpoints")
 	}
 
-	if endpointUpdateResult.ConntrackCleanupRequired {
+	if endpointUpdateResult.ConntrackCleanupRequired || len(proxier.deletedUDPServices) > 0 {
 		// Finish housekeeping, clear stale conntrack entries for UDP Services
-		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap, proxier.deletedUDPServices)
+		proxier.deletedUDPServices = make(proxy.ServicePortMap)
 	}
 	return
 }

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -155,10 +155,11 @@ type Proxier struct {
 	endpointsChanges *proxy.EndpointsChangeTracker
 	serviceChanges   *proxy.ServiceChangeTracker
 
-	mu             sync.Mutex // protects the following fields
-	svcPortMap     proxy.ServicePortMap
-	endpointsMap   proxy.EndpointsMap
-	topologyLabels map[string]string
+	mu                 sync.Mutex // protects the following fields
+	svcPortMap         proxy.ServicePortMap
+	endpointsMap       proxy.EndpointsMap
+	deletedUDPServices proxy.ServicePortMap
+	topologyLabels     map[string]string
 	// initialSync is a bool indicating if the proxier is syncing for the first time.
 	// It is set to true when a new proxier is initialized and then set to false on all
 	// future syncs.
@@ -346,8 +347,8 @@ func NewProxier(
 	proxier := &Proxier{
 		ipFamily:              ipFamily,
 		svcPortMap:            make(proxy.ServicePortMap),
-		serviceChanges:        proxy.NewServiceChangeTracker(ipFamily, newServiceInfo, nil),
 		endpointsMap:          make(proxy.EndpointsMap),
+		deletedUDPServices:    make(proxy.ServicePortMap),
 		endpointsChanges:      proxy.NewEndpointsChangeTracker(ipFamily, nodeName, nil, nil),
 		initialSync:           true,
 		syncPeriod:            syncPeriod,
@@ -377,6 +378,9 @@ func NewProxier(
 		gracefuldeleteManager: NewGracefulTerminationManager(ipvs),
 		logger:                logger,
 	}
+
+	proxier.serviceChanges = proxy.NewServiceChangeTracker(ipFamily, newServiceInfo, proxier.serviceMapChange)
+
 	// initialize ipsetList with all sets we needed
 	proxier.ipsetList = make(map[string]*IPSet)
 	for _, is := range ipsetInfo {
@@ -653,6 +657,21 @@ func (proxier *Proxier) OnTopologyChange(topologyLabels map[string]string) {
 // OnServiceCIDRsChanged is called whenever a change is observed
 // in any of the ServiceCIDRs, and provides complete list of service cidrs.
 func (proxier *Proxier) OnServiceCIDRsChanged(_ []string) {}
+
+// serviceMapChange is called by the ServiceChangeTracker when services change.
+// It captures deleted UDP services so their stale conntrack entries can be
+// cleaned up later in the same sync, even though they are no longer in svcPortMap.
+func (proxier *Proxier) serviceMapChange(previous, current proxy.ServicePortMap) {
+	for svcPortName, svc := range previous {
+		if _, ok := current[svcPortName]; ok {
+			continue
+		}
+		if svc.Protocol() != v1.ProtocolUDP {
+			continue
+		}
+		proxier.deletedUDPServices[svcPortName] = svc
+	}
+}
 
 // This is where all of the ipvs calls happen.
 func (proxier *Proxier) syncProxyRules() (retryError error) {
@@ -1246,9 +1265,10 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("internal", string(proxier.ipFamily)).Set(float64(proxier.serviceNoLocalEndpointsInternal.Len()))
 	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("external", string(proxier.ipFamily)).Set(float64(proxier.serviceNoLocalEndpointsExternal.Len()))
 
-	if endpointUpdateResult.ConntrackCleanupRequired {
+	if endpointUpdateResult.ConntrackCleanupRequired || len(proxier.deletedUDPServices) > 0 {
 		// Finish housekeeping, clear stale conntrack entries for UDP Services
-		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap, proxier.deletedUDPServices)
+		proxier.deletedUDPServices = make(proxy.ServicePortMap)
 	}
 	return
 }

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -154,10 +154,11 @@ type Proxier struct {
 	endpointsChanges *proxy.EndpointsChangeTracker
 	serviceChanges   *proxy.ServiceChangeTracker
 
-	mu             sync.Mutex // protects the following fields
-	svcPortMap     proxy.ServicePortMap
-	endpointsMap   proxy.EndpointsMap
-	topologyLabels map[string]string
+	mu                 sync.Mutex // protects the following fields
+	svcPortMap         proxy.ServicePortMap
+	endpointsMap       proxy.EndpointsMap
+	deletedUDPServices proxy.ServicePortMap
+	topologyLabels     map[string]string
 	// endpointSlicesSynced, and servicesSynced are set to true
 	// when corresponding objects are synced after startup. This is used to avoid
 	// updating nftables with some partial data after kube-proxy restart.
@@ -260,8 +261,8 @@ func NewProxier(ctx context.Context,
 	proxier := &Proxier{
 		ipFamily:                 ipFamily,
 		svcPortMap:               make(proxy.ServicePortMap),
-		serviceChanges:           proxy.NewServiceChangeTracker(ipFamily, newServiceInfo, nil),
 		endpointsMap:             make(proxy.EndpointsMap),
+		deletedUDPServices:       make(proxy.ServicePortMap),
 		endpointsChanges:         proxy.NewEndpointsChangeTracker(ipFamily, nodeName, newEndpointInfo, nil),
 		needFullSync:             true,
 		syncPeriod:               syncPeriod,
@@ -289,6 +290,8 @@ func NewProxier(ctx context.Context,
 		hairpinConnections:       newNFTElementStorage("set", hairpinConnectionsSet),
 		localhostNodePortRejects: newNFTElementStorage("map", localhostNodePortRejectMap),
 	}
+
+	proxier.serviceChanges = proxy.NewServiceChangeTracker(ipFamily, newServiceInfo, proxier.serviceMapChange)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeProxyNFTablesLocalhostNodePorts) {
 		proxier.localhostNodePortsEnabled = true
@@ -1169,6 +1172,21 @@ func (proxier *Proxier) logFailure(tx *knftables.Transaction) {
 	}
 }
 
+// serviceMapChange is called by the ServiceChangeTracker when services change.
+// It captures deleted UDP services so their stale conntrack entries can be
+// cleaned up later in the same sync, even though they are no longer in svcPortMap.
+func (proxier *Proxier) serviceMapChange(previous, current proxy.ServicePortMap) {
+	for svcPortName, svc := range previous {
+		if _, ok := current[svcPortName]; ok {
+			continue
+		}
+		if svc.Protocol() != v1.ProtocolUDP {
+			continue
+		}
+		proxier.deletedUDPServices[svcPortName] = svc
+	}
+}
+
 // This is where all of the nftables calls happen.
 // This assumes proxier.mu is NOT held
 func (proxier *Proxier) syncProxyRules() (retryError error) {
@@ -1913,9 +1931,10 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		proxier.localhostNodePortProxy.SyncNodePorts(localhostNodePorts)
 	}
 
-	if endpointUpdateResult.ConntrackCleanupRequired {
+	if endpointUpdateResult.ConntrackCleanupRequired || len(proxier.deletedUDPServices) > 0 {
 		// Finish housekeeping, clear stale conntrack entries for UDP Services
-		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap, proxier.deletedUDPServices)
+		proxier.deletedUDPServices = make(proxy.ServicePortMap)
 	}
 	return
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig network
/area kube-proxy

#### What this PR does / why we need it:

When a UDP service is deleted, kube-proxy removes its rules but leaves stale conntrack entries in place. One-way UDP flows (e.g. statsd, logging) keep refreshing the conntrack timeout, so traffic is DNATed to the old endpoint IP for as long as the source keeps sending,  kube-proxy doesn't clean it up on later syncs because the service is gone from `svcPortMap`. That IP may already have been reassigned to a different pod, so packets are silently delivered to
the wrong destination.

`CleanStaleEntries` builds its match set by iterating `svcPortMap`, but the deleted service is removed from `svcPortMap` before `CleanStaleEntries` runs, so its frontend IPs are not matched. This is an asymmetry with the "0 endpoints" case (PR #139629), which IS cleaned up because the service is still in `svcPortMap` with an empty endpoint set.

The fix uses the existing `processServiceMapChange` callback on `ServiceChangeTracker` to capture deleted UDP services' frontend IPs before they're lost, and passes them to `CleanStaleEntries` with an empty endpoint set, the same treatment as services with no serving endpoints.

The deleted-services loop in `CleanStaleEntries` runs before the main `svcPortMap` loop, so when a deleted service's frontend IP:port is reused by a live service, the live service's real endpoints take precedence and active flows are preserved.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

PR #139629 (1.37) added conntrack cleanup for UDP services with 0 serving endpoints, the service is still in `svcPortMap` with an empty endpoint set, so its flows are matched and cleaned. This PR extends the same mechanism to
deleted services, which are removed from `svcPortMap` before cleanup runs.

The `processServiceMapChange` callback (see `servicechangetracker.go`) was designed for "Proxier-specific cleanup." The fix uses it to capture deleted UDP services for conntrack cleanup in all three Linux proxiers.

The `CleanStaleEntries` trigger is widened from `endpointUpdateResult.ConntrackCleanupRequired` to also fire when there are captured deleted UDP services, so cleanup runs immediately on service deletion (same sync) rather than waiting for endpoint slice garbage collection.

NodePort cleanup is skipped for deleted services, consistent with the existing 0-endpoints behavior — matching on the destination port alone would remove flows not owned by kube-proxy.

The fix includes 3 new tests:

- `TestDeletedUDPServices` — **demonstrates the bug**: a deleted service's flows
  are not in `svcPortMap`, so without the fix they are not matched and not
  cleaned. Fails on pre-fix code (stale entries survive), passes with the fix.
- `TestDeletedUDPServicesIPReuse` — **regression guard for loop ordering**: a
  deleted service and a live service share the same frontend IPs; valid flows to
  the live service's serving endpoint must be preserved. Would fail if the
  deleted loop ran after the main loop (empty set overwrites real endpoints).
- `TestProcessServiceMapChange` — **callback coverage**: 3 subtests verifying
  UDP deletion is captured, TCP deletion is filtered out, and a UDP update is
  not captured as a deletion.

#### Does this PR introduce a user-facing change?

```release-note
kube-proxy now removes stale conntrack entries immediatly when a UDP Service is deleted.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
