### PR TITLE
Fix startup probe gating after container restart

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2692,7 +2692,12 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 		if !utilfeature.DefaultFeatureGate.Enabled(features.ChangeContainerStatusOnKubeletRestart) {
 			if cStatus.State == kubecontainer.ContainerStateRunning {
 				if oldStatus, ok := oldStatuses[status.Name]; ok && oldStatus.Started != nil {
-					status.Started = oldStatus.Started
+					// A kubelet restart loses in-memory probe results, so preserve Started
+					// for the same container. A replacement must pass its own startup probe.
+					// See https://github.com/kubernetes/kubernetes/issues/141155
+					if oldStatus.ContainerID == status.ContainerID {
+						status.Started = oldStatus.Started
+					}
 				}
 			}
 		}

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -3959,6 +3959,50 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 			},
 		},
 		{
+			name: "preserves Started for the same running container after kubelet restart",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{Name: "containerA"}},
+				},
+			},
+			currentStatus: &kubecontainer.PodStatus{
+				ContainerStatuses: []*kubecontainer.Status{{
+					Name:  "containerA",
+					ID:    kubecontainer.ContainerID{Type: "test", ID: "old"},
+					State: kubecontainer.ContainerStateRunning,
+				}},
+			},
+			previousStatus: []v1.ContainerStatus{
+				withID(startedState("containerA"), "test://old"),
+			},
+			containers: []v1.Container{{Name: "containerA"}},
+			expected: []v1.ContainerStatus{
+				startedState("containerA"),
+			},
+		},
+		{
+			name: "does not preserve Started for a replacement container after kubelet restart",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{Name: "containerA"}},
+				},
+			},
+			currentStatus: &kubecontainer.PodStatus{
+				ContainerStatuses: []*kubecontainer.Status{{
+					Name:  "containerA",
+					ID:    kubecontainer.ContainerID{Type: "test", ID: "new"},
+					State: kubecontainer.ContainerStateRunning,
+				}},
+			},
+			previousStatus: []v1.ContainerStatus{
+				withID(startedState("containerA"), "test://old"),
+			},
+			containers: []v1.Container{{Name: "containerA"}},
+			expected: []v1.ContainerStatus{
+				runningState("containerA"),
+			},
+		},
+		{
 			name: "containerB dies and triggers RestartAllContainers in place",
 			pod: &v1.Pod{
 				Spec: desiredState,
@@ -4193,9 +4237,10 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 		},
 	}
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-		features.ContainerRestartRules:                true,
-		features.NodeDeclaredFeatures:                 true,
-		features.RestartAllContainersOnContainerExits: true,
+		features.ChangeContainerStatusOnKubeletRestart: false,
+		features.ContainerRestartRules:                 true,
+		features.NodeDeclaredFeatures:                  true,
+		features.RestartAllContainersOnContainerExits:  true,
 	})
 
 	for _, test := range tests {

--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -402,6 +402,150 @@ var _ = SIGDescribe("Probing container", func() {
 	})
 
 	/*
+		Release: v1.38
+		Testname: Pod startup probe re-gates liveness and readiness after container restart
+		Description: A Pod with startup, liveness, and readiness probes restarts due to
+		liveness failure. The restarted container MUST pass startup probe
+		before liveness and readiness probes begin.
+	*/
+	f.It("should not run liveness or readiness probes before startup probe succeeds after container restart", f.WithNodeConformance(), func(ctx context.Context) {
+		cmd := []string{"/bin/sh", "-c", `
+instance=initial
+if test -f /state/container-seen; then
+  instance=replacement
+else
+  touch /state/container-seen
+fi
+echo "$instance" > /state/instance
+sleep 3600
+`}
+		startupProbe := &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				Exec: &v1.ExecAction{
+					Command: []string{"/bin/sh", "-c", `test "$(cat /state/instance)" = "initial"`},
+				},
+			},
+			// A longer startup period leaves enough time for the one-second
+			// liveness worker to expose an incorrectly inherited Started status.
+			PeriodSeconds:    10,
+			FailureThreshold: 100,
+		}
+		livenessProbe := &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				Exec: &v1.ExecAction{
+					Command: []string{"/bin/sh", "-c", `
+if test "$(cat /state/instance)" = "replacement"; then
+  touch /state/liveness-ran-on-replacement
+  exit 0
+fi
+test ! -f /state/fail-liveness
+`},
+				},
+			},
+			PeriodSeconds:    1,
+			FailureThreshold: 1,
+		}
+		readinessProbe := &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				Exec: &v1.ExecAction{
+					Command: []string{"/bin/sh", "-c", `
+if test "$(cat /state/instance)" = "replacement"; then
+  touch /state/readiness-ran-on-replacement
+fi
+exit 0
+`},
+				},
+			},
+			PeriodSeconds:    1,
+			FailureThreshold: 1,
+		}
+
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "startup-restart-" + string(uuid.NewUUID()),
+				Labels: map[string]string{"test": "startup-restart"},
+			},
+			Spec: v1.PodSpec{
+				TerminationGracePeriodSeconds: ptr.To[int64](2),
+				Containers: []v1.Container{
+					{
+						Name:           "busybox",
+						Image:          imageutils.GetE2EImage(imageutils.BusyBox),
+						Command:        cmd,
+						LivenessProbe:  livenessProbe,
+						ReadinessProbe: readinessProbe,
+						StartupProbe:   startupProbe,
+						VolumeMounts: []v1.VolumeMount{
+							{Name: "state", MountPath: "/state"},
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{
+						Name:         "state",
+						VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+					},
+				},
+			},
+		}
+
+		podClient := e2epod.NewPodClient(f)
+		ginkgo.DeferCleanup(func(ctx context.Context) error {
+			return podClient.Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
+		})
+
+		ginkgo.By("Creating the pod and waiting for startup probe to pass")
+		podClient.Create(ctx, pod)
+		framework.ExpectNoError(e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "container started and ready", 60*time.Second, func(pod *v1.Pod) (bool, error) {
+			if len(pod.Status.ContainerStatuses) == 0 {
+				return false, nil
+			}
+			status := pod.Status.ContainerStatuses[0]
+			return status.Started != nil && *status.Started && status.Ready, nil
+		}))
+
+		ginkgo.By("Triggering liveness probe failure to restart the container")
+		stdout, stderr, err := e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, "busybox", "/bin/sh", "-c", "touch /state/fail-liveness")
+		framework.Logf("exec stdout=%q stderr=%q err=%v", stdout, stderr, err)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Waiting for the replacement container to be running but not started")
+		framework.ExpectNoError(e2epod.WaitForPodCondition(ctx, f.ClientSet, f.Namespace.Name, pod.Name, "replacement container running but not started", 60*time.Second, func(pod *v1.Pod) (bool, error) {
+			if len(pod.Status.ContainerStatuses) == 0 {
+				return false, nil
+			}
+			status := pod.Status.ContainerStatuses[0]
+			return status.RestartCount >= 1 && status.State.Running != nil && status.Started != nil && !*status.Started && !status.Ready, nil
+		}))
+
+		ginkgo.By("Verifying startup probe gates liveness and readiness after restart")
+		gomega.Consistently(ctx, func(ctx context.Context) error {
+			currentPod, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if len(currentPod.Status.ContainerStatuses) != 1 {
+				return fmt.Errorf("got %d container statuses, want 1", len(currentPod.Status.ContainerStatuses))
+			}
+			status := currentPod.Status.ContainerStatuses[0]
+			if status.Started == nil || *status.Started {
+				return fmt.Errorf("replacement container Started is %v, want false", status.Started)
+			}
+			if status.Ready {
+				return fmt.Errorf("replacement container is ready before startup succeeded")
+			}
+			if status.RestartCount != 1 {
+				return fmt.Errorf("replacement container restart count is %d, want 1", status.RestartCount)
+			}
+			return nil
+		}, 10*time.Second, time.Second).Should(gomega.Succeed())
+
+		_, stderr, err = e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, "busybox", "/bin/sh", "-c",
+			"test ! -e /state/liveness-ran-on-replacement && test ! -e /state/readiness-ran-on-replacement")
+		framework.ExpectNoError(err, "liveness or readiness probe ran against the replacement container before startup succeeded: %s", stderr)
+	})
+
+	/*
 		Release: v1.16
 		Testname: Pod readiness probe, delayed by startup probe
 		Description: A Pod is created with startup and readiness probes. The Container is started by creating /tmp/startup after 45 seconds, delaying the ready state by this amount of time. This is similar to the "Pod readiness probe, with initial delay" test.

--- a/test/e2e_node/container_lifecycle_test.go
+++ b/test/e2e_node/container_lifecycle_test.go
@@ -6402,6 +6402,183 @@ var _ = SIGDescribe(framework.WithSerial(), "Not Change Container Status", frame
 	f := framework.NewDefaultFramework("not-change-container-status-test-serial")
 	addAfterEachForCleaningUpPods(f)
 	f.NamespacePodSecurityLevel = admissionapi.LevelPrivileged
+
+	// Regression test for https://github.com/kubernetes/kubernetes/issues/141155.
+	ginkgo.It("should gate probes when a container exits while the kubelet is stopped", func(ctx context.Context) {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "startup-gate-kubelet-restart",
+			},
+			Spec: v1.PodSpec{
+				TerminationGracePeriodSeconds: ptr.To[int64](2),
+				RestartPolicy:                 v1.RestartPolicyAlways,
+				Containers: []v1.Container{
+					{
+						Name:  "busybox",
+						Image: imageutils.GetE2EImage(imageutils.BusyBox),
+						Command: []string{"/bin/sh", "-c", `
+instance=initial
+if test -f /state/container-seen; then
+  instance=replacement
+else
+  touch /state/container-seen
+fi
+echo "$instance" > /state/instance
+sleep 3600
+`},
+						StartupProbe: &v1.Probe{
+							ProbeHandler: v1.ProbeHandler{
+								Exec: &v1.ExecAction{
+									Command: []string{"/bin/sh", "-c", `test "$(cat /state/instance)" = "initial" || test -f /state/allow-startup`},
+								},
+							},
+							// Widen the interval in which an incorrectly inherited Started
+							// status would allow the other probe workers to run.
+							PeriodSeconds:    10,
+							FailureThreshold: 100,
+						},
+						LivenessProbe: &v1.Probe{
+							ProbeHandler: v1.ProbeHandler{
+								Exec: &v1.ExecAction{
+									Command: []string{"/bin/sh", "-c", `
+if test "$(cat /state/instance)" = "replacement"; then
+  touch /state/liveness-ran-on-replacement
+fi
+exit 0
+`},
+								},
+							},
+							PeriodSeconds:    1,
+							FailureThreshold: 1,
+						},
+						ReadinessProbe: &v1.Probe{
+							ProbeHandler: v1.ProbeHandler{
+								Exec: &v1.ExecAction{
+									Command: []string{"/bin/sh", "-c", `
+if test "$(cat /state/instance)" = "replacement"; then
+  touch /state/readiness-ran-on-replacement
+fi
+exit 0
+`},
+								},
+							},
+							PeriodSeconds:    1,
+							FailureThreshold: 1,
+						},
+						VolumeMounts: []v1.VolumeMount{
+							{Name: "state", MountPath: "/state"},
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{
+						Name:         "state",
+						VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+					},
+				},
+			},
+		}
+
+		podClient := e2epod.NewPodClient(f)
+		pod = podClient.Create(ctx, pod)
+
+		ginkgo.By("Waiting for the initial container to pass its probes")
+		err := e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "initial container started and ready", f.Timeouts.PodStart,
+			func(p *v1.Pod) (bool, error) {
+				if len(p.Status.ContainerStatuses) != 1 {
+					return false, nil
+				}
+				status := p.Status.ContainerStatuses[0]
+				return status.State.Running != nil && status.Started != nil && *status.Started && status.Ready, nil
+			})
+		framework.ExpectNoError(err)
+
+		pod, err = podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		initialContainerID := pod.Status.ContainerStatuses[0].ContainerID
+
+		ginkgo.By("Finding the pod sandbox")
+		runtimeService, _, err := getCRIClient(ctx)
+		framework.ExpectNoError(err)
+		sandboxes, err := runtimeService.ListPodSandbox(ctx, &runtimeapi.PodSandboxFilter{})
+		framework.ExpectNoError(err)
+		var podSandboxID string
+		for _, sandbox := range sandboxes {
+			if sandbox.Metadata != nil && sandbox.Metadata.Name == pod.Name && sandbox.Metadata.Namespace == pod.Namespace {
+				podSandboxID = sandbox.Id
+				break
+			}
+		}
+		gomega.Expect(podSandboxID).ToNot(gomega.BeEmpty(), "pod sandbox for %s/%s was not found", pod.Namespace, pod.Name)
+
+		ginkgo.By("Stopping the kubelet and the pod sandbox")
+		restartKubelet := mustStopKubelet(ctx, f)
+		err = runtimeService.StopPodSandbox(ctx, podSandboxID)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Restarting the kubelet")
+		restartKubelet(ctx)
+
+		ginkgo.By("Waiting for the replacement container to remain gated by startup")
+		err = e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "replacement container running but not started", f.Timeouts.PodStart,
+			func(p *v1.Pod) (bool, error) {
+				if len(p.Status.ContainerStatuses) != 1 {
+					return false, nil
+				}
+				status := p.Status.ContainerStatuses[0]
+				return status.ContainerID != "" && status.ContainerID != initialContainerID && status.State.Running != nil && status.Started != nil && !*status.Started, nil
+			})
+		framework.ExpectNoError(err)
+
+		gomega.Consistently(ctx, func(ctx context.Context) error {
+			currentPod, err := podClient.Get(ctx, pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if len(currentPod.Status.ContainerStatuses) != 1 {
+				return fmt.Errorf("got %d container statuses, want 1", len(currentPod.Status.ContainerStatuses))
+			}
+			status := currentPod.Status.ContainerStatuses[0]
+			if status.ContainerID == initialContainerID {
+				return fmt.Errorf("container ID still refers to the initial container %q", initialContainerID)
+			}
+			if status.Started == nil || *status.Started {
+				return fmt.Errorf("replacement container Started is %v, want false", status.Started)
+			}
+			if status.Ready {
+				return fmt.Errorf("replacement container is ready before startup succeeded")
+			}
+			if status.RestartCount != 1 {
+				return fmt.Errorf("replacement container restart count is %d, want 1", status.RestartCount)
+			}
+			return nil
+		}, 5*time.Second, f.Timeouts.Poll).Should(gomega.Succeed())
+
+		_, stderr, err := e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, "busybox", "/bin/sh", "-c",
+			"test ! -e /state/liveness-ran-on-replacement && test ! -e /state/readiness-ran-on-replacement")
+		framework.ExpectNoError(err, "liveness or readiness probe ran against the replacement container before startup succeeded: %s", stderr)
+
+		ginkgo.By("Allowing startup to succeed")
+		_, stderr, err = e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, "busybox", "touch", "/state/allow-startup")
+		framework.ExpectNoError(err, "failed to allow the replacement container startup probe to succeed: %s", stderr)
+
+		err = e2epod.WaitForPodCondition(ctx, f.ClientSet, pod.Namespace, pod.Name, "replacement container started and ready", f.Timeouts.PodStart,
+			func(p *v1.Pod) (bool, error) {
+				if len(p.Status.ContainerStatuses) != 1 {
+					return false, nil
+				}
+				status := p.Status.ContainerStatuses[0]
+				return status.ContainerID != initialContainerID && status.Started != nil && *status.Started && status.Ready && status.RestartCount == 1, nil
+			})
+		framework.ExpectNoError(err)
+
+		gomega.Eventually(ctx, func() error {
+			_, _, err := e2epod.ExecCommandInContainerWithFullOutput(f, pod.Name, "busybox", "/bin/sh", "-c",
+				"test -e /state/liveness-ran-on-replacement && test -e /state/readiness-ran-on-replacement")
+			return err
+		}, f.Timeouts.PodStart, f.Timeouts.Poll).Should(gomega.Succeed(), "liveness and readiness probes should run after startup succeeds")
+	})
+
 	ginkgo.When("a Pod is running", func() {
 		testKubeletRestart := func(ctx context.Context, pod *v1.Pod) {
 			client := e2epod.NewPodClient(f)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Prevents replacement containers from inheriting the previous container's `Started` status when the container ID changes.

This ensures liveness and readiness probes remain gated until the replacement container passes its startup probe.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #141155

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed an issue where liveness and readiness probes could run before the startup probe succeeded after a container restart.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
