### PR TITLE
test: increase integration API server startup timeout

### DIFF
--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -223,7 +223,7 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 	kubeAPIServerClientConfig.ServerName = ""
 
 	// wait for health
-	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, time.Minute, true, func(ctx context.Context) (done bool, err error) {
 		select {
 		case err := <-errCh:
 			return false, err


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test
/sig auth


#### What this PR does / why we need it:
polling loop currently has a hard coded max duration of 10s so in the failing s390x integration runs, the helper does not observe all readiness conditions within that 10s. It returns `context deadline exceeded` and calls `t.Fatal` causing access review tests such as `TestSubjectAccessReview` and `TestSelfSubjectAccessReview` to fail during test server startup

this PR increases maximum readiness deadline from 10s to 60s

#### Which issue(s) this PR is related to:
#141284

#### Special notes for your reviewer:
 ran six sequential pairs of the full integration suite:
- without change: 10s readiness deadline
- with change: 60s readiness deadline

| Result | 10-second deadline | 60-second deadline |
|---|---:|---:|
| Exact access-review/helper deadline failure | **5/6** | **0/6** |
| `test/integration/auth` passed | **1/6** | **6/6** |
| Full integration suite passed | **0/6** | **5/6** |

Detailed interim results are recorded in:
https://github.com/kubernetes/kubernetes/issues/141284#issuecomment-5249905248

s390x integration tested commit:
https://github.com/sudharshanibm/kubernetes/commit/951bdab0d03d0197217f88498b4545e67674bd22

validation on the current commit:
<img width="325" height="44" alt="Screenshot 2026-08-11 at 2 35 27 PM" src="https://github.com/user-attachments/assets/7b113bca-98e6-45ba-872a-80b1c9c4f3f5" />


Does this PR introduce a user-facing change?
```
NONE
```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```
```
