### PR TITLE
Expose PlacementFeasible as an extension point

### DIFF
--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -74410,6 +74410,13 @@ func schema_k8sio_kube_scheduler_config_v1_Plugins(ref common.ReferenceCallback)
 							Ref:         ref(configv1.PluginSet{}.OpenAPIModelName()),
 						},
 					},
+					"placementFeasible": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PlacementFeasible is a list of plugins that should be invoked when evaluating if a placement is feasible for a pod group.",
+							Default:     map[string]interface{}{},
+							Ref:         ref(configv1.PluginSet{}.OpenAPIModelName()),
+						},
+					},
 					"podGroupPostFilter": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PodGroupPostFilter is a list of plugins that are invoked after the workload scheduling phase, but only when the PodGroup cannot be scheduled (equivalent to PostFilter for single pods).",

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -183,6 +183,9 @@ type Plugins struct {
 	// PlacementScore is a list of plugins that should be invoked during workload scheduling cycle when ranking pod group assignments.
 	PlacementScore PluginSet
 
+	// PlacementFeasible is a list of plugins that should be invoked when evaluating if a placement is feasible for a pod group.
+	PlacementFeasible PluginSet
+
 	// PodGroupPostFilter is a list of plugins that are invoked after the workload scheduling phase,
 	// but only when the PodGroup cannot be scheduled (equivalent to PostFilter for single pods).
 	PodGroupPostFilter PluginSet
@@ -242,6 +245,7 @@ func (p *Plugins) Names() []string {
 		return nil
 	}
 	extensions := []PluginSet{
+		p.MultiPoint,
 		p.PreEnqueue,
 		p.PreFilter,
 		p.Filter,
@@ -256,6 +260,8 @@ func (p *Plugins) Names() []string {
 		p.QueueSort,
 		p.PlacementGenerate,
 		p.PlacementScore,
+		p.PlacementFeasible,
+		p.PodGroupPostFilter,
 	}
 	n := sets.New[string]()
 	for _, e := range extensions {

--- a/pkg/scheduler/apis/config/types_test.go
+++ b/pkg/scheduler/apis/config/types_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package config
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestPluginsNames(t *testing.T) {
@@ -59,5 +61,24 @@ func TestPluginsNames(t *testing.T) {
 				t.Fatalf("plugins mismatch (-want +got):\n%s", d)
 			}
 		})
+	}
+}
+
+func TestPluginsNamesAllExtensionPoints(t *testing.T) {
+	plugins := &Plugins{}
+	val := reflect.ValueOf(plugins).Elem()
+
+	want := sets.New[string]()
+	for i := 0; i < val.NumField(); i++ {
+		name := val.Type().Field(i).Name
+		val.Field(i).Set(reflect.ValueOf(PluginSet{
+			Enabled: []Plugin{{Name: name}},
+		}))
+		want.Insert(name)
+	}
+
+	gotNames := plugins.Names()
+	if diff := cmp.Diff(sets.List(want), gotNames); diff != "" {
+		t.Errorf("plugins.Names() doesn't contain all extension points (-want,+got):\n%s", diff)
 	}
 }

--- a/pkg/scheduler/apis/config/v1/default_plugins.go
+++ b/pkg/scheduler/apis/config/v1/default_plugins.go
@@ -125,6 +125,7 @@ func mergePlugins(logger klog.Logger, defaultPlugins, customPlugins *v1.Plugins)
 	defaultPlugins.PostBind = mergePluginSet(logger, defaultPlugins.PostBind, customPlugins.PostBind)
 	defaultPlugins.PlacementGenerate = mergePluginSet(logger, defaultPlugins.PlacementGenerate, customPlugins.PlacementGenerate)
 	defaultPlugins.PlacementScore = mergePluginSet(logger, defaultPlugins.PlacementScore, customPlugins.PlacementScore)
+	defaultPlugins.PlacementFeasible = mergePluginSet(logger, defaultPlugins.PlacementFeasible, customPlugins.PlacementFeasible)
 	defaultPlugins.PodGroupPostFilter = mergePluginSet(logger, defaultPlugins.PodGroupPostFilter, customPlugins.PodGroupPostFilter)
 	return defaultPlugins
 }

--- a/pkg/scheduler/apis/config/v1/defaults.go
+++ b/pkg/scheduler/apis/config/v1/defaults.go
@@ -59,6 +59,8 @@ func pluginsNames(p *configv1.Plugins) []string {
 		p.QueueSort,
 		p.PlacementGenerate,
 		p.PlacementScore,
+		p.PlacementFeasible,
+		p.PodGroupPostFilter,
 	}
 	n := sets.New[string]()
 	for _, e := range extensions {

--- a/pkg/scheduler/apis/config/v1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1/defaults_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/util/feature"
 	componentbaseconfig "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/component-base/featuregate"
@@ -926,5 +928,24 @@ func TestPluginArgsDefaults(t *testing.T) {
 				t.Errorf("Got unexpected defaults (-want, +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestPluginsNames(t *testing.T) {
+	plugins := &configv1.Plugins{}
+	val := reflect.ValueOf(plugins).Elem()
+
+	want := sets.New[string]()
+	for i := 0; i < val.NumField(); i++ {
+		name := val.Type().Field(i).Name
+		val.Field(i).Set(reflect.ValueOf(configv1.PluginSet{
+			Enabled: []configv1.Plugin{{Name: name}},
+		}))
+		want.Insert(name)
+	}
+
+	gotNames := pluginsNames(plugins)
+	if diff := cmp.Diff(sets.List(want), gotNames); diff != "" {
+		t.Errorf("pluginsNames() doesn't contain all extension points (-want,+got):\n%s", diff)
 	}
 }

--- a/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1/zz_generated.conversion.go
@@ -767,6 +767,9 @@ func autoConvert_v1_Plugins_To_config_Plugins(in *configv1.Plugins, out *config.
 	if err := Convert_v1_PluginSet_To_config_PluginSet(&in.PlacementScore, &out.PlacementScore, s); err != nil {
 		return err
 	}
+	if err := Convert_v1_PluginSet_To_config_PluginSet(&in.PlacementFeasible, &out.PlacementFeasible, s); err != nil {
+		return err
+	}
 	if err := Convert_v1_PluginSet_To_config_PluginSet(&in.PodGroupPostFilter, &out.PodGroupPostFilter, s); err != nil {
 		return err
 	}
@@ -822,6 +825,9 @@ func autoConvert_config_Plugins_To_v1_Plugins(in *config.Plugins, out *configv1.
 		return err
 	}
 	if err := Convert_config_PluginSet_To_v1_PluginSet(&in.PlacementScore, &out.PlacementScore, s); err != nil {
+		return err
+	}
+	if err := Convert_config_PluginSet_To_v1_PluginSet(&in.PlacementFeasible, &out.PlacementFeasible, s); err != nil {
 		return err
 	}
 	if err := Convert_config_PluginSet_To_v1_PluginSet(&in.PodGroupPostFilter, &out.PodGroupPostFilter, s); err != nil {

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -177,6 +177,9 @@ func validatePluginConfig(path *field.Path, apiVersion string, profile *config.K
 			"preBind":            profile.Plugins.PreBind,
 			"bind":               profile.Plugins.Bind,
 			"postBind":           profile.Plugins.PostBind,
+			"placementGenerate":  profile.Plugins.PlacementGenerate,
+			"placementScore":     profile.Plugins.PlacementScore,
+			"placementFeasible":  profile.Plugins.PlacementFeasible,
 			"podGroupPostFilter": profile.Plugins.PodGroupPostFilter,
 		}
 

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -445,6 +445,7 @@ func (in *Plugins) DeepCopyInto(out *Plugins) {
 	in.MultiPoint.DeepCopyInto(&out.MultiPoint)
 	in.PlacementGenerate.DeepCopyInto(&out.PlacementGenerate)
 	in.PlacementScore.DeepCopyInto(&out.PlacementScore)
+	in.PlacementFeasible.DeepCopyInto(&out.PlacementFeasible)
 	in.PodGroupPostFilter.DeepCopyInto(&out.PodGroupPostFilter)
 	return
 }

--- a/pkg/scheduler/framework/interface.go
+++ b/pkg/scheduler/framework/interface.go
@@ -162,32 +162,6 @@ type SortedScoredNodes interface {
 	UnorderedList() []fwk.NodePluginScores
 }
 
-// PlacementFeasiblePlugin is an interface for plugins that are called after each pod in a pod group is evaluated.
-// It is used to determine if a pod group is schedulable, may become schedulable or will not become schedulable regardless of the scheduling result of the remaining pods in the pod group.
-type PlacementFeasiblePlugin interface {
-	fwk.Plugin
-
-	// PlacementFeasible is called after each pod in a pod group is evaluated.
-	// placementProgress contains information that plugins might additionally need when determining whether pod group scheduling placement is feasible.
-	// Return Wait status if the pod group cannot be scheduled in the current partially evaluated placement, but may become schedulable once more pods are evaluated.
-	// Return Unschedulable status if the pod group cannot be scheduled in the current placement.
-	// The scheduler will give up this placement and won't even evaluate remaining pods. The placement will remain eligible for preemption.
-	// Return Success status if the pod group can be scheduled in the current partially evaluated placement.
-	// After returning Success, the plugin should keep returning Success for the remaining pods.
-	PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, placementProgress PlacementProgress) *fwk.Status
-}
-
-// PlacementProgress contains information that plugins implementing the PlacementFeasiblePlugin
-// interface might additionally need when determining whether pod group scheduling placement is feasible.
-type PlacementProgress struct {
-	// Remaining is the number of children that have not been evaluated yet in the current scheduling cycle. For pod groups, this is the number of unscheduled pods.
-	Remaining int
-	// Scheduled is the number of children scheduled so far in the current pod group scheduling cycle
-	// for a particular (composite) pod group and placement. For a pod group the field includes the pods that are assigned
-	// or assumed in the current PodGroup scheduling cycle.
-	Scheduled int
-}
-
 // Framework manages the set of plugins in use by the scheduling framework.
 // Configured plugins are called at specified points in a scheduling context.
 type Framework interface {
@@ -268,13 +242,12 @@ type Framework interface {
 	// This function itself will NOT create a waiting pod object and the caller should call AddWaitingPod method to do this.
 	RunPermitPlugins(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (pluginsWaitTime map[string]time.Duration, status *fwk.Status)
 
-	// RunPlacementFeasiblePlugins runs the set of configured Permit plugins that implement PlacementFeasible interface.
-	// The result will be Success if all plugins return Success.
+	// RunPlacementFeasiblePlugins runs the set of configured PlacementFeasible plugins.
 	// The only other valid statuses are Wait and Unschedulable.
 	// If any plugin returns invalid status, the result will be Error and the remaining plugins won't be invoked.
 	// Otherwise, if at least 1 plugin returns Unschedulable, the remaining plugins won't be invoked and the result will be Unschedulable. The placement will remain eligible for preemption.
 	// Otherwise, if at least 1 plugin returns Wait, the remaining plugins will be invoked and the result will be Wait.
-	RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, placementProgress PlacementProgress) *fwk.Status
+	RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, placementProgress fwk.PlacementProgress) *fwk.Status
 
 	// AddWaitingPod creates a waiting pod instance and adds it to the framework.
 	// It takes the pluginsWaitTime map returned by the RunPermitPlugins.

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -27,7 +27,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
-	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/kubernetes/pkg/scheduler/util"
@@ -49,7 +48,7 @@ type GangScheduling struct {
 
 var _ fwk.EnqueueExtensions = &GangScheduling{}
 var _ fwk.PreEnqueuePlugin = &GangScheduling{}
-var _ framework.PlacementFeasiblePlugin = &GangScheduling{}
+var _ fwk.PlacementFeasiblePlugin = &GangScheduling{}
 
 // New initializes a new plugin and returns it.
 func New(_ context.Context, _ runtime.Object, fh fwk.Handle, fts feature.Features) (fwk.Plugin, error) {
@@ -349,7 +348,7 @@ func (pl *GangScheduling) isPGReady(snapshot fwk.PodGroupManager, namespace, pgN
 // PlacementFeasible is responsible for enforcing the gang's MinCount constraint in the pod group scheduling cycle.
 // The function will only return success once the gang's MinCount is satisfied or if the pod group is not using gang scheduling policy.
 // In case there are not enough remaining pods to satisfy the gang's MinCount, it returns Unschedulable which will terminate the pod group scheduling cycle early.
-func (pl *GangScheduling) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, args framework.PlacementProgress) *fwk.Status {
+func (pl *GangScheduling) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, args fwk.PlacementProgress) *fwk.Status {
 	minCount := getMinCount(podGroupInfo)
 	remaining := args.Remaining
 	scheduled := args.Scheduled

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -1079,7 +1079,7 @@ func TestPlacementFeasible(t *testing.T) {
 							mockState.scheduledPodsCount++
 						}
 
-						args := schedulerframework.PlacementProgress{
+						args := fwk.PlacementProgress{
 							Remaining: tc.childrenCount - (i + 1),
 							Scheduled: scheduled,
 						}

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -44,7 +44,6 @@ import (
 	apidispatcher "k8s.io/kubernetes/pkg/scheduler/backend/api_dispatcher"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 )
 
@@ -79,7 +78,7 @@ type frameworkImpl struct {
 	podGroupPostFilterPlugins []fwk.PodGroupPostFilterPlugin
 
 	placementGeneratePlugins   []fwk.PlacementGeneratePlugin
-	placementFeasiblePlugins   []framework.PlacementFeasiblePlugin
+	placementFeasiblePlugins   []fwk.PlacementFeasiblePlugin
 	placementScorePlugins      []fwk.PlacementScorePlugin
 	placementScorePluginWeight map[string]int
 
@@ -140,6 +139,7 @@ func (f *frameworkImpl) getExtensionPoints(plugins *config.Plugins) []extensionP
 		{&plugins.QueueSort, &f.queueSortPlugins},
 		{&plugins.PlacementGenerate, &f.placementGeneratePlugins},
 		{&plugins.PlacementScore, &f.placementScorePlugins},
+		{&plugins.PlacementFeasible, &f.placementFeasiblePlugins},
 		{&plugins.PodGroupPostFilter, &f.podGroupPostFilterPlugins},
 	}
 }
@@ -495,19 +495,6 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 		f.computeBatchablePlugins()
 	}
 
-	// Use GangScheduling plugin as the only PlacementFeasiblePlugin.
-	if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
-		if gs, ok := f.pluginsMap[names.GangScheduling]; ok {
-			if p, ok := gs.(framework.PlacementFeasiblePlugin); ok {
-				f.placementFeasiblePlugins = append(f.placementFeasiblePlugins, p)
-			} else {
-				return nil, fmt.Errorf("GenericWorkload is enabled, but GangScheduling plugin does not fulfill PlacementFeasiblePlugin interface")
-			}
-		} else {
-			logger.Error(nil, "GenericWorkload is enabled, but GangScheduling plugin is not set. Gang scheduling using PodGroups may not work as expected.")
-		}
-	}
-
 	if options.captureProfile != nil {
 		if len(outputProfile.PluginConfig) != 0 {
 			sort.Slice(outputProfile.PluginConfig, func(i, j int) bool {
@@ -745,9 +732,9 @@ func (f *frameworkImpl) expandMultiPointPlugins(logger klog.Logger, profile *con
 
 func shouldHaveEnqueueExtensions(p fwk.Plugin) bool {
 	switch p.(type) {
-	// Only PreEnqueue, PreFilter, Filter, Reserve, and Permit plugins can (should) have EnqueueExtensions.
+	// Only PreEnqueue, PreFilter, Filter, Reserve, Permit and PlacementFeasible plugins can (should) have EnqueueExtensions.
 	// See the comment of EnqueueExtensions for more detailed reason here.
-	case fwk.PreEnqueuePlugin, fwk.PreFilterPlugin, fwk.FilterPlugin, fwk.ReservePlugin, fwk.PermitPlugin:
+	case fwk.PreEnqueuePlugin, fwk.PreFilterPlugin, fwk.FilterPlugin, fwk.ReservePlugin, fwk.PermitPlugin, fwk.PlacementFeasiblePlugin:
 		return true
 	}
 	return false
@@ -755,7 +742,7 @@ func shouldHaveEnqueueExtensions(p fwk.Plugin) bool {
 
 func (f *frameworkImpl) fillEnqueueExtensions(p fwk.Plugin) {
 	if !shouldHaveEnqueueExtensions(p) {
-		// Ignore EnqueueExtensions from plugin which isn't PreEnqueue, PreFilter, Filter, Reserve, and Permit.
+		// Ignore EnqueueExtensions from plugin which isn't PreEnqueue, PreFilter, Filter, Reserve, Permit and PlacementFeasible.
 		return
 	}
 
@@ -2160,28 +2147,40 @@ func (f *frameworkImpl) runPermitPlugin(ctx context.Context, pl fwk.PermitPlugin
 	return status, timeout
 }
 
-// RunPlacementFeasiblePlugins runs the set of configured Permit plugins that implement PlacementFeasible interface.
+// RunPlacementFeasiblePlugins runs the set of configured PlacementFeasible plugins.
 // The result will be Success if all plugins return Success.
 // The only other valid statuses are Wait and Unschedulable.
 // If any plugin returns invalid status, the result will be Error and the remaining plugins won't be invoked.
 // Otherwise, if at least 1 plugin returns Unschedulable, the remaining plugins won't be invoked and the result will be Unschedulable.
 // Otherwise, if at least 1 plugin returns Wait, the remaining plugins will be invoked and the result will be Wait.
-func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, args framework.PlacementProgress) (status *fwk.Status) {
+func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, args fwk.PlacementProgress) (status *fwk.Status) {
 	startTime := time.Now()
 	defer func() {
 		metrics.FrameworkExtensionPointDuration.WithLabelValues(metrics.PlacementFeasible, status.Code().String(), f.profileName).Observe(metrics.SinceInSeconds(startTime))
 	}()
 
+	logger := klog.FromContext(ctx)
+	verboseLogs := logger.V(4).Enabled()
+	if verboseLogs {
+		logger = klog.LoggerWithName(logger, "PlacementFeasible")
+	}
 	for _, pl := range f.placementFeasiblePlugins {
+		ctx := ctx
+		if verboseLogs {
+			logger := klog.LoggerWithName(logger, pl.Name())
+			ctx = klog.NewContext(ctx, logger)
+		}
 		plStatus := f.runPlacementFeasiblePlugin(ctx, pl, placementCycleState, podGroupInfo, args)
 		if plStatus.IsSuccess() {
 			continue
 		}
 		if plStatus.Code() == fwk.Wait {
+			logger.V(4).Info("Plugin asked to wait for PodGroup placement to be feasible", "podGroupType", podGroupInfo.GetType(), "podGroup", klog.KObj(podGroupInfo), "plugin", pl.Name(), "status", plStatus.Message())
 			status = plStatus.WithPlugin(pl.Name())
 			continue
 		}
 		if plStatus.Code() == fwk.Unschedulable {
+			logger.V(4).Info("PodGroup placement rejected by plugin", "podGroupType", podGroupInfo.GetType(), "podGroup", klog.KObj(podGroupInfo), "plugin", pl.Name(), "status", plStatus.Message())
 			return plStatus.WithPlugin(pl.Name())
 		}
 		if plStatus.IsError() {
@@ -2193,7 +2192,7 @@ func (f *frameworkImpl) RunPlacementFeasiblePlugins(ctx context.Context, placeme
 	return status
 }
 
-func (f *frameworkImpl) runPlacementFeasiblePlugin(ctx context.Context, pl framework.PlacementFeasiblePlugin, state fwk.PlacementCycleState, podGroup fwk.PodGroupInfo, args framework.PlacementProgress) *fwk.Status {
+func (f *frameworkImpl) runPlacementFeasiblePlugin(ctx context.Context, pl fwk.PlacementFeasiblePlugin, state fwk.PlacementCycleState, podGroup fwk.PodGroupInfo, args fwk.PlacementProgress) *fwk.Status {
 	if !state.ShouldRecordPluginMetrics() {
 		return pl.PlacementFeasible(ctx, state, podGroup, args)
 	}

--- a/pkg/scheduler/framework/runtime/framework_test.go
+++ b/pkg/scheduler/framework/runtime/framework_test.go
@@ -229,7 +229,7 @@ func (pl *TestPlugin) PreFilter(ctx context.Context, state fwk.CycleState, p *v1
 	return pl.inj.PreFilterResult, fwk.NewStatus(fwk.Code(pl.inj.PreFilterStatus), injectReason)
 }
 
-func (pl *TestPlugin) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroup fwk.PodGroupInfo, args framework.PlacementProgress) *fwk.Status {
+func (pl *TestPlugin) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroup fwk.PodGroupInfo, args fwk.PlacementProgress) *fwk.Status {
 	return fwk.NewStatus(fwk.Code(pl.inj.PlacementFeasibleStatus), injectReason)
 }
 
@@ -667,126 +667,6 @@ func TestNewFrameworkErrors(t *testing.T) {
 	}
 }
 
-func TestNewFramework_PlacementFeasible(t *testing.T) {
-	tests := []struct {
-		name                       string
-		genericWorkloadEnabled     bool
-		registerGangScheduling     bool
-		placementFeasibleFulfilled bool
-		wantErr                    string
-		wantPlacementFeasible      bool
-	}{
-		{
-			name:                       "GenericWorkload enabled, GangScheduling does not fulfill PlacementFeasiblePlugin interface",
-			genericWorkloadEnabled:     true,
-			registerGangScheduling:     true,
-			placementFeasibleFulfilled: false,
-			wantErr:                    "GenericWorkload is enabled, but GangScheduling plugin does not fulfill PlacementFeasiblePlugin interface",
-		},
-		{
-			name:                       "GenericWorkload disabled, GangScheduling does not fulfill PlacementFeasiblePlugin interface",
-			genericWorkloadEnabled:     false,
-			registerGangScheduling:     true,
-			placementFeasibleFulfilled: false,
-			wantPlacementFeasible:      false,
-		},
-		{
-			name:                   "GenericWorkload enabled, GangScheduling plugin not present",
-			genericWorkloadEnabled: true,
-			registerGangScheduling: false,
-			wantPlacementFeasible:  false,
-		},
-		{
-			name:                       "GenericWorkload enabled, GangScheduling fulfills PlacementFeasiblePlugin interface",
-			genericWorkloadEnabled:     true,
-			registerGangScheduling:     true,
-			placementFeasibleFulfilled: true,
-			wantPlacementFeasible:      true,
-		},
-		{
-			name:                       "GenericWorkload disabled, GangScheduling fulfills PlacementFeasiblePlugin interface",
-			genericWorkloadEnabled:     false,
-			registerGangScheduling:     true,
-			placementFeasibleFulfilled: true,
-			wantPlacementFeasible:      false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-				features.GenericWorkload: tc.genericWorkloadEnabled,
-			})
-
-			_, ctx := ktesting.NewTestContext(t)
-
-			registry := Registry{}
-			profile := config.KubeSchedulerProfile{
-				Plugins: &config.Plugins{},
-			}
-
-			if tc.registerGangScheduling {
-				err := registry.Register(names.GangScheduling, func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
-					if tc.placementFeasibleFulfilled {
-						return &mockGangSchedulingWithPlacementFeasible{}, nil
-					}
-					return &mockGangScheduling{}, nil
-				})
-				if err != nil {
-					t.Fatalf("Failed to register GangScheduling plugin: %v", err)
-				}
-				profile.Plugins.MultiPoint = config.PluginSet{
-					Enabled: []config.Plugin{
-						{Name: names.GangScheduling},
-					},
-				}
-			}
-
-			f, err := newFrameworkWithQueueSortAndBind(ctx, registry, profile)
-
-			if len(tc.wantErr) > 0 {
-				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
-					t.Errorf("Unexpected error, got %v, expect: %s", err, tc.wantErr)
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("Failed to create framework: %v", err)
-			}
-
-			placementFeasiblePlugins := f.(*frameworkImpl).placementFeasiblePlugins
-			if tc.wantPlacementFeasible {
-				if len(placementFeasiblePlugins) != 1 || placementFeasiblePlugins[0].Name() != names.GangScheduling {
-					t.Errorf("Expected GangScheduling plugin in placementFeasiblePlugins, got: %v", placementFeasiblePlugins)
-				}
-			} else {
-				if len(placementFeasiblePlugins) != 0 {
-					t.Errorf("Expected empty placementFeasiblePlugins, got: %v", placementFeasiblePlugins)
-				}
-			}
-		})
-	}
-}
-
-type mockGangScheduling struct{}
-
-func (m *mockGangScheduling) Name() string {
-	return names.GangScheduling
-}
-
-var _ fwk.Plugin = &mockGangScheduling{}
-
-type mockGangSchedulingWithPlacementFeasible struct {
-	mockGangScheduling
-}
-
-func (p *mockGangSchedulingWithPlacementFeasible) PlacementFeasible(_ context.Context, _ fwk.PlacementCycleState, _ fwk.PodGroupInfo, _ framework.PlacementProgress) *fwk.Status {
-	return nil
-}
-
-var _ framework.PlacementFeasiblePlugin = &mockGangSchedulingWithPlacementFeasible{}
-
 func TestPodGroupPostFilterPlugins(t *testing.T) {
 	tests := []struct {
 		name                   string
@@ -1139,7 +1019,7 @@ type mockPlacementFeasiblePlugin struct {
 
 func (p *mockPlacementFeasiblePlugin) Name() string { return p.name }
 
-func (p *mockPlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroup fwk.PodGroupInfo, args framework.PlacementProgress) *fwk.Status {
+func (p *mockPlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroup fwk.PodGroupInfo, args fwk.PlacementProgress) *fwk.Status {
 	p.called = true
 	return p.status
 }
@@ -1220,13 +1100,16 @@ func TestRunPlacementFeasiblePlugins(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			f := &frameworkImpl{
-				placementFeasiblePlugins: make([]framework.PlacementFeasiblePlugin, len(tc.plugins)),
+				placementFeasiblePlugins: make([]fwk.PlacementFeasiblePlugin, len(tc.plugins)),
 			}
 			for i, p := range tc.plugins {
 				f.placementFeasiblePlugins[i] = p
 			}
 
-			status := f.RunPlacementFeasiblePlugins(ctx, framework.NewCycleState(), nil, framework.PlacementProgress{})
+			podGroupInfo := &framework.PodGroupInfo{
+				GenericPodGroup: fwk.NewGenericPodGroup(st.MakePodGroup().Name("pg").Namespace("default").Obj()),
+			}
+			status := f.RunPlacementFeasiblePlugins(ctx, framework.NewCycleState(), podGroupInfo, fwk.PlacementProgress{})
 
 			if diff := cmp.Diff(tc.expectedStatus, status, statusCmpOpts...); diff != "" {
 				t.Errorf("Unexpected status (-want, +got):\n%s", diff)
@@ -1271,6 +1154,7 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 				PostBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementGenerate:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementScore:     config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 5}}},
+				PlacementFeasible:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PodGroupPostFilter: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 			},
 		},
@@ -1309,6 +1193,7 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 				Bind:               config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PostBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementGenerate:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
+				PlacementFeasible:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PodGroupPostFilter: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 			},
 		},
@@ -1346,6 +1231,7 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 					{Name: testPlugin, Weight: 1},
 					{Name: placementScorePlugin1, Weight: 1},
 				}},
+				PlacementFeasible:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PodGroupPostFilter: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 			},
 		},
@@ -1380,6 +1266,7 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 				PostBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementGenerate:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementScore:     config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 1}}},
+				PlacementFeasible:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PodGroupPostFilter: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 			},
 		},
@@ -1421,6 +1308,7 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 				PostBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementGenerate:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementScore:     config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 1}}},
+				PlacementFeasible:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PodGroupPostFilter: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 			},
 		},
@@ -1462,6 +1350,7 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 				PostBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementGenerate:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementScore:     config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 1}}},
+				PlacementFeasible:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PodGroupPostFilter: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 			},
 		},
@@ -1506,6 +1395,7 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 				PostBind:           config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementGenerate:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PlacementScore:     config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin, Weight: 2}}},
+				PlacementFeasible:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PodGroupPostFilter: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 			},
 		},
@@ -1623,6 +1513,7 @@ func TestNewFrameworkMultiPointExpansion(t *testing.T) {
 					{Name: testPlugin, Weight: 2},
 					{Name: placementScorePlugin1, Weight: 6},
 				}},
+				PlacementFeasible:  config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 				PodGroupPostFilter: config.PluginSet{Enabled: []config.Plugin{{Name: testPlugin}}},
 			},
 		},
@@ -4594,7 +4485,7 @@ func TestRecordingMetrics(t *testing.T) {
 		{
 			name: "PlacementFeasible - Success",
 			action: func(ctx context.Context, f framework.Framework) {
-				f.RunPlacementFeasiblePlugins(ctx, state, nil, framework.PlacementProgress{})
+				f.RunPlacementFeasiblePlugins(ctx, state, nil, fwk.PlacementProgress{})
 			},
 			wantExtensionPoint: "PlacementFeasible",
 			wantStatus:         fwk.Success,
@@ -4691,7 +4582,7 @@ func TestRecordingMetrics(t *testing.T) {
 		{
 			name: "PlacementFeasible - Error",
 			action: func(ctx context.Context, f framework.Framework) {
-				f.RunPlacementFeasiblePlugins(ctx, state, nil, framework.PlacementProgress{})
+				f.RunPlacementFeasiblePlugins(ctx, state, nil, fwk.PlacementProgress{})
 			},
 			inject:             injectedResult{PlacementFeasibleStatus: int(fwk.Error)},
 			wantExtensionPoint: "PlacementFeasible",
@@ -4763,7 +4654,7 @@ func TestRecordingMetrics(t *testing.T) {
 			}()
 
 			if tt.wantExtensionPoint == "PlacementFeasible" {
-				f.(*frameworkImpl).placementFeasiblePlugins = []framework.PlacementFeasiblePlugin{plugin}
+				f.(*frameworkImpl).placementFeasiblePlugins = []fwk.PlacementFeasiblePlugin{plugin}
 			}
 
 			tt.action(ctx, f)

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -444,7 +444,7 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 
 	// Run PlacementFeasible plugins to check if the pod group can meet its constraints
 	// before even attempting to schedule any pods.
-	placementProgress := framework.PlacementProgress{
+	placementProgress := fwk.PlacementProgress{
 		Remaining: len(podGroupInfo.GetUnscheduledPods()),
 		Scheduled: podGroupState.ScheduledPodsCount(),
 	}
@@ -493,7 +493,7 @@ func (sched *Scheduler) podGroupSchedulingDefaultAlgorithm(ctx context.Context, 
 // the (composite) pod group can meet its constraints based on the placement progress.
 // It returns true when the scheduling should proceed, false otherwise.
 // Returned status is modified to be fine to be copied directly to the podGroupAlgorithmResult.
-func podGroupPotentiallyFeasible(ctx context.Context, schedFwk framework.Framework, placementCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, placementProgress framework.PlacementProgress) (bool, *fwk.Status) {
+func podGroupPotentiallyFeasible(ctx context.Context, schedFwk framework.Framework, placementCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, placementProgress fwk.PlacementProgress) (bool, *fwk.Status) {
 	status := schedFwk.RunPlacementFeasiblePlugins(ctx, placementCycleState, podGroupInfo, placementProgress)
 	switch status.Code() {
 	case fwk.Error:
@@ -1303,7 +1303,7 @@ func (sched *Scheduler) compositePodGroupSchedulingDefaultAlgorithm(ctx context.
 
 	// Run PlacementFeasible plugins to check if the composite pod group can meet its constraints
 	// before even attempting to schedule any children.
-	placementProgress := framework.PlacementProgress{
+	placementProgress := fwk.PlacementProgress{
 		Remaining: len(podGroupInfo.Children),
 	}
 	proceed, placementFeasibleStatus := podGroupPotentiallyFeasible(ctx, schedFwk, placementCycleState, podGroupInfo, placementProgress)

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -138,20 +138,17 @@ func (d *fakePlacementFeasiblePluginData) Clone() fwk.StateData {
 	return &fakePlacementFeasiblePluginData{placementIndex: d.placementIndex}
 }
 
-var _ framework.PlacementFeasiblePlugin = &fakePlacementFeasiblePlugin{}
-var _ fwk.PermitPlugin = &fakePlacementFeasiblePlugin{}
+var _ fwk.PlacementFeasiblePlugin = &fakePlacementFeasiblePlugin{}
 
 func (mp *fakePlacementFeasiblePlugin) Name() string {
-	// Name has to be GangScheduling for the PlacementFeasible plugin to be used.
-	// TODO: Remove this once the restriction is taken off.
-	return names.GangScheduling
+	return "fakePlacementFeasiblePlugin"
 }
 
 // PlacementFeasible simulates the evaluation of pod group placement constraints.
 // The mock uses a 2D slice (placementFeasibleStatuses) where:
 // - The outer slice represents distinct placements (e.g., when evaluating multiple topology placements).
 // - The inner slice represents the pod-by-pod evaluation within a single placement.
-func (mp *fakePlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, args framework.PlacementProgress) *fwk.Status {
+func (mp *fakePlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, placementCycleState fwk.PlacementCycleState, podGroupInfo fwk.PodGroupInfo, args fwk.PlacementProgress) *fwk.Status {
 	// If no mock statuses are configured, always succeed.
 	if len(mp.placementFeasibleStatuses) == 0 {
 		return nil
@@ -189,10 +186,6 @@ func (mp *fakePlacementFeasiblePlugin) PlacementFeasible(ctx context.Context, pl
 		}
 	}
 	return nil
-}
-
-func (mp *fakePlacementFeasiblePlugin) Permit(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
-	return nil, 0
 }
 
 func TestValidatePodGroup(t *testing.T) {
@@ -1458,7 +1451,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 						tf.RegisterPostFilterPlugin(tt.plugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 							return tt.plugin, nil
 						}),
-						tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+						tf.RegisterPlacementFeasiblePlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 							return placementFeasiblePlugin, nil
 						}),
 					}
@@ -2843,7 +2836,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 					tf.RegisterFilterPlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 						return &tt.placementPlugin, nil
 					}),
-					tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+					tf.RegisterPlacementFeasiblePlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 						return placementFeasiblePlugin, nil
 					}),
 				}
@@ -3219,7 +3212,7 @@ func TestPodGroupSchedulingPlacementAlgorithm_NominatedNode(t *testing.T) {
 				tf.RegisterFilterPlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 					return &tt.placementPlugin, nil
 				}),
-				tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+				tf.RegisterPlacementFeasiblePlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 					return placementFeasiblePlugin, nil
 				}),
 			}
@@ -3671,8 +3664,7 @@ var hierarchyKey fwk.StateKey = "hierarchyTracker"
 var _ fwk.FilterPlugin = &multiLevelPlacementStateTracker{}
 var _ fwk.PlacementGeneratePlugin = &multiLevelPlacementStateTracker{}
 var _ fwk.PlacementScorePlugin = &multiLevelPlacementStateTracker{}
-var _ framework.PlacementFeasiblePlugin = &multiLevelPlacementStateTracker{}
-var _ fwk.PermitPlugin = &multiLevelPlacementStateTracker{}
+var _ fwk.PlacementFeasiblePlugin = &multiLevelPlacementStateTracker{}
 
 type multiLevelPlacementStateTracker struct {
 	mu                            sync.Mutex
@@ -3685,7 +3677,7 @@ type multiLevelPlacementStateTracker struct {
 }
 
 func (p *multiLevelPlacementStateTracker) Name() string {
-	return names.GangScheduling
+	return "multiLevelPlacementStateTracker"
 }
 
 func collectHierarchyFromPlacementCycleState(cycleState fwk.PlacementCycleState, results *[]string) error {
@@ -3733,11 +3725,7 @@ func (p *multiLevelPlacementStateTracker) Filter(ctx context.Context, state fwk.
 	return nil
 }
 
-func (p *multiLevelPlacementStateTracker) Permit(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeName string) (*fwk.Status, time.Duration) {
-	return nil, 0
-}
-
-func (p *multiLevelPlacementStateTracker) PlacementFeasible(ctx context.Context, state fwk.PlacementCycleState, podGroup fwk.PodGroupInfo, args framework.PlacementProgress) *fwk.Status {
+func (p *multiLevelPlacementStateTracker) PlacementFeasible(ctx context.Context, state fwk.PlacementCycleState, podGroup fwk.PodGroupInfo, args fwk.PlacementProgress) *fwk.Status {
 	if args.Scheduled == 0 {
 		if podGroup.GetPodGroup() != nil {
 			trajectory := []string{}
@@ -3843,7 +3831,7 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 		tf.RegisterFilterPlugin(tracker.Name(), func(_ context.Context, _ runtime.Object, h fwk.Handle) (fwk.Plugin, error) {
 			return tracker, nil
 		}),
-		tf.RegisterPermitPlugin(tracker.Name(), func(_ context.Context, _ runtime.Object, h fwk.Handle) (fwk.Plugin, error) {
+		tf.RegisterPlacementFeasiblePlugin(tracker.Name(), func(_ context.Context, _ runtime.Object, h fwk.Handle) (fwk.Plugin, error) {
 			return tracker, nil
 		}),
 	}
@@ -4360,7 +4348,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				tf.RegisterReservePlugin(tt.placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 					return &tt.placementPlugin, nil
 				}),
-				tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+				tf.RegisterPlacementFeasiblePlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 					return placementFeasiblePlugin, nil
 				}),
 			}
@@ -4629,7 +4617,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				tf.RegisterFilterPlugin(placementPlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 					return &placementPlugin, nil
 				}),
-				tf.RegisterPreEnqueuePlugin(gangscheduling.Name, gangPluginFactory),
+				tf.RegisterPlacementFeasiblePlugin(gangscheduling.Name, gangPluginFactory),
 			}
 
 			for i, placementScorePluginData := range tt.pluginData {
@@ -5254,7 +5242,7 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 	}
 }
 
-func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
+func TestCPGHierarchicalScheduling_RecursiveAlgorithm(t *testing.T) {
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
 		features.CompositePodGroup:               true,
 		features.GenericWorkload:                 true,
@@ -5316,8 +5304,8 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 	defer cancel()
 
 	// Mock PlacementFeasible plugin
-	fakeGS := &fakePlacementFeasiblePlugin{}
-	fakeGS.placementFeasibleStatuses = [][]fwk.Code{
+	fakePlacementFeasible := &fakePlacementFeasiblePlugin{}
+	fakePlacementFeasible.placementFeasibleStatuses = [][]fwk.Code{
 		// Four distinct scheduling cycles:
 		// 1. cpg-root (success, 1 call: before children scheduling, evaluated=0)
 		// 2. pg1 scheduling (success, 2 calls: before and after p1, evaluated=0 and 1)
@@ -5332,8 +5320,8 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 	registry := frameworkruntime.Registry{
 		queuesort.Name:     queuesort.New,
 		defaultbinder.Name: defaultbinder.New,
-		names.GangScheduling: func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
-			return fakeGS, nil
+		fakePlacementFeasible.Name(): func(ctx context.Context, obj runtime.Object, handle fwk.Handle) (fwk.Plugin, error) {
+			return fakePlacementFeasible, nil
 		},
 	}
 
@@ -5346,9 +5334,8 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 			Bind: config.PluginSet{
 				Enabled: []config.Plugin{{Name: defaultbinder.Name}},
 			},
-			// Enable GangScheduling to run PlacementFeasible
-			Permit: config.PluginSet{
-				Enabled: []config.Plugin{{Name: names.GangScheduling}},
+			PlacementFeasible: config.PluginSet{
+				Enabled: []config.Plugin{{Name: fakePlacementFeasible.Name()}},
 			},
 		},
 	}
@@ -5615,7 +5602,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 		}),
 		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPreEnqueuePlugin(gangscheduling.Name, gangPluginFactory),
+		tf.RegisterPlacementFeasiblePlugin(gangscheduling.Name, gangPluginFactory),
 	}
 
 	clientObjs := []runtime.Object{testNode, rootCPG, cpgSub1, cpgSub2, cpgSub3, pg1, pg2, pg3, pg4, pg5, pg6, pg7}
@@ -5851,7 +5838,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 		}),
 		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPreEnqueuePlugin(gangscheduling.Name, gangPluginFactory),
+		tf.RegisterPlacementFeasiblePlugin(gangscheduling.Name, gangPluginFactory),
 	}
 
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
@@ -6071,7 +6058,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 		}),
 		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterPreEnqueuePlugin(gangscheduling.Name, gangPluginFactory),
+		tf.RegisterPlacementFeasiblePlugin(gangscheduling.Name, gangPluginFactory),
 	}
 
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
@@ -6628,7 +6615,7 @@ func TestPodGroupPotentiallyFeasible(t *testing.T) {
 			registry := []tf.RegisterPluginFunc{
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-				tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+				tf.RegisterPlacementFeasiblePlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 					return placementFeasiblePlugin, nil
 				}),
 			}
@@ -6644,7 +6631,7 @@ func TestPodGroupPotentiallyFeasible(t *testing.T) {
 				},
 				GenericPodGroup: fwk.NewGenericPodGroup(st.MakePodGroup().Name("pg").Obj()),
 			}
-			placementProgress := framework.PlacementProgress{
+			placementProgress := fwk.PlacementProgress{
 				Remaining: 1,
 				Scheduled: 0,
 			}
@@ -6836,9 +6823,9 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 				},
 			},
 			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
-				p1: sets.New("GangScheduling"),
+				p1: sets.New("fakePlacementFeasiblePlugin"),
 				p2: sets.New("FakePodGroupPlugin"),
-				p3: sets.New("GangScheduling"),
+				p3: sets.New("fakePlacementFeasiblePlugin"),
 			},
 		},
 		{
@@ -6882,9 +6869,9 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 				},
 			},
 			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
-				p1: sets.New("GangScheduling"),
+				p1: sets.New("fakePlacementFeasiblePlugin"),
 				p2: sets.New("FakePodGroupPlugin"),
-				p3: sets.New("GangScheduling"),
+				p3: sets.New("fakePlacementFeasiblePlugin"),
 			},
 		},
 		{
@@ -6928,9 +6915,9 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 				},
 			},
 			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
-				p1: sets.New("GangScheduling"),
+				p1: sets.New("fakePlacementFeasiblePlugin"),
 				p2: sets.New("FakePodGroupPlugin"),
-				p3: sets.New("GangScheduling"),
+				p3: sets.New("fakePlacementFeasiblePlugin"),
 			},
 		},
 		{
@@ -6974,9 +6961,9 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 				},
 			},
 			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
-				p1: sets.New("GangScheduling"),
+				p1: sets.New("fakePlacementFeasiblePlugin"),
 				p2: sets.New("FakePodGroupPlugin"),
-				p3: sets.New("GangScheduling"),
+				p3: sets.New("fakePlacementFeasiblePlugin"),
 			},
 		},
 		{
@@ -7234,9 +7221,9 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 				},
 			},
 			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
-				p1: sets.New("GangScheduling"),
-				p2: sets.New("GangScheduling"),
-				p3: sets.New("GangScheduling"),
+				p1: sets.New("fakePlacementFeasiblePlugin"),
+				p2: sets.New("fakePlacementFeasiblePlugin"),
+				p3: sets.New("fakePlacementFeasiblePlugin"),
 			},
 		},
 		{
@@ -7277,9 +7264,9 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 				},
 			},
 			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
-				p1: sets.New("GangScheduling"),
-				p2: sets.New("GangScheduling"),
-				p3: sets.New("GangScheduling"),
+				p1: sets.New("fakePlacementFeasiblePlugin"),
+				p2: sets.New("fakePlacementFeasiblePlugin"),
+				p3: sets.New("fakePlacementFeasiblePlugin"),
 			},
 		},
 		{
@@ -7376,7 +7363,7 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 			},
 			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
 				p4: sets.New("FakePodGroupPlugin"),
-				p5: sets.New("GangScheduling"),
+				p5: sets.New("fakePlacementFeasiblePlugin"),
 			},
 		},
 		{
@@ -7414,7 +7401,7 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 			},
 			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
 				p4: sets.New("FakePodGroupPlugin"),
-				p5: sets.New("GangScheduling"),
+				p5: sets.New("fakePlacementFeasiblePlugin"),
 			},
 		},
 		{
@@ -7633,8 +7620,8 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 				},
 			},
 			expectedUnschedulablePlugins: map[*v1.Pod]sets.Set[string]{
-				p4: sets.New("GangScheduling"),
-				p5: sets.New("GangScheduling"),
+				p4: sets.New("fakePlacementFeasiblePlugin"),
+				p5: sets.New("fakePlacementFeasiblePlugin"),
 			},
 		},
 	}
@@ -7684,7 +7671,7 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 						tf.RegisterPostFilterPlugin(tt.plugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 							return tt.plugin, nil
 						}),
-						tf.RegisterPermitPlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
+						tf.RegisterPlacementFeasiblePlugin(placementFeasiblePlugin.Name(), func(_ context.Context, _ runtime.Object, _ fwk.Handle) (fwk.Plugin, error) {
 							return placementFeasiblePlugin, nil
 						}),
 						tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),

--- a/pkg/scheduler/testing/framework/framework_helpers.go
+++ b/pkg/scheduler/testing/framework/framework_helpers.go
@@ -118,6 +118,11 @@ func RegisterPlacementScorePlugin(pluginName string, pluginNewFunc runtime.Plugi
 	return RegisterPluginAsExtensionsWithWeight(pluginName, weight, pluginNewFunc, "PlacementScore")
 }
 
+// RegisterPlacementFeasiblePlugin returns a function to register a PlacementFeasible Plugin to a given registry.
+func RegisterPlacementFeasiblePlugin(pluginName string, pluginNewFunc runtime.PluginFactory) RegisterPluginFunc {
+	return RegisterPluginAsExtensions(pluginName, pluginNewFunc, "PlacementFeasible")
+}
+
 // RegisterPluginAsExtensions returns a function to register a Plugin as given extensionPoints to a given registry.
 func RegisterPluginAsExtensions(pluginName string, pluginNewFunc runtime.PluginFactory, extensions ...string) RegisterPluginFunc {
 	return RegisterPluginAsExtensionsWithWeight(pluginName, 1, pluginNewFunc, extensions...)
@@ -176,6 +181,10 @@ func getPluginSetByExtension(plugins *schedulerapi.Plugins, extension string) *s
 		return &plugins.PlacementGenerate
 	case "PlacementScore":
 		return &plugins.PlacementScore
+	case "PlacementFeasible":
+		return &plugins.PlacementFeasible
+	case "PodGroupPostFilter":
+		return &plugins.PodGroupPostFilter
 	default:
 		return nil
 	}

--- a/staging/src/k8s.io/kube-scheduler/config/v1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/types.go
@@ -239,6 +239,9 @@ type Plugins struct {
 	// PlacementScore is a list of plugins that should be invoked during workload scheduling cycle when ranking pod group assignments.
 	PlacementScore PluginSet `json:"placementScore,omitempty"`
 
+	// PlacementFeasible is a list of plugins that should be invoked when evaluating if a placement is feasible for a pod group.
+	PlacementFeasible PluginSet `json:"placementFeasible,omitempty"`
+
 	// PodGroupPostFilter is a list of plugins that are invoked after the workload scheduling phase,
 	// but only when the PodGroup cannot be scheduled (equivalent to PostFilter for single pods).
 	PodGroupPostFilter PluginSet `json:"podGroupPostFilter,omitempty"`

--- a/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/zz_generated.deepcopy.go
@@ -487,6 +487,7 @@ func (in *Plugins) DeepCopyInto(out *Plugins) {
 	in.MultiPoint.DeepCopyInto(&out.MultiPoint)
 	in.PlacementGenerate.DeepCopyInto(&out.PlacementGenerate)
 	in.PlacementScore.DeepCopyInto(&out.PlacementScore)
+	in.PlacementFeasible.DeepCopyInto(&out.PlacementFeasible)
 	in.PodGroupPostFilter.DeepCopyInto(&out.PodGroupPostFilter)
 	return
 }

--- a/staging/src/k8s.io/kube-scheduler/framework/interface.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/interface.go
@@ -74,7 +74,10 @@ const (
 	// When the scheduling queue requeues Pods, which was rejected with UnschedulableAndUnresolvable in the last scheduling,
 	// the Pod goes through backoff.
 	UnschedulableAndUnresolvable
-	// Wait is used when a Permit plugin finds a pod scheduling should wait.
+	// Wait is used in the following scenarios:
+	// - when a Permit plugin finds a pod scheduling should wait.
+	// - when a PlacementFeasible plugin finds a pod group cannot be scheduled in the current partially evaluated placement,
+	//   but may become schedulable once more pods are evaluated.
 	Wait
 	// Skip is used in the following scenarios:
 	// - when a Bind plugin chooses to skip binding.
@@ -466,14 +469,14 @@ type QueueSortPlugin interface {
 
 // EnqueueExtensions is an optional interface that plugins can implement to efficiently
 // move unschedulable Pods in internal scheduling queues.
-// In the scheduler, Pods can be unschedulable by PreEnqueue, PreFilter, Filter, Reserve, and Permit plugins,
+// In the scheduler, Pods can be unschedulable by PreEnqueue, PreFilter, Filter, Reserve, Permit and PlacementFeasible plugins,
 // and Pods rejected by these plugins are requeued based on this extension point.
 // Failures from other extension points are regarded as temporal errors (e.g., network failure),
 // and the scheduler requeue Pods without this extension point - always requeue Pods to activeQ after backoff.
 // This is because such temporal errors cannot be resolved by specific cluster events,
 // and we have no choose but keep retrying scheduling until the failure is resolved.
 //
-// Plugins that make pod unschedulable (PreEnqueue, PreFilter, Filter, Reserve, and Permit plugins) must implement this interface,
+// Plugins that make pod unschedulable (PreEnqueue, PreFilter, Filter, Reserve, Permit and PlacementFeasible plugins) must implement this interface,
 // otherwise the default implementation will be used, which is less efficient in requeueing Pods rejected by the plugin.
 //
 // Also, if EventsToRegister returns an empty list, that means the Pods failed by the plugin are not requeued by any events,
@@ -836,6 +839,33 @@ type PlacementScorePlugin interface {
 
 	// PlacementScoreExtensions returns a PlacementScoreExtensions interface if it implements one, or nil if does not.
 	PlacementScoreExtensions() PlacementScoreExtensions
+}
+
+// PlacementFeasiblePlugin is an interface for plugins that are called after each pod in a pod group is evaluated.
+// It is used to determine if a pod group is schedulable, may become schedulable or will not become schedulable regardless of the scheduling result of the remaining pods in the pod group.
+type PlacementFeasiblePlugin interface {
+	Plugin
+
+	// PlacementFeasible is called after each pod in a pod group is evaluated.
+	// placementProgress contains information that plugins might additionally need when determining whether pod group scheduling placement is feasible.
+	// Return Wait status if the pod group cannot be scheduled in the current partially evaluated placement, but may become schedulable once more pods are evaluated.
+	// Return Unschedulable status if the pod group cannot be scheduled in the current placement.
+	// The scheduler will give up this placement and won't even evaluate remaining pods. The placement will remain eligible for preemption.
+	// Return Success status if the pod group can be scheduled in the current partially evaluated placement.
+	// After returning Success, the plugin should keep returning Success for the remaining pods.
+	PlacementFeasible(ctx context.Context, placementCycleState PlacementCycleState, podGroupInfo PodGroupInfo, placementProgress PlacementProgress) *Status
+}
+
+// PlacementProgress contains information that plugins implementing the PlacementFeasiblePlugin
+// can use when determining whether pod group scheduling placement is feasible.
+// It contains information about the children evaluation progress for the current pod group placement.
+type PlacementProgress struct {
+	// Remaining is the number of children that have not been evaluated yet in the current scheduling cycle. For pod groups, this is the number of unscheduled pods.
+	Remaining int
+	// Scheduled is the number of children scheduled so far in the current pod group scheduling cycle
+	// for a particular (composite) pod group and placement. For a pod group the field includes the pods that are assigned
+	// or assumed in the current PodGroup scheduling cycle.
+	Scheduled int
 }
 
 // Handle provides data and some tools that plugins can use. It is


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR exposes the PlacementFeasible as an extension point in kube-scheduler, allowing for out-of-tree usages or adjustments. PR also improves observability around `RunPlacementFeasiblePlugins`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

In some places, I spotted that PlacementGenerate, PlacementScore or PodGroupPostFilter extension points were not registered. This PR fixes them as well, but these adjustments were mostly test-only.

Generative AI was used in the PR preparation. Changes were carefully reviewed before pushing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Exposed PlacementFeasible as an extension point in kube-scheduler, allowing for out-of-tree PodGroup placement feasibility evaluation.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/4671
```
