### PR TITLE
HPA: cap replica count calculations at max int32

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -1454,7 +1454,7 @@ func calculateScaleUpLimitWithScalingRules(currentReplicas int32, scaleUpEvents,
 			proposed = periodStartReplicas + policy.Value
 		} else if policy.Type == autoscalingv2.PercentScalingPolicy {
 			// the proposal has to be rounded up because the proposed change might not increase the replica count causing the target to never scale up
-			proposed = int32(math.Ceil(float64(periodStartReplicas) * (1 + float64(policy.Value)/100)))
+			proposed = ceilToInt32(float64(periodStartReplicas) * (1 + float64(policy.Value)/100))
 		}
 		result = selectPolicyFn(result, proposed)
 	}

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	goruntime "runtime"
 	"strings"
 	"sync"
@@ -3414,6 +3415,37 @@ func TestReplicaLimits(t *testing.T) {
 			}, scaledToZeroFalse),
 		},
 		{
+			// Each pod requests 1000m and reports 15,000,000,000m, so utilization is
+			// 1,500,000,000% (still within int32) against a 1% target: a usage ratio of 1.5e9
+			// that asks for 4.5e9 replicas, beyond int32. The saturated proposal must be clamped
+			// by the normal limits down to maxReplicas rather than wrapping negative and
+			// collapsing to minReplicas.
+			name: "upscale with overflowing replica calculation clamped to max replicas",
+			fixture: horizontalScenario{
+				minReplicas:         1,
+				maxReplicas:         10,
+				specReplicas:        3,
+				statusReplicas:      3,
+				scaleUpRules:        generateScalingRules(0, 0, 700, 60, 0),
+				CPUTarget:           1,
+				reportedLevels:      []uint64{15_000_000_000, 15_000_000_000, 15_000_000_000},
+				reportedCPURequests: []resource.Quantity{resource.MustParse("1.0"), resource.MustParse("1.0"), resource.MustParse("1.0")},
+				resource: &fakeResource{
+					name:       "test-rc",
+					apiVersion: "v1",
+					kind:       "ReplicationController",
+				},
+			},
+			expectedDesiredReplicas: 10,
+			expectedScaleUpdated:    true,
+			expectedActionLabel:     monitor.ActionLabelScaleUp,
+			expectedConditions: statusOkWithOverrides(autoscalingv2.HorizontalPodAutoscalerCondition{
+				Type:   autoscalingv2.ScalingLimited,
+				Status: v1.ConditionTrue,
+				Reason: "TooManyReplicas",
+			}, scaledToZeroFalse),
+		},
+		{
 			name: "scale down to max immediately even with recent scale time",
 			fixture: horizontalScenario{
 				minReplicas:         2,
@@ -5030,25 +5062,66 @@ func TestConvertDesiredReplicasWithRules(t *testing.T) {
 }
 
 func TestCalculateScaleUpLimitWithScalingRules(t *testing.T) {
-	policy := autoscalingv2.MinChangePolicySelect
-
-	calculated := calculateScaleUpLimitWithScalingRules(1, []timestampedScaleEvent{}, []timestampedScaleEvent{}, &autoscalingv2.HPAScalingRules{
-		StabilizationWindowSeconds: new(int32(300)),
-		SelectPolicy:               &policy,
-		Policies: []autoscalingv2.HPAScalingPolicy{
-			{
-				Type:          autoscalingv2.PodsScalingPolicy,
-				Value:         2,
-				PeriodSeconds: 60,
+	tests := []struct {
+		name             string
+		currentReplicas  int32
+		selectPolicy     autoscalingv2.ScalingPolicySelect
+		policies         []autoscalingv2.HPAScalingPolicy
+		expectedReplicas int32
+	}{
+		{
+			name:            "min policy selects the smaller change",
+			currentReplicas: 1,
+			selectPolicy:    autoscalingv2.MinChangePolicySelect,
+			policies: []autoscalingv2.HPAScalingPolicy{
+				{Type: autoscalingv2.PodsScalingPolicy, Value: 2, PeriodSeconds: 60},
+				{Type: autoscalingv2.PercentScalingPolicy, Value: 50, PeriodSeconds: 60},
 			},
-			{
-				Type:          autoscalingv2.PercentScalingPolicy,
-				Value:         50,
-				PeriodSeconds: 60,
-			},
+			expectedReplicas: 2,
 		},
-	})
-	assert.Equal(t, int32(2), calculated)
+		{
+			// 100 replicas plus MaxInt32 percent of them exceeds int32 and must saturate
+			// rather than wrap.
+			name:            "percent policy overflow saturates to MaxInt32",
+			currentReplicas: 100,
+			selectPolicy:    autoscalingv2.MaxChangePolicySelect,
+			policies: []autoscalingv2.HPAScalingPolicy{
+				{Type: autoscalingv2.PercentScalingPolicy, Value: math.MaxInt32, PeriodSeconds: 60},
+			},
+			expectedReplicas: math.MaxInt32,
+		},
+		{
+			name:            "min policy: overflowing percent policy loses to pods policy",
+			currentReplicas: 100,
+			selectPolicy:    autoscalingv2.MinChangePolicySelect,
+			policies: []autoscalingv2.HPAScalingPolicy{
+				{Type: autoscalingv2.PercentScalingPolicy, Value: math.MaxInt32, PeriodSeconds: 60},
+				{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 60},
+			},
+			expectedReplicas: 110,
+		},
+		{
+			name:            "max policy: overflowing percent policy wins over pods policy",
+			currentReplicas: 100,
+			selectPolicy:    autoscalingv2.MaxChangePolicySelect,
+			policies: []autoscalingv2.HPAScalingPolicy{
+				{Type: autoscalingv2.PercentScalingPolicy, Value: math.MaxInt32, PeriodSeconds: 60},
+				{Type: autoscalingv2.PodsScalingPolicy, Value: 10, PeriodSeconds: 60},
+			},
+			expectedReplicas: math.MaxInt32,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calculated := calculateScaleUpLimitWithScalingRules(tt.currentReplicas, []timestampedScaleEvent{}, []timestampedScaleEvent{}, &autoscalingv2.HPAScalingRules{
+				StabilizationWindowSeconds: new(int32(300)),
+				SelectPolicy:               &tt.selectPolicy,
+				Policies:                   tt.policies,
+			})
+			assert.Equal(t, tt.expectedReplicas, calculated)
+		})
+	}
 }
 
 func TestCalculateScaleDownLimitWithBehaviors(t *testing.T) {

--- a/pkg/controller/podautoscaler/replica_calculator.go
+++ b/pkg/controller/podautoscaler/replica_calculator.go
@@ -115,7 +115,7 @@ func (c *ReplicaCalculator) GetResourceReplicas(ctx context.Context, currentRepl
 		}
 
 		// if we don't have any unready or missing pods, we can calculate the new replica count now
-		return int32(math.Ceil(usageRatio * float64(readyPodCount))), utilization, rawUtilization, timestamp, nil
+		return ceilToInt32(usageRatio * float64(readyPodCount)), utilization, rawUtilization, timestamp, nil
 	}
 
 	if len(missingPods) > 0 {
@@ -153,7 +153,7 @@ func (c *ReplicaCalculator) GetResourceReplicas(ctx context.Context, currentRepl
 		return currentReplicas, utilization, rawUtilization, timestamp, nil
 	}
 
-	newReplicas := int32(math.Ceil(newUsageRatio * float64(len(metrics))))
+	newReplicas := ceilToInt32(newUsageRatio * float64(len(metrics)))
 	if (newUsageRatio < 1.0 && newReplicas > currentReplicas) || (newUsageRatio > 1.0 && newReplicas < currentReplicas) {
 		// return the current replicas if the change of metrics length would cause a change in scale direction
 		return currentReplicas, utilization, rawUtilization, timestamp, nil
@@ -220,7 +220,7 @@ func (c *ReplicaCalculator) calcPlainMetricReplicas(metrics metricsclient.PodMet
 		}
 
 		// if we don't have any unready or missing pods, we can calculate the new replica count now
-		return int32(math.Ceil(usageRatio * float64(readyPodCount))), usage, nil
+		return ceilToInt32(usageRatio * float64(readyPodCount)), usage, nil
 	}
 
 	if len(missingPods) > 0 {
@@ -253,7 +253,7 @@ func (c *ReplicaCalculator) calcPlainMetricReplicas(metrics metricsclient.PodMet
 		return currentReplicas, usage, nil
 	}
 
-	newReplicas := int32(math.Ceil(newUsageRatio * float64(len(metrics))))
+	newReplicas := ceilToInt32(newUsageRatio * float64(len(metrics)))
 	if (newUsageRatio < 1.0 && newReplicas > currentReplicas) || (newUsageRatio > 1.0 && newReplicas < currentReplicas) {
 		// return the current replicas if the change of metrics length would cause a change in scale direction
 		return currentReplicas, usage, nil
@@ -290,17 +290,10 @@ func (c *ReplicaCalculator) getUsageRatioReplicaCount(currentReplicas int32, usa
 		if err != nil {
 			return 0, time.Time{}, fmt.Errorf("unable to calculate ready pods: %s", err)
 		}
-		// Calculate replicaCount as float64 first
-		replicaCountFloat := usageRatio * float64(readyPodCount)
-		// Check if replicaCount exceeds max int32
-		if replicaCountFloat > math.MaxInt32 {
-			replicaCount = math.MaxInt32
-		} else {
-			replicaCount = int32(math.Ceil(replicaCountFloat))
-		}
+		replicaCount = ceilToInt32(usageRatio * float64(readyPodCount))
 	} else {
 		// Scale to zero or n pods depending on usageRatio
-		replicaCount = int32(math.Ceil(usageRatio))
+		replicaCount = ceilToInt32(usageRatio)
 	}
 
 	return replicaCount, timestamp, err
@@ -318,7 +311,7 @@ func (c *ReplicaCalculator) GetObjectPerPodMetricReplicas(statusReplicas int32, 
 	usageRatio := float64(usage) / (float64(targetAverageUsage) * float64(replicaCount))
 	if !tolerances.isWithin(usageRatio) {
 		// update number of replicas if change is large enough
-		replicaCount = int32(math.Ceil(float64(usage) / float64(targetAverageUsage)))
+		replicaCount = ceilToInt32(float64(usage) / float64(targetAverageUsage))
 	}
 	usage = getPerPodUsage(usage, statusReplicas)
 	return replicaCount, usage, timestamp, nil
@@ -402,13 +395,7 @@ func (c *ReplicaCalculator) GetExternalPerPodMetricReplicas(statusReplicas int32
 	usageRatio := float64(usage) / (float64(targetUsagePerPod) * float64(replicaCount))
 	if !tolerances.isWithin(usageRatio) {
 		// update number of replicas if the change is large enough
-		replicaCountResult := math.Ceil(float64(usage) / float64(targetUsagePerPod))
-		// Ensure that the result exceeds the bounds of an int32
-		if replicaCountResult > float64(math.MaxInt32) {
-			replicaCount = math.MaxInt32
-		} else {
-			replicaCount = int32(replicaCountResult)
-		}
+		replicaCount = ceilToInt32(float64(usage) / float64(targetUsagePerPod))
 	}
 	usage = getPerPodUsage(usage, statusReplicas)
 	return replicaCount, usage, timestamp, nil
@@ -554,5 +541,17 @@ func calculatePodRequestsFromContainers(pod *v1.Pod, container string, resource 
 func removeMetricsForPods(metrics metricsclient.PodMetricsInfo, pods sets.Set[string]) {
 	for _, pod := range pods.UnsortedList() {
 		delete(metrics, pod)
+	}
+}
+
+func ceilToInt32(f float64) int32 {
+	c := math.Ceil(f)
+	switch {
+	case c > math.MaxInt32:
+		return math.MaxInt32
+	case c < math.MinInt32:
+		return math.MinInt32
+	default:
+		return int32(c)
 	}
 }

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -2538,3 +2538,26 @@ func TestGetPerPodUsage(t *testing.T) {
 		})
 	}
 }
+
+func TestCeilToInt32(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    float64
+		expected int32
+	}{
+		{name: "rounds up", input: 1.1, expected: 2},
+		{name: "rounds up for negatives", input: -1.9, expected: -1},
+		{name: "ceiling crosses max int32", input: float64(math.MaxInt32) + 0.5, expected: math.MaxInt32},
+		{name: "positive overflow", input: 5e9, expected: math.MaxInt32},
+		{name: "positive infinity", input: math.Inf(1), expected: math.MaxInt32},
+		{name: "negative overflow", input: -5e9, expected: math.MinInt32},
+		{name: "negative infinity", input: math.Inf(-1), expected: math.MinInt32},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ceilToInt32(tc.input); got != tc.expected {
+				t.Errorf("ceilToInt32(%v) = %d, want %d", tc.input, got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -511,6 +511,35 @@ func TestReplicaCalcResourceScale(t *testing.T) {
 			expectedRawValue:    numContainersPerPod * 600,
 		},
 		{
+			name: "scale up: replica count overflow saturates to MaxInt32",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				resource: &cpuResource{
+					requests: cpuRequests(3, "1.0"),
+					levels:   makePodMetricLevels(15_000_000_000, 15_000_000_000, 15_000_000_000),
+				},
+			},
+			targetUtilization:   1,
+			expectedReplicas:    math.MaxInt32,
+			expectedUtilization: 1_500_000_000,
+			expectedRawValue:    numContainersPerPod * 15_000_000_000,
+		},
+		{
+			name: "scale up: replica count overflow with unready pod saturates to MaxInt32",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				podReadiness:    []v1.ConditionStatus{v1.ConditionFalse, v1.ConditionTrue, v1.ConditionTrue},
+				resource: &cpuResource{
+					requests: cpuRequests(3, "1.0"),
+					levels:   makePodMetricLevels(15_000_000_000, 15_000_000_000, 15_000_000_000),
+				},
+			},
+			targetUtilization:   1,
+			expectedReplicas:    math.MaxInt32,
+			expectedUtilization: 1_500_000_000,
+			expectedRawValue:    numContainersPerPod * 15_000_000_000,
+		},
+		{
 			name: "scale up: hot-CPU container scales less",
 			fixture: calcScenario{
 				currentReplicas: 3,
@@ -1062,6 +1091,37 @@ func TestReplicaCalcPodMetric(t *testing.T) {
 			expectedUsage:    20000,
 		},
 		{
+			name: "scale up: replica count overflow saturates to MaxInt32",
+			fixture: calcScenario{
+				currentReplicas: 2,
+				metric:          podMetric(1_500_000_000, 1_500_000_000),
+			},
+			targetUsage:      1,
+			expectedReplicas: math.MaxInt32,
+			expectedUsage:    1_500_000_000,
+		},
+		{
+			name: "scale up: replica count overflow with missing metric saturates to MaxInt32",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				metric:          podMetric(1_500_000_000, 1_500_000_000),
+			},
+			targetUsage:      1,
+			expectedReplicas: math.MaxInt32,
+			expectedUsage:    1_500_000_000,
+		},
+		{
+			name: "scale up: replica count overflow with unready pod saturates to MaxInt32",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				podPhase:        []v1.PodPhase{v1.PodRunning, v1.PodRunning, v1.PodPending},
+				metric:          podMetric(1_500_000_000, 1_500_000_000, 1_500_000_000),
+			},
+			targetUsage:      1,
+			expectedReplicas: math.MaxInt32,
+			expectedUsage:    1_500_000_000,
+		},
+		{
 			name: "scale up: unready hot-CPU pod scales less",
 			fixture: calcScenario{
 				currentReplicas: 3,
@@ -1185,6 +1245,16 @@ func TestReplicaCalcObjectMetric(t *testing.T) {
 			expectedUsage:    math.MaxInt64,
 		},
 		{
+			name: "scale up from zero: replica count overflow saturates to MaxInt32",
+			fixture: calcScenario{
+				currentReplicas: 0,
+				metric:          objectMetric(math.MaxInt32 + 1),
+			},
+			targetUsage:      1,
+			expectedReplicas: math.MaxInt32,
+			expectedUsage:    math.MaxInt32 + 1,
+		},
+		{
 			name: "scale up: ignores unready pods",
 			fixture: calcScenario{
 				currentReplicas: 3,
@@ -1272,6 +1342,16 @@ func TestReplicaCalcObjectPerPodMetric(t *testing.T) {
 			perPodTargetUsage: 5000,
 			expectedReplicas:  4,
 			expectedUsage:     6667,
+		},
+		{
+			name: "scale up: replica count overflow saturates to MaxInt32",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				metric:          perPodMetric(math.MaxInt32 + 1),
+			},
+			perPodTargetUsage: 1,
+			expectedReplicas:  math.MaxInt32,
+			expectedUsage:     715827883, // ceil((MaxInt32 + 1) / 3)
 		},
 		{
 			name: "scale down",
@@ -1566,6 +1646,20 @@ func TestReplicaCalcResourceMissingMetrics(t *testing.T) {
 			expectedReplicas:    3,
 			expectedUtilization: 24,
 			expectedRawValue:    495, // numContainersPerPod * 247, for sufficiently large values of 247.
+		},
+		{
+			name: "some pods missing metrics: replica count overflow saturates to MaxInt32",
+			fixture: calcScenario{
+				currentReplicas: 3,
+				resource: &cpuResource{
+					requests: cpuRequests(3, "1.0"),
+					levels:   makePodMetricLevels(15_000_000_000, 15_000_000_000),
+				},
+			},
+			targetUtilization:   1,
+			expectedReplicas:    math.MaxInt32,
+			expectedUtilization: 1_500_000_000,
+			expectedRawValue:    numContainersPerPod * 15_000_000_000,
 		},
 		{
 			name: "no change: metric equal to target",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The HPA computes replica counts with `int32(math.Ceil(...))` on values that can exceed the `int32` range; Go leaves out-of-range float to `int`/`int32` conversion implementation-defined, so amd64 wraps to `MinInt32` while arm64/ppc64le/s390x saturate to `MaxInt32`, which are not consistent.

On amd64, an overflowing metric therefore scales the workload down to `minReplicas` during extreme overload (real world issue #126892: KEDA Prometheus scaler with target 0.1), and an overflowing Percent scaling policy freezes scale-up entirely.

Two of the nine conversions were already clamped to MaxInt32 (#127050 in v1.34, #126979 in v1.35); this PR routes all nine through a single `ceilToInt32` helper so the result saturates identically on every architecture, which is the semantics Go itself plans to adopt (golang/go#76264).

#### Which issue(s) this PR is related to:

Related to #126892 and #127022 (both closed without a full codebase sweep)

#### Special notes for your reviewer:

- The two existing guards are refactored onto the helper with no behavior change.
- The only **behavior change is amd64's overflow corner: wrap is changed to saturate**, which is consistent to other architectures and the two guarded sites already do.
- **`NaN` is deliberately not handled**, but if it's needed, let me know which value it should be resolved to and then I can add it.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug in the `HorizontalPodAutoscaler`: on amd64, an extremely large metric value could scale a workload down to `minReplicas` instead of up, and an extreme Percent scaling policy could block scaling up entirely. Replica calculations are now capped at the `int32` maximum, so the HPA scales up toward `maxReplicas`, matching the existing behavior on all other architectures.
```
