### PR TITLE
fix non-root image user test on Windows

### DIFF
--- a/test/e2e/common/node/security_context.go
+++ b/test/e2e/common/node/security_context.go
@@ -523,10 +523,16 @@ var _ = SIGDescribe("Security Context", func() {
 		ginkgo.It("should run with an image specified user ID", func(ctx context.Context) {
 			name := "implicit-nonroot-uid"
 			pod := makeNonRootPod(name, nonRootImage, nil)
+			expectedUser := "1234"
+			if framework.NodeOSDistroIs("windows") {
+				// The Windows nonroot image runs as ContainerUser.
+				pod.Spec.Containers[0].Command = []string{"cmd", "/S", "/C", "echo %username%"}
+				expectedUser = "ContainerUser"
+			}
 			podClient.Create(ctx, pod)
 
 			podClient.WaitForSuccess(ctx, name, framework.PodStartTimeout)
-			framework.ExpectNoError(podClient.MatchContainerOutput(ctx, name, name, "1234"))
+			framework.ExpectNoError(podClient.MatchContainerOutput(ctx, name, name, expectedUser))
 		})
 		ginkgo.It("should not run without a specified user ID", func(ctx context.Context) {
 			name := "implicit-root-uid"


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

Updates the runAsNonRoot test for an image-specified user to validate the platform-specific user of the nonroot test image. Linux continues to verify UID 1234, while Windows invokes `cmd` and verifies `ContainerUser`.

The existing Linux command (`id -u`) does not run in the Windows image, causing the Windows conformance job to time out.

#### Which issue(s) this PR fixes:

Fixes #141085

#### Special notes for your reviewer:

The explicit RunAsUser tests remain Linux-only because Windows uses RunAsUserName. This change keeps the image-specified-user scenario covered on both platforms.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
