### PR TITLE
Fix PodTopologySpread ignoring constraints with an empty (non-nil) labelSelector

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/common.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/common.go
@@ -143,7 +143,7 @@ func mergeLabelSetWithSelector(matchLabels labels.Set, s labels.Selector) labels
 }
 
 func countPodsMatchSelector(podInfos []fwk.PodInfo, selector labels.Selector, ns string) int {
-	if selector.Empty() {
+	if labels.MatchesNothing(selector) {
 		return 0
 	}
 	count := 0

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -1480,6 +1480,47 @@ func TestPreFilterState(t *testing.T) {
 			},
 			wantPrefilterStatus: fwk.NewStatus(fwk.Skip),
 		},
+		{
+			name: "empty (non-nil) label selector counts all pods per domain",
+			pod: st.MakePod().Name("p").Label("foo", "").
+				SpreadConstraint(1, "zone", v1.DoNotSchedule,
+					&metav1.LabelSelector{}, nil, nil, nil, nil).
+				Obj(),
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
+				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
+				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
+				st.MakeNode().Name("node-y").Label("zone", "zone2").Label("node", "node-y").Obj(),
+			},
+			existingPods: []*v1.Pod{
+				st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Obj(),
+				st.MakePod().Name("p-a2").Node("node-a").Label("foo", "").Obj(),
+				st.MakePod().Name("p-b1").Node("node-b").Label("foo", "").Obj(),
+				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
+				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Obj(),
+			},
+			want: &preFilterState{
+				Constraints: []topologySpreadConstraint{
+					{
+						MaxSkew:            1,
+						TopologyKey:        "zone",
+						Selector:           labels.Everything(),
+						MinDomains:         1,
+						NodeAffinityPolicy: v1.NodeInclusionPolicyHonor,
+						NodeTaintsPolicy:   v1.NodeInclusionPolicyIgnore,
+					},
+				},
+				CriticalPaths: []*criticalPaths{
+					{{"zone2", 2}, {"zone1", 3}},
+				},
+				TpValueToMatchNum: []map[string]int{
+					{
+						"zone1": 3, // p-a1, p-a2, p-b1
+						"zone2": 2, // p-y1, p-y2
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2996,6 +3037,58 @@ func TestSingleConstraint(t *testing.T) {
 				"node-y": fwk.Unschedulable,
 			},
 			enableNodeInclusionPolicy: true,
+		},
+		{
+			name: "empty (non-nil) label selector should count all namespace pods",
+			pod: st.MakePod().Name("p").Label("foo", "").
+				SpreadConstraint(1, "zone", v1.DoNotSchedule,
+					&metav1.LabelSelector{}, // {} -> Everything(); NOT nil
+					nil, nil, nil, nil).
+				Obj(),
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
+				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
+				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
+				st.MakeNode().Name("node-y").Label("zone", "zone2").Label("node", "node-y").Obj(),
+			},
+			existingPods: []*v1.Pod{
+				st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Obj(),
+				st.MakePod().Name("p-a2").Node("node-a").Label("foo", "").Obj(),
+			},
+			// zone1 has 2 matching pods, zone2 has 0, maxSkew=1:
+			// placing into zone1 -> skew 3 > 1 -> Unschedulable; zone2 -> Success.
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Unschedulable,
+				"node-b": fwk.Unschedulable,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success,
+			},
+		},
+		{
+			// a nil selector is labels.Nothing(), so no pod is counted in any domain
+			// and every node fits.
+			name: "nil label selector should count no pods",
+			pod: st.MakePod().Name("p").Label("foo", "").
+				SpreadConstraint(1, "zone", v1.DoNotSchedule,
+					nil, // nil -> Nothing(); NOT &metav1.LabelSelector{}
+					nil, nil, nil, nil).
+				Obj(),
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
+				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
+				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
+				st.MakeNode().Name("node-y").Label("zone", "zone2").Label("node", "node-y").Obj(),
+			},
+			existingPods: []*v1.Pod{
+				st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Obj(),
+				st.MakePod().Name("p-a2").Node("node-a").Label("foo", "").Obj(),
+			},
+			wantStatusCode: map[string]fwk.Code{
+				"node-a": fwk.Success,
+				"node-b": fwk.Success,
+				"node-x": fwk.Success,
+				"node-y": fwk.Success,
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

`countPodsMatchSelector` short-circuits with `if selector.Empty() { return 0 }`. `Empty()` reports whether a selector has *requirements*, not whether it *matches anything*, and the two are inverted for degenerate selectors:

- `labelSelector: nil` → `labels.Nothing()` → `Empty()==false` (matches zero pods)
- `labelSelector: {}` → `labels.Everything()` → `Empty()==true` (matches all pods)

So the branch never fires for the `nil` case it was written to optimize, and only fires for `Everything`, where it wrongly returns 0. The result: a `topologySpreadConstraint` with `labelSelector: {}` counts 0 pods in every domain, `maxSkew`/`whenUnsatisfiable: DoNotSchedule` become a silent no-op, and it behaves oppositely to an equivalent `matchLabels` selector that selects the same pods.

This replaces the predicate with `Requirements()`'s ok flag. In the `labels` package only `nothingSelector.Requirements()` returns `ok=false`; `internalSelector` (including `Everything`) returns `ok=true`. This restores the original optimization intent for `Nothing` while no longer clearing `Everything`. The `nil`/`Nothing` behavior is unchanged (still counts 0).

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fix https://github.com/kubernetes/kubernetes/issues/141339

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a bug in the PodTopologySpread scheduler plugin where a topology spread constraint with an empty (non-nil) `labelSelector` (`labelSelector: {}`) was silently ignored instead of matching all pods in the namespace.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
