### PR TITLE
limitranger: compare resource quantities exactly to avoid int64 overflow

### DIFF
--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -20,11 +20,14 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
+	"math/big"
 	"sort"
 	"strings"
 	"time"
 
 	"golang.org/x/sync/singleflight"
+	inf "gopkg.in/inf.v0"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -291,33 +294,37 @@ func mergePodResourceRequirements(pod *api.Pod, defaultRequirements *api.Resourc
 	}
 }
 
-// requestLimitEnforcedValues returns the specified values at a common precision to support comparability
-func requestLimitEnforcedValues(requestQuantity, limitQuantity, enforcedQuantity resource.Quantity) (request, limit, enforced int64) {
-	request = requestQuantity.Value()
-	limit = limitQuantity.Value()
-	enforced = enforcedQuantity.Value()
-	// do a more precise comparison if possible (if the value won't overflow)
-	if request <= resource.MaxMilliValue && limit <= resource.MaxMilliValue && enforced <= resource.MaxMilliValue {
-		request = requestQuantity.MilliValue()
-		limit = limitQuantity.MilliValue()
-		enforced = enforcedQuantity.MilliValue()
+// exceedsAllowed reports whether limit is greater than request times ratio.
+// Quantity has no multiply and inf.Dec.Mul adds the two scales as an int32, so
+// the product is formed here with the scale kept in int64 and handed to Cmp.
+func exceedsAllowed(limit, request, ratio resource.Quantity) bool {
+	requestDec, ratioDec := request.AsDec(), ratio.AsDec()
+	scale := int64(requestDec.Scale()) + int64(ratioDec.Scale())
+	// Quantity keeps at most nano precision, so the summed scale can only fall
+	// below inf.Scale, and only for operands whose product already exceeds
+	// every representable limit.
+	if scale < math.MinInt32 {
+		return false
 	}
-	return
+	product := new(inf.Dec)
+	product.SetUnscaledBig(new(big.Int).Mul(requestDec.UnscaledBig(), ratioDec.UnscaledBig()))
+	product.SetScale(inf.Scale(scale))
+	allowed := resource.NewDecimalQuantity(*product, resource.DecimalSI)
+	return limit.Cmp(*allowed) > 0
 }
 
 // minConstraint enforces the min constraint over the specified resource
 func minConstraint(limitType string, resourceName string, enforced resource.Quantity, request api.ResourceList, limit api.ResourceList) error {
 	req, reqExists := request[api.ResourceName(resourceName)]
 	lim, limExists := limit[api.ResourceName(resourceName)]
-	observedReqValue, observedLimValue, enforcedValue := requestLimitEnforcedValues(req, lim, enforced)
 
 	if !reqExists {
 		return fmt.Errorf("minimum %s usage per %s is %s.  No request is specified", resourceName, limitType, enforced.String())
 	}
-	if observedReqValue < enforcedValue {
+	if enforced.Cmp(req) > 0 {
 		return fmt.Errorf("minimum %s usage per %s is %s, but request is %s", resourceName, limitType, enforced.String(), req.String())
 	}
-	if limExists && (observedLimValue < enforcedValue) {
+	if limExists && enforced.Cmp(lim) > 0 {
 		return fmt.Errorf("minimum %s usage per %s is %s, but limit is %s", resourceName, limitType, enforced.String(), lim.String())
 	}
 	return nil
@@ -327,12 +334,11 @@ func minConstraint(limitType string, resourceName string, enforced resource.Quan
 // use when specify LimitType resource doesn't recognize limit values
 func maxRequestConstraint(limitType string, resourceName string, enforced resource.Quantity, request api.ResourceList) error {
 	req, reqExists := request[api.ResourceName(resourceName)]
-	observedReqValue, _, enforcedValue := requestLimitEnforcedValues(req, resource.Quantity{}, enforced)
 
 	if !reqExists {
 		return fmt.Errorf("maximum %s usage per %s is %s.  No request is specified", resourceName, limitType, enforced.String())
 	}
-	if observedReqValue > enforcedValue {
+	if req.Cmp(enforced) > 0 {
 		return fmt.Errorf("maximum %s usage per %s is %s, but request is %s", resourceName, limitType, enforced.String(), req.String())
 	}
 	return nil
@@ -342,15 +348,14 @@ func maxRequestConstraint(limitType string, resourceName string, enforced resour
 func maxConstraint(limitType string, resourceName string, enforced resource.Quantity, request api.ResourceList, limit api.ResourceList) error {
 	req, reqExists := request[api.ResourceName(resourceName)]
 	lim, limExists := limit[api.ResourceName(resourceName)]
-	observedReqValue, observedLimValue, enforcedValue := requestLimitEnforcedValues(req, lim, enforced)
 
 	if !limExists {
 		return fmt.Errorf("maximum %s usage per %s is %s.  No limit is specified", resourceName, limitType, enforced.String())
 	}
-	if observedLimValue > enforcedValue {
+	if lim.Cmp(enforced) > 0 {
 		return fmt.Errorf("maximum %s usage per %s is %s, but limit is %s", resourceName, limitType, enforced.String(), lim.String())
 	}
-	if reqExists && (observedReqValue > enforcedValue) {
+	if reqExists && req.Cmp(enforced) > 0 {
 		return fmt.Errorf("maximum %s usage per %s is %s, but request is %s", resourceName, limitType, enforced.String(), req.String())
 	}
 	return nil
@@ -360,25 +365,17 @@ func maxConstraint(limitType string, resourceName string, enforced resource.Quan
 func limitRequestRatioConstraint(limitType string, resourceName string, enforced resource.Quantity, request api.ResourceList, limit api.ResourceList) error {
 	req, reqExists := request[api.ResourceName(resourceName)]
 	lim, limExists := limit[api.ResourceName(resourceName)]
-	observedReqValue, observedLimValue, _ := requestLimitEnforcedValues(req, lim, enforced)
 
-	if !reqExists || (observedReqValue == int64(0)) {
+	if !reqExists || req.Sign() == 0 {
 		return fmt.Errorf("%s max limit to request ratio per %s is %s, but no request is specified or request is 0", resourceName, limitType, enforced.String())
 	}
-	if !limExists || (observedLimValue == int64(0)) {
+	if !limExists || lim.Sign() == 0 {
 		return fmt.Errorf("%s max limit to request ratio per %s is %s, but no limit is specified or limit is 0", resourceName, limitType, enforced.String())
 	}
 
-	observedRatio := float64(observedLimValue) / float64(observedReqValue)
-	displayObservedRatio := observedRatio
-	maxLimitRequestRatio := float64(enforced.Value())
-	if enforced.Value() <= resource.MaxMilliValue {
-		observedRatio = observedRatio * 1000
-		maxLimitRequestRatio = float64(enforced.MilliValue())
-	}
-
-	if observedRatio > maxLimitRequestRatio {
-		return fmt.Errorf("%s max limit to request ratio per %s is %s, but provided ratio is %f", resourceName, limitType, enforced.String(), displayObservedRatio)
+	if exceedsAllowed(lim, req, enforced) {
+		observedRatio := lim.AsApproximateFloat64() / req.AsApproximateFloat64()
+		return fmt.Errorf("%s max limit to request ratio per %s is %s, but provided ratio is %f", resourceName, limitType, enforced.String(), observedRatio)
 	}
 
 	return nil

--- a/plugin/pkg/admission/limitranger/admission_overflow_test.go
+++ b/plugin/pkg/admission/limitranger/admission_overflow_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitranger
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+// A quantity past the int64 range wraps through Value()/MilliValue(): 2^64
+// projects to 0 and 2^63 to a negative number. The constraints used to compare
+// those projections, so an oversized limit or request slipped past the range
+// and the LimitRange stopped being enforced. The exact comparison holds.
+func TestConstraintsAreOverflowSafe(t *testing.T) {
+	huge := resource.MustParse("18446744073709551616") // 2^64
+	normal := resource.MustParse("1000")
+	small := resource.MustParse("1")
+
+	if err := maxConstraint("Container", "memory", normal, api.ResourceList{}, api.ResourceList{api.ResourceMemory: huge}); err == nil {
+		t.Error("maxConstraint admitted a limit above the max")
+	}
+	if err := maxRequestConstraint("Container", "memory", normal, api.ResourceList{api.ResourceMemory: huge}); err == nil {
+		t.Error("maxRequestConstraint admitted a request above the max")
+	}
+	if err := minConstraint("Container", "memory", huge, api.ResourceList{api.ResourceMemory: small}, api.ResourceList{}); err == nil {
+		t.Error("minConstraint admitted a request below the min")
+	}
+	if err := limitRequestRatioConstraint("Container", "memory", normal, api.ResourceList{api.ResourceMemory: small}, api.ResourceList{api.ResourceMemory: huge}); err == nil {
+		t.Error("limitRequestRatioConstraint admitted a limit-to-request ratio above the max")
+	}
+
+	// The ratio path forms request*ratio, whose summed scale can fall past
+	// inf.Scale; a 3:1 ratio at an extreme exponent must still be rejected.
+	if err := limitRequestRatioConstraint("Container", "memory", resource.MustParse("2"),
+		api.ResourceList{api.ResourceMemory: resource.MustParse("1e2147483647")},
+		api.ResourceList{api.ResourceMemory: resource.MustParse("3e2147483647")}); err == nil {
+		t.Error("limitRequestRatioConstraint admitted a 3:1 ratio above the 2:1 max at an extreme scale")
+	}
+
+	// A within-limit value must still pass, so the exact comparison did not
+	// start rejecting ordinary requests.
+	if err := maxConstraint("Container", "memory", normal, api.ResourceList{}, api.ResourceList{api.ResourceMemory: small}); err != nil {
+		t.Errorf("maxConstraint rejected a within-limit value: %v", err)
+	}
+}
+
+func TestLimitRangerRatioIsExact(t *testing.T) {
+	// The ratio came from Value(), which wraps. A limit of 2^63+1 read as a
+	// small negative, so a ratio of 9.2e18 looked like it was under the maximum
+	// and was admitted. Two operands that both collapse to zero went the other
+	// way, and a ratio of exactly 1 was rejected as "limit is 0".
+	ratioOf := func(reqStr, limStr, maxRatioStr string) error {
+		enforced := resource.MustParse(maxRatioStr)
+		req := api.ResourceList{api.ResourceMemory: resource.MustParse(reqStr)}
+		lim := api.ResourceList{api.ResourceMemory: resource.MustParse(limStr)}
+		return limitRequestRatioConstraint("Container", "memory", enforced, req, lim)
+	}
+	testCases := []struct {
+		desc      string
+		req       string
+		lim       string
+		maxRatio  string
+		wantError bool
+	}{
+		{"ratio at the maximum", "100", "200", "2", false},
+		{"ratio above the maximum", "100", "300", "2", true},
+		{"limit whose projection wraps negative", "1", "9223372036854775809", "2", true},
+		{"equal request and limit at 2^63", "9223372036854775808", "9223372036854775808", "1", false},
+		{"equal request and limit at 2^64", "18446744073709551616", "18446744073709551616", "1", false},
+		{"ratio at the maximum past 2^63", "9223372036854775808", "18446744073709551616", "2", false},
+		{"ratio above the maximum past 2^63", "9223372036854775808", "27670116110564327424", "2", true},
+		// float64 cannot separate 2^54 from 2^54+1, so a ratio computed that way
+		// reads as exactly 2 on the row below the last one.
+		{"ratio one unit below the maximum", "9007199254740992", "18014398509481983", "2", false},
+		{"ratio exactly at the maximum", "9007199254740992", "18014398509481984", "2", false},
+		{"ratio one unit above the maximum", "9007199254740992", "18014398509481985", "2", true},
+	}
+	for _, testCase := range testCases {
+		if err := ratioOf(testCase.req, testCase.lim, testCase.maxRatio); (err != nil) != testCase.wantError {
+			t.Errorf("%s: got error %v, wantError %v", testCase.desc, err, testCase.wantError)
+		}
+	}
+}
+
+// Quantity.Cmp hands a decimal-backed operand to inf.Dec.Cmp, which aligns the
+// two scales by writing their difference out in digits. The exponent that sets
+// that difference comes from the request, so the constraints have to answer
+// without reading it. Allocation count is a proxy for that, not a bound on time
+// or bytes; it is here because it is deterministic enough to fail a regression.
+func TestConstraintAllocationsDoNotGrowWithTheExponent(t *testing.T) {
+	enforced := resource.MustParse("1Gi")
+	memory := func(value string) api.ResourceList {
+		return api.ResourceList{api.ResourceMemory: resource.MustParse(value)}
+	}
+	checks := map[string]func(api.ResourceList) error{
+		"min request": func(l api.ResourceList) error {
+			return minConstraint("Container", "memory", enforced, l, api.ResourceList{})
+		},
+		"min limit": func(l api.ResourceList) error {
+			return minConstraint("Container", "memory", enforced, memory("1Gi"), l)
+		},
+		"max limit": func(l api.ResourceList) error {
+			return maxConstraint("Container", "memory", enforced, api.ResourceList{}, l)
+		},
+		"max request": func(l api.ResourceList) error {
+			return maxConstraint("Container", "memory", enforced, l, memory("1Gi"))
+		},
+		"max request only": func(l api.ResourceList) error {
+			return maxRequestConstraint("Container", "memory", enforced, l)
+		},
+	}
+	// The two counts are equal without -race and differ by at most one with it,
+	// while reading the exponent adds thirty or more between these two values.
+	const slack = 8
+	for desc, check := range checks {
+		small := testing.AllocsPerRun(10, func() { _ = check(memory("1e100")) })
+		large := testing.AllocsPerRun(10, func() { _ = check(memory("1e10000000")) })
+		if large > small+slack {
+			t.Errorf("%s: %v allocations at 1e100 and %v at 1e10000000, so the comparison is reading the exponent", desc, small, large)
+		}
+	}
+}
+
+// The old comparison projected request, limit and enforced together, taking
+// milli units only when all three fit MaxMilliValue and whole units otherwise.
+// That made a verdict depend on the other operands and on whether Value()
+// happened to collapse one of them, so it is not a boundary this change can
+// keep. These four inputs are ordinary decimals that the projection accepted
+// and the exact comparison rejects.
+func TestConstraintsRejectValuesTheProjectionRounded(t *testing.T) {
+	memory := func(value string) api.ResourceList {
+		return api.ResourceList{api.ResourceMemory: resource.MustParse(value)}
+	}
+	testCases := []struct {
+		desc  string
+		check func() error
+	}{
+		{"request a fraction below the minimum", func() error {
+			return minConstraint("Container", "memory", resource.MustParse("1"), memory("0.9999"), api.ResourceList{})
+		}},
+		{"limit a fraction above the maximum", func() error {
+			return maxConstraint("Container", "memory", resource.MustParse("1.0001"), api.ResourceList{}, memory("1.0009"))
+		}},
+		{"request a fraction above the maximum", func() error {
+			return maxRequestConstraint("Container", "memory", resource.MustParse("1.0001"), memory("1.0009"))
+		}},
+		{"ratio a fraction above the maximum", func() error {
+			return limitRequestRatioConstraint("Container", "memory", resource.MustParse("2"), memory("1.0001"), memory("2.001"))
+		}},
+	}
+	for _, testCase := range testCases {
+		if err := testCase.check(); err == nil {
+			t.Errorf("%s: expected rejection", testCase.desc)
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

LimitRanger enforces a LimitRange's min, max, and limit/request ratio by projecting each quantity to int64 with `requestLimitEnforcedValues`, which uses `Value()` or `MilliValue()`. Those accessors wrap for a quantity past the int64 range: `2^64` projects to `0`, and `2^63` to a negative number. The constraints then compare the wrong numbers, and they go wrong in both directions. A container limit of `2^64` is admitted against a max of `1000`, a request of `1` is admitted against a min of `2^64`, and a limit of `2^63+1` against a request of `1` is admitted under a maximum ratio of `2`. Two operands that both collapse to zero fail the other way, and a ratio of exactly `1` is rejected with "limit is 0".

This is reachable today. CPU and memory are not integer-only, and the API does not cap a quantity's magnitude, so a large value is a valid, if unusual, request.

The constraints now compare with `Quantity.Cmp`. The ratio is compared as `limit > request * maxRatio`; `Quantity` has no multiply and `inf.Dec.Mul` adds the two scales as an `int32`, which wraps a vanishing product into a large one, so the product is formed from the coefficients with the scale kept in an `int64` and handed to `Cmp`.

#### Which issue(s) this PR fixes:

Related to #141166.

#### Special notes for your reviewer:

The first revision compared through a local helper. That came out on review: the slow path it worked around is `Quantity.Cmp` itself, and that is where it belongs. #142013 bounded `Cmp` across a wide scale difference, so the constraints call it directly here.

This changes the answer for some ordinary decimals, and that part is deliberate rather than incidental. `requestLimitEnforcedValues` chose its precision jointly: milli units only when the request, the limit and the enforced bound all fit `MaxMilliValue`, whole units otherwise. So the verdict on one pair depended on the third operand, and not monotonically. With `min=1` and `request=0.4`, a limit of `2` or `1e15` rejects, `1e16` and `1e17` accept, and `1e19` rejects again, because `Value()` collapses that limit to `0` and `0` passes the `<= MaxMilliValue` guard. There is no version of that boundary worth reproducing, so these four now fail where they were admitted:

| constraint | inputs | before | after |
| --- | --- | --- | --- |
| min | `min=1`, `request=0.9999` | admitted | rejected |
| max | `max=1.0001`, `limit=1.0009` | admitted | rejected |
| max request | `max=1.0001`, `request=1.0009` | admitted | rejected |
| ratio | `request=1.0001`, `limit=2.001`, `max=2` | admitted | rejected |

`SupportsAttributes` returns false for pod updates, so for a pod this reaches creates and the resize subresource, and a stored pod is not re-admitted. A PVC has no such exemption: every PVC update goes back through the plugin, and the plugin reads the new object, so an update that carries the stored request forward unchanged is rejected. `requests.storage: 1073741823.9999` against `min: 1Gi` is admitted on master and rejected here, and raising the request to the minimum clears it.

Above a maximum the same correction is not available, which is the part I would like decided here. `max: 1073741824.0001` and a stored `requests.storage: 1073741824.0009` have the same milli projection, so master admits the pair and this rejects it. Correcting it means lowering the request, and `ValidatePersistentVolumeClaimUpdate` forbids that: without `RecoverVolumeExpansionFailure` a decrease is refused outright, and with it a decrease still has to stay above `status.capacity`. For a bound claim reporting `1073741825` there is no request that satisfies both, so the way out is the administrator widening the LimitRange rather than the user editing the claim.

The min and max constraints go through `Cmp` too. `Quantity.Cmp` hands a decimal-backed operand to `inf.Dec.Cmp`, which aligns the two scales by writing their difference out in digits, so against a `1Gi` minimum a ten byte request of `1e10000000` used to be 779ms and 23MB per comparison. That is what the first revision avoided, and it is what #142013 fixed: the same comparison is 393ns now and does not move with the request's exponent. `TestConstraintAllocationsDoNotGrowWithTheExponent` pins that at the caller, comparing the allocation count at `1e100` and `1e10000000` for each of the five comparisons. Both are 13, and the test allows a slack of eight so that `-race` does not trip it. An integer resource still compares two int64-backed whole numbers directly and allocates nothing.

The ratio's product is formed from the coefficients rather than through `Value()` or `inf.Dec.Mul`, so nothing collapses or overflows it. A parseable quantity holds at most nano precision, so the product's scale only falls past `inf.Scale` when the operands are large enough that no representable limit can exceed their product. `TestConstraintsAreOverflowSafe` covers a 3:1 ratio at `1e2147483647`, and `TestLimitRangerRatioIsExact` pins the ratio one unit either side of the maximum at the caller: `9007199254740992` against `18014398509481985` has to be rejected under a maximum of 2, where a float64 ratio reads that pair as exactly 2.

`TestConstraintsRejectValuesTheProjectionRounded` covers the table above; `TestLimitRangerRatioIsExact` covers the admission at `2^63+1` and the rejection of a ratio of `1` at `2^63` and `2^64`; `TestConstraintsAreOverflowSafe` covers the four constraints against `2^64` and the ratio at an extreme scale. All three fail on master.

The table above is the part I would most like a second opinion on. The alternative is to keep the old answer inside the range where the projection was well defined, as #141349 does for the integer-resource check. Here that range is chosen from all three operands at once, so reproducing it means reproducing a verdict that changes with an unrelated value.

#### Does this PR introduce a user-facing change?

```release-note
LimitRanger now compares resource quantities exactly. A LimitRange min, max, or limit/request ratio is enforced for quantities large enough to overflow an int64 projection instead of being silently skipped, and a ratio constraint no longer rejects an equal request and limit above 2^63. Requests and limits within one milli-unit of a bound, such as a request of 0.9999 against a minimum of 1, are now rejected where the previous projection rounded them onto the bound. This applies to pod creation and to every PVC create and update, so a PVC already holding such a value has to have its request corrected before it can be updated. Where the stored request sits above a maximum rather than below a minimum, correcting it would mean decreasing the request, which PVC validation refuses; those claims need the LimitRange widened instead.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. AI-assisted tools were used during implementation, test planning, and review; I reviewed and validated the final change.
