### PR TITLE
CronJob controller: skip FailedDelete event when job is already deleted

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -770,6 +770,10 @@ func (jm *ControllerV2) removeOldestJobs(ctx context.Context, cj *batchv1.CronJo
 func deleteJob(logger klog.Logger, cj *batchv1.CronJob, job *batchv1.Job, jc jobControlInterface, recorder record.EventRecorder) bool {
 	// delete the job itself...
 	if err := jc.DeleteJob(job.Namespace, job.Name); err != nil {
+		if errors.IsNotFound(err) {
+			logger.V(4).Info("Job has already been deleted", "job", klog.KObj(job), "cronjob", klog.KObj(cj))
+			return false
+		}
 		recorder.Eventf(cj, corev1.EventTypeWarning, "FailedDelete", "Deleted job: %v", err)
 		logger.Error(err, "Error deleting job from cronjob", "job", klog.KObj(job), "cronjob", klog.KObj(cj))
 		return false

--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -1946,3 +1946,65 @@ func TestControllerV2ProcessNextItemClearFailureRate(t *testing.T) {
 		}
 	})
 }
+
+func TestControllerV2DeleteJob(t *testing.T) {
+	tests := []struct {
+		name              string
+		deleteErr         error
+		expectedSucceeded bool
+		expectedActive    int
+		expectedEvents    []string
+	}{
+		{
+			name:              "job deleted successfully",
+			deleteErr:         nil,
+			expectedSucceeded: true,
+			expectedActive:    0,
+			expectedEvents:    []string{"Normal SuccessfulDelete Deleted job my-job"},
+		},
+		{
+			name:              "job already deleted",
+			deleteErr:         errors.NewNotFound(schema.GroupResource{Group: "batch", Resource: "jobs"}, "my-job"),
+			expectedSucceeded: false,
+			expectedActive:    1,
+			expectedEvents:    []string{},
+		},
+		{
+			name:              "job deletion failed",
+			deleteErr:         fmt.Errorf("api server down"),
+			expectedSucceeded: false,
+			expectedActive:    1,
+			expectedEvents:    []string{"Warning FailedDelete Deleted job: api server down"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			cj := cronJob()
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-job",
+					Namespace: cj.Namespace,
+					UID:       types.UID("j1234"),
+				},
+			}
+			cj.Status.Active = []v1.ObjectReference{{UID: job.UID, Name: job.Name, Namespace: job.Namespace}}
+			jc := &fakeJobControl{Err: tc.deleteErr}
+			recorder := record.NewFakeRecorder(10)
+			succeeded := deleteJob(logger, &cj, job, jc, recorder)
+			if succeeded != tc.expectedSucceeded {
+				t.Errorf("deleteJob() = %t, want %t", succeeded, tc.expectedSucceeded)
+			}
+			if len(cj.Status.Active) != tc.expectedActive {
+				t.Errorf("got %d active jobs, want %d", len(cj.Status.Active), tc.expectedActive)
+			}
+			events := []string{}
+			for len(recorder.Events) > 0 {
+				events = append(events, <-recorder.Events)
+			}
+			if !reflect.DeepEqual(events, tc.expectedEvents) {
+				t.Errorf("got events %v, want %v", events, tc.expectedEvents)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig apps

#### What this PR does / why we need it:

When enforcing the history limits or replacing a job under the Replace concurrency policy, the job may already have been deleted: most often by a previous sync whose deletion is not yet reflected in the job informer cache. The controller then emitted a misleading "FailedDelete" warning event and logged an error, even though the desired state was achieved.

Log at V(4) instead of emitting the warning event and the error log when the deletion fails with NotFound. The return value and all existing messages are unchanged, so callers behave exactly as before.

#### Which issue(s) this PR is related to:

Fixes #141317

#### Special notes for your reviewer:

The event/log treatment matches [`RealPodControl.DeletePod`](https://github.com/kubernetes/kubernetes/blob/8c078bc32e90f0ea72f57169846b533e20b1ca71/pkg/controller/controller_utils.go#L627-L630), which logs `Pod has already been deleted.` at `V(4)` and skips the `FailedDelete` warning event for the same reason, and it matches how [`syncCronJob`](https://github.com/kubernetes/kubernetes/blob/8c078bc32e90f0ea72f57169846b533e20b1ca71/pkg/controller/cronjob/cronjob_controllerv2.go#L508-L513) handles a vanished active job via the Normal `MissingJob` event. The linked issue's expected behavior additionally suggests treating `NotFound` as success (removing the `.status.active` reference and proceeding under `Replace`); this PR deliberately takes the minimal step without changing any caller-visible behavior. Happy to extend if sig-apps prefers.

This PR was written with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the CronJob controller emitting a "FailedDelete" warning event and an error log when the job being deleted was already deleted, for example by a previous sync of the controller. Such deletions are now logged at debug verbosity (`-v=4`) instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```