### PR TITLE
feat: add PodConditionAnalyzer utility for pod status analysis

### DIFF
--- a/staging/src/k8s.io/api/core/v1/pod_utils.go
+++ b/staging/src/k8s.io/api/core/v1/pod_utils.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PodConditionAnalyzer provides utilities for analyzing pod conditions.
+type PodConditionAnalyzer struct {
+	pod *corev1.Pod
+}
+
+// NewPodConditionAnalyzer creates a new analyzer for the given pod.
+func NewPodConditionAnalyzer(pod *corev1.Pod) *PodConditionAnalyzer {
+	return &PodConditionAnalyzer{pod: pod}
+}
+
+// GetConditionStatus returns the status of a specific condition.
+func (a *PodConditionAnalyzer) GetConditionStatus(conditionType corev1.PodConditionType) corev1.ConditionStatus {
+	for _, condition := range a.pod.Status.Conditions {
+		if condition.Type == conditionType {
+			return condition.Status
+		}
+	}
+	return corev1.ConditionUnknown
+}
+
+// IsReady returns true if the pod has a Ready condition with status True.
+func (a *PodConditionAnalyzer) IsReady() bool {
+	return a.GetConditionStatus(corev1.PodReady) == corev1.ConditionTrue
+}
+
+// IsInitialized returns true if the pod has been initialized.
+func (a *PodConditionAnalyzer) IsInitialized() bool {
+	return a.GetConditionStatus(corev1.PodInitialized) == corev1.ConditionTrue
+}
+
+// IsPodScheduled returns true if the pod has been scheduled to a node.
+func (a *PodConditionAnalyzer) IsPodScheduled() bool {
+	return a.GetConditionStatus(corev1.PodScheduled) == corev1.ConditionTrue
+}
+
+// GetConditionAge returns the duration since a condition was last transitioned.
+func (a *PodConditionAnalyzer) GetConditionAge(conditionType corev1.PodConditionType) time.Duration {
+	for _, condition := range a.pod.Status.Conditions {
+		if condition.Type == conditionType {
+			return time.Since(condition.LastTransitionTime.Time)
+		}
+	}
+	return 0
+}
+
+// GetUnhealthyContainers returns containers that are not in a ready state.
+func (a *PodConditionAnalyzer) GetUnhealthyContainers() []corev1.ContainerStatus {
+	var unhealthy []corev1.ContainerStatus
+	for _, status := range a.pod.Status.ContainerStatuses {
+		if !status.Ready {
+			unhealthy = append(unhealthy, status)
+		}
+	}
+	return unhealthy
+}
+
+// GetRestartingContainers returns containers that have restarted more than the given threshold.
+func (a *PodConditionAnalyzer) GetRestartingContainers(threshold int32) []corev1.ContainerStatus {
+	var restarting []corev1.ContainerStatus
+	for _, status := range a.pod.Status.ContainerStatuses {
+		if status.RestartCount > threshold {
+			restarting = append(restarting, status)
+		}
+	}
+	return restarting
+}
+
+// GetWaitingContainers returns containers that are in a waiting state.
+func (a *PodConditionAnalyzer) GetWaitingContainers() []corev1.ContainerStatus {
+	var waiting []corev1.ContainerStatus
+	for _, status := range a.pod.Status.ContainerStatuses {
+		if status.State.Waiting != nil {
+			waiting = append(waiting, status)
+		}
+	}
+	return waiting
+}
+
+// GetSummary returns a human-readable summary of the pod status.
+func (a *PodConditionAnalyzer) GetSummary() string {
+	summary := fmt.Sprintf("Pod: %s/%s\n", a.pod.Namespace, a.pod.Name)
+	summary += fmt.Sprintf("Phase: %s\n", a.pod.Status.Phase)
+	summary += fmt.Sprintf("Ready: %v\n", a.IsReady())
+	summary += fmt.Sprintf("Restart Count: %d\n", a.GetTotalRestartCount())
+
+	if len(a.pod.Status.Conditions) > 0 {
+		summary += "Conditions:\n"
+		conditions := a.pod.Status.Conditions
+		sort.Slice(conditions, func(i, j int) bool {
+			return conditions[i].Type < conditions[j].Type
+		})
+		for _, c := range conditions {
+			summary += fmt.Sprintf("  %s: %s (last transition: %s ago)\n",
+				c.Type, c.Status, a.GetConditionAge(c.Type))
+		}
+	}
+
+	unhealthy := a.GetUnhealthyContainers()
+	if len(unhealthy) > 0 {
+		summary += fmt.Sprintf("Unhealthy Containers: %d\n", len(unhealthy))
+		for _, status := range unhealthy {
+			summary += fmt.Sprintf("  - %s\n", status.Name)
+		}
+	}
+
+	return summary
+}
+
+// GetTotalRestartCount returns the total restart count across all containers.
+func (a *PodConditionAnalyzer) GetTotalRestartCount() int32 {
+	var total int32
+	for _, status := range a.pod.Status.ContainerStatuses {
+		total += status.RestartCount
+	}
+	return total
+}
+
+// GetConditionMessages returns messages from all conditions.
+func (a *PodConditionAnalyzer) GetConditionMessages() []string {
+	var messages []string
+	for _, condition := range a.pod.Status.Conditions {
+		if condition.Message != "" {
+			messages = append(messages, fmt.Sprintf("[%s] %s", condition.Type, condition.Message))
+		}
+	}
+	return messages
+}

--- a/staging/src/k8s.io/api/core/v1/pod_utils_test.go
+++ b/staging/src/k8s.io/api/core/v1/pod_utils_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetConditionStatus(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod"},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				{Type: corev1.PodInitialized, Status: corev1.ConditionFalse},
+			},
+		},
+	}
+
+	analyzer := NewPodConditionAnalyzer(pod)
+
+	if analyzer.GetConditionStatus(corev1.PodReady) != corev1.ConditionTrue {
+		t.Error("Expected PodReady to be True")
+	}
+	if analyzer.GetConditionStatus(corev1.PodInitialized) != corev1.ConditionFalse {
+		t.Error("Expected PodInitialized to be False")
+	}
+	if analyzer.GetConditionStatus("Unknown") != corev1.ConditionUnknown {
+		t.Error("Expected unknown condition to return Unknown")
+	}
+}
+
+func TestIsReady(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   corev1.ConditionStatus
+		expected bool
+	}{
+		{"ready", corev1.ConditionTrue, true},
+		{"not ready", corev1.ConditionFalse, false},
+		{"unknown", corev1.ConditionUnknown, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: tt.status},
+					},
+				},
+			}
+			analyzer := NewPodConditionAnalyzer(pod)
+			if analyzer.IsReady() != tt.expected {
+				t.Errorf("Expected IsReady() = %v", tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetUnhealthyContainers(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "ready", Ready: true},
+				{Name: "not-ready", Ready: false},
+				{Name: "also-ready", Ready: true},
+			},
+		},
+	}
+
+	analyzer := NewPodConditionAnalyzer(pod)
+	unhealthy := analyzer.GetUnhealthyContainers()
+
+	if len(unhealthy) != 1 {
+		t.Errorf("Expected 1 unhealthy container, got %d", len(unhealthy))
+	}
+	if unhealthy[0].Name != "not-ready" {
+		t.Errorf("Expected not-ready, got %s", unhealthy[0].Name)
+	}
+}
+
+func TestGetRestartingContainers(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "low", RestartCount: 2},
+				{Name: "high", RestartCount: 10},
+				{Name: "medium", RestartCount: 5},
+			},
+		},
+	}
+
+	analyzer := NewPodConditionAnalyzer(pod)
+	restarting := analyzer.GetRestartingContainers(5)
+
+	if len(restarting) != 2 {
+		t.Errorf("Expected 2 restarting containers, got %d", len(restarting))
+	}
+}
+
+func TestGetTotalRestartCount(t *testing.T) {
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "a", RestartCount: 3},
+				{Name: "b", RestartCount: 7},
+			},
+		},
+	}
+
+	analyzer := NewPodConditionAnalyzer(pod)
+	total := analyzer.GetTotalRestartCount()
+
+	if total != 10 {
+		t.Errorf("Expected 10, got %d", total)
+	}
+}
+
+func TestGetConditionAge(t *testing.T) {
+	past := time.Now().Add(-5 * time.Minute)
+	pod := &corev1.Pod{
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, LastTransitionTime: metav1.Time{Time: past}},
+			},
+		},
+	}
+
+	analyzer := NewPodConditionAnalyzer(pod)
+	age := analyzer.GetConditionAge(corev1.PodReady)
+
+	if age < 4*time.Minute || age > 6*time.Minute {
+		t.Errorf("Expected ~5 minutes, got %v", age)
+	}
+}
+
+func TestGetSummary(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "app", Ready: true, RestartCount: 0},
+			},
+		},
+	}
+
+	analyzer := NewPodConditionAnalyzer(pod)
+	summary := analyzer.GetSummary()
+
+	if summary == "" {
+		t.Error("Expected non-empty summary")
+	}
+}


### PR DESCRIPTION
## What this PR does
Adds PodConditionAnalyzer utility to k8s.io/api/core/v1 for analyzing pod conditions and status.

## Why needed
Currently analyzing pod conditions requires manual iteration. This provides clean API.

## Changes
- pod_utils.go: New PodConditionAnalyzer with methods for condition status, ready check, unhealthy containers, restart counts, summary
- pod_utils_test.go: 8 test functions

## Usage
analyzer := v1.NewPodConditionAnalyzer(pod)
if analyzer.IsReady() { ... }
unhealthy := analyzer.GetUnhealthyContainers()