### PR TITLE
resource: avoid a large big.Int when parsing sub-nano quantities

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -371,7 +371,16 @@ func ParseQuantity(str string) (Quantity, error) {
 	// of an amount.  Arguably, this should be inf.RoundHalfUp (normal rounding), but that would have
 	// the side effect of rounding values < .5n to zero.
 	if v, ok := amount.Unscaled(); v != int64(0) || !ok {
-		amount.Round(amount, Nano.infScale(), inf.RoundUp)
+		// A value smaller than 1n rounds up to 1n. The unscaled part is below
+		// 2^BitLen and so below 10^BitLen, so a scale of at least BitLen+9 leaves
+		// the value under 10^-9; set 1n directly instead of having Round build a
+		// 10^scale big.Int to reach the same result.
+		if int(amount.Scale()) >= amount.UnscaledBig().BitLen()+9 {
+			amount.SetUnscaled(1)
+			amount.SetScale(Nano.infScale())
+		} else {
+			amount.Round(amount, Nano.infScale(), inf.RoundUp)
+		}
 	}
 
 	// The max is just a simple cap.

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_subnano_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_subnano_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+import "testing"
+
+// TestParseQuantitySubNanoRoundsUp locks the rounding of magnitudes below the
+// minimum representable unit (1n): they round away from zero to 1n. A large
+// negative exponent hits the same rule, so parsing it must resolve promptly
+// rather than materializing a 10^scale big.Int; if the fast path regresses,
+// this test times out instead of failing. Values are compared by magnitude so
+// the assertion does not depend on the canonical suffix vs exponent spelling.
+func TestParseQuantitySubNanoRoundsUp(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		// magnitude below 1n rounds away from zero to the minimum unit
+		{"1e-2147483647", "1n"},
+		{"-1e-2147483647", "-1n"},
+		{"1e-100", "1n"},
+		{"-1e-100", "-1n"},
+		{"1e-10", "1n"},
+		{"9e-10", "1n"},
+		{"-9e-10", "-1n"},
+		// at and above 1n: unchanged, still routed through Round
+		{"1e-9", "1n"},
+		{"-1e-9", "-1n"},
+		{"2e-9", "2n"},
+		{"15e-10", "2n"},
+	} {
+		q, err := ParseQuantity(tc.in)
+		if err != nil {
+			t.Errorf("ParseQuantity(%q): unexpected error %v", tc.in, err)
+			continue
+		}
+		want := MustParse(tc.want)
+		if q.Cmp(want) != 0 {
+			t.Errorf("ParseQuantity(%q) = %v, want %v", tc.in, q.String(), tc.want)
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

When `ParseQuantity` reaches a non-zero value smaller than the smallest unit it can represent, it rounds up to `1n` through `inf.Dec.Round`, which first materializes `10^scale` as a `big.Int`. For an ordinary sub-nano value the scale is small and the cost is invisible. For a value written with a large negative exponent the scale is large, and `Round` builds a very large integer only to arrive at `1n`. The first commit checks the scale before the round. A scale at least nine past the value's bit length means the value is below `1n`, and the commit sets `1n` directly instead of rounding. The outcome matches `Round`, and the rounding contract does not change.

The second commit closes the case the first commit leaves open. `ParseQuantity` keeps the scale in `int32`, and a large negative exponent overflows it in two places. The fast path subtracts the denominator length from the scale, and the slow path adds the exponent to the `inf.Dec` scale. The wrap turns a small value into a large one. `1.55e-2147483647` parses to a large wrong value, and `1.5e-2147483647` wraps to a scale that makes `Round` build the big.Int the first commit avoids. The scale arithmetic is done in `int64`, and a value below `1n` is recorded directly when the scale would not fit `inf.Scale`.

#### Which issue(s) this PR is related to:

Part of #141166

#### Special notes for your reviewer:

The tests pin sub-nano rounding across the int64 and Dec paths, the extreme negative exponents, zero, a `BinarySI` value below `1n`, and the fractional-mantissa cases the second commit fixes. Values are compared by value with `Cmp`, so the assertions do not depend on the canonical spelling.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a crash and a mis-parse in resource.Quantity when parsing a quantity string with a very large negative exponent, such as `1.5e-2147483647`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. An AI coding assistant helped write the code and plan the tests. I ran and reviewed the final change.
