### PR TITLE
Migrate LeaseCandidate.Spec.LeaseName to declarative validation

### DIFF
--- a/pkg/apis/coordination/v1alpha2/zz_generated.validations.go
+++ b/pkg/apis/coordination/v1alpha2/zz_generated.validations.go
@@ -29,6 +29,7 @@ import (
 	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
+	validate "k8s.io/apimachinery/pkg/api/validate"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -88,6 +89,70 @@ func Validate_LeaseCandidate(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field coordinationv1alpha2.LeaseCandidate.Spec has no validation
+	{ // field coordinationv1alpha2.LeaseCandidate.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *coordinationv1alpha2.LeaseCandidateSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_LeaseCandidateSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *coordinationv1alpha2.LeaseCandidate) *coordinationv1alpha2.LeaseCandidateSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_LeaseCandidateSpec validates an instance of LeaseCandidateSpec according
+// to declarative validation rules in the API schema.
+func Validate_LeaseCandidateSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *coordinationv1alpha2.LeaseCandidateSpec) (errs field.ErrorList) {
+
+	{ // field coordinationv1alpha2.LeaseCandidateSpec.LeaseName
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *coordinationv1alpha2.LeaseCandidateSpec) *string {
+				return &oldObj.LeaseName
+			})
+		errs = append(errs, fn(fldPath.Child("leaseName"), &obj.LeaseName, oldVal, oldObj != nil)...)
+	}
+
+	// field coordinationv1alpha2.LeaseCandidateSpec.PingTime has no validation
+	// field coordinationv1alpha2.LeaseCandidateSpec.RenewTime has no validation
+	// field coordinationv1alpha2.LeaseCandidateSpec.BinaryVersion has no validation
+	// field coordinationv1alpha2.LeaseCandidateSpec.EmulationVersion has no validation
+	// field coordinationv1alpha2.LeaseCandidateSpec.Strategy has no validation
 	return errs
 }

--- a/pkg/apis/coordination/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/coordination/v1beta1/zz_generated.validations.go
@@ -29,6 +29,7 @@ import (
 	equality "k8s.io/apimachinery/pkg/api/equality"
 	operation "k8s.io/apimachinery/pkg/api/operation"
 	safe "k8s.io/apimachinery/pkg/api/safe"
+	validate "k8s.io/apimachinery/pkg/api/validate"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -137,6 +138,70 @@ func Validate_LeaseCandidate(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field coordinationv1beta1.LeaseCandidate.Spec has no validation
+	{ // field coordinationv1beta1.LeaseCandidate.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *coordinationv1beta1.LeaseCandidateSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_LeaseCandidateSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *coordinationv1beta1.LeaseCandidate) *coordinationv1beta1.LeaseCandidateSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_LeaseCandidateSpec validates an instance of LeaseCandidateSpec according
+// to declarative validation rules in the API schema.
+func Validate_LeaseCandidateSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *coordinationv1beta1.LeaseCandidateSpec) (errs field.ErrorList) {
+
+	{ // field coordinationv1beta1.LeaseCandidateSpec.LeaseName
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *coordinationv1beta1.LeaseCandidateSpec) *string {
+				return &oldObj.LeaseName
+			})
+		errs = append(errs, fn(fldPath.Child("leaseName"), &obj.LeaseName, oldVal, oldObj != nil)...)
+	}
+
+	// field coordinationv1beta1.LeaseCandidateSpec.PingTime has no validation
+	// field coordinationv1beta1.LeaseCandidateSpec.RenewTime has no validation
+	// field coordinationv1beta1.LeaseCandidateSpec.BinaryVersion has no validation
+	// field coordinationv1beta1.LeaseCandidateSpec.EmulationVersion has no validation
+	// field coordinationv1beta1.LeaseCandidateSpec.Strategy has no validation
 	return errs
 }

--- a/pkg/apis/coordination/validation/validation.go
+++ b/pkg/apis/coordination/validation/validation.go
@@ -98,7 +98,7 @@ func ValidateLeaseCandidateSpec(spec *coordination.LeaseCandidateSpec, fldPath *
 	allErrs := field.ErrorList{}
 
 	if len(spec.LeaseName) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("leaseName"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("leaseName"), "").MarkCoveredByDeclarative())
 	}
 
 	ev := semver.Version{}

--- a/staging/src/k8s.io/api/coordination/v1alpha2/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1alpha2/generated.proto
@@ -59,6 +59,7 @@ message LeaseCandidateSpec {
   // leaseName is the name of the lease for which this candidate is contending.
   // This field is immutable.
   // +required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string leaseName = 1;
 
   // pingTime is the last time that the server has requested the LeaseCandidate

--- a/staging/src/k8s.io/api/coordination/v1alpha2/types.go
+++ b/staging/src/k8s.io/api/coordination/v1alpha2/types.go
@@ -45,6 +45,7 @@ type LeaseCandidateSpec struct {
 	// leaseName is the name of the lease for which this candidate is contending.
 	// This field is immutable.
 	// +required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	LeaseName string `json:"leaseName" protobuf:"bytes,1,name=leaseName"`
 	// pingTime is the last time that the server has requested the LeaseCandidate
 	// to renew. It is only done during leader election to check if any

--- a/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/coordination/v1beta1/generated.proto
@@ -74,6 +74,7 @@ message LeaseCandidateSpec {
   // may reference the same Lease.name.
   // This field is immutable.
   // +required
+  // +k8s:beta(since: "1.37")=+k8s:required
   optional string leaseName = 1;
 
   // pingTime is the last time that the server has requested the LeaseCandidate

--- a/staging/src/k8s.io/api/coordination/v1beta1/types.go
+++ b/staging/src/k8s.io/api/coordination/v1beta1/types.go
@@ -119,6 +119,7 @@ type LeaseCandidateSpec struct {
 	// may reference the same Lease.name.
 	// This field is immutable.
 	// +required
+	// +k8s:beta(since: "1.37")=+k8s:required
 	LeaseName string `json:"leaseName" protobuf:"bytes,1,name=leaseName"`
 	// pingTime is the last time that the server has requested the LeaseCandidate
 	// to renew. It is only done during leader election to check if any

--- a/test/declarative_validation/coordination/leasecandidate/declarative_validation_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/declarative_validation_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	apitesting "k8s.io/kubernetes/pkg/api/testing"
 	coordination "k8s.io/kubernetes/pkg/apis/coordination"
 	registry "k8s.io/kubernetes/pkg/registry/coordination/leasecandidate"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
@@ -52,6 +54,27 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		Verb:              "create",
 	}), metav1.NamespaceDefault)
 
+	testCases := map[string]struct {
+		input        coordination.LeaseCandidate
+		expectedErrs field.ErrorList
+	}{
+		"valid": {
+			input: mkValidLeaseCandidate(),
+		},
+		"missing leaseName": {
+			input: mkValidLeaseCandidate(tweakLeaseName("")),
+			expectedErrs: field.ErrorList{
+				field.Required(field.NewPath("spec").Child("leaseName"), "").MarkBeta(),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			apitesting.VerifyValidationEquivalence(t, ctx, &tc.input, registry.Strategy, tc.expectedErrs)
+		})
+	}
+
 	obj := mkValidLeaseCandidate()
 	meta.RunObjectMetaTestCases(t, ctx, &obj, registry.Strategy)
 }
@@ -71,8 +94,8 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy)
 }
 
-func mkValidLeaseCandidate() coordination.LeaseCandidate {
-	return coordination.LeaseCandidate{
+func mkValidLeaseCandidate(tweaks ...func(*coordination.LeaseCandidate)) coordination.LeaseCandidate {
+	lc := coordination.LeaseCandidate{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "valid-obj",
 			Namespace: metav1.NamespaceDefault,
@@ -83,5 +106,15 @@ func mkValidLeaseCandidate() coordination.LeaseCandidate {
 			EmulationVersion: "1.0.0",
 			Strategy:         coordination.OldestEmulationVersion,
 		},
+	}
+	for _, tweak := range tweaks {
+		tweak(&lc)
+	}
+	return lc
+}
+
+func tweakLeaseName(name string) func(*coordination.LeaseCandidate) {
+	return func(lc *coordination.LeaseCandidate) {
+		lc.Spec.LeaseName = name
 	}
 }

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1alpha2_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.leaseName": {
+				{ErrorType: "FieldValueRequired"},
+			},
 		},
 	)
 }

--- a/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/coordination/leasecandidate/zz_generated.validations.v1beta1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.leaseName": {
+				{ErrorType: "FieldValueRequired"},
+			},
 		},
 	)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

Migrates the `required` validation on `LeaseCandidate.Spec.LeaseName` from
hand-written Go to declarative validation, as part of KEP-5073 (Declarative
Validation).

`LeaseName` qualifies as a "good first migration" case: it is a simple
`len() == 0` required check on a non-pointer, always-validated struct field
that exists at the same path across all served versions (`coordination/v1alpha2`
and `coordination/v1beta1`) and is not `+optional`.

Changes:
- Add `+k8s:beta(since: "1.37")=+k8s:required` to `LeaseCandidateSpec.LeaseName`
  in both versioned `types.go` files (and the corresponding `generated.proto`).
- Regenerate `zz_generated.validations.go` via `validation-gen`.
- Annotate the existing hand-written check in `ValidateLeaseCandidateSpec` with
  `.MarkCoveredByDeclarative()` to record equivalence.
- Add a declarative-validation equivalence test for the `leasecandidate`
  registry and regenerate the coverage fixtures.

The `leasecandidate` registry strategy already embeds `rest.DeclarativeValidation`,
so no strategy wiring change is required.

Equivalence is confirmed by the per-resource `TestDeclarativeValidate` test and
by the central `TestVersionedValidationByFuzzing` fuzz test, both passing.

#### Which issue(s) this PR is related to:

Part of #135752
KEP: https://github.com/kubernetes/enhancements/issues/5073

#### Special notes for your reviewer:

Single-field, single-tag migration. `LeaseName` is immutable; only the
`required` check is migrated here — the immutability check remains hand-written.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
