### PR TITLE
kubectl: complete pod names and type/name forms for debug

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cmd.go
@@ -251,7 +251,11 @@ func NewKubectlCommand(o KubectlOptions) *cobra.Command {
 	getCmd := get.NewCmdGet("kubectl", f, o.IOStreams)
 	getCmd.ValidArgsFunction = utilcomp.ResourceTypeAndNameCompletionFunc(f)
 	debugCmd := debug.NewCmdDebug(f, o.IOStreams)
-	debugCmd.ValidArgsFunction = utilcomp.ResourceTypeAndNameCompletionFunc(f)
+	// debug takes a single positional (POD | TYPE/NAME), so use the pod-family
+	// completion: pod names and <type>/<name> slash forms. The get-style
+	// completion (bare <type> then space-separated <name>) produces invalid
+	// commands such as "kubectl debug pods <name>".
+	debugCmd.ValidArgsFunction = utilcomp.PodResourceNameCompletionFunc(f)
 
 	groups := templates.CommandGroups{
 		{

--- a/staging/src/k8s.io/kubectl/pkg/util/completion/completion_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/completion/completion_test.go
@@ -299,6 +299,50 @@ func TestPodResourceNameCompletionFuncNoArgsResources(t *testing.T) {
 		directive, cobra.ShellCompDirectiveNoFileComp|cobra.ShellCompDirectiveNoSpace)
 }
 
+func TestDebugCompletionUseCase(t *testing.T) {
+	// kubectl debug takes a single positional (POD | TYPE/NAME). The get-style
+	// completion suggests bare resource types (the shell then appends a space)
+	// and expects space-separated names afterwards, which produces invalid
+	// commands such as "kubectl debug pods <name>". The pod-family completion
+	// instead produces pod names and <type>/<name> slash forms, which are valid
+	// single positionals for debug.
+	dc := cmdtesting.NewFakeCachedDiscoveryClient()
+	dc.PreferredResources = []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: []string{"get", "list"}},
+			},
+		},
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Namespaced: true, Kind: "Deployment", Verbs: []string{"get", "list"}},
+			},
+		},
+	}
+
+	t.Run("get-style completion suggests a bare resource type", func(t *testing.T) {
+		tf, cmd := prepareCompletionTest()
+		tf.WithDiscoveryClient(dc)
+		pods, _, _ := cmdtesting.TestData()
+		addResourceToFactory(tf, pods)
+
+		comps, directive := ResourceTypeAndNameCompletionFunc(tf)(cmd, []string{}, "d")
+		checkCompletion(t, comps, []string{"deployments.apps"}, directive, cobra.ShellCompDirectiveNoFileComp)
+	})
+
+	t.Run("pod-family completion suggests a valid <type>/ form", func(t *testing.T) {
+		tf, cmd := prepareCompletionTest()
+		tf.WithDiscoveryClient(dc)
+		pods, _, _ := cmdtesting.TestData()
+		addResourceToFactory(tf, pods)
+
+		comps, directive := PodResourceNameCompletionFunc(tf)(cmd, []string{}, "d")
+		checkCompletion(t, comps, []string{"daemonsets/", "deployments/"}, directive, cobra.ShellCompDirectiveNoFileComp|cobra.ShellCompDirectiveNoSpace)
+	})
+}
+
 func TestPodResourceNameCompletionFuncTooManyArgs(t *testing.T) {
 	tf, cmd := prepareCompletionTest()
 	pods, _, _ := cmdtesting.TestData()


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`kubectl debug` takes a single positional (`POD | TYPE/NAME`), but its completion was wired to `ResourceTypeAndNameCompletionFunc` (the get-style completion), which suggests a bare resource type (the shell appends a space) and then a space-separated resource name. This produces invalid commands such as `kubectl debug pods <name>` (reported in #1861).

Switch `kubectl debug` to `PodResourceNameCompletionFunc` — the same completion used by `kubectl exec`, `kubectl attach` and `kubectl logs`:

- `kubectl debug <tab>` suggests pod names and `<type>/` forms (e.g. `deployments/`), which are valid single positionals
- `kubectl debug node/<tab>` still completes node names through the `<type>/<name>` path

#### Which issue(s) this PR fixes:

Fixes kubernetes/kubectl#1861

#### Special notes for your reviewer:

The completion behavior is covered by `TestDebugCompletionUseCase`, which documents the contrast between the get-style completion (bare `deployments.apps`, space appended) and the pod-family completion (`deployments/` with the no-space directive).

#### Does this PR introduce a user-facing change?

```release-note
Fixed shell completion for `kubectl debug`: it now suggests pod names and `<type>/<name>` forms instead of the invalid bare `<type>` + space-separated `<name>` sequence.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None
