### PR TITLE
Fix nil pointer dereference in syncVolume claim cache conversion

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -636,7 +636,7 @@ func (ctrl *PersistentVolumeController) syncVolume(ctx context.Context, volume *
 			var ok bool
 			claim, ok = obj.(*v1.PersistentVolumeClaim)
 			if !ok {
-				return fmt.Errorf("cannot convert object from volume cache to volume %q!?: %#v", claim.Spec.VolumeName, obj)
+				return fmt.Errorf("cannot convert object from claim cache to claim %q!?: %#v", claimName, obj)
 			}
 			logger.V(4).Info("Synchronizing PersistentVolume, claim found", "PVC", klog.KRef(volume.Spec.ClaimRef.Namespace, volume.Spec.ClaimRef.Name), "claimStatus", getClaimStatusForLogging(claim), "volumeName", volume.Name)
 		}

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -886,5 +887,31 @@ func TestRetroactiveStorageClassAssignment(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	for _, test := range tests {
 		runSyncTests(t, ctx, test.tests, test.storageClasses, nil)
+	}
+}
+
+// A failed type assertion on the claim cache entry leaves the local claim
+// variable nil, so syncVolume must not build its error message out of it.
+func TestSyncVolumeWithNonClaimObjectInClaimCache(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	ctrl, err := newTestController(ctx, &fake.Clientset{}, nil, false)
+	if err != nil {
+		t.Fatalf("construct persistent volume controller failed: %v", err)
+	}
+
+	// Store an object of the wrong type under the key syncVolume looks up.
+	if err := ctrl.claims.Add(&v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "claim1-1"},
+	}); err != nil {
+		t.Fatalf("seed claim cache: %v", err)
+	}
+
+	pv := newVolume("volume1-1", "1Gi", "uid1-1", "claim1-1", v1.VolumeBound, v1.PersistentVolumeReclaimRetain, classEmpty)
+	err = ctrl.syncVolume(ctx, pv)
+	if err == nil {
+		t.Fatal("syncVolume with a non-claim object in the claim cache = nil error, want an error")
+	}
+	if !strings.Contains(err.Error(), "cannot convert object from claim cache") {
+		t.Errorf("syncVolume error = %q, want it to report the failed claim cache conversion", err)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig storage

#### What this PR does / why we need it:

`syncVolume` panics instead of returning an error when the claim cache holds an object that is not a `*v1.PersistentVolumeClaim`:

```go
claim, ok = obj.(*v1.PersistentVolumeClaim)
if !ok {
    return fmt.Errorf("cannot convert object from volume cache to volume %q!?: %#v", claim.Spec.VolumeName, obj)
}
```

A comma-ok type assertion sets `claim` to nil when it fails, so the error path dereferences the nil pointer it was written to describe. The one branch meant to report the problem is the one that crashes the sync.

The message was copied from `syncUnboundClaim` and `syncBoundClaim` (lines 431 and 521), where it is correct: there `claim` is a non-nil function parameter and the assertion target is the volume. In `syncVolume` the roles are reversed, `claim` is the assertion target, and the copy became a nil dereference.

The fix reports the claim key, which is already in scope and non-nil. It also corrects the wording: `obj` comes from the claim cache, not the volume cache, so the message now matches the one used for the same situation at line 1428.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Reaching this in production requires a non-PVC object under the claim's cache key, so this is a latent panic rather than something users hit today. It is still the error path of a core control loop, and the message it prints is wrong about which cache it read.

Added `TestSyncVolumeWithNonClaimObjectInClaimCache`, which seeds the claim cache with a mismatched object. Against the current code the test fails with:

```
panic: runtime error: invalid memory address or nil pointer dereference
```

and it passes with the fix. Verified with `go test ./pkg/controller/volume/persistentvolume/...` (full package), `go vet`, and `gofmt`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a potential nil pointer dereference in the PersistentVolume controller when an object in the claim cache is not a PersistentVolumeClaim.
```
