### PR TITLE
scheduler: fix TestPreQueueingHint_Metrics race on metric flush

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -4806,7 +4806,8 @@ scheduler_pending_pods{queue="unschedulable"} 0
 				},
 			}
 			preenq := map[string]map[string]fwk.PreEnqueuePlugin{"": {(&preEnqueuePlugin{}).Name(): &preEnqueuePlugin{allowlists: []string{queueable}}}}
-			recorder := metrics.NewMetricsAsyncRecorder(3, 20*time.Microsecond, tCtx.Done())
+			recorderCtx, stopRecorder := context.WithCancel(tCtx)
+			recorder := metrics.NewMetricsAsyncRecorder(3, 20*time.Microsecond, recorderCtx.Done())
 			queue := NewTestQueue(tCtx, newDefaultQueueSort(), WithClock(testingclock.NewFakeClock(timestamp)), WithPreEnqueuePluginMap(preenq), WithPluginMetricsSamplePercent(test.pluginMetricsSamplePercent), WithMetricsRecorder(recorder), WithQueueingHintMapPerProfile(m))
 			queue.isPopFromBackoffQEnabled = !test.disablePopFromBackoffQ
 			for i, op := range test.operations {
@@ -4815,6 +4816,8 @@ scheduler_pending_pods{queue="unschedulable"} 0
 				}
 			}
 
+			stopRecorder()
+			<-recorder.IsStoppedCh
 			recorder.FlushMetrics()
 
 			if err := testutil.GatherAndCompare(metrics.GetGather(), strings.NewReader(test.wants), test.metricsName); err != nil {
@@ -9884,7 +9887,9 @@ func TestPreQueueingHint_Metrics(t *testing.T) {
 		},
 	}
 
-	q := NewTestQueue(ctx, newDefaultQueueSort(), WithQueueingHintMapPerProfile(m))
+	recorderCtx, stopRecorder := context.WithCancel(ctx)
+	recorder := metrics.NewMetricsAsyncRecorder(10, 20*time.Microsecond, recorderCtx.Done())
+	q := NewTestQueue(ctx, newDefaultQueueSort(), WithQueueingHintMapPerProfile(m), WithMetricsRecorder(recorder))
 
 	pod := st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()
 	q.Add(ctx, pod)
@@ -9896,7 +9901,12 @@ func TestPreQueueingHint_Metrics(t *testing.T) {
 	}
 
 	q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, st.MakeNode().Name("node1").Obj(), nil)
-	q.metricsRecorder.FlushMetrics()
+
+	// Stop the background flush goroutine and wait for it to exit before
+	// calling FlushMetrics, so there is no concurrent drain of the channels.
+	stopRecorder()
+	<-recorder.IsStoppedCh
+	recorder.FlushMetrics()
 
 	// Verify metric was incremented with "narrowed" label
 	narrowedCount, err := testutil.GetCounterMetricValue(metrics.PreQueueingHintEvaluations.WithLabelValues("testPlugin", "narrowed"))


### PR DESCRIPTION
The Unit test `TestPreQueueingHint_Metrics` flakes when run with stress:
```
Rajalakshmis-MacBook-Air:~ rajalakshmigirish$ git clone https://github.com/kubernetes/kubernetes
Cloning into 'kubernetes'...
remote: Enumerating objects: 1791880, done.
remote: Counting objects: 100% (47/47), done.
remote: Compressing objects: 100% (41/41), done.
remote: Total 1791880 (delta 18), reused 6 (delta 6), pack-reused 1791833 (from 3)
Receiving objects: 100% (1791880/1791880), 1.23 GiB | 9.29 MiB/s, done.
Resolving deltas: 100% (1308096/1308096), done.
Updating files: 100% (31299/31299), done.
Rajalakshmis-MacBook-Air:~ rajalakshmigirish$ cd kubernetes/
Rajalakshmis-MacBook-Air:kubernetes rajalakshmigirish$ go test ./pkg/scheduler/backend/queue/ -c -count=1
Rajalakshmis-MacBook-Air:kubernetes rajalakshmigirish$ go install golang.org/x/tools/cmd/stress@latest
go: downloading golang.org/x/tools v0.48.0
```

**Stress command before fix:**
```
Rajalakshmis-MacBook-Air:kubernetes rajalakshmigirish$ ~/go/bin/stress ./queue.test -test.run TestPreQueueingHint_Metrics

/var/folders/93/0l_9wj5965dfbh89wb86ywp00000gn/T/go-stress-20260812T143357-4055101494
--- FAIL: TestPreQueueingHint_Metrics (0.07s)
    feature_gate.go:170: I0812 14:34:01.275976] Updated featureGates={"SchedulerPreQueueingHints":true}
    scheduling_queue_test.go:9907: Expected narrowed count = 1, got 0
    feature_gate.go:170: I0812 14:34:01.344730] Updated featureGates={"SchedulerPreQueueingHints":false}
FAIL


ERROR: exit status 1

5s: 303 runs so far, 1 failures (0.33%), 10 active

/var/folders/93/0l_9wj5965dfbh89wb86ywp00000gn/T/go-stress-20260812T143357-1879025174
--- FAIL: TestPreQueueingHint_Metrics (0.11s)
    feature_gate.go:170: I0812 14:34:05.683894] Updated featureGates={"SchedulerPreQueueingHints":true}
    scheduling_queue_test.go:9907: Expected narrowed count = 1, got 0
    feature_gate.go:170: I0812 14:34:05.795685] Updated featureGates={"SchedulerPreQueueingHints":false}
FAIL


ERROR: exit status 1

10s: 714 runs so far, 2 failures (0.28%), 10 active
15s: 1114 runs so far, 2 failures (0.18%), 10 active
20s: 1508 runs so far, 2 failures (0.13%), 10 active
----
----
2m5s: 9207 runs so far, 17 failures (0.18%), 10 active
^C

INFO: canceling test context: received interrupt signal
Rajalakshmis-MacBook-Air:kubernetes rajalakshmigirish$ uname -a
Darwin Rajalakshmis-MacBook-Air.local 25.5.0 Darwin Kernel Version 25.5.0: Tue Jun  9 22:26:22 PDT 2026; root:xnu-12377.121.10~1/RELEASE_ARM64_T8132 arm64
Rajalakshmis-MacBook-Air:queue rajalakshmigirish$
```
**Stress command after fix:**
```
Rajalakshmis-MacBook-Air:queue rajalakshmigirish$ git diff
diff --git a/pkg/scheduler/backend/queue/scheduling_queue_test.go b/pkg/scheduler/backend/queue/scheduling_queue_test.go
index e54e2b2d9f6..d3d12be3298 100644
--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -9884,7 +9884,9 @@ func TestPreQueueingHint_Metrics(t *testing.T) {
                },
        }
 
-       q := NewTestQueue(ctx, newDefaultQueueSort(), WithQueueingHintMapPerProfile(m))
+       recorderCtx, stopRecorder := context.WithCancel(ctx)
+       recorder := metrics.NewMetricsAsyncRecorder(10, 20*time.Microsecond, recorderCtx.Done())
+       q := NewTestQueue(ctx, newDefaultQueueSort(), WithQueueingHintMapPerProfile(m), WithMetricsRecorder(recorder))
 
        pod := st.MakePod().Name("pod1").Namespace("ns1").UID("1").Obj()
        q.Add(ctx, pod)
@@ -9896,7 +9898,12 @@ func TestPreQueueingHint_Metrics(t *testing.T) {
        }
 
        q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, st.MakeNode().Name("node1").Obj(), nil)
-       q.metricsRecorder.FlushMetrics()
+
+       // Stop the background flush goroutine and wait for it to exit before
+       // calling FlushMetrics, so there is no concurrent drain of the channels.
+       stopRecorder()
+       <-recorder.IsStoppedCh
+       recorder.FlushMetrics()
 
        // Verify metric was incremented with "narrowed" label
        narrowedCount, err := testutil.GetCounterMetricValue(metrics.PreQueueingHintEvaluations.WithLabelValues("testPlugin", "narrowed"))
Rajalakshmis-MacBook-Air:queue rajalakshmigirish$ 
Rajalakshmis-MacBook-Air:kubernetes rajalakshmigirish$ ~/go/bin/stress ./queue.test -test.run TestPreQueueingHint_Metrics
5s: 290 runs so far, 0 failures, 10 active
10s: 681 runs so far, 0 failures, 10 active
15s: 1062 runs so far, 0 failures, 10 active
20s: 1435 runs so far, 0 failures, 10 active
25s: 1798 runs so far, 0 failures, 10 active
30s: 2167 runs so far, 0 failures, 10 active
35s: 2521 runs so far, 0 failures, 10 active
40s: 2855 runs so far, 0 failures, 10 active
45s: 3174 runs so far, 0 failures, 10 active
50s: 3484 runs so far, 0 failures, 10 active
55s: 3812 runs so far, 0 failures, 10 active
1m0s: 4099 runs so far, 0 failures, 10 active
1m5s: 4409 runs so far, 0 failures, 10 active
1m10s: 4734 runs so far, 0 failures, 10 active
1m15s: 5049 runs so far, 0 failures, 10 active
1m20s: 5362 runs so far, 0 failures, 10 active
1m25s: 5676 runs so far, 0 failures, 10 active
1m30s: 5985 runs so far, 0 failures, 10 active
1m35s: 6314 runs so far, 0 failures, 10 active
1m40s: 6628 runs so far, 0 failures, 10 active
^C
Rajalakshmis-MacBook-Air:kubernetes rajalakshmigirish$

```

The test `TestPreQueueingHint_Metrics` called FlushMetrics() while the recorder's background goroutine was also draining the same channel concurrently. The goroutine could grab the counter item from the channel but get preempted before writing to Prometheus, causing the test to read a stale zero.

Use a dedicated recorder passed via WithMetricsRecorder, stop its background goroutine with a cancel context, and wait on IsStoppedCh before calling FlushMetrics(). This ensures the test is the sole drainer of the channel when it reads the metric, which is the pattern IsStoppedCh was designed for.

#### What type of PR is this?
/kind bug
/kind flake