### PR TITLE
e2e: make service NodePort range configurable

### DIFF
--- a/test/conformance/image/README.md
+++ b/test/conformance/image/README.md
@@ -38,3 +38,24 @@ If you don't want to push the images, run `make` or `make build` instead
 kubectl create -f conformance-e2e.yaml
 ```
 
+#### Pass additional test arguments
+
+The conformance runner accepts additional command-line arguments through
+environment variables:
+
+- `E2E_EXTRA_GINKGO_ARGS` passes arguments to Ginkgo before the test binary.
+- `E2E_EXTRA_ARGS` passes arguments to `e2e.test` after the `--` separator.
+- `E2E_EXTRA_ARGS_SEP` changes how both values are split. The default separator
+  is a space.
+
+For example, when the kube-apiserver uses a non-default
+`--service-node-port-range`, pass the same range to `e2e.test`:
+
+```yaml
+env:
+- name: E2E_EXTRA_ARGS
+  value: "--service-node-port-range=20000-22767"
+```
+
+The configured range must match the kube-apiserver setting. If the environment
+variable is omitted, the test binary uses the default range `30000-32767`.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -37,6 +37,7 @@ import (
 	conformancetestdata "k8s.io/kubernetes/test/conformance/testdata"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	e2etestingmanifests "k8s.io/kubernetes/test/e2e/testing-manifests"
 	testfixtures "k8s.io/kubernetes/test/fixtures"
@@ -76,6 +77,7 @@ func handleFlags() {
 	config.CopyFlags(config.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
+	e2eservice.RegisterFlags(flag.CommandLine)
 	logcheck.RegisterFlags(flag.CommandLine)
 	flag.Parse()
 }

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -19,6 +19,7 @@ package service
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"math/rand"
 	"net"
@@ -49,8 +50,37 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// NodePortRange should match whatever the default/configured range is
+// NodePortRange is the range used by tests which create or validate NodePorts.
+// It must match the kube-apiserver --service-node-port-range setting and must
+// only be configured during startup, before tests begin running.
 var NodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
+
+type nodePortRangeValue struct{}
+
+func (nodePortRangeValue) String() string {
+	return NodePortRange.String()
+}
+
+func (nodePortRangeValue) Set(value string) error {
+	portRange, err := utilnet.ParsePortRange(value)
+	if err != nil {
+		return fmt.Errorf("parse service NodePort range %q: %w", value, err)
+	}
+	if portRange.Base < 1 || portRange.Size < 1 {
+		return fmt.Errorf("service NodePort range %q must be non-empty and contain only ports between 1 and 65535", value)
+	}
+
+	NodePortRange = *portRange
+	initializeStaticPortAllocator()
+	return nil
+}
+
+// RegisterFlags registers flags used by service tests. The flags must be
+// parsed during startup, before tests begin using the static port allocator.
+func RegisterFlags(flags *flag.FlagSet) {
+	usage := fmt.Sprintf("Port range reserved for Service NodePorts. Must match the kube-apiserver --service-node-port-range setting. (default %s)", NodePortRange.String())
+	flags.Var(nodePortRangeValue{}, "service-node-port-range", usage)
+}
 
 // It is copied from "k8s.io/kubernetes/pkg/registry/core/service/portallocator"
 var errAllocated = errors.New("provided port is already allocated")
@@ -73,11 +103,15 @@ func calculateRange(size int32) int32 {
 
 var staticPortAllocator *staticPortRange
 
-// Initialize only once per test
 func init() {
+	initializeStaticPortAllocator()
+}
+
+func initializeStaticPortAllocator() {
+	rangeSize := int32(NodePortRange.Size)
 	staticPortAllocator = &staticPortRange{
 		baseport:      int32(NodePortRange.Base),
-		length:        calculateRange(int32(NodePortRange.Size)),
+		length:        min(calculateRange(rangeSize), rangeSize),
 		reservedPorts: sets.New[int32](),
 	}
 }
@@ -111,7 +145,7 @@ func NewTestJig(client clientset.Interface, namespace, name string) *TestJig {
 func (s *staticPortRange) reservePort(port int32) bool {
 	s.Lock()
 	defer s.Unlock()
-	if port < s.baseport || port > s.baseport+s.length || s.reservedPorts.Has(port) {
+	if port < s.baseport || port >= s.baseport+s.length || s.reservedPorts.Has(port) {
 		return false
 	}
 	s.reservedPorts.Insert(port)

--- a/test/e2e/framework/service/jig_test.go
+++ b/test/e2e/framework/service/jig_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"flag"
+	"io"
+	"strings"
+	"testing"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+)
+
+func TestServiceNodePortRangeFlag(t *testing.T) {
+	originalRange := NodePortRange
+	t.Cleanup(func() {
+		NodePortRange = originalRange
+		initializeStaticPortAllocator()
+	})
+
+	tests := []struct {
+		name                string
+		value               string
+		want                utilnet.PortRange
+		wantAllocatorLength int32
+	}{
+		{
+			name:                "hyphen notation",
+			value:               "20000-22767",
+			want:                utilnet.PortRange{Base: 20000, Size: 2768},
+			wantAllocatorLength: 86,
+		},
+		{
+			name:                "offset notation",
+			value:               "20000+2767",
+			want:                utilnet.PortRange{Base: 20000, Size: 2768},
+			wantAllocatorLength: 86,
+		},
+		{
+			name:                "small range",
+			value:               "30000-30001",
+			want:                utilnet.PortRange{Base: 30000, Size: 2},
+			wantAllocatorLength: 2,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			flags := flag.NewFlagSet("test", flag.ContinueOnError)
+			flags.SetOutput(io.Discard)
+			RegisterFlags(flags)
+			if err := flags.Parse([]string{"--service-node-port-range=" + test.value}); err != nil {
+				t.Fatalf("parse flag: %v", err)
+			}
+
+			if NodePortRange != test.want {
+				t.Fatalf("NodePortRange = %#v, want %#v", NodePortRange, test.want)
+			}
+			if staticPortAllocator.baseport != int32(test.want.Base) {
+				t.Errorf("static allocator base = %d, want %d", staticPortAllocator.baseport, test.want.Base)
+			}
+			if staticPortAllocator.length != test.wantAllocatorLength {
+				t.Errorf("static allocator length = %d, want %d", staticPortAllocator.length, test.wantAllocatorLength)
+			}
+
+			port, err := staticPortAllocator.getUnusedPort()
+			if err != nil {
+				t.Fatalf("get unused port: %v", err)
+			}
+			if !test.want.Contains(int(port)) {
+				t.Errorf("unused port %d is outside configured range %s", port, test.want.String())
+			}
+
+			lastPort := int32(test.want.Base) + test.wantAllocatorLength - 1
+			if !staticPortAllocator.reservePort(lastPort) {
+				t.Errorf("expected static allocator to reserve upper-bound port %d", lastPort)
+			}
+			if firstOutOfRangePort := lastPort + 1; staticPortAllocator.reservePort(firstOutOfRangePort) {
+				t.Errorf("static allocator reserved out-of-range port %d", firstOutOfRangePort)
+			}
+		})
+	}
+}
+
+func TestServiceNodePortRangeFlagHelpIncludesDefault(t *testing.T) {
+	flags := flag.NewFlagSet("test", flag.ContinueOnError)
+	RegisterFlags(flags)
+
+	var output strings.Builder
+	flags.SetOutput(&output)
+	flags.PrintDefaults()
+	want := "(default " + NodePortRange.String() + ")"
+	if !strings.Contains(output.String(), want) {
+		t.Fatalf("flag help does not contain %q:\n%s", want, output.String())
+	}
+}
+
+func TestServiceNodePortRangeFlagRejectsInvalidRange(t *testing.T) {
+	originalRange := NodePortRange
+	t.Cleanup(func() {
+		NodePortRange = originalRange
+		initializeStaticPortAllocator()
+	})
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "malformed", value: "invalid"},
+		{name: "empty", value: ""},
+		{name: "includes port zero", value: "0-1"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			flags := flag.NewFlagSet("test", flag.ContinueOnError)
+			flags.SetOutput(io.Discard)
+			RegisterFlags(flags)
+			if err := flags.Parse([]string{"--service-node-port-range=" + test.value}); err == nil {
+				t.Fatalf("expected range %q to be rejected", test.value)
+			}
+			if NodePortRange != originalRange {
+				t.Fatalf("NodePortRange changed after invalid input: got %#v, want %#v", NodePortRange, originalRange)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/kind feature
/area conformance
/sig network
/sig testing

**What this PR does / why we need it**:

Adds `--service-node-port-range` to `e2e.test`, allowing conformance tests to match clusters whose kube-apiserver uses a non-default NodePort range.

The conformance image accepts the value through `E2E_EXTRA_ARGS`. The default remains `30000-32767`.

**Which issue(s) this PR fixes**:

Related to #89175

**Special notes for your reviewer**:

The range is supplied explicitly because kube-apiserver configuration is not reliably discoverable through the Kubernetes API (would appreciate pointers to an existing API).

This PR was written in part with the assistance of generative AI.

**Does this PR introduce a user-facing change?**:

```release-note
Conformance tests can now use `--service-node-port-range` to match clusters configured with a non-default NodePort range.
```
