### PR TITLE
Ignore NotFound errors when deleting EndpointSlices

### DIFF
--- a/staging/src/k8s.io/endpointslice/reconciler.go
+++ b/staging/src/k8s.io/endpointslice/reconciler.go
@@ -148,16 +148,24 @@ func (r *Reconciler) Reconcile(logger klog.Logger, service *corev1.Service, pods
 	// delete those which are of addressType that is no longer supported
 	// by the service
 	for _, sliceToDelete := range slicesToDelete {
-		err := r.client.DiscoveryV1().EndpointSlices(service.Namespace).Delete(context.TODO(), sliceToDelete.Name, metav1.DeleteOptions{})
-		if err != nil {
+		if err := r.deleteEndpointSlice(service, sliceToDelete); err != nil {
 			errs = append(errs, fmt.Errorf("error deleting %s EndpointSlice for Service %s/%s: %w", sliceToDelete.Name, service.Namespace, service.Name, err))
-		} else {
-			r.endpointSliceTracker.ExpectDeletion(sliceToDelete)
-			metrics.EndpointSliceChanges.WithLabelValues("delete").Inc()
 		}
 	}
 
 	return utilerrors.NewAggregate(errs)
+}
+
+// deleteEndpointSlice tolerates slices that have already been deleted.
+func (r *Reconciler) deleteEndpointSlice(service *corev1.Service, endpointSlice *discovery.EndpointSlice) error {
+	err := r.client.DiscoveryV1().EndpointSlices(service.Namespace).Delete(context.TODO(), endpointSlice.Name, metav1.DeleteOptions{})
+	if err != nil {
+		return utilerrors.FilterOut(err, errors.IsNotFound)
+	}
+
+	r.endpointSliceTracker.ExpectDeletion(endpointSlice)
+	metrics.EndpointSliceChanges.WithLabelValues("delete").Inc()
+	return nil
 }
 
 // reconcileByAddressType takes a set of pods currently matching a service selector and
@@ -462,12 +470,9 @@ func (r *Reconciler) finalize(
 	}
 
 	for _, endpointSlice := range slicesToDelete {
-		err := r.client.DiscoveryV1().EndpointSlices(service.Namespace).Delete(context.TODO(), endpointSlice.Name, metav1.DeleteOptions{})
-		if err != nil {
+		if err := r.deleteEndpointSlice(service, endpointSlice); err != nil {
 			return fmt.Errorf("failed to delete %s EndpointSlice for Service %s/%s: %v", endpointSlice.Name, service.Namespace, service.Name, err)
 		}
-		r.endpointSliceTracker.ExpectDeletion(endpointSlice)
-		metrics.EndpointSliceChanges.WithLabelValues("delete").Inc()
 	}
 
 	topologyLabel := "Disabled"

--- a/staging/src/k8s.io/endpointslice/reconciler_test.go
+++ b/staging/src/k8s.io/endpointslice/reconciler_test.go
@@ -1138,6 +1138,100 @@ func TestReconcileEndpointSlicesReplaceDeprecated(t *testing.T) {
 	cmc.Check(t)
 }
 
+func TestReconcilerDeleteEndpointSlice(t *testing.T) {
+	deletePaths := []struct {
+		name   string
+		delete func(*testing.T, *Reconciler, *corev1.Service, *discovery.EndpointSlice) error
+	}{
+		{
+			name: "unsupported address type",
+			delete: func(t *testing.T, r *Reconciler, service *corev1.Service, slice *discovery.EndpointSlice) error {
+				logger, _ := ktesting.NewTestContext(t)
+				return r.Reconcile(logger, service, nil, []*discovery.EndpointSlice{slice}, time.Now())
+			},
+		},
+		{
+			name: "finalize",
+			delete: func(_ *testing.T, r *Reconciler, service *corev1.Service, slice *discovery.EndpointSlice) error {
+				return r.finalize(service, nil, nil, []*discovery.EndpointSlice{slice}, time.Now())
+			},
+		},
+	}
+
+	testCases := []struct {
+		name                 string
+		createStoredSlice    bool
+		wantDeletionExpected bool
+		wantDeleteMetric     float64
+	}{
+		{
+			name: "already deleted",
+		},
+		{
+			name:                 "existing slice",
+			createStoredSlice:    true,
+			wantDeletionExpected: true,
+			wantDeleteMetric:     1,
+		},
+	}
+
+	for _, deletePath := range deletePaths {
+		t.Run(deletePath.name, func(t *testing.T) {
+			for _, testCase := range testCases {
+				t.Run(testCase.name, func(t *testing.T) {
+					client := newClientset()
+					resetMetrics()
+					namespace := "test"
+					service, endpointMeta := newServiceAndEndpointMeta("foo", namespace)
+					cachedSlice := newEmptyEndpointSlice(1, namespace, endpointMeta, service)
+					cachedSlice.Generation = 1
+					cachedSlice.AddressType = discovery.AddressTypeIPv6
+					cachedSlice.Labels = map[string]string{
+						discovery.LabelManagedBy:   controllerName,
+						discovery.LabelServiceName: service.Name,
+					}
+
+					if testCase.createStoredSlice {
+						createEndpointSlices(t, client, namespace, []*discovery.EndpointSlice{cachedSlice})
+					}
+					client.ClearActions()
+
+					r := newReconciler(client, nil, defaultMaxEndpointsPerSlice)
+					r.endpointSliceTracker.Update(cachedSlice)
+
+					if err := deletePath.delete(t, r, &service, cachedSlice); err != nil {
+						t.Fatalf("Expected EndpointSlice deletion to succeed, got %v", err)
+					}
+					expectActions(t, client.Actions(), 1, "delete", "endpointslices")
+
+					expectedGeneration := cachedSlice.Generation
+					if testCase.wantDeletionExpected {
+						expectedGeneration = -1
+					}
+					expectTrackedGeneration(t, r.endpointSliceTracker, cachedSlice, expectedGeneration)
+
+					deleted, err := testutil.GetCounterMetricValue(metrics.EndpointSliceChanges.WithLabelValues("delete"))
+					if err != nil {
+						t.Fatalf("Failed to get EndpointSlice deletion metric: %v", err)
+					}
+					if deleted != testCase.wantDeleteMetric {
+						t.Errorf("Expected EndpointSlice deletion metric %v, got %v", testCase.wantDeleteMetric, deleted)
+					}
+					if deletePath.name == "finalize" {
+						changed, err := testutil.GetHistogramMetricValue(metrics.EndpointSlicesChangedPerSync.WithLabelValues("Disabled", ""))
+						if err != nil {
+							t.Fatalf("Failed to get EndpointSlice changes per sync metric: %v", err)
+						}
+						if changed != 1 {
+							t.Errorf("Expected EndpointSlice changes per sync metric 1, got %v", changed)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
 // In this test, we want to verify that a Service recreation will result in new
 // EndpointSlices being created.
 func TestReconcileEndpointSlicesRecreation(t *testing.T) {


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Treat NotFound as an expected outcome when deleting an EndpointSlice that remains in the informer cache after it has already been deleted. This avoids unnecessary reconciliation retries under cache lag while recording deletion expectations and metrics only when a slice is actually deleted.

#### Does this PR introduce a user-facing change?

```release-note
The EndpointSlice controller no longer retries reconciliation when an EndpointSlice selected for deletion has already been removed.
```
