### PR TITLE
Ignore succeeded pods in HPA replica calculations

### DIFF
--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -424,7 +424,7 @@ func groupPods(pods []*v1.Pod, metrics metricsclient.PodMetricsInfo, resource v1
 	unreadyPods = sets.New[string]()
 	ignoredPods = sets.New[string]()
 	for _, pod := range pods {
-		if pod.DeletionTimestamp != nil || pod.Status.Phase == v1.PodFailed {
+		if pod.DeletionTimestamp != nil || podutil.IsPodTerminal(pod) {
 			ignoredPods.Insert(pod.Name)
 			continue
 		}

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -623,6 +623,39 @@ func TestReplicaCalcResourceScale(t *testing.T) {
 			expectedRawValue:    600,
 		},
 		{
+			name: "scale up: succeeded pods ignored",
+			fixture: calcScenario{
+				currentReplicas: 2,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodSucceeded, v1.PodSucceeded},
+				resource: &cpuResource{
+					requests: cpuRequests(4, "1.0"),
+					levels:   makePodMetricLevels(500, 700),
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    4,
+			expectedUtilization: 60,
+			expectedRawValue:    numContainersPerPod * 600,
+		},
+		{
+			name: "scale up: container metric with succeeded pods ignored",
+			fixture: calcScenario{
+				currentReplicas: 2,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodSucceeded, v1.PodSucceeded},
+				container:       "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(4, "1.0"),
+					levels:   [][]int64{{1000, 500}, {9000, 700}},
+				},
+			},
+			targetUtilization:   30,
+			expectedReplicas:    4,
+			expectedUtilization: 60,
+			expectedRawValue:    600,
+		},
+		{
 			name: "scale up: pods being deleted are ignored",
 			fixture: calcScenario{
 				currentReplicas:      2,
@@ -815,6 +848,39 @@ func TestReplicaCalcResourceScale(t *testing.T) {
 			expectedRawValue:    280,
 		},
 		{
+			name: "scale down: succeeded pods ignored",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodSucceeded, v1.PodSucceeded},
+				resource: &cpuResource{
+					requests: cpuRequests(7, "1.0"),
+					levels:   makePodMetricLevels(100, 300, 500, 250, 250),
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    3,
+			expectedUtilization: 28,
+			expectedRawValue:    numContainersPerPod * 280,
+		},
+		{
+			name: "scale down: container metric with succeeded pods ignored",
+			fixture: calcScenario{
+				currentReplicas: 5,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionTrue, v1.ConditionFalse, v1.ConditionFalse},
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodRunning, v1.PodSucceeded, v1.PodSucceeded},
+				container:       "container2",
+				resource: &cpuResource{
+					requests: cpuRequests(7, "1.0"),
+					levels:   [][]int64{{1000, 100}, {1000, 300}, {1000, 500}, {1000, 250}, {1000, 250}},
+				},
+			},
+			targetUtilization:   50,
+			expectedReplicas:    3,
+			expectedUtilization: 28,
+			expectedRawValue:    280,
+		},
+		{
 			name: "scale down: pods being deleted are ignored",
 			fixture: calcScenario{
 				currentReplicas:      5,
@@ -864,54 +930,6 @@ func TestReplicaCalcResourceScale(t *testing.T) {
 			assertResourceReplicas(t,
 				tc.expectedReplicas, tc.expectedUtilization, tc.expectedRawValue, tc.fixture.timestamp, tc.expectedError,
 				replicas, util, raw, ts, err,
-			)
-		})
-	}
-}
-
-func TestReplicaCalcRawResourceIgnoresSucceededPods(t *testing.T) {
-	testCases := []struct {
-		name             string
-		levels           [][]int64
-		targetUsage      int64
-		expectedReplicas int32
-		expectedUsage    int64
-	}{
-		{
-			name:             "scale up",
-			levels:           makePodMetricLevels(2000, 2000),
-			targetUsage:      1000,
-			expectedReplicas: 4,
-			expectedUsage:    2000,
-		},
-		{
-			name:             "scale down",
-			levels:           makePodMetricLevels(400, 400),
-			targetUsage:      1000,
-			expectedReplicas: 1,
-			expectedUsage:    400,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			fixture := calcScenario{
-				currentReplicas: 2,
-				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodSucceeded, v1.PodSucceeded},
-				container:       "container1",
-				resource: &cpuResource{
-					levels: tc.levels,
-				},
-			}
-			h := newReplicaCalcSetup(t, &fixture)
-
-			replicas, usage, ts, err := h.calc.GetRawResourceReplicas(
-				h.ctx, fixture.currentReplicas, tc.targetUsage,
-				v1.ResourceCPU, h.tolerances, h.namespace, h.selector, fixture.container,
-			)
-			assertMetricReplicas(t,
-				tc.expectedReplicas, tc.expectedUsage, fixture.timestamp, nil,
-				replicas, usage, ts, err,
 			)
 		})
 	}

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -256,7 +256,7 @@ func newFakePodClient(f *calcScenario) *fake.Clientset {
 	fakeClient.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		obj := &v1.PodList{}
 		podsCount := int(f.currentReplicas)
-		// Failed pods aren't included in currentReplicas.
+		// Terminal pods aren't included in currentReplicas.
 		if f.podPhase != nil && len(f.podPhase) > podsCount {
 			podsCount = len(f.podPhase)
 		}
@@ -864,6 +864,54 @@ func TestReplicaCalcResourceScale(t *testing.T) {
 			assertResourceReplicas(t,
 				tc.expectedReplicas, tc.expectedUtilization, tc.expectedRawValue, tc.fixture.timestamp, tc.expectedError,
 				replicas, util, raw, ts, err,
+			)
+		})
+	}
+}
+
+func TestReplicaCalcRawResourceIgnoresSucceededPods(t *testing.T) {
+	testCases := []struct {
+		name             string
+		levels           [][]int64
+		targetUsage      int64
+		expectedReplicas int32
+		expectedUsage    int64
+	}{
+		{
+			name:             "scale up",
+			levels:           makePodMetricLevels(2000, 2000),
+			targetUsage:      1000,
+			expectedReplicas: 4,
+			expectedUsage:    2000,
+		},
+		{
+			name:             "scale down",
+			levels:           makePodMetricLevels(400, 400),
+			targetUsage:      1000,
+			expectedReplicas: 1,
+			expectedUsage:    400,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := calcScenario{
+				currentReplicas: 2,
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodSucceeded, v1.PodSucceeded},
+				container:       "container1",
+				resource: &cpuResource{
+					levels: tc.levels,
+				},
+			}
+			h := newReplicaCalcSetup(t, &fixture)
+
+			replicas, usage, ts, err := h.calc.GetRawResourceReplicas(
+				h.ctx, fixture.currentReplicas, tc.targetUsage,
+				v1.ResourceCPU, h.tolerances, h.namespace, h.selector, fixture.container,
+			)
+			assertMetricReplicas(t,
+				tc.expectedReplicas, tc.expectedUsage, fixture.timestamp, nil,
+				replicas, usage, ts, err,
 			)
 		})
 	}
@@ -1769,7 +1817,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "bentham",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 					},
 				},
 			},
@@ -1789,7 +1837,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "lucretius",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 						StartTime: &metav1.Time{
 							Time: time.Now(),
 						},
@@ -1812,7 +1860,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "bentham",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 						StartTime: &metav1.Time{
 							Time: time.Now().Add(-1 * time.Minute),
 						},
@@ -1842,7 +1890,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "bentham",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 						StartTime: &metav1.Time{
 							Time: time.Now().Add(-1 * time.Minute),
 						},
@@ -1872,7 +1920,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "lucretius",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 						StartTime: &metav1.Time{
 							Time: time.Now().Add(-10 * time.Minute),
 						},
@@ -1902,7 +1950,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "bentham",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 						StartTime: &metav1.Time{
 							Time: time.Now().Add(-3 * time.Minute),
 						},
@@ -1932,7 +1980,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "lucretius",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 						StartTime: &metav1.Time{
 							Time: time.Now().Add(-10 * time.Minute),
 						},
@@ -1962,7 +2010,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "lucretius",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 						StartTime: &metav1.Time{
 							Time: time.Now().Add(-10 * time.Minute),
 						},
@@ -1992,7 +2040,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "epicurus",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 						StartTime: &metav1.Time{
 							Time: time.Now().Add(-3 * time.Minute),
 						},
@@ -2013,7 +2061,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "lucretius",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 						StartTime: &metav1.Time{
 							Time: time.Now(),
 						},
@@ -2024,7 +2072,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "niccolo",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 						StartTime: &metav1.Time{
 							Time: time.Now().Add(-3 * time.Minute),
 						},
@@ -2042,7 +2090,7 @@ func TestGroupPods(t *testing.T) {
 						Name: "epicurus",
 					},
 					Status: v1.PodStatus{
-						Phase: v1.PodSucceeded,
+						Phase: v1.PodRunning,
 						StartTime: &metav1.Time{
 							Time: time.Now().Add(-3 * time.Minute),
 						},
@@ -2117,6 +2165,26 @@ func TestGroupPods(t *testing.T) {
 			expectUnreadyPods:   sets.New[string](),
 			expectMissingPods:   sets.New[string](),
 			expectIgnoredPods:   sets.New[string]("failed"),
+		}, {
+			name: "ignore pods in a succeeded state",
+			pods: []*v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "succeeded",
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodSucceeded,
+					},
+				},
+			},
+			metrics: metricsclient.PodMetricsInfo{
+				"succeeded": metricsclient.PodMetric{Value: 1},
+			},
+			resource:            v1.ResourceCPU,
+			expectReadyPodCount: 0,
+			expectUnreadyPods:   sets.New[string](),
+			expectMissingPods:   sets.New[string](),
+			expectIgnoredPods:   sets.New[string]("succeeded"),
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Fixes HPA behavior which damps scaling when `Succeeded` pods are present matching the label selector. Adds tests to verify this behavior

#### Which issue(s) this PR is related to:
Fixes #141298

#### Special notes for your reviewer:
Tested via:
```
go test ./pkg/controller/podautoscaler/...
```

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
