### PR TITLE
Fix swapped name/namespace args to ValidateWebhookService

### DIFF
--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -403,7 +403,7 @@ func validateValidatingWebhook(hook *admissionregistration.ValidatingWebhook, op
 	case cc.URL != nil:
 		allErrors = append(allErrors, webhook.ValidateWebhookURL(fldPath.Child("clientConfig").Child("url"), *cc.URL, true)...)
 	case cc.Service != nil:
-		allErrors = append(allErrors, webhook.ValidateWebhookService(fldPath.Child("clientConfig").Child("service"), cc.Service.Name, cc.Service.Namespace, cc.Service.Path, cc.Service.Port)...)
+		allErrors = append(allErrors, webhook.ValidateWebhookService(fldPath.Child("clientConfig").Child("service"), cc.Service.Namespace, cc.Service.Name, cc.Service.Path, cc.Service.Port)...)
 	}
 
 	if !opts.ignoreMatchConditions {
@@ -461,7 +461,7 @@ func validateMutatingWebhook(hook *admissionregistration.MutatingWebhook, opts v
 	case cc.URL != nil:
 		allErrors = append(allErrors, webhook.ValidateWebhookURL(fldPath.Child("clientConfig").Child("url"), *cc.URL, true)...)
 	case cc.Service != nil:
-		allErrors = append(allErrors, webhook.ValidateWebhookService(fldPath.Child("clientConfig").Child("service"), cc.Service.Name, cc.Service.Namespace, cc.Service.Path, cc.Service.Port)...)
+		allErrors = append(allErrors, webhook.ValidateWebhookService(fldPath.Child("clientConfig").Child("service"), cc.Service.Namespace, cc.Service.Name, cc.Service.Path, cc.Service.Port)...)
 	}
 
 	if !opts.ignoreMatchConditions {

--- a/pkg/apis/admissionregistration/validation/validation_test.go
+++ b/pkg/apis/admissionregistration/validation/validation_test.go
@@ -811,6 +811,20 @@ func TestValidateValidatingWebhookConfiguration(t *testing.T) {
 		},
 		}, true),
 		expectedError: `webhooks[0].matchConditions: Too many: 65: must have at most 64 items`,
+	}, {
+		name: "missing service namespace",
+		config: newValidatingWebhookConfiguration([]admissionregistration.ValidatingWebhook{{
+			Name: "webhook.k8s.io",
+			ClientConfig: admissionregistration.WebhookClientConfig{
+				Service: &admissionregistration.ServiceReference{
+					Name: "n",
+					Port: 443,
+				},
+			},
+			SideEffects: &noSideEffect,
+		},
+		}, true),
+		expectedError: `webhooks[0].clientConfig.service.namespace: Required value`,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -1788,6 +1802,20 @@ func TestValidateMutatingWebhookConfiguration(t *testing.T) {
 		},
 		}, true),
 		expectedError: `webhooks[0].matchConditions: Too many: 65: must have at most 64 items`,
+	}, {
+		name: "missing service namespace",
+		config: newMutatingWebhookConfiguration([]admissionregistration.MutatingWebhook{{
+			Name: "webhook.k8s.io",
+			ClientConfig: admissionregistration.WebhookClientConfig{
+				Service: &admissionregistration.ServiceReference{
+					Name: "n",
+					Port: 443,
+				},
+			},
+			SideEffects: &noSideEffect,
+		},
+		}, true),
+		expectedError: `webhooks[0].clientConfig.service.namespace: Required value`,
 	}}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go
@@ -628,7 +628,7 @@ func validateCustomResourceConversion(conversion *apiextensions.CustomResourceCo
 			case cc.URL != nil:
 				allErrs = append(allErrs, webhook.ValidateWebhookURL(fldPath.Child("webhookClientConfig").Child("url"), *cc.URL, true)...)
 			case cc.Service != nil:
-				allErrs = append(allErrs, webhook.ValidateWebhookService(fldPath.Child("webhookClientConfig").Child("service"), cc.Service.Name, cc.Service.Namespace, cc.Service.Path, cc.Service.Port)...)
+				allErrs = append(allErrs, webhook.ValidateWebhookService(fldPath.Child("webhookClientConfig").Child("service"), cc.Service.Namespace, cc.Service.Name, cc.Service.Path, cc.Service.Port)...)
 			}
 			if len(cc.CABundle) > 0 && !opts.allowInvalidCABundle {
 				allErrs = append(allErrs, webhook.ValidateCABundle(fldPath.Child("webhookClientConfig").Child("caBundle"), cc.CABundle)...)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation_test.go
@@ -257,6 +257,55 @@ func TestValidateCustomResourceDefinition(t *testing.T) {
 			},
 		},
 		{
+			name: "webhookconfig: missing service namespace",
+			resource: &apiextensions.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},
+				Spec: apiextensions.CustomResourceDefinitionSpec{
+					Group: "group.com",
+					Scope: apiextensions.ResourceScope("Cluster"),
+					Names: apiextensions.CustomResourceDefinitionNames{
+						Plural:   "plural",
+						Singular: "singular",
+						Kind:     "Plural",
+						ListKind: "PluralList",
+					},
+					Versions: []apiextensions.CustomResourceDefinitionVersion{
+						{
+							Name:    "version",
+							Served:  true,
+							Storage: true,
+						},
+						{
+							Name:    "version2",
+							Served:  true,
+							Storage: false,
+						},
+					},
+					Conversion: &apiextensions.CustomResourceConversion{
+						Strategy: apiextensions.ConversionStrategyType("Webhook"),
+						WebhookClientConfig: &apiextensions.WebhookClientConfig{
+							Service: &apiextensions.ServiceReference{
+								Name: "n",
+								Port: 443,
+							},
+						},
+					},
+					Validation: &apiextensions.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensions.JSONSchemaProps{
+							Type: "object",
+						},
+					},
+					PreserveUnknownFields: ptr.To(false),
+				},
+				Status: apiextensions.CustomResourceDefinitionStatus{
+					StoredVersions: []string{"version"},
+				},
+			},
+			errors: []validationMatch{
+				required("spec", "conversion", "webhookClientConfig", "service", "namespace"),
+			},
+		},
+		{
 			name: "webhookconfig: invalid CABundle should be allowed on Create",
 			resource: &apiextensions.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{Name: "plural.group.com"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`ValidateWebhookService` in `staging/src/k8s.io/apiserver/pkg/util/webhook/validation.go` is declared with parameter order `(namespace, name string)`, but all three call sites pass `(Name, Namespace)` instead:

1. `staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation/validation.go` (CRD `spec.conversion.webhook.clientConfig`)
2. `pkg/apis/admissionregistration/validation/validation.go` (`ValidatingWebhookConfiguration` `clientConfig`)
3. `pkg/apis/admissionregistration/validation/validation.go` (`MutatingWebhookConfiguration` `clientConfig`)

Because the function reports errors using its own parameter names, this causes `Required value` errors to be reported against the wrong field: an empty `service.namespace` is reported as `...service.name: Required value` instead of `...service.namespace: Required value`, and vice versa.

This does not change whether validation passes or fails, only which field path is blamed when one of the two is empty.

#### Which issue(s) this PR is related to:

Fixes #141353


#### Special notes for your reviewer:
None.


#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
NONE
