### PR TITLE
test/e2e/network: use static nodePorts in the update nodePort tests

### DIFF
--- a/test/e2e/framework/network/nodeport.go
+++ b/test/e2e/framework/network/nodeport.go
@@ -1,0 +1,175 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// NodePortRange should match whatever the default/configured range is
+var NodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
+
+// staticPortRange implements port allocation model described here
+// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3668-reserved-service-nodeport-range
+type staticPortRange struct {
+	sync.Mutex
+	baseport      int32
+	length        int32
+	reservedPorts sets.Set[int32]
+}
+
+func calculateRange(size int32) int32 {
+	var minPort int32 = 16
+	var step int32 = 32
+	var maxPort int32 = 128
+	return min(max(minPort, size/step), maxPort)
+}
+
+var staticPortAllocator *staticPortRange
+
+// Initialize only once per test
+func init() {
+	staticPortAllocator = &staticPortRange{
+		baseport:      int32(NodePortRange.Base),
+		length:        calculateRange(int32(NodePortRange.Size)),
+		reservedPorts: sets.New[int32](),
+	}
+}
+
+// reservePort reserves the port provided as input.
+// If an invalid port was provided or if the port is already reserved, it returns false
+func (s *staticPortRange) reservePort(port int32) bool {
+	s.Lock()
+	defer s.Unlock()
+	if port < s.baseport || port > s.baseport+s.length || s.reservedPorts.Has(port) {
+		return false
+	}
+	s.reservedPorts.Insert(port)
+	return true
+}
+
+// getUnusedPort returns a free port from the range and returns its number and nil value
+// the port is not allocated so the consumer should allocate it explicitly calling allocatePort()
+// if none is available then it returns -1 and error
+func (s *staticPortRange) getUnusedPort() (int32, error) {
+	s.Lock()
+	defer s.Unlock()
+	// start in a random offset
+	start := rand.Int31n(s.length)
+	for i := int32(0); i < s.length; i++ {
+		port := s.baseport + (start+i)%(s.length)
+		if !s.reservedPorts.Has(port) {
+			return port, nil
+		}
+	}
+	return -1, fmt.Errorf("no free ports were found")
+}
+
+// releasePort releases the port passed as an argument
+func (s *staticPortRange) releasePort(port int32) {
+	s.Lock()
+	defer s.Unlock()
+	s.reservedPorts.Delete(port)
+}
+
+// getUnusedPorts returns count distinct free ports from the range.
+// Like getUnusedPort the ports are not reserved, so the consumer should create the
+// service first and then reserve them explicitly calling reservePorts().
+// if there are not enough free ports then it returns nil and error
+func (s *staticPortRange) getUnusedPorts(count int) ([]int32, error) {
+	s.Lock()
+	defer s.Unlock()
+	ports := make([]int32, 0, count)
+	// start in a random offset
+	start := rand.Int31n(s.length)
+	for i := int32(0); i < s.length && len(ports) < count; i++ {
+		port := s.baseport + (start+i)%(s.length)
+		if !s.reservedPorts.Has(port) {
+			ports = append(ports, port)
+		}
+	}
+	if len(ports) < count {
+		return nil, fmt.Errorf("only %d free ports were found, %d were requested", len(ports), count)
+	}
+	return ports, nil
+}
+
+// reservePorts reserves every port in ports. If any of them can not be reserved none of
+// them stays reserved and it returns false
+func (s *staticPortRange) reservePorts(ports []int32) bool {
+	reserved := make([]int32, 0, len(ports))
+	for _, port := range ports {
+		if !s.reservePort(port) {
+			s.releasePorts(reserved)
+			return false
+		}
+		reserved = append(reserved, port)
+	}
+	return true
+}
+
+// releasePorts releases every port in ports
+func (s *staticPortRange) releasePorts(ports []int32) {
+	for _, port := range ports {
+		s.releasePort(port)
+	}
+}
+
+// GetUnusedStaticNodePort returns a free port in static range and a nil value
+// If no port in static range is available it returns -1 and an error value
+// Note that it is not guaranteed that the returned port is actually available on the apiserver;
+// You must allocate a port, then attempt to create the service, then call
+// ReserveStaticNodePort.
+func GetUnusedStaticNodePort() (int32, error) {
+	return staticPortAllocator.getUnusedPort()
+}
+
+// ReserveStaticNodePort reserves the port provided as input. It is guaranteed
+// that no other test will receive this port from GetUnusedStaticNodePort until
+// after you call ReleaseStaticNodePort.
+//
+// port must have been previously allocated by GetUnusedStaticNodePort, and
+// then successfully used as a NodePort or HealthCheckNodePort when creating
+// a service. Trying to reserve a port that was not allocated by
+// GetUnusedStaticNodePort, or reserving it before creating the associated service
+// may cause other e2e tests to fail.
+//
+// If an invalid port was provided or if the port is already reserved, it returns false
+func ReserveStaticNodePort(port int32) bool {
+	return staticPortAllocator.reservePort(port)
+}
+
+// ReleaseStaticNodePort releases the specified port.
+// The corresponding service should have already been deleted, to ensure that the
+// port allocator doesn't try to reuse it before the apiserver considers it available.
+// The caller should do it like below:
+//
+//	ginkgo.DeferCleanup(func(ctx context.Context) {
+//		err := cs.CoreV1().Services(ns).Delete(ctx, serviceName, metav1.DeleteOptions{})
+//		if err != nil && !apierrors.IsNotFound(err) {
+//			framework.ExpectNoError(err, "failed to delete service %s in namespace %s", serviceName, ns)
+//		}
+//		e2enetwork.ReleaseStaticNodePort(nodePort)
+//	})
+func ReleaseStaticNodePort(port int32) {
+	staticPortAllocator.releasePort(port)
+}

--- a/test/e2e/framework/network/nodeport.go
+++ b/test/e2e/framework/network/nodeport.go
@@ -60,7 +60,7 @@ func init() {
 func (s *staticPortRange) reservePort(port int32) bool {
 	s.Lock()
 	defer s.Unlock()
-	if port < s.baseport || port > s.baseport+s.length || s.reservedPorts.Has(port) {
+	if port < s.baseport || port >= s.baseport+s.length || s.reservedPorts.Has(port) {
 		return false
 	}
 	s.reservedPorts.Insert(port)
@@ -71,17 +71,11 @@ func (s *staticPortRange) reservePort(port int32) bool {
 // the port is not allocated so the consumer should allocate it explicitly calling allocatePort()
 // if none is available then it returns -1 and error
 func (s *staticPortRange) getUnusedPort() (int32, error) {
-	s.Lock()
-	defer s.Unlock()
-	// start in a random offset
-	start := rand.Int31n(s.length)
-	for i := int32(0); i < s.length; i++ {
-		port := s.baseport + (start+i)%(s.length)
-		if !s.reservedPorts.Has(port) {
-			return port, nil
-		}
+	ports, err := s.getUnusedPorts(1)
+	if err != nil {
+		return -1, err
 	}
-	return -1, fmt.Errorf("no free ports were found")
+	return ports[0], nil
 }
 
 // releasePort releases the port passed as an argument
@@ -92,8 +86,8 @@ func (s *staticPortRange) releasePort(port int32) {
 }
 
 // getUnusedPorts returns count distinct free ports from the range.
-// Like getUnusedPort the ports are not reserved, so the consumer should create the
-// service first and then reserve them explicitly calling reservePorts().
+// The ports are not reserved, so the consumer should create the service first and then
+// reserve them explicitly calling reservePort() on each one.
 // if there are not enough free ports then it returns nil and error
 func (s *staticPortRange) getUnusedPorts(count int) ([]int32, error) {
 	s.Lock()
@@ -111,27 +105,6 @@ func (s *staticPortRange) getUnusedPorts(count int) ([]int32, error) {
 		return nil, fmt.Errorf("only %d free ports were found, %d were requested", len(ports), count)
 	}
 	return ports, nil
-}
-
-// reservePorts reserves every port in ports. If any of them can not be reserved none of
-// them stays reserved and it returns false
-func (s *staticPortRange) reservePorts(ports []int32) bool {
-	reserved := make([]int32, 0, len(ports))
-	for _, port := range ports {
-		if !s.reservePort(port) {
-			s.releasePorts(reserved)
-			return false
-		}
-		reserved = append(reserved, port)
-	}
-	return true
-}
-
-// releasePorts releases every port in ports
-func (s *staticPortRange) releasePorts(ports []int32) {
-	for _, port := range ports {
-		s.releasePort(port)
-	}
 }
 
 // GetUnusedStaticNodePort returns a free port in static range and a nil value

--- a/test/e2e/framework/network/nodeport_test.go
+++ b/test/e2e/framework/network/nodeport_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestCalculateRange(t *testing.T) {
+	testCases := []struct {
+		name string
+		size int32
+		want int32
+	}{
+		{name: "default node port range", size: 2768, want: 86},
+		{name: "tiny range clamps to the minimum", size: 64, want: 16},
+		{name: "huge range clamps to the maximum", size: 65535, want: 128},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := calculateRange(tc.size); got != tc.want {
+				t.Errorf("calculateRange(%d) = %d, want %d", tc.size, got, tc.want)
+			}
+		})
+	}
+}
+
+func newTestPortRange() *staticPortRange {
+	return &staticPortRange{
+		baseport:      30000,
+		length:        4,
+		reservedPorts: sets.New[int32](),
+	}
+}
+
+func TestStaticPortRangeGetUnusedPort(t *testing.T) {
+	s := newTestPortRange()
+	port, err := s.getUnusedPort()
+	if err != nil {
+		t.Fatalf("getUnusedPort() returned an unexpected error: %v", err)
+	}
+	if port < s.baseport || port >= s.baseport+s.length {
+		t.Errorf("getUnusedPort() = %d, want a port in [%d,%d)", port, s.baseport, s.baseport+s.length)
+	}
+}
+
+func TestStaticPortRangeExhausted(t *testing.T) {
+	s := newTestPortRange()
+	for i := int32(0); i < s.length; i++ {
+		port, err := s.getUnusedPort()
+		if err != nil {
+			t.Fatalf("getUnusedPort() returned an unexpected error on iteration %d: %v", i, err)
+		}
+		if !s.reservePort(port) {
+			t.Fatalf("reservePort(%d) = false, want true", port)
+		}
+	}
+	if _, err := s.getUnusedPort(); err == nil {
+		t.Error("getUnusedPort() returned no error with every port reserved, want an error")
+	}
+}
+
+func TestStaticPortRangeReservePort(t *testing.T) {
+	s := newTestPortRange()
+
+	if s.reservePort(s.baseport - 1) {
+		t.Errorf("reservePort(%d) = true for a port below the range, want false", s.baseport-1)
+	}
+	if !s.reservePort(s.baseport) {
+		t.Errorf("reservePort(%d) = false for the first port in the range, want true", s.baseport)
+	}
+	if s.reservePort(s.baseport) {
+		t.Errorf("reservePort(%d) = true for an already reserved port, want false", s.baseport)
+	}
+
+	last := s.baseport + s.length - 1
+	if !s.reservePort(last) {
+		t.Errorf("reservePort(%d) = false for the last port in the range, want true", last)
+	}
+
+	s.releasePort(s.baseport)
+	if !s.reservePort(s.baseport) {
+		t.Errorf("reservePort(%d) = false after releasing it, want true", s.baseport)
+	}
+}
+
+func TestStaticPortRangeGetUnusedPorts(t *testing.T) {
+	s := newTestPortRange()
+	ports, err := s.getUnusedPorts(3)
+	if err != nil {
+		t.Fatalf("getUnusedPorts(3) returned an unexpected error: %v", err)
+	}
+
+	if len(ports) != 3 {
+		t.Fatalf("getUnusedPorts(3) returned %d ports, want 3", len(ports))
+	}
+	if unique := sets.New[int32](ports...); unique.Len() != len(ports) {
+		t.Errorf("getUnusedPorts(3) returned duplicate ports: %v", ports)
+	}
+	for _, port := range ports {
+		if port < s.baseport || port >= s.baseport+s.length {
+			t.Errorf("getUnusedPorts(3) returned %d, want a port in [%d,%d)", port, s.baseport, s.baseport+s.length)
+		}
+	}
+
+	// The caller creates the service before reserving, so getUnusedPorts must leave
+	// the ports free.
+	if s.reservedPorts.Len() != 0 {
+		t.Errorf("getUnusedPorts(3) reserved %d ports, want 0", s.reservedPorts.Len())
+	}
+}
+
+func TestStaticPortRangeGetUnusedPortsExhausted(t *testing.T) {
+	s := newTestPortRange()
+	if _, err := s.getUnusedPorts(int(s.length) + 1); err == nil {
+		t.Error("getUnusedPorts() returned no error asking for more ports than the range holds, want an error")
+	}
+
+	// A reserved port is not free anymore, so the whole range can no longer be handed out.
+	ports, err := s.getUnusedPorts(int(s.length))
+	if err != nil {
+		t.Fatalf("getUnusedPorts(%d) returned an unexpected error: %v", s.length, err)
+	}
+	if !s.reservePorts(ports[:1]) {
+		t.Fatalf("reservePorts(%v) = false, want true", ports[:1])
+	}
+	if _, err := s.getUnusedPorts(int(s.length)); err == nil {
+		t.Error("getUnusedPorts() returned no error with a port reserved, want an error")
+	}
+}
+
+func TestStaticPortRangeReservePorts(t *testing.T) {
+	s := newTestPortRange()
+	ports, err := s.getUnusedPorts(2)
+	if err != nil {
+		t.Fatalf("getUnusedPorts(2) returned an unexpected error: %v", err)
+	}
+
+	if !s.reservePorts(ports) {
+		t.Fatalf("reservePorts(%v) = false, want true", ports)
+	}
+	for _, port := range ports {
+		if s.reservePort(port) {
+			t.Errorf("reservePort(%d) = true, want false because it is already reserved", port)
+		}
+	}
+
+	s.releasePorts(ports)
+	for _, port := range ports {
+		if !s.reservePort(port) {
+			t.Errorf("reservePort(%d) = false after releasePorts, want true", port)
+		}
+	}
+}
+
+// reservePorts must not leave the ports it already took reserved when one of them fails.
+func TestStaticPortRangeReservePortsPartialFailure(t *testing.T) {
+	s := newTestPortRange()
+	taken := s.baseport + 1
+	if !s.reservePort(taken) {
+		t.Fatalf("reservePort(%d) = false, want true", taken)
+	}
+
+	if s.reservePorts([]int32{s.baseport, taken}) {
+		t.Error("reservePorts() = true with an already reserved port, want false")
+	}
+	if s.reservedPorts.Has(s.baseport) {
+		t.Errorf("reservePorts() left %d reserved after failing, want it released", s.baseport)
+	}
+}

--- a/test/e2e/framework/network/nodeport_test.go
+++ b/test/e2e/framework/network/nodeport_test.go
@@ -137,50 +137,20 @@ func TestStaticPortRangeGetUnusedPortsExhausted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getUnusedPorts(%d) returned an unexpected error: %v", s.length, err)
 	}
-	if !s.reservePorts(ports[:1]) {
-		t.Fatalf("reservePorts(%v) = false, want true", ports[:1])
+	if !s.reservePort(ports[0]) {
+		t.Fatalf("reservePort(%d) = false, want true", ports[0])
 	}
 	if _, err := s.getUnusedPorts(int(s.length)); err == nil {
 		t.Error("getUnusedPorts() returned no error with a port reserved, want an error")
 	}
 }
 
-func TestStaticPortRangeReservePorts(t *testing.T) {
-	s := newTestPortRange()
-	ports, err := s.getUnusedPorts(2)
-	if err != nil {
-		t.Fatalf("getUnusedPorts(2) returned an unexpected error: %v", err)
-	}
-
-	if !s.reservePorts(ports) {
-		t.Fatalf("reservePorts(%v) = false, want true", ports)
-	}
-	for _, port := range ports {
-		if s.reservePort(port) {
-			t.Errorf("reservePort(%d) = true, want false because it is already reserved", port)
-		}
-	}
-
-	s.releasePorts(ports)
-	for _, port := range ports {
-		if !s.reservePort(port) {
-			t.Errorf("reservePort(%d) = false after releasePorts, want true", port)
-		}
-	}
-}
-
-// reservePorts must not leave the ports it already took reserved when one of them fails.
-func TestStaticPortRangeReservePortsPartialFailure(t *testing.T) {
-	s := newTestPortRange()
-	taken := s.baseport + 1
-	if !s.reservePort(taken) {
-		t.Fatalf("reservePort(%d) = false, want true", taken)
-	}
-
-	if s.reservePorts([]int32{s.baseport, taken}) {
-		t.Error("reservePorts() = true with an already reserved port, want false")
-	}
-	if s.reservedPorts.Has(s.baseport) {
-		t.Errorf("reservePorts() left %d reserved after failing, want it released", s.baseport)
+func TestStaticPortRangeReservePortOffByOne(t *testing.T) {
+	s := newTestPortRange() // baseport: 30000, length: 4 (valid ports: 30000..30003)
+	// baseport + length is 30004, which is 1 past the upper boundary [30000, 30004)
+	outOfRangePort := s.baseport + s.length
+	if s.reservePort(outOfRangePort) {
+		t.Errorf("reservePort(%d) = true for baseport+length (outside range [%d, %d)), want false",
+			outOfRangePort, s.baseport, s.baseport+s.length)
 	}
 }

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -124,6 +124,14 @@ func PreferExternalAddresses(config *NetworkingTestConfig) {
 	config.PreferExternalAddresses = true
 }
 
+// UseStaticNodePorts allocate the NodePortService nodePorts from the static portion of
+// the NodePort range and keep them reserved for the whole test. Tests that delete the
+// NodePortService and then check that its nodePort stops serving traffic need this,
+// otherwise a Service from a test running in parallel can get the same nodePort.
+func UseStaticNodePorts(config *NetworkingTestConfig) {
+	config.StaticNodePorts = true
+}
+
 // NewNetworkingTestConfig creates and sets up a new test config helper.
 func NewNetworkingTestConfig(ctx context.Context, f *framework.Framework, setters ...Option) *NetworkingTestConfig {
 	// default options
@@ -176,6 +184,9 @@ type NetworkingTestConfig struct {
 	// if the test pods are listening on sctp port. We need this as sctp tests
 	// are marked as disruptive as they may load the sctp module.
 	SCTPEnabled bool
+	// StaticNodePorts assigns the NodePortService nodePorts from the static portion
+	// of the NodePort range and keeps them reserved for the whole test.
+	StaticNodePorts bool
 	// DualStackEnabled enables dual stack on services
 	DualStackEnabled bool
 	// EndpointPods are the pods belonging to the Service created by this
@@ -754,8 +765,62 @@ func (config *NetworkingTestConfig) createNodePortServiceSpec(svcName string, se
 	return res
 }
 
+// staticNodePortRetries is how many times we try to create the NodePortService with
+// ports from the static range. The allocator only synchronizes tests in the same
+// process, so the apiserver can still reject a port taken by a parallel ginkgo process.
+const staticNodePortRetries = 5
+
 func (config *NetworkingTestConfig) createNodePortService(ctx context.Context, selector map[string]string) {
-	config.NodePortService = config.CreateService(ctx, config.createNodePortServiceSpec(nodePortServiceName, selector, false))
+	spec := config.createNodePortServiceSpec(nodePortServiceName, selector, false)
+	if config.StaticNodePorts {
+		config.NodePortService = config.createServiceWithStaticNodePorts(ctx, spec)
+		return
+	}
+	config.NodePortService = config.CreateService(ctx, spec)
+}
+
+// createServiceWithStaticNodePorts creates spec with its nodePorts taken from the static
+// portion of the NodePort range. The ports stay reserved until the test ends, so a
+// Service created by a parallel test can not get the same nodePort once this Service has
+// been deleted.
+func (config *NetworkingTestConfig) createServiceWithStaticNodePorts(ctx context.Context, spec *v1.Service) *v1.Service {
+	for range staticNodePortRetries {
+		ports, err := staticPortAllocator.getUnusedPorts(len(spec.Spec.Ports))
+		framework.ExpectNoError(err, "failed to find %d free node ports in the static range", len(spec.Spec.Ports))
+		for i := range spec.Spec.Ports {
+			spec.Spec.Ports[i].NodePort = ports[i]
+		}
+
+		_, err = config.getServiceClient().Create(ctx, spec, metav1.CreateOptions{})
+		if err != nil {
+			if apierrors.IsInvalid(err) {
+				framework.Logf("node ports %v are already allocated to another service, retrying: %v", ports, err)
+				continue
+			}
+			framework.Failf("Failed to create %s service: %v", spec.Name, err)
+		}
+
+		// Registered before the wait below so the service is removed and the ports
+		// released even if it times out. The service is deleted first because the
+		// apiserver keeps its nodePorts allocated until it is gone.
+		ginkgo.DeferCleanup(func(ctx context.Context) {
+			err := config.getServiceClient().Delete(ctx, spec.Name, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				framework.ExpectNoError(err, "error while deleting service %s", spec.Name)
+			}
+			staticPortAllocator.releasePorts(ports)
+		})
+
+		// The service is using the ports now, so they can be reserved.
+		if !staticPortAllocator.reservePorts(ports) {
+			framework.Failf("Failed to reserve node ports %v of service %s", ports, spec.Name)
+		}
+
+		return config.waitForCreatedService(ctx, spec.Name)
+	}
+
+	framework.Failf("Failed to create %s service with node ports from the static range after %d attempts", spec.Name, staticNodePortRetries)
+	return nil
 }
 
 func (config *NetworkingTestConfig) createSessionAffinityService(ctx context.Context, selector map[string]string) {
@@ -800,11 +865,16 @@ func (config *NetworkingTestConfig) CreateService(ctx context.Context, serviceSp
 	_, err := config.getServiceClient().Create(ctx, serviceSpec, metav1.CreateOptions{})
 	framework.ExpectNoError(err, fmt.Sprintf("Failed to create %s service: %v", serviceSpec.Name, err))
 
-	err = WaitForService(ctx, config.f.ClientSet, config.Namespace, serviceSpec.Name, true, 5*time.Second, 45*time.Second)
-	framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", serviceSpec.Name, err))
+	return config.waitForCreatedService(ctx, serviceSpec.Name)
+}
 
-	createdService, err := config.getServiceClient().Get(ctx, serviceSpec.Name, metav1.GetOptions{})
-	framework.ExpectNoError(err, fmt.Sprintf("Failed to create %s service: %v", serviceSpec.Name, err))
+// waitForCreatedService waits for the just created service to show up and returns it
+func (config *NetworkingTestConfig) waitForCreatedService(ctx context.Context, name string) *v1.Service {
+	err := WaitForService(ctx, config.f.ClientSet, config.Namespace, name, true, 5*time.Second, 45*time.Second)
+	framework.ExpectNoError(err, fmt.Sprintf("error while waiting for service:%s err: %v", name, err))
+
+	createdService, err := config.getServiceClient().Get(ctx, name, metav1.GetOptions{})
+	framework.ExpectNoError(err, fmt.Sprintf("Failed to create %s service: %v", name, err))
 
 	return createdService
 }

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -762,6 +762,13 @@ func (config *NetworkingTestConfig) createNodePortServiceSpec(svcName string, se
 		requireDual := v1.IPFamilyPolicyRequireDualStack
 		res.Spec.IPFamilyPolicy = &requireDual
 	}
+	if config.StaticNodePorts {
+		ports, err := staticPortAllocator.getUnusedPorts(len(res.Spec.Ports))
+		framework.ExpectNoError(err, "failed to find static nodeports for service %s", svcName)
+		for i := range res.Spec.Ports {
+			res.Spec.Ports[i].NodePort = ports[i]
+		}
+	}
 	return res
 }
 
@@ -771,56 +778,40 @@ func (config *NetworkingTestConfig) createNodePortServiceSpec(svcName string, se
 const staticNodePortRetries = 5
 
 func (config *NetworkingTestConfig) createNodePortService(ctx context.Context, selector map[string]string) {
-	spec := config.createNodePortServiceSpec(nodePortServiceName, selector, false)
+	retries := 1
 	if config.StaticNodePorts {
-		config.NodePortService = config.createServiceWithStaticNodePorts(ctx, spec)
-		return
+		retries = staticNodePortRetries
 	}
-	config.NodePortService = config.CreateService(ctx, spec)
-}
-
-// createServiceWithStaticNodePorts creates spec with its nodePorts taken from the static
-// portion of the NodePort range. The ports stay reserved until the test ends, so a
-// Service created by a parallel test can not get the same nodePort once this Service has
-// been deleted.
-func (config *NetworkingTestConfig) createServiceWithStaticNodePorts(ctx context.Context, spec *v1.Service) *v1.Service {
-	for range staticNodePortRetries {
-		ports, err := staticPortAllocator.getUnusedPorts(len(spec.Spec.Ports))
-		framework.ExpectNoError(err, "failed to find %d free node ports in the static range", len(spec.Spec.Ports))
-		for i := range spec.Spec.Ports {
-			spec.Spec.Ports[i].NodePort = ports[i]
-		}
-
-		_, err = config.getServiceClient().Create(ctx, spec, metav1.CreateOptions{})
+	for range retries {
+		spec := config.createNodePortServiceSpec(nodePortServiceName, selector, false)
+		_, err := config.getServiceClient().Create(ctx, spec, metav1.CreateOptions{})
 		if err != nil {
-			if apierrors.IsInvalid(err) {
-				framework.Logf("node ports %v are already allocated to another service, retrying: %v", ports, err)
+			if config.StaticNodePorts && apierrors.IsInvalid(err) {
+				framework.Logf("static node ports collision, retrying: %v", err)
 				continue
 			}
 			framework.Failf("Failed to create %s service: %v", spec.Name, err)
 		}
 
-		// Registered before the wait below so the service is removed and the ports
-		// released even if it times out. The service is deleted first because the
-		// apiserver keeps its nodePorts allocated until it is gone.
-		ginkgo.DeferCleanup(func(ctx context.Context) {
-			err := config.getServiceClient().Delete(ctx, spec.Name, metav1.DeleteOptions{})
-			if err != nil && !apierrors.IsNotFound(err) {
-				framework.ExpectNoError(err, "error while deleting service %s", spec.Name)
+		if config.StaticNodePorts {
+			// The service is using the ports now, so they can be reserved.
+			for _, port := range spec.Spec.Ports {
+				if !ReserveStaticNodePort(port.NodePort) {
+					framework.Failf("Failed to reserve node port %d", port.NodePort)
+				}
 			}
-			staticPortAllocator.releasePorts(ports)
-		})
-
-		// The service is using the ports now, so they can be reserved.
-		if !staticPortAllocator.reservePorts(ports) {
-			framework.Failf("Failed to reserve node ports %v of service %s", ports, spec.Name)
+			ginkgo.DeferCleanup(func(ctx context.Context) {
+				for _, port := range spec.Spec.Ports {
+					ReleaseStaticNodePort(port.NodePort)
+				}
+			})
 		}
 
-		return config.waitForCreatedService(ctx, spec.Name)
+		config.NodePortService = config.waitForCreatedService(ctx, spec.Name)
+		return
 	}
 
-	framework.Failf("Failed to create %s service with node ports from the static range after %d attempts", spec.Name, staticNodePortRetries)
-	return nil
+	framework.Failf("Failed to create %s service with node ports from the static range after %d attempts", nodePortServiceName, retries)
 }
 
 func (config *NetworkingTestConfig) createSessionAffinityService(ctx context.Context, selector map[string]string) {

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -20,11 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"net"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -35,13 +33,13 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2edeployment "k8s.io/kubernetes/test/e2e/framework/deployment"
+	e2enetwork "k8s.io/kubernetes/test/e2e/framework/network"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -49,38 +47,8 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// NodePortRange should match whatever the default/configured range is
-var NodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
-
 // It is copied from "k8s.io/kubernetes/pkg/registry/core/service/portallocator"
 var errAllocated = errors.New("provided port is already allocated")
-
-// staticPortRange implements port allocation model described here
-// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/3668-reserved-service-nodeport-range
-type staticPortRange struct {
-	sync.Mutex
-	baseport      int32
-	length        int32
-	reservedPorts sets.Set[int32]
-}
-
-func calculateRange(size int32) int32 {
-	var minPort int32 = 16
-	var step int32 = 32
-	var maxPort int32 = 128
-	return min(max(minPort, size/step), maxPort)
-}
-
-var staticPortAllocator *staticPortRange
-
-// Initialize only once per test
-func init() {
-	staticPortAllocator = &staticPortRange{
-		baseport:      int32(NodePortRange.Base),
-		length:        calculateRange(int32(NodePortRange.Size)),
-		reservedPorts: sets.New[int32](),
-	}
-}
 
 // TestJig is a test jig to help service testing.
 type TestJig struct {
@@ -106,41 +74,8 @@ func NewTestJig(client clientset.Interface, namespace, name string) *TestJig {
 	return j
 }
 
-// reservePort reserves the port provided as input.
-// If an invalid port was provided or if the port is already reserved, it returns false
-func (s *staticPortRange) reservePort(port int32) bool {
-	s.Lock()
-	defer s.Unlock()
-	if port < s.baseport || port > s.baseport+s.length || s.reservedPorts.Has(port) {
-		return false
-	}
-	s.reservedPorts.Insert(port)
-	return true
-}
-
-// getUnusedPort returns a free port from the range and returns its number and nil value
-// the port is not allocated so the consumer should allocate it explicitly calling allocatePort()
-// if none is available then it returns -1 and error
-func (s *staticPortRange) getUnusedPort() (int32, error) {
-	s.Lock()
-	defer s.Unlock()
-	// start in a random offset
-	start := rand.Int31n(s.length)
-	for i := int32(0); i < s.length; i++ {
-		port := s.baseport + (start+i)%(s.length)
-		if !s.reservedPorts.Has(port) {
-			return port, nil
-		}
-	}
-	return -1, fmt.Errorf("no free ports were found")
-}
-
-// releasePort releases the port passed as an argument
-func (s *staticPortRange) releasePort(port int32) {
-	s.Lock()
-	defer s.Unlock()
-	s.reservedPorts.Delete(port)
-}
+// The static NodePort allocator lives in test/e2e/framework/network, since that package
+// needs it and can not import this one. The functions below forward to it.
 
 // GetUnusedStaticNodePort returns a free port in static range and a nil value
 // If no port in static range is available it returns -1 and an error value
@@ -148,7 +83,7 @@ func (s *staticPortRange) releasePort(port int32) {
 // You must allocate a port, then attempt to create the service, then call
 // ReserveStaticNodePort.
 func GetUnusedStaticNodePort() (int32, error) {
-	return staticPortAllocator.getUnusedPort()
+	return e2enetwork.GetUnusedStaticNodePort()
 }
 
 // ReserveStaticNodePort reserves the port provided as input. It is guaranteed
@@ -163,7 +98,7 @@ func GetUnusedStaticNodePort() (int32, error) {
 //
 // If an invalid port was provided or if the port is already reserved, it returns false
 func ReserveStaticNodePort(port int32) bool {
-	return staticPortAllocator.reservePort(port)
+	return e2enetwork.ReserveStaticNodePort(port)
 }
 
 // ReleaseStaticNodePort releases the specified port.
@@ -179,7 +114,7 @@ func ReserveStaticNodePort(port int32) bool {
 //		e2eservice.ReleaseStaticNodePort(nodePort)
 //	})
 func ReleaseStaticNodePort(port int32) {
-	staticPortAllocator.releasePort(port)
+	e2enetwork.ReleaseStaticNodePort(port)
 }
 
 // newServiceTemplate returns the default v1.Service template for this j, but
@@ -490,7 +425,7 @@ func (j *TestJig) sanityCheckService(svc *v1.Service, svcType v1.ServiceType) (*
 			return nil, fmt.Errorf("unexpected Spec.Ports[%d].NodePort (%d) for service", i, port.NodePort)
 		}
 		if hasNodePort {
-			if !NodePortRange.Contains(int(port.NodePort)) {
+			if !e2enetwork.NodePortRange.Contains(int(port.NodePort)) {
 				return nil, fmt.Errorf("out-of-range nodePort (%d) for service", port.NodePort)
 			}
 		}
@@ -568,10 +503,10 @@ func (j *TestJig) WaitForNewIngressIP(ctx context.Context, existingIP string, ti
 func (j *TestJig) ChangeServiceNodePort(ctx context.Context, initial int) (*v1.Service, error) {
 	var err error
 	var service *v1.Service
-	for i := 1; i < NodePortRange.Size; i++ {
-		offs1 := initial - NodePortRange.Base
-		offs2 := (offs1 + i) % NodePortRange.Size
-		newPort := NodePortRange.Base + offs2
+	for i := 1; i < e2enetwork.NodePortRange.Size; i++ {
+		offs1 := initial - e2enetwork.NodePortRange.Base
+		offs2 := (offs1 + i) % e2enetwork.NodePortRange.Size
+		newPort := e2enetwork.NodePortRange.Base + offs2
 		service, err = j.UpdateService(ctx, func(s *v1.Service) {
 			s.Spec.Ports[0].NodePort = int32(newPort)
 		})

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -358,7 +358,10 @@ var _ = common.SIGDescribe("Networking", func() {
 
 		// Slow because we confirm that the nodePort doesn't serve traffic, which requires a period of polling.
 		f.It("should update nodePort: http", f.WithSlow(), func(ctx context.Context) {
-			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.UseHostNetwork)
+			// UseStaticNodePorts keeps the nodePort reserved after the Service is deleted
+			// below, so a Service from a test running in parallel can not get it and
+			// answer the probe.
+			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.UseHostNetwork, e2enetwork.UseStaticNodePorts)
 			ginkgo.By(fmt.Sprintf("dialing(http) %v (node) --> %v:%v (ctx, nodeIP) and getting ALL host endpoints", config.NodeIP, config.NodeIP, config.NodeHTTPPort))
 			err := config.DialFromNode(ctx, "http", config.NodeIP, config.NodeHTTPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {
@@ -389,7 +392,10 @@ var _ = common.SIGDescribe("Networking", func() {
 
 		// Slow because we confirm that the nodePort doesn't serve traffic, which requires a period of polling.
 		f.It("should update nodePort: udp", f.WithSlow(), func(ctx context.Context) {
-			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.UseHostNetwork)
+			// UseStaticNodePorts keeps the nodePort reserved after the Service is deleted
+			// below, so a Service from a test running in parallel can not get it and
+			// answer the probe.
+			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.UseHostNetwork, e2enetwork.UseStaticNodePorts)
 			ginkgo.By(fmt.Sprintf("dialing(udp) %v (node) --> %v:%v (nodeIP) and getting ALL host endpoints", config.NodeIP, config.NodeIP, config.NodeUDPPort))
 			err := config.DialFromNode(ctx, "udp", config.NodeIP, config.NodeUDPPort, config.MaxTries, 0, config.EndpointHostnames())
 			if err != nil {

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1657,14 +1657,14 @@ var _ = common.SIGDescribe("Services", func() {
 		if port.NodePort == 0 {
 			framework.Failf("got unexpected Spec.Ports[0].nodePort for new service: %v", service)
 		}
-		if !e2eservice.NodePortRange.Contains(int(port.NodePort)) {
+		if !e2enetwork.NodePortRange.Contains(int(port.NodePort)) {
 			framework.Failf("got unexpected (out-of-range) port for new service: %v", service)
 		}
 
 		outOfRangeNodePort := 0
 		for {
 			outOfRangeNodePort = 1 + rand.Intn(65535)
-			if !e2eservice.NodePortRange.Contains(outOfRangeNodePort) {
+			if !e2enetwork.NodePortRange.Contains(outOfRangeNodePort) {
 				break
 			}
 		}
@@ -1758,7 +1758,7 @@ var _ = common.SIGDescribe("Services", func() {
 		if port.NodePort == 0 {
 			framework.Failf("got unexpected Spec.Ports[0].nodePort for new service: %v", service)
 		}
-		if !e2eservice.NodePortRange.Contains(int(port.NodePort)) {
+		if !e2enetwork.NodePortRange.Contains(int(port.NodePort)) {
 			framework.Failf("got unexpected (out-of-range) port for new service: %v", service)
 		}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

The two `should update nodePort` tests delete the NodePort service and then check that the nodePort stops answering. Once the service is gone the apiserver can give that port to another test running in parallel, which answers the probe and fails the check.

Uses the static nodePort allocator from #127153. The apiserver does not hand out static range ports when it allocates dynamically, and the allocator holds the port until the test ends. Adds a `UseStaticNodePorts` option to `NetworkingTestConfig` and enables it on both tests.

#### Which issue(s) this PR is related to:
#139786

#### Notes
The allocator moved from `test/e2e/framework/service` to `test/e2e/framework/network`, since `NetworkingTestConfig` needs it and `service/util.go` already imports the network package. The three exported functions stay behind and forward to the new location. `NodePortRange` is no longer duplicated, callers use `e2enetwork.NodePortRange`. The moved code itself is unchanged.

The NodePortService has more than one port, so this adds `getUnusedPorts` to pick several  distinct free ports in one pass. The ports are still reserved only after the service has been created, the way `ReserveStaticNodePort` documents it.

Added unit tests for the allocator, there were none before.