### PR TITLE
fix: check ExtendedResourceClaimStatus in podEvictionTime for NoExecute eviction [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -1632,6 +1632,39 @@ func (tc *Controller) podEvictionTime(pod *v1.Pod) *evictionAndReason {
 		}
 	}
 
+	// Also check extended resource claims (KEP-5004, DRAExtendedResource).
+	// Pods using extended resource backed by DRA have their claim reference in
+	// pod.Status.ExtendedResourceClaimStatus, not in pod.Spec.ResourceClaims.
+	// Without this, NoExecute device taint eviction silently skips pods that
+	// request devices via the extended resource field (e.g. nvidia.com/gpu: 1),
+	// which is the default path for existing GPU workloads.
+	if pod.Status.ExtendedResourceClaimStatus != nil {
+		claimName := pod.Status.ExtendedResourceClaimStatus.ResourceClaimName
+		allocatedClaim, ok := tc.allocatedClaims[types.NamespacedName{Namespace: pod.Namespace, Name: claimName}]
+		if ok && allocatedClaim.eviction != nil {
+			if eviction == nil {
+				eviction = allocatedClaim.eviction
+			} else {
+				newEvictionTime := &evictionAndReason{
+					when:   allocatedClaim.eviction.when,
+					reason: slices.Clone(allocatedClaim.eviction.reason),
+				}
+				for _, reason := range eviction.reason {
+					index, found := slices.BinarySearchFunc(newEvictionTime.reason, reason, func(a, b trackedTaint) int { return a.Compare(b) })
+					if !found {
+						newEvictionTime.reason = slices.Insert(newEvictionTime.reason, index, reason)
+					}
+				}
+				if eviction.when.Before(&newEvictionTime.when) {
+					newEvictionTime.when = eviction.when
+				}
+				if !eviction.equal(newEvictionTime) {
+					eviction = newEvictionTime
+				}
+			}
+		}
+	}
+
 	return eviction
 }
 


### PR DESCRIPTION
### Which problem is this PR solving?

Fixes #141290

Pods using extended resource backed by DRA (KEP-5004, DRAExtendedResource) have their claim reference in `pod.Status.ExtendedResourceClaimStatus`, not in `pod.Spec.ResourceClaims`. The device-taint eviction controller only looked at `pod.Spec.ResourceClaims`, so NoExecute device taint eviction silently skipped pods that request devices via the extended resource field (e.g. `nvidia.com/gpu: 1`).

### Description of the changes

After the existing loop over `pod.Spec.ResourceClaims` in `podEvictionTime`, also check `pod.Status.ExtendedResourceClaimStatus` for the extended resource backed by DRA path. When present, look up the claim in `tc.allocatedClaims` and apply the same eviction logic.

This mirrors the same dual-location check already present in `pkg/controller/resourceclaim/controller.go`.

### How has this been tested?

Trivial change — the logic mirrors the existing pattern identically; no behavioral change for the `pod.Spec.ResourceClaims` path.

### Special notes for your reviewer

The reporter's issue body includes a complete live reproduction on a `kind` cluster (see #141290). I was unable to run the full integration test suite locally, but the change is a direct parallel of the existing pattern.