### PR TITLE
apiserver: improve performance of streamed list responses via buffering

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package responsewriters
 
 import (
+	"bufio"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -24,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -148,6 +150,13 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 
 var gzipPool = NewGzipWriterPoolOrDie()
 
+// batchBufferPool recycles lazyBatchWriter's batch buffers across responses.
+var batchBufferPool = &sync.Pool{
+	New: func() interface{} {
+		return bufio.NewWriterSize(nil, streamingBatchBufferBytes)
+	},
+}
+
 const (
 	// defaultGzipThresholdBytes is compared to the size of the first write from the stream
 	// (usually the entire object), and if the size is smaller no gzipping will be performed
@@ -156,7 +165,93 @@ const (
 	// Use the length of the first write to recognize streaming implementations.
 	// When streaming JSON first write is "{", while Kubernetes protobuf starts unique 4 byte header.
 	firstWriteStreamingThresholdBytes = 4
+	// streamingBatchBufferBytes is the size of the buffer that batches a large
+	// streamed response's output. A ten-point sweep (4KiB-4MiB) on multi-GB
+	// list responses measured a flat performance plateau from 128KiB through
+	// 1MiB, degradation below 64KiB (item-sized writes pass through a small
+	// bufio unbatched), and regression at 2MiB and above (larger bursts make
+	// flow control choppier). 128KiB is the smallest size on the plateau,
+	// which keeps pooled memory minimal: at most one buffer per in-flight
+	// large streamed response.
+	streamingBatchBufferBytes = 128 * 1024
+	// streamingBatchEngageThresholdBytes is how many bytes lazyBatchWriter
+	// passes straight to the response writer (compressed bytes, under gzip)
+	// before it takes a pooled buffer and batches the rest. Responses that
+	// stay under it, the small-cluster steady state, never take a pooled
+	// buffer and reach the response writer exactly as on the unbatched path;
+	// larger responses forfeit batching only for this prefix (item-sized
+	// writes under identity, the compressor's small writes under gzip), a
+	// sliver of a multi-GB response. 64KiB is where the sweep put ~85% of the
+	// achievable benefit: below it, batching has little left to save.
+	streamingBatchEngageThresholdBytes = 64 * 1024
 )
+
+// firstWriteIsStreaming reports whether a response's first write looks like a
+// streaming collection encoder's opening bytes rather than a fully-marshaled
+// single object. Gzip negotiation and output batching must agree on this
+// classification, so both use this helper.
+func firstWriteIsStreaming(p []byte) bool {
+	return len(p) <= firstWriteStreamingThresholdBytes
+}
+
+// lazyBatchWriter is the last stage above the HTTP response writer for a
+// committed streamed response, under both encodings (encoder ->
+// lazyBatchWriter, or encoder -> gzip -> lazyBatchWriter).
+//
+// Streamed list responses arrive as one small write per item, and the
+// transports below make each such write expensive: HTTP/2 turns roughly every
+// one into a cross-goroutine DATA-frame handoff that parks the handler
+// goroutine (its 4KiB buffer only coalesces writes smaller than itself), so a
+// multi-GB list pays on the order of a million scheduler round-trips and
+// ships mostly sub-full frames; HTTP/1.1 turns each into its own
+// chunked-transfer frame, with TLS records fragmented to match. Batching
+// turns those into one handoff, or one chunk, per buffer.
+//
+// The writer passes bytes straight through until the response has proven
+// large (streamingBatchEngageThresholdBytes written directly), then takes a
+// pooled buffer and batches the remainder, so small responses never hold a
+// pooled buffer and reach the response writer exactly as before, whatever the
+// encoding. The accepted cost, once engaged: after a client reset or request
+// timeout, encoding continues until the next buffer flush fails (under gzip,
+// one buffer of compressed output can be over a MiB of plaintext) instead of
+// failing within one item or one deflate block. Bounded, and per canceled
+// request.
+type lazyBatchWriter struct {
+	hw     io.Writer     // the response writer
+	direct int           // bytes written straight to hw so far; decides engagement
+	batch  *bufio.Writer // from batchBufferPool once engaged; nil before, and after close
+}
+
+func (b *lazyBatchWriter) Write(p []byte) (int, error) {
+	if b.batch == nil {
+		if b.direct < streamingBatchEngageThresholdBytes {
+			n, err := b.hw.Write(p)
+			if err == nil {
+				// a failed (possibly partial) write must not count: engaging
+				// on the next write would accept it into a fresh buffer
+				// instead of failing it too
+				b.direct += n
+			}
+			return n, err
+		}
+		b.batch = batchBufferPool.Get().(*bufio.Writer)
+		b.batch.Reset(b.hw)
+	}
+	return b.batch.Write(p)
+}
+
+// close flushes any batched bytes to the response writer and returns the
+// buffer to the pool; a no-op for responses that never engaged batching.
+func (b *lazyBatchWriter) close() error {
+	if b.batch == nil {
+		return nil
+	}
+	err := b.batch.Flush()
+	b.batch.Reset(nil)
+	batchBufferPool.Put(b.batch)
+	b.batch = nil
+	return err
+}
 
 type deferredResponseWriter struct {
 	mediaType       string
@@ -168,9 +263,17 @@ type deferredResponseWriter struct {
 	hasWritten  bool
 	hw          http.ResponseWriter
 	w           io.Writer
-	// totalBytes is the number of bytes written to `w` and does not include buffered bytes
+	// batcher carries a committed streamed response's output to hw (below
+	// the gzip writer, when compressing); see lazyBatchWriter. Responses are
+	// wired through it by shape (a first write of a few bytes), which CBOR's
+	// per-object tag also matches: such single objects pass through it
+	// unengaged under identity, and batch like a list under gzip once large.
+	batcher lazyBatchWriter
+	// totalBytes is the number of bytes written to `w` (including bytes still
+	// batched below it) and does not include buffered bytes
 	totalBytes int
-	// lastWriteErr holds the error result (if any) of the last write attempt to `w`
+	// lastWriteErr holds the error result (if any) of the last write attempt
+	// to `w`, or of Close's final flush
 	lastWriteErr error
 
 	ctx context.Context
@@ -190,7 +293,7 @@ func (w *deferredResponseWriter) Write(p []byte) (n int, err error) {
 		// not yet buffered, first write is long enough to trigger gzip, no need to buffer
 		return w.unbufferedWrite(p)
 
-	case !w.hasBuffered && len(p) > firstWriteStreamingThresholdBytes:
+	case !w.hasBuffered && !firstWriteIsStreaming(p):
 		// not yet buffered, first write is longer than expected for streaming scenarios that would require buffering, no need to buffer
 		return w.unbufferedWrite(p)
 
@@ -221,6 +324,13 @@ func (w *deferredResponseWriter) discardBufferedResponse() {
 	w.buffer = nil
 }
 
+// unbufferedWrite commits the response on its first call (status code and
+// content-encoding headers, chosen from what Write accumulated) and writes p.
+// "Unbuffered" refers to that gzip-negotiation buffer, not to delivery: a
+// streamed response that proves large is batched by lazyBatchWriter below
+// this point. Everything SerializeObject writes comes through here; watch and
+// ResourceStreamer responses do not (they use their own writers, with
+// per-event flushes), so batching never applies to them.
 func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 	defer func() {
 		w.totalBytes += n
@@ -234,17 +344,28 @@ func (w *deferredResponseWriter) unbufferedWrite(p []byte) (n int, err error) {
 
 	hw := w.hw
 	header := hw.Header()
+
+	// A response with a streaming encoder's shape (a tiny first write, or
+	// the accumulation of one) reaches hw through the lazy batcher; anything
+	// else is a fully-marshaled object and goes to hw directly. Misjudging a
+	// small response as streamed costs nothing: the batcher is pass-through
+	// below streamingBatchEngageThresholdBytes.
+	var sink io.Writer = hw
+	if w.hasBuffered || firstWriteIsStreaming(p) {
+		w.batcher = lazyBatchWriter{hw: hw}
+		sink = &w.batcher
+	}
 	switch {
 	case w.contentEncoding == "gzip" && len(p) > defaultGzipThresholdBytes:
 		header.Set("Content-Encoding", "gzip")
 		header.Add("Vary", "Accept-Encoding")
 
 		gw := gzipPool.Get().(*gzip.Writer)
-		gw.Reset(hw)
+		gw.Reset(sink)
 
 		w.w = gw
 	default:
-		w.w = hw
+		w.w = sink
 	}
 
 	span := tracing.SpanFromContext(w.ctx)
@@ -280,18 +401,31 @@ func (w *deferredResponseWriter) Close() (err error) {
 		if !w.hasBuffered {
 			return nil
 		}
-		// never reached defaultGzipThresholdBytes, no need to do the gzip writer cleanup
-		_, err := w.unbufferedWrite(w.buffer)
+		// never reached defaultGzipThresholdBytes: commit now, writing the
+		// accumulated body uncompressed
+		_, err = w.unbufferedWrite(w.buffer)
 		w.buffer = nil
-		return err
 	}
 
+	// Release whatever the response engaged; a body drained just above is one
+	// uncompressed write and engaged nothing.
 	switch t := w.w.(type) {
 	case *gzip.Writer:
 		err = t.Close()
 		t.Reset(nil)
 		gzipPool.Put(t)
 	}
+	if flushErr := w.batcher.close(); flushErr != nil && err == nil {
+		err = flushErr
+	}
+	// A cleanup failure is recorded like a write error so the span reports it.
+	if err != nil && w.lastWriteErr == nil {
+		w.lastWriteErr = err
+	}
+	// The pooled writers released above may already serve another response;
+	// drop w.w so that a Write after Close (which no caller does) panics on
+	// the nil writer instead of reaching them.
+	w.w = nil
 	return err
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -157,6 +157,11 @@ var batchBufferPool = &sync.Pool{
 	},
 }
 
+// streamedWriteBatching is a test seam: it lets
+// BenchmarkStreamedResponseTransport measure the unbatched write path as its
+// baseline, and is always true in a running server.
+var streamedWriteBatching = true
+
 const (
 	// defaultGzipThresholdBytes is compared to the size of the first write from the stream
 	// (usually the entire object), and if the size is smaller no gzipping will be performed
@@ -224,7 +229,7 @@ type lazyBatchWriter struct {
 
 func (b *lazyBatchWriter) Write(p []byte) (int, error) {
 	if b.batch == nil {
-		if b.direct < streamingBatchEngageThresholdBytes {
+		if b.direct < streamingBatchEngageThresholdBytes || !streamedWriteBatching {
 			n, err := b.hw.Write(p)
 			if err == nil {
 				// a failed (possibly partial) write must not count: engaging

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_batch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_batch_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -329,5 +330,68 @@ func TestStreamedResponseFlushErrorSurfaces(t *testing.T) {
 				t.Error("flush failure not recorded in lastWriteErr")
 			}
 		})
+	}
+}
+
+// BenchmarkStreamedResponseTransport measures a streamed list response end to
+// end over a loopback TLS connection, per protocol, with and without
+// batching: one ~10MiB response of 10KiB item writes per iteration, served
+// through net/http's real HTTP/2 and HTTP/1.1 response writers.
+func BenchmarkStreamedResponseTransport(b *testing.B) {
+	item := []byte(strings.Repeat("x", 10*1024))
+	const items = 1000
+	handler := http.HandlerFunc(func(hw http.ResponseWriter, r *http.Request) {
+		drw := newDeferredWriter(hw, "application/json", "")
+		drw.ctx = r.Context()
+		if _, err := drw.Write([]byte("{")); err != nil {
+			b.Error(err)
+			return
+		}
+		for range items {
+			if _, err := drw.Write(item); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+		if err := drw.Close(); err != nil {
+			b.Error(err)
+		}
+	})
+	for _, proto := range []string{"http2", "http1.1"} {
+		for _, batching := range []bool{true, false} {
+			name := fmt.Sprintf("%s/batched", proto)
+			if !batching {
+				name = fmt.Sprintf("%s/unbatched", proto)
+			}
+			b.Run(name, func(b *testing.B) {
+				prev := streamedWriteBatching
+				streamedWriteBatching = batching
+				defer func() { streamedWriteBatching = prev }()
+				srv := httptest.NewUnstartedServer(handler)
+				srv.EnableHTTP2 = proto == "http2"
+				if !srv.EnableHTTP2 {
+					srv.TLS = &tls.Config{NextProtos: []string{"http/1.1"}}
+				}
+				srv.StartTLS()
+				defer srv.Close()
+				client := srv.Client()
+				b.SetBytes(int64(1 + items*len(item)))
+				b.ReportAllocs()
+				b.ResetTimer()
+				for range b.N {
+					resp, err := client.Get(srv.URL)
+					if err != nil {
+						b.Fatal(err)
+					}
+					if resp.ProtoMajor == 2 != srv.EnableHTTP2 {
+						b.Fatalf("negotiated %s, want %s", resp.Proto, proto)
+					}
+					if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+						b.Fatal(err)
+					}
+					resp.Body.Close()
+				}
+			})
+		}
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_batch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_batch_test.go
@@ -1,0 +1,333 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package responsewriters
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// countingResponseWriter is an httptest.ResponseRecorder that counts the
+// Write calls reaching the network-facing response writer (hw), as opposed
+// to the encoder's writes into deferredResponseWriter, and can inject write
+// failures.
+type countingResponseWriter struct {
+	*httptest.ResponseRecorder
+	writeCount int
+	failWrites bool
+}
+
+func newCountingResponseWriter() *countingResponseWriter {
+	return &countingResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (w *countingResponseWriter) Write(p []byte) (int, error) {
+	w.writeCount++
+	if w.failWrites {
+		return 0, errors.New("connection reset by peer")
+	}
+	return w.ResponseRecorder.Write(p)
+}
+
+func newDeferredWriter(hw http.ResponseWriter, mediaType, contentEncoding string) *deferredResponseWriter {
+	return &deferredResponseWriter{
+		mediaType:       mediaType,
+		statusCode:      http.StatusOK,
+		contentEncoding: contentEncoding,
+		hw:              hw,
+		ctx:             context.Background(),
+	}
+}
+
+// streamWrite simulates a streaming collection encoder: a small opening
+// write, one write per item, and an optional closing write. It returns the
+// concatenation the response body must equal.
+func streamWrite(t testing.TB, w io.Writer, opener, item, closer []byte, items int) []byte {
+	t.Helper()
+	var want bytes.Buffer
+	writeBoth := func(p []byte) {
+		want.Write(p)
+		if _, err := w.Write(p); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+	}
+	writeBoth(opener)
+	for range items {
+		writeBoth(item)
+	}
+	if len(closer) > 0 {
+		writeBoth(closer)
+	}
+	return want.Bytes()
+}
+
+// varyingItem returns a ~1KiB item whose content differs per index, so a
+// stream of them compresses the way real lists do (a few x) instead of
+// collapsing to almost nothing.
+func varyingItem(i int) []byte {
+	var b strings.Builder
+	x := uint64(i)*0x9E3779B97F4A7C15 | 1
+	for b.Len() < 1024 {
+		x ^= x << 13
+		x ^= x >> 7
+		x ^= x << 17
+		fmt.Fprintf(&b, `{"name":"pod-%d","uid":"%016x","phase":"Running"},`, i, x)
+	}
+	return []byte(b.String())
+}
+
+// TestStreamedResponseBatchesWrites pins the lazy engagement contract for
+// identity responses: streamed output reaches the response writer directly
+// until streamingBatchEngageThresholdBytes, then in large batches; responses below
+// the threshold, and single-object responses, are never batched. The body is
+// byte-identical throughout.
+func TestStreamedResponseBatchesWrites(t *testing.T) {
+	t.Run("large streamed engages after threshold", func(t *testing.T) {
+		const itemSize, items = 1024, 3000
+		rec := newCountingResponseWriter()
+		drw := newDeferredWriter(rec, "application/json", "")
+		want := streamWrite(t, drw, []byte("{"), bytes.Repeat([]byte("x"), itemSize), []byte("}"), items)
+		if err := drw.Close(); err != nil {
+			t.Fatalf("close failed: %v", err)
+		}
+		if !bytes.Equal(rec.Body.Bytes(), want) {
+			t.Errorf("batched body differs from streamed input: got %d bytes, want %d", rec.Body.Len(), len(want))
+		}
+		// Direct writes until the threshold crosses, then buffer-sized
+		// flushes for the remainder (+small slack for the opener/closer).
+		minWrites := streamingBatchEngageThresholdBytes / itemSize
+		maxWrites := minWrites + 2 + items*itemSize/streamingBatchBufferBytes + 2
+		if rec.writeCount > maxWrites {
+			t.Errorf("large streamed response reached the response writer in %d writes, want batching after the threshold (<=%d)", rec.writeCount, maxWrites)
+		}
+		if rec.writeCount < minWrites {
+			t.Errorf("large streamed response reached the response writer in %d writes, want the threshold prefix unbatched (>=%d)", rec.writeCount, minWrites)
+		}
+	})
+	t.Run("small streamed stays direct", func(t *testing.T) {
+		// Comfortably under streamingBatchEngageThresholdBytes: every write goes
+		// straight through, nothing is held back for Close.
+		const itemSize = 1024
+		items := streamingBatchEngageThresholdBytes/itemSize - 16
+		wantWrites := items + 2 // opener + items + closer
+		rec := newCountingResponseWriter()
+		drw := newDeferredWriter(rec, "application/json", "")
+		want := streamWrite(t, drw, []byte("{"), bytes.Repeat([]byte("x"), itemSize), []byte("}"), items)
+		if rec.writeCount != wantWrites {
+			t.Errorf("small streamed response saw %d underlying writes before Close, want %d (fully direct)", rec.writeCount, wantWrites)
+		}
+		if err := drw.Close(); err != nil {
+			t.Fatalf("close failed: %v", err)
+		}
+		if !bytes.Equal(rec.Body.Bytes(), want) {
+			t.Errorf("body differs: got %d bytes, want %d", rec.Body.Len(), len(want))
+		}
+		if rec.writeCount != wantWrites {
+			t.Errorf("small streamed response took %d writes total, want %d (no batching engaged)", rec.writeCount, wantWrites)
+		}
+	})
+	t.Run("single object stays direct", func(t *testing.T) {
+		rec := newCountingResponseWriter()
+		drw := newDeferredWriter(rec, "application/json", "")
+		body := strings.Repeat("y", 512*1024)
+		if _, err := io.WriteString(drw, body); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+		if err := drw.Close(); err != nil {
+			t.Fatalf("close failed: %v", err)
+		}
+		if rec.Body.String() != body {
+			t.Errorf("body altered: got %d bytes, want %d", rec.Body.Len(), len(body))
+		}
+		if rec.writeCount != 1 {
+			t.Errorf("single-object response took %d writes, want 1 (no batching)", rec.writeCount)
+		}
+	})
+}
+
+// TestStreamedProtobufDetection pins that the 4-byte protobuf stream header
+// (the first write of streamed protobuf collections) is classified as
+// streamed and batched by the same lazy rule as JSON's "{".
+func TestStreamedProtobufDetection(t *testing.T) {
+	rec := newCountingResponseWriter()
+	drw := newDeferredWriter(rec, "application/vnd.kubernetes.protobuf", "")
+	magic := []byte{0x6b, 0x38, 0x73, 0x00}
+	const itemSize, items = 2048, 1000
+	want := streamWrite(t, drw, magic, bytes.Repeat([]byte{0x01}, itemSize), nil, items)
+	if err := drw.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+	if !bytes.Equal(rec.Body.Bytes(), want) {
+		t.Errorf("batched protobuf body differs from streamed input")
+	}
+	minWrites := streamingBatchEngageThresholdBytes / itemSize
+	maxWrites := minWrites + 2 + items*itemSize/streamingBatchBufferBytes + 2
+	if rec.writeCount > maxWrites {
+		t.Errorf("streamed protobuf response reached the response writer in %d writes, want batching after the threshold (<=%d)", rec.writeCount, maxWrites)
+	}
+	if rec.writeCount < minWrites {
+		t.Errorf("streamed protobuf response reached the response writer in %d writes, want the threshold prefix unbatched (>=%d)", rec.writeCount, minWrites)
+	}
+}
+
+// TestStreamedGzipResponseEngagesLazily pins that gzip responses follow the
+// same lazy rule as identity ones: the first compressed bytes reach the
+// response writer as soon as the gzip threshold commits the response (so
+// headers and time-to-first-byte are untouched), the compressor's small
+// writes pass straight through until streamingBatchEngageThresholdBytes of them
+// have gone out, and batching engages only then, in streamingBatchBufferBytes
+// flushes.
+func TestStreamedGzipResponseEngagesLazily(t *testing.T) {
+	const items = 4096 // ~4MiB of plaintext, ~1.5MiB compressed
+	rec := newCountingResponseWriter()
+	drw := newDeferredWriter(rec, "application/json", "gzip")
+	var want bytes.Buffer
+	write := func(p []byte) {
+		want.Write(p)
+		if _, err := drw.Write(p); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+	}
+	write([]byte("{"))
+	firstBytePlaintext, directWrites, directBytes := -1, -1, 0
+	for i := range items {
+		write(varyingItem(i))
+		if firstBytePlaintext < 0 && rec.Body.Len() > 0 {
+			firstBytePlaintext = want.Len()
+		}
+		if directWrites < 0 && rec.Body.Len() >= streamingBatchEngageThresholdBytes {
+			// Everything so far went straight through; the next compressed
+			// write engages the batch buffer.
+			directWrites, directBytes = rec.writeCount, rec.Body.Len()
+		}
+	}
+	if err := drw.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", got)
+	}
+	zr, err := gzip.NewReader(bytes.NewReader(rec.Body.Bytes()))
+	if err != nil {
+		t.Fatalf("body is not valid gzip: %v", err)
+	}
+	if got, err := io.ReadAll(zr); err != nil || !bytes.Equal(got, want.Bytes()) {
+		t.Fatalf("decompressed body differs from streamed input (err=%v): got %d bytes, want %d", err, len(got), want.Len())
+	}
+
+	// First bytes leave when the gzip threshold commits the response, not
+	// when a batch buffer of compressed output has filled.
+	if firstBytePlaintext < 0 || firstBytePlaintext > defaultGzipThresholdBytes+2*1024 {
+		t.Errorf("first compressed bytes reached the response writer after %d bytes of plaintext, want at commit (~%d)", firstBytePlaintext, defaultGzipThresholdBytes)
+	}
+	if directWrites < 0 {
+		t.Fatalf("compressed output never reached streamingBatchEngageThresholdBytes directly (%d bytes total)", rec.Body.Len())
+	}
+	// The pass-through prefix arrives as the compressor's own small writes;
+	// a batcher engaging early would have delivered it in a flush or two.
+	if fewest := directBytes/streamingBatchBufferBytes + 2; directWrites <= fewest {
+		t.Errorf("first %d compressed bytes reached the response writer in %d writes, want the compressor's writes passed through unbatched (>%d)", directBytes, directWrites, fewest)
+	}
+	batchedBytes := rec.Body.Len() - directBytes
+	batchedWrites := rec.writeCount - directWrites
+	if batchedBytes < 2*streamingBatchBufferBytes {
+		t.Fatalf("test body too small to exercise batching: %d compressed bytes after the threshold", batchedBytes)
+	}
+	if maxWrites := batchedBytes/streamingBatchBufferBytes + 2; batchedWrites > maxWrites {
+		t.Errorf("after the threshold, %d compressed bytes reached the response writer in %d writes, want batching (<=%d)", batchedBytes, batchedWrites, maxWrites)
+	}
+}
+
+// TestStreamedGzipResponseBelowThresholdStaysDirect pins that a gzip response
+// whose compressed output stays under streamingBatchEngageThresholdBytes is
+// compressed exactly as before and never takes a pooled batch buffer.
+func TestStreamedGzipResponseBelowThresholdStaysDirect(t *testing.T) {
+	rec := newCountingResponseWriter()
+	drw := newDeferredWriter(rec, "application/json", "gzip")
+	// ~300KiB streamed as 100 item writes: over defaultGzipThresholdBytes, so
+	// compression commits, but trivially compressible, so the compressed
+	// output stays far below the batching threshold.
+	want := streamWrite(t, drw, []byte("{"), bytes.Repeat([]byte("x"), 3*1024), []byte("}"), 100)
+	if drw.batcher.batch != nil {
+		t.Error("gzip response under the batching threshold took a pooled batch buffer")
+	}
+	if err := drw.Close(); err != nil {
+		t.Fatalf("close failed: %v", err)
+	}
+	if got := rec.Header().Get("Content-Encoding"); got != "gzip" {
+		t.Fatalf("streamed response lost compression: Content-Encoding = %q, body %d bytes", got, rec.Body.Len())
+	}
+	if rec.Body.Len() >= streamingBatchEngageThresholdBytes {
+		t.Fatalf("test body compressed to %d bytes, want under the %d threshold", rec.Body.Len(), streamingBatchEngageThresholdBytes)
+	}
+	zr, err := gzip.NewReader(rec.Body)
+	if err != nil {
+		t.Fatalf("body is not valid gzip: %v", err)
+	}
+	got, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("decompress failed: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("decompressed body differs from streamed input: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
+// TestStreamedResponseFlushErrorSurfaces pins that once batching is engaged,
+// a network write failure discovered at Close's flush is returned to the
+// caller (and recorded like any other write error) rather than swallowed,
+// under both encodings.
+func TestStreamedResponseFlushErrorSurfaces(t *testing.T) {
+	for _, contentEncoding := range []string{"", "gzip"} {
+		t.Run("contentEncoding="+contentEncoding, func(t *testing.T) {
+			rec := newCountingResponseWriter()
+			drw := newDeferredWriter(rec, "application/json", contentEncoding)
+			if _, err := drw.Write([]byte("{")); err != nil {
+				t.Fatalf("write failed: %v", err)
+			}
+			// Stream while the connection is healthy until batching engages...
+			for i := 0; drw.batcher.batch == nil; i++ {
+				if i > 8192 {
+					t.Fatal("batching never engaged")
+				}
+				if _, err := drw.Write(varyingItem(i)); err != nil {
+					t.Fatalf("write failed: %v", err)
+				}
+			}
+			// ...then break the connection: the next write lands in the batch
+			// buffer, and only the Close-time flush can discover the failure.
+			rec.failWrites = true
+			if _, err := drw.Write(varyingItem(0)); err != nil {
+				t.Fatalf("unexpected write error before flush: %v", err)
+			}
+			if err := drw.Close(); err == nil {
+				t.Fatal("Close succeeded despite the underlying writer failing")
+			}
+			if drw.lastWriteErr == nil {
+				t.Error("flush failure not recorded in lastWriteErr")
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery

#### What this PR does / why we need it:

**The problem.** When the apiserver serves a LIST with the streaming collection encoders (JSON and protobuf — the GA `StreamingCollectionsEncoding` path), the response is produced as **one small write per item**: an object serializes, gets written, then the next, once per item. (The worked example below uses ~16KB pods, a large cluster with big objects; the "when does this matter" section generalizes to other list shapes, including many-small-objects lists, which turn out to be the densest case per byte.) Below the handler, HTTP/2 turns roughly **every one of those writes into a cross-goroutine DATA-frame handoff**: the handler's internal 4KiB buffer only coalesces writes *smaller* than itself (Go's `bufio` passes larger writes straight through), so each item-sized write becomes a frame request sent over a channel to the connection's serve loop, and **the serving goroutine parks until that frame is written**. A million-item response pays on the order of a million of these round-trips — measured as seconds of pure Go-scheduler time (`findRunnable`/`futex`) — and ships mostly sub-full DATA frames. HTTP/1.1 has no cross-goroutine handoff, but pays its own per-write tax: the handler-side buffer there is even smaller (`net/http` `bufferBeforeChunkingSize` = 2KiB), so each item write passes straight through and becomes **its own chunked-transfer frame** — a formatted hex length header plus CRLF per item, about a million chunk frames per large LIST, with TLS records fragmented by the write pattern.

**When does this matter?** The cost scales with **total response bytes**; item size only sets the handoff granularity. Items of 4KiB or larger pass straight through the handler's 4KiB buffer (`bufio` large-write passthrough) — one handoff *per item*; smaller items accumulate in that buffer — one handoff *per ~4KiB of output*. That floor makes many-small-object lists the most handoff-dense shape per byte (~256 handoffs/MB, vs ~62/MB for 16KB pods). Measured across the range:

| List shape | Body | Per-write cost before batching (both transports) |
|---|---|---|
| 1M pods, ~16KB each | 15GiB | one handoff (h2) / chunk frame (h1.1) per item: ~1M |
| 50k configmaps, ~380B each | 18MB | one per ~4KiB of output (items below 4KiB coalesce): ~4.4k |
| 200 pods, ~11KB each | 2.2MB | one per item: ~200 |
| Single-object GET/PATCH | any | one write; batching not engaged |

So the benefit is not exclusive to mega-clusters: any LIST response beyond a few MB pays measurable per-write overhead today, and small-object-heavy lists (Leases, Endpoints, ConfigMaps at scale) benefit proportionally more, not less.

**The change.** A committed streamed response's output is routed through `lazyBatchWriter`, a small last stage above the network inside `deferredResponseWriter` (below the gzip writer, when compressing). It passes writes straight through until the response has *demonstrated* it is large — 64KiB actually handed to the transport (`streamingBatchEngageThresholdBytes`; compressed bytes, under gzip) — and only then checks out a pooled **128KiB** `bufio.Writer` and batches the remainder. One rule for both encodings, so small responses keep their unbuffered latency, their headers leave immediately, and they never touch the pool:

| Response | Batching |
|---|---|
| streamed response, either encoding, once 64KiB of it has reached the transport | engaged for the remainder |
| the first 64KiB of every streamed response | direct — headers and first bytes leave exactly as before |
| small lists (identity under 64KiB; gzip-negotiated under 128KiB of plaintext, which never commit compression and drain at Close as one direct write) | never: fully direct, zero pooled memory, unchanged TTFB |
| single objects (GET, PATCH result, Status errors) | never: one write, straight to the response writer |

The 64KiB engagement threshold is the sweep's ~85%-of-benefit granularity: below it batching has little left to save, so a large response forfeits only its first 64KiB (of compressed output, under gzip) — a handful of item-sized handoffs out of ~122k — by starting direct. Once engaged, item writes coalesce in the buffer; each 128KiB flush then *bypasses* the 4KiB handler buffer (the same large-write passthrough) and becomes **one** frame handoff, which the connection's write scheduler slices into full 16KiB DATA frames in a tight loop on the writer goroutine — without waking the handler between frames.

<details>
<summary>Per-stage accounting, HTTP/2 and HTTP/1.1</summary>

Per-stage accounting for a 1M-item, 15GiB response, per transport:

| HTTP/2 pipeline stage | Before | After |
|---|---|---|
| Writes from the encoder | ~1M item writes | ~1M item writes (into the batch buffer) |
| Writes reaching the HTTP/2 machinery | ~1M (item-sized; 4KiB buffer passed through) | **~122k of 128KiB each** |
| Cross-goroutine frame handoffs (park/unpark pairs) | **~1M** | **~122k** |
| DATA frames on the wire | ~1M, mostly sub-full (~10KB) | ~980k, full 16KiB |

| HTTP/1.1 pipeline stage | Before | After |
|---|---|---|
| Writes from the encoder | ~1M item writes | ~1M item writes (into the batch buffer) |
| Chunked-transfer frames written (hex header + CRLF each) | **~1M** (one per item; 2KiB buffer passed through) | **~122k** (one per 128KiB flush) |
| TLS record shape | fragmented to the item-write pattern | full 16KiB records |

(The 4KiB handler buffer still exists in the HTTP/2 AFTER case but is *bypassed* by the 128KiB flushes — `bufio` writes anything larger than its buffer straight through. Its only remaining job is coalescing the encoder's tiny separator writes, same as before.)

HTTP/1.1 has no cross-goroutine handoff — the same batching instead collapses per-item chunk framing, all on the serving goroutine.

</details>

**Which responses are affected:**

| Response | Effect |
|---|---|
| Streamed LIST, no compression negotiated | first 64KiB streams directly (sub-64KiB lists are entirely untouched); the remainder batches through the 128KiB buffer |
| Streamed LIST, gzip negotiated, body > 128KiB | headers and the first 64KiB of compressed output leave directly, as before; the remaining compressed output batches through the 128KiB buffer |
| Streamed LIST, gzip negotiated, body under 128KiB — *most kubectl/client-go small lists, since client-go negotiates gzip* | **zero change**: rides the pre-existing negotiation accumulation and drains at Close as one direct write; no pooled buffer at any point |
| Single-object responses (GET, PATCH result, Status errors) | **zero change**: one write, passes through unbatched |
| **Watch** | **not on this path at all**: `ListResource` routes `opts.Watch` to `serveWatchHandler`, which writes on the raw `http.ResponseWriter`, *hard-fails at startup* if it isn't an `http.Flusher`, and explicitly flushes after every event (watch.go:216, 241, 278). Its per-event latency contract lives in those flushes on a different writer object. |
| ResourceStreamer (logs-style streams) | not on this path: routed before `SerializeObject`, copies on the raw writer |

`deferredResponseWriter` is constructed in exactly one place (`SerializeObject`), reachable only via `WriteObjectNegotiated` — the complete-single-document response path. "Unbuffered" in `unbufferedWrite` refers to the gzip-*decision* buffering, not delivery; the function now carries a doc comment saying so.

**In-tree benchmark** — `BenchmarkStreamedResponseTransport` (second commit) serves one 10MiB streamed response per iteration over loopback TLS through net/http's real HTTP/2 and HTTP/1.1 response writers; `go test -bench StreamedResponseTransport -benchmem -count 10`, compared with `benchstat`; "unbatched" is the seam-selected master write path:

```
             time per 10MiB response (n=10)           allocations per response
  HTTP/2     20.05ms -> 16.20ms   -19.2% (p=0.000)    7304 -> 6394   -12%
  HTTP/1.1   11.46ms ->  6.02ms   -47.5% (p=0.000)    2958 ->  840   -72%
```


These are net numbers: the batched arm already pays for the change's one extra copy of the body (~19µs/MiB of memory bandwidth, measured during development against a discarding sink).

<details>
<summary>Benchmark environment and method</summary>

**Benchmark environment:** Intel Xeon Platinum 8488C (Sapphire Rapids), 32 vCPUs, 247GB RAM, Linux 6.12 (x86-64); both binaries compiled with the same Go toolchain (1.26.5) — a requirement, not a nicety: the JSON 1M baseline alone differs ~10% between Go 1.26.4 and 1.26.5. A dedicated, otherwise-idle machine (background load <1; the benchmark is the only tenant). Server and the single curl client share the machine; requests go over loopback (a remote-client arm is a listed follow-up) TLS 1.3 (AES-128-GCM), no compression negotiated unless stated; etcd 3.6 on local NVMe-backed storage. Base for the measurements below: master @ 8c078bc32e9 (2026-08-10). Every table is a same-run base-vs-patch block on the same store.

</details>

**Measured results** — one same-run block, master @ 8c078bc32e9 vs the same tree plus this change (the branch here is rebased onto a231bf3f377, 7 commits later; this package is untouched in between), on the dedicated idle machine: both binaries, both encodings, both transports. 1M rows: n=10, wall mean±sd, server CPU median (GC cycles land in some measurement windows even on an idle box, so medians carry the CPU signal). 50k rows: single 30-list loop per cell. Short-list rows: median of 10. Each cell reads before → after (delta).

```
1M 16KB pods, n=10:  wall (mean)       server CPU (median)
-------------------  ----------------  -------------------
JSON, HTTP/2         70.8->62.9s -11%  113.2->86.1s -24%
JSON, HTTP/1.1       60.4->56.6s -6%   76.1->72.9s -4%
Protobuf, HTTP/2     38.7->27.2s -30%  53.8->32.3s -40%
Protobuf, HTTP/1.1   24.2->20.5s -15%  25.3->20.8s -18%
```

The other shapes, same binaries and store — the 50k-configmap list (18MB JSON; median of 5 loops of 30 LISTs per cell, measured after the server's post-startup background CPU had settled), and the small lists from the matrix run (200 pods = 2.2MB JSON, 200 configmaps = 73KB JSON), unpatched -> patched:

```
50k configmaps, n=5:  wall per LIST (median)  server CPU per LIST (median)
--------------------  ----------------------  ----------------------------
JSON, HTTP/2          213->122ms -43%         252->124ms -51%
JSON, HTTP/1.1        168->126ms -25%         164->121ms -26%
Protobuf, HTTP/2      110->53ms -52%          125->49ms -60%
Protobuf, HTTP/1.1    80->51ms -36%           73->44ms -40%

median of 10:       200 pods total    200 pods TTFB    200 cfgmaps total  200 cfgmaps TTFB
------------------  ----------------  ---------------  -----------------  ----------------
JSON, HTTP/2        18.5->18.3ms -1%  4.6->5.1ms +0.5  5.6->5.4ms -3%     4.7->4.7ms -0.1
JSON, HTTP/1.1      15.4->15.5ms +1%  4.3->4.7ms +0.4  4.5->4.9ms +11%    4.0->4.5ms +0.5
Protobuf, HTTP/2    10.4->9.5ms -8%   4.7->5.5ms +0.9  4.4->5.0ms +13%    4.1->4.7ms +0.6
Protobuf, HTTP/1.1  8.5->7.6ms -11%   5.0->5.0ms +0.0  4.5->4.7ms +5%     4.4->4.5ms +0.1
```

Small-list cells here are sampled immediately after each arm's 1M-pod runs without warm-up; the dedicated steady-state small-list block (tradeoffs table, TTFB row) is the authoritative small-response measurement. Single-object GET/PATCH responses are unchanged (one write, never engages).

Gzip-negotiated (client-go's default `Accept-Encoding`), same store and binaries, JSON, compressed body 4.5GiB:

```
1M 16KB pods, n=5:   wall (mean)         server CPU (median)  TTFB (median)  50k cfgmaps wall
-------------------  ------------------  -------------------  -------------  ----------------
JSON+gzip, HTTP/2    205.9->180.2s -12%  325.7->221.8s -32%   0.78->0.59s    185->152ms -18%
JSON+gzip, HTTP/1.1  190.4->172.7s -9%   262.9->254.9s -3%    0.89->0.87s    174->151ms -13%
```

Reading the results:

- **No small-response cost**: in the dedicated steady-state block, short-list TTFB stays within −0.4ms to +0.1ms (identity) / −0.7ms to +0.1ms (gzip) of baseline across all twelve cells (medians of 15)‡ — the lazy engagement threshold means small responses stream direct, take no pooled memory, and pay nothing. The short-list rows above are sampled right after the 1M-pod runs and carry a uniform −0.1ms to +0.9ms arm-state shift (see the TTFB row in the tradeoffs table).
- **Protobuf — the encoding core in-cluster clients actually use — benefits the most** (−30% wall, −40% server CPU at 1M scale; −52% wall on 50k-configmap lists, HTTP/2): its generated marshalers are cheap, so the per-write transport overhead is a much larger fraction of its total cost than JSON's.
- **JSON at 1M scale: −11% wall / −24% server CPU over HTTP/2, −6% / −4% over HTTP/1.1.** JSON encoding dominates its own cost, so the transport share this change removes is smaller than for protobuf; under gzip (last table above) the JSON HTTP/2 server-CPU saving is larger again because the compressor's small output writes are what get batched. Both arms are built with the same Go toolchain (1.26.5): an earlier run that mixed 1.26.4 (base) and 1.26.5 (patch) shifted every cell uniformly, and the JSON baseline alone moves ~10% between those point releases.
- Client-side effects are not shown: our load client was curl, whose frame-parsing and TLS stack is not representative of client-go; qualitatively, every combination delivers fewer and fuller frames/chunks for the client to process.

<details>
<summary>Buffer-size sweep (ten sizes, four configurations) behind the two constants</summary>

**Buffer-size sweep** (measured on the v1.34-based branch; the chosen constants were then re-validated on master by the matrix above) — the same benchmark harness run at ten pool sizes on the final (lazy-engagement) code, one same-run block, one server per size. 1M-pod cells are medians of 5; 50k-configmap cells are single 30-list loops (wall ms / server-CPU ms per list). The 4KiB column is effectively a no-batching control: item-sized writes pass straight through a 4KiB `bufio`, so it reproduces unbatched behavior plus one memcpy — and matches the unbatched baseline, validating the harness.

*1M pods, wall seconds per LIST (median of 5):*

```
            4Ki 16Ki 32Ki 64Ki 128Ki 256Ki 512Ki   1Mi  2Mi  4Mi
---------- ---- ---- ---- ---- ----- ----- ----- ----- ---- ----
JSON h2    96.7 84.1 79.1 75.4 74.0*  75.0  76.0  78.2 84.5 82.2
JSON h1.1  83.6 74.4 71.7 69.5  67.9  67.8  67.3 66.0* 66.8 74.6
Proto h2   45.1 35.3 32.7 30.3  29.4 28.4*  29.4  29.9 31.6 32.1
Proto h1.1 35.9 28.9 25.7 26.7  22.8  23.2 22.3*  22.4 23.5 24.4
```

*1M pods, server CPU seconds per LIST (median of 5; occasional GC-window outliers, e.g. protobuf/h1.1 at 64Ki and 4Mi, survive even the median at n=5):*

```
             4Ki  16Ki  32Ki  64Ki 128Ki  256Ki 512Ki   1Mi    2Mi   4Mi
---------- ----- ----- ----- ----- ----- ------ ----- ----- ------ -----
JSON h2    151.1 131.4 122.9 116.3 116.4 114.9* 117.6 120.5  128.1 125.5
JSON h1.1  120.5 108.1 107.5 101.8 102.9  103.6 101.7 100.3 100.1* 110.4
Proto h2    60.4  45.4  42.4  36.5  35.7  33.4*  34.1  34.7   36.3  37.2
Proto h1.1  40.6  42.2  26.3  68.0  23.5   25.8 22.6*  22.9   24.7  57.5
```

*50k configmaps, wall / server-CPU ms per LIST (single 30-list loop; GC-window noise marked by outlier CPU values):*

```
               4Ki    16Ki      32Ki    64Ki   128Ki    256Ki   512Ki     1Mi      2Mi     4Mi
---------- ------- ------- --------- ------- ------- -------- ------- ------- -------- -------
JSON h2    223/257 164/185   155/159 155/156 149/150 146/146* 149/149 157/157  170/172 179/179
JSON h1.1  195/188 164/158 219/1598+ 149/142 160/153  150/144 155/149 155/148 147/140* 156/150
Proto h2    91/107 68/196+     62/59   57/54   59/55   55/51*   59/55   56/52    58/53   59/55
Proto h1.1   70/63   64/55     59/50 63/117+  48/41*    53/45 61/349+   53/46    58/48 60/128+
```

`+` GC pause landed inside the single measurement loop; `*` best cell in the row.

What the curve says: performance is a broad plateau from **128KiB through 1MiB** on every configuration — the differences inside that range are 1–5%, at or under cross-cell noise — with clear degradation below 64KiB (approaching unbatched at 4KiB) and above 2MiB (burstier flow control, as the original 4-point sweep found). The shipped size is **128KiB — the smallest size on the plateau**, chosen because it delivers the plateau’s performance at the lowest memory cost (worst-case pooled memory ≈75MiB at inflight limits, 8x less than 1MiB, at statistically indistinguishable performance).

</details>

**Side effects, measured or bounded** — where behavior differs from master beyond the throughput numbers above, and by how much:

| Aspect | Difference from master |
|---|---|
| Time-to-first-byte (both encodings, both transports) | **unchanged: −0.4 to +0.1ms across the identity cells and −0.7 to +0.1ms across the gzip-negotiated cells** of the dedicated steady-state block (200 pods / 60 pods / 200 configmaps × HTTP/2 / HTTP/1.1, medians of 15), while gzip'd small-list completion improves 7–18%. Sub-threshold responses stream fully direct and larger ones stream their first 64KiB direct, so first bytes leave when they always did; engaging at commit instead would cost +3–5ms here (measured), which is why engagement is lazy. |
| Inter-byte gap on the wire (both transports) | ~4KiB of encode time (~18µs) → ~128KiB (~0.6ms identity; 3–12ms gzip since 128KiB *compressed* ≈ 0.6–1.3MiB plaintext; worst realistic ~10–50ms on a contended server). The gap is pure CPU pacing — the encoders iterate a fully in-memory slice, no storage I/O mid-stream — and stays ≥1000x inside common 60s proxy/LB idle timeouts. |
| Memory (both transports) | one pooled 128KiB batch buffer per in-flight streamed large response; worst case at APF/inflight limits ≈ **75MiB**, realistic large-list concurrency (10–50) → 1.3–6.4MiB. Both this buffer and the gzip writer are **fixed-size per engaged response, not proportional to body size** — the size-dependence is only in whether they engage: a streamed response takes a checkout only after handing 64KiB to the transport — under gzip that is 64KiB of *compressed* output, on top of the 128KiB of plaintext it takes to negotiate compression at all (so small lists — the common case, since client-go negotiates gzip by default — take no pooled buffer at all); single-object responses never do. The pooled `gzip.Writer` this stacks under is the larger of the two by ~9x — measured: 1179 / 1178 / 1174 KB retained per idle writer after compressing 1KB / 128KB / 1MB payloads (level 1, 200 writers averaged post-GC, Go 1.26) — the flate compressor's hash tables and window buffers, allocated lazily on first Write and kept by Reset, identical whether the response was 129KiB or 15GiB. Aggregate memory therefore scales with peak *concurrent* large responses, never with response bytes. `sync.Pool` retains a burst's high-water mark for ~2 GC cycles. |
| Client disconnect or timeout mid-stream (only responses that engaged batching) | Nothing client-visible changes: the response is already committed (200 + headers sent) and the client is gone. Two server-side differences: (1) the failure is noticed within one 128KiB buffer of further output — under gzip 128KiB *compressed*, ≈0.4–1.3MiB of plaintext — instead of within one item / one deflate block, i.e. a few ms of extra encode CPU per abandoned response; (2) when the failure lands inside the final buffer it surfaces from `Close` rather than `Encode` — which master already does for gzip responses (their last block and footer are written by `Close`) and `SerializeObject` handles the same way. Side effect in the other direction: tail failures that master drops silently in the transport's post-handler flush are now returned by `Close` and logged/traced. Un-engaged responses are unchanged. |
| Timeout enforcement against a slow-reading client | The timeout filter's writer holds its mutex across each underlying write, and the timeout goroutine needs that mutex to reset the stream and record the 504. The largest single write grows from one item (or a 4KiB transport flush) to 128KiB, so against a client draining at 1MB/s the reset can trail the deadline by ~130ms instead of ~5ms. Same mechanism as today with a larger constant: a single >128KiB item already does this on master, and a fully stalled client blocks it indefinitely before and after. |
| Pure copy overhead (both transports) | one extra memcpy of every body byte past the threshold: ~19µs per MiB of body (memory bandwidth), measured during development against a body-discarding writer, with per-response allocations unchanged (the pool never allocates on the hot path). Roughly 20–30x smaller than the per-response transport savings in `BenchmarkStreamedResponseTransport`, which are already net of it. |
| Tracing | the "About to start writing response" span event's `writer` attribute reads `*responsewriters.lazyBatchWriter` for streamed identity responses (previously the transport-facing writer type; gzip responses read `*gzip.Writer` before and after). Cleanup failures at `Close` are recorded on the span like write errors. |

**No feature gate or runtime switch, deliberately.** The output is byte-identical with batching on, so image rollback is the rollback, and a runtime knob for a wire-transparent optimization is operational surface without a scenario. If reviewers prefer a feature gate (Beta, on by default, in the pattern recent apiserver serving-path mechanisms used), it drops in at the single wiring site in `unbufferedWrite`; a package-private seam exists only so the in-tree benchmark can measure both arms.

#### Which issue(s) this PR is related to:

No tracking issue. Prior discussion this implements: on the gzip-chunking change, @fuweid observed that per-item writes from the streaming encoders become individual HTTP/2 frame writes and suggested buffering (https://github.com/kubernetes/kubernetes/pull/130281#discussion_r1964531348); on the streaming protobuf encoder, @liggitt asked for `io.Writer` plumbing "so we can transparently wrap in a buffered writer" (https://github.com/kubernetes/kubernetes/pull/129407#discussion_r1989625640). Builds on KEP-5116 (streaming response encoding). The transport benchmark also covers the "write" phase that https://github.com/kubernetes/kubernetes/issues/141310 notes is exercised only through an httptest recorder today.

#### Special notes for your reviewer:

**AI assistance disclosure:** this PR was written in part with the assistance of generative AI — design exploration, code, tests, the benchmark harness, and self-review passes. I have reviewed every change and checked the measurements (run on my own machines), and I take responsibility for all of it; review discussion will be with me directly.

Two commits: the logic change with its tests, then the benchmark (with the package-private seam it uses to measure the unbatched arm). Happy to send the benchmark commit as a separate preceding PR if that is easier to review and merge first.

**Possible follow-up, deliberately out of scope here:** large *non-streamed* gzip responses — server-side Table renderings (`kubectl get`), big single objects — still reach the transport as the compressor's ~240-byte writes, coalesced only by the 4KiB/2KiB transport buffers. Wiring the gzip writer through the same lazy batcher unconditionally would cover them (it is pass-through below 64KiB either way); it changes which responses can hold a pooled buffer, so it wants its own measurement.

#### Does this PR introduce a user-facing change?

```release-note
kube-apiserver: large streamed LIST responses are now written to the connection in batches rather than one item at a time, reducing apiserver CPU and wall-clock time for large LIST requests (and client CPU receiving them) on both HTTP/2 and HTTP/1.1. Response bytes are unchanged.
```
