### PR TITLE
Fix taint eviction pod deletion latency metric unit

### DIFF
--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -117,7 +117,7 @@ func deletePodHandler(c clientset.Interface, emitEventFunc func(types.Namespaced
 			err = addConditionAndDeletePod(ctx, c, name, ns)
 			if err == nil {
 				metrics.PodDeletionsTotal.Inc()
-				metrics.PodDeletionsLatency.Observe(float64(time.Since(fireAt) * time.Second))
+				metrics.PodDeletionsLatency.Observe(time.Since(fireAt).Seconds())
 				break
 			}
 			time.Sleep(10 * time.Millisecond)

--- a/pkg/controller/tainteviction/taint_eviction_test.go
+++ b/pkg/controller/tainteviction/taint_eviction_test.go
@@ -37,6 +37,10 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/component-base/metrics/legacyregistry"
+	metricstestutil "k8s.io/component-base/metrics/testutil"
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/kubernetes/pkg/controller/tainteviction/metrics"
 	"k8s.io/kubernetes/pkg/controller/testutil"
 )
 
@@ -1001,4 +1005,38 @@ func TestPodDeletionEvent(t *testing.T) {
 			t.Errorf("emitPodDeletionEvent() returned data (-want,+got):\n%s", diff)
 		}
 	})
+}
+
+// The histogram is documented and bucketed in seconds, so the handler must
+// observe seconds rather than a raw Duration scaled by time.Second.
+func TestDeletePodHandlerObservesLatencyInSeconds(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	metrics.Register() // the histogram is only instantiated once registered
+	pod := testutil.NewPod("pod1", "node1")
+	fakeClientset := fake.NewSimpleClientset(pod)
+
+	before := podDeletionLatencySum(t)
+
+	fireAt := time.Now().Add(-2 * time.Second)
+	handler := deletePodHandler(fakeClientset, nil, "test")
+	if err := handler(ctx, fireAt, NewWorkArgs(pod.Name, pod.Namespace)); err != nil {
+		t.Fatalf("deletePodHandler: %v", err)
+	}
+
+	// The observation is a wall-clock delta of ~2s. Allow generous slack for a
+	// slow machine while staying far below the nanosecond-scaled value the bug
+	// produced (~2e18).
+	if observed := podDeletionLatencySum(t) - before; observed < 1 || observed > 60 {
+		t.Errorf("observed pod deletion latency = %v seconds, want a value near 2", observed)
+	}
+}
+
+func podDeletionLatencySum(t *testing.T) float64 {
+	t.Helper()
+	vec, err := metricstestutil.GetHistogramVecFromGatherer(legacyregistry.DefaultGatherer,
+		"taint_eviction_controller_pod_deletion_duration_seconds", map[string]string{})
+	if err != nil {
+		t.Fatalf("gather pod deletion latency: %v", err)
+	}
+	return vec.GetAggregatedSampleSum()
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig scheduling

#### What this PR does / why we need it:

`taint_eviction_controller_pod_deletion_duration_seconds` has never produced a usable value.

The handler observes:

```go
metrics.PodDeletionsLatency.Observe(float64(time.Since(fireAt) * time.Second))
```

`time.Since()` already returns a `time.Duration`, which is an `int64` count of nanoseconds. Multiplying it by `time.Second` scales every sample by another 1e9, while the metric is seconds on all three counts:

- name: `pod_deletion_duration_seconds`
- help: "Latency, **in seconds**, between the time when a taint effect has been activated for the Pod and its deletion"
- buckets: `0.005 … 240` (5ms to 4m)

Consequences:

- A 2s deletion is recorded as `2.0e18`, so every observation lands past the largest bucket. `histogram_quantile()` over this metric returns only `+Inf`, and `_sum` is meaningless, so the SLI is unusable.
- `time.Since(fireAt) * time.Second` overflows `int64` once the latency exceeds ~9.2s, wrapping the sample negative.

The fix observes `time.Since(fireAt).Seconds()`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Added `TestDeletePodHandlerObservesLatencyInSeconds`, which drives `deletePodHandler` with a `fireAt` 2 seconds in the past and reads the histogram back from the gatherer. Against the current code it reports:

```
observed pod deletion latency = 2.003498666e+18 seconds, want a value near 2
```

and it passes with the fix. The bound is deliberately loose (1s to 60s) so a slow CI machine cannot flake it while still being ~17 orders of magnitude away from the buggy value.

Verified with `go test ./pkg/controller/tainteviction/...` (full package), `go vet`, and `gofmt`.

Because only the reported value changes and not the metric name, type, or buckets, no dashboard or alert needs to be migrated; queries that currently return `+Inf` start returning real latencies.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the `taint_eviction_controller_pod_deletion_duration_seconds` metric reporting values scaled by 1e9 instead of seconds, which placed every observation outside the largest histogram bucket.
```
