### PR TITLE
DRA: avoid reserving claims for terminal Pods

### DIFF
--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -533,6 +533,9 @@ func (ec *Controller) podNeedsWork(pod *v1.Pod) (bool, string) {
 		// Nothing else to do for the pod.
 		return false, "pod is deleted"
 	}
+	if podutil.IsPodTerminal(pod) {
+		return false, "pod has terminated"
+	}
 
 	var doNothingReasons []string
 
@@ -903,9 +906,15 @@ func (ec *Controller) syncPod(ctx context.Context, namespace, name string) error
 		return err
 	}
 
-	// Ignore pods which are already getting deleted.
+	// Ignore pods which are already getting deleted or have terminated. A
+	// terminal Pod must not reserve an allocated claim again after syncClaim
+	// removed its stale reservation.
 	if pod.DeletionTimestamp != nil {
 		logger.V(5).Info("Nothing to do for pod, it is marked for deletion")
+		return nil
+	}
+	if podutil.IsPodTerminal(pod) {
+		logger.V(5).Info("Nothing to do for pod, it has terminated")
 		return nil
 	}
 

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -887,6 +887,30 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: claimCreateMetrics{},
 		},
 		{
+			name: "do not reserve static claim for terminal pre-scheduled pod",
+			pods: func() []*v1.Pod {
+				pod := makePod(testPodName, testNamespace, testPodUID, v1.PodResourceClaim{
+					Name:              podResourceClaimName,
+					ResourceClaimName: &testClaim.Name,
+				})
+				pod.Spec.NodeName = nodeName
+				pod.Status.Phase = v1.PodSucceeded
+				return []*v1.Pod{pod}
+			}(),
+			key: podKey(testPodWithNodeName),
+			claims: func() []*resourceapi.ResourceClaim {
+				claim := reserveClaim(testClaimAllocated, otherTestPod)
+				claim.OwnerReferences = nil
+				return []*resourceapi.ResourceClaim{claim}
+			}(),
+			expectedClaims: []resourceapi.ResourceClaim{func() resourceapi.ResourceClaim {
+				claim := reserveClaim(testClaimAllocated, otherTestPod)
+				claim.OwnerReferences = nil
+				return *claim
+			}()},
+			expectedMetrics: claimCreateMetrics{},
+		},
+		{
 			name: "delete-claim-when-done",
 			pods: func() []*v1.Pod {
 				pods := []*v1.Pod{testPodWithResource.DeepCopy()}
@@ -1541,7 +1565,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 		},
 		"completed-pod-with-regular-and-extended-resource-claim": {
 			createObjects: []object{completedPodWithRegularAndExtendedResourceClaim},
-			expectedKeys:  []string{extendedResourceClaimKey, testPodKey},
+			expectedKeys:  []string{extendedResourceClaimKey},
 		},
 		"new-podgroup-feature-disabled": {
 			featureCombinations: workloadResourceClaimsDisabled,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

Prevents terminal Pods from being queued or processed for ResourceClaim reservation work.

The controller already enqueues the referenced ResourceClaims for cleanup before deciding whether Pod work is needed. Without the terminal-Pod guard, a pre-scheduled terminal Pod could be processed after `syncClaim` removed its stale reservation and be added back to `status.reservedFor`. When another consumer kept a shared static claim allocated, cleanup and reservation processing could then alternate.

The regression covers an allocated, manually managed claim that remains reserved for another consumer while a terminal, pre-scheduled Pod still references it. An existing event-handler expectation is updated to confirm that extended ResourceClaim cleanup remains queued while terminal Pod processing is skipped.

#### Which issue(s) this PR is related to:

Fixes #141274

#### Special notes for your reviewer:

Validation used Go 1.26.5:

- focused regression test passed;
- restoring the pre-fix controller reproduced the failure (`ReservedFor` changed from one to two consumers);
- `go test -p=4 ./pkg/controller/resourceclaim -count=1` passed;
- `gofmt` and `git diff --check` passed.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the ResourceClaim controller repeatedly restoring terminal Pod entries in `status.reservedFor` for allocated claims that remain in use by other consumers.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
