### PR TITLE
test/e2e/apps: Add missing wait for pods readiness in sts test

### DIFF
--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -1383,7 +1383,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					pods.Items[i].Namespace,
 					pods.Items[i].Name,
 					pods.Items[i].Spec.Containers[0].Image,
-					oldImage)
+					newImage)
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, ss.Status.CurrentRevision), "Pod %s/%s has revision %s not equal to current revision %s",
 					pods.Items[i].Namespace,
 					pods.Items[i].Name,
@@ -1449,6 +1449,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 				update.Spec.Template.Spec.Containers[0].Image = newImage
 			})
 			framework.ExpectNoError(err)
+			e2estatefulset.WaitForRunningAndReady(ctx, c, *ss.Spec.Replicas, ss)
 			ss = waitForStatus(ctx, c, ss)
 			pods, err = e2estatefulset.GetPodList(ctx, c, ss)
 			framework.ExpectNoError(err)
@@ -1459,7 +1460,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					pods.Items[i].Namespace,
 					pods.Items[i].Name,
 					pods.Items[i].Spec.Containers[0].Image,
-					oldImage)
+					newImage)
 				gomega.Expect(pods.Items[i].Labels).To(gomega.HaveKeyWithValue(appsv1.StatefulSetRevisionLabel, ss.Status.CurrentRevision), "Pod %s/%s has revision %s not equal to current revision %s",
 					pods.Items[i].Namespace,
 					pods.Items[i].Name,


### PR DESCRIPTION
#### What type of PR is this?
/kind flake
/sig apps

#### What this PR does / why we need it:
During testing recreate strategy we are injecting a broken image to fail the entire statefulset. After that we're updating the statefulset with correct one and expect the controller correctly recreates pods. The problem was that we only waited for status.observedGeneration to catch up but not for pods, which in the next steps we iterated over and checked for updated image. Adding WaitForRunningAndReady, similarly how we do that early on in the test should resolve the problem.

#### Which issue(s) this PR is related to:
Fixes #141288

#### Special notes for your reviewer:
/assign @helayoty 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
