### PR TITLE
Resolve admission policy CRD paramKinds from CRD informer

### DIFF
--- a/cmd/kube-apiserver/app/config.go
+++ b/cmd/kube-apiserver/app/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/util/webhook"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane"
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver"
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
+	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 )
 
 type Config struct {
@@ -41,6 +43,7 @@ type Config struct {
 }
 
 type ExtraConfig struct {
+	kubeAdmissionPluginInitializer *kubeapiserveradmission.PluginInitializer
 }
 
 type completedConfig struct {
@@ -87,11 +90,12 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 
-	kubeAPIs, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(opts, genericConfig, versionedInformers, storageFactory)
+	kubeAPIs, serviceResolver, pluginInitializer, kubeAdmissionPluginInitializer, err := createKubeAPIServerConfig(opts, genericConfig, versionedInformers, storageFactory)
 	if err != nil {
 		return nil, err
 	}
 	c.KubeAPIs = kubeAPIs
+	c.ExtraConfig.kubeAdmissionPluginInitializer = kubeAdmissionPluginInitializer
 
 	apiExtensions, err := controlplaneapiserver.CreateAPIExtensionsConfig(*kubeAPIs.ControlPlane.Generic, kubeAPIs.ControlPlane.VersionedInformers, pluginInitializer, opts.CompletedOptions, opts.MasterCount,
 		serviceResolver, webhook.NewDefaultAuthenticationInfoResolverWrapper(kubeAPIs.ControlPlane.ProxyTransport, kubeAPIs.ControlPlane.Generic.EgressSelector, kubeAPIs.ControlPlane.Generic.LoopbackClientConfig, kubeAPIs.ControlPlane.Generic.TracerProvider))
@@ -99,6 +103,9 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 	c.ApiExtensions = apiExtensions
+	if apiExtensions.GenericConfig.MergedResourceConfig.ResourceEnabled(apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions")) {
+		kubeAdmissionPluginInitializer.ExpectCustomResourceDefinitionInformer()
+	}
 
 	aggregator, err := controlplaneapiserver.CreateAggregatorConfig(*kubeAPIs.ControlPlane.Generic, opts.CompletedOptions, kubeAPIs.ControlPlane.VersionedInformers, serviceResolver, kubeAPIs.ControlPlane.ProxyTransport, kubeAPIs.ControlPlane.Extra.PeerProxy, pluginInitializer)
 	if err != nil {

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -189,6 +189,13 @@ func CreateServerChain(config CompletedConfig) (*aggregatorapiserver.APIAggregat
 		return nil, err
 	}
 	crdAPIEnabled := config.ApiExtensions.GenericConfig.MergedResourceConfig.ResourceEnabled(apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"))
+	if crdAPIEnabled && config.kubeAdmissionPluginInitializer != nil {
+		if err := config.kubeAdmissionPluginInitializer.SetCustomResourceDefinitionInformer(
+			apiExtensionsServer.Informers.Apiextensions().V1().CustomResourceDefinitions(),
+		); err != nil {
+			return nil, fmt.Errorf("failed to configure admission paramKind resolver: %w", err)
+		}
+	}
 
 	kubeAPIServer, err := config.KubeAPIs.New(apiExtensionsServer.GenericAPIServer)
 	if err != nil {
@@ -217,6 +224,22 @@ func CreateKubeAPIServerConfig(
 	[]admission.PluginInitializer,
 	error,
 ) {
+	config, serviceResolver, initializers, _, err := createKubeAPIServerConfig(opts, genericConfig, versionedInformers, storageFactory)
+	return config, serviceResolver, initializers, err
+}
+
+func createKubeAPIServerConfig(
+	opts options.CompletedOptions,
+	genericConfig *genericapiserver.Config,
+	versionedInformers clientgoinformers.SharedInformerFactory,
+	storageFactory *serverstorage.DefaultStorageFactory,
+) (
+	*controlplane.Config,
+	aggregatorapiserver.ServiceResolver,
+	[]admission.PluginInitializer,
+	*kubeapiserveradmission.PluginInitializer,
+	error,
+) {
 	// global stuff
 	capabilities.Setup(opts.AllowPrivileged, opts.MaxConnectionBytesPerSec)
 
@@ -224,21 +247,31 @@ func CreateKubeAPIServerConfig(
 	kubeAdmissionConfig := &kubeapiserveradmission.Config{}
 	kubeInitializers, err := kubeAdmissionConfig.New()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create admission plugin initializer: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to create admission plugin initializer: %w", err)
+	}
+	var kubeAdmissionPluginInitializer *kubeapiserveradmission.PluginInitializer
+	for _, initializer := range kubeInitializers {
+		if typedInitializer, ok := initializer.(*kubeapiserveradmission.PluginInitializer); ok {
+			kubeAdmissionPluginInitializer = typedInitializer
+			break
+		}
+	}
+	if kubeAdmissionPluginInitializer == nil {
+		return nil, nil, nil, nil, fmt.Errorf("kube-apiserver admission plugin initializer is missing")
 	}
 
 	endpointSliceGetter, err := proxy.NewEndpointSliceIndexerGetter(versionedInformers.Discovery().V1().EndpointSlices())
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create endpoint slice getter: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to create endpoint slice getter: %w", err)
 	}
 
 	serviceResolver, err := buildServiceResolver(opts.EnableAggregatorRouting, genericConfig.LoopbackClientConfig.Host, versionedInformers, endpointSliceGetter)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("error building service resolver: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("error building service resolver: %w", err)
 	}
 	controlplaneConfig, admissionInitializers, err := controlplaneapiserver.CreateConfig(opts.CompletedOptions, genericConfig, versionedInformers, endpointSliceGetter, storageFactory, serviceResolver, kubeInitializers)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	config := &controlplane.Config{
@@ -268,14 +301,14 @@ func CreateKubeAPIServerConfig(
 		networkContext := egressselector.Cluster.AsNetworkContext()
 		dialer, err := config.ControlPlane.Generic.EgressSelector.Lookup(networkContext)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 		c := config.ControlPlane.Extra.ProxyTransport.Clone()
 		c.DialContext = dialer
 		config.ControlPlane.ProxyTransport = c
 	}
 
-	return config, serviceResolver, admissionInitializers, nil
+	return config, serviceResolver, admissionInitializers, kubeAdmissionPluginInitializer, nil
 }
 
 var testServiceResolver webhook.ServiceResolver

--- a/pkg/kubeapiserver/admission/initializer.go
+++ b/pkg/kubeapiserver/admission/initializer.go
@@ -18,8 +18,10 @@ package admission
 
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
+	policygeneric "k8s.io/apiserver/pkg/admission/plugin/policy/generic"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	policyloader "k8s.io/kubernetes/pkg/admission/plugin/policy/manifest/loader"
@@ -30,7 +32,12 @@ import (
 
 // PluginInitializer is used for initialization of the Kubernetes specific admission plugins.
 type PluginInitializer struct {
-	loaders *initializer.ManifestLoaders
+	loaders           *initializer.ManifestLoaders
+	paramKindResolver *crdParamKindResolver
+}
+
+type wantsParamKindResolver interface {
+	SetParamKindResolver(policygeneric.ParamKindResolver)
 }
 
 var _ admission.PluginInitializer = &PluginInitializer{}
@@ -38,8 +45,21 @@ var _ admission.PluginInitializer = &PluginInitializer{}
 // NewPluginInitializer constructs new instance of PluginInitializer
 func NewPluginInitializer() *PluginInitializer {
 	return &PluginInitializer{
-		loaders: newManifestLoaders(),
+		loaders:           newManifestLoaders(),
+		paramKindResolver: newCRDParamKindResolver(),
 	}
+}
+
+// ExpectCustomResourceDefinitionInformer makes parameter resolution wait for the
+// CRD informer when the apiextensions API is enabled.
+func (i *PluginInitializer) ExpectCustomResourceDefinitionInformer() {
+	i.paramKindResolver.ExpectCustomResourceDefinitionInformer()
+}
+
+// SetCustomResourceDefinitionInformer attaches the informer owned by the
+// apiextensions server before either server starts.
+func (i *PluginInitializer) SetCustomResourceDefinitionInformer(informer apiextensionsinformers.CustomResourceDefinitionInformer) error {
+	return i.paramKindResolver.SetCustomResourceDefinitionInformer(informer)
 }
 
 // Initialize checks the initialization interfaces implemented by each plugin
@@ -47,6 +67,9 @@ func NewPluginInitializer() *PluginInitializer {
 func (i *PluginInitializer) Initialize(plugin admission.Interface) {
 	if wants, ok := plugin.(initializer.WantsManifestLoaders); ok {
 		wants.SetManifestLoaders(i.loaders)
+	}
+	if wants, ok := plugin.(wantsParamKindResolver); ok {
+		wants.SetParamKindResolver(i.paramKindResolver)
 	}
 }
 

--- a/pkg/kubeapiserver/admission/paramkind_resolver.go
+++ b/pkg/kubeapiserver/admission/paramkind_resolver.go
@@ -1,0 +1,257 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	policygeneric "k8s.io/apiserver/pkg/admission/plugin/policy/generic"
+	"k8s.io/client-go/tools/cache"
+)
+
+const crdGroupKindIndex = "paramKindGroupKind"
+
+type crdParamKindResolver struct {
+	lock                sync.RWMutex
+	informer            cache.SharedIndexInformer
+	handlerRegistration cache.ResourceEventHandlerRegistration
+	informerExpected    bool
+	// Retain GVKs once served by an established CRD so stale discovery cannot resurrect them after removal.
+	knownGroupVersionKinds map[schema.GroupVersionKind]struct{}
+	callbacks              map[uint64]func(schema.GroupKind)
+	nextCallbackID         uint64
+}
+
+var _ policygeneric.ParamKindResolver = &crdParamKindResolver{}
+
+func newCRDParamKindResolver() *crdParamKindResolver {
+	return &crdParamKindResolver{
+		knownGroupVersionKinds: map[schema.GroupVersionKind]struct{}{},
+		callbacks:              map[uint64]func(schema.GroupKind){},
+	}
+}
+
+func (r *crdParamKindResolver) ExpectCustomResourceDefinitionInformer() {
+	r.lock.Lock()
+	r.informerExpected = true
+	r.lock.Unlock()
+}
+
+func (r *crdParamKindResolver) SetCustomResourceDefinitionInformer(informer apiextensionsinformers.CustomResourceDefinitionInformer) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.informer != nil {
+		return fmt.Errorf("custom resource definition informer is already configured")
+	}
+
+	sharedInformer := informer.Informer()
+	if err := sharedInformer.AddIndexers(cache.Indexers{crdGroupKindIndex: crdGroupKindIndexFunc}); err != nil {
+		return fmt.Errorf("failed to add paramKind index to custom resource definition informer: %w", err)
+	}
+	handlerRegistration, err := sharedInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			r.notifyChanges(obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			r.notifyChanges(oldObj, newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			r.notifyChanges(obj)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to register custom resource definition event handler: %w", err)
+	}
+	r.informer = sharedInformer
+	r.handlerRegistration = handlerRegistration
+	r.informerExpected = true
+	return nil
+}
+
+func (r *crdParamKindResolver) Resolve(_ context.Context, paramKind schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	if paramKind.Group == "" {
+		return nil, nil
+	}
+
+	r.lock.RLock()
+	informer := r.informer
+	r.lock.RUnlock()
+	if informer == nil {
+		return nil, nil
+	}
+
+	objects, err := informer.GetIndexer().ByIndex(crdGroupKindIndex, groupKindIndexKey(paramKind.GroupKind()))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, object := range objects {
+		crd, ok := object.(*apiextensionsv1.CustomResourceDefinition)
+		if !ok {
+			return nil, fmt.Errorf("unexpected object type %T in custom resource definition informer", object)
+		}
+		if crd.Spec.Group != paramKind.Group || crd.Status.AcceptedNames.Kind != paramKind.Kind || !isCRDEstablished(crd) {
+			continue
+		}
+		if !isCRDVersionServed(crd, paramKind.Version) {
+			return nil, nil
+		}
+
+		scope := meta.RESTScopeRoot
+		if crd.Spec.Scope == apiextensionsv1.NamespaceScoped {
+			scope = meta.RESTScopeNamespace
+		}
+		return &meta.RESTMapping{
+			Resource:         paramKind.GroupVersion().WithResource(crd.Status.AcceptedNames.Plural),
+			GroupVersionKind: paramKind,
+			Scope:            scope,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func (r *crdParamKindResolver) Handles(paramKind schema.GroupVersionKind) bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	_, known := r.knownGroupVersionKinds[paramKind]
+	return known
+}
+
+func (r *crdParamKindResolver) HasSynced() bool {
+	r.lock.RLock()
+	informer := r.informer
+	handlerRegistration := r.handlerRegistration
+	informerExpected := r.informerExpected
+	r.lock.RUnlock()
+	return (!informerExpected && informer == nil) || (handlerRegistration != nil && handlerRegistration.HasSynced())
+}
+
+func (r *crdParamKindResolver) RegisterForChanges(callback func(schema.GroupKind)) func() {
+	r.lock.Lock()
+	callbackID := r.nextCallbackID
+	r.nextCallbackID++
+	r.callbacks[callbackID] = callback
+	r.lock.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.lock.Lock()
+			delete(r.callbacks, callbackID)
+			r.lock.Unlock()
+		})
+	}
+}
+
+func (r *crdParamKindResolver) notifyChanges(objects ...interface{}) {
+	changedKinds := map[schema.GroupKind]struct{}{}
+	authoritativeKinds := map[schema.GroupVersionKind]struct{}{}
+	for _, object := range objects {
+		crd, ok := object.(*apiextensionsv1.CustomResourceDefinition)
+		if !ok {
+			if tombstone, tombstoneOK := object.(cache.DeletedFinalStateUnknown); tombstoneOK {
+				crd, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
+			}
+		}
+		if !ok {
+			continue
+		}
+		if crd.Spec.Names.Kind != "" {
+			changedKinds[schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind}] = struct{}{}
+		}
+		if crd.Status.AcceptedNames.Kind != "" {
+			changedKinds[schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Status.AcceptedNames.Kind}] = struct{}{}
+		}
+		if !isCRDEstablished(crd) || crd.Status.AcceptedNames.Kind == "" || crd.Status.AcceptedNames.Plural == "" {
+			continue
+		}
+		for _, version := range crd.Spec.Versions {
+			if version.Served {
+				authoritativeKinds[schema.GroupVersionKind{
+					Group:   crd.Spec.Group,
+					Version: version.Name,
+					Kind:    crd.Status.AcceptedNames.Kind,
+				}] = struct{}{}
+			}
+		}
+	}
+
+	r.lock.Lock()
+	for paramKind := range authoritativeKinds {
+		r.knownGroupVersionKinds[paramKind] = struct{}{}
+	}
+	callbacks := make([]func(schema.GroupKind), 0, len(r.callbacks))
+	for _, callback := range r.callbacks {
+		callbacks = append(callbacks, callback)
+	}
+	r.lock.Unlock()
+
+	for groupKind := range changedKinds {
+		for _, callback := range callbacks {
+			callback(groupKind)
+		}
+	}
+}
+
+func crdGroupKindIndexFunc(object interface{}) ([]string, error) {
+	crd, ok := object.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		return nil, fmt.Errorf("expected custom resource definition, got %T", object)
+	}
+	keys := map[string]struct{}{}
+	if crd.Spec.Names.Kind != "" {
+		keys[groupKindIndexKey(schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind})] = struct{}{}
+	}
+	if crd.Status.AcceptedNames.Kind != "" {
+		keys[groupKindIndexKey(schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Status.AcceptedNames.Kind})] = struct{}{}
+	}
+	result := make([]string, 0, len(keys))
+	for key := range keys {
+		result = append(result, key)
+	}
+	return result, nil
+}
+
+func groupKindIndexKey(groupKind schema.GroupKind) string {
+	return groupKind.Group + "/" + groupKind.Kind
+}
+
+func isCRDEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	for _, condition := range crd.Status.Conditions {
+		if condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func isCRDVersionServed(crd *apiextensionsv1.CustomResourceDefinition, version string) bool {
+	for _, crdVersion := range crd.Spec.Versions {
+		if crdVersion.Name == version {
+			return crdVersion.Served
+		}
+	}
+	return false
+}

--- a/pkg/kubeapiserver/admission/paramkind_resolver_test.go
+++ b/pkg/kubeapiserver/admission/paramkind_resolver_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubetesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestCRDParamKindResolver(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	tests := []struct {
+		name        string
+		crd         *apiextensionsv1.CustomResourceDefinition
+		want        *meta.RESTMapping
+		wantHandles bool
+	}{
+		{
+			name: "resolves established served CRD",
+			crd:  establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped),
+			want: &meta.RESTMapping{
+				Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+				GroupVersionKind: paramKind,
+				Scope:            meta.RESTScopeNamespace,
+			},
+			wantHandles: true,
+		},
+		{
+			name: "resolves cluster scoped CRD",
+			crd:  establishedCRD(paramKind, true, apiextensionsv1.ClusterScoped),
+			want: &meta.RESTMapping{
+				Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+				GroupVersionKind: paramKind,
+				Scope:            meta.RESTScopeRoot,
+			},
+			wantHandles: true,
+		},
+		{
+			name: "ignores unserved version",
+			crd:  establishedCRD(paramKind, false, apiextensionsv1.NamespaceScoped),
+		},
+		{
+			name: "ignores unestablished CRD",
+			crd: func() *apiextensionsv1.CustomResourceDefinition {
+				crd := establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped)
+				crd.Status.Conditions = nil
+				return crd
+			}(),
+		},
+		{
+			name: "ignores absent CRD",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var objects []runtime.Object
+			if test.crd != nil {
+				objects = append(objects, test.crd)
+			}
+			resolver, _ := startTestCRDParamKindResolver(t, objects...)
+
+			mapping, err := resolver.Resolve(context.Background(), paramKind)
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, mapping)
+			require.Equal(t, test.wantHandles, resolver.Handles(paramKind))
+		})
+	}
+}
+
+func TestCRDParamKindResolverClaimsOnlyServedAcceptedVersions(t *testing.T) {
+	acceptedParamKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v2", Kind: "ExampleParam"}
+	crd := establishedCRD(acceptedParamKind, true, apiextensionsv1.NamespaceScoped)
+	crd.Spec.Names.Kind = "ProposedParam"
+	crd.Spec.Versions = append(crd.Spec.Versions, apiextensionsv1.CustomResourceDefinitionVersion{Name: "v1", Served: false})
+	resolver, _ := startTestCRDParamKindResolver(t, crd)
+
+	require.True(t, resolver.Handles(acceptedParamKind))
+	require.False(t, resolver.Handles(schema.GroupVersionKind{Group: acceptedParamKind.Group, Version: "v1", Kind: acceptedParamKind.Kind}))
+	require.False(t, resolver.Handles(schema.GroupVersionKind{Group: acceptedParamKind.Group, Version: acceptedParamKind.Version, Kind: crd.Spec.Names.Kind}))
+}
+
+func TestCRDParamKindResolverRemainsAuthoritativeAfterVersionUnserved(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	crd := establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped)
+	resolver, client := startTestCRDParamKindResolver(t, crd)
+	changes := make(chan schema.GroupKind, 1)
+	unregister := resolver.RegisterForChanges(func(groupKind schema.GroupKind) {
+		changes <- groupKind
+	})
+	t.Cleanup(unregister)
+
+	updated := crd.DeepCopy()
+	updated.Spec.Versions[0].Served = false
+	_, err := client.ApiextensionsV1().CustomResourceDefinitions().Update(context.Background(), updated, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	select {
+	case groupKind := <-changes:
+		require.Equal(t, paramKind.GroupKind(), groupKind)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for CRD update notification")
+	}
+
+	mapping, err := resolver.Resolve(context.Background(), paramKind)
+	require.NoError(t, err)
+	require.Nil(t, mapping)
+	require.True(t, resolver.Handles(paramKind))
+}
+
+func TestCRDParamKindResolverRemainsAuthoritativeAfterDeletion(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	crd := establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped)
+	resolver, client := startTestCRDParamKindResolver(t, crd)
+	changes := make(chan schema.GroupKind, 1)
+	unregister := resolver.RegisterForChanges(func(groupKind schema.GroupKind) {
+		changes <- groupKind
+	})
+	t.Cleanup(unregister)
+
+	require.NoError(t, client.ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), crd.Name, metav1.DeleteOptions{}))
+	select {
+	case groupKind := <-changes:
+		require.Equal(t, paramKind.GroupKind(), groupKind)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for CRD deletion notification")
+	}
+
+	mapping, err := resolver.Resolve(context.Background(), paramKind)
+	require.NoError(t, err)
+	require.Nil(t, mapping)
+	require.True(t, resolver.Handles(paramKind))
+}
+
+func TestCRDParamKindResolverDoesNotListDuringResolution(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	client := apiextensionsfake.NewSimpleClientset(establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped))
+	var listCalls atomic.Int32
+	client.PrependReactor("list", "customresourcedefinitions", func(kubetesting.Action) (bool, runtime.Object, error) {
+		listCalls.Add(1)
+		return false, nil, nil
+	})
+	resolver := startTestCRDParamKindResolverWithClient(t, client)
+
+	_, err := resolver.Resolve(context.Background(), paramKind)
+	require.NoError(t, err)
+	_, err = resolver.Resolve(context.Background(), paramKind)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 1, listCalls.Load())
+}
+
+func TestCRDParamKindResolverSyncExpectation(t *testing.T) {
+	resolver := newCRDParamKindResolver()
+	require.True(t, resolver.HasSynced())
+
+	resolver.ExpectCustomResourceDefinitionInformer()
+	require.False(t, resolver.HasSynced())
+}
+
+func TestCRDParamKindResolverWaitsForHandlerSync(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	client := apiextensionsfake.NewSimpleClientset(establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped))
+	factory := apiextensionsinformers.NewSharedInformerFactory(client, 0)
+	informer := factory.Apiextensions().V1().CustomResourceDefinitions()
+	resolver := newCRDParamKindResolver()
+	require.NoError(t, resolver.SetCustomResourceDefinitionInformer(informer))
+
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	resolver.RegisterForChanges(func(schema.GroupKind) {
+		close(handlerStarted)
+		<-releaseHandler
+	})
+	t.Cleanup(func() {
+		select {
+		case <-releaseHandler:
+		default:
+			close(releaseHandler)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	factory.Start(ctx.Done())
+	require.True(t, cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced))
+	select {
+	case <-handlerStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for initial CRD event")
+	}
+	require.False(t, resolver.HasSynced())
+
+	close(releaseHandler)
+	require.True(t, cache.WaitForCacheSync(ctx.Done(), resolver.HasSynced))
+}
+
+func TestCRDParamKindResolverNotifiesOnCRDChanges(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	resolver, client := startTestCRDParamKindResolver(t)
+	changes := make(chan schema.GroupKind, 1)
+	unregister := resolver.RegisterForChanges(func(groupKind schema.GroupKind) {
+		changes <- groupKind
+	})
+	t.Cleanup(unregister)
+
+	_, err := client.ApiextensionsV1().CustomResourceDefinitions().Create(
+		context.Background(),
+		establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped),
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	select {
+	case groupKind := <-changes:
+		require.Equal(t, paramKind.GroupKind(), groupKind)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for CRD change notification")
+	}
+}
+
+func startTestCRDParamKindResolver(t *testing.T, objects ...runtime.Object) (*crdParamKindResolver, *apiextensionsfake.Clientset) {
+	t.Helper()
+	client := apiextensionsfake.NewSimpleClientset(objects...)
+	return startTestCRDParamKindResolverWithClient(t, client), client
+}
+
+func startTestCRDParamKindResolverWithClient(t *testing.T, client *apiextensionsfake.Clientset) *crdParamKindResolver {
+	t.Helper()
+	factory := apiextensionsinformers.NewSharedInformerFactory(client, 0)
+	informer := factory.Apiextensions().V1().CustomResourceDefinitions()
+	resolver := newCRDParamKindResolver()
+	require.NoError(t, resolver.SetCustomResourceDefinitionInformer(informer))
+	require.False(t, resolver.HasSynced())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	factory.Start(ctx.Done())
+	require.True(t, cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced))
+	require.True(t, resolver.HasSynced())
+	return resolver
+}
+
+func establishedCRD(paramKind schema.GroupVersionKind, served bool, scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "exampleparams." + paramKind.Group},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: paramKind.Group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "exampleparams",
+				Kind:   paramKind.Kind,
+			},
+			Scope: scope,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: paramKind.Version, Served: served, Storage: true},
+			},
+		},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			AcceptedNames: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "exampleparams",
+				Kind:   paramKind.Kind,
+			},
+			Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+				{Type: apiextensionsv1.Established, Status: apiextensionsv1.ConditionTrue},
+			},
+		},
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/plugin.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/plugin.go
@@ -42,6 +42,10 @@ import (
 type apiSourceFactory[H any] func(informers.SharedInformerFactory, kubernetes.Interface, dynamic.Interface, meta.RESTMapper) Source[H]
 type dispatcherFactory[H any] func(authorizer.UnconditionalAuthorizer, *matching.Matcher, kubernetes.Interface) Dispatcher[H]
 
+type wantsParamKindResolver interface {
+	SetParamKindResolver(ParamKindResolver)
+}
+
 // ReloadableSource extends HookSource with a method to run a reload loop
 // that watches for configuration changes and blocks until the context is canceled.
 type ReloadableSource[H any] interface {
@@ -90,10 +94,11 @@ type Plugin[H any] struct {
 	// apiServerID is the identity of this API server instance, used for metrics labeling.
 	apiServerID string
 
-	informerFactory informers.SharedInformerFactory
-	client          kubernetes.Interface
-	restMapper      meta.RESTMapper
-	dynamicClient   dynamic.Interface
+	informerFactory   informers.SharedInformerFactory
+	client            kubernetes.Interface
+	restMapper        meta.RESTMapper
+	dynamicClient     dynamic.Interface
+	paramKindResolver ParamKindResolver
 	// admissionConfigResources are admission configuration resources (VAP/MAP/VAPB/MAPB).
 	// API-based policies skip these to prevent circular dependencies, but static policies
 	// are safe to evaluate on them.
@@ -149,6 +154,12 @@ func (c *Plugin[H]) SetRESTMapper(mapper meta.RESTMapper) {
 
 func (c *Plugin[H]) SetDynamicClient(client dynamic.Interface) {
 	c.dynamicClient = client
+}
+
+// SetParamKindResolver configures a kube-apiserver-specific resolver for
+// parameter kinds not yet visible through the cached RESTMapper.
+func (c *Plugin[H]) SetParamKindResolver(resolver ParamKindResolver) {
+	c.paramKindResolver = resolver
 }
 
 func (c *Plugin[H]) SetDrainedNotification(stopCh <-chan struct{}) {
@@ -253,6 +264,9 @@ func (c *Plugin[H]) ValidateInitialization() error {
 	// Construct source once, avoiding overwriting if already set.
 	if c.source == nil {
 		apiSource := c.apiSourceFactory(c.informerFactory, c.client, c.dynamicClient, c.restMapper)
+		if wants, ok := apiSource.(wantsParamKindResolver); ok {
+			wants.SetParamKindResolver(c.paramKindResolver)
+		}
 
 		if len(c.staticManifestsDir) > 0 {
 			if c.staticSourceFactory == nil {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
@@ -18,14 +18,14 @@ package generic
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,6 +54,7 @@ type policySource[P runtime.Object, B runtime.Object, E Evaluator] struct {
 	policyInformer     generic.Informer[P]
 	bindingInformer    generic.Informer[B]
 	restMapper         meta.RESTMapper
+	paramKindResolver  ParamKindResolver
 	newPolicyAccessor  func(P) PolicyAccessor
 	newBindingAccessor func(B) BindingAccessor
 
@@ -71,14 +72,15 @@ type policySource[P runtime.Object, B runtime.Object, E Evaluator] struct {
 	compiledPolicies map[types.NamespacedName]compiledPolicyEntry[E]
 
 	// Temporary until we use the dynamic informer factory
-	paramsCRDControllers map[schema.GroupVersionKind]*paramInfo
+	paramsCRDControllers  map[schema.GroupVersionKind]*paramInfo
+	paramKindsToReconcile map[schema.GroupVersionKind]struct{}
 }
 
 type paramInfo struct {
 	mapping meta.RESTMapping
 
-	// When the param is changed, or the informer is done being used, the cancel
-	// func should be called to stop/cleanup the original informer
+	// For privately owned dynamic informers, cancelFunc stops the informer. It is
+	// a no-op for informers owned by the shared factory.
 	cancelFunc func()
 
 	// The lister for this param
@@ -88,6 +90,15 @@ type paramInfo struct {
 type compiledPolicyEntry[E Evaluator] struct {
 	policyVersion string
 	evaluator     E
+}
+
+// ParamKindResolver resolves param kinds that are not yet available through the
+// admission plugin's cached RESTMapper.
+type ParamKindResolver interface {
+	Resolve(context.Context, schema.GroupVersionKind) (*meta.RESTMapping, error)
+	Handles(schema.GroupVersionKind) bool
+	HasSynced() bool
+	RegisterForChanges(func(schema.GroupKind)) func()
 }
 
 type PolicyHook[P runtime.Object, B runtime.Object, E Evaluator] struct {
@@ -120,19 +131,51 @@ func NewPolicySource[P runtime.Object, B runtime.Object, E Evaluator](
 	dynamicClient dynamic.Interface,
 	restMapper meta.RESTMapper,
 ) Source[PolicyHook[P, B, E]] {
+	return newPolicySource(
+		policyInformer,
+		bindingInformer,
+		newPolicyAccessor,
+		newBindingAccessor,
+		compiler,
+		paramInformerFactory,
+		dynamicClient,
+		restMapper,
+		nil,
+	)
+}
+
+func newPolicySource[P runtime.Object, B runtime.Object, E Evaluator](
+	policyInformer cache.SharedIndexInformer,
+	bindingInformer cache.SharedIndexInformer,
+	newPolicyAccessor func(P) PolicyAccessor,
+	newBindingAccessor func(B) BindingAccessor,
+	compiler func(P) E,
+	paramInformerFactory informers.SharedInformerFactory,
+	dynamicClient dynamic.Interface,
+	restMapper meta.RESTMapper,
+	paramKindResolver ParamKindResolver,
+) Source[PolicyHook[P, B, E]] {
 	res := &policySource[P, B, E]{
-		compiler:             compiler,
-		policyInformer:       generic.NewInformer[P](policyInformer),
-		bindingInformer:      generic.NewInformer[B](bindingInformer),
-		compiledPolicies:     map[types.NamespacedName]compiledPolicyEntry[E]{},
-		newPolicyAccessor:    newPolicyAccessor,
-		newBindingAccessor:   newBindingAccessor,
-		paramsCRDControllers: map[schema.GroupVersionKind]*paramInfo{},
-		informerFactory:      paramInformerFactory,
-		dynamicClient:        dynamicClient,
-		restMapper:           restMapper,
+		compiler:              compiler,
+		policyInformer:        generic.NewInformer[P](policyInformer),
+		bindingInformer:       generic.NewInformer[B](bindingInformer),
+		compiledPolicies:      map[types.NamespacedName]compiledPolicyEntry[E]{},
+		newPolicyAccessor:     newPolicyAccessor,
+		newBindingAccessor:    newBindingAccessor,
+		paramsCRDControllers:  map[schema.GroupVersionKind]*paramInfo{},
+		paramKindsToReconcile: map[schema.GroupVersionKind]struct{}{},
+		informerFactory:       paramInformerFactory,
+		dynamicClient:         dynamicClient,
+		restMapper:            restMapper,
+		paramKindResolver:     paramKindResolver,
 	}
 	return res
+}
+
+// SetParamKindResolver configures a fallback resolver for parameter kinds not
+// yet visible through the cached RESTMapper.
+func (s *policySource[P, B, E]) SetParamKindResolver(resolver ParamKindResolver) {
+	s.paramKindResolver = resolver
 }
 
 // SetPolicyRefreshIntervalForTests allows the refresh interval to be overridden during tests.
@@ -152,9 +195,12 @@ func (s *policySource[P, B, E]) Run(ctx context.Context) error {
 	if s.ctx != nil {
 		return fmt.Errorf("policy source already running")
 	}
+	if s.paramKindResolver != nil {
+		unregister := s.paramKindResolver.RegisterForChanges(s.paramKindChanged)
+		defer unregister()
+	}
 
-	// Wait for initial cache sync of policies and informers before reconciling
-	// any
+	// Wait for initial cache sync of policies and bindings before reconciling.
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, s.UpstreamHasSynced) {
 		err := ctx.Err()
 		if err == nil {
@@ -215,7 +261,8 @@ func (s *policySource[P, B, E]) Run(ctx context.Context) error {
 }
 
 func (s *policySource[P, B, E]) UpstreamHasSynced() bool {
-	return s.policyInformer.HasSynced() && s.bindingInformer.HasSynced()
+	return s.policyInformer.HasSynced() &&
+		s.bindingInformer.HasSynced()
 }
 
 // HasSynced implements Source.
@@ -272,6 +319,17 @@ func (s *policySource[P, B, E]) notify() {
 	s.policiesDirty.Store(true)
 }
 
+func (s *policySource[P, B, E]) paramKindChanged(groupKind schema.GroupKind) {
+	s.lock.Lock()
+	for paramKind := range s.paramsCRDControllers {
+		if paramKind.GroupKind() == groupKind {
+			s.paramKindsToReconcile[paramKind] = struct{}{}
+		}
+	}
+	s.lock.Unlock()
+	s.notify()
+}
+
 // calculatePolicyData calculates the list of policies and bindings for each
 // policy. If there is an error in generation, it will return the error and
 // the partial list of policies that were able to be generated. Policies that
@@ -315,7 +373,7 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 			inf = s.policyInformer.Namespaced(policyKey.Namespace)
 		}
 		policySpec, err := inf.Get(policyKey.Name)
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Policy for bindings doesn't exist. This can happen if the policy
 			// was deleted before the binding, or the binding was created first.
 			//
@@ -362,9 +420,8 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 			ConfigurationError: configurationError,
 		})
 
-		// Should queue a re-sync for policy sync error. If our shared param
-		// informer can notify us when CRD discovery changes we can remove this
-		// and just rely on the informer to notify us when the CRDs change
+		// Keep retrying errors that may involve non-CRD kinds or transient
+		// failures. CRD lifecycle changes also mark affected mappings for refresh.
 		if configurationError != nil {
 			errs = append(errs, configurationError)
 		}
@@ -383,12 +440,13 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 		if _, wasSeen := usedParams[paramKind]; !wasSeen {
 			info.cancelFunc()
 			delete(s.paramsCRDControllers, paramKind)
+			delete(s.paramKindsToReconcile, paramKind)
 		}
 	}
 
 	err = nil
 	if len(errs) > 0 {
-		err = goerrors.Join(errs...)
+		err = errors.Join(errs...)
 	}
 	return result, err
 }
@@ -400,40 +458,47 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.GroupVersionKind) (informers.GenericInformer, meta.RESTScope, error) {
 	if paramSource == nil {
 		return nil, nil, nil
-	} else if info, ok := s.paramsCRDControllers[*paramSource]; ok {
-		return info.informer, info.mapping.Scope, nil
 	}
 
-	mapping, err := s.restMapper.RESTMapping(schema.GroupKind{
-		Group: paramSource.Group,
-		Kind:  paramSource.Kind,
-	}, paramSource.Version)
+	existingInfo, exists := s.paramsCRDControllers[*paramSource]
+	_, mustReconcile := s.paramKindsToReconcile[*paramSource]
+	if exists && !mustReconcile {
+		return existingInfo.informer, existingInfo.mapping.Scope, nil
+	}
+	delete(s.paramKindsToReconcile, *paramSource)
 
+	mapping, err := s.resolveParamKindRESTMappingLocked(*paramSource)
 	if err != nil {
-		// Failed to resolve. Return error so we retry again (rate limited)
-		// Save a record of this definition with an evaluator that unconditionally
-		return nil, nil, fmt.Errorf("failed to find resource referenced by paramKind: '%v'", *paramSource)
+		if exists {
+			existingInfo.cancelFunc()
+			delete(s.paramsCRDControllers, *paramSource)
+		}
+		return nil, nil, err
 	}
-
-	// We are not watching this param. Start an informer for it.
-	instanceContext, instanceCancel := context.WithCancel(s.ctx)
+	if exists && sameRESTMapping(&existingInfo.mapping, mapping) {
+		return existingInfo.informer, existingInfo.mapping.Scope, nil
+	}
+	if exists {
+		existingInfo.cancelFunc()
+		delete(s.paramsCRDControllers, *paramSource)
+	}
 
 	var informer informers.GenericInformer
+	var cancelInformer func()
 
 	// Try to see if our provided informer factory has an informer for this type.
-	// We assume the informer is already started, and starts all types associated
-	// with it.
 	if genericInformer, err := s.informerFactory.ForResource(mapping.Resource); err == nil {
 		informer = genericInformer
-
-		// Start the informer
-		s.informerFactory.Start(instanceContext.Done())
+		cancelInformer = func() {}
+		s.informerFactory.Start(s.ctx.Done())
 
 	} else {
 		// Dynamic JSON informer fallback.
 		// Cannot use shared dynamic informer since it would be impossible
 		// to clean CRD informers properly with multiple dependents
 		// (cannot start ahead of time, and cannot track dependencies via stopCh)
+		instanceContext, instanceCancel := context.WithCancel(s.ctx)
+		cancelInformer = instanceCancel
 		informer = dynamicinformer.NewFilteredDynamicInformer(
 			s.dynamicClient,
 			mapping.Resource,
@@ -450,11 +515,59 @@ func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.
 	klog.Infof("informer started for %v", *paramSource)
 	ret := &paramInfo{
 		mapping:    *mapping,
-		cancelFunc: instanceCancel,
+		cancelFunc: cancelInformer,
 		informer:   informer,
 	}
 	s.paramsCRDControllers[*paramSource] = ret
-	return ret.informer, mapping.Scope, nil
+	return ret.informer, ret.mapping.Scope, nil
+}
+
+func (s *policySource[P, B, E]) resolveParamKindFromResolverLocked(paramSource schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	mapping, err := s.paramKindResolver.Resolve(s.ctx, paramSource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve resource referenced by paramKind %q: %w", paramSource, err)
+	}
+	if mapping == nil {
+		return nil, fmt.Errorf("failed to find resource referenced by paramKind: '%v'", paramSource)
+	}
+	return mapping, nil
+}
+
+func sameRESTMapping(left, right *meta.RESTMapping) bool {
+	return left.Resource == right.Resource &&
+		left.GroupVersionKind == right.GroupVersionKind &&
+		left.Scope.Name() == right.Scope.Name()
+}
+
+func (s *policySource[P, B, E]) resolveParamKindRESTMappingLocked(paramSource schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	if s.paramKindResolver != nil {
+		if !s.paramKindResolver.HasSynced() {
+			return nil, fmt.Errorf("paramKind resolver is not yet synced for %q", paramSource)
+		}
+		if s.paramKindResolver.Handles(paramSource) {
+			return s.resolveParamKindFromResolverLocked(paramSource)
+		}
+	}
+	mapping, err := s.restMapper.RESTMapping(schema.GroupKind{
+		Group: paramSource.Group,
+		Kind:  paramSource.Kind,
+	}, paramSource.Version)
+	if err == nil {
+		return mapping, nil
+	}
+	if meta.IsNoMatchError(err) && s.paramKindResolver != nil {
+		mapping, resolveErr := s.paramKindResolver.Resolve(s.ctx, paramSource)
+		if resolveErr != nil {
+			return nil, fmt.Errorf("failed to resolve resource referenced by paramKind %q: %w", paramSource, resolveErr)
+		}
+		if mapping != nil {
+			return mapping, nil
+		}
+	}
+
+	// Failed to resolve. Return error so we retry again (rate limited)
+	// Save a record of this definition with an evaluator that unconditionally
+	return nil, fmt.Errorf("failed to find resource referenced by paramKind: '%v'", paramSource)
 }
 
 // For testing

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_internal_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_internal_test.go
@@ -1,0 +1,486 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/policy/matching"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/kubernetes"
+)
+
+type internalFakeDispatcher struct{}
+
+func (d *internalFakeDispatcher) Dispatch(context.Context, admission.Attributes, admission.ObjectInterfaces, []PolicyHook[*internalFakePolicy, *internalFakeBinding, Evaluator]) error {
+	return nil
+}
+
+func (d *internalFakeDispatcher) Start(context.Context) error {
+	return nil
+}
+
+func makeInternalFakeDispatcher(authorizer.UnconditionalAuthorizer, *matching.Matcher, kubernetes.Interface) Dispatcher[PolicyHook[*internalFakePolicy, *internalFakeBinding, Evaluator]] {
+	return &internalFakeDispatcher{}
+}
+
+type internalFakePolicy struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	ParamKind *v1.ParamKind
+}
+
+func (p *internalFakePolicy) GetName() string                         { return p.Name }
+func (p *internalFakePolicy) GetNamespace() string                    { return p.Namespace }
+func (p *internalFakePolicy) GetParamKind() *v1.ParamKind             { return p.ParamKind }
+func (p *internalFakePolicy) GetMatchConstraints() *v1.MatchResources { return nil }
+func (p *internalFakePolicy) GetFailurePolicy() *v1.FailurePolicyType { return nil }
+func (p *internalFakePolicy) DeepCopyObject() runtime.Object          { copy := *p; return &copy }
+
+type internalFakeBinding struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	PolicyName string
+}
+
+func (b *internalFakeBinding) GetName() string      { return b.Name }
+func (b *internalFakeBinding) GetNamespace() string { return b.Namespace }
+func (b *internalFakeBinding) GetPolicyName() types.NamespacedName {
+	return types.NamespacedName{Name: b.PolicyName}
+}
+func (b *internalFakeBinding) GetParamRef() *v1.ParamRef             { return nil }
+func (b *internalFakeBinding) GetMatchResources() *v1.MatchResources { return nil }
+func (b *internalFakeBinding) DeepCopyObject() runtime.Object        { copy := *b; return &copy }
+
+type fixedErrorRESTMapper struct {
+	err error
+}
+
+func (m fixedErrorRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, m.err
+}
+
+func (m fixedErrorRESTMapper) KindsFor(schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, m.err
+}
+
+func (m fixedErrorRESTMapper) ResourceFor(schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, m.err
+}
+
+func (m fixedErrorRESTMapper) ResourcesFor(schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, m.err
+}
+
+func (m fixedErrorRESTMapper) RESTMapping(schema.GroupKind, ...string) (*meta.RESTMapping, error) {
+	return nil, m.err
+}
+
+func (m fixedErrorRESTMapper) RESTMappings(schema.GroupKind, ...string) ([]*meta.RESTMapping, error) {
+	return nil, m.err
+}
+
+func (m fixedErrorRESTMapper) ResourceSingularizer(string) (string, error) {
+	return "", m.err
+}
+
+type fakeParamKindResolver struct {
+	mapping   *meta.RESTMapping
+	err       error
+	handles   func(schema.GroupVersionKind) bool
+	hasSynced func() bool
+}
+
+func (r fakeParamKindResolver) Resolve(context.Context, schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	return r.mapping, r.err
+}
+
+func (r fakeParamKindResolver) Handles(paramKind schema.GroupVersionKind) bool {
+	return r.handles == nil || r.handles(paramKind)
+}
+
+func (r fakeParamKindResolver) HasSynced() bool {
+	return r.hasSynced == nil || r.hasSynced()
+}
+
+func (r fakeParamKindResolver) RegisterForChanges(func(schema.GroupKind)) func() {
+	return func() {}
+}
+
+func TestResolveParamKindRESTMappingWaitsForResolverSync(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{paramKind.GroupVersion()})
+	restMapper.AddSpecific(
+		paramKind,
+		paramKind.GroupVersion().WithResource("exampleparams"),
+		paramKind.GroupVersion().WithResource("exampleparam"),
+		meta.RESTScopeNamespace,
+	)
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:        context.Background(),
+		restMapper: restMapper,
+		paramKindResolver: fakeParamKindResolver{
+			handles:   func(schema.GroupVersionKind) bool { return false },
+			hasSynced: func() bool { return false },
+		},
+	}
+
+	mapping, err := source.resolveParamKindRESTMappingLocked(paramKind)
+
+	require.ErrorContains(t, err, "paramKind resolver is not yet synced")
+	require.Nil(t, mapping)
+}
+
+func TestPolicySourceInitializesAndRecoversWithUnsyncedParamKindResolver(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	mapping := meta.RESTMapping{
+		Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+		GroupVersionKind: paramKind,
+		Scope:            meta.RESTScopeNamespace,
+	}
+	policyWithParams := &internalFakePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "with-params"},
+		ParamKind:  &v1.ParamKind{APIVersion: paramKind.GroupVersion().String(), Kind: paramKind.Kind},
+	}
+	policyWithoutParams := &internalFakePolicy{ObjectMeta: metav1.ObjectMeta{Name: "without-params"}}
+	var resolverSynced atomic.Bool
+	testContext, testCancel, err := NewPolicyTestContext(
+		t,
+		func(policy *internalFakePolicy) PolicyAccessor { return policy },
+		func(binding *internalFakeBinding) BindingAccessor { return binding },
+		func(*internalFakePolicy) Evaluator { return nil },
+		makeInternalFakeDispatcher,
+		[]runtime.Object{
+			policyWithParams,
+			policyWithoutParams,
+			&internalFakeBinding{ObjectMeta: metav1.ObjectMeta{Name: "with-params"}, PolicyName: policyWithParams.Name},
+			&internalFakeBinding{ObjectMeta: metav1.ObjectMeta{Name: "without-params"}, PolicyName: policyWithoutParams.Name},
+		},
+		[]meta.RESTMapping{mapping},
+		fakeParamKindResolver{
+			mapping:   &mapping,
+			handles:   func(schema.GroupVersionKind) bool { return resolverSynced.Load() },
+			hasSynced: resolverSynced.Load,
+		},
+	)
+	require.NoError(t, err)
+	defer testCancel()
+
+	started := make(chan error, 1)
+	go func() { started <- testContext.Start() }()
+	select {
+	case err := <-started:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("policy source did not initialize while the parameter resolver was unsynced")
+	}
+
+	require.True(t, testContext.Source.HasSynced())
+	hooks := testContext.Source.Hooks()
+	require.Len(t, hooks, 2)
+	for _, hook := range hooks {
+		if hook.Policy.Name == policyWithParams.Name {
+			require.ErrorContains(t, hook.ConfigurationError, "paramKind resolver is not yet synced")
+			require.Nil(t, hook.ParamInformer)
+		} else {
+			require.Equal(t, policyWithoutParams.Name, hook.Policy.Name)
+			require.NoError(t, hook.ConfigurationError)
+		}
+	}
+
+	resolverSynced.Store(true)
+	require.Eventually(t, func() bool {
+		for _, hook := range testContext.Source.Hooks() {
+			if hook.Policy.Name == policyWithParams.Name {
+				return hook.ConfigurationError == nil && hook.ParamInformer != nil
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestResolveParamKindRESTMappingUsesInjectedResolverWhenRESTMapperIsStale(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	expected := &meta.RESTMapping{
+		Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+		GroupVersionKind: paramKind,
+		Scope:            meta.RESTScopeNamespace,
+	}
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx: context.Background(),
+		restMapper: fixedErrorRESTMapper{err: &meta.NoKindMatchError{
+			GroupKind:        paramKind.GroupKind(),
+			SearchedVersions: []string{paramKind.Version},
+		}},
+		paramKindResolver: fakeParamKindResolver{mapping: expected},
+	}
+
+	mapping, err := source.resolveParamKindRESTMappingLocked(paramKind)
+
+	require.NoError(t, err)
+	require.Equal(t, expected, mapping)
+}
+
+func TestResolveParamKindRESTMappingKeepsResolverErrorsFailClosed(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx: context.Background(),
+		restMapper: fixedErrorRESTMapper{err: &meta.NoKindMatchError{
+			GroupKind:        paramKind.GroupKind(),
+			SearchedVersions: []string{paramKind.Version},
+		}},
+		paramKindResolver: fakeParamKindResolver{err: errors.New("unable to list CRDs")},
+	}
+
+	_, err := source.resolveParamKindRESTMappingLocked(paramKind)
+
+	require.ErrorContains(t, err, "unable to list CRDs")
+}
+
+func TestResolveParamKindRESTMappingRejectsStalePositiveRESTMapping(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{paramKind.GroupVersion()})
+	restMapper.AddSpecific(
+		paramKind,
+		paramKind.GroupVersion().WithResource("exampleparams"),
+		paramKind.GroupVersion().WithResource("exampleparam"),
+		meta.RESTScopeNamespace,
+	)
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:               context.Background(),
+		restMapper:        restMapper,
+		paramKindResolver: fakeParamKindResolver{},
+	}
+
+	_, err := source.resolveParamKindRESTMappingLocked(paramKind)
+
+	require.ErrorContains(t, err, "failed to find resource referenced by paramKind")
+}
+
+func TestResolveParamKindRESTMappingUsesRESTMapperForUnclaimedKind(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	expected := &meta.RESTMapping{
+		Resource:         paramKind.GroupVersion().WithResource("aggregatedparams"),
+		GroupVersionKind: paramKind,
+		Scope:            meta.RESTScopeNamespace,
+	}
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{paramKind.GroupVersion()})
+	restMapper.AddSpecific(paramKind, expected.Resource, expected.Resource, expected.Scope)
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:        context.Background(),
+		restMapper: restMapper,
+		paramKindResolver: fakeParamKindResolver{handles: func(schema.GroupVersionKind) bool {
+			return false
+		}},
+	}
+
+	mapping, err := source.resolveParamKindRESTMappingLocked(paramKind)
+
+	require.NoError(t, err)
+	require.Equal(t, expected, mapping)
+}
+
+func TestPolicySourcePublishesConfigurationErrorWhenParamKindCannotBeResolved(t *testing.T) {
+	policy := &internalFakePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy"},
+		ParamKind:  &v1.ParamKind{APIVersion: "params.example.com/v1", Kind: "ExampleParam"},
+	}
+	binding := &internalFakeBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-binding"},
+		PolicyName: "test-policy",
+	}
+	testContext, testCancel, err := NewPolicyTestContext(
+		t,
+		func(p *internalFakePolicy) PolicyAccessor { return p },
+		func(b *internalFakeBinding) BindingAccessor { return b },
+		func(*internalFakePolicy) Evaluator { return nil },
+		makeInternalFakeDispatcher,
+		[]runtime.Object{policy, binding},
+		nil,
+		fakeParamKindResolver{err: errors.New("unable to resolve CRD")},
+	)
+	require.NoError(t, err)
+	defer testCancel()
+
+	require.NoError(t, testContext.Start())
+
+	require.Len(t, testContext.Source.Hooks(), 1)
+	require.ErrorContains(t, testContext.Source.Hooks()[0].ConfigurationError, "unable to resolve CRD")
+}
+
+func TestPolicySourceMarksParamInformerForReconciliationWhenKindChanges(t *testing.T) {
+	changedKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	unrelatedKind := schema.GroupVersionKind{Group: "other.example.com", Version: "v1", Kind: "OtherParam"}
+	changedCanceled := false
+	unrelatedCanceled := false
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		paramsCRDControllers: map[schema.GroupVersionKind]*paramInfo{
+			changedKind: {
+				cancelFunc: func() { changedCanceled = true },
+			},
+			unrelatedKind: {
+				cancelFunc: func() { unrelatedCanceled = true },
+			},
+		},
+		paramKindsToReconcile: map[schema.GroupVersionKind]struct{}{},
+	}
+
+	source.paramKindChanged(changedKind.GroupKind())
+
+	require.False(t, changedCanceled)
+	require.False(t, unrelatedCanceled)
+	require.Contains(t, source.paramsCRDControllers, changedKind)
+	require.Contains(t, source.paramsCRDControllers, unrelatedKind)
+	require.Contains(t, source.paramKindsToReconcile, changedKind)
+	require.NotContains(t, source.paramKindsToReconcile, unrelatedKind)
+	require.True(t, source.policiesDirty.Load())
+}
+
+func TestPolicySourceCleansReconciliationStateForOrphanedParamInformer(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	testContext, testCancel, err := NewPolicyTestContext(
+		t,
+		func(p *internalFakePolicy) PolicyAccessor { return p },
+		func(b *internalFakeBinding) BindingAccessor { return b },
+		func(*internalFakePolicy) Evaluator { return nil },
+		makeInternalFakeDispatcher,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	defer testCancel()
+	require.NoError(t, testContext.Start())
+
+	canceled := false
+	source := testContext.Source.(*policySource[*internalFakePolicy, *internalFakeBinding, Evaluator])
+	source.lock.Lock()
+	source.paramsCRDControllers[paramKind] = &paramInfo{cancelFunc: func() { canceled = true }}
+	source.paramKindsToReconcile[paramKind] = struct{}{}
+	source.lock.Unlock()
+
+	_, err = source.calculatePolicyData()
+
+	require.NoError(t, err)
+	require.True(t, canceled)
+	require.NotContains(t, source.paramsCRDControllers, paramKind)
+	require.NotContains(t, source.paramKindsToReconcile, paramKind)
+}
+
+func TestPolicySourcePreservesParamInformerWhenMappingIsUnchanged(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	mapping := meta.RESTMapping{
+		Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+		GroupVersionKind: paramKind,
+		Scope:            meta.RESTScopeNamespace,
+	}
+	canceled := false
+	existingInfo := &paramInfo{
+		mapping:    mapping,
+		cancelFunc: func() { canceled = true },
+	}
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:                   context.Background(),
+		paramKindResolver:     fakeParamKindResolver{mapping: &mapping},
+		paramsCRDControllers:  map[schema.GroupVersionKind]*paramInfo{paramKind: existingInfo},
+		paramKindsToReconcile: map[schema.GroupVersionKind]struct{}{},
+	}
+	source.paramKindChanged(paramKind.GroupKind())
+
+	_, resolvedScope, err := source.ensureParamsForPolicyLocked(&paramKind)
+
+	require.NoError(t, err)
+	require.Same(t, existingInfo, source.paramsCRDControllers[paramKind])
+	require.Equal(t, mapping.Scope, resolvedScope)
+	require.False(t, canceled)
+	require.NotContains(t, source.paramKindsToReconcile, paramKind)
+}
+
+func TestPolicySourcePreservesUnclaimedParamInformerOnCRDChange(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	mapping := meta.RESTMapping{
+		Resource:         paramKind.GroupVersion().WithResource("aggregatedparams"),
+		GroupVersionKind: paramKind,
+		Scope:            meta.RESTScopeNamespace,
+	}
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{paramKind.GroupVersion()})
+	restMapper.AddSpecific(paramKind, mapping.Resource, mapping.Resource, mapping.Scope)
+	canceled := false
+	existingInfo := &paramInfo{
+		mapping:    mapping,
+		cancelFunc: func() { canceled = true },
+	}
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:        context.Background(),
+		restMapper: restMapper,
+		paramKindResolver: fakeParamKindResolver{handles: func(schema.GroupVersionKind) bool {
+			return false
+		}},
+		paramsCRDControllers:  map[schema.GroupVersionKind]*paramInfo{paramKind: existingInfo},
+		paramKindsToReconcile: map[schema.GroupVersionKind]struct{}{},
+	}
+	source.paramKindChanged(paramKind.GroupKind())
+
+	_, resolvedScope, err := source.ensureParamsForPolicyLocked(&paramKind)
+
+	require.NoError(t, err)
+	require.Same(t, existingInfo, source.paramsCRDControllers[paramKind])
+	require.Equal(t, mapping.Scope, resolvedScope)
+	require.False(t, canceled)
+	require.NotContains(t, source.paramKindsToReconcile, paramKind)
+}
+
+func TestPolicySourceStopsParamInformerWhenMappingDisappears(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	canceled := false
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:               context.Background(),
+		paramKindResolver: fakeParamKindResolver{},
+		paramsCRDControllers: map[schema.GroupVersionKind]*paramInfo{
+			paramKind: {
+				mapping: meta.RESTMapping{
+					Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+					GroupVersionKind: paramKind,
+					Scope:            meta.RESTScopeNamespace,
+				},
+				cancelFunc: func() { canceled = true },
+			},
+		},
+		paramKindsToReconcile: map[schema.GroupVersionKind]struct{}{},
+	}
+	source.paramKindChanged(paramKind.GroupKind())
+
+	_, _, err := source.ensureParamsForPolicyLocked(&paramKind)
+
+	require.ErrorContains(t, err, "failed to find resource referenced by paramKind")
+	require.True(t, canceled)
+	require.NotContains(t, source.paramsCRDControllers, paramKind)
+	require.NotContains(t, source.paramKindsToReconcile, paramKind)
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
@@ -60,6 +60,7 @@ func TestPolicySourceHasSyncedEmpty(t *testing.T) {
 		makeTestDispatcher,
 		nil,
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 	defer testCancel()
@@ -92,6 +93,7 @@ func TestPolicySourceHasSyncedInitialList(t *testing.T) {
 		func(fp *FakePolicy) generic.Evaluator { return nil },
 		makeTestDispatcher,
 		initialObjects,
+		nil,
 		nil,
 	)
 	require.NoError(t, err)
@@ -162,6 +164,7 @@ func TestPolicySourceBindsToPolicies(t *testing.T) {
 		func(fp *FakePolicy) generic.Evaluator { return nil },
 		makeTestDispatcher,
 		initialObjects,
+		nil,
 		nil,
 	)
 	require.NoError(t, err)
@@ -282,6 +285,7 @@ func TestCollectParamsHandlesCacheMiss(t *testing.T) {
 		makeTestDispatcher,
 		nil,
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 	defer testCancel()
@@ -387,6 +391,7 @@ func TestCollectParamsHandlesMissingCRD(t *testing.T) {
 		func(fb *FakeBinding) generic.BindingAccessor { return fb },
 		func(fp *FakePolicy) generic.Evaluator { return nil },
 		makeTestDispatcher,
+		nil,
 		nil,
 		nil,
 	)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_test_context.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_test_context.go
@@ -84,6 +84,7 @@ func NewPolicyTestContext[P, B runtime.Object, E Evaluator](
 	dispatcher dispatcherFactory[PolicyHook[P, B, E]],
 	initialObjects []runtime.Object,
 	paramMappings []meta.RESTMapping,
+	paramKindResolver ParamKindResolver,
 ) (*PolicyTestContext[P, B, E], func(), error) {
 	var Pexample P
 	var Bexample B
@@ -203,6 +204,7 @@ func NewPolicyTestContext[P, B runtime.Object, E Evaluator](
 			return source
 		}, dispatcher)
 	plugin.SetEnabled(true)
+	plugin.SetParamKindResolver(paramKindResolver)
 
 	featureGate := featuregate.NewFeatureGate()
 	effectiveVersion := compatibility.DefaultBuildEffectiveVersion()

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin_test.go
@@ -69,7 +69,9 @@ func setupTest(
 				},
 				Scope: meta.RESTScopeNamespace,
 			},
-		})
+		},
+		nil,
+	)
 	require.NoError(t, err)
 	t.Cleanup(testCancel)
 	require.NoError(t, testContext.Start())

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -395,6 +395,7 @@ func setupTestCommon(
 				Scope:            meta.RESTScopeRoot,
 			},
 		},
+		nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(testContextCancel)

--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -2571,6 +2571,92 @@ func Test_ValidateSecondaryAuthorization(t *testing.T) {
 	}
 }
 
+func TestCRDParamKindResolvesBeforeDiscoveryRefresh(t *testing.T) {
+	resetPolicyRefreshInterval := generic.SetPolicyRefreshIntervalForTests(policyRefreshInterval)
+	defer resetPolicyRefreshInterval()
+
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
+	}, framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	client := clientset.NewForConfigOrDie(server.ClientConfig)
+	dynamicClient := dynamic.NewForConfigOrDie(server.ClientConfig)
+	apiextensionsClient := apiextensionsclientset.NewForConfigOrDie(server.ClientConfig)
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "exampleparams." + paramKind.Group},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: paramKind.Group,
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "exampleparams",
+				Kind:   paramKind.Kind,
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    paramKind.Version,
+				Served:  true,
+				Storage: true,
+				Schema:  fixtures.AllowAllSchema(),
+			}},
+		},
+	}
+
+	policy := withValidations([]admissionregistrationv1.Validation{{
+		Expression: "object.metadata.name.startsWith(params.metadata.name)",
+		Message:    "wrong prefix",
+	}}, withParams(withCRDParamKind(paramKind.Kind, paramKind.Group, paramKind.Version), withNamespaceMatch(withFailurePolicy(admissionregistrationv1.Fail, makePolicy("fresh-crd-param")))))
+	if _, err := client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(context.Background(), policy, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	binding := makeBinding("fresh-crd-param-binding", policy.Name, "test")
+	if _, err := client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Create(context.Background(), binding, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := client.CoreV1().Namespaces().Patch(ctx, "default", types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
+		if err == nil || strings.Contains(err.Error(), "not yet synced to use for admission") {
+			return false, nil
+		}
+		if strings.Contains(err.Error(), "failed to find resource referenced by paramKind") {
+			return true, nil
+		}
+		return false, err
+	}); err != nil {
+		t.Fatalf("failed to prime stale paramKind REST mapping: %v", err)
+	}
+
+	// Wait only for establishment, not discovery. The admission RESTMapper must
+	// remain stale so this exercises the CRD informer fallback.
+	etcd.CreateTestCRDs(t, apiextensionsClient, true, crd)
+	param := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":      "test",
+			"namespace": "default",
+		},
+	}}
+	param.SetGroupVersionKind(paramKind)
+	paramResource := paramKind.GroupVersion().WithResource(crd.Spec.Names.Plural)
+	if _, err := dynamicClient.Resource(paramResource).Namespace("default").Create(context.Background(), param, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, err := client.CoreV1().Namespaces().Patch(ctx, "default", types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
+		if err == nil || strings.Contains(err.Error(), "failed to find resource referenced by paramKind") || strings.Contains(err.Error(), "not yet synced to use for admission") {
+			return false, nil
+		}
+		if strings.Contains(err.Error(), "wrong prefix") {
+			return true, nil
+		}
+		return false, err
+	}); err != nil {
+		t.Fatalf("policy did not resolve the established CRD before discovery refresh: %v", err)
+	}
+}
+
 func TestCRDsOnStartup(t *testing.T) {
 
 	testContext, testCancel := context.WithCancel(context.Background())
@@ -2675,10 +2761,6 @@ func TestCRDsOnStartup(t *testing.T) {
 			}
 
 			if strings.Contains(err.Error(), "not yet synced to use for admission") {
-				return false, nil
-			}
-
-			if strings.Contains(err.Error(), "failed to find resource referenced by paramKind") {
 				return false, nil
 			}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Admission policy sources currently resolve `paramKind` through cached API discovery, which can remain stale after a CRD is established or after kube-apiserver restarts. A fail-closed policy can therefore reject requests because it temporarily treats an existing CRD parameter kind as missing.

This adds a kube-apiserver-owned resolver backed by the shared CRD informer. It resolves established and served CRDs from an index and reconciles affected parameter informers when mappings change or disappear. Policy-source readiness waits only for policy and binding caches; individual parameter resolution waits for the CRD resolver’s initial handler synchronization. While the resolver is unsynchronized, policies with `paramKind` receive a retryable configuration error through the existing `failurePolicy` handling, rather than making the whole admission plugin unready. Resolution performs no additional CRD API `LIST`.

#### Which issue(s) this PR is related to:

Fixes #124237

Downstream impact: https://github.com/open-policy-agent/gatekeeper/issues/4530

#### Special notes for your reviewer:

The generic plumbing applies to validating and mutating admission policies; CRD knowledge remains kube-apiserver-specific. This is a correctness fix and is not feature-gated.

This intentionally leaves parameter-informer warm-up behavior unchanged. #141367 tracks the behavior and draft #141369 is the stacked named-parameter follow-up.

The CI follow-up moves the CRD synchronization check out of global readiness to preserve startup when CRD listing is broken (`TestAPIServiceWaitOnStart`). The stale-discovery regression test now uses a Namespace probe instead of the deprecated `Endpoints` marker. Added tests cover initialization with an unsynchronized resolver, rejection of stale mappings, and recovery after resolver synchronization.

The new regression test fails on `master`:

```console
--- FAIL: TestCRDParamKindResolvesBeforeDiscoveryRefresh (15.81s)
    validatingadmissionpolicy_test.go:2661: policy did not resolve the established CRD before discovery refresh: context deadline exceeded
FAIL
```

Validated with:

```console
go test ./cmd/kube-apiserver/app ./pkg/kubeapiserver/admission ./staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic -count=1
PATH="$PATH:$PWD/third_party/etcd" go test ./test/integration/apiserver/cel -run '^(TestCRDParamKindResolvesBeforeDiscoveryRefresh|TestCRDsOnStartup)$' -count=1
```

#### Does this PR introduce a user-facing change?

```release-note
Admission policies now resolve CRD parameter kinds from the CRD informer without waiting for cached API discovery to refresh.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/sig api-machinery
/area apiserver
