### PR TITLE
Fix windows backslash escaping

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec.go
@@ -73,7 +73,9 @@ func (p localPath) StripSlashes() localPath {
 }
 
 func isRelative(base, target localPath) bool {
-	relative, err := filepath.Rel(base.String(), target.String())
+	baseNormalized := strings.ReplaceAll(stripTrailingSlash(base.String()), `\`, "/")
+	targetNormalized := strings.ReplaceAll(stripTrailingSlash(target.String()), `\`, "/")
+	relative, err := filepath.Rel(baseNormalized, targetNormalized)
 	if err != nil {
 		return false
 	}
@@ -141,11 +143,18 @@ func stripLeadingSlash(file string) string {
 // stripPathShortcuts removes any leading or trailing "../" from a given path
 func stripPathShortcuts(p string) string {
 	newPath := p
-	trimmed := strings.TrimPrefix(newPath, "../")
+	trimmedPosix := strings.TrimPrefix(newPath, "../")
 
-	for trimmed != newPath {
-		newPath = trimmed
-		trimmed = strings.TrimPrefix(newPath, "../")
+	for trimmedPosix != newPath {
+		newPath = trimmedPosix
+		trimmedPosix = strings.TrimPrefix(newPath, "../")
+	}
+
+	trimmedWindows := strings.TrimPrefix(newPath, `..\`)
+
+	for trimmedWindows != newPath {
+		newPath = trimmedWindows
+		trimmedWindows = strings.TrimPrefix(newPath, `..\`)
 	}
 
 	// trim leftover {".", ".."}
@@ -153,7 +162,7 @@ func stripPathShortcuts(p string) string {
 		newPath = ""
 	}
 
-	if len(newPath) > 0 && string(newPath[0]) == "/" {
+	if len(newPath) > 0 && (string(newPath[0]) == "/" || string(newPath[0]) == `\`) {
 		return newPath[1:]
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cp
 
 import "testing"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec_test.go
@@ -1,0 +1,152 @@
+package cp
+
+import "testing"
+
+func TestIsRelative(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		base     string
+		expected bool
+	}{
+		{
+			name:     "test single path shortcut prefix",
+			input:    "../foo/bar",
+			base:     "../",
+			expected: true,
+		},
+		{
+			name:     "test single path shortcut prefix (Windows)",
+			input:    `..\foo\bar`,
+			base:     `..\`,
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts",
+			input:    "../../foo/bar",
+			base:     "../",
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts (Windows)",
+			input:    `..\..\foo\bar`,
+			base:     `..\`,
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts with absolute path",
+			input:    "/tmp/one/two/../../foo/bar",
+			base:     "/",
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts with absolute path (Windows)",
+			input:    `\tmp\one\two\..\..\foo\bar`,
+			base:     `\`,
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory",
+			input:    "../../",
+			base:     "../",
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory (Windows)",
+			input:    `..\..\`,
+			base:     `..\`,
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory and no trailing slash",
+			input:    "../..",
+			base:     "../",
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory and no trailing slash (Windows)",
+			input:    `..\..`,
+			base:     `..\`,
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts with absolute path and filename containing leading dots",
+			input:    "/tmp/one/two/../../foo/..bar",
+			base:     "/",
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts with absolute path and filename containing leading dots (Windows)",
+			input:    `\tmp\one\two\..\..\foo\..bar`,
+			base:     `\`,
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory and filename containing leading dots",
+			input:    "../...foo",
+			base:     "../",
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory and filename containing leading dots (Windows)",
+			input:    `..\...foo`,
+			base:     `..\`,
+			expected: true,
+		},
+		{
+			name:     "test filename containing leading dots",
+			input:    "/...foo",
+			base:     "/",
+			expected: true,
+		},
+		{
+			name:     "test root directory",
+			input:    "/",
+			base:     "/",
+			expected: true,
+		},
+		{
+			name:     "test root directory (Windows)",
+			input:    `\`,
+			base:     `\`,
+			expected: true,
+		},
+		{
+			name:     "test basic relative path",
+			input:    "/a/b/c",
+			base:     "/a",
+			expected: true,
+		},
+		{
+			name:     "test basic relative path (Windows)",
+			input:    `\a\b\c`,
+			base:     `\a`,
+			expected: true,
+		},
+		{
+			name:     "test basic non relative path",
+			input:    "/a/b/c",
+			base:     "/f",
+			expected: false,
+		},
+		{
+			name:     "test basic non relative path (Windows)",
+			input:    `\a\b\c`,
+			base:     `\f`,
+			expected: false,
+		},
+		{
+			name:     "test mix of Windows base and linux input",
+			input:    `\a\b\c`,
+			base:     `/f`,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		result := isRelative(newLocalPath(test.base), newLocalPath(test.input))
+		if result != test.expected {
+			t.Errorf("%s: %t, saw: %t", test.name, test.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Fixes case where isRelative doesn't handle Windows `\` properly allowing users to provide improperly escaped relative paths.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
