### PR TITLE
Avoid leaking node-specific kubelet config into the ConfigMap

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/config.go
+++ b/cmd/kubeadm/app/phases/kubelet/config.go
@@ -49,11 +49,14 @@ func WriteConfigToDisk(cfg *kubeadmapi.ClusterConfiguration, kubeletDir, patches
 		return errors.New("no kubelet component config found")
 	}
 
-	if err := kubeletCfg.Mutate(); err != nil {
+	// Node-specific mutations must not leak into the cluster-wide configuration
+	// that may be uploaded after this file is written.
+	localKubeletCfg := kubeletCfg.DeepCopy()
+	if err := localKubeletCfg.Mutate(); err != nil {
 		return err
 	}
 
-	kubeletBytes, err := kubeletCfg.Marshal()
+	kubeletBytes, err := localKubeletCfg.Marshal()
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/phases/kubelet/config_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/config_test.go
@@ -36,6 +36,7 @@ import (
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/componentconfigs"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 )
 
@@ -179,6 +180,36 @@ func TestApplyKubeletConfigPatchFromFile(t *testing.T) {
 	}
 }
 
+func TestWriteConfigToDiskDoesNotMutateClusterConfiguration(t *testing.T) {
+	kubeletDir := t.TempDir()
+	if err := WriteInstanceConfigToDisk(&kubeletconfig.KubeletConfiguration{}, kubeletDir); err != nil {
+		t.Fatalf("could not write kubelet instance configuration: %v", err)
+	}
+
+	kubeletCfg := &mutatingComponentConfig{value: "cluster-wide"}
+	cfg := &kubeadmapi.ClusterConfiguration{
+		ComponentConfigs: kubeadmapi.ComponentConfigMap{
+			componentconfigs.KubeletGroup: kubeletCfg,
+		},
+	}
+
+	if err := WriteConfigToDisk(cfg, kubeletDir, "", io.Discard); err != nil {
+		t.Fatalf("could not write kubelet configuration: %v", err)
+	}
+
+	if kubeletCfg.value != "cluster-wide" {
+		t.Fatalf("expected cluster-wide configuration to remain unchanged, got %q", kubeletCfg.value)
+	}
+
+	written, err := os.ReadFile(filepath.Join(kubeletDir, kubeadmconstants.KubeletConfigurationFileName))
+	if err != nil {
+		t.Fatalf("could not read kubelet configuration: %v", err)
+	}
+	if !bytes.Contains(written, []byte("healthzBindAddress: node-specific")) {
+		t.Fatalf("expected node-specific mutation in written configuration, got:\n%s", written)
+	}
+}
+
 func TestApplyPatchesToConfig(t *testing.T) {
 	const (
 		expectedAddress = "barfoo"
@@ -223,4 +254,42 @@ func TestApplyPatchesToConfig(t *testing.T) {
 	if *newTyped.HealthzPort != expectedPort {
 		t.Fatalf("expected port: %d, got: %d", expectedPort, *newTyped.HealthzPort)
 	}
+}
+
+type mutatingComponentConfig struct {
+	value string
+}
+
+func (c *mutatingComponentConfig) DeepCopy() kubeadmapi.ComponentConfig {
+	return &mutatingComponentConfig{value: c.value}
+}
+
+func (c *mutatingComponentConfig) Marshal() ([]byte, error) {
+	return fmt.Appendf(nil, "apiVersion: kubelet.config.k8s.io/v1beta1\nkind: KubeletConfiguration\nhealthzBindAddress: %s\n", c.value), nil
+}
+
+func (c *mutatingComponentConfig) Unmarshal(kubeadmapi.DocumentMap) error {
+	return nil
+}
+
+func (c *mutatingComponentConfig) Default(*kubeadmapi.ClusterConfiguration, *kubeadmapi.APIEndpoint, *kubeadmapi.NodeRegistrationOptions) {
+}
+
+func (c *mutatingComponentConfig) IsUserSupplied() bool {
+	return false
+}
+
+func (c *mutatingComponentConfig) SetUserSupplied(bool) {
+}
+
+func (c *mutatingComponentConfig) Mutate() error {
+	c.value = "node-specific"
+	return nil
+}
+
+func (c *mutatingComponentConfig) Set(interface{}) {
+}
+
+func (c *mutatingComponentConfig) Get() interface{} {
+	return c
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR prevents node-specific kubelet configuration mutations from changing the cluster-wide `KubeletConfiguration` held by kubeadm.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes kubernetes/kubeadm#3327

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: no longer persists a node-specific systemd-resolved resolvConf path in the cluster-wide kubelet-config ConfigMap during init.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

**AI usage disclosure:** 

The test code was written by DeepSeek V4 and reviewed by me.


