### PR TITLE
fix: exclude Succeeded pods from HPA groupPods calculation

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -424,7 +424,7 @@ func groupPods(pods []*v1.Pod, metrics metricsclient.PodMetricsInfo, resource v1
 	unreadyPods = sets.New[string]()
 	ignoredPods = sets.New[string]()
 	for _, pod := range pods {
-		if pod.DeletionTimestamp != nil || pod.Status.Phase == v1.PodFailed {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded {
 			ignoredPods.Insert(pod.Name)
 			continue
 		}


### PR DESCRIPTION
**What this PR does / why we need it:**

Succeeded pods are in a terminal state and should never be included in HPA calculations. The  function in  already excludes pods with  and  phase, but it does not exclude  pods. This causes Succeeded pods to fall through to , skewing the replica count calculation.

**Which issue(s) this PR fixes:**

Fixes #141298

**Special notes for your reviewer:**

This is a minimal one-line change. The missingPods logic assigns either the target value (downscale) or zero (scale-up) to missing pods. When a large number of Succeeded pods are present, they can:
- Dampen downscaling (missing pods assigned target value increases the average)
- Dampen scaling up (missing pods assigned zero decreases the average)

**Checklist:**

- [x] Bug fix
- [x] Tests: existing tests already cover Succeeded pod scenarios, but they were not testing the exclusion behavior. Adding a dedicated test case for Succeeded pods in groupPods.