### PR TITLE
Stop counting undispatched bookmarks in watch cache events_dispatched_total

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -941,9 +941,9 @@ func (c *Cacher) dispatchEvents() {
 			// checking if resourceVersion here has changed.
 			if event.Type != watch.Bookmark {
 				c.dispatchEvent(&event)
+				metrics.EventsCounter.WithLabelValues(c.groupResource.Group, c.groupResource.Resource).Inc()
 			}
 			lastProcessedResourceVersion = event.ResourceVersion
-			metrics.EventsCounter.WithLabelValues(c.groupResource.Group, c.groupResource.Resource).Inc()
 		case <-bookmarkTimer.C():
 			bookmarkTimer.Reset(wait.Jitter(time.Second, 0.25))
 			bookmarkEvent := &watchCacheEvent{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Moves the `apiserver_watch_cache_events_dispatched_total` increment inside the branch that actually dispatches, so it stops counting the `watch.Bookmark` events that `dispatchEvents` explicitly refuses to dispatch.

#### Which issue(s) this PR is related to:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Fixed apiserver_watch_cache_events_dispatched_total to not count bookmark events.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```