### PR TITLE
core/validation: check integer resources exactly to avoid int64 overflow

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -8543,12 +8543,24 @@ func ValidateResourceQuotaSpec(resourceQuotaSpec *core.ResourceQuotaSpec, fld *f
 	return allErrs
 }
 
+// isIntegerResourceValue reports whether q may be used where whole units are
+// required. Wherever the milli projection fits in an int64 this is the check
+// that has always been applied, so values it accepted, such as 1.9999, still
+// pass. Past that range only an exact whole number passes.
+func isIntegerResourceValue(q resource.Quantity) bool {
+	if _, integer := q.AsScale(0); integer {
+		return true
+	}
+	milli, ok := q.AsMilliInt64()
+	return ok && milli%1000 == 0
+}
+
 // ValidateResourceQuantityValue enforces that specified quantity is valid for specified resource
 func ValidateResourceQuantityValue(resource core.ResourceName, value resource.Quantity, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, ValidateNonnegativeQuantity(value, fldPath)...)
 	if helper.IsIntegerResourceName(resource) {
-		if value.MilliValue()%int64(1000) != int64(0) {
+		if !isIntegerResourceValue(value) {
 			allErrs = append(allErrs, field.Invalid(fldPath, value, isNotIntegerErrorMsg))
 		}
 	}

--- a/pkg/apis/core/validation/validation_integer_overflow_test.go
+++ b/pkg/apis/core/validation/validation_integer_overflow_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	core "k8s.io/kubernetes/pkg/apis/core"
+)
+
+// An integer resource accepts any whole number and rejects a fraction, at every
+// magnitude. A sub-milli fraction just below an integer stays accepted.
+func TestValidateResourceQuantityValueIntegerOverflow(t *testing.T) {
+	intResource := core.ResourceName("example.com/device") // an integer resource
+
+	cases := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"small-integer", "4", false},
+		{"integer-in-milli-form", "1000m", false},
+		{"whole-number-past-the-milli-range", "10000000000000000", false},    // 10^16
+		{"larger-whole-number-past-the-range", "1000000000000000000", false}, // 10^18
+		{"whole-number-past-the-int64-range", "18446744073709551616", false}, // 2^64
+		{"fractional", "1500m", true},
+		{"fractional-milli", "2500m", true},
+		{"just-above-an-integer", "1.0001", true},
+		// still fractions, still rejected
+		{"huge-fractional-past-the-int64-range", "18446744073709551616500m", true}, // 2^64 + 0.5
+		{"fractional-past-the-milli-range", "1000000000000000500m", true},          // 10^15 + 0.5
+		// the milli projection rounds these onto a whole number, so they pass
+		{"within-one-milli-below-an-integer", "1.9999", false},
+		{"within-one-milli-below-one", "0.9999", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := resource.MustParse(tc.value)
+			errs := ValidateResourceQuantityValue(intResource, q, field.NewPath("x"))
+			if gotErr := len(errs) > 0; gotErr != tc.wantErr {
+				t.Errorf("value %s: got errors %v, wantErr=%v", tc.value, errs, tc.wantErr)
+			}
+		})
+	}
+}
+
+// The same accept/reject boundary must hold on the int64 and the promoted
+// inf.Dec forms.
+func TestValidateResourceQuantityValueIntegerBoundary(t *testing.T) {
+	intResource := core.ResourceName("example.com/device")
+
+	testCases := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{"a milli below an integer", "0.999", true},
+		{"just inside a milli of an integer", "0.999000001", false},
+		{"the integer itself", "1", false},
+		{"just above an integer", "1.000000001", true},
+		{"a milli below the next integer", "1.999", true},
+		{"just inside a milli of the next integer", "1.999000001", false},
+		{"the largest integer whose milli value fits", "9223372036854775", false},
+		{"the first integer whose milli value overflows", "9223372036854776", false},
+		{"a fraction whose milli value is the rail", "9223372036854775807m", true},
+		{"a fraction whose milli value overflows past it", "9223372036854775808m", true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, form := range []string{"parsed", "promoted to inf.Dec"} {
+				q := resource.MustParse(tc.value)
+				if form != "parsed" {
+					q.ToDec()
+				}
+				errs := ValidateResourceQuantityValue(intResource, q, field.NewPath("x"))
+				if gotErr := len(errs) > 0; gotErr != tc.wantErr {
+					t.Errorf("%s %s: got errors %v, wantErr=%v", tc.value, form, errs, tc.wantErr)
+				}
+			}
+		})
+	}
+}
+
+// A value the check has always accepted stays accepted through the container path.
+func TestValidateContainerResourceRequirementsKeepsRoundedValues(t *testing.T) {
+	requirements := &core.ResourceRequirements{
+		Limits: core.ResourceList{core.ResourceName("example.com/device"): resource.MustParse("1.9999")},
+	}
+	if errs := ValidateContainerResourceRequirements(requirements, sets.New[string](), field.NewPath("resources"), PodValidationOptions{}); len(errs) > 0 {
+		t.Errorf("a value the check has always accepted was rejected: %v", errs)
+	}
+}
+
+// ValidateResourceQuotaUpdate revalidates spec.hard without consulting the
+// stored value, so a quota already holding a whole number past the milli range
+// could not be updated at all, not even to change a label.
+func TestValidateResourceQuotaUpdateRevalidatesStoredQuantities(t *testing.T) {
+	quota := func(hard, label string) *core.ResourceQuota {
+		return &core.ResourceQuota{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "quota", Namespace: "ns", ResourceVersion: "1",
+				Labels: map[string]string{"team": label},
+			},
+			Spec: core.ResourceQuotaSpec{
+				Hard: core.ResourceList{core.ResourcePods: resource.MustParse(hard)},
+			},
+		}
+	}
+	stored := quota("10000000000000000", "before")
+	if errs := ValidateResourceQuotaUpdate(quota("10000000000000000", "after"), stored); len(errs) != 0 {
+		t.Errorf("a label-only update to a quota holding 10^16 pods should pass, got %v", errs)
+	}
+
+	fractional := quota("18446744073709551616m", "before")
+	if errs := ValidateResourceQuotaUpdate(quota("18446744073709551616m", "after"), fractional); len(errs) == 0 {
+		t.Errorf("18446744073709551616m is not a whole number of pods and should still be rejected")
+	}
+}
+
+// The answer belongs to the number, not to how it was written, and it has to be
+// the right answer: these are whole numbers.
+func TestValidateResourceQuantityValueIgnoresSpelling(t *testing.T) {
+	intResource := core.ResourceName("example.com/device")
+	spellings := [][]string{
+		{"1e16", "10P", "10000000000000000"},
+		{"1e18", "1E", "1000000000000000000"},
+		{"1e19", "10000000000000000000"},
+		{"2e9", "2G", "2000000000"},
+	}
+	for _, group := range spellings {
+		first := len(ValidateResourceQuantityValue(intResource, resource.MustParse(group[0]), field.NewPath("x")))
+		for _, value := range group[1:] {
+			got := len(ValidateResourceQuantityValue(intResource, resource.MustParse(value), field.NewPath("x")))
+			if got != first {
+				t.Errorf("%s and %s are the same quantity but got %d and %d errors", group[0], value, first, got)
+			}
+		}
+		if first != 0 {
+			t.Errorf("%s is a whole number and should be accepted, got %d errors", group[0], first)
+		}
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig apps

#### What this PR does / why we need it:

`ValidateResourceQuantityValue` checks that an integer resource (for example an extended resource) has a whole-number value with `value.MilliValue()%1000 == 0`. `MilliValue()` projects through int64 and saturates past the milli range, and `MaxInt64 % 1000` is 807, so a whole number such as `10^16` ("10P") or `10^18` ("1E") is reported as fractional and rejected with "must be an integer".

This is reachable today, since a resource quantity's magnitude is not capped.

The fix answers with `Quantity.AsScale(0)`, whose second return reports whether the value is already an integer without projecting through int64. Where the projection does fit, it keeps the old answer.

That second half is deliberate. `MilliValue()` rounds away from zero, so a value within one milli of the next integer projects onto a whole number of milli units and passed the old check: `1.9999` and `0.9999` are accepted on master today. `AsScale(0)` on its own would start rejecting them, and a ResourceQuota, LimitRange or Pod holding such a value would stop being updatable. Whether to tighten that boundary is a separate compatibility decision, so this change is limited to the range that saturates.

#### Which issue(s) this PR fixes:

Related to #141166.

#### Special notes for your reviewer:

A differential over 8804 spellings agrees on all 8683 whose milli projection fits in an int64. The 112 that move all move the same way, from rejected to accepted, and every one of them is a whole number: `10000000000000000` and `1e16`, `1000000000000000000` and `1E`, `9223372036854776`, `18446744073709551616`, `1Ei`, and every power of ten from `1e16` up, in both signs. Nothing moves from accepted to rejected, so no object that validates today stops validating.

`TestValidateResourceQuantityValueIntegerOverflow` fails on exactly those rows with the production change reverted. `TestValidateResourceQuantityValueIgnoresSpelling` pins that three spellings of the same quantity draw the same answer and that the answer is the right one; reverted, it reports that `1e16`, `1e18` and `1e19` are whole numbers and were rejected.

`TestValidateResourceQuantityValueIntegerBoundary` pins both ends of the band, on the parsed int64 form and on the promoted `inf.Dec` form, since the two take different paths. It also pins `9223372036854775` and `9223372036854776`, the last integer whose milli value fits and the first whose milli value overflows; the second is the row that fails without the change. `TestValidateContainerResourceRequirementsKeepsRoundedValues` reaches the check the way a container does, so the compatibility claim is not resting on a helper-level assertion alone. That test passes on master too, by design: it guards the band and not the fix.

The band is the part worth a second look. Keeping it means `1.9999` stays valid for an integer resource, which is not obviously right; tightening it would be a separate change with its own release note, and would fail updates to a ResourceQuota, LimitRange or Pod already holding such a value.

`ValidateResourceQuotaUpdate` revalidates `spec.hard` without consulting the stored value, so the bug reaches objects that already exist. A quota holding `10000000000000000` pods cannot be updated at all on master, not even to change a label: it fails with `spec.hard[pods]: Invalid value: "10P": must be an integer`. `TestValidateResourceQuotaUpdateRevalidatesStoredQuantities` pins that, and pins that `18446744073709551616m`, which is 2^64 milli units and not a whole number of pods, is still rejected.

One thing changed under this PR while it sat. An earlier revision also moved `18446744073709551616m` from accepted to rejected, because `MilliValue()` used to wrap onto a multiple of 1000 there. #141305 has merged since, `MilliValue()` saturates now, and master rejects that value on its own, so that half of the change is gone and the release note no longer carries it.

#### Does this PR introduce a user-facing change?

```release-note
Integer resource quantities (such as extended resources) that are whole numbers large enough to overflow an int64 milli projection are no longer incorrectly rejected as "must be an integer".
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. AI-assisted tools were used during implementation, test planning, and review; I reviewed and validated the final change.
