### PR TITLE
Include minCompatibilityVersion info in featuregates yaml

### DIFF
--- a/test/compatibility_lifecycle/cmd/feature_gates.go
+++ b/test/compatibility_lifecycle/cmd/feature_gates.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/cobra"
 
 	yaml "go.yaml.in/yaml/v2"
+
 	"k8s.io/apimachinery/pkg/util/version"
 	baseversion "k8s.io/component-base/version"
 )
@@ -50,10 +51,11 @@ const (
 )
 
 type featureSpec struct {
-	Default       bool   `yaml:"default" json:"default"`
-	LockToDefault bool   `yaml:"lockToDefault" json:"lockToDefault"`
-	PreRelease    string `yaml:"preRelease" json:"preRelease"`
-	Version       string `yaml:"version" json:"version"`
+	Default                 bool   `yaml:"default" json:"default"`
+	LockToDefault           bool   `yaml:"lockToDefault" json:"lockToDefault"`
+	PreRelease              string `yaml:"preRelease" json:"preRelease"`
+	Version                 string `yaml:"version" json:"version"`
+	MinCompatibilityVersion string `yaml:"minCompatibilityVersion,omitempty" json:"minCompatibilityVersion,omitempty"`
 }
 
 type featureInfo struct {
@@ -503,6 +505,13 @@ func parseFeatureSpec(variables map[string]ast.Expr, v ast.Expr) (featureSpec, e
 					return spec, err
 				}
 				spec.Version = ver
+
+			case "MinCompatibilityVersion":
+				ver, err := parseVersion(eltType.Value)
+				if err != nil {
+					return spec, err
+				}
+				spec.MinCompatibilityVersion = ver
 			}
 
 		default:

--- a/test/compatibility_lifecycle/cmd/feature_gates_test.go
+++ b/test/compatibility_lifecycle/cmd/feature_gates_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
@@ -484,6 +485,10 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 	CPUCFSQuotaPeriod: {
 		{Version: version.MustParse("1.29"), Default: false, PreRelease: featuregate.Alpha},
 	},
+	DRAFractionalCapacityRange: {
+		{Version: version.MustParse("1.37"), Default: false, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("1.37"), Default: true, PreRelease: featuregate.Beta, MinCompatibilityVersion: version.MustParse("1.37")},
+	},
 	genericfeatures.AggregatedDiscoveryEndpoint: {
 		{Version: version.MustParse("1.30"), Default: false, PreRelease: featuregate.Alpha},
 	},
@@ -502,6 +507,14 @@ var defaultVersionedKubernetesFeatureGates = map[featuregate.Feature]featuregate
 					FullName: "CPUCFSQuotaPeriod",
 					VersionedSpecs: []featureSpec{
 						{Default: false, PreRelease: "Alpha", Version: "1.29"},
+					},
+				},
+				{
+					Name:     "DRAFractionalCapacityRange",
+					FullName: "DRAFractionalCapacityRange",
+					VersionedSpecs: []featureSpec{
+						{Default: false, PreRelease: "Beta", Version: "1.37"},
+						{Default: true, PreRelease: "Beta", Version: "1.37", MinCompatibilityVersion: "1.37"},
 					},
 				},
 				{

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -587,6 +587,7 @@
     lockToDefault: false
     preRelease: Beta
     version: "1.37"
+    minCompatibilityVersion: "1.37"
 - name: DRAListTypeAttributes
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind failing-test

#### What this PR does / why we need it:

Includes minCompatibilityVersion info in recorded feature-gates yaml to inform emulated version tests.

#### Which issue(s) this PR is related to:

xref https://github.com/kubernetes/kubernetes/issues/141283

```release-note
NONE
```