### PR TITLE
apiserver/cacher: fold unfiltered list benchmark into BenchmarkStoreList

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -750,6 +750,13 @@ func BenchmarkStoreWriteThroughput(b *testing.B) {
 
 func BenchmarkStoreList(b *testing.B) {
 	klog.SetLogger(logr.Discard())
+	b.Run("Unfiltered/Objects=5000", func(b *testing.B) {
+		data := storagetesting.PrepareBenchmarkData(1, 5_000, 1)
+		ctx, cacher, _, terminate := testSetupWithEtcdServer(b)
+		b.Cleanup(terminate)
+		require.NoError(b, storagetesting.PrecreateBenchmarkPods(ctx, cacher, data))
+		storagetesting.RunBenchmarkStoreListUnfiltered(ctx, b, cacher, data)
+	})
 	// Based on https://github.com/kubernetes/community/blob/master/sig-scalability/configs-and-limits/thresholds.md
 	dimensions := []struct {
 		namespaceCount       int

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -2429,23 +2429,6 @@ func BenchmarkCacher_GetList(b *testing.B) {
 	}
 }
 
-func benchmarkPods(n int) []example.Pod {
-	pods := make([]example.Pod, n)
-	for i := range pods {
-		pods[i].Namespace = "default"
-		pods[i].Name = fmt.Sprintf("pod-%d", i)
-		pods[i].ResourceVersion = strconv.Itoa(i)
-		// Give each pod ~2KB of unique payload so the benchmark operates on
-		// realistically sized objects.
-		data := make([]byte, 1024*2)
-		rand.Read(data)
-		pods[i].Spec.NodeSelector = map[string]string{
-			"key": string(data),
-		}
-	}
-	return pods
-}
-
 func newDelegatorWithPods(tb testing.TB, pods []example.Pod) *CacheDelegator {
 	store := &cachertesting.MockStorage{
 		GetListFn: func(_ context.Context, _ string, _ storage.ListOptions, listObj runtime.Object) error {
@@ -2464,27 +2447,6 @@ func newDelegatorWithPods(tb testing.TB, pods []example.Pod) *CacheDelegator {
 	delegator := NewCacheDelegator(cacher, store)
 	tb.Cleanup(delegator.Stop)
 	return delegator
-}
-
-func BenchmarkCacher_GetList_AllPods(b *testing.B) {
-	totalObjectNum := 10_000
-	delegator := newDelegatorWithPods(b, benchmarkPods(totalObjectNum))
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		result := &example.PodList{}
-		err := delegator.GetList(context.TODO(), "/pods/", storage.ListOptions{
-			Predicate:       storage.Everything,
-			Recursive:       true,
-			ResourceVersion: "12345",
-		}, result)
-		if err != nil {
-			b.Fatalf("GetList cache: %v", err)
-		}
-		if len(result.Items) != totalObjectNum {
-			b.Fatalf("expect %d but got %d", totalObjectNum, len(result.Items))
-		}
-	}
 }
 
 // TestWatchListIsSynchronisedWhenNoEventsFromStoreReceived makes sure that

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_benchmarks.go
@@ -426,6 +426,10 @@ func RunBenchmarkStoreList(ctx context.Context, b *testing.B, store storage.Inte
 	}
 }
 
+func RunBenchmarkStoreListUnfiltered(ctx context.Context, b *testing.B, store storage.Interface, data BenchmarkData) {
+	runBenchmarkStoreList(ctx, b, store, 0, "", cluster, data, false)
+}
+
 func runBenchmarkStoreList(ctx context.Context, b *testing.B, store storage.Interface, limit int64, match metav1.ResourceVersionMatch, scope scope, data BenchmarkData, useIndex bool) {
 	objectCount := atomic.Uint64{}
 	listCount := atomic.Uint64{}


### PR DESCRIPTION
/kind cleanup
/sig api-machinery
#### What this PR does / why we need it:

This PR folds the unfiltered full-list cacher benchmark into `BenchmarkStoreList`, so related LIST benchmarks live under one benchmark entry point.

```text
BenchmarkStoreList
 ├── Scale matrix (existing)
 │   └── Namespaces=<N>/Pods=<P>/Nodes=<M>
 │       └── Indexed=true|false
 │           └── RV=|Exact|NotOlderThan
 │               └── Scope=cluster|node|namespace
 │                   └── Paginate=0|100|1000
 ├── Selector selectivity (folds BenchmarkCacher_GetList)       [PR: #141309]
 │   ├── Objects=5000/MatchPercent=1/Indexed=false|true
 │   ├── Objects=5000/MatchPercent=10/Indexed=false|true
 │   ├── Objects=5000/MatchPercent=20/Indexed=false|true
 │   ├── Objects=5000/MatchPercent=50/Indexed=false|true
 │   └── Objects=5000/MatchPercent=100/Indexed=false|true
 └── Unfiltered full list (folds BenchmarkCacher_GetList_AllPods)   [this PR]
     └── Objects=5000
```
- before: `8059a7316b6^`
- after: `8059a7316b6` (`Presize list results for unfiltered list requests served from the watch cache`)
- related optimization context: #140200
Old whitebox benchmark:

```text
BenchmarkCacher_GetList_AllPods-14

sec/op      701.7µ ± 11%   401.9µ ± 9%   -42.73% (p=0.000 n=10)
B/op        6.006Mi ± 0%   5.371Mi ± 0%  -10.58% (p=0.000 n=10)
allocs/op   67.00 ± 0%     49.00 ± 0%    -26.87% (p=0.000 n=10)
```

Folded benchmark with the same object count:

```text
BenchmarkStoreList/Unfiltered/Objects=10000-14

sec/op        837.5µ ± 11%   730.3µ ± 12%   -12.80% (p=0.005 n=10)
list-calls/s  1.194k ± 10%   1.369k ± 13%   +14.70% (p=0.005 n=10)
list-objs/s   11.94M ± 10%   13.69M ± 13%   +14.66% (p=0.005 n=10)
B/op          6.025Mi ± 0%   5.390Mi ± 0%   -10.54% (p=0.000 n=10)
allocs/op     285.5 ± 1%     267.5 ± 1%     -6.30% (p=0.000 n=10)
```
#### Which issue(s) this PR is related to:

Related to #141310

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```