### PR TITLE
client-go/cache: avoid fake source shutdown deadlock

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -171,6 +171,16 @@ func (c *controller) Run(stopCh <-chan struct{}) {
 // RunWithContext implements [Controller.RunWithContext].
 func (c *controller) RunWithContext(ctx context.Context) {
 	defer utilruntime.HandleCrashWithContext(ctx)
+
+	// The reflector must not outlive this call when processLoop panics and
+	// unwinds past the normal shutdown path.
+	ctx, cancel := context.WithCancel(ctx)
+	var wg wait.Group
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
 	go func() {
 		<-ctx.Done()
 		c.config.Queue.Close()
@@ -202,12 +212,9 @@ func (c *controller) RunWithContext(ctx context.Context) {
 	c.reflector = r
 	c.reflectorMutex.Unlock()
 
-	var wg wait.Group
-
 	wg.StartWithContext(ctx, r.RunWithContext)
 
 	wait.UntilWithContext(ctx, c.processLoop, time.Second)
-	wg.Wait()
 }
 
 // Returns true once this controller has completed an initial resource listing

--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -472,6 +472,58 @@ func TestPanicPropagated(t *testing.T) {
 	}
 }
 
+func TestRunWithContextStopsReflectorAfterProcessPanic(t *testing.T) {
+	_, testCtx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(testCtx)
+	defer cancel()
+
+	fakeWatch := watch.NewRaceFreeFake()
+	watchStarted := make(chan struct{})
+	controller := New(&Config{
+		Queue: NewDeltaFIFOWithOptions(DeltaFIFOOptions{}),
+		ListerWatcher: &ListWatch{
+			ListFunc: func(metav1.ListOptions) (runtime.Object, error) {
+				return &v1.PodList{ListMeta: metav1.ListMeta{ResourceVersion: "1"}}, nil
+			},
+			WatchFunc: func(metav1.ListOptions) (watch.Interface, error) {
+				close(watchStarted)
+				return fakeWatch, nil
+			},
+		},
+		ObjectType: &v1.Pod{},
+		Process: func(interface{}, bool) error {
+			panic("process panic")
+		},
+	})
+
+	propagated := make(chan interface{}, 1)
+	go func() {
+		defer func() {
+			propagated <- recover()
+		}()
+		controller.RunWithContext(ctx)
+	}()
+
+	select {
+	case <-watchStarted:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("reflector did not start watching")
+	}
+	fakeWatch.Action(watch.Bookmark, &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		ResourceVersion: "1",
+		Annotations:     map[string]string{metav1.InitialEventsAnnotationKey: "true"},
+	}})
+	fakeWatch.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test", ResourceVersion: "2"}})
+
+	select {
+	case panicValue := <-propagated:
+		assert.Equal(t, "process panic", panicValue)
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("controller did not propagate the process panic")
+	}
+	assert.True(t, fakeWatch.IsStopped(), "controller returned before its reflector stopped")
+}
+
 func TestTransformingInformer(t *testing.T) {
 	// source simulates an apiserver object endpoint.
 	source := newFakeControllerSource(t)

--- a/staging/src/k8s.io/client-go/tools/cache/testing/fake_controller_source.go
+++ b/staging/src/k8s.io/client-go/tools/cache/testing/fake_controller_source.go
@@ -62,6 +62,7 @@ type FakeControllerSource struct {
 	changes     []watch.Event // one change per resourceVersion
 	Broadcaster *watch.Broadcaster
 	lastRV      int
+	shutdown    bool
 
 	// Set this to simulate an error on List()
 	ListError error
@@ -162,6 +163,9 @@ func (f *FakeControllerSource) Change(e watch.Event, watchProbability float64) {
 }
 
 func (f *FakeControllerSource) getListItemsLocked() ([]runtime.Object, error) {
+	if f.shutdown {
+		return nil, errFakeControllerSourceShutdown
+	}
 	list := make([]runtime.Object, 0, len(f.Items))
 	for _, obj := range f.Items {
 		// Must make a copy to allow clients to modify the object.
@@ -243,6 +247,9 @@ func (f *FakePVCControllerSource) List(options metav1.ListOptions) (runtime.Obje
 func (f *FakeControllerSource) Watch(options metav1.ListOptions) (watch.Interface, error) {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
+	if f.shutdown {
+		return nil, errFakeControllerSourceShutdown
+	}
 	rc, err := strconv.Atoi(options.ResourceVersion)
 	if err != nil {
 		return nil, err
@@ -282,10 +289,13 @@ func (f *FakeControllerSource) Watch(options metav1.ListOptions) (watch.Interfac
 	return f.Broadcaster.Watch()
 }
 
+var errFakeControllerSourceShutdown = errors.New("fake controller source is shut down")
+
 // Shutdown closes the underlying broadcaster, waiting for events to be
-// delivered. It's an error to call any method after calling shutdown. This is
-// enforced by Shutdown() leaving f locked.
+// delivered. List and Watch return an error after Shutdown.
 func (f *FakeControllerSource) Shutdown() {
-	f.lock.Lock() // Purposely no unlock.
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.shutdown = true
 	f.Broadcaster.Shutdown()
 }

--- a/staging/src/k8s.io/client-go/tools/cache/testing/fake_controller_source_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/testing/fake_controller_source_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package framework
 
 import (
+	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -133,4 +135,47 @@ func TestResetWatch(t *testing.T) {
 	go consume(t, w, []string{"4"}, wg)
 	source.Shutdown()
 	wg.Wait()
+}
+
+func TestShutdownDoesNotBlockListOrWatch(t *testing.T) {
+	source := NewFakeControllerSource()
+	source.Shutdown()
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "list",
+			call: func() error {
+				_, err := source.List(metav1.ListOptions{})
+				return err
+			},
+		},
+		{
+			name: "watch",
+			call: func() error {
+				_, err := source.Watch(metav1.ListOptions{ResourceVersion: "0"})
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- test.call()
+			}()
+
+			select {
+			case err := <-errCh:
+				if !errors.Is(err, errFakeControllerSourceShutdown) {
+					t.Fatalf("expected shutdown error, got %v", err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("call blocked after fake controller source shutdown")
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

Stops the controller from orphaning its reflector when processing panics. Makes `FakeControllerSource` return an error after shutdown instead of holding its lock forever. Adds regression tests for both paths.

#### Which issue(s) this PR is related to:

#141277

#### Special notes for your reviewer:

NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
```
