### PR TITLE
job: fix delegated PodGroup creation window closing prematurely

### DIFF
--- a/pkg/controller/job/job_scheduling_manager.go
+++ b/pkg/controller/job/job_scheduling_manager.go
@@ -124,15 +124,13 @@ func (jm *Controller) ensureWorkloadAndPodGroup(ctx context.Context, job *batch.
 		return nil, nil, nil
 	}
 
-	// Objects are only created for a Job that has never started, so a
-	// Job that predates the feature gate being enabled is left untouched.
-	// An already-started Job discovers and reuses existing objects
-	// but never creates new ones.
-	newJob := isNewJob(job, pods)
-
-	// Case 1 - manage the PodGroup only.
+	// Case 1 - manage the PodGroup only (delegated, non-root Job).
+	// The PodGroup materializes from a parent-owned Workload that may not be
+	// discoverable until a sync after the Job's first one, so creation is gated
+	// on canCreateDelegatedPodGroup rather than isNewJob (whose StartTime and
+	// Suspended-condition checks the first sync would immediately trip).
 	if mode == managePodGroupOnly {
-		pg, err := jm.getOrCreateDelegatedPodGroup(ctx, job, newJob)
+		pg, err := jm.getOrCreateDelegatedPodGroup(ctx, job, canCreateDelegatedPodGroup(job, pods))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -140,6 +138,12 @@ func (jm *Controller) ensureWorkloadAndPodGroup(ctx context.Context, job *batch.
 	}
 
 	// Case 2 - manage both Workload and PodGroup (root Job).
+	//
+	// Objects are only created for a Job that has never started, so a
+	// Job that predates the feature gate being enabled is left untouched.
+	// An already-started Job discovers and reuses existing objects
+	// but never creates new ones.
+	newJob := isNewJob(job, pods)
 	wl, err := jm.getOrCreateWorkload(ctx, job, newJob)
 	if err != nil || wl == nil {
 		return nil, nil, err
@@ -288,7 +292,7 @@ func (jm *Controller) findParentWorkload(job *batch.Job) (*schedulingv1beta1.Wor
 // the parent-owned Workload via the named PodGroupTemplate from the delegation
 // annotation and carries only a controller ownerRef to the Job.
 func (jm *Controller) getOrCreateDelegatedPodGroup(ctx context.Context,
-	job *batch.Job, newJob bool) (*schedulingv1beta1.PodGroup, error) {
+	job *batch.Job, canCreate bool) (*schedulingv1beta1.PodGroup, error) {
 	logger := klog.FromContext(ctx)
 
 	parentWorkload, err := jm.findParentWorkload(job)
@@ -324,10 +328,10 @@ func (jm *Controller) getOrCreateDelegatedPodGroup(ctx context.Context,
 			break
 		}
 	}
-	// Create only when the Job has no pods yet and none exists; otherwise
+	// Create only when the Job has never run and none exists yet; otherwise
 	// discover-only. A create that races with another actor returns
 	// AlreadyExists, which requeues the Job so the next sync discovers it.
-	if updatedPG == nil && newJob {
+	if updatedPG == nil && canCreate {
 		// A delegated Job maps to a parent-owned Workload, so the PodGroup does
 		// not link the Workload as an owner (linkWorkloadOwner=false).
 		updatedPG, err = jm.createPodGroup(ctx, job, parentWorkload, templateName, false, builder)
@@ -379,6 +383,16 @@ func isNewJob(job *batch.Job, pods []*v1.Pod) bool {
 		return false
 	}
 	return findConditionByType(job.Status.Conditions, batch.JobSuspended) == nil
+}
+
+// canCreateDelegatedPodGroup reports whether the delegated path may still
+// create this Job's PodGroup: true only while the Job has never run (no pods,
+// no terminal counters). Unlike isNewJob it ignores StartTime and the Suspended
+// condition, which the Job's first sync writes before the parent-owned Workload
+// this path depends on is necessarily discoverable; gating on them would close
+// the creation window after a single sync.
+func canCreateDelegatedPodGroup(job *batch.Job, pods []*v1.Pod) bool {
+	return len(pods) == 0 && job.Status.Succeeded == 0 && job.Status.Failed == 0
 }
 
 // getOrCreateWorkload returns the Workload for this Job, creating one if needed.

--- a/pkg/controller/job/job_scheduling_manager_test.go
+++ b/pkg/controller/job/job_scheduling_manager_test.go
@@ -790,6 +790,54 @@ func TestEnsureWorkloadAndPodGroup(t *testing.T) {
 			wantPodGroupName:         delegatedPodGroupName,
 			wantPodGroupGangMinCount: new(int32(4)),
 		},
+		// Regression coverage for https://github.com/kubernetes/kubernetes/issues/141380:
+		// the parent Workload can become discoverable on a sync after the
+		// delegated Job's own first sync already wrote StartTime or the
+		// Suspended condition. Unlike the root (manageBoth) path, the
+		// delegated path must still create the PodGroup once the dependency
+		// resolves, since it does not treat those fields as closing the
+		// creation window (see canCreateDelegatedPodGroup).
+		"delegated Job creates the PodGroup once the parent Workload appears, even after StartTime was set": {
+			job: func() *batch.Job {
+				j := delegatedJob.DeepCopy()
+				now := metav1.Now()
+				j.Status.StartTime = &now
+				return j
+			}(),
+			existingWorkloads:        []*schedulingv1beta1.Workload{makeParentWorkload(4)},
+			wantPodGroup:             true,
+			wantPodGroupName:         delegatedPodGroupName,
+			wantPodGroupGangMinCount: new(int32(4)),
+		},
+		"delegated Job creates the PodGroup once the parent Workload appears, even after the Suspended condition was set": {
+			job: func() *batch.Job {
+				j := delegatedJob.DeepCopy()
+				j.Status.Conditions = []batch.JobCondition{
+					{
+						Type:   batch.JobSuspended,
+						Status: v1.ConditionTrue,
+					},
+				}
+				return j
+			}(),
+			existingWorkloads:        []*schedulingv1beta1.Workload{makeParentWorkload(4)},
+			wantPodGroup:             true,
+			wantPodGroupName:         delegatedPodGroupName,
+			wantPodGroupGangMinCount: new(int32(4)),
+		},
+		"delegated Job with pods already running does not create a PodGroup even once the parent Workload appears": {
+			job:               delegatedJob,
+			pods:              []*v1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Namespace: metav1.NamespaceDefault}}},
+			existingWorkloads: []*schedulingv1beta1.Workload{makeParentWorkload(4)},
+		},
+		"delegated Job that already terminated does not create a PodGroup once the parent Workload appears": {
+			job: func() *batch.Job {
+				j := delegatedJob.DeepCopy()
+				j.Status.Succeeded = 3
+				return j
+			}(),
+			existingWorkloads: []*schedulingv1beta1.Workload{makeParentWorkload(4)},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/test/integration/job/job_test.go
+++ b/test/integration/job/job_test.go
@@ -4882,6 +4882,30 @@ func waitForWorkload(ctx context.Context, t *testing.T, clientSet clientset.Inte
 	return workload
 }
 
+// ensurePodGroupAbsent fails if a PodGroup owned by the given Job exists at any
+// point during window. Unlike waitForPodGroup with expectAbsent=true, which
+// returns as soon as a single list comes back empty, this verifies sustained
+// absence: it keeps checking for the full window and only passes if no owned
+// PodGroup is ever observed.
+func ensurePodGroupAbsent(ctx context.Context, t *testing.T, clientSet clientset.Interface, job *batchv1.Job, window time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		podGroups, err := clientSet.SchedulingV1beta1().PodGroups(job.Namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			t.Fatalf("Failed to list PodGroups: %v", err)
+		}
+		for i := range podGroups.Items {
+			for _, ref := range podGroups.Items[i].OwnerReferences {
+				if ref.UID == job.UID && ref.Kind == "Job" {
+					t.Fatalf("Unexpected PodGroup %q owned by Job %q", podGroups.Items[i].Name, job.Name)
+				}
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
 // waitForPodGroup waits for a PodGroup owned by the given Job to appear
 // (expectAbsent=false) or to not exist (expectAbsent=true).
 func waitForPodGroup(ctx context.Context, t *testing.T, clientSet clientset.Interface, job *batchv1.Job, expectAbsent bool, timeout time.Duration) *schedulingv1beta1.PodGroup {
@@ -5742,5 +5766,111 @@ func TestJobDelegatedPodGroup(t *testing.T) {
 		if ref.UID == jobObj.UID {
 			t.Errorf("parent Workload unexpectedly owned by delegated Job %q", jobObj.Name)
 		}
+	}
+}
+
+// TestJobDelegatedPodGroupRetriesAfterFirstSync verifies that a delegated
+// Job whose parent-owned Workload isn't discoverable yet on its first sync
+// still gets its PodGroup created on a later sync once the Workload exists.
+// The Job is created suspended so its first sync writes the JobSuspended
+// condition without creating any pods; under the old isNewJob-based gating
+// that write closed the delegation window for good, so no subsequent sync
+// (here, the resume) could ever create the PodGroup.
+func TestJobDelegatedPodGroupRetriesAfterFirstSync(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, feature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.GenericWorkload: true,
+		features.WorkloadWithJob: true,
+	})
+
+	closeFn, restConfig, clientSet, ns := setup(t, "delegated-podgroup-retry")
+	t.Cleanup(closeFn)
+	ctx, cancel := startJobControllerAndWaitForCaches(t, restConfig)
+	t.Cleanup(cancel)
+
+	const (
+		parentKind   = "SuperJob"
+		parentGroup  = "example.com"
+		parentName   = "parent-superjob"
+		templateName = "workers"
+	)
+
+	// Created suspended and before the parent Workload exists, so the first
+	// sync has no Workload to delegate to.
+	jobObj, err := createJobWithDefaults(ctx, clientSet, ns.Name, &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "delegated-job",
+			Annotations: map[string]string{apischeduling.GroupTemplateNameAnnotation: templateName},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: parentGroup + "/v1",
+				Kind:       parentKind,
+				Name:       parentName,
+				UID:        types.UID("parent-superjob-uid"),
+				Controller: new(true),
+			}},
+		},
+		Spec: batchv1.JobSpec{
+			Parallelism:    new(int32(3)),
+			Completions:    new(int32(3)),
+			CompletionMode: new(batchv1.IndexedCompletion),
+			Suspend:        new(true),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create delegated Job: %v", err)
+	}
+
+	// Wait for the first sync to complete and write the JobSuspended
+	// condition. Under the old isNewJob-based gating this write alone would
+	// have permanently closed the delegation window.
+	validateJobCondition(ctx, t, clientSet, jobObj, batchv1.JobSuspended)
+
+	// No PodGroup yet: the parent Workload is not discoverable, so there is
+	// nothing to materialize it from.
+	ensurePodGroupAbsent(ctx, t, clientSet, jobObj, 2*time.Second)
+
+	// The parent Workload only becomes discoverable now, on a later sync.
+	parentWorkload, err := clientSet.SchedulingV1beta1().Workloads(ns.Name).Create(ctx, &schedulingv1beta1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent-workload",
+			Namespace: ns.Name,
+		},
+		Spec: schedulingv1beta1.WorkloadSpec{
+			ControllerRef: &schedulingv1beta1.TypedLocalObjectReference{
+				APIGroup: parentGroup,
+				Kind:     parentKind,
+				Name:     parentName,
+			},
+			PodGroupTemplates: []schedulingv1beta1.PodGroupTemplate{{
+				Name: templateName,
+				SchedulingPolicy: schedulingv1beta1.PodGroupSchedulingPolicy{
+					Gang: &schedulingv1beta1.GangSchedulingPolicy{MinCount: 3},
+				},
+			}},
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create parent Workload: %v", err)
+	}
+
+	// Resume the Job, mirroring a queueing controller admitting the Workload.
+	// The old isNewJob-based gating returned false on this sync too (the
+	// Suspended condition persists), so the PodGroup would never be created;
+	// with the delegated gating the sync creates it now that the parent
+	// Workload is discoverable and the Job still has no pods.
+	if _, err := updateJob(ctx, clientSet.BatchV1().Jobs(ns.Name), jobObj.Name, func(j *batchv1.Job) {
+		j.Spec.Suspend = new(false)
+	}); err != nil {
+		t.Fatalf("Failed to resume Job: %v", err)
+	}
+
+	// The delegation window stayed open across syncs: a sync well after the
+	// Job's first one creates the PodGroup now that the parent Workload
+	// resolves and the Job still has no pods.
+	podGroup := waitForPodGroup(ctx, t, clientSet, jobObj, false, wait.ForeverTestTimeout)
+	if podGroup.Spec.WorkloadRef == nil ||
+		podGroup.Spec.WorkloadRef.WorkloadName != parentWorkload.Name ||
+		podGroup.Spec.WorkloadRef.TemplateName != templateName {
+		t.Errorf("PodGroup workloadRef = %+v, want workload %q template %q",
+			podGroup.Spec.WorkloadRef, parentWorkload.Name, templateName)
 	}
 }


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it
`isNewJob()` gates delegated-PodGroup creation on `job.Status.StartTime` and
the `Suspended` condition, both of which `syncJob()` writes during the Job's
first reconcile — the same sync that evaluates `isNewJob()`. That makes the
first sync a Job's only chance to get a delegated PodGroup created: if the
parent-owned Workload isn't discoverable yet (e.g. a JobSet child Job created
before/concurrently with its parent's Workload, or a Job created suspended),
`getOrCreateDelegatedPodGroup` logs "will retry" but no real retry is
possible — `isNewJob()` returns `false` forever after.

This gives the delegated path its own eligibility check
(`isNewJobForDelegation`) gated purely on "no pods yet," instead of reusing
`isNewJob`'s StartTime/Suspended-condition checks. Those checks exist to
avoid creating scheduling objects for Jobs that predate the feature gate —
that concern doesn't apply to delegation, which is opt-in via an annotation.
The root (non-delegated) path is unchanged.

Added an integration test, `TestJobDelegatedPodGroupRetriesAfterFirstSync`,
covering the suspended/no-parent-Workload scenario end to end.

## Which issue(s) this PR fixes
Fixes #141380

## Special notes for your reviewer
Found and root-caused while validating kubernetes-sigs/jobset's delegated-
PodGroup gang-scheduling e2e tests against WorkloadWithJob (KEP-5547, alpha).
cc @helayoty @mm4tt @wojtek-t

I used an AI coding assistant (Claude Code) to help investigate this and
draft the fix and tests. I reviewed and verified everything myself and can
answer questions about any part of it.

## Does this PR introduce a user-facing change?
```release-note
Fixed a bug in the alpha Workload-aware scheduling support where a delegated PodGroup for a non-root Job could permanently fail to be created if the parent-owned Workload wasn't yet discoverable during the Job's first sync, for example a JobSet child Job created concurrently with its parent's Workload, or a Job created suspended.
```