### PR TITLE
kubectl: match kuberc defaults by full command path

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc.go
@@ -178,7 +178,7 @@ func (p *Preferences) applyOverrides(rootCmd *cobra.Command, kuberc *config.Pref
 			fmt.Fprintf(errOut, "Warning: command %q not found to set kuberc override\n", c.Command)
 			continue
 		}
-		if overrideCmd.Name() != cmd.Name() {
+		if overrideCmd.CommandPath() != cmd.CommandPath() {
 			continue
 		}
 

--- a/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/kuberc/kuberc_test.go
@@ -913,6 +913,99 @@ func TestApplyOverride(t *testing.T) {
 	}
 }
 
+// TestApplyOverrideDoesNotMatchUnrelatedLeafCommand verifies that a default
+// configured for one command is not applied to an unrelated command that only
+// shares the same leaf name (e.g. "config view" vs "kuberc view").
+// See https://github.com/kubernetes/kubectl/issues/1862.
+func TestApplyOverrideDoesNotMatchUnrelatedLeafCommand(t *testing.T) {
+	// newRootCmd builds a command tree with two distinct subtrees that share the
+	// same "view" leaf name: "config view" and "kuberc view".
+	newRootCmd := func() *cobra.Command {
+		rootCmd := &cobra.Command{Use: "root"}
+
+		configCmd := &cobra.Command{Use: "config"}
+		configView := &cobra.Command{Use: "view"}
+		configView.Flags().String("output", "yaml", "")
+		configCmd.AddCommand(configView)
+
+		kubercCmd := &cobra.Command{Use: "kuberc"}
+		kubercView := &cobra.Command{Use: "view"}
+		kubercView.Flags().String("output", "yaml", "")
+		kubercCmd.AddCommand(kubercView)
+
+		rootCmd.AddCommand(configCmd, kubercCmd)
+		return rootCmd
+	}
+
+	// The default targets "config view" only.
+	getPreferencesFunc := func(kuberc string, errOut io.Writer) (*config.Preference, error) {
+		return &config.Preference{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Preference",
+				APIVersion: "kubectl.config.k8s.io/v1alpha1",
+			},
+			Defaults: []config.CommandDefaults{
+				{
+					Command: "config view",
+					Options: []config.CommandOptionDefault{
+						{Name: "output", Default: "json"},
+					},
+				},
+			},
+		}, nil
+	}
+
+	tests := []struct {
+		name           string
+		args           []string
+		findArgs       []string
+		expectedOutput string
+	}{
+		{
+			name:           "unrelated leaf command is not overridden",
+			args:           []string{"root", "kuberc", "view"},
+			findArgs:       []string{"kuberc", "view"},
+			expectedOutput: "yaml",
+		},
+		{
+			name:           "targeted command is still overridden",
+			args:           []string{"root", "config", "view"},
+			findArgs:       []string{"config", "view"},
+			expectedOutput: "json",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rootCmd := newRootCmd()
+			opts := genericclioptions.NewConfigFlags(false)
+			prefHandler := NewPreferences()
+			prefHandler.AddFlags(rootCmd.PersistentFlags())
+			pref, ok := prefHandler.(*Preferences)
+			if !ok {
+				t.Fatal("unexpected type. Expected *Preferences")
+			}
+			pref.getPreferencesFunc = getPreferencesFunc
+			errWriter := &bytes.Buffer{}
+
+			if _, err := pref.Apply(rootCmd, opts, test.args, errWriter); err != nil {
+				t.Fatalf("unexpected error %v\n", err)
+			}
+			if errWriter.String() != "" {
+				t.Fatalf("unexpected error message %s\n", errWriter.String())
+			}
+
+			actualCmd, _, err := rootCmd.Find(test.findArgs)
+			if err != nil {
+				t.Fatalf("unable to find the command %v\n", err)
+			}
+			if got := actualCmd.Flag("output").Value.String(); got != test.expectedOutput {
+				t.Fatalf("unexpected flag value for %q: expected %s actual %s\n", actualCmd.CommandPath(), test.expectedOutput, got)
+			}
+		})
+	}
+}
+
 func TestApplyOverrideBool(t *testing.T) {
 	tests := []testApplyOverride[bool]{
 		{


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig cli

#### What this PR does / why we need it:
kuberc determined whether a configured default applied to the running command by comparing only the leaf command name (`Command.Name()`). As a result, a default configured for one command (e.g. `config view`) was also applied to an unrelated command sharing the same leaf name (e.g. `kuberc view`).

This compares the full command path (`Command.CommandPath()`) instead, so a kuberc default only applies to the exact command it was configured for.

#### Which issue(s) this PR is related to:
Fixes kubernetes/kubectl#1862

#### Special notes for your reviewer:
Added a regression test (`TestApplyOverrideDoesNotMatchUnrelatedLeafCommand`) covering both the fixed collision and that the intended command is still matched.

#### Does this PR introduce a user-facing change?
```release-note
Fixed kubectl so a kuberc default configured for one command is no longer applied to an unrelated command that shares the same leaf name (e.g. `config view` vs `kuberc view`).
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs

```
