### PR TITLE
apiserver/cacher: align listSnapshot continueKey semantics with the btree

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/snapshot_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/snapshot_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSnapshotOrderedListPrefix(t *testing.T) {
+	// Elements are deliberately unordered; snapshots must return keys in order.
+	elements := []*Element{
+		testStorageElement("/pods/ns1/b", "b", 2),
+		testStorageElement("/pods/ns2/d", "d", 4),
+		testStorageElement("/pods/ns1/a", "a", 1),
+		testStorageElement("/pods/ns1/c", "c", 3),
+	}
+	// orderedListSnapshot is excluded: it serves a pre-computed range and
+	// ignores prefix and continueKey by contract. Prefixes are "/"-terminated
+	// as the cacher produces them; the implementations differ on other
+	// prefixes (strings.HasPrefix in the btree, path segments in
+	// listSnapshot).
+	snapshots := []struct {
+		name        string
+		newSnapshot func(t *testing.T) Snapshot
+	}{
+		{
+			name: "Indexer",
+			newSnapshot: func(t *testing.T) Snapshot {
+				indexer := newThreadedBtreeStoreIndexer(nil, btreeDegree)
+				for _, elem := range elements {
+					require.NoError(t, indexer.Add(elem))
+				}
+				return indexer.Clone()
+			},
+		},
+		{
+			name: "btreeStore",
+			newSnapshot: func(t *testing.T) Snapshot {
+				store := newBtreeStore(btreeDegree)
+				for _, elem := range elements {
+					require.NoError(t, store.Add(elem))
+				}
+				return &store
+			},
+		},
+		{
+			name: "listSnapshot",
+			newSnapshot: func(t *testing.T) Snapshot {
+				items := make([]interface{}, 0, len(elements))
+				for _, elem := range elements {
+					items = append(items, elem)
+				}
+				return listSnapshot{Items: items}
+			},
+		},
+	}
+	testCases := []struct {
+		name        string
+		prefix      string
+		continueKey string
+		expectKeys  []string
+	}{
+		{name: "whole range", prefix: "/pods/", expectKeys: []string{"/pods/ns1/a", "/pods/ns1/b", "/pods/ns1/c", "/pods/ns2/d"}},
+		{name: "namespace prefix", prefix: "/pods/ns1/", expectKeys: []string{"/pods/ns1/a", "/pods/ns1/b", "/pods/ns1/c"}},
+		{name: "continue token", prefix: "/pods/ns1/", continueKey: "/pods/ns1/a\x00", expectKeys: []string{"/pods/ns1/b", "/pods/ns1/c"}},
+		// A continue token is the inclusive lower bound of the next page:
+		// the apiserver encodes it as lastReturnedKey+"\x00" (the successor
+		// string, which no real key equals) and etcd ranges start inclusively
+		// at the given key, so an element whose key equals continueKey is
+		// returned.
+		{name: "continue from existing key", prefix: "/pods/ns1/", continueKey: "/pods/ns1/b", expectKeys: []string{"/pods/ns1/b", "/pods/ns1/c"}},
+		{name: "continue past last key", prefix: "/pods/ns1/", continueKey: "/pods/ns1/c\x00", expectKeys: nil},
+		{name: "no match", prefix: "/pods/ns3/", expectKeys: nil},
+	}
+	for _, s := range snapshots {
+		t.Run(s.name, func(t *testing.T) {
+			snapshot := s.newSnapshot(t)
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					items, err := snapshot.OrderedListPrefix(tc.prefix, tc.continueKey)
+					require.NoError(t, err)
+					var keys []string
+					for _, item := range items {
+						keys = append(keys, item.(*Element).Key)
+					}
+					assert.Equal(t, tc.expectKeys, keys)
+				})
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/store/watch_cache_storage.go
@@ -167,7 +167,7 @@ func (l listSnapshot) OrderedListPrefix(prefix string, continueKey string) ([]in
 		if !ok {
 			return nil, fmt.Errorf("non *Element returned from storage: %v", item)
 		}
-		if len(continueKey) > 0 && continueKey >= elem.Key {
+		if len(continueKey) > 0 && continueKey > elem.Key {
 			continue
 		}
 		if !key.HasPathPrefix(elem.Key, prefix) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

As discussed on #141359: the watch cache's snapshot implementations disagree about whether a range starts at or after `continueKey`. Given a `continueKey` equal to an existing key, the btree includes that element (`AscendGreaterOrEqual`) while `listSnapshot` excludes it (`continueKey >= elem.Key` skips it):

```
--- FAIL: TestSnapshotOrderedListPrefix/listSnapshot/continue_from_existing_key
    Error:    Not equal:
              expected: []string{"/pods/ns1/b", "/pods/ns1/c"}
              actual  : []string{"/pods/ns1/c"}
```

A continue token names the first key of the next page, so the start of the range is inclusive, like an etcd range. This makes `listSnapshot` agree (`>=` → `>`) and pins the behavior in `TestSnapshotOrderedListPrefix`, one suite run against each `Snapshot` implementation with different setup.

This is not reachable in practice — index-bucket snapshots are only used for lists without a continue token (`watchCache` passes no match values on continuation), and apiserver continue tokens point just past the last returned key (`lastKey + "\x00"`) — so there is no user-facing behavior change; the fix keeps the implementations interchangeable under the interface contract.

Once #141359 merges, the suite extends naturally to `RangePrefix` and `Count` (whose `listSnapshot` implementation carries a copy of this filter and needs the same one-character alignment) — kept out of this PR to keep it standalone against master.

#### Special notes for your reviewer

This PR was put together with the assistance of generative AI.

#### Which issue(s) this PR is related to:

Discussed on #141359.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
