### PR TITLE
Add RISC-V build for the pause image

### DIFF
--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -20,7 +20,7 @@ IMAGE = $(REGISTRY)/pause
 TAG ?= 3.10.2
 REV = $(shell git describe --contains --always --match='v*')
 
-# Architectures supported: amd64, arm64, ppc64le and s390x
+# Architectures supported: amd64, arm64, ppc64le, s390x and riscv64
 ARCH ?= amd64
 # Operating systems supported: linux, windows
 OS ?= linux
@@ -38,7 +38,7 @@ BASE := ${BASE.${OS}}
 JQ_IMAGE := ghcr.io/jqlang/jq@sha256:a186dcd84a1e28bb48cdf3d7768b890d08621a87bb651fadb7db6815a6bf5ad5
 
 ALL_OS = linux windows
-ALL_ARCH.linux = amd64 arm64 ppc64le s390x
+ALL_ARCH.linux = amd64 arm64 ppc64le s390x riscv64
 ALL_OS_ARCH.linux = $(foreach arch, ${ALL_ARCH.linux}, linux-$(arch))
 ALL_ARCH.windows = amd64
 # ALL_OSVERSIONS lists all os.versions in BASE.windows.
@@ -72,6 +72,7 @@ TRIPLE.linux-amd64 := x86_64-linux-gnu
 TRIPLE.linux-arm64 := aarch64-linux-gnu
 TRIPLE.linux-ppc64le := powerpc64le-linux-gnu
 TRIPLE.linux-s390x := s390x-linux-gnu
+TRIPLE.linux-riscv64 := riscv64-linux-gnu
 TRIPLE := ${TRIPLE.${OS}-${ARCH}}
 
 # If you want to build AND push all containers, see the 'all-push' rule.
@@ -123,7 +124,7 @@ bin/wincat-windows-${ARCH}: windows/wincat/wincat.go
 
 container: .container-${OS}-$(ARCH)
 .container-linux-$(ARCH): bin/$(BIN)-$(OS)-$(ARCH)
-	docker buildx build --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
+	docker buildx build --provenance=false --sbom=false --pull --output=type=${OUTPUT_TYPE} --platform ${OS}/$(ARCH) \
 		-t $(IMAGE):$(TAG)-${OS}-$(ARCH) --build-arg BASE=${BASE} --build-arg ARCH=$(ARCH) .
 	touch $@
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a RISC-V build to the pause container image produced; no code changes.

We need it, as K3s supports building for `riscv64` (relevant discussions are [here](https://github.com/k3s-io/k3s/issues/7151) and [here](https://github.com/k3s-io/k3s/pull/7778)), but the pause image is incompatible with the architecture. The pause image is built using the kube-cross container, which now lacks a cross-compiler for `riscv64` (relevant PR [here](https://github.com/kubernetes/release/pull/4489)). This is a necessary step towards eventual RISC-V support in  Kubernetes.

#### Which issue(s) this PR is related to:

This contributes to #132836.

#### Special notes for your reviewer:

This requires the architecture to be added in the kube-cross container (relevant PR [here](https://github.com/kubernetes/release/pull/4489)).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:


```docs

```
