### PR TITLE
node: give the node authorizer its own Pod watch

### DIFF
--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -233,6 +233,7 @@ func BuildGenericConfig(
 		genericConfig.EgressSelector,
 		genericConfig.APIServerID,
 		versionedInformers,
+		clientgoExternalClient,
 	)
 	if err != nil {
 		lastErr = fmt.Errorf("invalid authorization config: %w", err)
@@ -253,8 +254,8 @@ func BuildGenericConfig(
 }
 
 // BuildAuthorizer constructs the authorizer. If authorization is not set in s, it returns nil, nil, false, nil
-func BuildAuthorizer(ctx context.Context, s options.CompletedOptions, egressSelector *egressselector.EgressSelector, apiserverID string, versionedInformers clientgoinformers.SharedInformerFactory) (authorizer.Authorizer, authorizer.RuleResolver, bool, error) {
-	authorizationConfig, err := s.Authorization.ToAuthorizationConfig(versionedInformers)
+func BuildAuthorizer(ctx context.Context, s options.CompletedOptions, egressSelector *egressselector.EgressSelector, apiserverID string, versionedInformers clientgoinformers.SharedInformerFactory, client clientgoclientset.Interface) (authorizer.Authorizer, authorizer.RuleResolver, bool, error) {
+	authorizationConfig, err := s.Authorization.ToAuthorizationConfig(versionedInformers, client)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/kubeapiserver/authorizer/config.go
+++ b/pkg/kubeapiserver/authorizer/config.go
@@ -36,6 +36,7 @@ import (
 	versionedinformers "k8s.io/client-go/informers"
 	certinformersv1 "k8s.io/client-go/informers/certificates/v1"
 	resourceinformers "k8s.io/client-go/informers/resource/v1"
+	clientgoclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/auth/authorizer/abac"
 	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
 	"k8s.io/kubernetes/pkg/features"
@@ -60,6 +61,10 @@ type Config struct {
 	WebhookRetryBackoff *wait.Backoff
 
 	VersionedInformerFactory versionedinformers.SharedInformerFactory
+
+	// Client is used by authorizer modes that need their own dedicated
+	// watch instead of sharing VersionedInformerFactory's cache.
+	Client clientgoclientset.Interface
 
 	// Optional field, custom dial function used to connect to webhook
 	CustomDial utilnet.DialFunc
@@ -115,11 +120,12 @@ func (config Config) New(ctx context.Context, serverID string) (authorizer.Autho
 			node.AddGraphEventHandlers(
 				graph,
 				config.VersionedInformerFactory.Core().V1().Nodes(),
-				config.VersionedInformerFactory.Core().V1().Pods(),
+				config.Client.CoreV1(),
 				config.VersionedInformerFactory.Core().V1().PersistentVolumes(),
 				config.VersionedInformerFactory.Storage().V1().VolumeAttachments(),
 				slices, // Nil check in AddGraphEventHandlers can be removed when always creating this.
 				podCertificateRequestInformer,
+				ctx.Done(),
 			)
 			r.nodeAuthorizer = node.NewAuthorizer(graph, nodeidentifier.NewDefaultNodeIdentifier(), bootstrappolicy.NodeRules())
 

--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -31,6 +31,7 @@ import (
 	authzconfig "k8s.io/apiserver/pkg/apis/apiserver"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	versionedinformers "k8s.io/client-go/informers"
+	clientgoclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/kubeapiserver/authorizer"
 	authzmodes "k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 )
@@ -205,7 +206,7 @@ func (o *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 // ToAuthorizationConfig convert BuiltInAuthorizationOptions to authorizer.Config
-func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFactory versionedinformers.SharedInformerFactory) (*authorizer.Config, error) {
+func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFactory versionedinformers.SharedInformerFactory, client clientgoclientset.Interface) (*authorizer.Config, error) {
 	if o == nil {
 		return nil, nil
 	}
@@ -241,6 +242,7 @@ func (o *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFac
 	return &authorizer.Config{
 		PolicyFile:               o.PolicyFile,
 		VersionedInformerFactory: versionedInformerFactory,
+		Client:                   client,
 		WebhookRetryBackoff:      o.WebhookRetryBackoff,
 
 		ReloadFile:                            o.AuthorizationConfigurationFile,

--- a/plugin/pkg/auth/authorizer/node/graph_populator.go
+++ b/plugin/pkg/auth/authorizer/node/graph_populator.go
@@ -28,7 +28,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	certsv1informers "k8s.io/client-go/informers/certificates/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
@@ -113,7 +112,7 @@ func AddGraphEventHandlers(
 		synced = append(synced, pcrHandler.HasSynced)
 	}
 
-	go cache.WaitForNamedCacheSync("node_authorizer", wait.NeverStop, synced...)
+	go cache.WaitForNamedCacheSync("node_authorizer", stopCh, synced...)
 }
 
 func (g *graphPopulator) addPod(obj interface{}) {

--- a/plugin/pkg/auth/authorizer/node/graph_populator.go
+++ b/plugin/pkg/auth/authorizer/node/graph_populator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package node
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/klog/v2"
@@ -25,11 +26,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
 	certsv1informers "k8s.io/client-go/informers/certificates/v1"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	resourceinformers "k8s.io/client-go/informers/resource/v1"
 	storageinformers "k8s.io/client-go/informers/storage/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/dynamic-resource-allocation/resourceclaim"
 	"k8s.io/utils/ptr"
@@ -42,21 +47,37 @@ type graphPopulator struct {
 func AddGraphEventHandlers(
 	graph *Graph,
 	nodes corev1informers.NodeInformer,
-	pods corev1informers.PodInformer,
+	podsClient corev1client.PodsGetter,
 	pvs corev1informers.PersistentVolumeInformer,
 	attachments storageinformers.VolumeAttachmentInformer,
 	slices resourceinformers.ResourceSliceInformer,
 	pcrs certsv1informers.PodCertificateRequestInformer,
+	stopCh <-chan struct{},
 ) {
 	g := &graphPopulator{
 		graph: graph,
 	}
 
-	podHandler, _ := pods.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    g.addPod,
-		UpdateFunc: g.updatePod,
-		DeleteFunc: g.deletePod,
-	})
+	// Pods get their own Reflector instead of a shared informer, backed by
+	// podEventStore, so the node authorizer's need for full pod visibility
+	// doesn't force every other consumer of the shared Pod informer
+	// (admission plugins) to also keep full pod objects cached.
+	podStore := newPodEventStore(g)
+	podReflector := cache.NewReflector(
+		&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return podsClient.Pods(metav1.NamespaceAll).List(context.Background(), options)
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				options.Watch = true
+				return podsClient.Pods(metav1.NamespaceAll).Watch(context.Background(), options)
+			},
+		},
+		&corev1.Pod{},
+		podStore,
+		0,
+	)
+	go podReflector.Run(stopCh)
 
 	pvsHandler, _ := pvs.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    g.addPV,
@@ -71,7 +92,7 @@ func AddGraphEventHandlers(
 	})
 
 	synced := []cache.InformerSynced{
-		podHandler.HasSynced, pvsHandler.HasSynced, attachHandler.HasSynced,
+		podStore.HasSynced, pvsHandler.HasSynced, attachHandler.HasSynced,
 	}
 
 	if slices != nil {

--- a/plugin/pkg/auth/authorizer/node/pod_event_store.go
+++ b/plugin/pkg/auth/authorizer/node/pod_event_store.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// podEventStore feeds Pod watch events into a graphPopulator without
+// retaining full Pod objects. Per pod it keeps only a fingerprint: the
+// handful of fields graphPopulator.updatePod compares to decide whether a
+// change is relevant to the node authorization graph, reused unmodified so
+// this doesn't drift from that tested logic.
+type podEventStore struct {
+	populator *graphPopulator
+
+	mu    sync.Mutex
+	known map[string]*corev1.Pod
+
+	hasSynced atomic.Bool
+}
+
+func newPodEventStore(populator *graphPopulator) *podEventStore {
+	return &podEventStore{
+		populator: populator,
+		known:     map[string]*corev1.Pod{},
+	}
+}
+
+func podFingerprint(pod *corev1.Pod) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+			UID:       pod.UID,
+		},
+		Spec: corev1.PodSpec{
+			NodeName:            pod.Spec.NodeName,
+			EphemeralContainers: make([]corev1.EphemeralContainer, len(pod.Spec.EphemeralContainers)),
+		},
+		Status: corev1.PodStatus{
+			ResourceClaimStatuses:       pod.Status.ResourceClaimStatuses,
+			ExtendedResourceClaimStatus: pod.Status.ExtendedResourceClaimStatus,
+		},
+	}
+}
+
+func (s *podEventStore) HasSynced() bool {
+	return s.hasSynced.Load()
+}
+
+func (s *podEventStore) Add(obj interface{}) error {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return fmt.Errorf("podEventStore.Add: unexpected type %T", obj)
+	}
+	key, err := cache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.known[key] = podFingerprint(pod)
+	s.mu.Unlock()
+	s.populator.addPod(pod)
+	return nil
+}
+
+func (s *podEventStore) Update(obj interface{}) error {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return fmt.Errorf("podEventStore.Update: unexpected type %T", obj)
+	}
+	key, err := cache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	oldFingerprint := s.known[key]
+	s.known[key] = podFingerprint(pod)
+	s.mu.Unlock()
+	if oldFingerprint != nil {
+		s.populator.updatePod(oldFingerprint, pod)
+	} else {
+		s.populator.addPod(pod)
+	}
+	return nil
+}
+
+func (s *podEventStore) Delete(obj interface{}) error {
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		obj = tombstone.Obj
+	}
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return fmt.Errorf("podEventStore.Delete: unexpected type %T", obj)
+	}
+	key, err := cache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	delete(s.known, key)
+	s.mu.Unlock()
+	s.populator.deletePod(pod)
+	return nil
+}
+
+// Replace handles both the reflector's initial List and any relist after a
+// watch reconnects. Deletions that happened while disconnected are detected
+// by diffing against the fingerprints kept from before the relist, the same
+// way a full object store would, just against fingerprints instead of full
+// pods.
+func (s *podEventStore) Replace(list []interface{}, _ string) error {
+	s.mu.Lock()
+	oldKnown := s.known
+	s.mu.Unlock()
+
+	newKnown := make(map[string]*corev1.Pod, len(list))
+	for _, item := range list {
+		pod, ok := item.(*corev1.Pod)
+		if !ok {
+			continue
+		}
+		key, err := cache.MetaNamespaceKeyFunc(pod)
+		if err != nil {
+			continue
+		}
+		if oldFingerprint, existed := oldKnown[key]; existed {
+			s.populator.updatePod(oldFingerprint, pod)
+		} else {
+			s.populator.addPod(pod)
+		}
+		newKnown[key] = podFingerprint(pod)
+	}
+
+	for key, oldFingerprint := range oldKnown {
+		if _, stillPresent := newKnown[key]; stillPresent {
+			continue
+		}
+		namespace, name, err := cache.SplitMetaNamespaceKey(key)
+		if err != nil {
+			continue
+		}
+		s.populator.deletePod(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec:       corev1.PodSpec{NodeName: oldFingerprint.Spec.NodeName},
+		})
+	}
+
+	s.mu.Lock()
+	s.known = newKnown
+	s.mu.Unlock()
+	s.hasSynced.Store(true)
+	return nil
+}
+
+// The methods below aren't used on Reflector's write path but are required
+// to satisfy cache.Store.
+
+func (s *podEventStore) List() []interface{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	items := make([]interface{}, 0, len(s.known))
+	for _, fp := range s.known {
+		items = append(items, fp)
+	}
+	return items
+}
+
+func (s *podEventStore) ListKeys() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys := make([]string, 0, len(s.known))
+	for k := range s.known {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func (s *podEventStore) Get(obj interface{}) (item interface{}, exists bool, err error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil, false, fmt.Errorf("podEventStore.Get: unexpected type %T", obj)
+	}
+	key, err := cache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		return nil, false, err
+	}
+	return s.GetByKey(key)
+}
+
+func (s *podEventStore) GetByKey(key string) (item interface{}, exists bool, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	fp, ok := s.known[key]
+	return fp, ok, nil
+}
+
+func (s *podEventStore) Resync() error {
+	return nil
+}
+
+func (s *podEventStore) LastStoreSyncResourceVersion() string {
+	return ""
+}
+
+func (s *podEventStore) Bookmark(_ string) {}
+
+var _ cache.Store = &podEventStore{}

--- a/plugin/pkg/auth/authorizer/node/pod_event_store_test.go
+++ b/plugin/pkg/auth/authorizer/node/pod_event_store_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
+	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
+)
+
+func canGetSecret(t *testing.T, authz authorizer.Authorizer, nodeName, namespace, secret string) bool {
+	t.Helper()
+	u := &user.DefaultInfo{Name: "system:node:" + nodeName, Groups: []string{"system:nodes"}}
+	decision, _, err := authz.Authorize(context.Background(), authorizer.AttributesRecord{
+		User:            u,
+		ResourceRequest: true,
+		Verb:            "get",
+		Resource:        "secrets",
+		Namespace:       namespace,
+		Name:            secret,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return decision == authorizer.DecisionAllow
+}
+
+func secretPod(name, namespace, nodeName, uid, secret string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: types.UID(uid)},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{
+				{
+					Name: "c",
+					EnvFrom: []corev1.EnvFromSource{
+						{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: secret}}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestPodEventStoreAddDelete(t *testing.T) {
+	g := NewGraph()
+	authz := NewAuthorizer(g, nodeidentifier.NewDefaultNodeIdentifier(), bootstrappolicy.NodeRules())
+	populator := &graphPopulator{graph: g}
+	store := newPodEventStore(populator)
+
+	pod := secretPod("pod1", "ns1", "node1", "pod1uid", "secret1")
+
+	if err := store.Add(pod); err != nil {
+		t.Fatalf("Add: unexpected error: %v", err)
+	}
+	if !canGetSecret(t, authz, "node1", "ns1", "secret1") {
+		t.Errorf("after Add: expected node1 to be authorized for secret1")
+	}
+
+	if err := store.Delete(pod); err != nil {
+		t.Fatalf("Delete: unexpected error: %v", err)
+	}
+	if canGetSecret(t, authz, "node1", "ns1", "secret1") {
+		t.Errorf("after Delete: expected node1 to no longer be authorized for secret1")
+	}
+}
+
+func TestPodEventStoreUpdateFastPath(t *testing.T) {
+	g := NewGraph()
+	authz := NewAuthorizer(g, nodeidentifier.NewDefaultNodeIdentifier(), bootstrappolicy.NodeRules())
+	populator := &graphPopulator{graph: g}
+	store := newPodEventStore(populator)
+
+	pod := secretPod("pod1", "ns1", "node1", "pod1uid", "secret1")
+	if err := store.Add(pod); err != nil {
+		t.Fatalf("Add: unexpected error: %v", err)
+	}
+
+	// An update that doesn't touch node assignment, UID, ephemeral
+	// containers or resource claim statuses should hit updatePod's
+	// fast-path and not disturb the existing graph edges.
+	unrelatedChange := pod.DeepCopy()
+	unrelatedChange.Labels = map[string]string{"unrelated": "change"}
+	if err := store.Update(unrelatedChange); err != nil {
+		t.Fatalf("Update: unexpected error: %v", err)
+	}
+	if !canGetSecret(t, authz, "node1", "ns1", "secret1") {
+		t.Errorf("after no-op Update: expected node1 to still be authorized for secret1")
+	}
+
+	// A relevant change (new ephemeral container referencing a different
+	// secret) must not be skipped.
+	ephChange := pod.DeepCopy()
+	ephChange.Spec.EphemeralContainers = []corev1.EphemeralContainer{
+		{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name: "debug",
+				EnvFrom: []corev1.EnvFromSource{
+					{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secret2"}}},
+				},
+			},
+		},
+	}
+	if err := store.Update(ephChange); err != nil {
+		t.Fatalf("Update: unexpected error: %v", err)
+	}
+	if !canGetSecret(t, authz, "node1", "ns1", "secret2") {
+		t.Errorf("after ephemeral container Update: expected node1 to be authorized for secret2")
+	}
+}
+
+func TestPodEventStoreReplaceDetectsRelistDeletion(t *testing.T) {
+	g := NewGraph()
+	authz := NewAuthorizer(g, nodeidentifier.NewDefaultNodeIdentifier(), bootstrappolicy.NodeRules())
+	populator := &graphPopulator{graph: g}
+	store := newPodEventStore(populator)
+
+	pod1 := secretPod("pod1", "ns1", "node1", "pod1uid", "secret1")
+	pod2 := secretPod("pod2", "ns1", "node2", "pod2uid", "secret2")
+
+	if err := store.Replace([]interface{}{pod1, pod2}, "1"); err != nil {
+		t.Fatalf("initial Replace: unexpected error: %v", err)
+	}
+	if !store.HasSynced() {
+		t.Errorf("expected HasSynced to be true after the first Replace")
+	}
+	if !canGetSecret(t, authz, "node1", "ns1", "secret1") {
+		t.Errorf("after initial Replace: expected node1 to be authorized for secret1")
+	}
+	if !canGetSecret(t, authz, "node2", "ns1", "secret2") {
+		t.Errorf("after initial Replace: expected node2 to be authorized for secret2")
+	}
+
+	// Simulate a relist after the watch reconnected while pod2 was deleted:
+	// the reflector only knows the current state (pod1), not that pod2 is
+	// gone. Replace must diff against the fingerprints kept from before to
+	// detect and process the deletion, without ever having stored the full
+	// pod2 object.
+	if err := store.Replace([]interface{}{pod1}, "2"); err != nil {
+		t.Fatalf("relist Replace: unexpected error: %v", err)
+	}
+	if !canGetSecret(t, authz, "node1", "ns1", "secret1") {
+		t.Errorf("after relist Replace: expected node1 to still be authorized for secret1")
+	}
+	if canGetSecret(t, authz, "node2", "ns1", "secret2") {
+		t.Errorf("after relist Replace: expected node2 to no longer be authorized for secret2, deletion should have been detected")
+	}
+}
+
+func TestPodEventStoreReplaceAppliesFastPathAcrossRelists(t *testing.T) {
+	g := NewGraph()
+	authz := NewAuthorizer(g, nodeidentifier.NewDefaultNodeIdentifier(), bootstrappolicy.NodeRules())
+	populator := &graphPopulator{graph: g}
+	store := newPodEventStore(populator)
+
+	pod := secretPod("pod1", "ns1", "node1", "pod1uid", "secret1")
+	if err := store.Replace([]interface{}{pod}, "1"); err != nil {
+		t.Fatalf("initial Replace: unexpected error: %v", err)
+	}
+
+	changed := pod.DeepCopy()
+	changed.Spec.EphemeralContainers = []corev1.EphemeralContainer{
+		{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name: "debug",
+				EnvFrom: []corev1.EnvFromSource{
+					{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "secret2"}}},
+				},
+			},
+		},
+	}
+	if err := store.Replace([]interface{}{changed}, "2"); err != nil {
+		t.Fatalf("second Replace: unexpected error: %v", err)
+	}
+	if !canGetSecret(t, authz, "node1", "ns1", "secret2") {
+		t.Errorf("after second Replace: expected node1 to be authorized for secret2, fingerprint diff across Replace calls should have detected the change")
+	}
+}


### PR DESCRIPTION
Part of #125469.

Picking up the node authorizer piece of that issue.

### What changed

The node authorizer shares a Pod informer with the NodeRestriction, PodSecurity, and ResourceQuota admission plugins. It needs full pod objects, so that forces the shared cache to stay full for everyone else too, even though NodeRestriction and ResourceQuota only need a few fields each.

This gives the node authorizer its own Pod watch instead. It's backed by a small `cache.Store` (`podEventStore`) that keeps only a per-pod fingerprint (not the full pod!): node name, UID, ephemeral container count, resource claim statuses. The existing `addPod`/`updatePod`/`deletePod` logic is reused as-is, so nothing about how changes are detected has changed.

> [!WARNING]
> This doesn't save memory by itself. The shared cache is still untouched, and PodSecurity still needs full pods from it. This just removes one of two things blocking a future trim of that cache; PodSecurity is the other, coming as a follow-up.

### Testing

New tests cover add/delete, that no-op updates still skip correctly, that real changes still rebuild the graph, and that deletions are caught correctly even across a reconnect/relist. Existing tests are untouched and still pass.

---

Opening as a draft for early feedback on the approach before going further.

This PR was written in part with the assistance of generative AI.