### PR TITLE
Enforce pod UID in kubelet exec and run routes

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2816,6 +2816,14 @@ func (kl *Kubelet) findContainer(ctx context.Context, podFullName string, podUID
 	if err != nil {
 		return nil, err
 	}
+	// When a non-empty pod UID is supplied it must match the current pod with
+	// this full name. FindPod below resolves by full name whenever it is set,
+	// so without this check a request carrying a stale or mismatched UID could
+	// resolve to a recreated pod that merely shares the namespace/name. This
+	// mirrors the UID enforcement already performed by GetAttach.
+	if apiPod, found := kl.GetPodByFullName(podFullName); found && podUID != "" && apiPod.UID != podUID {
+		return nil, fmt.Errorf("pod %s not found", podFullName)
+	}
 	// Resolve and type convert back again.
 	// We need the static pod UID but the kubecontainer API works with types.UID.
 	podUID = types.UID(kl.podManager.TranslatePodUID(podUID))

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -6051,6 +6051,79 @@ func TestGetExec(t *testing.T) {
 	}
 }
 
+// TestGetExecAndRunEnforcePodUID verifies that the UID-qualified exec and run
+// routes reject a request whose pod UID does not match the current pod. A stale
+// or mismatched UID must not resolve to a recreated pod that merely shares the
+// namespace/name, keeping exec/run consistent with the UID enforcement already
+// performed by GetAttach. See https://github.com/kubernetes/kubernetes/issues/139987.
+func TestGetExecAndRunEnforcePodUID(t *testing.T) {
+	const (
+		podName      = "podFoo"
+		podNamespace = "nsFoo"
+		containerID  = "containerFoo"
+	)
+	currentUID := types.UID("current-uid")
+	podFullName := kubecontainer.GetPodFullName(podWithUIDNameNs(currentUID, podName, podNamespace))
+
+	testcases := []struct {
+		description string
+		requestUID  types.UID
+		expectError bool
+	}{
+		{
+			description: "matching uid is accepted",
+			requestUID:  currentUID,
+			expectError: false,
+		},
+		{
+			description: "empty uid falls back to name-based lookup",
+			requestUID:  "",
+			expectError: false,
+		},
+		{
+			description: "stale uid is rejected",
+			requestUID:  types.UID("stale-uid"),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.description, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+			defer testKubelet.Cleanup()
+			kubelet := testKubelet.kubelet
+
+			// The currently running pod is registered under currentUID.
+			kubelet.podManager.SetPods([]*v1.Pod{podWithUIDNameNs(currentUID, podName, podNamespace)})
+			testKubelet.fakeRuntime.PodList = []*containertest.FakePod{
+				{Pod: &kubecontainer.Pod{
+					ID:        currentUID,
+					Name:      podName,
+					Namespace: podNamespace,
+					Containers: []*kubecontainer.Container{
+						{Name: containerID, ID: kubecontainer.ContainerID{Type: "test", ID: containerID}},
+					},
+				}},
+			}
+			streamingRuntime := &containertest.FakeStreamingRuntime{FakeRuntime: testKubelet.fakeRuntime}
+			kubelet.containerRuntime = streamingRuntime
+			kubelet.streamingRuntime = streamingRuntime
+			kubelet.runner = &containertest.FakeContainerCommandRunner{Stdout: "ok"}
+
+			_, execErr := kubelet.GetExec(tCtx, podFullName, tc.requestUID, containerID, []string{"ls"}, remotecommand.Options{})
+			_, runErr := kubelet.RunInContainer(tCtx, podFullName, tc.requestUID, containerID, []string{"ls"})
+			if tc.expectError {
+				require.Error(t, execErr, "GetExec should reject a mismatched pod UID")
+				require.Error(t, runErr, "RunInContainer should reject a mismatched pod UID")
+			} else {
+				require.NoError(t, execErr, "GetExec should accept a matching/empty pod UID")
+				require.NoError(t, runErr, "RunInContainer should accept a matching/empty pod UID")
+			}
+		})
+	}
+}
+
 func TestGetPortForward(t *testing.T) {
 	const (
 		podName                = "podFoo"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The UID-qualified kubelet streaming routes `/exec/{namespace}/{pod}/{uid}/{container}`
and `/run/{namespace}/{pod}/{uid}/{container}` accept a pod UID but do not enforce it.

`findContainer` resolves the pod through `kubecontainer.Pods.FindPod`, which matches on
the pod full name whenever it is set, so the supplied UID never participates in the
lookup. A request carrying a stale or mismatched UID therefore resolves to whichever pod
currently holds that namespace/name — including a pod recreated after the UID in the
request was issued.

This change rejects a non-empty pod UID that does not match the current pod with that
full name, mirroring the enforcement `GetAttach` already performs. An empty UID still
falls back to name-based lookup, so the non-UID routes and internal callers are
unaffected. This makes exec and run consistent with attach and port-forward.

#### Which issue(s) this PR fixes:

Fixes #139987

#### Special notes for your reviewer:

Replaces #141028, which I closed after a bad force-push from a shallow clone broke the
commit's ancestry and mangled the diff. This is the same change, plus the `require`
fix for the testifylint hint. @haircommander reviewed and LGTM'd the original.

Adds `TestGetExecAndRunEnforcePodUID`, covering a matching UID, an empty UID, and a
stale UID, against both `GetExec` and `RunInContainer`.

One thing worth a look: `GetPodByFullName` returns the config-source UID, so for a
static pod a UID-qualified request using the *mirror* pod UID would now be rejected.
`GetAttach` already behaves this way, and the apiserver's `streamLocation` builds
stream URLs without a UID segment, so `kubectl exec` never takes the UID-qualified
path. I kept the check consistent with attach rather than diverging, but happy to
compare against `TranslatePodUID(podUID)` instead if you'd prefer exec resolve mirror
UIDs correctly.

Development of this change was AI-assisted. I have reviewed and tested it myself.

#### Does this PR introduce a user-facing change?

```release-note
The kubelet now enforces the pod UID supplied to the UID-qualified `/exec` and `/run`
streaming routes. A request with a stale or mismatched UID is rejected rather than
resolving to a different pod that shares the same namespace and name. Requests that
omit the UID are unaffected.
```