### PR TITLE
Sync group snapshot and enable its test in all configurations

### DIFF
--- a/cluster/addons/volumesnapshots/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
+++ b/cluster/addons/volumesnapshots/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotclasses.yaml
@@ -1,0 +1,263 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/1337"
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: volumegroupsnapshotclasses.groupsnapshot.storage.k8s.io
+spec:
+  group: groupsnapshot.storage.k8s.io
+  names:
+    kind: VolumeGroupSnapshotClass
+    listKind: VolumeGroupSnapshotClassList
+    plural: volumegroupsnapshotclasses
+    shortNames:
+    - vgsclass
+    - vgsclasses
+    singular: volumegroupsnapshotclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .driver
+      name: Driver
+      type: string
+    - description: Determines whether a VolumeGroupSnapshotContent created through
+        the VolumeGroupSnapshotClass should be deleted when its bound VolumeGroupSnapshot
+        is deleted.
+      jsonPath: .deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VolumeGroupSnapshotClass specifies parameters that a underlying storage system
+          uses when creating a volume group snapshot. A specific VolumeGroupSnapshotClass
+          is used by specifying its name in a VolumeGroupSnapshot object.
+          VolumeGroupSnapshotClasses are non-namespaced.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          deletionPolicy:
+            description: |-
+              DeletionPolicy determines whether a VolumeGroupSnapshotContent created
+              through the VolumeGroupSnapshotClass should be deleted when its bound
+              VolumeGroupSnapshot is deleted.
+              Supported values are "Retain" and "Delete".
+              "Retain" means that the VolumeGroupSnapshotContent and its physical group
+              snapshot on underlying storage system are kept.
+              "Delete" means that the VolumeGroupSnapshotContent and its physical group
+              snapshot on underlying storage system are deleted.
+              Required.
+            enum:
+            - Delete
+            - Retain
+            type: string
+            x-kubernetes-validations:
+            - message: deletionPolicy is immutable once set
+              rule: self == oldSelf
+          driver:
+            description: |-
+              Driver is the name of the storage driver expected to handle this VolumeGroupSnapshotClass.
+              Required.
+            type: string
+            x-kubernetes-validations:
+            - message: driver is immutable once set
+              rule: self == oldSelf
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          parameters:
+            additionalProperties:
+              type: string
+            description: |-
+              Parameters is a key-value map with storage driver specific parameters for
+              creating group snapshots.
+              These values are opaque to Kubernetes and are passed directly to the driver.
+            type: object
+            x-kubernetes-validations:
+            - message: parameters are immutable once set
+              rule: self == oldSelf
+        required:
+        - deletionPolicy
+        - driver
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .driver
+      name: Driver
+      type: string
+    - description: Determines whether a VolumeGroupSnapshotContent created through
+        the VolumeGroupSnapshotClass should be deleted when its bound VolumeGroupSnapshot
+        is deleted.
+      jsonPath: .deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VolumeGroupSnapshotClass specifies parameters that a underlying storage system
+          uses when creating a volume group snapshot. A specific VolumeGroupSnapshotClass
+          is used by specifying its name in a VolumeGroupSnapshot object.
+          VolumeGroupSnapshotClasses are non-namespaced.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          deletionPolicy:
+            description: |-
+              DeletionPolicy determines whether a VolumeGroupSnapshotContent created
+              through the VolumeGroupSnapshotClass should be deleted when its bound
+              VolumeGroupSnapshot is deleted.
+              Supported values are "Retain" and "Delete".
+              "Retain" means that the VolumeGroupSnapshotContent and its physical group
+              snapshot on underlying storage system are kept.
+              "Delete" means that the VolumeGroupSnapshotContent and its physical group
+              snapshot on underlying storage system are deleted.
+              Required.
+            enum:
+            - Delete
+            - Retain
+            type: string
+          driver:
+            description: |-
+              Driver is the name of the storage driver expected to handle this VolumeGroupSnapshotClass.
+              Required.
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          parameters:
+            additionalProperties:
+              type: string
+            description: |-
+              Parameters is a key-value map with storage driver specific parameters for
+              creating group snapshots.
+              These values are opaque to Kubernetes and are passed directly to the driver.
+            type: object
+        required:
+        - deletionPolicy
+        - driver
+        type: object
+    served: true
+    storage: false
+    subresources: {}
+  - additionalPrinterColumns:
+    - jsonPath: .driver
+      name: Driver
+      type: string
+    - description: Determines whether a VolumeGroupSnapshotContent created through
+        the VolumeGroupSnapshotClass should be deleted when its bound VolumeGroupSnapshot
+        is deleted.
+      jsonPath: .deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VolumeGroupSnapshotClass specifies parameters that a underlying storage system
+          uses when creating a volume group snapshot. A specific VolumeGroupSnapshotClass
+          is used by specifying its name in a VolumeGroupSnapshot object.
+          VolumeGroupSnapshotClasses are non-namespaced.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          deletionPolicy:
+            description: |-
+              DeletionPolicy determines whether a VolumeGroupSnapshotContent created
+              through the VolumeGroupSnapshotClass should be deleted when its bound
+              VolumeGroupSnapshot is deleted.
+              Supported values are "Retain" and "Delete".
+              "Retain" means that the VolumeGroupSnapshotContent and its physical group
+              snapshot on underlying storage system are kept.
+              "Delete" means that the VolumeGroupSnapshotContent and its physical group
+              snapshot on underlying storage system are deleted.
+              Required.
+            enum:
+            - Delete
+            - Retain
+            type: string
+            x-kubernetes-validations:
+            - message: deletionPolicy is immutable once set
+              rule: self == oldSelf
+          driver:
+            description: |-
+              Driver is the name of the storage driver expected to handle this VolumeGroupSnapshotClass.
+              Required.
+            type: string
+            x-kubernetes-validations:
+            - message: driver is immutable once set
+              rule: self == oldSelf
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          parameters:
+            additionalProperties:
+              type: string
+            description: |-
+              Parameters is a key-value map with storage driver specific parameters for
+              creating group snapshots.
+              These values are opaque to Kubernetes and are passed directly to the driver.
+            type: object
+            x-kubernetes-validations:
+            - message: parameters are immutable once set
+              rule: self == oldSelf
+        required:
+        - deletionPolicy
+        - driver
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/cluster/addons/volumesnapshots/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
+++ b/cluster/addons/volumesnapshots/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshotcontents.yaml
@@ -1,0 +1,981 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/1337"
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: volumegroupsnapshotcontents.groupsnapshot.storage.k8s.io
+spec:
+  group: groupsnapshot.storage.k8s.io
+  names:
+    kind: VolumeGroupSnapshotContent
+    listKind: VolumeGroupSnapshotContentList
+    plural: volumegroupsnapshotcontents
+    shortNames:
+    - vgsc
+    - vgscs
+    singular: volumegroupsnapshotcontent
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Indicates if all the individual snapshots in the group are ready
+        to be used to restore a group of volumes.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: Determines whether this VolumeGroupSnapshotContent and its physical
+        group snapshot on the underlying storage system should be deleted when its
+        bound VolumeGroupSnapshot is deleted.
+      jsonPath: .spec.deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - description: Name of the CSI driver used to create the physical group snapshot
+        on the underlying storage system.
+      jsonPath: .spec.driver
+      name: Driver
+      type: string
+    - description: Name of the VolumeGroupSnapshotClass from which this group snapshot
+        was (or will be) created.
+      jsonPath: .spec.volumeGroupSnapshotClassName
+      name: VolumeGroupSnapshotClass
+      type: string
+    - description: Namespace of the VolumeGroupSnapshot object to which this VolumeGroupSnapshotContent
+        object is bound.
+      jsonPath: .spec.volumeGroupSnapshotRef.namespace
+      name: VolumeGroupSnapshotNamespace
+      type: string
+    - description: Name of the VolumeGroupSnapshot object to which this VolumeGroupSnapshotContent
+        object is bound.
+      jsonPath: .spec.volumeGroupSnapshotRef.name
+      name: VolumeGroupSnapshot
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VolumeGroupSnapshotContent represents the actual "on-disk" group snapshot object
+          in the underlying storage system
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Spec defines properties of a VolumeGroupSnapshotContent created by the underlying storage system.
+              Required.
+            properties:
+              deletionPolicy:
+                description: |-
+                  DeletionPolicy determines whether this VolumeGroupSnapshotContent and the
+                  physical group snapshot on the underlying storage system should be deleted
+                  when the bound VolumeGroupSnapshot is deleted.
+                  Supported values are "Retain" and "Delete".
+                  "Retain" means that the VolumeGroupSnapshotContent and its physical group
+                  snapshot on underlying storage system are kept.
+                  "Delete" means that the VolumeGroupSnapshotContent and its physical group
+                  snapshot on underlying storage system are deleted.
+                  For dynamically provisioned group snapshots, this field will automatically
+                  be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field
+                  defined in the corresponding VolumeGroupSnapshotClass.
+                  For pre-existing snapshots, users MUST specify this field when creating the
+                  VolumeGroupSnapshotContent object.
+                  Required.
+                enum:
+                - Delete
+                - Retain
+                type: string
+              driver:
+                description: |-
+                  Driver is the name of the CSI driver used to create the physical group snapshot on
+                  the underlying storage system.
+                  This MUST be the same as the name returned by the CSI GetPluginName() call for
+                  that driver.
+                  Required.
+                type: string
+                x-kubernetes-validations:
+                - message: driver is immutable once set
+                  rule: self == oldSelf
+              source:
+                description: |-
+                  Source specifies whether the snapshot is (or should be) dynamically provisioned
+                  or already exists, and just requires a Kubernetes object representation.
+                  This field is immutable after creation.
+                  Required.
+                properties:
+                  groupSnapshotHandles:
+                    description: |-
+                      GroupSnapshotHandles specifies the CSI "group_snapshot_id" of a pre-existing
+                      group snapshot and a list of CSI "snapshot_id" of pre-existing snapshots
+                      on the underlying storage system for which a Kubernetes object
+                      representation was (or should be) created.
+                      This field is immutable.
+                    properties:
+                      volumeGroupSnapshotHandle:
+                        description: |-
+                          VolumeGroupSnapshotHandle specifies the CSI "group_snapshot_id" of a pre-existing
+                          group snapshot on the underlying storage system for which a Kubernetes object
+                          representation was (or should be) created.
+                          This field is immutable.
+                          Required.
+                        type: string
+                      volumeSnapshotHandles:
+                        description: |-
+                          VolumeSnapshotHandles is a list of CSI "snapshot_id" of pre-existing
+                          snapshots on the underlying storage system for which Kubernetes objects
+                          representation were (or should be) created.
+                          This field is immutable.
+                          Required.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - volumeGroupSnapshotHandle
+                    - volumeSnapshotHandles
+                    type: object
+                    x-kubernetes-validations:
+                    - message: groupSnapshotHandles is immutable
+                      rule: self == oldSelf
+                  volumeHandles:
+                    description: |-
+                      VolumeHandles is a list of volume handles on the backend to be snapshotted
+                      together. It is specified for dynamic provisioning of the VolumeGroupSnapshot.
+                      This field is immutable.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-validations:
+                    - message: volumeHandles is immutable
+                      rule: self == oldSelf
+                type: object
+                x-kubernetes-validations:
+                - message: volumeHandles is required once set
+                  rule: '!has(oldSelf.volumeHandles) || has(self.volumeHandles)'
+                - message: groupSnapshotHandles is required once set
+                  rule: '!has(oldSelf.groupSnapshotHandles) || has(self.groupSnapshotHandles)'
+                - message: exactly one of volumeHandles and groupSnapshotHandles must
+                    be set
+                  rule: (has(self.volumeHandles) && !has(self.groupSnapshotHandles))
+                    || (!has(self.volumeHandles) && has(self.groupSnapshotHandles))
+              volumeGroupSnapshotClassName:
+                description: |-
+                  VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass from
+                  which this group snapshot was (or will be) created.
+                  Note that after provisioning, the VolumeGroupSnapshotClass may be deleted or
+                  recreated with different set of values, and as such, should not be referenced
+                  post-snapshot creation.
+                  For dynamic provisioning, this field must be set.
+                  This field may be unset for pre-provisioned snapshots.
+                type: string
+                x-kubernetes-validations:
+                - message: volumeGroupSnapshotClassName is immutable once set
+                  rule: self == oldSelf
+              volumeGroupSnapshotRef:
+                description: |-
+                  VolumeGroupSnapshotRef specifies the VolumeGroupSnapshot object to which this
+                  VolumeGroupSnapshotContent object is bound.
+                  VolumeGroupSnapshot.Spec.VolumeGroupSnapshotContentName field must reference to
+                  this VolumeGroupSnapshotContent's name for the bidirectional binding to be valid.
+                  For a pre-existing VolumeGroupSnapshotContent object, name and namespace of the
+                  VolumeGroupSnapshot object MUST be provided for binding to happen.
+                  This field is immutable after creation.
+                  Required.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: both volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace
+                    must be set
+                  rule: has(self.name) && has(self.__namespace__)
+                - message: volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace
+                    are immutable
+                  rule: self.name == oldSelf.name && self.__namespace__ == oldSelf.__namespace__
+                - message: volumeGroupSnapshotRef.uid is immutable once set
+                  rule: '!has(oldSelf.uid) || (has(self.uid) && self.uid == oldSelf.uid)'
+            required:
+            - deletionPolicy
+            - driver
+            - source
+            - volumeGroupSnapshotRef
+            type: object
+          status:
+            description: status represents the current information of a group snapshot.
+            properties:
+              creationTime:
+                description: |-
+                  CreationTime is the timestamp when the point-in-time group snapshot is taken
+                  by the underlying storage system.
+                  If not specified, it indicates the creation time is unknown.
+                  If not specified, it means the readiness of a group snapshot is unknown.
+                  This field is the source for the CreationTime field in VolumeGroupSnapshotStatus
+                format: date-time
+                type: string
+              error:
+                description: |-
+                  Error is the last observed error during group snapshot creation, if any.
+                  Upon success after retry, this error field will be cleared.
+                properties:
+                  message:
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
+                    type: string
+                  time:
+                    description: time is the timestamp when the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              readyToUse:
+                description: |-
+                  ReadyToUse indicates if all the individual snapshots in the group are ready to be
+                  used to restore a group of volumes.
+                  ReadyToUse becomes true when ReadyToUse of all individual snapshots become true.
+                type: boolean
+              volumeGroupSnapshotHandle:
+                description: |-
+                  VolumeGroupSnapshotHandle is a unique id returned by the CSI driver
+                  to identify the VolumeGroupSnapshot on the storage system.
+                  If a storage system does not provide such an id, the
+                  CSI driver can choose to return the VolumeGroupSnapshot name.
+                type: string
+                x-kubernetes-validations:
+                - message: volumeGroupSnapshotHandle is immutable once set
+                  rule: self == oldSelf
+              volumeSnapshotInfoList:
+                description: |-
+                  This field is introduced in v1beta2
+                  It is replacing VolumeSnapshotHandlePairList
+                  VolumeSnapshotInfoList is a list of snapshot information returned by
+                  by the CSI driver to identify snapshots on the storage system.
+                items:
+                  description: |-
+                    The VolumeSnapshotInfo struct is added in v1beta2
+                    VolumeSnapshotInfo contains information for a snapshot
+                  properties:
+                    creationTime:
+                      description: |-
+                        creationTime is the timestamp when the point-in-time snapshot is taken
+                        by the underlying storage system.
+                      format: int64
+                      type: integer
+                    readyToUse:
+                      description: ReadyToUse indicates if the snapshot is ready to
+                        be used to restore a volume.
+                      type: boolean
+                    restoreSize:
+                      description: |-
+                        RestoreSize represents the minimum size of volume required to create a volume
+                        from this snapshot.
+                      format: int64
+                      type: integer
+                    snapshotHandle:
+                      description: SnapshotHandle is the CSI "snapshot_id" of this
+                        snapshot on the underlying storage system.
+                      type: string
+                    volumeHandle:
+                      description: |-
+                        VolumeHandle specifies the CSI "volume_id" of the volume from which this snapshot
+                        was taken from.
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Indicates if all the individual snapshots in the group are ready
+        to be used to restore a group of volumes.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: Determines whether this VolumeGroupSnapshotContent and its physical
+        group snapshot on the underlying storage system should be deleted when its
+        bound VolumeGroupSnapshot is deleted.
+      jsonPath: .spec.deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - description: Name of the CSI driver used to create the physical group snapshot
+        on the underlying storage system.
+      jsonPath: .spec.driver
+      name: Driver
+      type: string
+    - description: Name of the VolumeGroupSnapshotClass from which this group snapshot
+        was (or will be) created.
+      jsonPath: .spec.volumeGroupSnapshotClassName
+      name: VolumeGroupSnapshotClass
+      type: string
+    - description: Namespace of the VolumeGroupSnapshot object to which this VolumeGroupSnapshotContent
+        object is bound.
+      jsonPath: .spec.volumeGroupSnapshotRef.namespace
+      name: VolumeGroupSnapshotNamespace
+      type: string
+    - description: Name of the VolumeGroupSnapshot object to which this VolumeGroupSnapshotContent
+        object is bound.
+      jsonPath: .spec.volumeGroupSnapshotRef.name
+      name: VolumeGroupSnapshot
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VolumeGroupSnapshotContent represents the actual "on-disk" group snapshot object
+          in the underlying storage system
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Spec defines properties of a VolumeGroupSnapshotContent created by the underlying storage system.
+              Required.
+            properties:
+              deletionPolicy:
+                description: |-
+                  DeletionPolicy determines whether this VolumeGroupSnapshotContent and the
+                  physical group snapshot on the underlying storage system should be deleted
+                  when the bound VolumeGroupSnapshot is deleted.
+                  Supported values are "Retain" and "Delete".
+                  "Retain" means that the VolumeGroupSnapshotContent and its physical group
+                  snapshot on underlying storage system are kept.
+                  "Delete" means that the VolumeGroupSnapshotContent and its physical group
+                  snapshot on underlying storage system are deleted.
+                  For dynamically provisioned group snapshots, this field will automatically
+                  be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field
+                  defined in the corresponding VolumeGroupSnapshotClass.
+                  For pre-existing snapshots, users MUST specify this field when creating the
+                  VolumeGroupSnapshotContent object.
+                  Required.
+                enum:
+                - Delete
+                - Retain
+                type: string
+              driver:
+                description: |-
+                  Driver is the name of the CSI driver used to create the physical group snapshot on
+                  the underlying storage system.
+                  This MUST be the same as the name returned by the CSI GetPluginName() call for
+                  that driver.
+                  Required.
+                type: string
+              source:
+                description: |-
+                  Source specifies whether the snapshot is (or should be) dynamically provisioned
+                  or already exists, and just requires a Kubernetes object representation.
+                  This field is immutable after creation.
+                  Required.
+                properties:
+                  groupSnapshotHandles:
+                    description: |-
+                      GroupSnapshotHandles specifies the CSI "group_snapshot_id" of a pre-existing
+                      group snapshot and a list of CSI "snapshot_id" of pre-existing snapshots
+                      on the underlying storage system for which a Kubernetes object
+                      representation was (or should be) created.
+                      This field is immutable.
+                    properties:
+                      volumeGroupSnapshotHandle:
+                        description: |-
+                          VolumeGroupSnapshotHandle specifies the CSI "group_snapshot_id" of a pre-existing
+                          group snapshot on the underlying storage system for which a Kubernetes object
+                          representation was (or should be) created.
+                          This field is immutable.
+                          Required.
+                        type: string
+                      volumeSnapshotHandles:
+                        description: |-
+                          VolumeSnapshotHandles is a list of CSI "snapshot_id" of pre-existing
+                          snapshots on the underlying storage system for which Kubernetes objects
+                          representation were (or should be) created.
+                          This field is immutable.
+                          Required.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - volumeGroupSnapshotHandle
+                    - volumeSnapshotHandles
+                    type: object
+                    x-kubernetes-validations:
+                    - message: groupSnapshotHandles is immutable
+                      rule: self == oldSelf
+                  volumeHandles:
+                    description: |-
+                      VolumeHandles is a list of volume handles on the backend to be snapshotted
+                      together. It is specified for dynamic provisioning of the VolumeGroupSnapshot.
+                      This field is immutable.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-validations:
+                    - message: volumeHandles is immutable
+                      rule: self == oldSelf
+                type: object
+                x-kubernetes-validations:
+                - message: volumeHandles is required once set
+                  rule: '!has(oldSelf.volumeHandles) || has(self.volumeHandles)'
+                - message: groupSnapshotHandles is required once set
+                  rule: '!has(oldSelf.groupSnapshotHandles) || has(self.groupSnapshotHandles)'
+                - message: exactly one of volumeHandles and groupSnapshotHandles must
+                    be set
+                  rule: (has(self.volumeHandles) && !has(self.groupSnapshotHandles))
+                    || (!has(self.volumeHandles) && has(self.groupSnapshotHandles))
+              volumeGroupSnapshotClassName:
+                description: |-
+                  VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass from
+                  which this group snapshot was (or will be) created.
+                  Note that after provisioning, the VolumeGroupSnapshotClass may be deleted or
+                  recreated with different set of values, and as such, should not be referenced
+                  post-snapshot creation.
+                  For dynamic provisioning, this field must be set.
+                  This field may be unset for pre-provisioned snapshots.
+                type: string
+              volumeGroupSnapshotRef:
+                description: |-
+                  VolumeGroupSnapshotRef specifies the VolumeGroupSnapshot object to which this
+                  VolumeGroupSnapshotContent object is bound.
+                  VolumeGroupSnapshot.Spec.VolumeGroupSnapshotContentName field must reference to
+                  this VolumeGroupSnapshotContent's name for the bidirectional binding to be valid.
+                  For a pre-existing VolumeGroupSnapshotContent object, name and namespace of the
+                  VolumeGroupSnapshot object MUST be provided for binding to happen.
+                  This field is immutable after creation.
+                  Required.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: both volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace
+                    must be set
+                  rule: has(self.name) && has(self.__namespace__)
+            required:
+            - deletionPolicy
+            - driver
+            - source
+            - volumeGroupSnapshotRef
+            type: object
+          status:
+            description: status represents the current information of a group snapshot.
+            properties:
+              creationTime:
+                description: |-
+                  CreationTime is the timestamp when the point-in-time group snapshot is taken
+                  by the underlying storage system.
+                  If not specified, it indicates the creation time is unknown.
+                  If not specified, it means the readiness of a group snapshot is unknown.
+                  The format of this field is a Unix nanoseconds time encoded as an int64.
+                  On Unix, the command date +%s%N returns the current time in nanoseconds
+                  since 1970-01-01 00:00:00 UTC.
+                  This field is the source for the CreationTime field in VolumeGroupSnapshotStatus
+                format: date-time
+                type: string
+              error:
+                description: |-
+                  Error is the last observed error during group snapshot creation, if any.
+                  Upon success after retry, this error field will be cleared.
+                properties:
+                  message:
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
+                    type: string
+                  time:
+                    description: time is the timestamp when the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              readyToUse:
+                description: |-
+                  ReadyToUse indicates if all the individual snapshots in the group are ready to be
+                  used to restore a group of volumes.
+                  ReadyToUse becomes true when ReadyToUse of all individual snapshots become true.
+                type: boolean
+              volumeGroupSnapshotHandle:
+                description: |-
+                  VolumeGroupSnapshotHandle is a unique id returned by the CSI driver
+                  to identify the VolumeGroupSnapshot on the storage system.
+                  If a storage system does not provide such an id, the
+                  CSI driver can choose to return the VolumeGroupSnapshot name.
+                type: string
+              volumeSnapshotHandlePairList:
+                description: |-
+                  VolumeSnapshotHandlePairList is a list of CSI "volume_id" and "snapshot_id"
+                  pair returned by the CSI driver to identify snapshots and their source volumes
+                  on the storage system.
+                items:
+                  description: VolumeSnapshotHandlePair defines a pair of a source
+                    volume handle and a snapshot handle
+                  properties:
+                    snapshotHandle:
+                      description: |-
+                        SnapshotHandle is a unique id returned by the CSI driver to identify a volume
+                        snapshot on the storage system
+                        Required.
+                      type: string
+                    volumeHandle:
+                      description: |-
+                        VolumeHandle is a unique id returned by the CSI driver to identify a volume
+                        on the storage system
+                        Required.
+                      type: string
+                  required:
+                  - snapshotHandle
+                  - volumeHandle
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Indicates if all the individual snapshots in the group are ready
+        to be used to restore a group of volumes.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: Determines whether this VolumeGroupSnapshotContent and its physical
+        group snapshot on the underlying storage system should be deleted when its
+        bound VolumeGroupSnapshot is deleted.
+      jsonPath: .spec.deletionPolicy
+      name: DeletionPolicy
+      type: string
+    - description: Name of the CSI driver used to create the physical group snapshot
+        on the underlying storage system.
+      jsonPath: .spec.driver
+      name: Driver
+      type: string
+    - description: Name of the VolumeGroupSnapshotClass from which this group snapshot
+        was (or will be) created.
+      jsonPath: .spec.volumeGroupSnapshotClassName
+      name: VolumeGroupSnapshotClass
+      type: string
+    - description: Namespace of the VolumeGroupSnapshot object to which this VolumeGroupSnapshotContent
+        object is bound.
+      jsonPath: .spec.volumeGroupSnapshotRef.namespace
+      name: VolumeGroupSnapshotNamespace
+      type: string
+    - description: Name of the VolumeGroupSnapshot object to which this VolumeGroupSnapshotContent
+        object is bound.
+      jsonPath: .spec.volumeGroupSnapshotRef.name
+      name: VolumeGroupSnapshot
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VolumeGroupSnapshotContent represents the actual "on-disk" group snapshot object
+          in the underlying storage system
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Spec defines properties of a VolumeGroupSnapshotContent created by the underlying storage system.
+              Required.
+            properties:
+              deletionPolicy:
+                description: |-
+                  DeletionPolicy determines whether this VolumeGroupSnapshotContent and the
+                  physical group snapshot on the underlying storage system should be deleted
+                  when the bound VolumeGroupSnapshot is deleted.
+                  Supported values are "Retain" and "Delete".
+                  "Retain" means that the VolumeGroupSnapshotContent and its physical group
+                  snapshot on underlying storage system are kept.
+                  "Delete" means that the VolumeGroupSnapshotContent and its physical group
+                  snapshot on underlying storage system are deleted.
+                  For dynamically provisioned group snapshots, this field will automatically
+                  be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field
+                  defined in the corresponding VolumeGroupSnapshotClass.
+                  For pre-existing snapshots, users MUST specify this field when creating the
+                  VolumeGroupSnapshotContent object.
+                  Required.
+                enum:
+                - Delete
+                - Retain
+                type: string
+              driver:
+                description: |-
+                  Driver is the name of the CSI driver used to create the physical group snapshot on
+                  the underlying storage system.
+                  This MUST be the same as the name returned by the CSI GetPluginName() call for
+                  that driver.
+                  Required.
+                type: string
+                x-kubernetes-validations:
+                - message: driver is immutable once set
+                  rule: self == oldSelf
+              source:
+                description: |-
+                  Source specifies whether the snapshot is (or should be) dynamically provisioned
+                  or already exists, and just requires a Kubernetes object representation.
+                  This field is immutable after creation.
+                  Required.
+                properties:
+                  groupSnapshotHandles:
+                    description: |-
+                      GroupSnapshotHandles specifies the CSI "group_snapshot_id" of a pre-existing
+                      group snapshot and a list of CSI "snapshot_id" of pre-existing snapshots
+                      on the underlying storage system for which a Kubernetes object
+                      representation was (or should be) created.
+                      This field is immutable.
+                    properties:
+                      volumeGroupSnapshotHandle:
+                        description: |-
+                          VolumeGroupSnapshotHandle specifies the CSI "group_snapshot_id" of a pre-existing
+                          group snapshot on the underlying storage system for which a Kubernetes object
+                          representation was (or should be) created.
+                          This field is immutable.
+                          Required.
+                        type: string
+                      volumeSnapshotHandles:
+                        description: |-
+                          VolumeSnapshotHandles is a list of CSI "snapshot_id" of pre-existing
+                          snapshots on the underlying storage system for which Kubernetes objects
+                          representation were (or should be) created.
+                          This field is immutable.
+                          Required.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - volumeGroupSnapshotHandle
+                    - volumeSnapshotHandles
+                    type: object
+                    x-kubernetes-validations:
+                    - message: groupSnapshotHandles is immutable
+                      rule: self == oldSelf
+                  volumeHandles:
+                    description: |-
+                      VolumeHandles is a list of volume handles on the backend to be snapshotted
+                      together. It is specified for dynamic provisioning of the VolumeGroupSnapshot.
+                      This field is immutable.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-validations:
+                    - message: volumeHandles is immutable
+                      rule: self == oldSelf
+                type: object
+                x-kubernetes-validations:
+                - message: volumeHandles is required once set
+                  rule: '!has(oldSelf.volumeHandles) || has(self.volumeHandles)'
+                - message: groupSnapshotHandles is required once set
+                  rule: '!has(oldSelf.groupSnapshotHandles) || has(self.groupSnapshotHandles)'
+                - message: exactly one of volumeHandles and groupSnapshotHandles must
+                    be set
+                  rule: (has(self.volumeHandles) && !has(self.groupSnapshotHandles))
+                    || (!has(self.volumeHandles) && has(self.groupSnapshotHandles))
+              volumeGroupSnapshotClassName:
+                description: |-
+                  VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass from
+                  which this group snapshot was (or will be) created.
+                  Note that after provisioning, the VolumeGroupSnapshotClass may be deleted or
+                  recreated with different set of values, and as such, should not be referenced
+                  post-snapshot creation.
+                  For dynamic provisioning, this field must be set.
+                  This field may be unset for pre-provisioned snapshots.
+                type: string
+                x-kubernetes-validations:
+                - message: volumeGroupSnapshotClassName is immutable once set
+                  rule: self == oldSelf
+              volumeGroupSnapshotRef:
+                description: |-
+                  VolumeGroupSnapshotRef specifies the VolumeGroupSnapshot object to which this
+                  VolumeGroupSnapshotContent object is bound.
+                  VolumeGroupSnapshot.Spec.VolumeGroupSnapshotContentName field must reference to
+                  this VolumeGroupSnapshotContent's name for the bidirectional binding to be valid.
+                  For a pre-existing VolumeGroupSnapshotContent object, name and namespace of the
+                  VolumeGroupSnapshot object MUST be provided for binding to happen.
+                  This field is immutable after creation.
+                  Required.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+                x-kubernetes-validations:
+                - message: both volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace
+                    must be set
+                  rule: has(self.name) && has(self.__namespace__)
+                - message: volumeGroupSnapshotRef.name and volumeGroupSnapshotRef.namespace
+                    are immutable
+                  rule: self.name == oldSelf.name && self.__namespace__ == oldSelf.__namespace__
+                - message: volumeGroupSnapshotRef.uid is immutable once set
+                  rule: '!has(oldSelf.uid) || (has(self.uid) && self.uid == oldSelf.uid)'
+            required:
+            - deletionPolicy
+            - driver
+            - source
+            - volumeGroupSnapshotRef
+            type: object
+          status:
+            description: status represents the current information of a group snapshot.
+            properties:
+              creationTime:
+                description: |-
+                  CreationTime is the timestamp when the point-in-time group snapshot is taken
+                  by the underlying storage system.
+                  If not specified, it indicates the creation time is unknown.
+                  If not specified, it means the readiness of a group snapshot is unknown.
+                  This field is the source for the CreationTime field in VolumeGroupSnapshotStatus
+                format: date-time
+                type: string
+              error:
+                description: |-
+                  Error is the last observed error during group snapshot creation, if any.
+                  Upon success after retry, this error field will be cleared.
+                properties:
+                  message:
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
+                    type: string
+                  time:
+                    description: time is the timestamp when the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              readyToUse:
+                description: |-
+                  ReadyToUse indicates if all the individual snapshots in the group are ready to be
+                  used to restore a group of volumes.
+                  ReadyToUse becomes true when ReadyToUse of all individual snapshots become true.
+                type: boolean
+              volumeGroupSnapshotHandle:
+                description: |-
+                  VolumeGroupSnapshotHandle is a unique id returned by the CSI driver
+                  to identify the VolumeGroupSnapshot on the storage system.
+                  If a storage system does not provide such an id, the
+                  CSI driver can choose to return the VolumeGroupSnapshot name.
+                type: string
+                x-kubernetes-validations:
+                - message: volumeGroupSnapshotHandle is immutable once set
+                  rule: self == oldSelf
+              volumeSnapshotInfoList:
+                description: |-
+                  This field is introduced in v1beta2
+                  It is replacing VolumeSnapshotHandlePairList
+                  VolumeSnapshotInfoList is a list of snapshot information returned by
+                  by the CSI driver to identify snapshots on the storage system.
+                items:
+                  description: |-
+                    The VolumeSnapshotInfo struct is added in v1beta2
+                    VolumeSnapshotInfo contains information for a snapshot
+                  properties:
+                    creationTime:
+                      description: |-
+                        creationTime is the timestamp when the point-in-time snapshot is taken
+                        by the underlying storage system.
+                      format: int64
+                      type: integer
+                    readyToUse:
+                      description: ReadyToUse indicates if the snapshot is ready to
+                        be used to restore a volume.
+                      type: boolean
+                    restoreSize:
+                      description: |-
+                        RestoreSize represents the minimum size of volume required to create a volume
+                        from this snapshot.
+                      format: int64
+                      type: integer
+                    snapshotHandle:
+                      description: SnapshotHandle is the CSI "snapshot_id" of this
+                        snapshot on the underlying storage system.
+                      type: string
+                    volumeHandle:
+                      description: |-
+                        VolumeHandle specifies the CSI "volume_id" of the volume from which this snapshot
+                        was taken from.
+                      type: string
+                  type: object
+                type: array
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster/addons/volumesnapshots/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
+++ b/cluster/addons/volumesnapshots/crd/groupsnapshot.storage.k8s.io_volumegroupsnapshots.yaml
@@ -1,0 +1,682 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+  annotations:
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/1337"
+    controller-gen.kubebuilder.io/version: v0.15.0
+  name: volumegroupsnapshots.groupsnapshot.storage.k8s.io
+spec:
+  group: groupsnapshot.storage.k8s.io
+  names:
+    kind: VolumeGroupSnapshot
+    listKind: VolumeGroupSnapshotList
+    plural: volumegroupsnapshots
+    shortNames:
+    - vgs
+    singular: volumegroupsnapshot
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Indicates if all the individual snapshots in the group are ready
+        to be used to restore a group of volumes.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: The name of the VolumeGroupSnapshotClass requested by the VolumeGroupSnapshot.
+      jsonPath: .spec.volumeGroupSnapshotClassName
+      name: VolumeGroupSnapshotClass
+      type: string
+    - description: Name of the VolumeGroupSnapshotContent object to which the VolumeGroupSnapshot
+        object intends to bind to. Please note that verification of binding actually
+        requires checking both VolumeGroupSnapshot and VolumeGroupSnapshotContent
+        to ensure both are pointing at each other. Binding MUST be verified prior
+        to usage of this object.
+      jsonPath: .status.boundVolumeGroupSnapshotContentName
+      name: VolumeGroupSnapshotContent
+      type: string
+    - description: Timestamp when the point-in-time group snapshot was taken by the
+        underlying storage system.
+      jsonPath: .status.creationTime
+      name: CreationTime
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VolumeGroupSnapshot is a user's request for creating either a point-in-time
+          group snapshot or binding to a pre-existing group snapshot.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Spec defines the desired characteristics of a group snapshot requested by a user.
+              Required.
+            properties:
+              source:
+                description: |-
+                  Source specifies where a group snapshot will be created from.
+                  This field is immutable after creation.
+                  Required.
+                properties:
+                  selector:
+                    description: |-
+                      Selector is a label query over persistent volume claims that are to be
+                      grouped together for snapshotting.
+                      This labelSelector will be used to match the label added to a PVC.
+                      If the label is added or removed to a volume after a group snapshot
+                      is created, the existing group snapshots won't be modified.
+                      Once a VolumeGroupSnapshotContent is created and the sidecar starts to process
+                      it, the volume list will not change with retries.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                    - message: selector is immutable
+                      rule: self == oldSelf
+                  volumeGroupSnapshotContentName:
+                    description: |-
+                      VolumeGroupSnapshotContentName specifies the name of a pre-existing VolumeGroupSnapshotContent
+                      object representing an existing volume group snapshot.
+                      This field should be set if the volume group snapshot already exists and
+                      only needs a representation in Kubernetes.
+                      This field is immutable.
+                    type: string
+                    x-kubernetes-validations:
+                    - message: volumeGroupSnapshotContentName is immutable
+                      rule: self == oldSelf
+                type: object
+                x-kubernetes-validations:
+                - message: selector is required once set
+                  rule: '!has(oldSelf.selector) || has(self.selector)'
+                - message: volumeGroupSnapshotContentName is required once set
+                  rule: '!has(oldSelf.volumeGroupSnapshotContentName) || has(self.volumeGroupSnapshotContentName)'
+                - message: exactly one of selector and volumeGroupSnapshotContentName
+                    must be set
+                  rule: (has(self.selector) && !has(self.volumeGroupSnapshotContentName))
+                    || (!has(self.selector) && has(self.volumeGroupSnapshotContentName))
+              volumeGroupSnapshotClassName:
+                description: |-
+                  VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass
+                  requested by the VolumeGroupSnapshot.
+                  VolumeGroupSnapshotClassName may be left nil to indicate that the default
+                  class will be used.
+                  Empty string is not allowed for this field.
+                type: string
+                x-kubernetes-validations:
+                - message: volumeGroupSnapshotClassName must not be the empty string
+                    when set
+                  rule: size(self) > 0
+            required:
+            - source
+            type: object
+          status:
+            description: |-
+              Status represents the current information of a group snapshot.
+              Consumers must verify binding between VolumeGroupSnapshot and
+              VolumeGroupSnapshotContent objects is successful (by validating that both
+              VolumeGroupSnapshot and VolumeGroupSnapshotContent point to each other) before
+              using this object.
+            properties:
+              boundVolumeGroupSnapshotContentName:
+                description: |-
+                  BoundVolumeGroupSnapshotContentName is the name of the VolumeGroupSnapshotContent
+                  object to which this VolumeGroupSnapshot object intends to bind to.
+                  If not specified, it indicates that the VolumeGroupSnapshot object has not
+                  been successfully bound to a VolumeGroupSnapshotContent object yet.
+                  NOTE: To avoid possible security issues, consumers must verify binding between
+                  VolumeGroupSnapshot and VolumeGroupSnapshotContent objects is successful
+                  (by validating that both VolumeGroupSnapshot and VolumeGroupSnapshotContent
+                  point at each other) before using this object.
+                type: string
+                x-kubernetes-validations:
+                - message: boundVolumeGroupSnapshotContentName is immutable once set
+                  rule: self == oldSelf
+              creationTime:
+                description: |-
+                  CreationTime is the timestamp when the point-in-time group snapshot is taken
+                  by the underlying storage system.
+                  If not specified, it may indicate that the creation time of the group snapshot
+                  is unknown.
+                  This field is updated based on the CreationTime field in VolumeGroupSnapshotContentStatus
+                format: date-time
+                type: string
+              error:
+                description: |-
+                  Error is the last observed error during group snapshot creation, if any.
+                  This field could be helpful to upper level controllers (i.e., application
+                  controller) to decide whether they should continue on waiting for the group
+                  snapshot to be created based on the type of error reported.
+                  The snapshot controller will keep retrying when an error occurs during the
+                  group snapshot creation. Upon success, this error field will be cleared.
+                properties:
+                  message:
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
+                    type: string
+                  time:
+                    description: time is the timestamp when the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              readyToUse:
+                description: |-
+                  ReadyToUse indicates if all the individual snapshots in the group are ready
+                  to be used to restore a group of volumes.
+                  ReadyToUse becomes true when ReadyToUse of all individual snapshots become true.
+                  If not specified, it means the readiness of a group snapshot is unknown.
+                type: boolean
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Indicates if all the individual snapshots in the group are ready
+        to be used to restore a group of volumes.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: The name of the VolumeGroupSnapshotClass requested by the VolumeGroupSnapshot.
+      jsonPath: .spec.volumeGroupSnapshotClassName
+      name: VolumeGroupSnapshotClass
+      type: string
+    - description: Name of the VolumeGroupSnapshotContent object to which the VolumeGroupSnapshot
+        object intends to bind to. Please note that verification of binding actually
+        requires checking both VolumeGroupSnapshot and VolumeGroupSnapshotContent
+        to ensure both are pointing at each other. Binding MUST be verified prior
+        to usage of this object.
+      jsonPath: .status.boundVolumeGroupSnapshotContentName
+      name: VolumeGroupSnapshotContent
+      type: string
+    - description: Timestamp when the point-in-time group snapshot was taken by the
+        underlying storage system.
+      jsonPath: .status.creationTime
+      name: CreationTime
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VolumeGroupSnapshot is a user's request for creating either a point-in-time
+          group snapshot or binding to a pre-existing group snapshot.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Spec defines the desired characteristics of a group snapshot requested by a user.
+              Required.
+            properties:
+              source:
+                description: |-
+                  Source specifies where a group snapshot will be created from.
+                  This field is immutable after creation.
+                  Required.
+                properties:
+                  selector:
+                    description: |-
+                      Selector is a label query over persistent volume claims that are to be
+                      grouped together for snapshotting.
+                      This labelSelector will be used to match the label added to a PVC.
+                      If the label is added or removed to a volume after a group snapshot
+                      is created, the existing group snapshots won't be modified.
+                      Once a VolumeGroupSnapshotContent is created and the sidecar starts to process
+                      it, the volume list will not change with retries.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                    - message: selector is immutable
+                      rule: self == oldSelf
+                  volumeGroupSnapshotContentName:
+                    description: |-
+                      VolumeGroupSnapshotContentName specifies the name of a pre-existing VolumeGroupSnapshotContent
+                      object representing an existing volume group snapshot.
+                      This field should be set if the volume group snapshot already exists and
+                      only needs a representation in Kubernetes.
+                      This field is immutable.
+                    type: string
+                    x-kubernetes-validations:
+                    - message: volumeGroupSnapshotContentName is immutable
+                      rule: self == oldSelf
+                type: object
+                x-kubernetes-validations:
+                - message: selector is required once set
+                  rule: '!has(oldSelf.selector) || has(self.selector)'
+                - message: volumeGroupSnapshotContentName is required once set
+                  rule: '!has(oldSelf.volumeGroupSnapshotContentName) || has(self.volumeGroupSnapshotContentName)'
+                - message: exactly one of selector and volumeGroupSnapshotContentName
+                    must be set
+                  rule: (has(self.selector) && !has(self.volumeGroupSnapshotContentName))
+                    || (!has(self.selector) && has(self.volumeGroupSnapshotContentName))
+              volumeGroupSnapshotClassName:
+                description: |-
+                  VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass
+                  requested by the VolumeGroupSnapshot.
+                  VolumeGroupSnapshotClassName may be left nil to indicate that the default
+                  class will be used.
+                  Empty string is not allowed for this field.
+                type: string
+                x-kubernetes-validations:
+                - message: volumeGroupSnapshotClassName must not be the empty string
+                    when set
+                  rule: size(self) > 0
+            required:
+            - source
+            type: object
+          status:
+            description: |-
+              Status represents the current information of a group snapshot.
+              Consumers must verify binding between VolumeGroupSnapshot and
+              VolumeGroupSnapshotContent objects is successful (by validating that both
+              VolumeGroupSnapshot and VolumeGroupSnapshotContent point to each other) before
+              using this object.
+            properties:
+              boundVolumeGroupSnapshotContentName:
+                description: |-
+                  BoundVolumeGroupSnapshotContentName is the name of the VolumeGroupSnapshotContent
+                  object to which this VolumeGroupSnapshot object intends to bind to.
+                  If not specified, it indicates that the VolumeGroupSnapshot object has not
+                  been successfully bound to a VolumeGroupSnapshotContent object yet.
+                  NOTE: To avoid possible security issues, consumers must verify binding between
+                  VolumeGroupSnapshot and VolumeGroupSnapshotContent objects is successful
+                  (by validating that both VolumeGroupSnapshot and VolumeGroupSnapshotContent
+                  point at each other) before using this object.
+                type: string
+              creationTime:
+                description: |-
+                  CreationTime is the timestamp when the point-in-time group snapshot is taken
+                  by the underlying storage system.
+                  If not specified, it may indicate that the creation time of the group snapshot
+                  is unknown.
+                  The format of this field is a Unix nanoseconds time encoded as an int64.
+                  On Unix, the command date +%s%N returns the current time in nanoseconds
+                  since 1970-01-01 00:00:00 UTC.
+                  This field is updated based on the CreationTime field in VolumeGroupSnapshotContentStatus
+                format: date-time
+                type: string
+              error:
+                description: |-
+                  Error is the last observed error during group snapshot creation, if any.
+                  This field could be helpful to upper level controllers (i.e., application
+                  controller) to decide whether they should continue on waiting for the group
+                  snapshot to be created based on the type of error reported.
+                  The snapshot controller will keep retrying when an error occurs during the
+                  group snapshot creation. Upon success, this error field will be cleared.
+                properties:
+                  message:
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
+                    type: string
+                  time:
+                    description: time is the timestamp when the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              readyToUse:
+                description: |-
+                  ReadyToUse indicates if all the individual snapshots in the group are ready
+                  to be used to restore a group of volumes.
+                  ReadyToUse becomes true when ReadyToUse of all individual snapshots become true.
+                  If not specified, it means the readiness of a group snapshot is unknown.
+                type: boolean
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Indicates if all the individual snapshots in the group are ready
+        to be used to restore a group of volumes.
+      jsonPath: .status.readyToUse
+      name: ReadyToUse
+      type: boolean
+    - description: The name of the VolumeGroupSnapshotClass requested by the VolumeGroupSnapshot.
+      jsonPath: .spec.volumeGroupSnapshotClassName
+      name: VolumeGroupSnapshotClass
+      type: string
+    - description: Name of the VolumeGroupSnapshotContent object to which the VolumeGroupSnapshot
+        object intends to bind to. Please note that verification of binding actually
+        requires checking both VolumeGroupSnapshot and VolumeGroupSnapshotContent
+        to ensure both are pointing at each other. Binding MUST be verified prior
+        to usage of this object.
+      jsonPath: .status.boundVolumeGroupSnapshotContentName
+      name: VolumeGroupSnapshotContent
+      type: string
+    - description: Timestamp when the point-in-time group snapshot was taken by the
+        underlying storage system.
+      jsonPath: .status.creationTime
+      name: CreationTime
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VolumeGroupSnapshot is a user's request for creating either a point-in-time
+          group snapshot or binding to a pre-existing group snapshot.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Spec defines the desired characteristics of a group snapshot requested by a user.
+              Required.
+            properties:
+              source:
+                description: |-
+                  Source specifies where a group snapshot will be created from.
+                  This field is immutable after creation.
+                  Required.
+                properties:
+                  selector:
+                    description: |-
+                      Selector is a label query over persistent volume claims that are to be
+                      grouped together for snapshotting.
+                      This labelSelector will be used to match the label added to a PVC.
+                      If the label is added or removed to a volume after a group snapshot
+                      is created, the existing group snapshots won't be modified.
+                      Once a VolumeGroupSnapshotContent is created and the sidecar starts to process
+                      it, the volume list will not change with retries.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                    - message: selector is immutable
+                      rule: self == oldSelf
+                  volumeGroupSnapshotContentName:
+                    description: |-
+                      VolumeGroupSnapshotContentName specifies the name of a pre-existing VolumeGroupSnapshotContent
+                      object representing an existing volume group snapshot.
+                      This field should be set if the volume group snapshot already exists and
+                      only needs a representation in Kubernetes.
+                      This field is immutable.
+                    type: string
+                    x-kubernetes-validations:
+                    - message: volumeGroupSnapshotContentName is immutable
+                      rule: self == oldSelf
+                type: object
+                x-kubernetes-validations:
+                - message: selector is required once set
+                  rule: '!has(oldSelf.selector) || has(self.selector)'
+                - message: volumeGroupSnapshotContentName is required once set
+                  rule: '!has(oldSelf.volumeGroupSnapshotContentName) || has(self.volumeGroupSnapshotContentName)'
+                - message: exactly one of selector and volumeGroupSnapshotContentName
+                    must be set
+                  rule: (has(self.selector) && !has(self.volumeGroupSnapshotContentName))
+                    || (!has(self.selector) && has(self.volumeGroupSnapshotContentName))
+              volumeGroupSnapshotClassName:
+                description: |-
+                  VolumeGroupSnapshotClassName is the name of the VolumeGroupSnapshotClass
+                  requested by the VolumeGroupSnapshot.
+                  VolumeGroupSnapshotClassName may be left nil to indicate that the default
+                  class will be used.
+                  Empty string is not allowed for this field.
+                type: string
+                x-kubernetes-validations:
+                - message: volumeGroupSnapshotClassName must not be the empty string
+                    when set
+                  rule: size(self) > 0
+            required:
+            - source
+            type: object
+          status:
+            description: |-
+              Status represents the current information of a group snapshot.
+              Consumers must verify binding between VolumeGroupSnapshot and
+              VolumeGroupSnapshotContent objects is successful (by validating that both
+              VolumeGroupSnapshot and VolumeGroupSnapshotContent point to each other) before
+              using this object.
+            properties:
+              boundVolumeGroupSnapshotContentName:
+                description: |-
+                  BoundVolumeGroupSnapshotContentName is the name of the VolumeGroupSnapshotContent
+                  object to which this VolumeGroupSnapshot object intends to bind to.
+                  If not specified, it indicates that the VolumeGroupSnapshot object has not
+                  been successfully bound to a VolumeGroupSnapshotContent object yet.
+                  NOTE: To avoid possible security issues, consumers must verify binding between
+                  VolumeGroupSnapshot and VolumeGroupSnapshotContent objects is successful
+                  (by validating that both VolumeGroupSnapshot and VolumeGroupSnapshotContent
+                  point at each other) before using this object.
+                type: string
+                x-kubernetes-validations:
+                - message: boundVolumeGroupSnapshotContentName is immutable once set
+                  rule: self == oldSelf
+              creationTime:
+                description: |-
+                  CreationTime is the timestamp when the point-in-time group snapshot is taken
+                  by the underlying storage system.
+                  If not specified, it may indicate that the creation time of the group snapshot
+                  is unknown.
+                  This field is updated based on the CreationTime field in VolumeGroupSnapshotContentStatus
+                format: date-time
+                type: string
+              error:
+                description: |-
+                  Error is the last observed error during group snapshot creation, if any.
+                  This field could be helpful to upper level controllers (i.e., application
+                  controller) to decide whether they should continue on waiting for the group
+                  snapshot to be created based on the type of error reported.
+                  The snapshot controller will keep retrying when an error occurs during the
+                  group snapshot creation. Upon success, this error field will be cleared.
+                properties:
+                  message:
+                    description: |-
+                      message is a string detailing the encountered error during snapshot
+                      creation if specified.
+                      NOTE: message may be logged, and it should not contain sensitive
+                      information.
+                    type: string
+                  time:
+                    description: time is the timestamp when the error was encountered.
+                    format: date-time
+                    type: string
+                type: object
+              readyToUse:
+                description: |-
+                  ReadyToUse indicates if all the individual snapshots in the group are ready
+                  to be used to restore a group of volumes.
+                  ReadyToUse becomes true when ReadyToUse of all individual snapshots become true.
+                  If not specified, it means the readiness of a group snapshot is unknown.
+                type: boolean
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/cluster/addons/volumesnapshots/volume-snapshot-controller/rbac-volume-snapshot-controller.yaml
+++ b/cluster/addons/volumesnapshots/volume-snapshot-controller/rbac-volume-snapshot-controller.yaml
@@ -1,4 +1,6 @@
 # RBAC file for the volume snapshot controller.
+# Source: https://github.com/kubernetes-csi/external-snapshotter/tree/master/deploy/kubernetes/snapshot-controller
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -24,9 +26,6 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "watch", "update"]
-  - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
-    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
@@ -38,17 +37,28 @@ rules:
     verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots/status"]
     verbs: ["update", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents/status"]
     verbs: ["patch"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create", "list", "watch", "delete", "get", "update"]
-
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshotcontents/status"]
+    verbs: ["patch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshots"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["groupsnapshot.storage.k8s.io"]
+    resources: ["volumegroupsnapshots/status"]
+    verbs: ["update", "patch"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
+++ b/cluster/addons/volumesnapshots/volume-snapshot-controller/volume-snapshot-controller-deployment.yaml
@@ -27,3 +27,4 @@ spec:
             - "--v=5"
             - "--metrics-path=/metrics"
             - "--http-endpoint=:9102"
+            - "--feature-gates=CSIVolumeGroupSnapshot=true"

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -163,6 +163,7 @@ func InitHostPathCSIDriver() storageframework.TestDriver {
 		storageframework.CapReadWriteOncePod:               true,
 		storageframework.CapMultiplePVsSameID:              true,
 		storageframework.CapFSResizeFromSourceNotSupported: true,
+		storageframework.CapVolumeGroupSnapshot:            true,
 		// There are extensive tests that NodeStage / NodePublish are called with -o context in csimock/csi_selinux_mount.go,
 		// but the csi-driver-hostpath can't physically make -o context to appear in the mount table that the CapSELinuxMount tests expect.
 		storageframework.CapSELinuxMount: false,
@@ -172,10 +173,6 @@ func InitHostPathCSIDriver() storageframework.TestDriver {
 		// test. --maxvolumespernode=10 gets
 		// added when patching the deployment.
 		storageframework.CapVolumeLimits: true,
-	}
-	// TODO: It can be removed after the VolumeGroupSnapshot feature is default enabled
-	if os.Getenv("CSI_PROW_ENABLE_GROUP_SNAPSHOT") == "true" {
-		capabilities[storageframework.CapVolumeGroupSnapshot] = true
 	}
 	if os.Getenv("CSI_PROW_ENABLE_SNAPSHOT_METADATA") == "true" {
 		capabilities[storageframework.CapSnapshotMetadata] = true
@@ -305,14 +302,13 @@ func (h *hostpathCSIDriver) PrepareTest(ctx context.Context, f *framework.Framew
 		DriverContainerArguments: []string{"--feature-gates=VolumeAttributesClass=true"},
 	})
 
-	// VGS E2E FeatureGate patches
-	// TODO: These can be removed after the VolumeGroupSnapshot feature is default enabled
-	if os.Getenv("CSI_PROW_ENABLE_GROUP_SNAPSHOT") == "true" {
-		patches = append(patches, utils.PatchCSIOptions{
-			DriverContainerName:      "csi-snapshotter",
-			DriverContainerArguments: []string{"--feature-gates=CSIVolumeGroupSnapshot=true"},
-		})
-	}
+	// VolumeGroupSnapshot feature E2E patches
+	// It is GA in Kubernetes, just the feature gate is erroneously disabled by default.
+	// TODO: remove this after the feature gate is enabled by default.
+	patches = append(patches, utils.PatchCSIOptions{
+		DriverContainerName:      "csi-snapshotter",
+		DriverContainerArguments: []string{"--feature-gates=CSIVolumeGroupSnapshot=true"},
+	})
 
 	// SnapshotMetadata feature E2E patches
 	// TODO: These can be removed after the SnapshotMetadata feature is default enabled


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Volume group snapshots are GA in Kubernetes 1.36 and the external-snapshotter 8.6. Sync their RBACs and CRDs from the external-snapshotter v8.6.0 and enable them in all test configurations / jobs.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
Volume group snapshot is GA in the external-snapshotter and snapshot-controller, however, it's still off by default. So I explicitly enabled it on command line of both components.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
