### PR TITLE
resource: add Quantity.AsScaledInt64 and AsMilliInt64

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1422,7 +1422,16 @@ func parseResourceList(m map[string]string) (v1.ResourceList, error) {
 				return nil, fmt.Errorf("resource quantity for %q cannot be negative: %v", k, v)
 			}
 			if v1.ResourceName(k) == v1.ResourceCPU {
-				q.SetMilli((q.ScaledValue(resource.Micro) + 500) / 1000)
+				// Round to the nearest milli while micro-cores fit an int64, where
+				// micro+500 used to wrap into a negative reservation. Past that the
+				// value is kept as parsed, so the cutoff is a step, not a no-op.
+				if micro, ok := q.AsScaledInt64(resource.Micro); ok {
+					milli := micro / 1000
+					if micro%1000 >= 500 {
+						milli++
+					}
+					q.SetMilli(milli)
+				}
 			}
 			rl[v1.ResourceName(k)] = q
 		default:

--- a/cmd/kubelet/app/server_test.go
+++ b/cmd/kubelet/app/server_test.go
@@ -27,6 +27,7 @@ import (
 
 	yaml "go.yaml.in/yaml/v2"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
 	kubeletconfiginternal "k8s.io/kubernetes/pkg/kubelet/apis/config"
@@ -103,6 +104,28 @@ func TestParseResourceList(t *testing.T) {
 		q := rl[v1.ResourceCPU]
 		require.Equal(t, test.expected, q.String(), test.name)
 	}
+}
+
+func TestParseResourceListCPUOverflowsMicro(t *testing.T) {
+	// The old rounding read the quantity through a wrapping micro projection, so
+	// a reservation past that range was stored as a negative number of cores.
+	for _, v := range []string{"1e30", "10000000000000", "9223372036854775808u"} {
+		rl, err := parseResourceList(map[string]string{"cpu": v})
+		require.NoError(t, err, v)
+		q := rl[v1.ResourceCPU]
+		require.Equal(t, 1, q.Sign(), v)
+		require.Zero(t, q.Cmp(resource.MustParse(v)), "%s: kept unrounded, got %s", v, q.String())
+	}
+
+	// The largest micro value that fits, where adding 500 before dividing does not.
+	rl, err := parseResourceList(map[string]string{"cpu": "9223372036854775807u"})
+	require.NoError(t, err)
+	q := rl[v1.ResourceCPU]
+	require.Equal(t, int64(9223372036854776), q.MilliValue())
+
+	// Rounding stops at the cutoff rather than continuing past it, so the largest
+	// rounded value sits above the smallest kept one.
+	require.Equal(t, 1, q.Cmp(resource.MustParse("9223372036854775808u")))
 }
 
 func TestMergeKubeletConfigurations(t *testing.T) {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount.go
@@ -109,16 +109,35 @@ func (a int64Amount) AsInt64() (int64, bool) {
 }
 
 // AsScaledInt64 returns an int64 representing the value of this amount at the specified scale,
-// rounding up, or false if that would result in overflow. (1e20).AsScaledInt64(1) would result
-// in overflow because 1e19 is not representable as an int64. Note that setting a scale larger
-// than the current value may result in loss of precision - i.e. (1e-6).AsScaledInt64(0) would
-// return 1, because 0.000001 is rounded up to 1.
+// rounding away from zero. ok is false when the value overflows int64, in which case the result
+// saturates to mostNegative or mostPositive. (1e20).AsScaledInt64(1) overflows because 1e19 is not
+// representable as an int64. Setting a scale larger than the current value may lose precision:
+// (1e-6).AsScaledInt64(0) returns 1, because 0.000001 rounds away from zero to 1.
 func (a int64Amount) AsScaledInt64(scale Scale) (result int64, ok bool) {
-	if a.scale < scale {
-		result, _ = negativeScaleInt64(a.value, scale-a.scale)
+	if a.value == 0 {
+		return 0, true
+	}
+	// Widen first: the delta of two int32 scales can need 33 bits.
+	delta := int64(a.scale) - int64(scale)
+	if delta < 0 {
+		// Scaling down past 10^-log10MaxInt64 leaves only the rounding unit.
+		if delta <= -log10MaxInt64 {
+			if a.value < 0 {
+				return -1, true
+			}
+			return 1, true
+		}
+		result, _ = negativeScaleInt64(a.value, Scale(-delta))
 		return result, true
 	}
-	return positiveScaleInt64(a.value, a.scale-scale)
+	// Scaling up: 10^log10MaxInt64 already exceeds int64.
+	if delta >= log10MaxInt64 {
+		if a.value < 0 {
+			return mostNegative, false
+		}
+		return mostPositive, false
+	}
+	return positiveScaleInt64(a.value, Scale(delta))
 }
 
 // AsDec returns an inf.Dec representation of this value.

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/amount_test.go
@@ -31,7 +31,8 @@ func TestInt64AmountAsInt64(t *testing.T) {
 		{100, 0, 100, true},
 		{100, 1, 1000, true},
 		{100, -5, 0, false},
-		{100, 100, 0, false},
+		// overflow saturates to the sign-correct rail; ok stays false.
+		{100, 100, mostPositive, false},
 	} {
 		r, ok := int64Amount{value: test.value, scale: test.scale}.AsInt64()
 		if r != test.result {
@@ -208,7 +209,7 @@ func TestInt64AmountAsScaledInt64(t *testing.T) {
 		{"test when i.scale < scaled ", int64Amount{value: 100, scale: 0}, 5, 1, true},
 		{"test when i.scale = scaled", int64Amount{value: 100, scale: 1}, 1, 100, true},
 		{"test when i.scale > scaled and result doesn't overflow", int64Amount{value: 100, scale: 5}, 2, 100000, true},
-		{"test when i.scale > scaled and result overflows", int64Amount{value: 876, scale: 30}, 4, 0, false},
+		{"test when i.scale > scaled and result overflows (saturates to the sign-correct rail)", int64Amount{value: 876, scale: 30}, 4, mostPositive, false},
 		{"test when i.scale < 0 and fraction exists", int64Amount{value: 93, scale: -1}, 0, 10, true},
 		{"test when i.scale < 0 and fraction doesn't exist", int64Amount{value: 100, scale: -1}, 0, 10, true},
 		{"test when i.value < 0 and fraction exists", int64Amount{value: -1932, scale: 2}, 4, -20, true},

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/checked_accessors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/checked_accessors_test.go
@@ -1,0 +1,331 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import (
+	"math"
+	"math/big"
+	"testing"
+)
+
+// pow10Big returns 10^n as a *big.Int.
+func pow10Big(n int) *big.Int {
+	return new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(n)), nil)
+}
+
+// TestPositiveScaleInt64Saturation pins the int64-path saturation: an overflow
+// lands on the rail matching the sign of base, and ok reports the overflow.
+func TestPositiveScaleInt64Saturation(t *testing.T) {
+	for _, tc := range []struct {
+		base   int64
+		scale  Scale
+		want   int64
+		wantOK bool
+	}{
+		{0, 100, 0, true},                     // zero cannot overflow
+		{0, 2000000000, 0, true},              // zero short-circuits an extreme scale (no hang)
+		{1, 18, 1000000000000000000, true},    // 1e18 fits
+		{-1, 18, -1000000000000000000, true},  // -1e18 fits
+		{mostPositive, 0, mostPositive, true}, // scale 0 is identity
+		{mostPositive / 10, 1, (mostPositive / 10) * 10, true},
+		{mostPositive, 1, mostPositive, false}, // was -10 before the fix
+		{mostNegative, 1, mostNegative, false},
+		{mostNegative, 2, mostNegative, false},
+		{5, 20, mostPositive, false},  // positive overflow -> +rail
+		{-5, 20, mostNegative, false}, // negative overflow -> -rail
+		{-1, 19, mostNegative, false}, // -1e19 overflows
+	} {
+		got, ok := positiveScaleInt64(tc.base, tc.scale)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("positiveScaleInt64(%d, %d) = (%d, %t), want (%d, %t)", tc.base, tc.scale, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+// TestScaledValueSaturationAndRounding pins the Dec-path (big.Int) behavior:
+// away-from-zero rounding that matches negativeScaleInt64, and saturation with
+// ok=false on overflow, across the fast and big scale-down paths and scale-up.
+func TestScaledValueSaturationAndRounding(t *testing.T) {
+	neg := func(b *big.Int) *big.Int { return new(big.Int).Neg(b) }
+	add := func(b *big.Int, n int64) *big.Int { return new(big.Int).Add(b, big.NewInt(n)) }
+	for _, tc := range []struct {
+		name     string
+		unscaled *big.Int
+		scale    int64
+		newScale int64
+		want     int64
+		wantOK   bool
+	}{
+		{"pos round away", big.NewInt(95), 1, 0, 10, true},   // 9.5 -> 10
+		{"neg round away", big.NewInt(-95), 1, 0, -10, true}, // -9.5 -> -10
+		{"pos exact", big.NewInt(100), 1, 0, 10, true},
+		{"neg exact", big.NewInt(-100), 1, 0, -10, true},
+		{"pos tiny fraction", big.NewInt(1), 3, 0, 1, true},                  // 0.001 -> 1
+		{"neg tiny fraction", big.NewInt(-1), 3, 0, -1, true},                // -0.001 -> -1
+		{"scale-down pos overflow", pow10Big(30), 3, 0, mostPositive, false}, // 1e27 > maxint
+		{"scale-down neg overflow", neg(pow10Big(30)), 3, 0, mostNegative, false},
+		{"scale-up pos overflow", pow10Big(30), 0, 3, mostPositive, false},
+		{"scale-up neg overflow", neg(pow10Big(30)), 0, 3, mostNegative, false},
+		{"identity pos overflow", pow10Big(19), 0, 0, mostPositive, false}, // 1e19 > maxint
+		{"identity neg overflow", neg(pow10Big(19)), 0, 0, mostNegative, false},
+		{"identity fits", big.NewInt(12345), 0, 0, 12345, true},
+		// big scale-down path (unscaled exceeds int64) with a surviving quotient
+		{"big-path pos round fits", add(pow10Big(20), 5), 5, 0, 1000000000000001, true},
+		{"big-path neg round fits", neg(add(pow10Big(20), 5)), 5, 0, -1000000000000001, true},
+		// extreme scales must stay bounded, not build a giant power of ten
+		{"scale-up extreme pos saturates", big.NewInt(7), 0, 2000000000, mostPositive, false},
+		{"scale-up extreme neg saturates", big.NewInt(-7), 0, 2000000000, mostNegative, false},
+		{"scale-up extreme zero", big.NewInt(0), 0, 2000000000, 0, true},
+		{"scale-down extreme pos rounds to one", big.NewInt(7), 2000000000, 0, 1, true},
+		{"scale-down extreme neg rounds to minus one", big.NewInt(-7), 2000000000, 0, -1, true},
+		{"scale-down extreme zero", big.NewInt(0), 2000000000, 0, 0, true},
+	} {
+		got, ok := scaledValue(tc.unscaled, tc.scale, tc.newScale)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("%s: scaledValue = (%d, %t), want (%d, %t)", tc.name, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+// TestQuantityAsScaledInt64Boundaries exercises the public accessor and locks
+// the headline case: a scaled quantity whose integer value overflows returns
+// the saturated rail with ok=false instead of a wrapped value.
+func TestQuantityAsScaledInt64Boundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		q      *Quantity
+		scale  Scale
+		want   int64
+		wantOK bool
+	}{
+		{"maxint x10 saturates", NewScaledQuantity(mostPositive, 1), 0, mostPositive, false},
+		{"minint x10 saturates", NewScaledQuantity(mostNegative, 1), 0, mostNegative, false},
+		{"exact value", NewScaledQuantity(12345, 0), 0, 12345, true},
+		{"milli fits", NewScaledQuantity(5, 0), Milli, 5000, true},
+		{"milli pos overflow saturates", NewScaledQuantity(mostPositive, 0), Milli, mostPositive, false},
+		{"milli neg overflow saturates", NewScaledQuantity(mostNegative, 0), Milli, mostNegative, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := tc.q.AsScaledInt64(tc.scale)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("AsScaledInt64(%d) = (%d, %t), want (%d, %t)", tc.scale, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestQuantityValueSaturates pins the headline case: NewScaledQuantity(mostPositive, 1).Value()
+// returns the rail rather than a wrapped -10.
+func TestQuantityValueSaturates(t *testing.T) {
+	if got := NewScaledQuantity(mostPositive, 1).Value(); got != mostPositive {
+		t.Errorf("NewScaledQuantity(mostPositive, 1).Value() = %d, want %d", got, int64(mostPositive))
+	}
+	if got := NewScaledQuantity(mostNegative, 1).Value(); got != mostNegative {
+		t.Errorf("NewScaledQuantity(mostNegative, 1).Value() = %d, want %d", got, int64(mostNegative))
+	}
+	if got := NewScaledQuantity(mostPositive, 0).MilliValue(); got != mostPositive {
+		t.Errorf("NewScaledQuantity(mostPositive, 0).MilliValue() = %d, want %d", got, int64(mostPositive))
+	}
+}
+
+// TestQuantityScaledInt64BackendsAgree is the brute-force differential: for a
+// dense grid of boundary values and scales, the int64 backend and the promoted
+// inf.Dec backend must return the same (value, ok) from AsScaledInt64. This is
+// what guarantees q.Value() and q.ToDec().Value() no longer disagree.
+func TestQuantityScaledInt64BackendsAgree(t *testing.T) {
+	values := []int64{
+		0, 1, -1, 2, -2, 9, -9, 10, -10, 12345, -12345,
+		999999999999999999, -999999999999999999,
+		mostPositive, mostNegative, mostPositive - 1, mostNegative + 1,
+		mostPositive / 10, mostNegative / 10,
+		mostPositive / 1000, mostNegative / 1000,
+		1 << 62, -(1 << 62),
+	}
+	for _, v := range values {
+		for scale := Scale(-18); scale <= 18; scale++ {
+			for target := Scale(-18); target <= 18; target++ {
+				qi := NewScaledQuantity(v, scale)
+				v1, ok1 := qi.AsScaledInt64(target)
+				qi.ToDec()
+				v2, ok2 := qi.AsScaledInt64(target)
+				if v1 != v2 || ok1 != ok2 {
+					t.Fatalf("backends disagree for value=%d scale=%d target=%d: int64=(%d,%t) dec=(%d,%t)",
+						v, scale, target, v1, ok1, v2, ok2)
+				}
+			}
+		}
+	}
+}
+
+// TestQuantityDecOnlyOverflow covers unscaled magnitudes that cannot be built
+// from an int64 (parsed decimals), where only the Dec path is exercised.
+func TestQuantityDecOnlyOverflow(t *testing.T) {
+	for _, tc := range []struct {
+		in     string
+		want   int64
+		wantOK bool
+	}{
+		{"1e100", mostPositive, false},
+		{"-1e100", mostNegative, false},
+		{"9223372036854775807", mostPositive, true},   // exactly maxint
+		{"-9223372036854775808", mostNegative, true},  // exactly minint
+		{"9223372036854775808", mostPositive, false},  // maxint + 1
+		{"-9223372036854775809", mostNegative, false}, // minint - 1
+	} {
+		q := MustParse(tc.in)
+		q.ToDec()
+		got, ok := q.AsScaledInt64(0)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("%q Dec AsScaledInt64(0) = (%d, %t), want (%d, %t)", tc.in, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+// TestQuantityExtremeScaleStaysBounded drives the public accessor with scales in
+// the billions. These must return promptly (the guards keep the int64 loop and
+// the big.Int power bounded) and the two backends must still agree.
+func TestQuantityExtremeScaleStaysBounded(t *testing.T) {
+	for _, tc := range []struct {
+		value  int64
+		target Scale
+	}{
+		{7, 2000000000},
+		{-7, 2000000000},
+		{7, -2000000000},
+		{-7, -2000000000},
+		{0, 2000000000},
+		{0, -2000000000},
+		{mostPositive, -2000000000},
+		{mostNegative, -2000000000},
+	} {
+		qi := NewScaledQuantity(tc.value, 0)
+		v1, ok1 := qi.AsScaledInt64(tc.target)
+		qi.ToDec()
+		v2, ok2 := qi.AsScaledInt64(tc.target)
+		if v1 != v2 || ok1 != ok2 {
+			t.Errorf("value=%d target=%d: int64=(%d,%t) dec=(%d,%t)", tc.value, tc.target, v1, ok1, v2, ok2)
+		}
+	}
+}
+
+// FuzzQuantityScaledInt64BackendsAgree drives the same differential with random
+// values and scales so the int64 and Dec backends are checked far past the
+// hand-picked grid.
+func FuzzQuantityScaledInt64BackendsAgree(f *testing.F) {
+	f.Add(int64(0), int8(0), int8(0))
+	f.Add(int64(mostPositive), int8(1), int8(0))
+	f.Add(int64(mostNegative), int8(1), int8(0))
+	f.Add(int64(-95), int8(1), int8(0))
+	f.Fuzz(func(t *testing.T, value int64, scaleByte, targetByte int8) {
+		scale := Scale(int(scaleByte) % 40)
+		target := Scale(int(targetByte) % 40)
+		qi := NewScaledQuantity(value, scale)
+		v1, ok1 := qi.AsScaledInt64(target)
+		qi.ToDec()
+		v2, ok2 := qi.AsScaledInt64(target)
+		if v1 != v2 || ok1 != ok2 {
+			t.Fatalf("backends disagree: value=%d scale=%d target=%d int64=(%d,%t) dec=(%d,%t)",
+				value, scale, target, v1, ok1, v2, ok2)
+		}
+	})
+}
+
+// TestQuantityAsScaledInt64ExtremeScales covers scale deltas that overflow int32
+// when computed the naive way: a source and target near opposite ends of the
+// range, and the int32 endpoints themselves.
+func TestQuantityAsScaledInt64ExtremeScales(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		value  int64
+		scale  Scale
+		target Scale
+		want   int64
+		wantOK bool
+	}{
+		{"neg-source-pos-target-rounds-up", 7, Scale(-2000000000), Scale(2000000000), 1, true},
+		{"neg-source-pos-target-negative", -7, Scale(-2000000000), Scale(2000000000), -1, true},
+		{"pos-source-neg-target-saturates", 7, Scale(2000000000), Scale(-2000000000), mostPositive, false},
+		{"neg-source-neg-target-saturates", -7, Scale(2000000000), Scale(-2000000000), mostNegative, false},
+		{"minint32-target-saturates", 7, 0, Scale(math.MinInt32), mostPositive, false},
+		{"maxint32-target-rounds-up", 7, 0, Scale(math.MaxInt32), 1, true},
+		{"minint32-source-rounds-up", 1, Scale(math.MinInt32), 0, 1, true},
+		{"zero-value-any-scale", 0, Scale(math.MinInt32), Scale(math.MaxInt32), 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := NewScaledQuantity(tc.value, tc.scale).AsScaledInt64(tc.target)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("value=%d scale=%d target=%d: got (%d,%t), want (%d,%t)",
+					tc.value, tc.scale, tc.target, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestQuantityDecExtremeTarget checks that an int32-endpoint target scale on the
+// Dec backend is handled without the infScale() negation overflow.
+func TestQuantityDecExtremeTarget(t *testing.T) {
+	for _, tc := range []struct {
+		in     string
+		target Scale
+		want   int64
+		wantOK bool
+	}{
+		{"7", Scale(math.MinInt32), mostPositive, false},
+		{"7", Scale(math.MaxInt32), 1, true},
+		{"-7", Scale(math.MinInt32), mostNegative, false},
+	} {
+		q := MustParse(tc.in)
+		q.ToDec()
+		got, ok := q.AsScaledInt64(tc.target)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("%q ToDec().AsScaledInt64(%d) = (%d,%t), want (%d,%t)", tc.in, tc.target, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+// TestQuantityWrapperParity locks the wrappers to their checked accessors on both
+// backends, and exercises AsMilliInt64 directly.
+func TestQuantityWrapperParity(t *testing.T) {
+	for _, vs := range []struct {
+		v int64
+		s Scale
+	}{
+		{0, 0}, {5, 0}, {-5, 0}, {12345, 0},
+		{mostPositive, 0}, {mostNegative, 0}, {mostPositive, 1}, {mostNegative, 1},
+		{7, -6}, {-7, -6},
+	} {
+		for _, dec := range []bool{false, true} {
+			q := NewScaledQuantity(vs.v, vs.s)
+			if dec {
+				q.ToDec()
+			}
+			if v, _ := q.AsScaledInt64(0); q.Value() != v {
+				t.Errorf("dec=%t value=%d scale=%d: Value()=%d, AsScaledInt64(0)=%d", dec, vs.v, vs.s, q.Value(), v)
+			}
+			milli, mok := q.AsMilliInt64()
+			if s, sok := q.AsScaledInt64(Milli); milli != s || mok != sok {
+				t.Errorf("dec=%t value=%d scale=%d: AsMilliInt64()=(%d,%t), AsScaledInt64(Milli)=(%d,%t)", dec, vs.v, vs.s, milli, mok, s, sok)
+			}
+			if q.MilliValue() != milli {
+				t.Errorf("dec=%t value=%d scale=%d: MilliValue()=%d, AsMilliInt64()=%d", dec, vs.v, vs.s, q.MilliValue(), milli)
+			}
+			if v, _ := q.AsScaledInt64(Kilo); q.ScaledValue(Kilo) != v {
+				t.Errorf("dec=%t value=%d scale=%d: ScaledValue(Kilo)=%d, AsScaledInt64(Kilo)=%d", dec, vs.v, vs.s, q.ScaledValue(Kilo), v)
+			}
+		}
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
@@ -48,8 +48,8 @@ var (
 	// quantity greater than MaxMilliValue can still have a MilliValue that fits. For
 	// a non-negative quantity, compare it against MaxMilliQuantity with Quantity.Cmp
 	// instead. Comparing Quantity.Value against MaxMilliValue is unreliable: Value
-	// silently overflows for a quantity larger than MaxInt64, and an overflowed
-	// result is undefined.
+	// saturates for a quantity outside int64, so it cannot tell one that is merely
+	// large from one that is larger still.
 	MaxMilliValue = int64(((1 << 63) - 1) / 1000)
 )
 
@@ -57,8 +57,8 @@ var (
 // an int64, so that MilliValue and ScaledValue(Milli) do not overflow. For a
 // non-negative q, q.Cmp(MaxMilliQuantity()) <= 0 reports whether q.MilliValue()
 // and q.ScaledValue(Milli) fit an int64. Prefer it over comparing q.Value()
-// against MaxMilliValue, which is unreliable because Value silently overflows
-// for a quantity larger than MaxInt64.
+// against MaxMilliValue, which is unreliable because Value saturates for a
+// quantity outside int64.
 //
 // The bound is one-sided: a large negative q also overflows those methods (its
 // value in milli-units is below MinInt64), so a q that may be negative must be
@@ -69,6 +69,9 @@ func MaxMilliQuantity() Quantity {
 
 const mostNegative = -(mostPositive + 1)
 const mostPositive = 1<<63 - 1
+
+// log10MaxInt64 is the exponent of the first power of ten that exceeds mostPositive.
+const log10MaxInt64 = 19
 
 // int64Add returns a+b, or false if that would overflow int64.
 func int64Add(a, b int64) (int64, bool) {
@@ -153,32 +156,46 @@ func int64MultiplyScale1000(a int64) (int64, bool) {
 	return c, c/1000 == a
 }
 
-// positiveScaleInt64 multiplies base by 10^scale, returning false if the
-// value overflows. Passing a negative scale is undefined.
+// positiveScaleInt64 multiplies base by 10^scale. On overflow it returns false
+// and saturates to the int64 rail matching base's sign. Passing a negative
+// scale is undefined.
 func positiveScaleInt64(base int64, scale Scale) (int64, bool) {
+	if base == 0 {
+		// 0 stays 0; the default case would otherwise loop scale times for nothing.
+		return 0, true
+	}
+	var result int64
+	ok := true
 	switch scale {
 	case 0:
 		return base, true
 	case 1:
-		return int64MultiplyScale10(base)
+		result, ok = int64MultiplyScale10(base)
 	case 2:
-		return int64MultiplyScale100(base)
+		result, ok = int64MultiplyScale100(base)
 	case 3:
-		return int64MultiplyScale1000(base)
+		result, ok = int64MultiplyScale1000(base)
 	case 6:
-		return int64MultiplyScale(base, 1000000)
+		result, ok = int64MultiplyScale(base, 1000000)
 	case 9:
-		return int64MultiplyScale(base, 1000000000)
+		result, ok = int64MultiplyScale(base, 1000000000)
 	default:
-		value := base
-		var ok bool
+		result = base
 		for i := Scale(0); i < scale; i++ {
-			if value, ok = int64MultiplyScale(value, 10); !ok {
-				return 0, false
+			if result, ok = int64MultiplyScale(result, 10); !ok {
+				break
 			}
 		}
-		return value, true
 	}
+	if !ok {
+		// base * 10^scale keeps base's sign until it overflows, so the rail is
+		// determined by that sign.
+		if base < 0 {
+			return mostNegative, false
+		}
+		return mostPositive, false
+	}
+	return result, true
 }
 
 // negativeScaleInt64 reduces base by the provided scale, rounding up, until the

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -854,35 +854,47 @@ func NewScaledQuantity(value int64, scale Scale) *Quantity {
 	}
 }
 
-// Value returns the unscaled value of q rounded up to the nearest integer away
-// from 0. This silently overflows an int64 for a quantity larger than MaxInt64;
-// an overflowed result is undefined and must not be used. To avoid overflow,
-// compare q against a bound with Quantity.Cmp before converting.
+// Value returns the value of q rounded to an integer, away from zero. It
+// saturates to math.MinInt64 or math.MaxInt64 when the value does not fit;
+// call AsScaledInt64 to detect that.
 func (q *Quantity) Value() int64 {
-	return q.ScaledValue(0)
+	value, _ := q.AsScaledInt64(0)
+	return value
 }
 
-// MilliValue returns the value of ceil(q * 1000). This silently overflows an
-// int64 for a large enough q; an overflowed result is undefined and must not be
-// used. To avoid overflow for a non-negative q, compare q against
-// MaxMilliQuantity() with Quantity.Cmp before converting.
+// MilliValue returns the value of q*1000 rounded to an integer, away from zero.
+// It saturates like Value; call AsMilliInt64 to detect overflow.
 func (q *Quantity) MilliValue() int64 {
-	return q.ScaledValue(Milli)
+	value, _ := q.AsMilliInt64()
+	return value
 }
 
-// ScaledValue returns the value of ceil(q / 10^scale).
-// For example, NewQuantity(1, DecimalSI).ScaledValue(Milli) returns 1000.
-// This silently overflows an int64 for a large enough q; an overflowed result is
-// undefined and must not be used. To avoid overflow for a non-negative q at the
-// milli scale, compare q against MaxMilliQuantity() with Quantity.Cmp before
-// converting.
+// ScaledValue returns the value of q/10^scale rounded to an integer, away from
+// zero. It saturates like Value; call AsScaledInt64 to detect overflow.
 func (q *Quantity) ScaledValue(scale Scale) int64 {
+	value, _ := q.AsScaledInt64(scale)
+	return value
+}
+
+// AsScaledInt64 returns the value of q/10^scale as an int64, rounded away from
+// zero. ok is false when the value overflows int64, and then value saturates to
+// math.MinInt64 or math.MaxInt64. The int64 and inf.Dec backends agree for
+// values both can represent; a source scale near the int32 minimum is not
+// representable in inf.Dec, so calling q.ToDec() first can differ there.
+func (q *Quantity) AsScaledInt64(scale Scale) (value int64, ok bool) {
 	if q.d.Dec == nil {
-		i, _ := q.i.AsScaledInt64(scale)
-		return i
+		return q.i.AsScaledInt64(scale)
 	}
 	dec := q.d.Dec
-	return scaledValue(dec.UnscaledBig(), int(dec.Scale()), int(scale.infScale()))
+	// Negate after widening: inf.Scale(-math.MinInt32) overflows back to itself.
+	return scaledValue(dec.UnscaledBig(), int64(dec.Scale()), -int64(scale))
+}
+
+// AsMilliInt64 returns the value of q*1000 as an int64, rounded away from zero.
+// ok is false when the value overflows int64, and then value saturates as
+// AsScaledInt64 describes.
+func (q *Quantity) AsMilliInt64() (value int64, ok bool) {
+	return q.AsScaledInt64(Milli)
 }
 
 // Set sets q's value to be value.

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_overflow_test.go
@@ -33,15 +33,6 @@ import (
 //   - archSplitCases: ToDec rows whose int64 accessors are arch-dependent
 //     (golang/go#45588: MinInt64 amd64, MaxInt64 arm64), so they are guarded.
 
-const (
-	// Shared TODO text. #141166 settles the overflow value: cap at the
-	// MinInt64/MaxInt64 rail (matching strconv). The checked-accessor API shape
-	// that carries the overflow bool is still being finalized.
-	saturatePos = "want math.MaxInt64 once positive overflow saturates instead of wrapping (#141166)"
-	saturateNeg = "want math.MinInt64 once negative overflow saturates instead of wrapping or reading zero (#141166)"
-	// String drops the DecimalSI suffix above 10^18.
-)
-
 type accessorCase struct {
 	name string
 	load func() Quantity
@@ -77,9 +68,9 @@ func quantityAccessorCases() []accessorCase {
 		// --- In range or capped at parse time: only the smaller accessors overflow. ---
 		{
 			name: "int64-max-parsed", load: func() Quantity { return MustParse("9223372036854775807") },
-			wantSign:  1,
-			wantValue: math.MaxInt64,
-			wantMilli: -1000, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 9223372036854776,
 			wantAsInt64:    math.MaxInt64, wantAsInt64OK: true,
 			wantFloat:       9.223372036854776e+18,
@@ -88,9 +79,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "int64-max-constructed", load: func() Quantity { return *NewQuantity(math.MaxInt64, DecimalSI) },
-			wantSign:  1,
-			wantValue: math.MaxInt64,
-			wantMilli: -1000, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 9223372036854776,
 			wantAsInt64:    math.MaxInt64, wantAsInt64OK: true,
 			wantFloat:       9.223372036854776e+18,
@@ -99,9 +90,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "int64-min-constructed", load: func() Quantity { return *NewQuantity(math.MinInt64, DecimalSI) },
-			wantSign:  -1,
-			wantValue: math.MinInt64,
-			wantMilli: 0, milliTODO: saturateNeg,
+			wantSign:       -1,
+			wantValue:      math.MinInt64,
+			wantMilli:      math.MinInt64,
 			wantScaledKilo: -9223372036854776,
 			wantAsInt64:    math.MinInt64, wantAsInt64OK: true,
 			wantFloat:       -9.223372036854776e+18,
@@ -110,9 +101,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "ten-to-18-parsed", load: func() Quantity { return MustParse("1E") },
-			wantSign:  1,
-			wantValue: 1000000000000000000,
-			wantMilli: 0, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      1000000000000000000,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 1000000000000000,
 			wantAsInt64:    1000000000000000000, wantAsInt64OK: true,
 			wantFloat:  1e18,
@@ -120,9 +111,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "binary-8Ei-caps-at-max", load: func() Quantity { return MustParse("8Ei") },
-			wantSign:  1,
-			wantValue: math.MaxInt64,
-			wantMilli: -1000, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 9223372036854776,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:       9.223372036854776e+18,
@@ -131,9 +122,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "binary-negative-8Ei-caps-at-negative-max", load: func() Quantity { return MustParse("-8Ei") },
-			wantSign:  -1,
-			wantValue: -math.MaxInt64,
-			wantMilli: 1000, milliTODO: saturateNeg,
+			wantSign:       -1,
+			wantValue:      -math.MaxInt64,
+			wantMilli:      math.MinInt64,
 			wantScaledKilo: -9223372036854776,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  -9.223372036854776e+18,
@@ -141,9 +132,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "binary-20Ei-caps-at-max", load: func() Quantity { return MustParse("20Ei") },
-			wantSign:  1,
-			wantValue: math.MaxInt64,
-			wantMilli: -1000, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 9223372036854776,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:       9.223372036854776e+18,
@@ -152,9 +143,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "binary-negative-20Ei-caps-at-negative-max", load: func() Quantity { return MustParse("-20Ei") },
-			wantSign:  -1,
-			wantValue: -math.MaxInt64,
-			wantMilli: 1000, milliTODO: saturateNeg,
+			wantSign:       -1,
+			wantValue:      -math.MaxInt64,
+			wantMilli:      math.MinInt64,
 			wantScaledKilo: -9223372036854776,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  -9.223372036854776e+18,
@@ -164,9 +155,9 @@ func quantityAccessorCases() []accessorCase {
 		// --- Positive magnitude over int64: Value and MilliValue wrap or truncate. ---
 		{
 			name: "two-to-63-parsed", load: func() Quantity { return MustParse("9223372036854775808") },
-			wantSign:  1,
-			wantValue: math.MinInt64, valueTODO: saturatePos,
-			wantMilli: 0, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 9223372036854776, // 2^63/1000 rounds back under int64
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  9.223372036854776e+18,
@@ -174,9 +165,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "two-to-64-parsed", load: func() Quantity { return MustParse("18446744073709551616") },
-			wantSign:  1,
-			wantValue: 0, valueTODO: saturatePos,
-			wantMilli: 0, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 18446744073709552, // 2^64/1000 fits, so ScaledValue is correct here
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  1.8446744073709552e+19,
@@ -184,9 +175,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "ten-to-20-parsed", load: func() Quantity { return MustParse("100E") },
-			wantSign:  1,
-			wantValue: 0, valueTODO: saturatePos,
-			wantMilli: 0, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 100000000000000000,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  1e20,
@@ -194,9 +185,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "ten-to-21-parsed", load: func() Quantity { return MustParse("1000E") },
-			wantSign:  1,
-			wantValue: 0, valueTODO: saturatePos,
-			wantMilli: 0, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 1000000000000000000,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  1e21,
@@ -204,9 +195,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "five-times-ten-to-21-parsed", load: func() Quantity { return MustParse("5000E") },
-			wantSign:  1,
-			wantValue: 0, valueTODO: saturatePos,
-			wantMilli: 0, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 5000000000000000000,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  5e21,
@@ -214,19 +205,19 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "ten-to-100-parsed", load: func() Quantity { return MustParse("1e100") },
-			wantSign:  1,
-			wantValue: 0, valueTODO: saturatePos,
-			wantMilli: 0, milliTODO: saturatePos,
-			wantScaledKilo: 0, scaledTODO: saturatePos, // 1e97 also overflows
-			wantAsInt64: 0, wantAsInt64OK: false,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
+			wantScaledKilo: math.MaxInt64, // 1e97 also overflows
+			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  1e100,
 			wantString: "10e99", // lossless: 10e99 == 1e100
 		},
 		{
 			name: "scaled-one-times-ten-to-21", load: func() Quantity { return *NewScaledQuantity(1, 21) },
-			wantSign:  1,
-			wantValue: 0, valueTODO: saturatePos,
-			wantMilli: 0, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 1000000000000000000,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  1e21,
@@ -236,9 +227,9 @@ func quantityAccessorCases() []accessorCase {
 			// NewScaledQuantity(MaxInt64, 1) is MaxInt64*10; Value wraps to -10,
 			// the accidental negative that validateBasicResource rejects today.
 			name: "scaled-max-times-ten", load: func() Quantity { return *NewScaledQuantity(math.MaxInt64, 1) },
-			wantSign:  1,
-			wantValue: -10, valueTODO: saturatePos,
-			wantMilli: 0, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 92233720368547759, // MaxInt64*10/1000 fits
 			wantAsInt64:    -10, wantAsInt64OK: false,
 			wantFloat:  9.223372036854776e+19,
@@ -249,9 +240,9 @@ func quantityAccessorCases() []accessorCase {
 		{
 			// MinInt64 from a string takes the int64 fast path, like NewQuantity(MinInt64).
 			name: "int64-min-parsed", load: func() Quantity { return MustParse("-9223372036854775808") },
-			wantSign:  -1,
-			wantValue: math.MinInt64,
-			wantMilli: 0, milliTODO: saturateNeg,
+			wantSign:       -1,
+			wantValue:      math.MinInt64,
+			wantMilli:      math.MinInt64,
 			wantScaledKilo: -9223372036854776,
 			wantAsInt64:    math.MinInt64, wantAsInt64OK: true,
 			wantFloat:       -9.223372036854776e+18,
@@ -260,9 +251,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "int64-min-plus-one-parsed", load: func() Quantity { return MustParse("-9223372036854775807") },
-			wantSign:  -1,
-			wantValue: math.MinInt64 + 1,
-			wantMilli: 1000, milliTODO: saturateNeg,
+			wantSign:       -1,
+			wantValue:      math.MinInt64 + 1,
+			wantMilli:      math.MinInt64,
 			wantScaledKilo: -9223372036854776,
 			wantAsInt64:    math.MinInt64 + 1, wantAsInt64OK: true,
 			wantFloat:  -9.223372036854776e+18,
@@ -271,19 +262,19 @@ func quantityAccessorCases() []accessorCase {
 		// --- Negative values kept in the int64 backend at a large scale; Value and Milli overflow to zero. ---
 		{
 			name: "negative-ten-to-30-parsed", load: func() Quantity { return MustParse("-1e30") },
-			wantSign:  -1,
-			wantValue: 0, valueTODO: saturateNeg,
-			wantMilli: 0, milliTODO: saturateNeg,
-			wantScaledKilo: 0, scaledTODO: saturateNeg,
-			wantAsInt64: 0, wantAsInt64OK: false,
+			wantSign:       -1,
+			wantValue:      math.MinInt64,
+			wantMilli:      math.MinInt64,
+			wantScaledKilo: math.MinInt64,
+			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  -1e30,
 			wantString: "-1e30",
 		},
 		{
 			name: "negative-ten-to-20-parsed", load: func() Quantity { return MustParse("-100E") },
-			wantSign:  -1,
-			wantValue: 0, valueTODO: saturateNeg,
-			wantMilli: 0, milliTODO: saturateNeg,
+			wantSign:       -1,
+			wantValue:      math.MinInt64,
+			wantMilli:      math.MinInt64,
 			wantScaledKilo: -100000000000000000,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  -1e20,
@@ -291,9 +282,9 @@ func quantityAccessorCases() []accessorCase {
 		},
 		{
 			name: "negative-ten-to-21-parsed", load: func() Quantity { return MustParse("-1000E") },
-			wantSign:  -1,
-			wantValue: 0, valueTODO: saturateNeg,
-			wantMilli: 0, milliTODO: saturateNeg,
+			wantSign:       -1,
+			wantValue:      math.MinInt64,
+			wantMilli:      math.MinInt64,
 			wantScaledKilo: -1000000000000000000,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  -1e21,
@@ -409,9 +400,9 @@ func quantityAccessorCases() []accessorCase {
 				q.Add(*NewQuantity(math.MaxInt64, DecimalSI))
 				return *q
 			},
-			wantSign:  1,
-			wantValue: -2, valueTODO: saturatePos,
-			wantMilli: -2000, milliTODO: saturatePos,
+			wantSign:       1,
+			wantValue:      math.MaxInt64,
+			wantMilli:      math.MaxInt64,
 			wantScaledKilo: 18446744073709552,
 			wantAsInt64:    0, wantAsInt64OK: false,
 			wantFloat:  1.8446744073709552e+19,
@@ -549,12 +540,10 @@ func TestQuantityParseErrorBaseline(t *testing.T) {
 // amd64 and arm64 result, and the check accepts either. The two are equal for a
 // portable column, so a wrapper or scale that quietly changed would still fail.
 //
-// TODO: these rows resolve when #141166's checked accessors cap the result at
-// the MinInt64/MaxInt64 rail and report overflow. golang/go#76264 might later
-// make Go's float-to-int step saturate on every arch, but that alone is not
-// enough: it adds no overflow bool and does not fix the int64 multiply after it
-// (ten-to-20-parsed-via-dec's MilliValue is 100 * MaxInt64, which still wraps to
-// -100). Collapse each pair once #141166 lands; until then they track the split.
+// The pairs are equal now: capping at the MinInt64/MaxInt64 rail made every
+// overflowing column portable, so golang/go#45588 no longer reaches them. They
+// stay paired so a change that reintroduced an arch-dependent result would
+// still have to edit both columns to pass.
 type archSplitCase struct {
 	name       string
 	load       func() Quantity
@@ -574,26 +563,26 @@ func quantityArchSplitCases() []archSplitCase {
 		{
 			name: "ten-to-100-parsed-via-dec", load: func() Quantity { q := MustParse("1e100"); q.ToDec(); return q },
 			wantSign: 1, wantString: "10e99",
-			valueAmd64: math.MinInt64, valueArm64: math.MaxInt64,
-			milliAmd64: math.MinInt64, milliArm64: math.MaxInt64,
-			scaledAmd64: math.MinInt64, scaledArm64: math.MaxInt64,
+			valueAmd64: math.MaxInt64, valueArm64: math.MaxInt64,
+			milliAmd64: math.MaxInt64, milliArm64: math.MaxInt64,
+			scaledAmd64: math.MaxInt64, scaledArm64: math.MaxInt64,
 			wantAsInt64OK: false, wantFloat: 1e100,
 		},
 		{
 			name: "ten-to-19-parsed-via-dec", load: func() Quantity { q := MustParse("1e19"); q.ToDec(); return q },
 			wantSign: 1, wantString: "10e18",
-			valueAmd64: math.MinInt64, valueArm64: math.MaxInt64,
-			milliAmd64: math.MinInt64, milliArm64: math.MaxInt64,
+			valueAmd64: math.MaxInt64, valueArm64: math.MaxInt64,
+			milliAmd64: math.MaxInt64, milliArm64: math.MaxInt64,
 			scaledAmd64: 10000000000000000, scaledArm64: 10000000000000000, // Pow10(16) fits, portable
 			wantAsInt64OK: false, wantFloat: 1e19,
 		},
 		{
-			// Value uses Pow10(18) (fits), so its wrap is portable; MilliValue uses
-			// Pow10(21) and lands on 0 (amd64) or -100 (arm64).
+			// Saturation removed the split: every overflowing column now reads
+			// math.MaxInt64 on both arches. ScaledValue(Kilo) is 1e17, which fits.
 			name: "ten-to-20-parsed-via-dec", load: func() Quantity { q := MustParse("100E"); q.ToDec(); return q },
 			wantSign: 1, wantString: "100E",
-			valueAmd64: 7766279631452241920, valueArm64: 7766279631452241920,
-			milliAmd64: 0, milliArm64: -100,
+			valueAmd64: math.MaxInt64, valueArm64: math.MaxInt64,
+			milliAmd64: math.MaxInt64, milliArm64: math.MaxInt64,
 			scaledAmd64: 100000000000000000, scaledArm64: 100000000000000000, // 1e17
 			wantAsInt64OK: false, wantFloat: 1e20,
 		},

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/scale_int.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/scale_int.go
@@ -35,73 +35,105 @@ func init() {
 	}
 }
 
-// scaledValue scales given unscaled value from scale to new Scale and returns
-// an int64. When scaling down, the result is rounded away from zero (e.g. 1.5
-// becomes 2 and -1.5 becomes -2), matching the behavior documented on
-// Quantity.Value. The final result might overflow.
+// scaledValue scales unscaled from scale to newScale and returns it as an int64.
+// Scaling down rounds away from zero (1.5 to 2, -1.5 to -2), matching
+// negativeScaleInt64. ok is false when the true value overflows int64, and then
+// the result saturates to mostNegative or mostPositive.
 //
-// scale, newScale represents the scale of the unscaled decimal.
+// scale, newScale represent the scale of the unscaled decimal.
 // The mathematical value of the decimal is unscaled * 10**(-scale).
-func scaledValue(unscaled *big.Int, scale, newScale int) int64 {
+func scaledValue(unscaled *big.Int, scale, newScale int64) (int64, bool) {
 	dif := scale - newScale
 	if dif == 0 {
-		return unscaled.Int64()
+		return bigToInt64Saturated(unscaled)
 	}
 
-	// Handle scale up
-	// This is an easy case, we do not need to care about rounding and overflow.
-	// If any intermediate operation causes overflow, the result will overflow.
+	// Scale up: multiply by 10^(-dif). No case here needs a big.Int.
 	if dif < 0 {
-		return unscaled.Int64() * int64(math.Pow10(-dif))
+		if unscaled.Sign() == 0 {
+			return 0, true
+		}
+		// Bound dif before Scale(-dif) narrows it: 2^32 would come back as 0.
+		if dif <= -log10MaxInt64 {
+			if unscaled.Sign() < 0 {
+				return mostNegative, false
+			}
+			return mostPositive, false
+		}
+		// A coefficient already outside int64 only grows here.
+		if !unscaled.IsInt64() {
+			if unscaled.Sign() < 0 {
+				return mostNegative, false
+			}
+			return mostPositive, false
+		}
+		return positiveScaleInt64(unscaled.Int64(), Scale(-dif))
 	}
 
-	// Handle scale down
-	// We have to be careful about the intermediate operations.
+	// Scale down: divide by 10^dif, rounding the quotient away from zero.
 
-	// fast path when |unscaled| < max.Int64 and exp(10,dif) < max.Int64
-	const log10MaxInt64 = 19
-	if unscaled.Cmp(maxInt64) < 0 && unscaled.Cmp(minInt64) > 0 && dif < log10MaxInt64 {
-		divide := int64(math.Pow10(dif))
-		result := unscaled.Int64() / divide
-		mod := unscaled.Int64() % divide
-		// Go integer division truncates toward zero and mod takes the sign of the
-		// dividend, so a non-zero mod means we need to nudge the result one step
-		// further from zero to round away from it.
-		if mod > 0 {
-			return result + 1
+	// Fast path when unscaled fits int64 and the divisor stays below it. The
+	// quotient is then strictly smaller in magnitude, so it cannot overflow.
+	if unscaled.IsInt64() && dif < log10MaxInt64 {
+		u := unscaled.Int64()
+		divide := int64(math.Pow10(int(dif)))
+		q := u / divide
+		if u%divide != 0 {
+			if u < 0 {
+				q--
+			} else {
+				q++
+			}
 		}
-		if mod < 0 {
-			return result - 1
-		}
-		return result
+		return q, true
 	}
 
-	// We should only convert back to int64 when getting the result.
+	// Only the rounding sign survives, and no divisor has to be built:
+	// dif >= BitLen implies 10^dif > 2^dif >= 2^BitLen > |unscaled|.
+	if dif >= int64(unscaled.BitLen()) {
+		switch unscaled.Sign() {
+		case 0:
+			return 0, true
+		case -1:
+			return -1, true
+		default:
+			return 1, true
+		}
+	}
+
 	divisor := intPool.Get().(*big.Int)
 	exp := intPool.Get().(*big.Int)
-	result := intPool.Get().(*big.Int)
+	quotient := intPool.Get().(*big.Int)
+	remainder := intPool.Get().(*big.Int)
 	defer func() {
 		intPool.Put(divisor)
 		intPool.Put(exp)
-		intPool.Put(result)
+		intPool.Put(quotient)
+		intPool.Put(remainder)
 	}()
 
 	// divisor = 10^(dif)
-	// TODO: create loop up table if exp costs too much.
-	divisor.Exp(bigTen, exp.SetInt64(int64(dif)), nil)
-	// reuse exp
-	remainder := exp
-
-	// result = unscaled / divisor
-	// remainder = unscaled % divisor
-	// big.Int.DivMod is Euclidean: remainder is always in [0, divisor). For a
-	// negative dividend the quotient is already floored (further from zero), so
-	// no adjustment is needed. For a positive dividend with a non-zero remainder
-	// we step the quotient up by one to round away from zero.
-	result.DivMod(unscaled, divisor, remainder)
-	if remainder.Sign() != 0 && unscaled.Sign() > 0 {
-		return result.Int64() + 1
+	divisor.Exp(bigTen, exp.SetInt64(dif), nil)
+	// QuoRem truncates toward zero, so the step below rounds away from it.
+	quotient.QuoRem(unscaled, divisor, remainder)
+	if remainder.Sign() != 0 {
+		if unscaled.Sign() < 0 {
+			quotient.Sub(quotient, bigOne)
+		} else {
+			quotient.Add(quotient, bigOne)
+		}
 	}
+	return bigToInt64Saturated(quotient)
+}
 
-	return result.Int64()
+// bigToInt64Saturated returns v as an int64, saturating to mostNegative or
+// mostPositive when v does not fit. ok is false when saturation occurred.
+func bigToInt64Saturated(v *big.Int) (int64, bool) {
+	if v.IsInt64() {
+		return v.Int64(), true
+	}
+	if v.Sign() < 0 {
+		return mostNegative, false
+	}
+	return mostPositive, false
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/scale_int_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/scale_int_test.go
@@ -25,8 +25,8 @@ import (
 func TestScaledValueInternal(t *testing.T) {
 	tests := []struct {
 		unscaled *big.Int
-		scale    int
-		newScale int
+		scale    int64
+		newScale int64
 
 		want int64
 	}{
@@ -74,9 +74,12 @@ func TestScaledValueInternal(t *testing.T) {
 
 	for i, tt := range tests {
 		old := (&big.Int{}).Set(tt.unscaled)
-		got := scaledValue(tt.unscaled, tt.scale, tt.newScale)
+		got, ok := scaledValue(tt.unscaled, tt.scale, tt.newScale)
 		if got != tt.want {
 			t.Errorf("#%d: got = %v, want %v", i, got, tt.want)
+		}
+		if !ok {
+			t.Errorf("#%d: reported overflow, want a representable value", i)
 		}
 		if tt.unscaled.Cmp(old) != 0 {
 			t.Errorf("#%d: unscaled = %v, want %v", i, tt.unscaled, old)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change
/sig api-machinery

#### What this PR does / why we need it:

`Quantity.Value`, `MilliValue` and `ScaledValue` wrap silently on overflow, so `NewScaledQuantity(math.MaxInt64, 1).Value()` returns `-10` rather than a bounded value.

This adds `AsScaledInt64(scale) (int64, bool)` and `AsMilliInt64() (int64, bool)`, each returning `ok == false` when the value does not fit an int64 and saturating to `math.MinInt64` or `math.MaxInt64` on the sign-correct rail. The three existing wrappers become thin callers that drop the boolean, so they saturate instead of wrapping. The int64 and inf.Dec backends are made to agree for values both can represent, and the scale arithmetic is widened so a source or target scale near the int32 limits cannot wrap before the conversion runs.

Saturating an accessor does not by itself make a caller safe: a caller that adds two projected values, or that does arithmetic on one, still needs its own bound. This PR carries only the kubelet reservation fix that came out of review; the other callers are listed at the end.

#### Which issue(s) this PR is related to:

Part of #141166.

The dependencies have merged: #141264 (MinInt64 negation in `Neg` and `Sub`), #138510 (negative rounding in `scaledValue`), #141169 (`validateBasicResource` uses `Sign()`), #141181 (no longer relies on `Value()` overflow to detect sign).

#141938 merged while this was open and moves 19-digit values onto the int64 backend, raising `maxInt64Factors` to 19. The commit 2 baseline pins per value which backend it goes through, so the two edit the same rows. This is rebased onto it; the flipped rows and the rows #141938 corrected are both present afterwards, and `pkg/api/resource` passes on the result.

#### Special notes for your reviewer:

Shape: this lands the accessors and the wrapper flip together, per the decision on this PR. The commits are:

1. `resource: add Quantity.AsScaledInt64 and AsMilliInt64`. The checked API and the wrapper flip, including keeping the scale-up branch on the int64 path so an extreme scale does not materialize a power of ten. The `MaxMilliValue` and `MaxMilliQuantity` docs said `Value` overflows silently with an undefined result, which stops being true here, so they now describe saturation.
2. `resource: flip the accessor baseline for the saturating wrappers`. #141170 pinned today's wrapping results and named, per field, what each should become. 36 fields move to a rail and drop their note; rows flagged for other fixes are untouched. The arch-split pairs now hold the same value in both columns, since capping makes every overflowing column portable and golang/go#45588 no longer reaches them. The rows stay paired so a regression to an arch-dependent result would still have to edit both.
3. `kubelet: keep a large CPU reservation from wrapping to a negative`. The one requested in review. `parseResourceList` rounds CPU to the nearest milli through its value in micro-cores, and that projection wraps past the int64 micro range: on master `cpu: "10000000000000"` is stored as `-8446744073709551m`. It now rounds only where micro fits an int64 and keeps the value as parsed past that. The cutoff is a step rather than a no-op: `9223372036854775807u` rounds to `9223372036854776m` while `9223372036854775808u`, one micro higher, keeps its sub-milli digits, so the two sides of it are not ordered. Smoothing that out needs a big.Int at 9.2e12 cores. The same function already stores `memory: 1e30` unchanged, so failing on an oversized CPU value would have made CPU the only resource that stops kubelet from starting.

Verification, beyond the tests in the diff:

- `scaledValue` against its pre-flip semantics over 6936 combinations of value, scale and target scale: identical on every input the old code could represent, `ok == false` and a rail on every input it could not. The away-from-zero rounding from #138510 is preserved; `QuoRem` with a two-sided adjustment gives the same result as the previous `DivMod` on positive, negative and exact quotients.
- The flipped baseline rows against an independent `big.Int` oracle that derives the expected result from `AsDec` rather than from the accessors: 31 rows times three accessors, so 93 pinned values, all matching. Re-run after the rebase, since #141938 edits some of those rows.
- The rounding in commit 3 against the old expression over the range micro fits: identical, and the old one is shown to wrap above it.
- `AsScaledInt64` against a `big.Rat` oracle over 111910 combinations of value and source and target scale, both int32 limits included: the boolean matches whether the exact value fits an int64, the value matches when it does, and the rail matches its sign when it does not.
- Commit 3 has a test that fails with only its production change reverted, and pins both sides of the micro cutoff.

Callers left out of this PR:

An earlier revision of this PR also carried an HPA request check and a kubelet QoS aggregate cap. I have dropped both. They guard real bugs, but the flip is not what creates them: two requests of `4611686018427387904` milli units are each representable, so the same sum wraps on master with no saturation involved. Each is better as its own change against master, with its own failing case and its own reviewers. The QoS CPU aggregate also cannot be asserted end to end from here, because `MilliCPUToShares` folds an oversized value into `MinShares` until #141327 lands.

#141348, #141349 and #141352 fix LimitRanger, the integer-resource check and hugepage divisibility on the same footing. The remaining `Value()` readers that do arithmetic are tracked under #141166.

#### Does this PR introduce a user-facing change?

```release-note
`resource.Quantity` gains `AsScaledInt64` and `AsMilliInt64`, which report int64 overflow with a boolean. `Value`, `MilliValue` and `ScaledValue` now saturate to `math.MinInt64` or `math.MaxInt64` on overflow instead of returning a wrapped value. A kubelet CPU reservation no longer wraps to a negative value when the configured quantity exceeds that range.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. AI-assisted tools were used during implementation, test planning, and review; I reviewed and validated the final change.



