### PR TITLE
Fix strategic merge patch conflict detection for primitive list directives

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1964,42 +1964,126 @@ func mergingMapFieldsHaveConflicts(
 
 func mapsHaveConflicts(typedLeft, typedRight map[string]interface{}, schema LookupPatchMeta) (bool, error) {
 	for key, leftValue := range typedLeft {
-		if key != directiveMarker && key != retainKeysDirective {
+		if key == directiveMarker || key == retainKeysDirective {
+			continue
+		}
+		if strings.HasPrefix(key, deleteFromPrimitiveListDirectivePrefix+"/") ||
+			strings.HasPrefix(key, setElementOrderDirectivePrefix+"/") {
+			// Parallel-list directive keys are not real struct fields, so the
+			// schema lookup below would fail for them. Compare their values
+			// directly instead, matching how mergeMap treats them when merging
+			// two patches (differing $setElementOrder lists are rejected and a
+			// later $deleteFromPrimitiveList overwrites an earlier one).
 			if rightValue, ok := typedRight[key]; ok {
-				var subschema LookupPatchMeta
-				var patchMeta PatchMeta
-				var patchStrategy string
-				var err error
-				switch leftValue.(type) {
-				case []interface{}:
-					subschema, patchMeta, err = schema.LookupPatchMetadataForSlice(key)
-					if err != nil {
-						return true, err
-					}
-					_, patchStrategy, err = extractRetainKeysPatchStrategy(patchMeta.patchStrategies)
-					if err != nil {
-						return true, err
-					}
-				case map[string]interface{}:
-					subschema, patchMeta, err = schema.LookupPatchMetadataForStruct(key)
-					if err != nil {
-						return true, err
-					}
-					_, patchStrategy, err = extractRetainKeysPatchStrategy(patchMeta.patchStrategies)
-					if err != nil {
-						return true, err
-					}
-				}
-
-				if hasConflicts, err := mergingMapFieldsHaveConflicts(leftValue, rightValue,
-					subschema, patchStrategy, patchMeta.GetPatchMergeKey()); hasConflicts {
+				hasConflict, err := parallelListDirectivesConflict(key, leftValue, rightValue)
+				if err != nil {
 					return true, err
 				}
+				if hasConflict {
+					return true, nil
+				}
+			}
+			continue
+		}
+		if rightValue, ok := typedRight[key]; ok {
+			var subschema LookupPatchMeta
+			var patchMeta PatchMeta
+			var patchStrategy string
+			var err error
+			switch leftValue.(type) {
+			case []interface{}:
+				subschema, patchMeta, err = schema.LookupPatchMetadataForSlice(key)
+				if err != nil {
+					return true, err
+				}
+				_, patchStrategy, err = extractRetainKeysPatchStrategy(patchMeta.patchStrategies)
+				if err != nil {
+					return true, err
+				}
+			case map[string]interface{}:
+				subschema, patchMeta, err = schema.LookupPatchMetadataForStruct(key)
+				if err != nil {
+					return true, err
+				}
+				_, patchStrategy, err = extractRetainKeysPatchStrategy(patchMeta.patchStrategies)
+				if err != nil {
+					return true, err
+				}
+			}
+
+			if hasConflicts, err := mergingMapFieldsHaveConflicts(leftValue, rightValue,
+				subschema, patchStrategy, patchMeta.GetPatchMergeKey()); hasConflicts {
+				return true, err
 			}
 		}
 	}
 
 	return false, nil
+}
+
+// parallelListDirectivesConflict reports whether two occurrences of the same
+// parallel-list directive key disagree.
+//
+// $setElementOrder lists are compared as-is, because their order is the meaning
+// of the directive. $deleteFromPrimitiveList lists are compared as sets,
+// because deleteFromSlice treats them as one: element order and duplicates do
+// not change the result. Any other difference is a conflict. The comparison is
+// symmetric on purpose: MergingMapsHaveConflicts also guards patch composition
+// (see MergeStrategicMergeMapPatchUsingLookupPatchMeta), where a later directive
+// overrides an earlier one, so any disagreement between the two deletion sets is
+// a conflict regardless of which side is larger.
+//
+// The elements of a $deleteFromPrimitiveList list are primitives. A non-scalar
+// element cannot be used as a set key (and deleteFromSlice would fail on it as
+// well), so report an error rather than let the comparison panic.
+func parallelListDirectivesConflict(key string, leftValue, rightValue interface{}) (bool, error) {
+	if strings.HasPrefix(key, deleteFromPrimitiveListDirectivePrefix+"/") {
+		leftList, leftOk := leftValue.([]interface{})
+		rightList, rightOk := rightValue.([]interface{})
+		if leftOk && rightOk {
+			leftSet, err := scalarSetForDirective(key, leftList)
+			if err != nil {
+				return true, err
+			}
+			rightSet, err := scalarSetForDirective(key, rightList)
+			if err != nil {
+				return true, err
+			}
+			return !scalarSetsEqual(leftSet, rightSet), nil
+		}
+	}
+	return !reflect.DeepEqual(leftValue, rightValue), nil
+}
+
+// scalarSetForDirective collects the distinct elements of a primitive-list
+// directive value into a set. A $deleteFromPrimitiveList element is meant to be
+// a scalar; a non-comparable element cannot be a set key, so recover from the
+// resulting panic and report it as an error instead, the way the schema lookup
+// this replaced reported an error for these directive keys.
+func scalarSetForDirective(key string, list []interface{}) (set map[interface{}]struct{}, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			set, err = nil, fmt.Errorf("%s contains a non-comparable element: %v", key, r)
+		}
+	}()
+	set = make(map[interface{}]struct{}, len(list))
+	for _, element := range list {
+		set[element] = struct{}{}
+	}
+	return set, nil
+}
+
+// scalarSetsEqual reports whether two scalar sets contain the same elements.
+func scalarSetsEqual(left, right map[interface{}]struct{}) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for element := range left {
+		if _, ok := right[element]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func slicesHaveConflicts(

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -7059,3 +7059,248 @@ func TestUnknownField(t *testing.T) {
 		})
 	}
 }
+
+func TestMergingMapsHaveConflictsPrimitiveListDirectives(t *testing.T) {
+	testCases := []struct {
+		name             string
+		left             map[string]interface{}
+		right            map[string]interface{}
+		expectedConflict bool
+	}{
+		{
+			name: "identical deleteFromPrimitiveList directives are not a conflict",
+			left: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(2)},
+			},
+			right: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(2)},
+			},
+			expectedConflict: false,
+		},
+		{
+			name: "identical setElementOrder directives are not a conflict",
+			left: map[string]interface{}{
+				"$setElementOrder/mergingIntList": []interface{}{int64(1), int64(3)},
+			},
+			right: map[string]interface{}{
+				"$setElementOrder/mergingIntList": []interface{}{int64(1), int64(3)},
+			},
+			expectedConflict: false,
+		},
+		{
+			// Merging two patches with differing deletion lists silently drops
+			// the earlier one (preprocessDeletionListForMerging overwrites it),
+			// so the conflict check must report a conflict.
+			name: "differing deleteFromPrimitiveList directives are a conflict",
+			left: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(2)},
+			},
+			right: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(3)},
+			},
+			expectedConflict: true,
+		},
+		{
+			// Merging two patches with differing setElementOrder lists is
+			// rejected by mergePatchIntoOriginal, so the conflict check must
+			// report a conflict.
+			name: "differing setElementOrder directives are a conflict",
+			left: map[string]interface{}{
+				"$setElementOrder/mergingIntList": []interface{}{int64(1), int64(3)},
+			},
+			right: map[string]interface{}{
+				"$setElementOrder/mergingIntList": []interface{}{int64(3), int64(1)},
+			},
+			expectedConflict: true,
+		},
+		{
+			name: "directive present on one side only is not a conflict",
+			left: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(2)},
+			},
+			right:            map[string]interface{}{},
+			expectedConflict: false,
+		},
+		{
+			// deleteFromSlice treats the deletion list as a set, so element
+			// order does not change the meaning of the directive.
+			name: "reordered deleteFromPrimitiveList directives are not a conflict",
+			left: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(2), int64(3)},
+			},
+			right: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(3), int64(2)},
+			},
+			expectedConflict: false,
+		},
+		{
+			// deleteFromSlice treats the deletion list as a set, so duplicate
+			// elements do not change the meaning of the directive.
+			name: "duplicated deleteFromPrimitiveList directives are not a conflict",
+			left: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(2)},
+			},
+			right: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(2), int64(2)},
+			},
+			expectedConflict: false,
+		},
+		{
+			// The deletion sets differ in size, so one directive deletes an
+			// element the other does not: a conflict.
+			name: "deleteFromPrimitiveList directives of different sizes are a conflict",
+			left: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(2), int64(3)},
+			},
+			right: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(2)},
+			},
+			expectedConflict: true,
+		},
+		{
+			// Same size, different members: still a conflict.
+			name: "deleteFromPrimitiveList directives with different members are a conflict",
+			left: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(2), int64(3)},
+			},
+			right: map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": []interface{}{int64(2), int64(4)},
+			},
+			expectedConflict: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			conflict, err := MergingMapsHaveConflicts(tc.left, tc.right, mergeItemStructSchema)
+			if err != nil {
+				t.Fatalf("MergingMapsHaveConflicts returned unexpected error: %v", err)
+			}
+			if conflict != tc.expectedConflict {
+				t.Fatalf("expected conflict=%v, got %v", tc.expectedConflict, conflict)
+			}
+		})
+	}
+}
+
+func TestMergingMapsHaveConflictsNestedPrimitiveListDirectives(t *testing.T) {
+	type nestedMergingList struct {
+		MergingIntList []int `json:"mergingIntList,omitempty" patchStrategy:"merge"`
+	}
+	type nestedHolder struct {
+		Inner nestedMergingList `json:"inner,omitempty"`
+	}
+	schema, err := NewPatchMetaFromStruct(nestedHolder{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nested := func(deletions ...interface{}) map[string]interface{} {
+		return map[string]interface{}{
+			"inner": map[string]interface{}{
+				"$deleteFromPrimitiveList/mergingIntList": deletions,
+			},
+		}
+	}
+
+	conflict, err := MergingMapsHaveConflicts(nested(int64(2)), nested(int64(2)), schema)
+	if err != nil {
+		t.Fatalf("nested identical directives returned unexpected error: %v", err)
+	}
+	if conflict {
+		t.Fatalf("nested identical directives reported as conflict")
+	}
+
+	conflict, err = MergingMapsHaveConflicts(nested(int64(2)), nested(int64(3)), schema)
+	if err != nil {
+		t.Fatalf("nested differing directives returned unexpected error: %v", err)
+	}
+	if !conflict {
+		t.Fatalf("nested differing directives not reported as conflict")
+	}
+}
+
+func TestThreeWayMergePatchPrimitiveListDeletionIdempotent(t *testing.T) {
+	original := []byte(`{"mergingIntList":[1,2,3]}`)
+	modified := []byte(`{"mergingIntList":[1,3]}`)
+	current := []byte(`{"mergingIntList":[1,3]}`)
+
+	// Deleting an element of a primitive merge list whose deletion is already
+	// reflected in the live object (i.e. the live object has drifted from the
+	// last-applied state) must not error with overwrite=false.
+	patch, err := CreateThreeWayMergePatch(original, modified, current, mergeItemStructSchema, false)
+	if err != nil {
+		t.Fatalf("CreateThreeWayMergePatch returned unexpected error: %v", err)
+	}
+
+	// current already matches modified, so an (incorrect) empty patch would
+	// pass the applied-result check below; assert the patch content itself.
+	expectedPatch := []byte(`{"$deleteFromPrimitiveList/mergingIntList":[2],"$setElementOrder/mergingIntList":[1,3]}`)
+	var expectedPatchObj, patchObj map[string]interface{}
+	if err := json.Unmarshal(expectedPatch, &expectedPatchObj); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(patch, &patchObj); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(expectedPatchObj, patchObj) {
+		t.Fatalf("expected patch %s, got %s", expectedPatch, patch)
+	}
+
+	applied, err := StrategicMergePatch(current, patch, MergeItem{})
+	if err != nil {
+		t.Fatalf("StrategicMergePatch returned unexpected error: %v", err)
+	}
+
+	var modifiedObj, appliedObj map[string]interface{}
+	if err := json.Unmarshal(modified, &modifiedObj); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(applied, &appliedObj); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(modifiedObj, appliedObj) {
+		t.Fatalf("expected applied result %s, got %s", modified, applied)
+	}
+}
+
+func TestThreeWayMergePatchPrimitiveListDifferingDeletionsConflict(t *testing.T) {
+	original := []byte(`{"mergingIntList":[1,2,3]}`)
+	modified := []byte(`{"mergingIntList":[1,3]}`)
+	current := []byte(`{"mergingIntList":[1,2]}`)
+
+	// The user deletes 2 while the live object drifted by deleting 3: the
+	// deletion directives differ, so overwrite=false must report a proper
+	// conflict instead of an internal schema-lookup error.
+	_, err := CreateThreeWayMergePatch(original, modified, current, mergeItemStructSchema, false)
+	if err == nil {
+		t.Fatalf("expected a conflict error, got none")
+	}
+	if !mergepatch.IsConflict(err) {
+		t.Fatalf("expected a conflict error, got: %v", err)
+	}
+}
+
+// A $deleteFromPrimitiveList directive carries primitives. A non-comparable
+// element cannot be used as a set member, so the conflict check must return an
+// error rather than panic (it panicked when such a value was fed straight into
+// deduplicateAndSortScalars, whose == comparison rejects uncomparable types).
+func TestMergingMapsHaveConflictsPrimitiveListNonScalar(t *testing.T) {
+	cases := []struct {
+		name string
+		list []interface{}
+	}{
+		{"slice elements", []interface{}{[]interface{}{int64(1)}, []interface{}{int64(2)}}},
+		{"map elements", []interface{}{map[string]interface{}{"a": int64(1)}, map[string]interface{}{"b": int64(2)}}},
+		{"typed slice elements", []interface{}{[]string{"a"}, []string{"b"}}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			left := map[string]interface{}{"$deleteFromPrimitiveList/mergingIntList": c.list}
+			right := map[string]interface{}{"$deleteFromPrimitiveList/mergingIntList": c.list}
+			if _, err := MergingMapsHaveConflicts(left, right, mergeItemStructSchema); err == nil {
+				t.Fatalf("expected an error for a non-comparable deletion element, got none")
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

Fixes strategic merge patch conflict detection for primitive list fields using `patchStrategy: merge`.

`strategicpatch.CreateThreeWayMergePatch` can emit the synthetic directive keys `$deleteFromPrimitiveList/<field>` and `$setElementOrder/<field>` for primitive list fields. With `overwrite=false` it calls `MergingMapsHaveConflicts` to detect conflicts. `mapsHaveConflicts` passed every key except `$patch` and `$retainKeys` to the schema lookup; the parallel-list directive keys are not real struct fields, so when the same key appeared on both sides the lookup failed with:

```
unable to find api field in struct ... for the json field "$deleteFromPrimitiveList/<field>"
```

This happens when the user's change deletes an element from a primitive merge list and the live object has already dropped the same element out-of-band (e.g. a controller removing an entry from `metadata.finalizers`, a `[]string` with `patchStrategy: merge`). Identical deletions are not a conflict, and the caller got an internal error instead of either success or a proper `ErrConflict`.

Through `kubectl` this is reachable with `kubectl apply --overwrite=false`; the default apply is unaffected because `--overwrite` defaults to `true` and skips the conflict check. Library consumers calling `CreateThreeWayMergePatch(..., overwrite=false)` hit it directly.

This PR makes `mapsHaveConflicts` compare the parallel-list directive values directly instead of passing the keys to the schema lookup: identical directives are not a conflict, differing directives are. `$deleteFromPrimitiveList` lists are compared as sets (element order and duplicates do not change what `deleteFromSlice` does with them), while `$setElementOrder` lists are compared as-is, because their order is the meaning of the directive.

#### Which issue(s) this PR is related to:

Fixes #141388

#### Special notes for your reviewer:

- The change is confined to `mapsHaveConflicts`, which is only reached via `MergingMapsHaveConflicts` / `CreateThreeWayMergePatch` with `overwrite=false`.
- Differing directives must be reported as conflicts (rather than skipped) because `MergingMapsHaveConflicts` is the documented precondition for `MergeStrategicMergeMapPatch`: there, a later `$deleteFromPrimitiveList` silently overwrites an earlier one (`preprocessDeletionListForMerging` with `MergeParallelList: false`), and differing `$setElementOrder` lists are rejected by `mergePatchIntoOriginal` with `ErrBadPatchFormatForSetElementOrderList`. The `DeepEqual` comparison mirrors the equality checks that machinery already applies to `$retainKeys` and `$setElementOrder`.
- In the `CreateThreeWayMergePatch` path this means: a deletion already reflected in the live object succeeds (identical directives), while a live object that drifted by deleting a *different* element now yields a proper `ErrConflict` instead of the internal schema-lookup error. `$setElementOrder/<field>` cannot currently appear on the right-hand side (`changedMap`) in this path, so its handling only affects direct `MergingMapsHaveConflicts` callers.
- The prefix match requires the `/` separator (`$deleteFromPrimitiveList/`, `$setElementOrder/`), which is how every generated directive key is formed; a malformed key like `$setElementOrderWhatever` falls through to the schema lookup and errors, mirroring how `extractKey` rejects it in the merge machinery.
- Added regression tests: a `MergingMapsHaveConflicts` matrix (identical / differing / one-sided / reordered / duplicated directive values), a nested-field case (directive keys below the top level), an end-to-end `CreateThreeWayMergePatch(overwrite=false)` case that previously errored (asserting the exact patch content, since `current == modified` would let an empty patch pass the applied-result check), and a differing-deletions case asserting a proper conflict error.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where strategic merge patch conflict detection (`kubectl apply --overwrite=false`, or `CreateThreeWayMergePatch` with `overwrite=false`) failed with `unable to find api field ... for the json field "$deleteFromPrimitiveList/..."` when the live object had also had elements deleted from a primitive list field with a merge patch strategy. Identical deletion sets now succeed; different deletion sets now report a proper conflict.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
