### PR TITLE
client-go: disambiguate colliding Event names on coarse timers

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_recorder_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder_test.go
@@ -224,9 +224,17 @@ func TestEventf(t *testing.T) {
 					t.Errorf("Event Name = %s; not a valid name: %v", actualEvent.Name, errs)
 				} // Overwrite fields that are not relevant for comparison
 				tc.expectedEvent.EventTime = actualEvent.EventTime
-				// invalid event names generate random names
-				if tc.expectedEvent.Name == "" {
+				switch {
+				case tc.expectedEvent.Name == "":
+					// invalid event names generate random names
 					actualEvent.Name = ""
+				case strings.HasPrefix(actualEvent.Name, tc.expectedEvent.Name):
+					// generated names carry a disambiguating counter suffix
+					// after the timestamp; the prefix through the timestamp
+					// is still deterministic
+					tc.expectedEvent.Name = actualEvent.Name
+				default:
+					t.Errorf("Event Name = %s; expected prefix %s", actualEvent.Name, tc.expectedEvent.Name)
 				}
 				if diff := cmp.Diff(tc.expectedEvent, actualEvent); diff != "" {
 					t.Errorf("Unexpected event diff (-want, +got):\n%s", diff)

--- a/staging/src/k8s.io/client-go/tools/record/util/util.go
+++ b/staging/src/k8s.io/client-go/tools/record/util/util.go
@@ -19,6 +19,7 @@ package util
 import (
 	"fmt"
 	"net/http"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 
@@ -43,12 +44,21 @@ func IsKeyNotFoundError(err error) bool {
 	return statusErr != nil && statusErr.Status().Code == http.StatusNotFound
 }
 
+// eventNameCounter disambiguates events generated within the same clock tick.
+// unixNano alone is not sufficient on platforms with coarse timer resolution
+// (observed on Windows, where time.Now() can advance in ~15ms steps): two
+// distinct calls to EventRecorder.Event()/Eventf() for the same object could
+// otherwise compute the same Event name, and the second Create would be
+// silently rejected by the apiserver as AlreadyExists.
+// See https://github.com/kubernetes/kubernetes/issues/134993.
+var eventNameCounter atomic.Uint64
+
 // GenerateEventName generates a valid Event name from the referenced name and the passed UNIX timestamp.
 // The referenced Object name may not be a valid name for Events and cause the Event to fail
 // to be created, so we need to generate a new one in that case.
 // Ref: https://issues.k8s.io/127594
 func GenerateEventName(refName string, unixNano int64) string {
-	name := fmt.Sprintf("%s.%x", refName, unixNano)
+	name := fmt.Sprintf("%s.%x.%x", refName, unixNano, eventNameCounter.Add(1))
 	if errs := apimachineryvalidation.NameIsDNSSubdomain(name, false); len(errs) > 0 {
 		// Using an uuid guarantees uniqueness and correctness
 		name = uuid.New().String()

--- a/staging/src/k8s.io/client-go/tools/record/util/util_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/util/util_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -26,14 +27,14 @@ import (
 func TestGenerateEventName(t *testing.T) {
 	timestamp := int64(105999103295324396)
 	testCases := []struct {
-		name     string
-		refName  string
-		expected string
+		name           string
+		refName        string
+		expectedPrefix string
 	}{
 		{
-			name:     "valid name",
-			refName:  "test-pod",
-			expected: "test-pod.178959f726d80ec",
+			name:           "valid name",
+			refName:        "test-pod",
+			expectedPrefix: "test-pod.178959f726d80ec.",
 		},
 		{
 			name:    "invalid name - too long",
@@ -62,11 +63,52 @@ func TestGenerateEventName(t *testing.T) {
 
 			}
 
-			if tc.expected != "" && (actual != tc.expected) {
-				t.Errorf("generateEventName(%s) returned %s expected %s", tc.refName, actual, tc.expected)
+			if tc.expectedPrefix != "" && !strings.HasPrefix(actual, tc.expectedPrefix) {
+				t.Errorf("generateEventName(%s) returned %s expected prefix %s", tc.refName, actual, tc.expectedPrefix)
 			}
 
 		})
 
+	}
+}
+
+// TestGenerateEventNameUniqueOnCollidingTimestamp guards against a regression
+// where two events for the same object, generated within the same timer tick
+// (e.g. on platforms with coarse timer resolution such as Windows), computed
+// to the same Event name and silently collided on the apiserver.
+// See https://github.com/kubernetes/kubernetes/issues/134993.
+func TestGenerateEventNameUniqueOnCollidingTimestamp(t *testing.T) {
+	timestamp := int64(105999103295324396)
+
+	first := GenerateEventName("test-pod", timestamp)
+	second := GenerateEventName("test-pod", timestamp)
+
+	if first == second {
+		t.Errorf("GenerateEventName produced the same name %q for two events sharing a timestamp", first)
+	}
+}
+
+// TestGenerateEventNameConcurrentUnique verifies GenerateEventName is safe to
+// call concurrently, which is the actual calling pattern from EventRecorder
+// implementations: controllers record events from arbitrary goroutines.
+func TestGenerateEventNameConcurrentUnique(t *testing.T) {
+	const n = 1000
+	names := make([]string, n)
+	var wg sync.WaitGroup
+	for i := range names {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			names[i] = GenerateEventName("test-pod", 105999103295324396)
+		}(i)
+	}
+	wg.Wait()
+
+	seen := make(map[string]bool, n)
+	for _, name := range names {
+		if seen[name] {
+			t.Fatalf("duplicate generated name %q under concurrent calls", name)
+		}
+		seen[name] = true
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`GenerateEventName` builds an Event's `Name` from the referenced object's name and `time.Now().UnixNano()`. On timers with coarse resolution (seen on Windows, where `time.Now()` can tick in ~0.5-15ms steps), two `Event()`/`Eventf()` calls for the same object can land on the same timestamp and produce the same name. The second `Create` then fails with `AlreadyExists`, gets logged at `V(5)`, and is silently dropped instead of retried, so callers lose events with no error.

This adds a small atomic counter to the generated name so two calls in the same tick no longer collide. `Event()`/`Eventf()` can run on different goroutines at once, so the counter needs to be atomic. The timestamp stays in the name so events still sort roughly by creation order, and `GenerateEventName`'s signature is unchanged.

`metadata.GenerateName` would also solve this, but the fake clientset used in unit tests doesn't expand it, so it would just move the same collision into test code instead of fixing it.

#### Which issue(s) this PR fixes

Fixes #134993

#### Special notes for your reviewer

I used an AI coding assistant (Claude Code) to help investigate this and draft the fix and tests. I reviewed and verified everything myself and can answer questions about any part of it.

I confirmed the new tests actually catch the bug: with the `util.go` fix reverted, both fail against the old name-generation code; with it restored, everything passes, including `go test -race`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
