### PR TITLE
scheduler: populate pod NodeUID during binding

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3961,6 +3961,9 @@ type PodSpec struct {
 	// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
 	// +optional
 	NodeName string
+	// NodeUID indicates the UID of the Node object where this pod is scheduled.
+	// +optional
+	NodeUID types.UID
 	// Use the host's network namespace.  If this option is set, the ports that will be
 	// used must be specified.
 	// Optional: Default to false

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -1298,6 +1298,7 @@ func Validate_PodSpec(
 	// field corev1.PodSpec.DeprecatedServiceAccount has no validation
 	// field corev1.PodSpec.AutomountServiceAccountToken has no validation
 	// field corev1.PodSpec.NodeName has no validation
+	// field corev1.PodSpec.NodeUID has no validation
 	// field corev1.PodSpec.HostNetwork has no validation
 	// field corev1.PodSpec.HostPID has no validation
 	// field corev1.PodSpec.HostIPC has no validation

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -29099,6 +29099,13 @@ func schema_k8sio_api_core_v1_PodSpec(ref common.ReferenceCallback) common.OpenA
 							Format:      "",
 						},
 					},
+					"nodeUID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodeUID indicates the UID of the Node object where this pod is scheduled.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"hostNetwork": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Host networking requested for this pod. Use the host's network namespace. When using HostNetwork you should specify ports so the scheduler is aware. When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`, and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`. Default to false.",

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -195,7 +195,7 @@ func (r *BindingREST) Create(ctx context.Context, name string, obj runtime.Objec
 		}
 	}
 
-	err = r.assignPod(ctx, binding.UID, binding.ResourceVersion, binding.Name, binding.Target.Name, binding.Annotations, binding.Labels, dryrun.IsDryRun(options.DryRun))
+	err = r.assignPod(ctx, binding.UID, binding.ResourceVersion, binding.Name, binding.Target.Name, binding.Target.UID, binding.Annotations, binding.Labels, dryrun.IsDryRun(options.DryRun))
 	out = &metav1.Status{Status: metav1.StatusSuccess}
 	return
 }
@@ -210,7 +210,7 @@ func (r *BindingREST) PreserveRequestObjectMetaSystemFieldsOnSubresourceCreate()
 // setPodNodeAndMetadata sets the given pod's nodeName to 'machine' if and only if
 // the pod is unassigned, and merges the provided annotations and labels with those of the pod.
 // Returns the current state of the pod, or an error.
-func (r *BindingREST) setPodNodeAndMetadata(ctx context.Context, podUID types.UID, podResourceVersion, podID, machine string, annotations, labels map[string]string, dryRun bool) (finalPod *api.Pod, err error) {
+func (r *BindingREST) setPodNodeAndMetadata(ctx context.Context, podUID types.UID, podResourceVersion, podID, machine string, nodeUID types.UID, annotations, labels map[string]string, dryRun bool) (finalPod *api.Pod, err error) {
 	podKey, err := r.store.KeyFunc(ctx, podID)
 	if err != nil {
 		return nil, err
@@ -243,6 +243,7 @@ func (r *BindingREST) setPodNodeAndMetadata(ctx context.Context, podUID types.UI
 			return nil, fmt.Errorf("pod %v has non-empty .spec.schedulingGates", pod.Name)
 		}
 		pod.Spec.NodeName = machine
+		pod.Spec.NodeUID = nodeUID
 		// Clear nomination hint to prevent stale information affecting external components.
 		if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.ClearingNominatedNodeNameAfterBinding) {
 			pod.Status.NominatedNodeName = ""
@@ -287,8 +288,8 @@ func copyLabelsWithOverwriting(pod *api.Pod, labels map[string]string) {
 }
 
 // assignPod assigns the given pod to the given machine.
-func (r *BindingREST) assignPod(ctx context.Context, podUID types.UID, podResourceVersion, podID string, machine string, annotations, labels map[string]string, dryRun bool) (err error) {
-	if _, err = r.setPodNodeAndMetadata(ctx, podUID, podResourceVersion, podID, machine, annotations, labels, dryRun); err != nil {
+func (r *BindingREST) assignPod(ctx context.Context, podUID types.UID, podResourceVersion, podID string, machine string, nodeUID types.UID, annotations, labels map[string]string, dryRun bool) (err error) {
+	if _, err = r.setPodNodeAndMetadata(ctx, podUID, podResourceVersion, podID, machine, nodeUID, annotations, labels, dryRun); err != nil {
 		err = storeerr.InterpretGetError(err, api.Resource("pods"), podID)
 		err = storeerr.InterpretUpdateError(err, api.Resource("pods"), podID)
 		if _, ok := err.(*errors.StatusError); !ok {

--- a/pkg/registry/core/pod/storage/storage_test.go
+++ b/pkg/registry/core/pod/storage/storage_test.go
@@ -1039,7 +1039,11 @@ func TestEtcdCreateBinding(t *testing.T) {
 		"kindNode": {
 			binding: api.Binding{
 				ObjectMeta: metav1.ObjectMeta{Namespace: metav1.NamespaceDefault, Name: "foo"},
-				Target:     api.ObjectReference{Name: "machine3", Kind: "Node"},
+				Target: api.ObjectReference{
+					Name: "machine3",
+					Kind: "Node",
+					UID:  "node-uid-3",
+				},
 			},
 			errOK: func(err error) bool { return err == nil },
 		},
@@ -1068,6 +1072,8 @@ func TestEtcdCreateBinding(t *testing.T) {
 				t.Errorf("%s: unexpected error: %v", k, err)
 			} else if pod.(*api.Pod).Spec.NodeName != test.binding.Target.Name {
 				t.Errorf("%s: expected: %v, got: %v", k, pod.(*api.Pod).Spec.NodeName, test.binding.Target.Name)
+			} else if pod.(*api.Pod).Spec.NodeUID != test.binding.Target.UID {
+				t.Errorf("%s: expected NodeUID: %v, got: %v", k, test.binding.Target.UID, pod.(*api.Pod).Spec.NodeUID)
 			}
 		}
 	}

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
@@ -52,25 +51,13 @@ func (b DefaultBinder) Name() string {
 // Bind binds pods to nodes using the k8s client.
 func (b DefaultBinder) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
 	logger := klog.FromContext(ctx)
-	var nodeUID types.UID
 
-	if snapshot := b.handle.SnapshotSharedLister(); snapshot != nil {
-		nodeInfo, err := snapshot.NodeInfos().Get(nodeName)
-		if err == nil && nodeInfo != nil && nodeInfo.Node() != nil {
-			nodeUID = nodeInfo.Node().UID
-		}
-	} else if informerFactory := b.handle.SharedInformerFactory(); informerFactory != nil {
-		node, err := informerFactory.Core().V1().Nodes().Lister().Get(nodeName)
-		if err == nil {
-			nodeUID = node.UID
-		}
-	}
 	binding := &v1.Binding{
 		ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace, Name: p.Name, UID: p.UID},
 		Target: v1.ObjectReference{
 			Kind: "Node",
 			Name: nodeName,
-			UID:  nodeUID,
+			UID:  p.Spec.NodeUID,
 		},
 	}
 	if b.handle.APICacher() != nil {

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -51,6 +51,18 @@ func (b DefaultBinder) Name() string {
 // Bind binds pods to nodes using the k8s client.
 func (b DefaultBinder) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
 	logger := klog.FromContext(ctx)
+	var err error
+	if snapshot := b.handle.SnapshotSharedLister(); snapshot != nil {
+		nodeInfo, err := snapshot.NodeInfos().Get(nodeName)
+		if err == nil && nodeInfo != nil && nodeInfo.Node() != nil {
+			p.Spec.NodeUID = nodeInfo.Node().UID
+		}
+	} else if informerFactory := b.handle.SharedInformerFactory(); informerFactory != nil {
+		node, err := informerFactory.Core().V1().Nodes().Lister().Get(nodeName)
+		if err == nil {
+			p.Spec.NodeUID = node.UID
+		}
+	}
 	binding := &v1.Binding{
 		ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace, Name: p.Name, UID: p.UID},
 		Target:     v1.ObjectReference{Kind: "Node", Name: nodeName},
@@ -68,7 +80,7 @@ func (b DefaultBinder) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod
 		return nil
 	}
 	logger.V(3).Info("Attempting to bind pod to node", "pod", klog.KObj(p), "node", klog.KRef("", nodeName))
-	err := util.BindPod(ctx, b.handle.ClientSet(), binding)
+	err = util.BindPod(ctx, b.handle.ClientSet(), binding)
 	if err != nil {
 		return fwk.AsStatus(err)
 	}

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
@@ -51,21 +52,26 @@ func (b DefaultBinder) Name() string {
 // Bind binds pods to nodes using the k8s client.
 func (b DefaultBinder) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod, nodeName string) *fwk.Status {
 	logger := klog.FromContext(ctx)
-	var err error
+	var nodeUID types.UID
+
 	if snapshot := b.handle.SnapshotSharedLister(); snapshot != nil {
 		nodeInfo, err := snapshot.NodeInfos().Get(nodeName)
 		if err == nil && nodeInfo != nil && nodeInfo.Node() != nil {
-			p.Spec.NodeUID = nodeInfo.Node().UID
+			nodeUID = nodeInfo.Node().UID
 		}
 	} else if informerFactory := b.handle.SharedInformerFactory(); informerFactory != nil {
 		node, err := informerFactory.Core().V1().Nodes().Lister().Get(nodeName)
 		if err == nil {
-			p.Spec.NodeUID = node.UID
+			nodeUID = node.UID
 		}
 	}
 	binding := &v1.Binding{
 		ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace, Name: p.Name, UID: p.UID},
-		Target:     v1.ObjectReference{Kind: "Node", Name: nodeName},
+		Target: v1.ObjectReference{
+			Kind: "Node",
+			Name: nodeName,
+			UID:  nodeUID,
+		},
 	}
 	if b.handle.APICacher() != nil {
 		// When API cacher is available, use it to bind the pod.
@@ -80,7 +86,7 @@ func (b DefaultBinder) Bind(ctx context.Context, state fwk.CycleState, p *v1.Pod
 		return nil
 	}
 	logger.V(3).Info("Attempting to bind pod to node", "pod", klog.KObj(p), "node", klog.KRef("", nodeName))
-	err = util.BindPod(ctx, b.handle.ClientSet(), binding)
+	err := util.BindPod(ctx, b.handle.ClientSet(), binding)
 	if err != nil {
 		return fwk.AsStatus(err)
 	}

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
@@ -27,7 +27,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -57,7 +56,11 @@ func TestDefaultBinder(t *testing.T) {
 			name: "successful",
 			wantBinding: &v1.Binding{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "foo"},
-				Target:     v1.ObjectReference{Kind: "Node", Name: testNode},
+				Target: v1.ObjectReference{
+					Kind: "Node",
+					Name: testNode,
+					UID:  "test-node-uid",
+				},
 			},
 		}, {
 			name:      "binding error",
@@ -123,9 +126,7 @@ func TestDefaultBinder(t *testing.T) {
 
 				binder := &DefaultBinder{handle: fh}
 				status := binder.Bind(ctx, nil, testPod, testNode)
-				if got := testPod.Spec.NodeUID; got != types.UID("test-node-uid") {
-					t.Errorf("got NodeUID %q, want %q", got, types.UID("test-node-uid"))
-				}
+
 				if got := status.AsError(); (tt.injectErr != nil) != (got != nil) {
 					t.Errorf("got error %q, want %q", got, tt.injectErr)
 				}

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
@@ -46,6 +46,7 @@ func init() {
 
 func TestDefaultBinder(t *testing.T) {
 	testPod := st.MakePod().Name("foo").Namespace("ns").Obj()
+	testPod.Spec.NodeUID = "test-node-uid"
 	testNode := "foohost.kubernetes.mydomain.com"
 	tests := []struct {
 		name        string
@@ -83,7 +84,7 @@ func TestDefaultBinder(t *testing.T) {
 				testNodeObj := &v1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: string(testNode),
-						UID:  "test-node-uid",
+						UID:  "different-node-uid",
 					},
 				}
 

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
@@ -27,6 +27,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/klog/v2/ktesting"
@@ -71,6 +73,20 @@ func TestDefaultBinder(t *testing.T) {
 
 				var gotBinding *v1.Binding
 				client := fake.NewClientset(testPod)
+
+				informerFactory := informers.NewSharedInformerFactory(client, 0)
+				nodeInformer := informerFactory.Core().V1().Nodes().Informer()
+
+				testNodeObj := &v1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: string(testNode),
+						UID:  "test-node-uid",
+					},
+				}
+
+				if err := nodeInformer.GetIndexer().Add(testNodeObj); err != nil {
+					t.Fatal(err)
+				}
 				client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
 					if action.GetSubresource() != "binding" {
 						return false, nil, nil
@@ -89,7 +105,14 @@ func TestDefaultBinder(t *testing.T) {
 					defer apiDispatcher.Close()
 				}
 
-				fh, err := frameworkruntime.NewFramework(ctx, nil, nil, frameworkruntime.WithClientSet(client), frameworkruntime.WithAPIDispatcher(apiDispatcher))
+				fh, err := frameworkruntime.NewFramework(
+					ctx,
+					nil,
+					nil,
+					frameworkruntime.WithClientSet(client),
+					frameworkruntime.WithInformerFactory(informerFactory),
+					frameworkruntime.WithAPIDispatcher(apiDispatcher),
+				)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -100,6 +123,9 @@ func TestDefaultBinder(t *testing.T) {
 
 				binder := &DefaultBinder{handle: fh}
 				status := binder.Bind(ctx, nil, testPod, testNode)
+				if got := testPod.Spec.NodeUID; got != types.UID("test-node-uid") {
+					t.Errorf("got NodeUID %q, want %q", got, types.UID("test-node-uid"))
+				}
 				if got := status.AsError(); (tt.injectErr != nil) != (got != nil) {
 					t.Errorf("got error %q, want %q", got, tt.injectErr)
 				}

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder_test.go
@@ -27,7 +27,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/klog/v2/ktesting"
@@ -78,19 +77,6 @@ func TestDefaultBinder(t *testing.T) {
 				var gotBinding *v1.Binding
 				client := fake.NewClientset(testPod)
 
-				informerFactory := informers.NewSharedInformerFactory(client, 0)
-				nodeInformer := informerFactory.Core().V1().Nodes().Informer()
-
-				testNodeObj := &v1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: string(testNode),
-						UID:  "different-node-uid",
-					},
-				}
-
-				if err := nodeInformer.GetIndexer().Add(testNodeObj); err != nil {
-					t.Fatal(err)
-				}
 				client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
 					if action.GetSubresource() != "binding" {
 						return false, nil, nil
@@ -114,7 +100,6 @@ func TestDefaultBinder(t *testing.T) {
 					nil,
 					nil,
 					frameworkruntime.WithClientSet(client),
-					frameworkruntime.WithInformerFactory(informerFactory),
 					frameworkruntime.WithAPIDispatcher(apiDispatcher),
 				)
 				if err != nil {

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -28,6 +28,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -324,6 +325,7 @@ func (sched *Scheduler) assumeAndReserve(
 	// This allows us to keep scheduling without waiting on binding to occur.
 	assumedPodInfo := podInfo.DeepCopy()
 	assumedPod := assumedPodInfo.Pod
+	assumedPod.Spec.NodeUID = scheduleResult.SuggestedHostUID
 	// assume modifies `assumedPod` by setting NodeName=scheduleResult.SuggestedHost
 	err := sched.assume(logger, state, assumedPodInfo, scheduleResult.SuggestedHost)
 	if err != nil {
@@ -590,14 +592,16 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 
 	// When only one node after predicate, just use it.
 	if len(feasibleNodes) == 1 {
-		node := feasibleNodes[0].Node().Name
+		selectedNode := feasibleNodes[0].Node()
+		node := selectedNode.Name
 		if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
 			fwk.StoreScheduleResults(ctx, podInfo.PodSignature, nodeHint, node, nil, sched.CurrentCycle())
 		}
 		return ScheduleResult{
-			SuggestedHost:  node,
-			EvaluatedNodes: 1 + diagnosis.NodeToStatus.Len(),
-			FeasibleNodes:  1,
+			SuggestedHost:    node,
+			SuggestedHostUID: selectedNode.UID,
+			EvaluatedNodes:   1 + diagnosis.NodeToStatus.Len(),
+			FeasibleNodes:    1,
 		}, nil
 	}
 
@@ -608,6 +612,14 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 
 	sortedPrioritizedNodes := framework.NewSortedScoredNodes(priorityList)
 	node := sortedPrioritizedNodes.Pop().Name
+
+	var nodeUID types.UID
+	for i := range feasibleNodes {
+		if feasibleNodes[i].Node().Name == node {
+			nodeUID = feasibleNodes[i].Node().UID
+			break
+		}
+	}
 	trace.Step("Prioritizing done")
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
@@ -615,9 +627,10 @@ func (sched *Scheduler) schedulePod(ctx context.Context, fwk framework.Framework
 	}
 
 	return ScheduleResult{
-		SuggestedHost:  node,
-		EvaluatedNodes: len(feasibleNodes) + diagnosis.NodeToStatus.Len(),
-		FeasibleNodes:  len(feasibleNodes),
+		SuggestedHost:    node,
+		SuggestedHostUID: nodeUID,
+		EvaluatedNodes:   len(feasibleNodes) + diagnosis.NodeToStatus.Len(),
+		FeasibleNodes:    len(feasibleNodes),
 	}, err
 }
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -639,9 +639,6 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 
 	logger, ctx := ktesting.NewTestContext(t)
 
-	client := clientsetfake.NewClientset()
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
-
 	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
 	registry := frameworkruntime.Registry{
 		queuesort.Name:     queuesort.New,
@@ -660,7 +657,6 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 	}
 	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
 		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
-		frameworkruntime.WithInformerFactory(informerFactory),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create new framework: %v", err)
@@ -712,8 +708,6 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, ctx := ktesting.NewTestContext(t)
-			client := clientsetfake.NewClientset()
-			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			podGroup := st.MakePodGroup().Name("pg").Namespace("default").Obj()
 			p1 := st.MakePod().Name("p1").Namespace("default").UID("p1").PodGroupName(podGroup.Name).SchedulerName("test-scheduler").Obj()
 			p2 := st.MakePod().Name("p2").Namespace("default").UID("p2").PodGroupName(podGroup.Name).SchedulerName("test-scheduler").Obj()
@@ -735,7 +729,6 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			}
 			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
 				frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
-				frameworkruntime.WithInformerFactory(informerFactory),
 			)
 			if err != nil {
 				t.Fatalf("Failed to create new framework: %v", err)

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -639,6 +639,9 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 
 	logger, ctx := ktesting.NewTestContext(t)
 
+	client := clientsetfake.NewClientset()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+
 	cache := internalcache.New(ctx, nil, true, true /* CompositePodGroup */)
 	registry := frameworkruntime.Registry{
 		queuesort.Name:     queuesort.New,
@@ -657,6 +660,7 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 	}
 	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
 		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+		frameworkruntime.WithInformerFactory(informerFactory),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create new framework: %v", err)
@@ -708,6 +712,8 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, ctx := ktesting.NewTestContext(t)
+			client := clientsetfake.NewClientset()
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			podGroup := st.MakePodGroup().Name("pg").Namespace("default").Obj()
 			p1 := st.MakePod().Name("p1").Namespace("default").UID("p1").PodGroupName(podGroup.Name).SchedulerName("test-scheduler").Obj()
 			p2 := st.MakePod().Name("p2").Namespace("default").UID("p2").PodGroupName(podGroup.Name).SchedulerName("test-scheduler").Obj()
@@ -729,6 +735,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 			}
 			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
 				frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+				frameworkruntime.WithInformerFactory(informerFactory),
 			)
 			if err != nil {
 				t.Fatalf("Failed to create new framework: %v", err)
@@ -827,8 +834,12 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 			},
 		},
 	}
+	client := clientsetfake.NewClientset(testPodGroup)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+
 	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
 		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+		frameworkruntime.WithInformerFactory(informerFactory),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create new framework: %v", err)
@@ -843,8 +854,6 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 		},
 	}
 
-	client := clientsetfake.NewClientset(testPodGroup)
-	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 
@@ -920,6 +929,9 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
+	if err := informerFactory.Core().V1().Nodes().Informer().GetIndexer().Add(testNode); err != nil {
+		t.Fatalf("Failed to add test node to informer: %v", err)
+	}
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 	snapshot := internalcache.NewEmptySnapshot()
 
@@ -1851,6 +1863,12 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				pg = tt.existingPodGroup
 			}
 			client := clientsetfake.NewClientset(testNode, pg)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+			if err := informerFactory.Core().V1().Nodes().Informer().GetIndexer().Add(testNode); err != nil {
+				t.Fatalf("Failed to add test node to informer: %v", err)
+			}
 			client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
 				if action.GetSubresource() != "binding" {
 					return false, nil, nil
@@ -1882,6 +1900,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
 				frameworkruntime.WithClientSet(client),
 				frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+				frameworkruntime.WithInformerFactory(informerFactory),
 				frameworkruntime.WithWaitingPods(waitingPods),
 				frameworkruntime.WithPodsInPreBind(podInPreBind),
 			)
@@ -1893,10 +1912,6 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			cache.AddNode(klog.FromContext(ctx), testNode)
 			apg := framework.NewGenericPodGroup(pg)
 			cache.AddGenericPodGroup(apg)
-
-			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			informerFactory.Start(ctx.Done())
-			informerFactory.WaitForCacheSync(ctx.Done())
 
 			fakeClock := testingclock.NewFakeClock(time.Now())
 			schedulingQueue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc(), internalqueue.WithClock(fakeClock))
@@ -4548,6 +4563,11 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	client := clientsetfake.NewClientset(testPodGroup)
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+	informerFactory.Start(ctx.Done())
+	informerFactory.WaitForCacheSync(ctx.Done())
+
 	registry := frameworkruntime.Registry{
 		queuesort.Name:     queuesort.New,
 		defaultbinder.Name: defaultbinder.New,
@@ -4565,6 +4585,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	}
 	schedFwk1, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg1,
 		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+		frameworkruntime.WithInformerFactory(informerFactory),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create new framework 1: %v", err)
@@ -4574,6 +4595,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	profileCfg2.SchedulerName = "sched2"
 	schedFwk2, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg2,
 		frameworkruntime.WithEventRecorder(events.NewFakeRecorder(100)),
+		frameworkruntime.WithInformerFactory(informerFactory),
 	)
 	if err != nil {
 		t.Fatalf("Failed to create new framework 2: %v", err)

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -2271,7 +2271,11 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 			case b := <-bindingChan:
 				expectBinding := &v1.Binding{
 					ObjectMeta: metav1.ObjectMeta{Name: "bar", UID: types.UID("bar")},
-					Target:     v1.ObjectReference{Kind: "Node", Name: node.Name},
+					Target: v1.ObjectReference{
+						Kind: "Node",
+						Name: node.Name,
+						UID:  node.UID,
+					},
 				}
 				if diff := cmp.Diff(expectBinding, b); diff != "" {
 					t.Errorf("unexpected binding (-want,+got):\n%s", diff)
@@ -2404,8 +2408,19 @@ func TestSchedulerWithVolumeBinding(t *testing.T) {
 				AllBound: true,
 			},
 			expectAssumeCalled: true,
-			expectPodBind:      &v1.Binding{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "foo-ns", UID: types.UID("foo")}, Target: v1.ObjectReference{Kind: "Node", Name: "node1"}},
-			eventReason:        "Scheduled",
+			expectPodBind: &v1.Binding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo-ns",
+					UID:       types.UID("foo"),
+				},
+				Target: v1.ObjectReference{
+					Kind: "Node",
+					Name: "node1",
+					UID:  "node1",
+				},
+			},
+			eventReason: "Scheduled",
 		},
 		{
 			name: "bound/invalid pv affinity",
@@ -2437,8 +2452,19 @@ func TestSchedulerWithVolumeBinding(t *testing.T) {
 			volumeBinderConfig: &volumebinding.FakeVolumeBinderConfig{},
 			expectAssumeCalled: true,
 			expectBindCalled:   true,
-			expectPodBind:      &v1.Binding{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "foo-ns", UID: types.UID("foo")}, Target: v1.ObjectReference{Kind: "Node", Name: "node1"}},
-			eventReason:        "Scheduled",
+			expectPodBind: &v1.Binding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo-ns",
+					UID:       types.UID("foo"),
+				},
+				Target: v1.ObjectReference{
+					Kind: "Node",
+					Name: "node1",
+					UID:  "node1",
+				},
+			},
+			eventReason: "Scheduled",
 		},
 		{
 			name: "predicate error",
@@ -4982,7 +5008,11 @@ func setupTestSchedulerWithOnePodOnNode(ctx context.Context, t *testing.T, clien
 	case b := <-bindingChan:
 		expectBinding := &v1.Binding{
 			ObjectMeta: metav1.ObjectMeta{Name: pod.Name, UID: types.UID(pod.Name)},
-			Target:     v1.ObjectReference{Kind: "Node", Name: node.Name},
+			Target: v1.ObjectReference{
+				Kind: "Node",
+				Name: node.Name,
+				UID:  node.UID,
+			},
 		}
 		if diff := cmp.Diff(expectBinding, b); diff != "" {
 			t.Errorf("Unexpected binding (-want,+got):\n%s", diff)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -147,6 +148,8 @@ type Option func(*schedulerOptions)
 type ScheduleResult struct {
 	// Name of the selected node.
 	SuggestedHost string
+	// UID of the selected node.
+	SuggestedHostUID types.UID
 	// The number of nodes the scheduler evaluated the pod against in the filtering
 	// phase and beyond.
 	EvaluatedNodes int

--- a/staging/src/k8s.io/api/core/v1/generated.pb.go
+++ b/staging/src/k8s.io/api/core/v1/generated.pb.go
@@ -10020,6 +10020,13 @@ func (m *PodSpec) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+	i -= len(m.NodeUID)
+	copy(dAtA[i:], m.NodeUID)
+	i = encodeVarintGenerated(dAtA, i, uint64(len(m.NodeUID)))
+	i--
+	dAtA[i] = 0x2
+	i--
+	dAtA[i] = 0xea
 	if len(m.EvictionResponders) > 0 {
 		for iNdEx := len(m.EvictionResponders) - 1; iNdEx >= 0; iNdEx-- {
 			{
@@ -19264,6 +19271,8 @@ func (m *PodSpec) Size() (n int) {
 			n += 2 + l + sovGenerated(uint64(l))
 		}
 	}
+	l = len(m.NodeUID)
+	n += 2 + l + sovGenerated(uint64(l))
 	return n
 }
 
@@ -23860,6 +23869,7 @@ func (this *PodSpec) String() string {
 		`HostnameOverride:` + valueToStringGenerated(this.HostnameOverride) + `,`,
 		`SchedulingGroup:` + strings.Replace(this.SchedulingGroup.String(), "PodSchedulingGroup", "PodSchedulingGroup", 1) + `,`,
 		`EvictionResponders:` + repeatedStringForEvictionResponders + `,`,
+		`NodeUID:` + fmt.Sprintf("%v", this.NodeUID) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -56923,6 +56933,38 @@ func (m *PodSpec) Unmarshal(dAtA []byte) error {
 			if err := m.EvictionResponders[len(m.EvictionResponders)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 45:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NodeUID", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowGenerated
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthGenerated
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.NodeUID = k8s_io_apimachinery_pkg_types.UID(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -4748,6 +4748,10 @@ message PodSpec {
   // +optional
   optional string nodeName = 10;
 
+  // NodeUID indicates the UID of the Node object where this pod is scheduled.
+  // +optional
+  optional string nodeUID = 45;
+
   // Host networking requested for this pod. Use the host's network namespace.
   // When using HostNetwork you should specify ports so the scheduler is aware.
   // When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`,

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4456,6 +4456,9 @@ type PodSpec struct {
 	// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
 	// +optional
 	NodeName string `json:"nodeName,omitempty" protobuf:"bytes,10,opt,name=nodeName"`
+	// NodeUID indicates the UID of the Node object where this pod is scheduled.
+	// +optional
+	NodeUID types.UID `json:"nodeUID,omitempty" protobuf:"bytes,45,opt,name=nodeUID,casttype=k8s.io/apimachinery/pkg/types.UID"`
 	// Host networking requested for this pod. Use the host's network namespace.
 	// When using HostNetwork you should specify ports so the scheduler is aware.
 	// When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`,

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -1978,6 +1978,7 @@ var map_PodSpec = map[string]string{
 	"serviceAccount":                "DeprecatedServiceAccount is a deprecated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.",
 	"automountServiceAccountToken":  "AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.",
 	"nodeName":                      "NodeName indicates in which node this pod is scheduled. If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName. Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod. This field should not be used to express a desire for the pod to be scheduled on a specific node. https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename",
+	"nodeUID":                       "NodeUID indicates the UID of the Node object where this pod is scheduled.",
 	"hostNetwork":                   "Host networking requested for this pod. Use the host's network namespace. When using HostNetwork you should specify ports so the scheduler is aware. When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`, and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`. Default to false.",
 	"hostPID":                       "Use the host's pid namespace. Optional: Default to false.",
 	"hostIPC":                       "Use the host's ipc namespace. Optional: Default to false.",

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podspec.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/podspec.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 // PodSpecApplyConfiguration represents a declarative configuration of the PodSpec type for use
@@ -97,6 +98,8 @@ type PodSpecApplyConfiguration struct {
 	// This field should not be used to express a desire for the pod to be scheduled on a specific node.
 	// https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
 	NodeName *string `json:"nodeName,omitempty"`
+	// NodeUID indicates the UID of the Node object where this pod is scheduled.
+	NodeUID *types.UID `json:"nodeUID,omitempty"`
 	// Host networking requested for this pod. Use the host's network namespace.
 	// When using HostNetwork you should specify ports so the scheduler is aware.
 	// When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`,
@@ -437,6 +440,14 @@ func (b *PodSpecApplyConfiguration) WithAutomountServiceAccountToken(value bool)
 // If called multiple times, the NodeName field is set to the value of the last call.
 func (b *PodSpecApplyConfiguration) WithNodeName(value string) *PodSpecApplyConfiguration {
 	b.NodeName = &value
+	return b
+}
+
+// WithNodeUID sets the NodeUID field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the NodeUID field is set to the value of the last call.
+func (b *PodSpecApplyConfiguration) WithNodeUID(value types.UID) *PodSpecApplyConfiguration {
+	b.NodeUID = &value
 	return b
 }
 

--- a/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/internal/internal.go
@@ -7275,6 +7275,9 @@ var schemaYAML = typed.YAMLObject(`types:
           elementType:
             scalar: string
           elementRelationship: atomic
+    - name: nodeUID
+      type:
+        scalar: string
     - name: os
       type:
         namedType: io.k8s.api.core.v1.PodOS


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

This PR adds an optional `NodeUID` field to `PodSpec` and populates it during pod binding.

The scheduler records the UID of the target Node when the default binder binds a pod. This allows a pod to retain the identity of the specific Node object it was scheduled onto, rather than relying only on `spec.nodeName`.

This provides the foundation for distinguishing Node instances when a Node name is recycled.

The PR also updates the corresponding generated API, OpenAPI, protobuf, validation, and applyconfiguration code, along with the relevant scheduler and default binder tests.

#### Which issue(s) is this PR related to:

Related to #141365

#### Special notes for your reviewer:

- Adds the optional `PodSpec.NodeUID` field.
- Populates `PodSpec.NodeUID` during default binding using the Node from the scheduler snapshot, with an informer-based fallback.
- Updates generated API and client code.
- Adds/updates tests for the default binder and scheduler PodGroup paths.
- `go test ./pkg/scheduler/...` passes.
- This PR focuses on the NodeUID API and binding portion of #141365. PodGC and authorization consumers are not changed by this PR.

#### Does this PR introduce a user-facing change?

NONE