### PR TITLE
Fix goroutine leak in TestStoreResourceVersionWithNonMetaTransform

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -1333,7 +1333,15 @@ func TestStoreResourceVersionWithNonMetaTransform(t *testing.T) {
 			Namespace: "default",
 		},
 	})
+
+	done := make(chan struct{})
 	t.Cleanup(func() {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Errorf("controller failed to stop")
+		}
+
 		source.Shutdown()
 	})
 
@@ -1374,7 +1382,12 @@ func TestStoreResourceVersionWithNonMetaTransform(t *testing.T) {
 		},
 	}
 	c := New(cfg)
-	go c.RunWithContext(ctx)
+
+	go func() {
+		defer close(done)
+		c.RunWithContext(ctx)
+	}()
+
 	if !WaitForCacheSync(ctx.Done(), c.HasSynced) {
 		t.Fatal("Timed out waiting for cache sync")
 	}


### PR DESCRIPTION
What type of PR is this?
/kind flake

What this PR does / why we need it:

Fix goroutine leak in `TestStoreResourceVersionWithNonMetaTransform` test.

The `TestStoreResourceVersionWithNonMetaTransform` test starts a controller with RunWithContext but does not wait for it to terminate before shutting down the FakeControllerSource. FakeControllerSource.Shutdown() intentionally acquires its lock permanently. If the reflector attempts to establish another watch during shutdown, it can block in FakeControllerSource.Watch() waiting for RLock(), resulting in leaked goroutines reported by goleak. Fix by waiting for RunWithContext() to exit before calling Shutdown()


Under certain timing conditions, the reflector may still be attempting to create a watch when Shutdown() is called, causing it to block in FakeControllerSource.Watch() and resulting in goleak failures.
```
goleak: found unexpected goroutines

controller.RunWithContext
  -> wait.Group.Wait()

Reflector.watch
  -> FakeControllerSource.Watch()
  -> f.lock.RLock()
```

Which issue(s) this PR is related to:
Fixes https://github.com/kubernetes/kubernetes/issues/141315
Does this PR introduce a user-facing change?
```
NONE
```