### PR TITLE
test: verify MemoryQoS controls derived from admitted Pod

### DIFF
--- a/test/e2e_node/memory_qos_test.go
+++ b/test/e2e_node/memory_qos_test.go
@@ -425,6 +425,60 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 	f.Describe("memory.high throttling", func() {
 		ginkgo.AfterEach(func(ctx context.Context) { restoreConfig(ctx) })
 
+		ginkgo.It("should realize the effective controls derived from the admitted Pod", func(ctx context.Context) {
+			throttlingFactor := 0.9
+			configureMemoryQoSWithPolicy(ctx, throttlingFactor, kubeletconfig.TieredReservationMemoryReservationPolicy)
+
+			pod := memqosMakePod("memqos-effective-state", f.Namespace.Name,
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("128Mi")},
+				v1.ResourceList{v1.ResourceMemory: resource.MustParse("256Mi")},
+			)
+			pod = e2epod.NewPodClient(f).CreateSync(ctx, pod)
+			gomega.Expect(pod.Status.QOSClass).To(gomega.Equal(v1.PodQOSBurstable))
+
+			container := pod.Spec.Containers[0]
+			requestBytes := container.Resources.Requests.Memory().Value()
+			limitBytes := container.Resources.Limits.Memory().Value()
+			expectedHigh := memqosExpectedMemoryHigh(requestBytes, limitBytes, throttlingFactor)
+
+			expectedPod := map[string]string{
+				cgroupMemoryMin:  "0",
+				cgroupMemoryLow:  strconv.FormatInt(requestBytes, 10),
+				cgroupMemoryHigh: "max",
+				cgroupMemoryMax:  strconv.FormatInt(limitBytes, 10),
+			}
+			expectedContainer := map[string]string{
+				cgroupMemoryMin:  "0",
+				cgroupMemoryLow:  strconv.FormatInt(requestBytes, 10),
+				cgroupMemoryHigh: strconv.FormatInt(expectedHigh, 10),
+				cgroupMemoryMax:  strconv.FormatInt(limitBytes, 10),
+			}
+
+			podCgroupPath := memqosGetPodCgroupPath(pod, cgroupDriver)
+			containerCgroupPath := memqosGetContainerCgroupPath(
+				podCgroupPath,
+				pod.Status.ContainerStatuses[0].ContainerID,
+				cgroupDriver,
+			)
+
+			for _, target := range []struct {
+				name     string
+				path     string
+				expected map[string]string
+			}{
+				{name: "Pod", path: podCgroupPath, expected: expectedPod},
+				{name: "container", path: containerCgroupPath, expected: expectedContainer},
+			} {
+				for _, control := range []string{cgroupMemoryMin, cgroupMemoryLow, cgroupMemoryHigh, cgroupMemoryMax} {
+					observed, err := memqosReadCgroupFile(target.path, control)
+					framework.ExpectNoError(err, "reading %s %s", target.name, control)
+					framework.Logf("%s %s: got=%q, expected=%q", target.name, control, observed, target.expected[control])
+					gomega.Expect(observed).To(gomega.Equal(target.expected[control]),
+						"%s %s should match the value derived from the admitted Pod", target.name, control)
+				}
+			}
+		})
+
 		ginkgo.It("should set memory.high for Burstable pod using formula", func(ctx context.Context) {
 			throttlingFactor := 0.9
 			configureMemoryQoS(ctx, throttlingFactor)
@@ -443,13 +497,14 @@ var _ = SIGDescribe("MemoryQoS", framework.WithSerial(), func() {
 			for _, cs := range pod.Status.ContainerStatuses {
 				containerCgroupPath := memqosGetContainerCgroupPath(podCgroupPath, cs.ContainerID, cgroupDriver)
 
-				containerMemHigh, err := memqosReadCgroupInt64(containerCgroupPath, cgroupMemoryHigh)
+				containerMemHigh, err := memqosReadCgroupFile(containerCgroupPath, cgroupMemoryHigh)
 				framework.ExpectNoError(err, "reading container memory.high")
 
 				expected := memqosExpectedMemoryHigh(requestsMem.Value(), limitsMem.Value(), throttlingFactor)
-				framework.Logf("Container %s memory.high: got=%d, expected=%d", cs.Name, containerMemHigh, expected)
-				gomega.Expect(containerMemHigh).To(gomega.Equal(expected),
-					"memory.high should match formula: floor[(req + factor * (limit - req)) / pageSize] * pageSize")
+				expectedMemHigh := strconv.FormatInt(expected, 10)
+				framework.Logf("Container %s memory.high: got=%q, expected=%q", cs.Name, containerMemHigh, expectedMemHigh)
+				gomega.Expect(containerMemHigh).To(gomega.Equal(expectedMemHigh),
+					"effective memory.high should match the value derived from the admitted resources")
 			}
 		})
 


### PR DESCRIPTION
/kind cleanup
/sig node

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR adds a focused node e2e test for MemoryQoS on cgroup v2.

The test creates a Burstable Pod, derives the expected `memory.min`, `memory.low`, `memory.high`, and `memory.max` values from the admitted Pod resources, and compares them with the values read from the Pod and container cgroups.

It also makes the existing `memory.high` test easier to understand when it fails. A read error and an unexpected value now produce different messages, without adding a separate comparison model.

#### Which issue(s) this PR is related to:

Related to #141286

KEP: https://github.com/kubernetes/enhancements/issues/2570

#### Special notes for your reviewer:

The change is limited to `test/e2e_node/memory_qos_test.go`. The current upstream checks, including the containerd node e2e jobs, are passing.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/2570
```
