### PR TITLE
Add a wait for 2 ReplicaSets to show up in test-cmd

### DIFF
--- a/test/cmd/apps.sh
+++ b/test/cmd/apps.sh
@@ -479,6 +479,7 @@ run_deployment_tests() {
   kube::test::get_object_assert deployment "{{range.items}}{{${image_field1:?}}}:{{end}}" "${IMAGE_PERL}:"
   # Set the deployment's image
   kubectl set image deployment nginx-deployment nginx="${IMAGE_DEPLOYMENT_R2}" "${kube_flags[@]:?}"
+  kube::test::wait_object_assert rs "{{(len .items)}}" '2'
   kube::test::get_object_assert deployment "{{range.items}}{{${image_field0:?}}}:{{end}}" "${IMAGE_DEPLOYMENT_R2}:"
   kube::test::get_object_assert deployment "{{range.items}}{{${image_field1:?}}}:{{end}}" "${IMAGE_PERL}:"
   # Get rollout history


### PR DESCRIPTION
#### What type of PR is this?
/kind flake
/sig cli

#### What this PR does / why we need it:
In https://github.com/kubernetes/kubernetes/blob/52ba90138eb40cab0987dac73e05c838149bdd1c/test/cmd/apps.sh#L481-L486 we modify deployment's image and immediately after check its rollout history. In some cases as reported in https://github.com/kubernetes/kubernetes/issues/141356 this will cause the 2nd version of deployment not to show up:
```
apps.sh:483: Successful get deployment {{range.items}}{{(index .spec.template.spec.containers 
...
FAIL!
deployment.apps/nginx-deployment 
REVISION  CHANGE-CAUSE
1         <none>
has not:2         <none>
```

Adding a wait for 2 ReplicaSets after setting the image should alleviate that temporary problem. 

#### Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/141356

#### Special notes for your reviewer:
/assign @ardaguclu 

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
