### PR TITLE
Read named admission policy params while informers sync

### DIFF
--- a/cmd/kube-apiserver/app/config.go
+++ b/cmd/kube-apiserver/app/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/util/webhook"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane"
 	controlplaneapiserver "k8s.io/kubernetes/pkg/controlplane/apiserver"
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
+	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 )
 
 type Config struct {
@@ -41,6 +43,7 @@ type Config struct {
 }
 
 type ExtraConfig struct {
+	kubeAdmissionPluginInitializer *kubeapiserveradmission.PluginInitializer
 }
 
 type completedConfig struct {
@@ -87,11 +90,12 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 
-	kubeAPIs, serviceResolver, pluginInitializer, err := CreateKubeAPIServerConfig(opts, genericConfig, versionedInformers, storageFactory)
+	kubeAPIs, serviceResolver, pluginInitializer, kubeAdmissionPluginInitializer, err := createKubeAPIServerConfig(opts, genericConfig, versionedInformers, storageFactory)
 	if err != nil {
 		return nil, err
 	}
 	c.KubeAPIs = kubeAPIs
+	c.ExtraConfig.kubeAdmissionPluginInitializer = kubeAdmissionPluginInitializer
 
 	apiExtensions, err := controlplaneapiserver.CreateAPIExtensionsConfig(*kubeAPIs.ControlPlane.Generic, kubeAPIs.ControlPlane.VersionedInformers, pluginInitializer, opts.CompletedOptions, opts.MasterCount,
 		serviceResolver, webhook.NewDefaultAuthenticationInfoResolverWrapper(kubeAPIs.ControlPlane.ProxyTransport, kubeAPIs.ControlPlane.Generic.EgressSelector, kubeAPIs.ControlPlane.Generic.LoopbackClientConfig, kubeAPIs.ControlPlane.Generic.TracerProvider))
@@ -99,6 +103,9 @@ func NewConfig(opts options.CompletedOptions) (*Config, error) {
 		return nil, err
 	}
 	c.ApiExtensions = apiExtensions
+	if apiExtensions.GenericConfig.MergedResourceConfig.ResourceEnabled(apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions")) {
+		kubeAdmissionPluginInitializer.ExpectCustomResourceDefinitionInformer()
+	}
 
 	aggregator, err := controlplaneapiserver.CreateAggregatorConfig(*kubeAPIs.ControlPlane.Generic, opts.CompletedOptions, kubeAPIs.ControlPlane.VersionedInformers, serviceResolver, kubeAPIs.ControlPlane.ProxyTransport, kubeAPIs.ControlPlane.Extra.PeerProxy, pluginInitializer)
 	if err != nil {

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -189,6 +189,13 @@ func CreateServerChain(config CompletedConfig) (*aggregatorapiserver.APIAggregat
 		return nil, err
 	}
 	crdAPIEnabled := config.ApiExtensions.GenericConfig.MergedResourceConfig.ResourceEnabled(apiextensionsv1.SchemeGroupVersion.WithResource("customresourcedefinitions"))
+	if crdAPIEnabled && config.kubeAdmissionPluginInitializer != nil {
+		if err := config.kubeAdmissionPluginInitializer.SetCustomResourceDefinitionInformer(
+			apiExtensionsServer.Informers.Apiextensions().V1().CustomResourceDefinitions(),
+		); err != nil {
+			return nil, fmt.Errorf("failed to configure admission paramKind resolver: %w", err)
+		}
+	}
 
 	kubeAPIServer, err := config.KubeAPIs.New(apiExtensionsServer.GenericAPIServer)
 	if err != nil {
@@ -217,6 +224,22 @@ func CreateKubeAPIServerConfig(
 	[]admission.PluginInitializer,
 	error,
 ) {
+	config, serviceResolver, initializers, _, err := createKubeAPIServerConfig(opts, genericConfig, versionedInformers, storageFactory)
+	return config, serviceResolver, initializers, err
+}
+
+func createKubeAPIServerConfig(
+	opts options.CompletedOptions,
+	genericConfig *genericapiserver.Config,
+	versionedInformers clientgoinformers.SharedInformerFactory,
+	storageFactory *serverstorage.DefaultStorageFactory,
+) (
+	*controlplane.Config,
+	aggregatorapiserver.ServiceResolver,
+	[]admission.PluginInitializer,
+	*kubeapiserveradmission.PluginInitializer,
+	error,
+) {
 	// global stuff
 	capabilities.Setup(opts.AllowPrivileged, opts.MaxConnectionBytesPerSec)
 
@@ -224,21 +247,31 @@ func CreateKubeAPIServerConfig(
 	kubeAdmissionConfig := &kubeapiserveradmission.Config{}
 	kubeInitializers, err := kubeAdmissionConfig.New()
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create admission plugin initializer: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to create admission plugin initializer: %w", err)
+	}
+	var kubeAdmissionPluginInitializer *kubeapiserveradmission.PluginInitializer
+	for _, initializer := range kubeInitializers {
+		if typedInitializer, ok := initializer.(*kubeapiserveradmission.PluginInitializer); ok {
+			kubeAdmissionPluginInitializer = typedInitializer
+			break
+		}
+	}
+	if kubeAdmissionPluginInitializer == nil {
+		return nil, nil, nil, nil, fmt.Errorf("kube-apiserver admission plugin initializer is missing")
 	}
 
 	endpointSliceGetter, err := proxy.NewEndpointSliceIndexerGetter(versionedInformers.Discovery().V1().EndpointSlices())
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to create endpoint slice getter: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to create endpoint slice getter: %w", err)
 	}
 
 	serviceResolver, err := buildServiceResolver(opts.EnableAggregatorRouting, genericConfig.LoopbackClientConfig.Host, versionedInformers, endpointSliceGetter)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("error building service resolver: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("error building service resolver: %w", err)
 	}
 	controlplaneConfig, admissionInitializers, err := controlplaneapiserver.CreateConfig(opts.CompletedOptions, genericConfig, versionedInformers, endpointSliceGetter, storageFactory, serviceResolver, kubeInitializers)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	config := &controlplane.Config{
@@ -268,14 +301,14 @@ func CreateKubeAPIServerConfig(
 		networkContext := egressselector.Cluster.AsNetworkContext()
 		dialer, err := config.ControlPlane.Generic.EgressSelector.Lookup(networkContext)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 		c := config.ControlPlane.Extra.ProxyTransport.Clone()
 		c.DialContext = dialer
 		config.ControlPlane.ProxyTransport = c
 	}
 
-	return config, serviceResolver, admissionInitializers, nil
+	return config, serviceResolver, admissionInitializers, kubeAdmissionPluginInitializer, nil
 }
 
 var testServiceResolver webhook.ServiceResolver

--- a/pkg/kubeapiserver/admission/initializer.go
+++ b/pkg/kubeapiserver/admission/initializer.go
@@ -18,8 +18,10 @@ package admission
 
 import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
+	policygeneric "k8s.io/apiserver/pkg/admission/plugin/policy/generic"
 	"k8s.io/apiserver/pkg/features"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	policyloader "k8s.io/kubernetes/pkg/admission/plugin/policy/manifest/loader"
@@ -30,7 +32,12 @@ import (
 
 // PluginInitializer is used for initialization of the Kubernetes specific admission plugins.
 type PluginInitializer struct {
-	loaders *initializer.ManifestLoaders
+	loaders           *initializer.ManifestLoaders
+	paramKindResolver *crdParamKindResolver
+}
+
+type wantsParamKindResolver interface {
+	SetParamKindResolver(policygeneric.ParamKindResolver)
 }
 
 var _ admission.PluginInitializer = &PluginInitializer{}
@@ -38,8 +45,21 @@ var _ admission.PluginInitializer = &PluginInitializer{}
 // NewPluginInitializer constructs new instance of PluginInitializer
 func NewPluginInitializer() *PluginInitializer {
 	return &PluginInitializer{
-		loaders: newManifestLoaders(),
+		loaders:           newManifestLoaders(),
+		paramKindResolver: newCRDParamKindResolver(),
 	}
+}
+
+// ExpectCustomResourceDefinitionInformer makes parameter resolution wait for the
+// CRD informer when the apiextensions API is enabled.
+func (i *PluginInitializer) ExpectCustomResourceDefinitionInformer() {
+	i.paramKindResolver.ExpectCustomResourceDefinitionInformer()
+}
+
+// SetCustomResourceDefinitionInformer attaches the informer owned by the
+// apiextensions server before either server starts.
+func (i *PluginInitializer) SetCustomResourceDefinitionInformer(informer apiextensionsinformers.CustomResourceDefinitionInformer) error {
+	return i.paramKindResolver.SetCustomResourceDefinitionInformer(informer)
 }
 
 // Initialize checks the initialization interfaces implemented by each plugin
@@ -47,6 +67,9 @@ func NewPluginInitializer() *PluginInitializer {
 func (i *PluginInitializer) Initialize(plugin admission.Interface) {
 	if wants, ok := plugin.(initializer.WantsManifestLoaders); ok {
 		wants.SetManifestLoaders(i.loaders)
+	}
+	if wants, ok := plugin.(wantsParamKindResolver); ok {
+		wants.SetParamKindResolver(i.paramKindResolver)
 	}
 }
 

--- a/pkg/kubeapiserver/admission/paramkind_resolver.go
+++ b/pkg/kubeapiserver/admission/paramkind_resolver.go
@@ -1,0 +1,257 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	policygeneric "k8s.io/apiserver/pkg/admission/plugin/policy/generic"
+	"k8s.io/client-go/tools/cache"
+)
+
+const crdGroupKindIndex = "paramKindGroupKind"
+
+type crdParamKindResolver struct {
+	lock                sync.RWMutex
+	informer            cache.SharedIndexInformer
+	handlerRegistration cache.ResourceEventHandlerRegistration
+	informerExpected    bool
+	// Retain GVKs once served by an established CRD so stale discovery cannot resurrect them after removal.
+	knownGroupVersionKinds map[schema.GroupVersionKind]struct{}
+	callbacks              map[uint64]func(schema.GroupKind)
+	nextCallbackID         uint64
+}
+
+var _ policygeneric.ParamKindResolver = &crdParamKindResolver{}
+
+func newCRDParamKindResolver() *crdParamKindResolver {
+	return &crdParamKindResolver{
+		knownGroupVersionKinds: map[schema.GroupVersionKind]struct{}{},
+		callbacks:              map[uint64]func(schema.GroupKind){},
+	}
+}
+
+func (r *crdParamKindResolver) ExpectCustomResourceDefinitionInformer() {
+	r.lock.Lock()
+	r.informerExpected = true
+	r.lock.Unlock()
+}
+
+func (r *crdParamKindResolver) SetCustomResourceDefinitionInformer(informer apiextensionsinformers.CustomResourceDefinitionInformer) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.informer != nil {
+		return fmt.Errorf("custom resource definition informer is already configured")
+	}
+
+	sharedInformer := informer.Informer()
+	if err := sharedInformer.AddIndexers(cache.Indexers{crdGroupKindIndex: crdGroupKindIndexFunc}); err != nil {
+		return fmt.Errorf("failed to add paramKind index to custom resource definition informer: %w", err)
+	}
+	handlerRegistration, err := sharedInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			r.notifyChanges(obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			r.notifyChanges(oldObj, newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			r.notifyChanges(obj)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to register custom resource definition event handler: %w", err)
+	}
+	r.informer = sharedInformer
+	r.handlerRegistration = handlerRegistration
+	r.informerExpected = true
+	return nil
+}
+
+func (r *crdParamKindResolver) Resolve(_ context.Context, paramKind schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	if paramKind.Group == "" {
+		return nil, nil
+	}
+
+	r.lock.RLock()
+	informer := r.informer
+	r.lock.RUnlock()
+	if informer == nil {
+		return nil, nil
+	}
+
+	objects, err := informer.GetIndexer().ByIndex(crdGroupKindIndex, groupKindIndexKey(paramKind.GroupKind()))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, object := range objects {
+		crd, ok := object.(*apiextensionsv1.CustomResourceDefinition)
+		if !ok {
+			return nil, fmt.Errorf("unexpected object type %T in custom resource definition informer", object)
+		}
+		if crd.Spec.Group != paramKind.Group || crd.Status.AcceptedNames.Kind != paramKind.Kind || !isCRDEstablished(crd) {
+			continue
+		}
+		if !isCRDVersionServed(crd, paramKind.Version) {
+			return nil, nil
+		}
+
+		scope := meta.RESTScopeRoot
+		if crd.Spec.Scope == apiextensionsv1.NamespaceScoped {
+			scope = meta.RESTScopeNamespace
+		}
+		return &meta.RESTMapping{
+			Resource:         paramKind.GroupVersion().WithResource(crd.Status.AcceptedNames.Plural),
+			GroupVersionKind: paramKind,
+			Scope:            scope,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func (r *crdParamKindResolver) Handles(paramKind schema.GroupVersionKind) bool {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	_, known := r.knownGroupVersionKinds[paramKind]
+	return known
+}
+
+func (r *crdParamKindResolver) HasSynced() bool {
+	r.lock.RLock()
+	informer := r.informer
+	handlerRegistration := r.handlerRegistration
+	informerExpected := r.informerExpected
+	r.lock.RUnlock()
+	return (!informerExpected && informer == nil) || (handlerRegistration != nil && handlerRegistration.HasSynced())
+}
+
+func (r *crdParamKindResolver) RegisterForChanges(callback func(schema.GroupKind)) func() {
+	r.lock.Lock()
+	callbackID := r.nextCallbackID
+	r.nextCallbackID++
+	r.callbacks[callbackID] = callback
+	r.lock.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.lock.Lock()
+			delete(r.callbacks, callbackID)
+			r.lock.Unlock()
+		})
+	}
+}
+
+func (r *crdParamKindResolver) notifyChanges(objects ...interface{}) {
+	changedKinds := map[schema.GroupKind]struct{}{}
+	authoritativeKinds := map[schema.GroupVersionKind]struct{}{}
+	for _, object := range objects {
+		crd, ok := object.(*apiextensionsv1.CustomResourceDefinition)
+		if !ok {
+			if tombstone, tombstoneOK := object.(cache.DeletedFinalStateUnknown); tombstoneOK {
+				crd, ok = tombstone.Obj.(*apiextensionsv1.CustomResourceDefinition)
+			}
+		}
+		if !ok {
+			continue
+		}
+		if crd.Spec.Names.Kind != "" {
+			changedKinds[schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind}] = struct{}{}
+		}
+		if crd.Status.AcceptedNames.Kind != "" {
+			changedKinds[schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Status.AcceptedNames.Kind}] = struct{}{}
+		}
+		if !isCRDEstablished(crd) || crd.Status.AcceptedNames.Kind == "" || crd.Status.AcceptedNames.Plural == "" {
+			continue
+		}
+		for _, version := range crd.Spec.Versions {
+			if version.Served {
+				authoritativeKinds[schema.GroupVersionKind{
+					Group:   crd.Spec.Group,
+					Version: version.Name,
+					Kind:    crd.Status.AcceptedNames.Kind,
+				}] = struct{}{}
+			}
+		}
+	}
+
+	r.lock.Lock()
+	for paramKind := range authoritativeKinds {
+		r.knownGroupVersionKinds[paramKind] = struct{}{}
+	}
+	callbacks := make([]func(schema.GroupKind), 0, len(r.callbacks))
+	for _, callback := range r.callbacks {
+		callbacks = append(callbacks, callback)
+	}
+	r.lock.Unlock()
+
+	for groupKind := range changedKinds {
+		for _, callback := range callbacks {
+			callback(groupKind)
+		}
+	}
+}
+
+func crdGroupKindIndexFunc(object interface{}) ([]string, error) {
+	crd, ok := object.(*apiextensionsv1.CustomResourceDefinition)
+	if !ok {
+		return nil, fmt.Errorf("expected custom resource definition, got %T", object)
+	}
+	keys := map[string]struct{}{}
+	if crd.Spec.Names.Kind != "" {
+		keys[groupKindIndexKey(schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Spec.Names.Kind})] = struct{}{}
+	}
+	if crd.Status.AcceptedNames.Kind != "" {
+		keys[groupKindIndexKey(schema.GroupKind{Group: crd.Spec.Group, Kind: crd.Status.AcceptedNames.Kind})] = struct{}{}
+	}
+	result := make([]string, 0, len(keys))
+	for key := range keys {
+		result = append(result, key)
+	}
+	return result, nil
+}
+
+func groupKindIndexKey(groupKind schema.GroupKind) string {
+	return groupKind.Group + "/" + groupKind.Kind
+}
+
+func isCRDEstablished(crd *apiextensionsv1.CustomResourceDefinition) bool {
+	for _, condition := range crd.Status.Conditions {
+		if condition.Type == apiextensionsv1.Established && condition.Status == apiextensionsv1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func isCRDVersionServed(crd *apiextensionsv1.CustomResourceDefinition, version string) bool {
+	for _, crdVersion := range crd.Spec.Versions {
+		if crdVersion.Name == version {
+			return crdVersion.Served
+		}
+	}
+	return false
+}

--- a/pkg/kubeapiserver/admission/paramkind_resolver_test.go
+++ b/pkg/kubeapiserver/admission/paramkind_resolver_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	apiextensionsinformers "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubetesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestCRDParamKindResolver(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	tests := []struct {
+		name        string
+		crd         *apiextensionsv1.CustomResourceDefinition
+		want        *meta.RESTMapping
+		wantHandles bool
+	}{
+		{
+			name: "resolves established served CRD",
+			crd:  establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped),
+			want: &meta.RESTMapping{
+				Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+				GroupVersionKind: paramKind,
+				Scope:            meta.RESTScopeNamespace,
+			},
+			wantHandles: true,
+		},
+		{
+			name: "resolves cluster scoped CRD",
+			crd:  establishedCRD(paramKind, true, apiextensionsv1.ClusterScoped),
+			want: &meta.RESTMapping{
+				Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+				GroupVersionKind: paramKind,
+				Scope:            meta.RESTScopeRoot,
+			},
+			wantHandles: true,
+		},
+		{
+			name: "ignores unserved version",
+			crd:  establishedCRD(paramKind, false, apiextensionsv1.NamespaceScoped),
+		},
+		{
+			name: "ignores unestablished CRD",
+			crd: func() *apiextensionsv1.CustomResourceDefinition {
+				crd := establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped)
+				crd.Status.Conditions = nil
+				return crd
+			}(),
+		},
+		{
+			name: "ignores absent CRD",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var objects []runtime.Object
+			if test.crd != nil {
+				objects = append(objects, test.crd)
+			}
+			resolver, _ := startTestCRDParamKindResolver(t, objects...)
+
+			mapping, err := resolver.Resolve(context.Background(), paramKind)
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, mapping)
+			require.Equal(t, test.wantHandles, resolver.Handles(paramKind))
+		})
+	}
+}
+
+func TestCRDParamKindResolverClaimsOnlyServedAcceptedVersions(t *testing.T) {
+	acceptedParamKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v2", Kind: "ExampleParam"}
+	crd := establishedCRD(acceptedParamKind, true, apiextensionsv1.NamespaceScoped)
+	crd.Spec.Names.Kind = "ProposedParam"
+	crd.Spec.Versions = append(crd.Spec.Versions, apiextensionsv1.CustomResourceDefinitionVersion{Name: "v1", Served: false})
+	resolver, _ := startTestCRDParamKindResolver(t, crd)
+
+	require.True(t, resolver.Handles(acceptedParamKind))
+	require.False(t, resolver.Handles(schema.GroupVersionKind{Group: acceptedParamKind.Group, Version: "v1", Kind: acceptedParamKind.Kind}))
+	require.False(t, resolver.Handles(schema.GroupVersionKind{Group: acceptedParamKind.Group, Version: acceptedParamKind.Version, Kind: crd.Spec.Names.Kind}))
+}
+
+func TestCRDParamKindResolverRemainsAuthoritativeAfterVersionUnserved(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	crd := establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped)
+	resolver, client := startTestCRDParamKindResolver(t, crd)
+	changes := make(chan schema.GroupKind, 1)
+	unregister := resolver.RegisterForChanges(func(groupKind schema.GroupKind) {
+		changes <- groupKind
+	})
+	t.Cleanup(unregister)
+
+	updated := crd.DeepCopy()
+	updated.Spec.Versions[0].Served = false
+	_, err := client.ApiextensionsV1().CustomResourceDefinitions().Update(context.Background(), updated, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	select {
+	case groupKind := <-changes:
+		require.Equal(t, paramKind.GroupKind(), groupKind)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for CRD update notification")
+	}
+
+	mapping, err := resolver.Resolve(context.Background(), paramKind)
+	require.NoError(t, err)
+	require.Nil(t, mapping)
+	require.True(t, resolver.Handles(paramKind))
+}
+
+func TestCRDParamKindResolverRemainsAuthoritativeAfterDeletion(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	crd := establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped)
+	resolver, client := startTestCRDParamKindResolver(t, crd)
+	changes := make(chan schema.GroupKind, 1)
+	unregister := resolver.RegisterForChanges(func(groupKind schema.GroupKind) {
+		changes <- groupKind
+	})
+	t.Cleanup(unregister)
+
+	require.NoError(t, client.ApiextensionsV1().CustomResourceDefinitions().Delete(context.Background(), crd.Name, metav1.DeleteOptions{}))
+	select {
+	case groupKind := <-changes:
+		require.Equal(t, paramKind.GroupKind(), groupKind)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for CRD deletion notification")
+	}
+
+	mapping, err := resolver.Resolve(context.Background(), paramKind)
+	require.NoError(t, err)
+	require.Nil(t, mapping)
+	require.True(t, resolver.Handles(paramKind))
+}
+
+func TestCRDParamKindResolverDoesNotListDuringResolution(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	client := apiextensionsfake.NewSimpleClientset(establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped))
+	var listCalls atomic.Int32
+	client.PrependReactor("list", "customresourcedefinitions", func(kubetesting.Action) (bool, runtime.Object, error) {
+		listCalls.Add(1)
+		return false, nil, nil
+	})
+	resolver := startTestCRDParamKindResolverWithClient(t, client)
+
+	_, err := resolver.Resolve(context.Background(), paramKind)
+	require.NoError(t, err)
+	_, err = resolver.Resolve(context.Background(), paramKind)
+	require.NoError(t, err)
+
+	require.EqualValues(t, 1, listCalls.Load())
+}
+
+func TestCRDParamKindResolverSyncExpectation(t *testing.T) {
+	resolver := newCRDParamKindResolver()
+	require.True(t, resolver.HasSynced())
+
+	resolver.ExpectCustomResourceDefinitionInformer()
+	require.False(t, resolver.HasSynced())
+}
+
+func TestCRDParamKindResolverWaitsForHandlerSync(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	client := apiextensionsfake.NewSimpleClientset(establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped))
+	factory := apiextensionsinformers.NewSharedInformerFactory(client, 0)
+	informer := factory.Apiextensions().V1().CustomResourceDefinitions()
+	resolver := newCRDParamKindResolver()
+	require.NoError(t, resolver.SetCustomResourceDefinitionInformer(informer))
+
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	resolver.RegisterForChanges(func(schema.GroupKind) {
+		close(handlerStarted)
+		<-releaseHandler
+	})
+	t.Cleanup(func() {
+		select {
+		case <-releaseHandler:
+		default:
+			close(releaseHandler)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	factory.Start(ctx.Done())
+	require.True(t, cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced))
+	select {
+	case <-handlerStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for initial CRD event")
+	}
+	require.False(t, resolver.HasSynced())
+
+	close(releaseHandler)
+	require.True(t, cache.WaitForCacheSync(ctx.Done(), resolver.HasSynced))
+}
+
+func TestCRDParamKindResolverNotifiesOnCRDChanges(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	resolver, client := startTestCRDParamKindResolver(t)
+	changes := make(chan schema.GroupKind, 1)
+	unregister := resolver.RegisterForChanges(func(groupKind schema.GroupKind) {
+		changes <- groupKind
+	})
+	t.Cleanup(unregister)
+
+	_, err := client.ApiextensionsV1().CustomResourceDefinitions().Create(
+		context.Background(),
+		establishedCRD(paramKind, true, apiextensionsv1.NamespaceScoped),
+		metav1.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	select {
+	case groupKind := <-changes:
+		require.Equal(t, paramKind.GroupKind(), groupKind)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for CRD change notification")
+	}
+}
+
+func startTestCRDParamKindResolver(t *testing.T, objects ...runtime.Object) (*crdParamKindResolver, *apiextensionsfake.Clientset) {
+	t.Helper()
+	client := apiextensionsfake.NewSimpleClientset(objects...)
+	return startTestCRDParamKindResolverWithClient(t, client), client
+}
+
+func startTestCRDParamKindResolverWithClient(t *testing.T, client *apiextensionsfake.Clientset) *crdParamKindResolver {
+	t.Helper()
+	factory := apiextensionsinformers.NewSharedInformerFactory(client, 0)
+	informer := factory.Apiextensions().V1().CustomResourceDefinitions()
+	resolver := newCRDParamKindResolver()
+	require.NoError(t, resolver.SetCustomResourceDefinitionInformer(informer))
+	require.False(t, resolver.HasSynced())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	factory.Start(ctx.Done())
+	require.True(t, cache.WaitForCacheSync(ctx.Done(), informer.Informer().HasSynced))
+	require.True(t, resolver.HasSynced())
+	return resolver
+}
+
+func establishedCRD(paramKind schema.GroupVersionKind, served bool, scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+			Kind:       "CustomResourceDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: "exampleparams." + paramKind.Group},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: paramKind.Group,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "exampleparams",
+				Kind:   paramKind.Kind,
+			},
+			Scope: scope,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: paramKind.Version, Served: served, Storage: true},
+			},
+		},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			AcceptedNames: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "exampleparams",
+				Kind:   paramKind.Kind,
+			},
+			Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{
+				{Type: apiextensionsv1.Established, Status: apiextensionsv1.ConditionTrue},
+			},
+		},
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/plugin.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/plugin.go
@@ -42,6 +42,10 @@ import (
 type apiSourceFactory[H any] func(informers.SharedInformerFactory, kubernetes.Interface, dynamic.Interface, meta.RESTMapper) Source[H]
 type dispatcherFactory[H any] func(authorizer.UnconditionalAuthorizer, *matching.Matcher, kubernetes.Interface) Dispatcher[H]
 
+type wantsParamKindResolver interface {
+	SetParamKindResolver(ParamKindResolver)
+}
+
 // ReloadableSource extends HookSource with a method to run a reload loop
 // that watches for configuration changes and blocks until the context is canceled.
 type ReloadableSource[H any] interface {
@@ -90,10 +94,11 @@ type Plugin[H any] struct {
 	// apiServerID is the identity of this API server instance, used for metrics labeling.
 	apiServerID string
 
-	informerFactory informers.SharedInformerFactory
-	client          kubernetes.Interface
-	restMapper      meta.RESTMapper
-	dynamicClient   dynamic.Interface
+	informerFactory   informers.SharedInformerFactory
+	client            kubernetes.Interface
+	restMapper        meta.RESTMapper
+	dynamicClient     dynamic.Interface
+	paramKindResolver ParamKindResolver
 	// admissionConfigResources are admission configuration resources (VAP/MAP/VAPB/MAPB).
 	// API-based policies skip these to prevent circular dependencies, but static policies
 	// are safe to evaluate on them.
@@ -149,6 +154,12 @@ func (c *Plugin[H]) SetRESTMapper(mapper meta.RESTMapper) {
 
 func (c *Plugin[H]) SetDynamicClient(client dynamic.Interface) {
 	c.dynamicClient = client
+}
+
+// SetParamKindResolver configures a kube-apiserver-specific resolver for
+// parameter kinds not yet visible through the cached RESTMapper.
+func (c *Plugin[H]) SetParamKindResolver(resolver ParamKindResolver) {
+	c.paramKindResolver = resolver
 }
 
 func (c *Plugin[H]) SetDrainedNotification(stopCh <-chan struct{}) {
@@ -253,6 +264,9 @@ func (c *Plugin[H]) ValidateInitialization() error {
 	// Construct source once, avoiding overwriting if already set.
 	if c.source == nil {
 		apiSource := c.apiSourceFactory(c.informerFactory, c.client, c.dynamicClient, c.restMapper)
+		if wants, ok := apiSource.(wantsParamKindResolver); ok {
+			wants.SetParamKindResolver(c.paramKindResolver)
+		}
 
 		if len(c.staticManifestsDir) > 0 {
 			if c.staticSourceFactory == nil {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_dispatcher.go
@@ -39,6 +39,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+const directParamReadTimeout = time.Second
+
 // PolicyInvocation is a single policy-binding-param tuple from a Policy Hook
 // in the context of a specific request. The params have already been resolved
 // and any error in configuration or setting up the invocation is stored in
@@ -171,14 +173,15 @@ func (d *policyDispatcher[P, B, E]) Dispatch(ctx context.Context, a admission.At
 			}
 
 			// Collect params for this binding
-			params, err := CollectParams(
+			params, err := CollectParamsWithContext(
+				ctx,
 				policyAccessor.GetParamKind(),
 				hook.ParamInformer,
+				hook.ParamMapping,
 				hook.ParamScope,
 				bindingAccessor.GetParamRef(),
 				a.GetNamespace(),
 				hook.DynamicClient,
-				hook.RESTMapper,
 			)
 			if err != nil {
 				// There was an error collecting params for this binding.
@@ -271,7 +274,7 @@ func (d *policyDispatcher[P, B, E]) Dispatch(ctx context.Context, a admission.At
 // returns a single-element list with a nil param.
 //
 // The dynamicClient and restMapper parameters enable direct API fallback when
-// the informer cache hasn't received the watch event for a newly created param yet.
+// the informer cache has not synchronized a parameter yet.
 func CollectParams(
 	paramKind *v1.ParamKind,
 	paramInformer informers.GenericInformer,
@@ -281,10 +284,60 @@ func CollectParams(
 	dynamicClient dynamic.Interface,
 	restMapper meta.RESTMapper,
 ) ([]runtime.Object, error) {
+	if paramKind != nil && paramRef != nil && paramInformer != nil {
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if !cache.WaitForCacheSync(timeoutCtx.Done(), paramInformer.Informer().HasSynced) {
+			return nil, fmt.Errorf("paramKind kind `%v` not yet synced to use for admission", paramKind.String())
+		}
+	}
+	return collectParams(context.Background(), paramKind, paramInformer, paramScope, nil, paramRef, namespace, dynamicClient, restMapper)
+}
+
+// CollectParamsWithContext resolves parameters using the mapping selected by
+// the policy source. Named parameters use the informer as the fast path and
+// direct reads during initial synchronization or on cache misses. Selector
+// references retain the bounded informer synchronization wait.
+func CollectParamsWithContext(
+	ctx context.Context,
+	paramKind *v1.ParamKind,
+	paramInformer informers.GenericInformer,
+	paramMapping *meta.RESTMapping,
+	paramScope meta.RESTScope,
+	paramRef *v1.ParamRef,
+	namespace string,
+	dynamicClient dynamic.Interface,
+) ([]runtime.Object, error) {
+	if paramMapping != nil {
+		paramScope = paramMapping.Scope
+	}
+	if paramRef != nil && paramRef.Selector != nil && paramInformer != nil {
+		timeoutCtx, cancel := context.WithTimeout(ctx, directParamReadTimeout)
+		defer cancel()
+		if !cache.WaitForCacheSync(timeoutCtx.Done(), paramInformer.Informer().HasSynced) {
+			return nil, fmt.Errorf("paramKind kind `%v` not yet synced to use for admission", paramKind.String())
+		}
+	}
+	return collectParams(ctx, paramKind, paramInformer, paramScope, paramMapping, paramRef, namespace, dynamicClient, nil)
+}
+
+func collectParams(
+	ctx context.Context,
+	paramKind *v1.ParamKind,
+	paramInformer informers.GenericInformer,
+	paramScope meta.RESTScope,
+	paramMapping *meta.RESTMapping,
+	paramRef *v1.ParamRef,
+	namespace string,
+	dynamicClient dynamic.Interface,
+	restMapper meta.RESTMapper,
+) ([]runtime.Object, error) {
 	// If definition has paramKind, paramRef is required in binding.
 	// If definition has no paramKind, paramRef set in binding will be ignored.
 	var params []runtime.Object
 	var paramStore cache.GenericNamespaceLister
+	var paramsNamespace string
+	var informerSynced bool
 
 	// Make sure the param kind is ready to use
 	if paramKind != nil && paramRef != nil {
@@ -292,12 +345,15 @@ func CollectParams(
 			return nil, fmt.Errorf("paramKind kind `%v` not known",
 				paramKind.String())
 		}
+		if paramScope == nil {
+			return nil, fmt.Errorf("paramKind kind `%v` has no REST scope", paramKind.String())
+		}
 
 		// Set up cluster-scoped, or namespaced access to the params
 		// "default" if not provided, and paramKind is namespaced
 		paramStore = paramInformer.Lister()
 		if paramScope.Name() == meta.RESTScopeNameNamespace {
-			paramsNamespace := namespace
+			paramsNamespace = namespace
 			if len(paramRef.Namespace) > 0 {
 				paramsNamespace = paramRef.Namespace
 			} else if len(paramsNamespace) == 0 {
@@ -308,17 +364,7 @@ func CollectParams(
 
 			paramStore = paramInformer.Lister().ByNamespace(paramsNamespace)
 		}
-
-		// If the param informer for this admission policy has not yet
-		// had time to perform an initial listing, don't attempt to use
-		// it.
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		defer cancel()
-
-		if !cache.WaitForCacheSync(timeoutCtx.Done(), paramInformer.Informer().HasSynced) {
-			return nil, fmt.Errorf("paramKind kind `%v` not yet synced to use for admission",
-				paramKind.String())
-		}
+		informerSynced = paramInformer.Informer().HasSynced()
 	}
 
 	// Find params to use with policy
@@ -341,17 +387,21 @@ func CollectParams(
 			return nil, fmt.Errorf("paramRef.name and paramRef.selector are mutually exclusive")
 		}
 
-		// First attempt: try to get the param from the informer cache (fast path)
-		param, err := paramStore.Get(paramRef.Name)
-
-		// If cache returns NotFound and we have a client, try direct API call as fallback.
-		// This handles the race condition where resources (ConfigMap, Policy, Binding, and Param)
-		// are created in quick succession. The informer cache may have completed its initial
-		// sync (checked by WaitForCacheSync above), but newly created params might not have
-		// propagated to the cache yet. The direct API call ensures we get the correct answer
-		// without timing-dependent retry logic.
-		if apierrors.IsNotFound(err) && dynamicClient != nil && restMapper != nil && paramKind != nil {
-			param, err = getParamDirectly(dynamicClient, restMapper, paramKind, paramRef, namespace, paramScope)
+		var param runtime.Object
+		var err error
+		if informerSynced {
+			param, err = paramStore.Get(paramRef.Name)
+		}
+		if !informerSynced || apierrors.IsNotFound(err) {
+			mapping, mappingErr := mappingForDirectRead(paramKind, paramMapping, restMapper)
+			if mappingErr != nil {
+				return nil, mappingErr
+			}
+			if dynamicClient != nil && mapping != nil {
+				param, err = getParamDirectly(ctx, dynamicClient, mapping, paramRef.Name, paramsNamespace)
+			} else if !informerSynced {
+				return nil, fmt.Errorf("paramKind kind `%v` not yet synced to use for admission", paramKind.String())
+			}
 		}
 
 		switch {
@@ -369,6 +419,9 @@ func CollectParams(
 			// and unset namespace for cluster scoped resource
 			return nil, err
 		default:
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			// Internal error
 			utilruntime.HandleError(err)
 			return nil, err
@@ -384,6 +437,9 @@ func CollectParams(
 
 		paramList, err := paramStore.List(selector)
 		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			// There was a bad internal error
 			utilruntime.HandleError(err)
 			return nil, err
@@ -404,61 +460,49 @@ func CollectParams(
 	return params, nil
 }
 
-// getParamDirectly performs a direct API call to retrieve a param when the informer
-// cache doesn't have it yet. This handles the race condition where a param resource
-// is created but the watch event hasn't propagated to the informer cache.
-func getParamDirectly(
-	dynamicClient dynamic.Interface,
-	restMapper meta.RESTMapper,
-	paramKind *v1.ParamKind,
-	paramRef *v1.ParamRef,
-	namespace string,
-	paramScope meta.RESTScope,
-) (runtime.Object, error) {
-	// Convert GVK to GVR using the RESTMapper
+func mappingForDirectRead(paramKind *v1.ParamKind, mapping *meta.RESTMapping, restMapper meta.RESTMapper) (*meta.RESTMapping, error) {
+	if mapping != nil {
+		return mapping, nil
+	}
+	if restMapper == nil {
+		return nil, nil
+	}
 	gv, err := schema.ParseGroupVersion(paramKind.APIVersion)
 	if err != nil {
 		return nil, fmt.Errorf("invalid paramKind APIVersion %q: %w", paramKind.APIVersion, err)
 	}
-	gvk := gv.WithKind(paramKind.Kind)
-
-	mapping, err := restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	mapping, err = restMapper.RESTMapping(gv.WithKind(paramKind.Kind).GroupKind(), gv.Version)
+	if meta.IsNoMatchError(err) {
+		return nil, nil
+	}
 	if err != nil {
-		// An unknown paramKind (CRD not registered or deleted) is reported as
-		// NotFound so the caller routes it through ParameterNotFoundAction
-		// instead of failing the admission request as an internal error.
-		if meta.IsNoMatchError(err) {
-			return nil, apierrors.NewNotFound(schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind}, paramRef.Name)
-		}
-		return nil, fmt.Errorf("failed to find REST mapping for %v: %w", gvk, err)
+		return nil, fmt.Errorf("failed to find REST mapping for %v: %w", gv.WithKind(paramKind.Kind), err)
 	}
+	return mapping, nil
+}
 
-	// Determine the namespace for the Get request
-	var targetNamespace string
-	if paramScope.Name() == meta.RESTScopeNameNamespace {
-		if len(paramRef.Namespace) > 0 {
-			targetNamespace = paramRef.Namespace
-		} else {
-			targetNamespace = namespace
-		}
-	}
-
-	// Perform the direct API call with a timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+func getParamDirectly(
+	ctx context.Context,
+	dynamicClient dynamic.Interface,
+	mapping *meta.RESTMapping,
+	name string,
+	namespace string,
+) (runtime.Object, error) {
+	ctx, cancel := context.WithTimeout(ctx, directParamReadTimeout)
 	defer cancel()
-
-	var resourceClient dynamic.ResourceInterface
-	if targetNamespace != "" {
-		resourceClient = dynamicClient.Resource(mapping.Resource).Namespace(targetNamespace)
-	} else {
-		resourceClient = dynamicClient.Resource(mapping.Resource)
-	}
-
-	param, err := resourceClient.Get(ctx, paramRef.Name, metav1.GetOptions{})
+	resourceClient := paramResourceClient(dynamicClient, mapping, namespace)
+	param, err := resourceClient.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
-	return convertParamToInformerRepresentation(gvk, param)
+	return convertParamToInformerRepresentation(mapping.GroupVersionKind, param)
+}
+
+func paramResourceClient(dynamicClient dynamic.Interface, mapping *meta.RESTMapping, namespace string) dynamic.ResourceInterface {
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		return dynamicClient.Resource(mapping.Resource).Namespace(namespace)
+	}
+	return dynamicClient.Resource(mapping.Resource)
 }
 
 // convertParamToInformerRepresentation makes a get response object look like an informer object by

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_dispatcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_dispatcher_test.go
@@ -17,15 +17,26 @@ limitations under the License.
 package generic
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	v1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
 )
 
 // TestConvertParamToInformerRepresentation verifies that params fetched with the
@@ -118,4 +129,281 @@ func TestConvertParamToInformerRepresentation(t *testing.T) {
 			require.Equal(t, tt.wantObject, converted)
 		})
 	}
+}
+
+func TestCollectParamsWithContextReadsUnsyncedNamedParamDirectly(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestParam"}
+	gvr := gvk.GroupVersion().WithResource("testparams")
+	mapping := &meta.RESTMapping{Resource: gvr, GroupVersionKind: gvk, Scope: meta.RESTScopeNamespace}
+	param := newUnstructuredParam(gvk, "matching", "default", nil)
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), param)
+	informer := dynamicinformer.NewFilteredDynamicInformer(
+		client,
+		gvr,
+		metav1.NamespaceAll,
+		0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		nil,
+	)
+	require.False(t, informer.Informer().HasSynced())
+
+	params, err := CollectParamsWithContext(
+		context.Background(),
+		&v1.ParamKind{APIVersion: gvk.GroupVersion().String(), Kind: gvk.Kind},
+		informer,
+		mapping,
+		nil,
+		&v1.ParamRef{Name: "matching", Namespace: "default"},
+		"default",
+		client,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, params, 1)
+	accessor, err := meta.Accessor(params[0])
+	require.NoError(t, err)
+	require.Equal(t, "matching", accessor.GetName())
+	require.Len(t, client.Actions(), 1)
+	require.Equal(t, "get", client.Actions()[0].GetVerb())
+}
+
+func TestCollectParamsWithContextWaitsForUnsyncedSelector(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestParam"}
+	gvr := gvk.GroupVersion().WithResource("testparams")
+	mapping := &meta.RESTMapping{Resource: gvr, GroupVersionKind: gvk, Scope: meta.RESTScopeNamespace}
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	informer := dynamicinformer.NewFilteredDynamicInformer(
+		client,
+		gvr,
+		metav1.NamespaceAll,
+		0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		nil,
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := CollectParamsWithContext(
+		ctx,
+		&v1.ParamKind{APIVersion: gvk.GroupVersion().String(), Kind: gvk.Kind},
+		informer,
+		mapping,
+		nil,
+		&v1.ParamRef{
+			Namespace: "default",
+			Selector:  &metav1.LabelSelector{MatchLabels: map[string]string{"selected": "true"}},
+		},
+		"default",
+		client,
+	)
+
+	require.ErrorContains(t, err, "not yet synced to use for admission")
+	require.Empty(t, client.Actions(), "selector references must not issue direct LIST requests")
+}
+
+func TestCollectParamsWithContextPropagatesCancellation(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestParam"}
+	gvr := gvk.GroupVersion().WithResource("testparams")
+	mapping := &meta.RESTMapping{Resource: gvr, GroupVersionKind: gvk, Scope: meta.RESTScopeNamespace}
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	informer := dynamicinformer.NewFilteredDynamicInformer(
+		client,
+		gvr,
+		metav1.NamespaceAll,
+		0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		nil,
+	)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := CollectParamsWithContext(
+		ctx,
+		&v1.ParamKind{APIVersion: gvk.GroupVersion().String(), Kind: gvk.Kind},
+		informer,
+		mapping,
+		nil,
+		&v1.ParamRef{Name: "test", Namespace: "default"},
+		"default",
+		contextAwareDynamicClient{Interface: client},
+	)
+
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestCollectParamsWithContextAppliesNotFoundActionToDirectReads(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestParam"}
+	gvr := gvk.GroupVersion().WithResource("testparams")
+	mapping := &meta.RESTMapping{Resource: gvr, GroupVersionKind: gvk, Scope: meta.RESTScopeNamespace}
+
+	tests := []struct {
+		name      string
+		paramRef  *v1.ParamRef
+		wantError bool
+	}{
+		{
+			name: "missing name is allowed",
+			paramRef: &v1.ParamRef{
+				Name:                    "missing",
+				Namespace:               "default",
+				ParameterNotFoundAction: ptr.To(v1.AllowAction),
+			},
+		},
+		{
+			name: "missing name is denied",
+			paramRef: &v1.ParamRef{
+				Name:                    "missing",
+				Namespace:               "default",
+				ParameterNotFoundAction: ptr.To(v1.DenyAction),
+			},
+			wantError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+				runtime.NewScheme(),
+				map[schema.GroupVersionResource]string{gvr: "TestParamList"},
+			)
+			informer := dynamicinformer.NewFilteredDynamicInformer(
+				client,
+				gvr,
+				metav1.NamespaceAll,
+				0,
+				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+				nil,
+			)
+
+			params, err := CollectParamsWithContext(
+				context.Background(),
+				&v1.ParamKind{APIVersion: gvk.GroupVersion().String(), Kind: gvk.Kind},
+				informer,
+				mapping,
+				nil,
+				test.paramRef,
+				"default",
+				client,
+			)
+
+			if test.wantError {
+				require.ErrorContains(t, err, "no params found")
+			} else {
+				require.NoError(t, err)
+			}
+			require.Empty(t, params)
+		})
+	}
+}
+
+func TestCollectParamsWithContextReturnsDirectReadErrors(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "example.com", Version: "v1", Kind: "TestParam"}
+	gvr := gvk.GroupVersion().WithResource("testparams")
+	mapping := &meta.RESTMapping{Resource: gvr, GroupVersionKind: gvk, Scope: meta.RESTScopeNamespace}
+
+	tests := []struct {
+		name         string
+		verb         string
+		paramRef     *v1.ParamRef
+		directErr    error
+		wantInternal bool
+	}{
+		{
+			name:      "name timeout",
+			verb:      "get",
+			paramRef:  &v1.ParamRef{Name: "test", Namespace: "default", ParameterNotFoundAction: ptr.To(v1.AllowAction)},
+			directErr: context.DeadlineExceeded,
+		},
+		{
+			name:         "name server error",
+			verb:         "get",
+			paramRef:     &v1.ParamRef{Name: "test", Namespace: "default", ParameterNotFoundAction: ptr.To(v1.AllowAction)},
+			directErr:    apierrors.NewInternalError(errors.New("backend unavailable")),
+			wantInternal: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+				runtime.NewScheme(),
+				map[schema.GroupVersionResource]string{gvr: "TestParamList"},
+			)
+			client.PrependReactor(test.verb, gvr.Resource, func(clienttesting.Action) (bool, runtime.Object, error) {
+				return true, nil, test.directErr
+			})
+			informer := dynamicinformer.NewFilteredDynamicInformer(
+				client,
+				gvr,
+				metav1.NamespaceAll,
+				0,
+				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+				nil,
+			)
+
+			params, err := CollectParamsWithContext(
+				context.Background(),
+				&v1.ParamKind{APIVersion: gvk.GroupVersion().String(), Kind: gvk.Kind},
+				informer,
+				mapping,
+				nil,
+				test.paramRef,
+				"default",
+				client,
+			)
+
+			require.Empty(t, params)
+			if test.wantInternal {
+				require.True(t, apierrors.IsInternalError(err), "expected internal error, got %v", err)
+			} else {
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+			}
+			require.Len(t, client.Actions(), 1)
+			require.Equal(t, test.verb, client.Actions()[0].GetVerb())
+		})
+	}
+}
+
+func newUnstructuredParam(gvk schema.GroupVersionKind, name, namespace string, labels map[string]string) *unstructured.Unstructured {
+	unstructuredLabels := make(map[string]interface{}, len(labels))
+	for key, value := range labels {
+		unstructuredLabels[key] = value
+	}
+	param := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": gvk.GroupVersion().String(),
+		"kind":       gvk.Kind,
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+			"labels":    unstructuredLabels,
+		},
+	}}
+	return param
+}
+
+type contextAwareDynamicClient struct {
+	dynamic.Interface
+}
+
+func (c contextAwareDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &contextAwareNamespaceableResource{NamespaceableResourceInterface: c.Interface.Resource(resource)}
+}
+
+type contextAwareNamespaceableResource struct {
+	dynamic.NamespaceableResourceInterface
+}
+
+func (r *contextAwareNamespaceableResource) Namespace(namespace string) dynamic.ResourceInterface {
+	return &contextAwareResource{ResourceInterface: r.NamespaceableResourceInterface.Namespace(namespace)}
+}
+
+type contextAwareResource struct {
+	dynamic.ResourceInterface
+}
+
+func (r *contextAwareResource) Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return r.ResourceInterface.Get(ctx, name, options, subresources...)
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
@@ -109,6 +109,9 @@ type PolicyHook[P runtime.Object, B runtime.Object, E Evaluator] struct {
 	// there is no param or if there was a configuration error
 	ParamInformer informers.GenericInformer
 	ParamScope    meta.RESTScope
+	// ParamMapping is the mapping selected for ParamKind by the policy source.
+	// API-backed hooks use it for direct reads while ParamInformer is warming.
+	ParamMapping *meta.RESTMapping
 
 	// DynamicClient is used for direct API calls to handle cache misses
 	DynamicClient dynamic.Interface
@@ -408,13 +411,18 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 			usedParams[*parsedParamKind] = struct{}{}
 		}
 
-		paramInformer, paramScope, configurationError := s.ensureParamsForPolicyLocked(parsedParamKind)
+		paramInformer, paramMapping, configurationError := s.ensureParamsForPolicyLocked(parsedParamKind)
+		var paramScope meta.RESTScope
+		if paramMapping != nil {
+			paramScope = paramMapping.Scope
+		}
 		result = append(result, PolicyHook[P, B, E]{
 			Policy:             policySpec,
 			Bindings:           bindingSpecs,
 			Evaluator:          s.compilePolicyLocked(policySpec),
 			ParamInformer:      paramInformer,
 			ParamScope:         paramScope,
+			ParamMapping:       paramMapping,
 			DynamicClient:      s.dynamicClient,
 			RESTMapper:         s.restMapper,
 			ConfigurationError: configurationError,
@@ -452,10 +460,10 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 }
 
 // ensureParamsForPolicyLocked ensures that the informer for the paramKind is
-// started and returns the informer and the scope of the paramKind.
+// started and returns the informer and REST mapping of the paramKind.
 //
 // Must be called under write lock
-func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.GroupVersionKind) (informers.GenericInformer, meta.RESTScope, error) {
+func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.GroupVersionKind) (informers.GenericInformer, *meta.RESTMapping, error) {
 	if paramSource == nil {
 		return nil, nil, nil
 	}
@@ -463,7 +471,7 @@ func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.
 	existingInfo, exists := s.paramsCRDControllers[*paramSource]
 	_, mustReconcile := s.paramKindsToReconcile[*paramSource]
 	if exists && !mustReconcile {
-		return existingInfo.informer, existingInfo.mapping.Scope, nil
+		return existingInfo.informer, &existingInfo.mapping, nil
 	}
 	delete(s.paramKindsToReconcile, *paramSource)
 
@@ -476,7 +484,7 @@ func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.
 		return nil, nil, err
 	}
 	if exists && sameRESTMapping(&existingInfo.mapping, mapping) {
-		return existingInfo.informer, existingInfo.mapping.Scope, nil
+		return existingInfo.informer, &existingInfo.mapping, nil
 	}
 	if exists {
 		existingInfo.cancelFunc()
@@ -519,7 +527,7 @@ func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.
 		informer:   informer,
 	}
 	s.paramsCRDControllers[*paramSource] = ret
-	return ret.informer, ret.mapping.Scope, nil
+	return ret.informer, &ret.mapping, nil
 }
 
 func (s *policySource[P, B, E]) resolveParamKindFromResolverLocked(paramSource schema.GroupVersionKind) (*meta.RESTMapping, error) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source.go
@@ -18,14 +18,14 @@ package generic
 
 import (
 	"context"
-	goerrors "errors"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,6 +54,7 @@ type policySource[P runtime.Object, B runtime.Object, E Evaluator] struct {
 	policyInformer     generic.Informer[P]
 	bindingInformer    generic.Informer[B]
 	restMapper         meta.RESTMapper
+	paramKindResolver  ParamKindResolver
 	newPolicyAccessor  func(P) PolicyAccessor
 	newBindingAccessor func(B) BindingAccessor
 
@@ -71,14 +72,15 @@ type policySource[P runtime.Object, B runtime.Object, E Evaluator] struct {
 	compiledPolicies map[types.NamespacedName]compiledPolicyEntry[E]
 
 	// Temporary until we use the dynamic informer factory
-	paramsCRDControllers map[schema.GroupVersionKind]*paramInfo
+	paramsCRDControllers  map[schema.GroupVersionKind]*paramInfo
+	paramKindsToReconcile map[schema.GroupVersionKind]struct{}
 }
 
 type paramInfo struct {
 	mapping meta.RESTMapping
 
-	// When the param is changed, or the informer is done being used, the cancel
-	// func should be called to stop/cleanup the original informer
+	// For privately owned dynamic informers, cancelFunc stops the informer. It is
+	// a no-op for informers owned by the shared factory.
 	cancelFunc func()
 
 	// The lister for this param
@@ -88,6 +90,15 @@ type paramInfo struct {
 type compiledPolicyEntry[E Evaluator] struct {
 	policyVersion string
 	evaluator     E
+}
+
+// ParamKindResolver resolves param kinds that are not yet available through the
+// admission plugin's cached RESTMapper.
+type ParamKindResolver interface {
+	Resolve(context.Context, schema.GroupVersionKind) (*meta.RESTMapping, error)
+	Handles(schema.GroupVersionKind) bool
+	HasSynced() bool
+	RegisterForChanges(func(schema.GroupKind)) func()
 }
 
 type PolicyHook[P runtime.Object, B runtime.Object, E Evaluator] struct {
@@ -120,19 +131,51 @@ func NewPolicySource[P runtime.Object, B runtime.Object, E Evaluator](
 	dynamicClient dynamic.Interface,
 	restMapper meta.RESTMapper,
 ) Source[PolicyHook[P, B, E]] {
+	return newPolicySource(
+		policyInformer,
+		bindingInformer,
+		newPolicyAccessor,
+		newBindingAccessor,
+		compiler,
+		paramInformerFactory,
+		dynamicClient,
+		restMapper,
+		nil,
+	)
+}
+
+func newPolicySource[P runtime.Object, B runtime.Object, E Evaluator](
+	policyInformer cache.SharedIndexInformer,
+	bindingInformer cache.SharedIndexInformer,
+	newPolicyAccessor func(P) PolicyAccessor,
+	newBindingAccessor func(B) BindingAccessor,
+	compiler func(P) E,
+	paramInformerFactory informers.SharedInformerFactory,
+	dynamicClient dynamic.Interface,
+	restMapper meta.RESTMapper,
+	paramKindResolver ParamKindResolver,
+) Source[PolicyHook[P, B, E]] {
 	res := &policySource[P, B, E]{
-		compiler:             compiler,
-		policyInformer:       generic.NewInformer[P](policyInformer),
-		bindingInformer:      generic.NewInformer[B](bindingInformer),
-		compiledPolicies:     map[types.NamespacedName]compiledPolicyEntry[E]{},
-		newPolicyAccessor:    newPolicyAccessor,
-		newBindingAccessor:   newBindingAccessor,
-		paramsCRDControllers: map[schema.GroupVersionKind]*paramInfo{},
-		informerFactory:      paramInformerFactory,
-		dynamicClient:        dynamicClient,
-		restMapper:           restMapper,
+		compiler:              compiler,
+		policyInformer:        generic.NewInformer[P](policyInformer),
+		bindingInformer:       generic.NewInformer[B](bindingInformer),
+		compiledPolicies:      map[types.NamespacedName]compiledPolicyEntry[E]{},
+		newPolicyAccessor:     newPolicyAccessor,
+		newBindingAccessor:    newBindingAccessor,
+		paramsCRDControllers:  map[schema.GroupVersionKind]*paramInfo{},
+		paramKindsToReconcile: map[schema.GroupVersionKind]struct{}{},
+		informerFactory:       paramInformerFactory,
+		dynamicClient:         dynamicClient,
+		restMapper:            restMapper,
+		paramKindResolver:     paramKindResolver,
 	}
 	return res
+}
+
+// SetParamKindResolver configures a fallback resolver for parameter kinds not
+// yet visible through the cached RESTMapper.
+func (s *policySource[P, B, E]) SetParamKindResolver(resolver ParamKindResolver) {
+	s.paramKindResolver = resolver
 }
 
 // SetPolicyRefreshIntervalForTests allows the refresh interval to be overridden during tests.
@@ -152,9 +195,12 @@ func (s *policySource[P, B, E]) Run(ctx context.Context) error {
 	if s.ctx != nil {
 		return fmt.Errorf("policy source already running")
 	}
+	if s.paramKindResolver != nil {
+		unregister := s.paramKindResolver.RegisterForChanges(s.paramKindChanged)
+		defer unregister()
+	}
 
-	// Wait for initial cache sync of policies and informers before reconciling
-	// any
+	// Wait for initial cache sync of policies and bindings before reconciling.
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, s.UpstreamHasSynced) {
 		err := ctx.Err()
 		if err == nil {
@@ -215,7 +261,8 @@ func (s *policySource[P, B, E]) Run(ctx context.Context) error {
 }
 
 func (s *policySource[P, B, E]) UpstreamHasSynced() bool {
-	return s.policyInformer.HasSynced() && s.bindingInformer.HasSynced()
+	return s.policyInformer.HasSynced() &&
+		s.bindingInformer.HasSynced()
 }
 
 // HasSynced implements Source.
@@ -272,6 +319,17 @@ func (s *policySource[P, B, E]) notify() {
 	s.policiesDirty.Store(true)
 }
 
+func (s *policySource[P, B, E]) paramKindChanged(groupKind schema.GroupKind) {
+	s.lock.Lock()
+	for paramKind := range s.paramsCRDControllers {
+		if paramKind.GroupKind() == groupKind {
+			s.paramKindsToReconcile[paramKind] = struct{}{}
+		}
+	}
+	s.lock.Unlock()
+	s.notify()
+}
+
 // calculatePolicyData calculates the list of policies and bindings for each
 // policy. If there is an error in generation, it will return the error and
 // the partial list of policies that were able to be generated. Policies that
@@ -315,7 +373,7 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 			inf = s.policyInformer.Namespaced(policyKey.Namespace)
 		}
 		policySpec, err := inf.Get(policyKey.Name)
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// Policy for bindings doesn't exist. This can happen if the policy
 			// was deleted before the binding, or the binding was created first.
 			//
@@ -362,9 +420,8 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 			ConfigurationError: configurationError,
 		})
 
-		// Should queue a re-sync for policy sync error. If our shared param
-		// informer can notify us when CRD discovery changes we can remove this
-		// and just rely on the informer to notify us when the CRDs change
+		// Keep retrying errors that may involve non-CRD kinds or transient
+		// failures. CRD lifecycle changes also mark affected mappings for refresh.
 		if configurationError != nil {
 			errs = append(errs, configurationError)
 		}
@@ -383,12 +440,13 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 		if _, wasSeen := usedParams[paramKind]; !wasSeen {
 			info.cancelFunc()
 			delete(s.paramsCRDControllers, paramKind)
+			delete(s.paramKindsToReconcile, paramKind)
 		}
 	}
 
 	err = nil
 	if len(errs) > 0 {
-		err = goerrors.Join(errs...)
+		err = errors.Join(errs...)
 	}
 	return result, err
 }
@@ -400,40 +458,47 @@ func (s *policySource[P, B, E]) calculatePolicyData() ([]PolicyHook[P, B, E], er
 func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.GroupVersionKind) (informers.GenericInformer, meta.RESTScope, error) {
 	if paramSource == nil {
 		return nil, nil, nil
-	} else if info, ok := s.paramsCRDControllers[*paramSource]; ok {
-		return info.informer, info.mapping.Scope, nil
 	}
 
-	mapping, err := s.restMapper.RESTMapping(schema.GroupKind{
-		Group: paramSource.Group,
-		Kind:  paramSource.Kind,
-	}, paramSource.Version)
+	existingInfo, exists := s.paramsCRDControllers[*paramSource]
+	_, mustReconcile := s.paramKindsToReconcile[*paramSource]
+	if exists && !mustReconcile {
+		return existingInfo.informer, existingInfo.mapping.Scope, nil
+	}
+	delete(s.paramKindsToReconcile, *paramSource)
 
+	mapping, err := s.resolveParamKindRESTMappingLocked(*paramSource)
 	if err != nil {
-		// Failed to resolve. Return error so we retry again (rate limited)
-		// Save a record of this definition with an evaluator that unconditionally
-		return nil, nil, fmt.Errorf("failed to find resource referenced by paramKind: '%v'", *paramSource)
+		if exists {
+			existingInfo.cancelFunc()
+			delete(s.paramsCRDControllers, *paramSource)
+		}
+		return nil, nil, err
 	}
-
-	// We are not watching this param. Start an informer for it.
-	instanceContext, instanceCancel := context.WithCancel(s.ctx)
+	if exists && sameRESTMapping(&existingInfo.mapping, mapping) {
+		return existingInfo.informer, existingInfo.mapping.Scope, nil
+	}
+	if exists {
+		existingInfo.cancelFunc()
+		delete(s.paramsCRDControllers, *paramSource)
+	}
 
 	var informer informers.GenericInformer
+	var cancelInformer func()
 
 	// Try to see if our provided informer factory has an informer for this type.
-	// We assume the informer is already started, and starts all types associated
-	// with it.
 	if genericInformer, err := s.informerFactory.ForResource(mapping.Resource); err == nil {
 		informer = genericInformer
-
-		// Start the informer
-		s.informerFactory.Start(instanceContext.Done())
+		cancelInformer = func() {}
+		s.informerFactory.Start(s.ctx.Done())
 
 	} else {
 		// Dynamic JSON informer fallback.
 		// Cannot use shared dynamic informer since it would be impossible
 		// to clean CRD informers properly with multiple dependents
 		// (cannot start ahead of time, and cannot track dependencies via stopCh)
+		instanceContext, instanceCancel := context.WithCancel(s.ctx)
+		cancelInformer = instanceCancel
 		informer = dynamicinformer.NewFilteredDynamicInformer(
 			s.dynamicClient,
 			mapping.Resource,
@@ -450,11 +515,59 @@ func (s *policySource[P, B, E]) ensureParamsForPolicyLocked(paramSource *schema.
 	klog.Infof("informer started for %v", *paramSource)
 	ret := &paramInfo{
 		mapping:    *mapping,
-		cancelFunc: instanceCancel,
+		cancelFunc: cancelInformer,
 		informer:   informer,
 	}
 	s.paramsCRDControllers[*paramSource] = ret
-	return ret.informer, mapping.Scope, nil
+	return ret.informer, ret.mapping.Scope, nil
+}
+
+func (s *policySource[P, B, E]) resolveParamKindFromResolverLocked(paramSource schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	mapping, err := s.paramKindResolver.Resolve(s.ctx, paramSource)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve resource referenced by paramKind %q: %w", paramSource, err)
+	}
+	if mapping == nil {
+		return nil, fmt.Errorf("failed to find resource referenced by paramKind: '%v'", paramSource)
+	}
+	return mapping, nil
+}
+
+func sameRESTMapping(left, right *meta.RESTMapping) bool {
+	return left.Resource == right.Resource &&
+		left.GroupVersionKind == right.GroupVersionKind &&
+		left.Scope.Name() == right.Scope.Name()
+}
+
+func (s *policySource[P, B, E]) resolveParamKindRESTMappingLocked(paramSource schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	if s.paramKindResolver != nil {
+		if !s.paramKindResolver.HasSynced() {
+			return nil, fmt.Errorf("paramKind resolver is not yet synced for %q", paramSource)
+		}
+		if s.paramKindResolver.Handles(paramSource) {
+			return s.resolveParamKindFromResolverLocked(paramSource)
+		}
+	}
+	mapping, err := s.restMapper.RESTMapping(schema.GroupKind{
+		Group: paramSource.Group,
+		Kind:  paramSource.Kind,
+	}, paramSource.Version)
+	if err == nil {
+		return mapping, nil
+	}
+	if meta.IsNoMatchError(err) && s.paramKindResolver != nil {
+		mapping, resolveErr := s.paramKindResolver.Resolve(s.ctx, paramSource)
+		if resolveErr != nil {
+			return nil, fmt.Errorf("failed to resolve resource referenced by paramKind %q: %w", paramSource, resolveErr)
+		}
+		if mapping != nil {
+			return mapping, nil
+		}
+	}
+
+	// Failed to resolve. Return error so we retry again (rate limited)
+	// Save a record of this definition with an evaluator that unconditionally
+	return nil, fmt.Errorf("failed to find resource referenced by paramKind: '%v'", paramSource)
 }
 
 // For testing

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_internal_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_internal_test.go
@@ -1,0 +1,486 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	v1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/admission/plugin/policy/matching"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/client-go/kubernetes"
+)
+
+type internalFakeDispatcher struct{}
+
+func (d *internalFakeDispatcher) Dispatch(context.Context, admission.Attributes, admission.ObjectInterfaces, []PolicyHook[*internalFakePolicy, *internalFakeBinding, Evaluator]) error {
+	return nil
+}
+
+func (d *internalFakeDispatcher) Start(context.Context) error {
+	return nil
+}
+
+func makeInternalFakeDispatcher(authorizer.UnconditionalAuthorizer, *matching.Matcher, kubernetes.Interface) Dispatcher[PolicyHook[*internalFakePolicy, *internalFakeBinding, Evaluator]] {
+	return &internalFakeDispatcher{}
+}
+
+type internalFakePolicy struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	ParamKind *v1.ParamKind
+}
+
+func (p *internalFakePolicy) GetName() string                         { return p.Name }
+func (p *internalFakePolicy) GetNamespace() string                    { return p.Namespace }
+func (p *internalFakePolicy) GetParamKind() *v1.ParamKind             { return p.ParamKind }
+func (p *internalFakePolicy) GetMatchConstraints() *v1.MatchResources { return nil }
+func (p *internalFakePolicy) GetFailurePolicy() *v1.FailurePolicyType { return nil }
+func (p *internalFakePolicy) DeepCopyObject() runtime.Object          { copy := *p; return &copy }
+
+type internalFakeBinding struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	PolicyName string
+}
+
+func (b *internalFakeBinding) GetName() string      { return b.Name }
+func (b *internalFakeBinding) GetNamespace() string { return b.Namespace }
+func (b *internalFakeBinding) GetPolicyName() types.NamespacedName {
+	return types.NamespacedName{Name: b.PolicyName}
+}
+func (b *internalFakeBinding) GetParamRef() *v1.ParamRef             { return nil }
+func (b *internalFakeBinding) GetMatchResources() *v1.MatchResources { return nil }
+func (b *internalFakeBinding) DeepCopyObject() runtime.Object        { copy := *b; return &copy }
+
+type fixedErrorRESTMapper struct {
+	err error
+}
+
+func (m fixedErrorRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, m.err
+}
+
+func (m fixedErrorRESTMapper) KindsFor(schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, m.err
+}
+
+func (m fixedErrorRESTMapper) ResourceFor(schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, m.err
+}
+
+func (m fixedErrorRESTMapper) ResourcesFor(schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, m.err
+}
+
+func (m fixedErrorRESTMapper) RESTMapping(schema.GroupKind, ...string) (*meta.RESTMapping, error) {
+	return nil, m.err
+}
+
+func (m fixedErrorRESTMapper) RESTMappings(schema.GroupKind, ...string) ([]*meta.RESTMapping, error) {
+	return nil, m.err
+}
+
+func (m fixedErrorRESTMapper) ResourceSingularizer(string) (string, error) {
+	return "", m.err
+}
+
+type fakeParamKindResolver struct {
+	mapping   *meta.RESTMapping
+	err       error
+	handles   func(schema.GroupVersionKind) bool
+	hasSynced func() bool
+}
+
+func (r fakeParamKindResolver) Resolve(context.Context, schema.GroupVersionKind) (*meta.RESTMapping, error) {
+	return r.mapping, r.err
+}
+
+func (r fakeParamKindResolver) Handles(paramKind schema.GroupVersionKind) bool {
+	return r.handles == nil || r.handles(paramKind)
+}
+
+func (r fakeParamKindResolver) HasSynced() bool {
+	return r.hasSynced == nil || r.hasSynced()
+}
+
+func (r fakeParamKindResolver) RegisterForChanges(func(schema.GroupKind)) func() {
+	return func() {}
+}
+
+func TestResolveParamKindRESTMappingWaitsForResolverSync(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{paramKind.GroupVersion()})
+	restMapper.AddSpecific(
+		paramKind,
+		paramKind.GroupVersion().WithResource("exampleparams"),
+		paramKind.GroupVersion().WithResource("exampleparam"),
+		meta.RESTScopeNamespace,
+	)
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:        context.Background(),
+		restMapper: restMapper,
+		paramKindResolver: fakeParamKindResolver{
+			handles:   func(schema.GroupVersionKind) bool { return false },
+			hasSynced: func() bool { return false },
+		},
+	}
+
+	mapping, err := source.resolveParamKindRESTMappingLocked(paramKind)
+
+	require.ErrorContains(t, err, "paramKind resolver is not yet synced")
+	require.Nil(t, mapping)
+}
+
+func TestPolicySourceInitializesAndRecoversWithUnsyncedParamKindResolver(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	mapping := meta.RESTMapping{
+		Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+		GroupVersionKind: paramKind,
+		Scope:            meta.RESTScopeNamespace,
+	}
+	policyWithParams := &internalFakePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "with-params"},
+		ParamKind:  &v1.ParamKind{APIVersion: paramKind.GroupVersion().String(), Kind: paramKind.Kind},
+	}
+	policyWithoutParams := &internalFakePolicy{ObjectMeta: metav1.ObjectMeta{Name: "without-params"}}
+	var resolverSynced atomic.Bool
+	testContext, testCancel, err := NewPolicyTestContext(
+		t,
+		func(policy *internalFakePolicy) PolicyAccessor { return policy },
+		func(binding *internalFakeBinding) BindingAccessor { return binding },
+		func(*internalFakePolicy) Evaluator { return nil },
+		makeInternalFakeDispatcher,
+		[]runtime.Object{
+			policyWithParams,
+			policyWithoutParams,
+			&internalFakeBinding{ObjectMeta: metav1.ObjectMeta{Name: "with-params"}, PolicyName: policyWithParams.Name},
+			&internalFakeBinding{ObjectMeta: metav1.ObjectMeta{Name: "without-params"}, PolicyName: policyWithoutParams.Name},
+		},
+		[]meta.RESTMapping{mapping},
+		fakeParamKindResolver{
+			mapping:   &mapping,
+			handles:   func(schema.GroupVersionKind) bool { return resolverSynced.Load() },
+			hasSynced: resolverSynced.Load,
+		},
+	)
+	require.NoError(t, err)
+	defer testCancel()
+
+	started := make(chan error, 1)
+	go func() { started <- testContext.Start() }()
+	select {
+	case err := <-started:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("policy source did not initialize while the parameter resolver was unsynced")
+	}
+
+	require.True(t, testContext.Source.HasSynced())
+	hooks := testContext.Source.Hooks()
+	require.Len(t, hooks, 2)
+	for _, hook := range hooks {
+		if hook.Policy.Name == policyWithParams.Name {
+			require.ErrorContains(t, hook.ConfigurationError, "paramKind resolver is not yet synced")
+			require.Nil(t, hook.ParamInformer)
+		} else {
+			require.Equal(t, policyWithoutParams.Name, hook.Policy.Name)
+			require.NoError(t, hook.ConfigurationError)
+		}
+	}
+
+	resolverSynced.Store(true)
+	require.Eventually(t, func() bool {
+		for _, hook := range testContext.Source.Hooks() {
+			if hook.Policy.Name == policyWithParams.Name {
+				return hook.ConfigurationError == nil && hook.ParamInformer != nil
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestResolveParamKindRESTMappingUsesInjectedResolverWhenRESTMapperIsStale(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	expected := &meta.RESTMapping{
+		Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+		GroupVersionKind: paramKind,
+		Scope:            meta.RESTScopeNamespace,
+	}
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx: context.Background(),
+		restMapper: fixedErrorRESTMapper{err: &meta.NoKindMatchError{
+			GroupKind:        paramKind.GroupKind(),
+			SearchedVersions: []string{paramKind.Version},
+		}},
+		paramKindResolver: fakeParamKindResolver{mapping: expected},
+	}
+
+	mapping, err := source.resolveParamKindRESTMappingLocked(paramKind)
+
+	require.NoError(t, err)
+	require.Equal(t, expected, mapping)
+}
+
+func TestResolveParamKindRESTMappingKeepsResolverErrorsFailClosed(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx: context.Background(),
+		restMapper: fixedErrorRESTMapper{err: &meta.NoKindMatchError{
+			GroupKind:        paramKind.GroupKind(),
+			SearchedVersions: []string{paramKind.Version},
+		}},
+		paramKindResolver: fakeParamKindResolver{err: errors.New("unable to list CRDs")},
+	}
+
+	_, err := source.resolveParamKindRESTMappingLocked(paramKind)
+
+	require.ErrorContains(t, err, "unable to list CRDs")
+}
+
+func TestResolveParamKindRESTMappingRejectsStalePositiveRESTMapping(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{paramKind.GroupVersion()})
+	restMapper.AddSpecific(
+		paramKind,
+		paramKind.GroupVersion().WithResource("exampleparams"),
+		paramKind.GroupVersion().WithResource("exampleparam"),
+		meta.RESTScopeNamespace,
+	)
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:               context.Background(),
+		restMapper:        restMapper,
+		paramKindResolver: fakeParamKindResolver{},
+	}
+
+	_, err := source.resolveParamKindRESTMappingLocked(paramKind)
+
+	require.ErrorContains(t, err, "failed to find resource referenced by paramKind")
+}
+
+func TestResolveParamKindRESTMappingUsesRESTMapperForUnclaimedKind(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	expected := &meta.RESTMapping{
+		Resource:         paramKind.GroupVersion().WithResource("aggregatedparams"),
+		GroupVersionKind: paramKind,
+		Scope:            meta.RESTScopeNamespace,
+	}
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{paramKind.GroupVersion()})
+	restMapper.AddSpecific(paramKind, expected.Resource, expected.Resource, expected.Scope)
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:        context.Background(),
+		restMapper: restMapper,
+		paramKindResolver: fakeParamKindResolver{handles: func(schema.GroupVersionKind) bool {
+			return false
+		}},
+	}
+
+	mapping, err := source.resolveParamKindRESTMappingLocked(paramKind)
+
+	require.NoError(t, err)
+	require.Equal(t, expected, mapping)
+}
+
+func TestPolicySourcePublishesConfigurationErrorWhenParamKindCannotBeResolved(t *testing.T) {
+	policy := &internalFakePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-policy"},
+		ParamKind:  &v1.ParamKind{APIVersion: "params.example.com/v1", Kind: "ExampleParam"},
+	}
+	binding := &internalFakeBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-binding"},
+		PolicyName: "test-policy",
+	}
+	testContext, testCancel, err := NewPolicyTestContext(
+		t,
+		func(p *internalFakePolicy) PolicyAccessor { return p },
+		func(b *internalFakeBinding) BindingAccessor { return b },
+		func(*internalFakePolicy) Evaluator { return nil },
+		makeInternalFakeDispatcher,
+		[]runtime.Object{policy, binding},
+		nil,
+		fakeParamKindResolver{err: errors.New("unable to resolve CRD")},
+	)
+	require.NoError(t, err)
+	defer testCancel()
+
+	require.NoError(t, testContext.Start())
+
+	require.Len(t, testContext.Source.Hooks(), 1)
+	require.ErrorContains(t, testContext.Source.Hooks()[0].ConfigurationError, "unable to resolve CRD")
+}
+
+func TestPolicySourceMarksParamInformerForReconciliationWhenKindChanges(t *testing.T) {
+	changedKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	unrelatedKind := schema.GroupVersionKind{Group: "other.example.com", Version: "v1", Kind: "OtherParam"}
+	changedCanceled := false
+	unrelatedCanceled := false
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		paramsCRDControllers: map[schema.GroupVersionKind]*paramInfo{
+			changedKind: {
+				cancelFunc: func() { changedCanceled = true },
+			},
+			unrelatedKind: {
+				cancelFunc: func() { unrelatedCanceled = true },
+			},
+		},
+		paramKindsToReconcile: map[schema.GroupVersionKind]struct{}{},
+	}
+
+	source.paramKindChanged(changedKind.GroupKind())
+
+	require.False(t, changedCanceled)
+	require.False(t, unrelatedCanceled)
+	require.Contains(t, source.paramsCRDControllers, changedKind)
+	require.Contains(t, source.paramsCRDControllers, unrelatedKind)
+	require.Contains(t, source.paramKindsToReconcile, changedKind)
+	require.NotContains(t, source.paramKindsToReconcile, unrelatedKind)
+	require.True(t, source.policiesDirty.Load())
+}
+
+func TestPolicySourceCleansReconciliationStateForOrphanedParamInformer(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	testContext, testCancel, err := NewPolicyTestContext(
+		t,
+		func(p *internalFakePolicy) PolicyAccessor { return p },
+		func(b *internalFakeBinding) BindingAccessor { return b },
+		func(*internalFakePolicy) Evaluator { return nil },
+		makeInternalFakeDispatcher,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	defer testCancel()
+	require.NoError(t, testContext.Start())
+
+	canceled := false
+	source := testContext.Source.(*policySource[*internalFakePolicy, *internalFakeBinding, Evaluator])
+	source.lock.Lock()
+	source.paramsCRDControllers[paramKind] = &paramInfo{cancelFunc: func() { canceled = true }}
+	source.paramKindsToReconcile[paramKind] = struct{}{}
+	source.lock.Unlock()
+
+	_, err = source.calculatePolicyData()
+
+	require.NoError(t, err)
+	require.True(t, canceled)
+	require.NotContains(t, source.paramsCRDControllers, paramKind)
+	require.NotContains(t, source.paramKindsToReconcile, paramKind)
+}
+
+func TestPolicySourcePreservesParamInformerWhenMappingIsUnchanged(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	mapping := meta.RESTMapping{
+		Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+		GroupVersionKind: paramKind,
+		Scope:            meta.RESTScopeNamespace,
+	}
+	canceled := false
+	existingInfo := &paramInfo{
+		mapping:    mapping,
+		cancelFunc: func() { canceled = true },
+	}
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:                   context.Background(),
+		paramKindResolver:     fakeParamKindResolver{mapping: &mapping},
+		paramsCRDControllers:  map[schema.GroupVersionKind]*paramInfo{paramKind: existingInfo},
+		paramKindsToReconcile: map[schema.GroupVersionKind]struct{}{},
+	}
+	source.paramKindChanged(paramKind.GroupKind())
+
+	_, resolvedScope, err := source.ensureParamsForPolicyLocked(&paramKind)
+
+	require.NoError(t, err)
+	require.Same(t, existingInfo, source.paramsCRDControllers[paramKind])
+	require.Equal(t, mapping.Scope, resolvedScope)
+	require.False(t, canceled)
+	require.NotContains(t, source.paramKindsToReconcile, paramKind)
+}
+
+func TestPolicySourcePreservesUnclaimedParamInformerOnCRDChange(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	mapping := meta.RESTMapping{
+		Resource:         paramKind.GroupVersion().WithResource("aggregatedparams"),
+		GroupVersionKind: paramKind,
+		Scope:            meta.RESTScopeNamespace,
+	}
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{paramKind.GroupVersion()})
+	restMapper.AddSpecific(paramKind, mapping.Resource, mapping.Resource, mapping.Scope)
+	canceled := false
+	existingInfo := &paramInfo{
+		mapping:    mapping,
+		cancelFunc: func() { canceled = true },
+	}
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:        context.Background(),
+		restMapper: restMapper,
+		paramKindResolver: fakeParamKindResolver{handles: func(schema.GroupVersionKind) bool {
+			return false
+		}},
+		paramsCRDControllers:  map[schema.GroupVersionKind]*paramInfo{paramKind: existingInfo},
+		paramKindsToReconcile: map[schema.GroupVersionKind]struct{}{},
+	}
+	source.paramKindChanged(paramKind.GroupKind())
+
+	_, resolvedScope, err := source.ensureParamsForPolicyLocked(&paramKind)
+
+	require.NoError(t, err)
+	require.Same(t, existingInfo, source.paramsCRDControllers[paramKind])
+	require.Equal(t, mapping.Scope, resolvedScope)
+	require.False(t, canceled)
+	require.NotContains(t, source.paramKindsToReconcile, paramKind)
+}
+
+func TestPolicySourceStopsParamInformerWhenMappingDisappears(t *testing.T) {
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	canceled := false
+	source := &policySource[runtime.Object, runtime.Object, Evaluator]{
+		ctx:               context.Background(),
+		paramKindResolver: fakeParamKindResolver{},
+		paramsCRDControllers: map[schema.GroupVersionKind]*paramInfo{
+			paramKind: {
+				mapping: meta.RESTMapping{
+					Resource:         paramKind.GroupVersion().WithResource("exampleparams"),
+					GroupVersionKind: paramKind,
+					Scope:            meta.RESTScopeNamespace,
+				},
+				cancelFunc: func() { canceled = true },
+			},
+		},
+		paramKindsToReconcile: map[schema.GroupVersionKind]struct{}{},
+	}
+	source.paramKindChanged(paramKind.GroupKind())
+
+	_, _, err := source.ensureParamsForPolicyLocked(&paramKind)
+
+	require.ErrorContains(t, err, "failed to find resource referenced by paramKind")
+	require.True(t, canceled)
+	require.NotContains(t, source.paramsCRDControllers, paramKind)
+	require.NotContains(t, source.paramKindsToReconcile, paramKind)
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_internal_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_internal_test.go
@@ -414,11 +414,11 @@ func TestPolicySourcePreservesParamInformerWhenMappingIsUnchanged(t *testing.T) 
 	}
 	source.paramKindChanged(paramKind.GroupKind())
 
-	_, resolvedScope, err := source.ensureParamsForPolicyLocked(&paramKind)
+	_, resolvedMapping, err := source.ensureParamsForPolicyLocked(&paramKind)
 
 	require.NoError(t, err)
 	require.Same(t, existingInfo, source.paramsCRDControllers[paramKind])
-	require.Equal(t, mapping.Scope, resolvedScope)
+	require.Equal(t, &mapping, resolvedMapping)
 	require.False(t, canceled)
 	require.NotContains(t, source.paramKindsToReconcile, paramKind)
 }
@@ -448,11 +448,11 @@ func TestPolicySourcePreservesUnclaimedParamInformerOnCRDChange(t *testing.T) {
 	}
 	source.paramKindChanged(paramKind.GroupKind())
 
-	_, resolvedScope, err := source.ensureParamsForPolicyLocked(&paramKind)
+	_, resolvedMapping, err := source.ensureParamsForPolicyLocked(&paramKind)
 
 	require.NoError(t, err)
 	require.Same(t, existingInfo, source.paramsCRDControllers[paramKind])
-	require.Equal(t, mapping.Scope, resolvedScope)
+	require.Equal(t, &mapping, resolvedMapping)
 	require.False(t, canceled)
 	require.NotContains(t, source.paramKindsToReconcile, paramKind)
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_source_test.go
@@ -60,6 +60,7 @@ func TestPolicySourceHasSyncedEmpty(t *testing.T) {
 		makeTestDispatcher,
 		nil,
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 	defer testCancel()
@@ -92,6 +93,7 @@ func TestPolicySourceHasSyncedInitialList(t *testing.T) {
 		func(fp *FakePolicy) generic.Evaluator { return nil },
 		makeTestDispatcher,
 		initialObjects,
+		nil,
 		nil,
 	)
 	require.NoError(t, err)
@@ -162,6 +164,7 @@ func TestPolicySourceBindsToPolicies(t *testing.T) {
 		func(fp *FakePolicy) generic.Evaluator { return nil },
 		makeTestDispatcher,
 		initialObjects,
+		nil,
 		nil,
 	)
 	require.NoError(t, err)
@@ -282,6 +285,7 @@ func TestCollectParamsHandlesCacheMiss(t *testing.T) {
 		makeTestDispatcher,
 		nil,
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 	defer testCancel()
@@ -387,6 +391,7 @@ func TestCollectParamsHandlesMissingCRD(t *testing.T) {
 		func(fb *FakeBinding) generic.BindingAccessor { return fb },
 		func(fp *FakePolicy) generic.Evaluator { return nil },
 		makeTestDispatcher,
+		nil,
 		nil,
 		nil,
 	)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_test_context.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic/policy_test_context.go
@@ -84,6 +84,7 @@ func NewPolicyTestContext[P, B runtime.Object, E Evaluator](
 	dispatcher dispatcherFactory[PolicyHook[P, B, E]],
 	initialObjects []runtime.Object,
 	paramMappings []meta.RESTMapping,
+	paramKindResolver ParamKindResolver,
 ) (*PolicyTestContext[P, B, E], func(), error) {
 	var Pexample P
 	var Bexample B
@@ -203,6 +204,7 @@ func NewPolicyTestContext[P, B runtime.Object, E Evaluator](
 			return source
 		}, dispatcher)
 	plugin.SetEnabled(true)
+	plugin.SetParamKindResolver(paramKindResolver)
 
 	featureGate := featuregate.NewFeatureGate()
 	effectiveVersion := compatibility.DefaultBuildEffectiveVersion()

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/mutating/plugin_test.go
@@ -69,7 +69,9 @@ func setupTest(
 				},
 				Scope: meta.RESTScopeNamespace,
 			},
-		})
+		},
+		nil,
+	)
 	require.NoError(t, err)
 	t.Cleanup(testCancel)
 	require.NoError(t, testContext.Start())

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -395,6 +395,7 @@ func setupTestCommon(
 				Scope:            meta.RESTScopeRoot,
 			},
 		},
+		nil,
 	)
 	require.NoError(t, err)
 	t.Cleanup(testContextCancel)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/admission_test.go
@@ -18,6 +18,7 @@ package validating_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -29,6 +30,7 @@ import (
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -45,7 +47,9 @@ import (
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/warning"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
+	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/utils/ptr"
 )
 
@@ -872,6 +876,60 @@ func TestInvalidParamSourceInstanceName(t *testing.T) {
 	require.ErrorContains(t, err,
 		"no params found for policy binding with `Deny` parameterNotFoundAction")
 	require.Empty(t, passedParams)
+}
+
+func TestDirectParamReadErrorsFailClosed(t *testing.T) {
+	tests := []struct {
+		name      string
+		directErr error
+		wantError string
+	}{
+		{
+			name:      "timeout",
+			directErr: context.DeadlineExceeded,
+			wantError: context.DeadlineExceeded.Error(),
+		},
+		{
+			name:      "server error",
+			directErr: apierrors.NewInternalError(errors.New("backend unavailable")),
+			wantError: "backend unavailable",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			compiler := &fakeCompiler{}
+			matcher := &fakeMatcher{DefaultMatch: true}
+			testContext := setupTestCommon(t, compiler, matcher, false)
+			client, ok := testContext.DynamicClient.(*dynamicfake.FakeDynamicClient)
+			require.True(t, ok)
+			client.PrependReactor("get", "paramsconfigs", func(clienttesting.Action) (bool, runtime.Object, error) {
+				return true, nil, test.directErr
+			})
+			require.NoError(t, testContext.Start())
+
+			var evaluations atomic.Int32
+			compiler.RegisterDefinition(denyPolicy, func(context.Context, schema.GroupVersionResource, *admission.VersionedAttributes, runtime.Object, *v1.Namespace, int64, authorizer.UnconditionalAuthorizer) validating.ValidateResult {
+				evaluations.Add(1)
+				return validating.ValidateResult{Decisions: []validating.PolicyDecision{{Action: validating.ActionAdmit}}}
+			})
+
+			binding := denyBinding.DeepCopy()
+			binding.Spec.ParamRef.ParameterNotFoundAction = ptr.To(admissionregistrationv1.AllowAction)
+			require.NoError(t, testContext.UpdateAndWait(denyPolicy, binding))
+
+			err := testContext.Plugin.Dispatch(
+				testContext,
+				attributeRecord(nil, fakeParams, admission.Create),
+				&admission.RuntimeObjectInterfaces{},
+			)
+
+			require.ErrorContains(t, err, "failed to configure binding")
+			require.ErrorContains(t, err, test.wantError)
+			require.NotContains(t, err.Error(), "no params found")
+			require.Zero(t, evaluations.Load(), "policy evaluation must not run after a parameter read fault")
+		})
+	}
 }
 
 // Show that policy still gets evaluated with `nil` param if paramRef & namespaceParamRef

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating/dispatcher.go
@@ -148,14 +148,15 @@ func (c *dispatcher) Dispatch(ctx context.Context, a admission.Attributes, o adm
 				continue
 			}
 
-			params, err := generic.CollectParams(
+			params, err := generic.CollectParamsWithContext(
+				ctx,
 				hook.Policy.Spec.ParamKind,
 				hook.ParamInformer,
+				hook.ParamMapping,
 				hook.ParamScope,
 				binding.Spec.ParamRef,
 				a.GetNamespace(),
 				hook.DynamicClient,
-				hook.RESTMapper,
 			)
 
 			if err != nil {

--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -2571,6 +2571,92 @@ func Test_ValidateSecondaryAuthorization(t *testing.T) {
 	}
 }
 
+func TestCRDParamKindResolvesBeforeDiscoveryRefresh(t *testing.T) {
+	resetPolicyRefreshInterval := generic.SetPolicyRefreshIntervalForTests(policyRefreshInterval)
+	defer resetPolicyRefreshInterval()
+
+	server := apiservertesting.StartTestServerOrDie(t, nil, []string{
+		"--enable-admission-plugins", "ValidatingAdmissionPolicy",
+	}, framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	client := clientset.NewForConfigOrDie(server.ClientConfig)
+	dynamicClient := dynamic.NewForConfigOrDie(server.ClientConfig)
+	apiextensionsClient := apiextensionsclientset.NewForConfigOrDie(server.ClientConfig)
+	paramKind := schema.GroupVersionKind{Group: "params.example.com", Version: "v1", Kind: "ExampleParam"}
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "exampleparams." + paramKind.Group},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: paramKind.Group,
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "exampleparams",
+				Kind:   paramKind.Kind,
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    paramKind.Version,
+				Served:  true,
+				Storage: true,
+				Schema:  fixtures.AllowAllSchema(),
+			}},
+		},
+	}
+
+	policy := withValidations([]admissionregistrationv1.Validation{{
+		Expression: "object.metadata.name.startsWith(params.metadata.name)",
+		Message:    "wrong prefix",
+	}}, withParams(withCRDParamKind(paramKind.Kind, paramKind.Group, paramKind.Version), withNamespaceMatch(withFailurePolicy(admissionregistrationv1.Fail, makePolicy("fresh-crd-param")))))
+	if _, err := client.AdmissionregistrationV1().ValidatingAdmissionPolicies().Create(context.Background(), policy, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	binding := makeBinding("fresh-crd-param-binding", policy.Name, "test")
+	if _, err := client.AdmissionregistrationV1().ValidatingAdmissionPolicyBindings().Create(context.Background(), binding, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, wait.ForeverTestTimeout, true, func(ctx context.Context) (bool, error) {
+		_, err := client.CoreV1().Namespaces().Patch(ctx, "default", types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
+		if err == nil || strings.Contains(err.Error(), "not yet synced to use for admission") {
+			return false, nil
+		}
+		if strings.Contains(err.Error(), "failed to find resource referenced by paramKind") {
+			return true, nil
+		}
+		return false, err
+	}); err != nil {
+		t.Fatalf("failed to prime stale paramKind REST mapping: %v", err)
+	}
+
+	// Wait only for establishment, not discovery. The admission RESTMapper must
+	// remain stale so this exercises the CRD informer fallback.
+	etcd.CreateTestCRDs(t, apiextensionsClient, true, crd)
+	param := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"name":      "test",
+			"namespace": "default",
+		},
+	}}
+	param.SetGroupVersionKind(paramKind)
+	paramResource := paramKind.GroupVersion().WithResource(crd.Spec.Names.Plural)
+	if _, err := dynamicClient.Resource(paramResource).Namespace("default").Create(context.Background(), param, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		_, err := client.CoreV1().Namespaces().Patch(ctx, "default", types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
+		if err == nil || strings.Contains(err.Error(), "failed to find resource referenced by paramKind") || strings.Contains(err.Error(), "not yet synced to use for admission") {
+			return false, nil
+		}
+		if strings.Contains(err.Error(), "wrong prefix") {
+			return true, nil
+		}
+		return false, err
+	}); err != nil {
+		t.Fatalf("policy did not resolve the established CRD before discovery refresh: %v", err)
+	}
+}
+
 func TestCRDsOnStartup(t *testing.T) {
 
 	testContext, testCancel := context.WithCancel(context.Background())
@@ -2675,10 +2761,6 @@ func TestCRDsOnStartup(t *testing.T) {
 			}
 
 			if strings.Contains(err.Error(), "not yet synced to use for admission") {
-				return false, nil
-			}
-
-			if strings.Contains(err.Error(), "failed to find resource referenced by paramKind") {
 				return false, nil
 			}
 

--- a/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
+++ b/test/integration/apiserver/cel/validatingadmissionpolicy_test.go
@@ -2645,7 +2645,7 @@ func TestCRDParamKindResolvesBeforeDiscoveryRefresh(t *testing.T) {
 
 	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		_, err := client.CoreV1().Namespaces().Patch(ctx, "default", types.JSONPatchType, []byte("[]"), metav1.PatchOptions{})
-		if err == nil || strings.Contains(err.Error(), "failed to find resource referenced by paramKind") || strings.Contains(err.Error(), "not yet synced to use for admission") {
+		if err == nil || strings.Contains(err.Error(), "failed to find resource referenced by paramKind") {
 			return false, nil
 		}
 		if strings.Contains(err.Error(), "wrong prefix") {
@@ -2757,10 +2757,6 @@ func TestCRDsOnStartup(t *testing.T) {
 
 			_, err = client.CoreV1().Namespaces().Create(testContext, disallowedNamespace, metav1.CreateOptions{})
 			if err == nil {
-				return false, nil
-			}
-
-			if strings.Contains(err.Error(), "not yet synced to use for admission") {
 				return false, nil
 			}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

After a CRD `paramKind` resolves, its parameter informer can still be warming after kube-apiserver startup. The existing one-second sync wait then becomes a policy configuration error and can reject otherwise valid requests under `failurePolicy: Fail`.

For `paramRef.name`, this uses the mapping selected by the policy source to issue a request-context-bound, one-second direct `GET` while the informer is unsynchronized or after a named cache miss. Once synchronized, the informer remains the fast path. Cancellation, `NotFound` handling, timeouts, and API failures retain the existing fail-closed semantics.

Selector references remain informer-backed and never issue a direct `LIST`.

#### Which issue(s) this PR is related to:

Fixes #141367

Depends on #141368

Downstream impact: https://github.com/open-policy-agent/gatekeeper/issues/4530

#### Special notes for your reviewer:

This is stacked on #141368. The PR1-only kind image removed stale-discovery errors but produced this denial during restart:

GitHub stacked PRs do not support cross-fork base branches, so this draft targets `master` and temporarily includes both commits. Review only the PR1-to-PR2 range below. After #141368 merges, this branch will be rebased onto `master` and the draft will contain only the named-parameter change.

```console
The leases "gatekeeper-probe" is invalid: : ValidatingAdmissionPolicy 'gatekeeper-4530' with binding 'gatekeeper-4530' denied request: failed to configure binding: paramKind kind `&ParamKind{APIVersion:constraints.gatekeeper.sh/v1beta1,Kind:K8sPSPPrivilegedContainer,}` not yet synced to use for admission
```

Across three kube-apiserver restarts:

```console
variant        failed-to-find  not-yet-synced
resolver-only  0               1
full-fix       0               0
```

The full build admitted every valid Lease probe after restart and continued denying the intentionally invalid probe with the policy's CEL message.

Review the stacked delta with:

```console
git diff JaydipGabani/f/vap_crd_paramkind_resolver...JaydipGabani/f/vap_named_param_warmup
```

Validated with:

```console
go test ./staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic ./staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating -count=1
go test -race ./staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/generic ./staging/src/k8s.io/apiserver/pkg/admission/plugin/policy/validating -run '^(TestCollectParamsWithContext|TestDirectParamReadErrorsFailClosed|TestConvertParamToInformerRepresentation)$' -count=1
PATH="$PATH:$PWD/third_party/etcd" go test ./test/integration/apiserver/cel -run '^TestCRDsOnStartup$' -count=1
```

#### Does this PR introduce a user-facing change?

```release-note
Admission policies with a named parameter no longer transiently reject requests while the parameter informer is syncing after kube-apiserver startup.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

/sig api-machinery
/area apiserver
