### PR TITLE
kube-proxy: clean stale conntrack for deleted UDP services

### DIFF
--- a/pkg/proxy/conntrack/cleanup.go
+++ b/pkg/proxy/conntrack/cleanup.go
@@ -42,8 +42,11 @@ import (
 // for a service that do not correspond to a serving endpoint.
 // List existing conntrack entries and calculate the desired conntrack state
 // based on the current Services and Endpoints.
+// deletedServices holds the ServicePorts removed since the last sync; all the
+// entries directed to their frontends are stale and are removed too.
 func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
-	svcPortMap proxy.ServicePortMap, endpointsMap proxy.EndpointsMap) {
+	svcPortMap proxy.ServicePortMap, endpointsMap proxy.EndpointsMap,
+	deletedServices proxy.ServicePortMap) {
 
 	start := time.Now()
 	klog.V(4).InfoS("Started to reconcile conntrack entries", "ipFamily", ipFamily)
@@ -64,61 +67,77 @@ func CleanStaleEntries(ct Interface, ipFamily v1.IPFamily,
 	// serviceNodePortEndpoints maps service NodePort to the set of serving endpoints  (Endpoint IP and Port).
 	serviceNodePortEndpoints := make(map[int]sets.Set[string])
 
-	for svcName, svc := range svcPortMap {
-		// we are only interested in UDP services
-		if svc.Protocol() != v1.ProtocolUDP {
-			continue
-		}
-
-		endpoints := sets.New[string]()
-		for _, endpoint := range endpointsMap[svcName] {
-			// We need to remove all the conntrack entries for a Service (IP or NodePort)
-			// that are not pointing to a serving endpoint.
-			// We map all the serving endpoints of the service and clear all the conntrack
-			// entries which are destined for the service and are not DNATed to these endpoints.
-			// Changes to the service should not affect existing flows, so we do not take
-			// traffic policies, topology, or terminating status of the service into account.
-			// This ensures that the behavior of UDP services remains consistent with TCP
-			// services.
-			if endpoint.IsServing() {
-				portStr := strconv.Itoa(int(endpoint.Port()))
-				endpoints.Insert(net.JoinHostPort(endpoint.IP(), portStr))
+	// Deleted services are paired with a nil EndpointsMap so that they register an
+	// empty set of serving endpoints: every flow towards their frontends is stale.
+	// Looking them up in endpointsMap instead would be wrong, because the
+	// EndpointSlice deletion can lag the Service deletion by a sync: the service
+	// would still look like it had serving endpoints, and it is reported as deleted
+	// only once, so no later sync would clean those flows up.
+	// They are processed first so that a frontend IP already reused by a live
+	// service is overwritten with that service's serving endpoints below.
+	for _, services := range []struct {
+		svcPortMap   proxy.ServicePortMap
+		endpointsMap proxy.EndpointsMap
+	}{
+		{deletedServices, nil},
+		{svcPortMap, endpointsMap},
+	} {
+		for svcName, svc := range services.svcPortMap {
+			// we are only interested in UDP services
+			if svc.Protocol() != v1.ProtocolUDP {
+				continue
 			}
-		}
 
-		// Note: a Service without any serving endpoints is processed too, with an
-		// empty endpoints set, so that all the existing entries directed to its
-		// frontends are removed. The REJECT (iptables) / reject (nftables) rule
-		// installed for a Service with no endpoints does not cover the previously
-		// established flows: those are DNATed to the (deleted) endpoint IP before
-		// the reject rule, which matches on the Service IP, can be evaluated.
-		// One-way UDP flows (e.g. statsd) refresh the conntrack entry timeout with
-		// every packet, so without this cleanup they keep sending traffic to the
-		// deleted endpoint IP indefinitely.
+			endpoints := sets.New[string]()
+			for _, endpoint := range services.endpointsMap[svcName] {
+				// We need to remove all the conntrack entries for a Service (IP or NodePort)
+				// that are not pointing to a serving endpoint.
+				// We map all the serving endpoints of the service and clear all the conntrack
+				// entries which are destined for the service and are not DNATed to these endpoints.
+				// Changes to the service should not affect existing flows, so we do not take
+				// traffic policies, topology, or terminating status of the service into account.
+				// This ensures that the behavior of UDP services remains consistent with TCP
+				// services.
+				if endpoint.IsServing() {
+					portStr := strconv.Itoa(int(endpoint.Port()))
+					endpoints.Insert(net.JoinHostPort(endpoint.IP(), portStr))
+				}
+			}
 
-		// we need to filter entries that are directed to a Service IP:Port frontend
-		// that does not have an Endpoint IP:Port backend as part of the serving endpoints
-		portStr := strconv.Itoa(svc.Port())
-		// clusterIP:Port
-		serviceIPEndpoints[net.JoinHostPort(svc.ClusterIP().String(), portStr)] = endpoints
-		// loadbalancerIP:Port
-		for _, loadBalancerIP := range svc.LoadBalancerVIPs() {
-			serviceIPEndpoints[net.JoinHostPort(loadBalancerIP.String(), portStr)] = endpoints
-		}
-		// externalIP:Port
-		for _, externalIP := range svc.ExternalIPs() {
-			serviceIPEndpoints[net.JoinHostPort(externalIP.String(), portStr)] = endpoints
-		}
-		// we need to filter entries that are directed to a *:NodePort that does not have
-		// an Endpoint IP:Port backend as part of the serving endpoints.
-		// NodePort entries are matched on the destination port only, so with an
-		// empty endpoints set every UDP flow towards that port number would be
-		// removed, including flows not owned by kube-proxy (e.g. traffic to an
-		// unrelated host on the same port). Skip NodePort cleanup for services
-		// without serving endpoints until the match can be restricted to node IPs.
-		if svc.NodePort() != 0 && endpoints.Len() > 0 {
-			// *:NodePort
-			serviceNodePortEndpoints[svc.NodePort()] = endpoints
+			// Note: a Service without any serving endpoints is processed too, with an
+			// empty endpoints set, so that all the existing entries directed to its
+			// frontends are removed. The REJECT (iptables) / reject (nftables) rule
+			// installed for a Service with no endpoints does not cover the previously
+			// established flows: those are DNATed to the (deleted) endpoint IP before
+			// the reject rule, which matches on the Service IP, can be evaluated.
+			// One-way UDP flows (e.g. statsd) refresh the conntrack entry timeout with
+			// every packet, so without this cleanup they keep sending traffic to the
+			// deleted endpoint IP indefinitely.
+
+			// we need to filter entries that are directed to a Service IP:Port frontend
+			// that does not have an Endpoint IP:Port backend as part of the serving endpoints
+			portStr := strconv.Itoa(svc.Port())
+			// clusterIP:Port
+			serviceIPEndpoints[net.JoinHostPort(svc.ClusterIP().String(), portStr)] = endpoints
+			// loadbalancerIP:Port
+			for _, loadBalancerIP := range svc.LoadBalancerVIPs() {
+				serviceIPEndpoints[net.JoinHostPort(loadBalancerIP.String(), portStr)] = endpoints
+			}
+			// externalIP:Port
+			for _, externalIP := range svc.ExternalIPs() {
+				serviceIPEndpoints[net.JoinHostPort(externalIP.String(), portStr)] = endpoints
+			}
+			// we need to filter entries that are directed to a *:NodePort that does not have
+			// an Endpoint IP:Port backend as part of the serving endpoints.
+			// NodePort entries are matched on the destination port only, so with an
+			// empty endpoints set every UDP flow towards that port number would be
+			// removed, including flows not owned by kube-proxy (e.g. traffic to an
+			// unrelated host on the same port). Skip NodePort cleanup for services
+			// without serving endpoints until the match can be restricted to node IPs.
+			if svc.NodePort() != 0 && endpoints.Len() > 0 {
+				// *:NodePort
+				serviceNodePortEndpoints[svc.NodePort()] = endpoints
+			}
 		}
 	}
 

--- a/pkg/proxy/conntrack/cleanup_test.go
+++ b/pkg/proxy/conntrack/cleanup_test.go
@@ -323,7 +323,7 @@ func TestCleanStaleEntries(t *testing.T) {
 	)
 
 	legacyregistry.MustRegister(metrics.ReconcileConntrackFlowsDeletedEntriesTotal)
-	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap)
+	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap, nil)
 	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
 
 	metricCount, err := testutil.GetCounterMetricValue(metrics.ReconcileConntrackFlowsDeletedEntriesTotal.WithLabelValues(string(testIPFamily)))
@@ -430,7 +430,7 @@ func TestPerformanceCleanStaleEntries(t *testing.T) {
 	fake := &fakeHandler{entries: flows}
 	ct := newConntracker(fake)
 
-	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap)
+	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap, nil)
 	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
 	if len(actualEntries) != expectedEntries {
 		t.Errorf("unexpected number of entries, got %d expected %d", len(actualEntries), expectedEntries)
@@ -547,7 +547,417 @@ func TestServiceWithoutEndpoints(t *testing.T) {
 		},
 	)
 
-	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap)
+	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap, nil)
+	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
+
+	require.Len(t, actualEntries, len(entriesAfterCleanup))
+
+	// sort the actual flows before comparison
+	sort.Slice(actualEntries, func(i, j int) bool {
+		return actualEntries[i].String() < actualEntries[j].String()
+	})
+	// sort the expected flows before comparison
+	sort.Slice(entriesAfterCleanup, func(i, j int) bool {
+		return entriesAfterCleanup[i].String() < entriesAfterCleanup[j].String()
+	})
+
+	if diff := cmp.Diff(entriesAfterCleanup, actualEntries); len(diff) > 0 {
+		t.Errorf("unexpected entries after cleanup: %s", diff)
+	}
+}
+
+func TestDeletedUDPServices(t *testing.T) {
+	sct := proxy.NewServiceChangeTracker(v1.IPv4Protocol, nil, nil)
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testServiceName,
+			Namespace: testServiceNamespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP:   testClusterIP,
+			ExternalIPs: []string{testExternalIP},
+			Ports: []v1.ServicePort{
+				{
+					Name:     "test-udp",
+					Port:     testServicePort,
+					NodePort: testServiceNodePort,
+					Protocol: v1.ProtocolUDP,
+				},
+			},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{
+					IP: testLoadBalancerIP,
+				}},
+			},
+		},
+	}
+
+	sct.Update(nil, svc)
+	svcPortMap := make(proxy.ServicePortMap)
+	_ = svcPortMap.Update(sct)
+
+	udpPortName := proxy.ServicePortName{
+		NamespacedName: types.NamespacedName{
+			Namespace: svc.Namespace,
+			Name:      svc.Name,
+		},
+		Port:     svc.Spec.Ports[0].Name,
+		Protocol: svc.Spec.Ports[0].Protocol,
+	}
+
+	// Capture the ServicePort data before deleting the service.
+	deletedSvc := svcPortMap[udpPortName]
+
+	sct.Update(svc, nil)
+	_ = svcPortMap.Update(sct)
+	if len(svcPortMap) != 0 {
+		t.Fatalf("expected svcPortMap to be empty after deletion, got %+v", svcPortMap)
+	}
+
+	deletedServices := proxy.ServicePortMap{
+		udpPortName: deletedSvc,
+	}
+
+	flows := []*netlink.ConntrackFlow{}
+	var entriesAfterCleanup []*netlink.ConntrackFlow
+
+	// UDP flows to the deleted service's frontends are stale and must be
+	// cleared. Since the service is deleted, endpoints are forced empty and
+	// all flows to its frontends are removed.
+	for _, origDest := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
+		for _, dnatDest := range []string{testServingEndpointIP, testDeletedEndpointIP} {
+			flows = append(flows, generateConntrackEntry(origDest, testServicePort, dnatDest, testEndpointPort, unix.IPPROTO_UDP))
+		}
+	}
+
+	// UDP entries not directed to a service frontend are preserved.
+	entry := generateConntrackEntry(testExternalIP, testNonServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	// non-UDP entries must be preserved.
+	entry = generateConntrackEntry(testExternalIP, testServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_TCP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	// *:NodePort entries are matched on the destination port only, which with
+	// an empty endpoints set would also remove flows not owned by kube-proxy,
+	// so NodePort cleanup is skipped for deleted services and these entries
+	// must be preserved.
+	entry = generateConntrackEntry("", testServiceNodePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	ct := newConntracker(
+		&fakeHandler{
+			entries: flows,
+		},
+	)
+
+	CleanStaleEntries(ct, testIPFamily, svcPortMap, nil, deletedServices)
+	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
+
+	require.Len(t, actualEntries, len(entriesAfterCleanup))
+
+	// sort the actual flows before comparison
+	sort.Slice(actualEntries, func(i, j int) bool {
+		return actualEntries[i].String() < actualEntries[j].String()
+	})
+	// sort the expected flows before comparison
+	sort.Slice(entriesAfterCleanup, func(i, j int) bool {
+		return entriesAfterCleanup[i].String() < entriesAfterCleanup[j].String()
+	})
+
+	if diff := cmp.Diff(entriesAfterCleanup, actualEntries); len(diff) > 0 {
+		t.Errorf("unexpected entries after cleanup: %s", diff)
+	}
+}
+
+// TestDeletedUDPServicesWithLingeringEndpoints checks that a deleted service's
+// flows are cleared even when its EndpointSlice has not been deleted yet. The
+// EndpointSlice deletion can lag the Service deletion by a sync, and a service is
+// reported as deleted only once, so resolving a deleted service against
+// endpointsMap would leak its flows permanently.
+func TestDeletedUDPServicesWithLingeringEndpoints(t *testing.T) {
+	sct := proxy.NewServiceChangeTracker(v1.IPv4Protocol, nil, nil)
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testServiceName,
+			Namespace: testServiceNamespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP:   testClusterIP,
+			ExternalIPs: []string{testExternalIP},
+			Ports: []v1.ServicePort{
+				{
+					Name:     "test-udp",
+					Port:     testServicePort,
+					NodePort: testServiceNodePort,
+					Protocol: v1.ProtocolUDP,
+				},
+			},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{
+					IP: testLoadBalancerIP,
+				}},
+			},
+		},
+	}
+
+	sct.Update(nil, svc)
+	svcPortMap := make(proxy.ServicePortMap)
+	_ = svcPortMap.Update(sct)
+
+	udpPortName := proxy.ServicePortName{
+		NamespacedName: types.NamespacedName{
+			Namespace: svc.Namespace,
+			Name:      svc.Name,
+		},
+		Port:     svc.Spec.Ports[0].Name,
+		Protocol: svc.Spec.Ports[0].Protocol,
+	}
+
+	// Capture the ServicePort data before deleting the service.
+	deletedSvc := svcPortMap[udpPortName]
+
+	sct.Update(svc, nil)
+	_ = svcPortMap.Update(sct)
+	if len(svcPortMap) != 0 {
+		t.Fatalf("expected svcPortMap to be empty after deletion, got %+v", svcPortMap)
+	}
+
+	deletedServices := proxy.ServicePortMap{
+		udpPortName: deletedSvc,
+	}
+
+	// endpointsMap still holds a serving endpoint for the deleted service,
+	// as it would if the EndpointSlice deletion lands a sync later.
+	ect := proxy.NewEndpointsChangeTracker(v1.IPv4Protocol, "test-worker", nil, nil)
+	ect.EndpointSliceUpdate(&discovery.EndpointSlice{
+		AddressType: discovery.AddressTypeIPv4,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-0", testServiceName),
+			Namespace: testServiceNamespace,
+			Labels:    map[string]string{discovery.LabelServiceName: testServiceName},
+		},
+		Endpoints: []discovery.Endpoint{
+			{
+				Addresses:  []string{testServingEndpointIP},
+				Conditions: discovery.EndpointConditions{Serving: new(true)},
+			},
+		},
+		Ports: []discovery.EndpointPort{
+			{
+				Name:     new(svc.Spec.Ports[0].Name),
+				Port:     new(int32(testEndpointPort)),
+				Protocol: new(v1.ProtocolUDP),
+			},
+		},
+	}, false)
+	endpointsMap := make(proxy.EndpointsMap)
+	_ = endpointsMap.Update(ect)
+
+	var flows []*netlink.ConntrackFlow
+
+	// UDP flows to the deleted service's frontends are stale and must be cleared,
+	// even though they are DNATed to the lingering serving endpoint.
+	for _, origDest := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
+		flows = append(flows, generateConntrackEntry(origDest, testServicePort, testServingEndpointIP, testEndpointPort, unix.IPPROTO_UDP))
+	}
+
+	// *:NodePort entries are matched on the destination port only, so NodePort
+	// cleanup is skipped for a service registered with an empty endpoints set and
+	// this entry must be preserved. It would be removed if the deleted service
+	// were resolved against endpointsMap, since that would register its NodePort.
+	nodePortEntry := generateConntrackEntry("", testServiceNodePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+	flows = append(flows, nodePortEntry)
+	entriesAfterCleanup := []*netlink.ConntrackFlow{nodePortEntry}
+
+	ct := newConntracker(
+		&fakeHandler{
+			entries: flows,
+		},
+	)
+
+	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap, deletedServices)
+	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
+
+	require.Len(t, actualEntries, len(entriesAfterCleanup))
+	if diff := cmp.Diff(entriesAfterCleanup, actualEntries); len(diff) > 0 {
+		t.Errorf("unexpected entries after cleanup: %s", diff)
+	}
+}
+
+func TestDeletedUDPServicesIPReuse(t *testing.T) {
+	sct := proxy.NewServiceChangeTracker(v1.IPv4Protocol, nil, nil)
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testServiceName,
+			Namespace: testServiceNamespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP:   testClusterIP,
+			ExternalIPs: []string{testExternalIP},
+			Ports: []v1.ServicePort{
+				{
+					Name:     "test-udp",
+					Port:     testServicePort,
+					NodePort: testServiceNodePort,
+					Protocol: v1.ProtocolUDP,
+				},
+			},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{
+					IP: testLoadBalancerIP,
+				}},
+			},
+		},
+	}
+
+	sct.Update(nil, svc)
+	svcPortMap := make(proxy.ServicePortMap)
+	_ = svcPortMap.Update(sct)
+
+	udpPortName := proxy.ServicePortName{
+		NamespacedName: types.NamespacedName{
+			Namespace: svc.Namespace,
+			Name:      svc.Name,
+		},
+		Port:     svc.Spec.Ports[0].Name,
+		Protocol: svc.Spec.Ports[0].Protocol,
+	}
+
+	// Capture the ServicePort data before deleting the service.
+	deletedSvc := svcPortMap[udpPortName]
+
+	sct.Update(svc, nil)
+	_ = svcPortMap.Update(sct)
+	if len(svcPortMap) != 0 {
+		t.Fatalf("expected svcPortMap to be empty after deletion, got %+v", svcPortMap)
+	}
+
+	deletedServices := proxy.ServicePortMap{
+		udpPortName: deletedSvc,
+	}
+
+	// Create a second service that reuses the deleted service's frontend IPs.
+	reusedServiceName := "cleanup-test-reused"
+	svc2 := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      reusedServiceName,
+			Namespace: testServiceNamespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP:   testClusterIP,
+			ExternalIPs: []string{testExternalIP},
+			Ports: []v1.ServicePort{
+				{
+					Name:     "test-udp",
+					Port:     testServicePort,
+					NodePort: testServiceNodePort,
+					Protocol: v1.ProtocolUDP,
+				},
+			},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{
+					IP: testLoadBalancerIP,
+				}},
+			},
+		},
+	}
+
+	sct.Update(nil, svc2)
+	_ = svcPortMap.Update(sct)
+
+	udpPortName2 := proxy.ServicePortName{
+		NamespacedName: types.NamespacedName{
+			Namespace: svc2.Namespace,
+			Name:      svc2.Name,
+		},
+		Port:     svc2.Spec.Ports[0].Name,
+		Protocol: svc2.Spec.Ports[0].Protocol,
+	}
+	if svcPortMap[udpPortName2] == nil {
+		t.Fatalf("expected svcPortMap to contain reused service %q", udpPortName2.String())
+	}
+
+	ect := proxy.NewEndpointsChangeTracker(v1.IPv4Protocol, "test-worker", nil, nil)
+	eps := &discovery.EndpointSlice{
+		AddressType: discovery.AddressTypeIPv4,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-0", reusedServiceName),
+			Namespace: testServiceNamespace,
+			Labels:    map[string]string{discovery.LabelServiceName: reusedServiceName},
+		},
+		Endpoints: []discovery.Endpoint{
+			{
+				Addresses:  []string{testServingEndpointIP},
+				Conditions: discovery.EndpointConditions{Serving: new(true)},
+			},
+		},
+		Ports: []discovery.EndpointPort{
+			{
+				Name:     new("test-udp"),
+				Port:     new(int32(testEndpointPort)),
+				Protocol: new(v1.ProtocolUDP),
+			},
+		},
+	}
+
+	ect.EndpointSliceUpdate(eps, false)
+	endpointsMap := make(proxy.EndpointsMap)
+	_ = endpointsMap.Update(ect)
+
+	flows := []*netlink.ConntrackFlow{}
+	var entriesAfterCleanup []*netlink.ConntrackFlow
+
+	// Flows to the reused frontend IPs that are DNATed to the current
+	// service's serving endpoint must be preserved.
+	for _, origDest := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
+		entry := generateConntrackEntry(origDest, testServicePort, testServingEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+		flows = append(flows, entry)
+		entriesAfterCleanup = append(entriesAfterCleanup, entry)
+	}
+
+	// Flows to the reused frontend IPs that are DNATed to a deleted endpoint
+	// must be cleared.
+	for _, origDest := range []string{testClusterIP, testLoadBalancerIP, testExternalIP} {
+		flows = append(flows, generateConntrackEntry(origDest, testServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP))
+	}
+
+	// UDP entries not directed to a service frontend are preserved.
+	entry := generateConntrackEntry(testExternalIP, testNonServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	// non-UDP entries must be preserved.
+	entry = generateConntrackEntry(testExternalIP, testServicePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_TCP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+
+	// *:NodePort entries are matched on the destination port only. The
+	// current service has serving endpoints, so only flows to a deleted
+	// endpoint are stale.
+	entry = generateConntrackEntry("", testServiceNodePort, testServingEndpointIP, testEndpointPort, unix.IPPROTO_UDP)
+	flows = append(flows, entry)
+	entriesAfterCleanup = append(entriesAfterCleanup, entry)
+	flows = append(flows, generateConntrackEntry("", testServiceNodePort, testDeletedEndpointIP, testEndpointPort, unix.IPPROTO_UDP))
+
+	ct := newConntracker(
+		&fakeHandler{
+			entries: flows,
+		},
+	)
+
+	CleanStaleEntries(ct, testIPFamily, svcPortMap, endpointsMap, deletedServices)
 	actualEntries, _ := ct.ListEntries(ipFamilyMap[testIPFamily])
 
 	require.Len(t, actualEntries, len(entriesAfterCleanup))

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1420,9 +1420,9 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		proxier.logger.Error(err, "Error syncing healthcheck endpoints")
 	}
 
-	if endpointUpdateResult.ConntrackCleanupRequired {
+	if endpointUpdateResult.ConntrackCleanupRequired || serviceUpdateResult.ConntrackCleanupRequired {
 		// Finish housekeeping, clear stale conntrack entries for UDP Services
-		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap, serviceUpdateResult.DeletedServices)
 	}
 	return
 }

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -681,7 +681,7 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	// We assume that if this was called, we really want to sync them,
 	// even if nothing changed in the meantime. In other words, callers are
 	// responsible for detecting no-op changes and not calling this function.
-	_ = proxier.svcPortMap.Update(proxier.serviceChanges)
+	serviceUpdateResult := proxier.svcPortMap.Update(proxier.serviceChanges)
 	endpointUpdateResult := proxier.endpointsMap.Update(proxier.endpointsChanges)
 
 	proxier.logger.V(3).Info("Syncing ipvs proxier rules")
@@ -1246,9 +1246,9 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("internal", string(proxier.ipFamily)).Set(float64(proxier.serviceNoLocalEndpointsInternal.Len()))
 	metrics.SyncProxyRulesNoLocalEndpointsTotal.WithLabelValues("external", string(proxier.ipFamily)).Set(float64(proxier.serviceNoLocalEndpointsExternal.Len()))
 
-	if endpointUpdateResult.ConntrackCleanupRequired {
+	if endpointUpdateResult.ConntrackCleanupRequired || serviceUpdateResult.ConntrackCleanupRequired {
 		// Finish housekeeping, clear stale conntrack entries for UDP Services
-		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap, serviceUpdateResult.DeletedServices)
 	}
 	return
 }

--- a/pkg/proxy/nftables/proxier.go
+++ b/pkg/proxy/nftables/proxier.go
@@ -1913,9 +1913,9 @@ func (proxier *Proxier) syncProxyRules() (retryError error) {
 		proxier.localhostNodePortProxy.SyncNodePorts(localhostNodePorts)
 	}
 
-	if endpointUpdateResult.ConntrackCleanupRequired {
+	if endpointUpdateResult.ConntrackCleanupRequired || serviceUpdateResult.ConntrackCleanupRequired {
 		// Finish housekeeping, clear stale conntrack entries for UDP Services
-		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap)
+		conntrack.CleanStaleEntries(proxier.conntrack, proxier.ipFamily, proxier.svcPortMap, proxier.endpointsMap, serviceUpdateResult.DeletedServices)
 	}
 	return
 }

--- a/pkg/proxy/servicechangetracker.go
+++ b/pkg/proxy/servicechangetracker.go
@@ -17,6 +17,7 @@ limitations under the License.
 package proxy
 
 import (
+	"maps"
 	"reflect"
 	"sync"
 
@@ -114,6 +115,14 @@ type UpdateServiceMapResult struct {
 	// UpdatedServices lists the names of all services added/updated/deleted since the
 	// last Update.
 	UpdatedServices sets.Set[types.NamespacedName]
+	// DeletedServices holds all the ServicePorts removed since the last Update,
+	// either because their Service was deleted or because the port was removed
+	// from it. Callers can use this to clean up stale state (e.g. conntrack
+	// entries for deleted UDP services).
+	DeletedServices ServicePortMap
+	// ConntrackCleanupRequired will be true if any UDP ServicePort was deleted, false otherwise.
+	// It's used to minimise conntrack cleanup calls.
+	ConntrackCleanupRequired bool
 }
 
 // HealthCheckNodePorts returns a map of Service names to HealthCheckNodePort values
@@ -171,6 +180,7 @@ func (sm ServicePortMap) Update(sct *ServiceChangeTracker) UpdateServiceMapResul
 
 	result := UpdateServiceMapResult{
 		UpdatedServices: sets.New[types.NamespacedName](),
+		DeletedServices: ServicePortMap{},
 	}
 
 	for nn, change := range sct.items {
@@ -183,7 +193,21 @@ func (sm ServicePortMap) Update(sct *ServiceChangeTracker) UpdateServiceMapResul
 		// filter out the Update event of current changes from previous changes
 		// before calling unmerge() so that can skip deleting the Update events.
 		change.previous.filter(change.current)
+		maps.Copy(result.DeletedServices, change.previous)
 		sm.unmerge(change.previous)
+
+		// result.ConntrackCleanupRequired should be true if any one of the deleted
+		// ServicePorts is UDP. Once true, we don't update the value.
+		if result.ConntrackCleanupRequired {
+			continue
+		}
+		// Check if the deleted service had any UDP ServicePort
+		for svcPort := range change.previous {
+			if svcPort.Protocol == v1.ProtocolUDP {
+				result.ConntrackCleanupRequired = true
+				break
+			}
+		}
 	}
 	// clear changes after applying them to ServicePortMap.
 	sct.items = make(map[types.NamespacedName]*serviceChange)

--- a/pkg/proxy/servicechangetracker_test.go
+++ b/pkg/proxy/servicechangetracker_test.go
@@ -844,6 +844,135 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 	}
 }
 
+func TestUpdateDeletedServices(t *testing.T) {
+	udpSvc := makeTestService("ns1", "udp-svc", func(svc *v1.Service) {
+		svc.Spec.Type = v1.ServiceTypeClusterIP
+		svc.Spec.ClusterIP = "172.16.55.4"
+		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "p1", "UDP", 1234, 4321, 0)
+	})
+	tcpSvc := makeTestService("ns1", "tcp-svc", func(svc *v1.Service) {
+		svc.Spec.Type = v1.ServiceTypeClusterIP
+		svc.Spec.ClusterIP = "172.16.55.5"
+		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "p1", "TCP", 1235, 5321, 0)
+	})
+
+	udpPortName := makeServicePortName("ns1", "udp-svc", "p1", v1.ProtocolUDP)
+	tcpPortName := makeServicePortName("ns1", "tcp-svc", "p1", v1.ProtocolTCP)
+
+	t.Run("initial add has no deleted services", func(t *testing.T) {
+		fp := newFakeProxier(v1.IPv4Protocol, time.Time{})
+		fp.addService(udpSvc)
+		fp.addService(tcpSvc)
+
+		result := fp.svcPortMap.Update(fp.serviceChanges)
+		if len(result.DeletedServices) != 0 {
+			t.Errorf("expected 0 deleted services, got %d", len(result.DeletedServices))
+		}
+		if result.ConntrackCleanupRequired {
+			t.Errorf("expected no conntrack cleanup required")
+		}
+		for _, svc := range []*v1.Service{udpSvc, tcpSvc} {
+			name := makeNSN(svc.Namespace, svc.Name)
+			if !result.UpdatedServices.Has(name) {
+				t.Errorf("expected updated service for %q", name)
+			}
+		}
+		if len(result.UpdatedServices) != 2 {
+			t.Errorf("expected 2 updated services, got %d", len(result.UpdatedServices))
+		}
+	})
+
+	t.Run("single udp deletion", func(t *testing.T) {
+		fp := newFakeProxier(v1.IPv4Protocol, time.Time{})
+		fp.addService(udpSvc)
+		fp.addService(tcpSvc)
+		fp.svcPortMap.Update(fp.serviceChanges)
+
+		fp.deleteService(udpSvc)
+		result := fp.svcPortMap.Update(fp.serviceChanges)
+
+		if len(result.DeletedServices) != 1 {
+			t.Errorf("expected 1 deleted service, got %d", len(result.DeletedServices))
+		}
+		if !result.ConntrackCleanupRequired {
+			t.Errorf("expected conntrack cleanup required")
+		}
+		if deletedSvc, ok := result.DeletedServices[udpPortName]; !ok {
+			t.Errorf("expected deleted service for %q", udpPortName)
+		} else {
+			if deletedSvc.ClusterIP().String() != "172.16.55.4" {
+				t.Errorf("expected deleted UDP service ClusterIP 172.16.55.4, got %s", deletedSvc.ClusterIP().String())
+			}
+			if deletedSvc.Port() != 1234 {
+				t.Errorf("expected deleted UDP service port 1234, got %d", deletedSvc.Port())
+			}
+			if deletedSvc.Protocol() != v1.ProtocolUDP {
+				t.Errorf("expected deleted UDP service protocol UDP, got %s", deletedSvc.Protocol())
+			}
+		}
+		if _, ok := result.DeletedServices[tcpPortName]; ok {
+			t.Errorf("did not expect deleted service for %q", tcpPortName)
+		}
+	})
+
+	t.Run("single tcp deletion", func(t *testing.T) {
+		fp := newFakeProxier(v1.IPv4Protocol, time.Time{})
+		fp.addService(udpSvc)
+		fp.addService(tcpSvc)
+		fp.svcPortMap.Update(fp.serviceChanges)
+
+		fp.deleteService(tcpSvc)
+		result := fp.svcPortMap.Update(fp.serviceChanges)
+
+		if len(result.DeletedServices) != 1 {
+			t.Errorf("expected 1 deleted service, got %d", len(result.DeletedServices))
+		}
+		if result.ConntrackCleanupRequired {
+			t.Errorf("expected no conntrack cleanup required")
+		}
+		if deletedSvc, ok := result.DeletedServices[tcpPortName]; !ok {
+			t.Errorf("expected deleted service for %q", tcpPortName)
+		} else {
+			if deletedSvc.ClusterIP().String() != "172.16.55.5" {
+				t.Errorf("expected deleted TCP service ClusterIP 172.16.55.5, got %s", deletedSvc.ClusterIP().String())
+			}
+			if deletedSvc.Port() != 1235 {
+				t.Errorf("expected deleted TCP service port 1235, got %d", deletedSvc.Port())
+			}
+			if deletedSvc.Protocol() != v1.ProtocolTCP {
+				t.Errorf("expected deleted TCP service protocol TCP, got %s", deletedSvc.Protocol())
+			}
+		}
+		if _, ok := result.DeletedServices[udpPortName]; ok {
+			t.Errorf("did not expect deleted service for %q", udpPortName)
+		}
+	})
+
+	t.Run("all deleted service ports are surfaced", func(t *testing.T) {
+		fp := newFakeProxier(v1.IPv4Protocol, time.Time{})
+		fp.addService(udpSvc)
+		fp.addService(tcpSvc)
+		fp.svcPortMap.Update(fp.serviceChanges)
+
+		fp.deleteService(udpSvc)
+		fp.deleteService(tcpSvc)
+		result := fp.svcPortMap.Update(fp.serviceChanges)
+
+		if len(result.DeletedServices) != 2 {
+			t.Errorf("expected 2 deleted services, got %d", len(result.DeletedServices))
+		}
+		if !result.ConntrackCleanupRequired {
+			t.Errorf("expected conntrack cleanup required")
+		}
+		if _, ok := result.DeletedServices[udpPortName]; !ok {
+			t.Errorf("expected deleted service for %q", udpPortName)
+		}
+		if _, ok := result.DeletedServices[tcpPortName]; !ok {
+			t.Errorf("expected deleted service for %q", tcpPortName)
+		}
+	})
+}
+
 func TestServiceCacheLeaks(t *testing.T) {
 	fp := newFakeProxier(v1.IPv4Protocol, time.Time{})
 

--- a/test/e2e/network/conntrack.go
+++ b/test/e2e/network/conntrack.go
@@ -354,6 +354,78 @@ var _ = common.SIGDescribe("Conntrack", func() {
 		}
 	})
 
+	ginkgo.It("should clear conntrack entries when a UDP service is deleted", func(ctx context.Context) {
+
+		// Create a ClusterIP service
+		udpJig := e2eservice.NewTestJig(cs, ns, serviceName)
+		ginkgo.By("creating a UDP service " + serviceName + " with type=ClusterIP in " + ns)
+		udpService, err := udpJig.CreateUDPService(ctx, func(svc *v1.Service) {
+			svc.Spec.Type = v1.ServiceTypeClusterIP
+			svc.Spec.Ports = []v1.ServicePort{
+				{Port: 80, Name: "udp", Protocol: v1.ProtocolUDP, TargetPort: intstr.FromInt32(80)},
+			}
+		})
+		framework.ExpectNoError(err)
+
+		// Create a pod in one node to create the UDP traffic against the ClusterIP service every 5 seconds
+		ginkgo.By("creating a client pod for probing the service " + serviceName)
+		clientPod := e2epod.NewAgnhostPod(ns, podClient, nil, nil, nil)
+		nodeSelection := e2epod.NodeSelection{Name: clientNodeInfo.name}
+		e2epod.SetNodeSelection(&clientPod.Spec, nodeSelection)
+		cmd := generateProbeCommand("hostname", udpService.Spec.ClusterIP, udpService.Spec.Ports[0].Port, srcPort, 5)
+		clientPod.Spec.Containers[0].Command = []string{"/bin/sh", "-c", cmd}
+		clientPod.Spec.Containers[0].Name = podClient
+		e2epod.NewPodClient(fr).CreateSync(ctx, clientPod)
+
+		// Read the client pod logs
+		logs, err := e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
+		framework.ExpectNoError(err)
+		framework.Logf("Pod client logs: %s", logs)
+
+		// Add a backend pod to the service in the other node
+		ginkgo.By("creating a backend pod " + podBackend1 + " for the service " + serviceName)
+		serverPod1 := e2epod.NewAgnhostPod(ns, podBackend1, nil, nil, nil, "netexec", fmt.Sprintf("--udp-port=%d", 80))
+		serverPod1.Labels = udpJig.Labels
+		nodeSelection = e2epod.NodeSelection{Name: serverNodeInfo.name}
+		e2epod.SetNodeSelection(&serverPod1.Spec, nodeSelection)
+		e2epod.NewPodClient(fr).CreateSync(ctx, serverPod1)
+
+		err = e2eendpointslice.WaitForEndpointPods(ctx, cs, ns, serviceName, podBackend1)
+		framework.ExpectNoError(err)
+
+		// Note that the fact that EndpointSlice object already exists, does NOT mean
+		// that iptables (or whatever else is used) was already programmed.
+		// Additionally take into account that UDP conntract entries timeout is
+		// 30 seconds by default.
+		// Based on the above check if the pod receives the traffic.
+		ginkgo.By("checking client pod connected to the backend 1 on Node IP " + serverNodeInfo.nodeIP)
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn(podBackend1, podClient)); err != nil {
+			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
+			framework.ExpectNoError(err)
+			framework.Logf("Pod client logs: %s", logs)
+			framework.Failf("Failed to connect to backend 1")
+		}
+
+		// Delete the service but leave the backend pod running
+		ginkgo.By("deleting the UDP service " + serviceName)
+		err = cs.CoreV1().Services(ns).Delete(ctx, serviceName, metav1.DeleteOptions{})
+		framework.ExpectNoError(err)
+
+		// After deleting the service, the conntrack entries should be cleared so
+		// the client stops receiving traffic.
+		// UDP conntrack entries timeout is 30 sec by default.
+		ginkgo.By("checking client pod stops receiving traffic after the service is deleted")
+		// "FAIL\n" is the probe's enter-fail sentinel; the "FAIL (N times)" summary
+		// printed when leaving the fail state does not contain "FAIL\n", so only an
+		// actual failure matches.
+		if err := wait.PollUntilContextTimeout(ctx, 5*time.Second, time.Minute, true, logContainsFn("FAIL\n", podClient)); err != nil {
+			logs, err = e2epod.GetPodLogs(ctx, cs, ns, podClient, podClient)
+			framework.ExpectNoError(err)
+			framework.Logf("Pod client logs: %s", logs)
+			framework.Failf("Client pod did not stop receiving traffic after service deletion")
+		}
+	})
+
 	// Regression test for https://issues.k8s.io/126934
 	ginkgo.It("should be able to preserve UDP traffic when server pod cycles for a ClusterIP service with InternalTrafficPolicy set to Local", func(ctx context.Context) {
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig network
/area kube-proxy

#### What this PR does / why we need it:

When a UDP Service is deleted, kube-proxy drops its rules but leaves stale conntrack entries behind, one-way UDP flows (statsd, logging) keep refreshing the timeout, so traffic keeps being DNATed to the old endpoint IP, which may already have been reassigned (_The impact is misdelivery and leakage, not an outage._). `CleanStaleEntries` builds its match set from `svcPortMap`, but the deleted service is removed from it before cleanup runs.

Surface deleted service ports via `UpdateServiceMapResult.DeletedServices`; each proxier filters to UDP and passes them to `CleanStaleEntries` with an empty endpoint set, mirroring the existing handling for services with no serving endpoints (#139629).

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

A better design/implementation of #141275 per review feedback: deleted-service info now flows through `UpdateServiceMapResult` instead of a per-proxier field. The tracker stays protocol-agnostic; UDP filtering lives in the proxier. For reproducing the bug check [1](https://github.com/kubernetes/kubernetes/pull/141371#issuecomment-5295604544) or [2](https://github.com/kubernetes/kubernetes/pull/141371#issuecomment-5296463816).

#### Does this PR introduce a user-facing change?

```release-note
conntrack entries for a deleted UDP Service's frontend IPs are now cleared on deletion instead of waiting to expire.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
