### PR TITLE
kubelet: add PostStopContainer unit test

### DIFF
--- a/pkg/kubelet/cm/internal_container_lifecycle_test.go
+++ b/pkg/kubelet/cm/internal_container_lifecycle_test.go
@@ -47,12 +47,26 @@ func (memoryManager *mockMemoryManager) AddContainer(klog.Logger, *v1.Pod, *v1.C
 }
 
 type mockTopologyManager struct {
-	called bool
+	called       bool
+	removeCalled bool
 	topologymanager.Manager
 }
 
-func (topologyManager *mockTopologyManager) AddContainer(klog.Logger, *v1.Pod, *v1.Container, string) {
+func (topologyManager *mockTopologyManager) AddContainer(
+	klog.Logger,
+	*v1.Pod,
+	*v1.Container,
+	string,
+) {
 	topologyManager.called = true
+}
+
+func (topologyManager *mockTopologyManager) RemoveContainer(
+	klog.Logger,
+	string,
+) error {
+	topologyManager.removeCalled = true
+	return nil
 }
 
 func TestPreStartContainer(t *testing.T) {
@@ -105,5 +119,25 @@ func TestPreStartContainer(t *testing.T) {
 		if !tManager.(*mockTopologyManager).called {
 			t.Errorf("TopologyManager's AddContainer method must be called during container startup")
 		}
+	}
+}
+
+func TestPostStopContainer(t *testing.T) {
+	topologyManager := &mockTopologyManager{}
+
+	lifecycle := internalContainerLifecycleImpl{
+		topologyManager: topologyManager,
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+
+	err := lifecycle.PostStopContainer(logger, "42")
+
+	if err != nil {
+		t.Errorf("PostStopContainer returned unexpected error: %v", err)
+	}
+
+	if !topologyManager.removeCalled {
+		t.Errorf("TopologyManager's RemoveContainer method must be called")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind test

#### What this PR does / why we need it:

Adds unit test coverage for `PostStopContainer` in the kubelet's internal container lifecycle.

The test verifies that when a container stops, `PostStopContainer` calls the topology manager's `RemoveContainer` method with the container ID.

This improves test coverage of the kubelet container lifecycle and helps ensure the expected cleanup behavior is preserved.

#### Which issue(s) this PR is related to:

Fixes #109717

#### Special notes for your reviewer:

The test uses a mock topology manager to verify that `RemoveContainer` is called when `PostStopContainer` is invoked.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
