### PR TITLE
scheduler: migrate scheduling API usage from v1beta1 to v1alpha3

### DIFF
--- a/pkg/scheduler/backend/cache/cache.go
+++ b/pkg/scheduler/backend/cache/cache.go
@@ -25,7 +25,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -1012,7 +1011,7 @@ type podGroupListerImpl struct {
 }
 
 // Get returns the cached pod group object.
-func (l *podGroupListerImpl) Get(namespace, name string) (*schedulingv1beta1.PodGroup, error) {
+func (l *podGroupListerImpl) Get(namespace, name string) (*schedulingv1alpha3.PodGroup, error) {
 	if !l.cache.genericWorkloadEnabled {
 		return nil, fmt.Errorf("generic workload feature gate is disabled")
 	}
@@ -1126,7 +1125,7 @@ func (cache *cacheImpl) applyPVCRefCountDelta(snapshot *Snapshot) error {
 }
 
 // AddPodGroup adds a pod group object to the cache.
-func (cache *cacheImpl) AddPodGroup(podGroup *schedulingv1beta1.PodGroup) {
+func (cache *cacheImpl) AddPodGroup(podGroup *schedulingv1alpha3.PodGroup) {
 	if !cache.genericWorkloadEnabled {
 		return
 	}
@@ -1158,7 +1157,7 @@ func (cache *cacheImpl) AddPodGroup(podGroup *schedulingv1beta1.PodGroup) {
 }
 
 // UpdatePodGroup updates a pod group object in the cache.
-func (cache *cacheImpl) UpdatePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1beta1.PodGroup) {
+func (cache *cacheImpl) UpdatePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1alpha3.PodGroup) {
 	if !cache.genericWorkloadEnabled {
 		return
 	}
@@ -1176,7 +1175,7 @@ func (cache *cacheImpl) UpdatePodGroup(logger klog.Logger, oldPodGroup, newPodGr
 }
 
 // RemovePodGroup removes a pod group object from the cache.
-func (cache *cacheImpl) RemovePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+func (cache *cacheImpl) RemovePodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup) {
 	if !cache.genericWorkloadEnabled {
 		return
 	}

--- a/pkg/scheduler/backend/cache/cache_test.go
+++ b/pkg/scheduler/backend/cache/cache_test.go
@@ -29,7 +29,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -702,7 +701,7 @@ func Test_AddPodGroupMember(t *testing.T) {
 
 	tests := []struct {
 		name                    string
-		initPodGroup            *schedulingv1beta1.PodGroup
+		initPodGroup            *schedulingv1alpha3.PodGroup
 		pod                     *v1.Pod
 		genericWorkloadEnabled  bool
 		expectInUnscheduledPods bool
@@ -889,7 +888,7 @@ func Test_RemovePodGroupMember(t *testing.T) {
 	tests := []struct {
 		name                     string
 		initPods                 []*v1.Pod
-		initPodGroup             *schedulingv1beta1.PodGroup
+		initPodGroup             *schedulingv1alpha3.PodGroup
 		podToDelete              *v1.Pod
 		expectPodGroupStateCount int
 		genericWorkloadEnabled   bool
@@ -986,22 +985,22 @@ func Test_AddPodGroup(t *testing.T) {
 		compositePodGroupEnabled bool
 		initPod                  *v1.Pod // From old tests
 		initialCPGs              []*schedulingv1alpha3.CompositePodGroup
-		podGroupsToAdd           []*schedulingv1beta1.PodGroup
-		wantPodGroups            map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+		podGroupsToAdd           []*schedulingv1alpha3.PodGroup
+		wantPodGroups            map[fwk.EntityKey]*schedulingv1alpha3.PodGroup
 		wantChildren             map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
 			name:                     "add pod group with GenericWorkload disabled should be no-op",
-			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{podGroup},
+			podGroupsToAdd:           []*schedulingv1alpha3.PodGroup{podGroup},
 			genericWorkloadEnabled:   false,
 			compositePodGroupEnabled: true,
 		},
 		{
 			name:                     "add pod group",
-			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{podGroup},
+			podGroupsToAdd:           []*schedulingv1alpha3.PodGroup{podGroup},
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns", "pg"): podGroup,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
@@ -1009,10 +1008,10 @@ func Test_AddPodGroup(t *testing.T) {
 		{
 			name:                     "add pod group when state already exists (from pod group members)",
 			initPod:                  pod,
-			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{podGroup},
+			podGroupsToAdd:           []*schedulingv1alpha3.PodGroup{podGroup},
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns", "pg"): podGroup,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
@@ -1021,8 +1020,8 @@ func Test_AddPodGroup(t *testing.T) {
 			name:                     "add single pod group (hierarchical)",
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
-			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg1},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:           []*schedulingv1alpha3.PodGroup{pg1},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg1"): pg1,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
@@ -1031,8 +1030,8 @@ func Test_AddPodGroup(t *testing.T) {
 			name:                     "add multiple pod groups (hierarchical)",
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
-			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg1, pg2},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:           []*schedulingv1alpha3.PodGroup{pg1, pg2},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg1"): pg1,
 				fwk.PodGroupKey("ns1", "pg2"): pg2,
 			},
@@ -1042,8 +1041,8 @@ func Test_AddPodGroup(t *testing.T) {
 			name:                     "add pod group with parent",
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
-			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:           []*schedulingv1alpha3.PodGroup{pg3WithParent},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
@@ -1054,8 +1053,8 @@ func Test_AddPodGroup(t *testing.T) {
 			name:                     "add pod group with parent, parent already in children",
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
-			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:           []*schedulingv1alpha3.PodGroup{pg3WithParent, pg4WithParent},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
 				fwk.PodGroupKey("ns1", "pg4"): pg4WithParent,
 			},
@@ -1071,8 +1070,8 @@ func Test_AddPodGroup(t *testing.T) {
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpgChild},
-			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:           []*schedulingv1alpha3.PodGroup{pg3WithParent},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
@@ -1086,8 +1085,8 @@ func Test_AddPodGroup(t *testing.T) {
 			name:                     "add pod group with parent when CompositePodGroup disabled",
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: false,
-			podGroupsToAdd:           []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:           []*schedulingv1alpha3.PodGroup{pg3WithParent},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
@@ -1117,7 +1116,7 @@ func Test_AddPodGroup(t *testing.T) {
 				return
 			}
 
-			gotPodGroups := make(map[fwk.EntityKey]*schedulingv1beta1.PodGroup)
+			gotPodGroups := make(map[fwk.EntityKey]*schedulingv1alpha3.PodGroup)
 			for k, pgs := range cache.podGroupStates {
 				if pgs.podGroup != nil {
 					gotPodGroups[k] = pgs.podGroup
@@ -1147,11 +1146,11 @@ func Test_UpdatePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name                   string
-		initPodGroup           *schedulingv1beta1.PodGroup
-		oldPodGroup            *schedulingv1beta1.PodGroup
-		newPodGroup            *schedulingv1beta1.PodGroup
+		initPodGroup           *schedulingv1alpha3.PodGroup
+		oldPodGroup            *schedulingv1alpha3.PodGroup
+		newPodGroup            *schedulingv1alpha3.PodGroup
 		genericWorkloadEnabled bool
-		expectPodGroup         *schedulingv1beta1.PodGroup
+		expectPodGroup         *schedulingv1alpha3.PodGroup
 	}{
 		{
 			name:                   "update pod group with GenericWorkload disabled should be no-op",
@@ -1208,12 +1207,12 @@ func Test_RemovePodGroup(t *testing.T) {
 		genericWorkloadEnabled   bool
 		compositePodGroupEnabled bool
 		initPod                  *v1.Pod // From old tests
-		initialPodGroups         []*schedulingv1beta1.PodGroup
+		initialPodGroups         []*schedulingv1alpha3.PodGroup
 		initialCPGs              []*schedulingv1alpha3.CompositePodGroup
-		podGroupToDelete         *schedulingv1beta1.PodGroup
+		podGroupToDelete         *schedulingv1alpha3.PodGroup
 		expectStateExists        string // "true", "false", or "" to skip
 		expectPodsCount          int
-		wantPodGroups            map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+		wantPodGroups            map[fwk.EntityKey]*schedulingv1alpha3.PodGroup
 		wantChildren             map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
@@ -1225,7 +1224,7 @@ func Test_RemovePodGroup(t *testing.T) {
 		{
 			name:                     "remove pod group with GenericWorkload enabled",
 			podGroupToDelete:         podGroup,
-			initialPodGroups:         []*schedulingv1beta1.PodGroup{podGroup},
+			initialPodGroups:         []*schedulingv1alpha3.PodGroup{podGroup},
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
 			expectStateExists:        "false",
@@ -1233,7 +1232,7 @@ func Test_RemovePodGroup(t *testing.T) {
 		{
 			name:                     "remove pod group when it still has pod members",
 			initPod:                  pod,
-			initialPodGroups:         []*schedulingv1beta1.PodGroup{podGroup},
+			initialPodGroups:         []*schedulingv1alpha3.PodGroup{podGroup},
 			podGroupToDelete:         podGroup,
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
@@ -1244,9 +1243,9 @@ func Test_RemovePodGroup(t *testing.T) {
 			name:                     "delete pod group with parent, parent has other pod group children",
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
-			initialPodGroups:         []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
+			initialPodGroups:         []*schedulingv1alpha3.PodGroup{pg3WithParent, pg4WithParent},
 			podGroupToDelete:         pg3WithParent,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg4"): pg4WithParent,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
@@ -1257,10 +1256,10 @@ func Test_RemovePodGroup(t *testing.T) {
 			name:                     "delete pod group with parent, parent has other composite pod group children",
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
-			initialPodGroups:         []*schedulingv1beta1.PodGroup{pg3WithParent},
+			initialPodGroups:         []*schedulingv1alpha3.PodGroup{pg3WithParent},
 			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpgChild},
 			podGroupToDelete:         pg3WithParent,
-			wantPodGroups:            map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			wantPodGroups:            map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				cpg1Key: sets.New(fwk.CompositePodGroupKey("ns1", "cpgChild")),
 			},
@@ -1309,7 +1308,7 @@ func Test_RemovePodGroup(t *testing.T) {
 			}
 
 			if tt.wantPodGroups != nil {
-				gotPodGroups := make(map[fwk.EntityKey]*schedulingv1beta1.PodGroup)
+				gotPodGroups := make(map[fwk.EntityKey]*schedulingv1alpha3.PodGroup)
 				for k, pgs := range cache.podGroupStates {
 					if pgs.podGroup != nil {
 						gotPodGroups[k] = pgs.podGroup
@@ -3323,7 +3322,7 @@ func Test_AddCompositePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		initialPGs   []*schedulingv1beta1.PodGroup
+		initialPGs   []*schedulingv1alpha3.PodGroup
 		cpgsToAdd    []*schedulingv1alpha3.CompositePodGroup
 		wantCPGs     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
 		wantChildren map[fwk.EntityKey]sets.Set[fwk.EntityKey]
@@ -3353,7 +3352,7 @@ func Test_AddCompositePodGroup(t *testing.T) {
 		},
 		{
 			name:       "add composite pod group with parent, parent already has pod group child",
-			initialPGs: []*schedulingv1beta1.PodGroup{pgChild},
+			initialPGs: []*schedulingv1alpha3.PodGroup{pgChild},
 			cpgsToAdd:  []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
 			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
 				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
@@ -3417,7 +3416,7 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		initialPGs   []*schedulingv1beta1.PodGroup
+		initialPGs   []*schedulingv1alpha3.PodGroup
 		initialCPGs  []*schedulingv1alpha3.CompositePodGroup
 		cpgToDelete  *schedulingv1alpha3.CompositePodGroup
 		wantCPGs     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
@@ -3432,7 +3431,7 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 		},
 		{
 			name:        "delete composite pod group with parent, parent has both other pg and cpg children",
-			initialPGs:  []*schedulingv1beta1.PodGroup{pgChild},
+			initialPGs:  []*schedulingv1alpha3.PodGroup{pgChild},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
 			cpgToDelete: cpg3WithParent,
 			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
@@ -3447,7 +3446,7 @@ func Test_RemoveCompositePodGroup(t *testing.T) {
 		},
 		{
 			name:        "delete mid cpg from root-mid-leaf hierarchy",
-			initialPGs:  []*schedulingv1beta1.PodGroup{pgLeaf},
+			initialPGs:  []*schedulingv1alpha3.PodGroup{pgLeaf},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpgMid},
 			cpgToDelete: cpgMid,
 			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
@@ -3519,7 +3518,7 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 	tests := []struct {
 		name                     string
 		pod                      *v1.Pod
-		initialPGs               []*schedulingv1beta1.PodGroup
+		initialPGs               []*schedulingv1alpha3.PodGroup
 		initialCPGs              []*schedulingv1alpha3.CompositePodGroup
 		genericWorkloadEnabled   bool
 		compositePodGroupEnabled bool
@@ -3542,7 +3541,7 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 		{
 			name:                   "simple pod group",
 			pod:                    pod1,
-			initialPGs:             []*schedulingv1beta1.PodGroup{pg1},
+			initialPGs:             []*schedulingv1alpha3.PodGroup{pg1},
 			genericWorkloadEnabled: true,
 			wantPGKeys: []fwk.EntityKey{
 				fwk.PodGroupKey("ns1", "pg1"),
@@ -3551,7 +3550,7 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 		{
 			name:                     "pod group with parent CPG",
 			pod:                      pod2,
-			initialPGs:               []*schedulingv1beta1.PodGroup{pg2},
+			initialPGs:               []*schedulingv1alpha3.PodGroup{pg2},
 			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
@@ -3565,7 +3564,7 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 		{
 			name:                     "pod group with parent CPG hierarchy",
 			pod:                      pod3,
-			initialPGs:               []*schedulingv1beta1.PodGroup{pg3},
+			initialPGs:               []*schedulingv1alpha3.PodGroup{pg3},
 			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpg2, cpg3},
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
@@ -3580,7 +3579,7 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 		{
 			name:                     "cycle detection in hierarchy",
 			pod:                      podCycle,
-			initialPGs:               []*schedulingv1beta1.PodGroup{pgCycle},
+			initialPGs:               []*schedulingv1alpha3.PodGroup{pgCycle},
 			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpgCycle1, cpgCycle2},
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: true,
@@ -3589,7 +3588,7 @@ func Test_BuildHierarchySnapshotFromPod(t *testing.T) {
 		{
 			name:                     "pod group with parent CPG but feature disabled",
 			pod:                      pod2,
-			initialPGs:               []*schedulingv1beta1.PodGroup{pg2},
+			initialPGs:               []*schedulingv1alpha3.PodGroup{pg2},
 			initialCPGs:              []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			genericWorkloadEnabled:   true,
 			compositePodGroupEnabled: false,

--- a/pkg/scheduler/backend/cache/interface.go
+++ b/pkg/scheduler/backend/cache/interface.go
@@ -19,7 +19,6 @@ package cache
 import (
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -140,13 +139,13 @@ type Cache interface {
 	RemovePodGroupMember(pod *v1.Pod)
 
 	// AddPodGroup adds a pod group object to the cache.
-	AddPodGroup(podGroup *schedulingv1beta1.PodGroup)
+	AddPodGroup(podGroup *schedulingv1alpha3.PodGroup)
 
 	// UpdatePodGroup updates a pod group object in the cache.
-	UpdatePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1beta1.PodGroup)
+	UpdatePodGroup(logger klog.Logger, oldPodGroup, newPodGroup *schedulingv1alpha3.PodGroup)
 
 	// RemovePodGroup removes a pod group object from the cache.
-	RemovePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
+	RemovePodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup)
 
 	// AddCompositePodGroup adds a composite pod group to the cache.
 	AddCompositePodGroup(logger klog.Logger, cpg *schedulingv1alpha3.CompositePodGroup)

--- a/pkg/scheduler/backend/cache/podgroupstate.go
+++ b/pkg/scheduler/backend/cache/podgroupstate.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -57,7 +56,7 @@ type podGroupStateData struct {
 	// assignedPods tracks all pods belonging to the group that are assigned (bound).
 	assignedPods sets.Set[types.UID]
 	// podGroup is the cached API object of the PodGroup.
-	podGroup *schedulingv1beta1.PodGroup
+	podGroup *schedulingv1alpha3.PodGroup
 }
 
 func newPodGroupStateData() podGroupStateData {
@@ -194,7 +193,7 @@ func (d *podGroupStateData) clone() podGroupStateData {
 }
 
 // setPodGroup sets the PodGroup object.
-func (d *podGroupStateData) setPodGroup(podGroup *schedulingv1beta1.PodGroup) {
+func (d *podGroupStateData) setPodGroup(podGroup *schedulingv1alpha3.PodGroup) {
 	d.generation = nextPodGroupGeneration()
 	d.podGroup = podGroup
 }
@@ -359,7 +358,7 @@ func (pgs *podGroupState) forgetPod(podUID types.UID) {
 
 // setPodGroup sets the PodGroup object.
 // It must be called under the cache lock.
-func (pgs *podGroupState) setPodGroup(podGroup *schedulingv1beta1.PodGroup) {
+func (pgs *podGroupState) setPodGroup(podGroup *schedulingv1alpha3.PodGroup) {
 	pgs.lock.Lock()
 	defer pgs.lock.Unlock()
 
@@ -437,7 +436,7 @@ func (pgs *podGroupState) ScheduledPodsCount() int {
 }
 
 // PodGroup returns the PodGroup API object.
-func (pgs *podGroupState) PodGroup() *schedulingv1beta1.PodGroup {
+func (pgs *podGroupState) PodGroup() *schedulingv1alpha3.PodGroup {
 	pgs.lock.RLock()
 	defer pgs.lock.RUnlock()
 

--- a/pkg/scheduler/backend/cache/snapshot.go
+++ b/pkg/scheduler/backend/cache/snapshot.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -219,7 +218,7 @@ func NewSnapshot(pods []*v1.Pod, nodes []*v1.Node) *Snapshot {
 
 // NewTestSnapshotWithPodGroups initializes a Snapshot struct with pod groups and returns it.
 // It should be used only in the tests.
-func NewTestSnapshotWithPodGroups(pods []*v1.Pod, nodes []*v1.Node, podGroups []*schedulingv1beta1.PodGroup) *Snapshot {
+func NewTestSnapshotWithPodGroups(pods []*v1.Pod, nodes []*v1.Node, podGroups []*schedulingv1alpha3.PodGroup) *Snapshot {
 	s := NewSnapshot(pods, nodes)
 	for _, podGroup := range podGroups {
 		key := fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)
@@ -235,7 +234,7 @@ func NewTestSnapshotWithPodGroups(pods []*v1.Pod, nodes []*v1.Node, podGroups []
 
 // NewTestSnapshotWithCompositePodGroups initializes a Snapshot struct with pod groups and composite pod groups and returns it.
 // It should be used only in the tests.
-func NewTestSnapshotWithCompositePodGroups(pods []*v1.Pod, nodes []*v1.Node, podGroups []*schedulingv1beta1.PodGroup, compositePodGroups []*schedulingv1alpha3.CompositePodGroup) *Snapshot {
+func NewTestSnapshotWithCompositePodGroups(pods []*v1.Pod, nodes []*v1.Node, podGroups []*schedulingv1alpha3.PodGroup, compositePodGroups []*schedulingv1alpha3.CompositePodGroup) *Snapshot {
 	s := NewTestSnapshotWithPodGroups(pods, nodes, podGroups)
 	for _, cpg := range compositePodGroups {
 		key := fwk.CompositePodGroupKey(cpg.Namespace, cpg.Name)
@@ -441,7 +440,7 @@ type podGroupSnapshotListerImpl struct {
 	snapshot *Snapshot
 }
 
-func (l *podGroupSnapshotListerImpl) Get(namespace, name string) (*schedulingv1beta1.PodGroup, error) {
+func (l *podGroupSnapshotListerImpl) Get(namespace, name string) (*schedulingv1alpha3.PodGroup, error) {
 	if !l.snapshot.genericWorkloadEnabled {
 		return nil, fmt.Errorf("generic workload feature gate is disabled")
 	}

--- a/pkg/scheduler/backend/cache/snapshot_test.go
+++ b/pkg/scheduler/backend/cache/snapshot_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	v1 "k8s.io/api/core/v1"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -1574,7 +1574,7 @@ func TestSnapshot_AddRemovePod(t *testing.T) {
 		name                            string
 		initialPods                     []*v1.Pod
 		initialNodes                    []*v1.Node
-		initialPodGroups                []*schedulingv1beta1.PodGroup
+		initialPodGroups                []*schedulingv1alpha3.PodGroup
 		operations                      []operation
 		expectedAffinityNodeNames       sets.Set[string]
 		expectedAntiAffNodeNames        sets.Set[string]
@@ -1779,7 +1779,7 @@ func TestSnapshot_AddRemovePod(t *testing.T) {
 			name:             "PodGroup state updates",
 			initialNodes:     []*v1.Node{st.MakeNode().Name("node-1").Obj(), st.MakeNode().Name("node-2").Obj()},
 			initialPods:      []*v1.Pod{},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{st.MakePodGroup().Name("pg1").Namespace("ns").Obj()},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{st.MakePodGroup().Name("pg1").Namespace("ns").Obj()},
 			operations: []operation{
 				{opType: "add", pod: st.MakePod().Name("p1").UID("uid-1").Namespace("ns").PodGroupName("pg1").Node("node-1").Obj()},
 				{opType: "add", pod: st.MakePod().Name("p2").UID("uid-2").Namespace("ns").PodGroupName("pg1").Node("node-2").Obj()},

--- a/pkg/scheduler/backend/queue/pod_group_member_pods_test.go
+++ b/pkg/scheduler/backend/queue/pod_group_member_pods_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/scheduling/v1beta1"
+	"k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/util/sets"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -313,7 +313,7 @@ func TestPodGroupMemberPods_Clear(t *testing.T) {
 	tests := []struct {
 		name        string
 		podsToAdd   []*framework.QueuedPodInfo
-		clearGroup  *v1beta1.PodGroup
+		clearGroup  *v1alpha3.PodGroup
 		wantCleared sets.Set[*framework.QueuedPodInfo]
 		want        map[fwk.EntityKey]map[fwk.EntityKey]*framework.QueuedPodInfo
 	}{

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -35,7 +35,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -134,12 +133,12 @@ type SchedulingQueue interface {
 	MoveAllToActiveOrBackoffQueue(logger klog.Logger, event fwk.ClusterEvent, oldObj, newObj interface{}, preCheck PreEnqueueCheck)
 	// AddPodGroup adds a new PodGroup object to the queue,
 	// requeuing all pods associated with the pod group.
-	AddPodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
+	AddPodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup)
 	// UpdatePodGroup updates an existing PodGroup object in the queue.
-	UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
+	UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup)
 	// DeletePodGroup removes a PodGroup object from the queue,
 	// moving all pods associated with the pod group to the incompletePodGroupPods.
-	DeletePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup)
+	DeletePodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup)
 
 	// Close closes the SchedulingQueue so that the goroutine which is
 	// waiting to pop items can exit gracefully.
@@ -1560,7 +1559,7 @@ func (p *PriorityQueue) deletePod(pod *v1.Pod) {
 
 // AddPodGroup adds a new PodGroup object to the queue,
 // requeuing all pods associated with the pod group.
-func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -1598,7 +1597,7 @@ func (p *PriorityQueue) AddPodGroup(logger klog.Logger, podGroup *schedulingv1be
 }
 
 // UpdatePodGroup updates an existing PodGroup object in the queue.
-func (p *PriorityQueue) UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+func (p *PriorityQueue) UpdatePodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -1621,7 +1620,7 @@ func (p *PriorityQueue) UpdatePodGroup(logger klog.Logger, podGroup *schedulingv
 
 // DeletePodGroup removes a PodGroup object from the queue,
 // moving all pods associated with the pod group to the incompletePodGroupPods.
-func (p *PriorityQueue) DeletePodGroup(logger klog.Logger, podGroup *schedulingv1beta1.PodGroup) {
+func (p *PriorityQueue) DeletePodGroup(logger klog.Logger, podGroup *schedulingv1alpha3.PodGroup) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
@@ -2258,7 +2257,7 @@ func podGroupKeyForPod(pod *v1.Pod) fwk.EntityKey {
 	return fwk.PodGroupKey(pod.Namespace, *pod.Spec.SchedulingGroup.PodGroupName)
 }
 
-func podGroupKey(podGroup *schedulingv1beta1.PodGroup) fwk.EntityKey {
+func podGroupKey(podGroup *schedulingv1alpha3.PodGroup) fwk.EntityKey {
 	return fwk.PodGroupKey(podGroup.Namespace, podGroup.Name)
 }
 

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -215,7 +214,7 @@ func TestPriorityQueue_Add(t *testing.T) {
 			objs := []runtime.Object{medPod, unschedPod, highPod}
 			q := NewTestQueueWithObjects(ctx, newDefaultQueueSort(), objs)
 			if tt.usePodGroups {
-				podGroups := []*schedulingv1beta1.PodGroup{
+				podGroups := []*schedulingv1alpha3.PodGroup{
 					st.MakePodGroup().Name("pg-med").Namespace(medPod.Namespace).Priority(midPriority).Obj(),
 					st.MakePodGroup().Name("pg-unsched").Namespace(unschedPod.Namespace).Priority(lowPriority).Obj(),
 					st.MakePodGroup().Name("pg-high").Namespace(highPod.Namespace).Priority(highPriority).Obj(),
@@ -354,7 +353,7 @@ func Test_InFlightPods(t *testing.T) {
 		// podGroupAttempted is the PodGroup that was attempted to schedule.
 		podGroupAttempted *framework.QueuedPodGroupInfo
 		// podGroupAdded is the PodGroup that is added/updated in the queue.
-		podGroupAdded *schedulingv1beta1.PodGroup
+		podGroupAdded *schedulingv1alpha3.PodGroup
 		callback      func(t *testing.T, q *PriorityQueue)
 	}
 
@@ -1087,7 +1086,7 @@ func Test_InFlightPods(t *testing.T) {
 				defer cancel()
 				obj := make([]runtime.Object, 0, len(test.initialPods))
 				pgNamesSeen := sets.New[string]()
-				var podGroupsToAdd []*schedulingv1beta1.PodGroup
+				var podGroupsToAdd []*schedulingv1alpha3.PodGroup
 				for _, p := range test.initialPods {
 					obj = append(obj, p)
 					if p.Spec.SchedulingGroup != nil && p.Spec.SchedulingGroup.PodGroupName != nil {
@@ -6411,7 +6410,7 @@ const (
 	stateIncomplete
 )
 
-func setupInitialPodGroupState(t *testing.T, ctx context.Context, q *PriorityQueue, initialPods []*v1.Pod, initialState initialQueueState, initialPodGroup *schedulingv1beta1.PodGroup) {
+func setupInitialPodGroupState(t *testing.T, ctx context.Context, q *PriorityQueue, initialPods []*v1.Pod, initialState initialQueueState, initialPodGroup *schedulingv1alpha3.PodGroup) {
 	t.Helper()
 
 	if initialState != stateIncomplete {
@@ -8286,7 +8285,7 @@ func TestDeletePodGroup(t *testing.T) {
 func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 	tests := []struct {
 		name                   string
-		initialPodGroups       []*schedulingv1beta1.PodGroup
+		initialPodGroups       []*schedulingv1alpha3.PodGroup
 		initialCPGs            []*schedulingv1alpha3.CompositePodGroup
 		initialPods            []*v1.Pod
 		beforeAdd              func(ctx context.Context, q *PriorityQueue)
@@ -8297,7 +8296,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 	}{
 		{
 			name: "Root with pods",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -8310,7 +8309,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 		},
 		{
 			name: "Root without pods",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
 			cpgToAdd:               st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
@@ -8320,7 +8319,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 		},
 		{
 			name: "Root when another root exists",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").Obj(),
 			},
@@ -8338,7 +8337,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 		},
 		{
 			name: "Non-root when parent is missing",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -8351,7 +8350,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 		},
 		{
 			name: "Non-root when parent is root",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
 			},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
@@ -8367,7 +8366,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 		},
 		{
 			name: "Non-root when parent is root and is already in active queue with another pod",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
@@ -8385,7 +8384,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 		},
 		{
 			name: "Non-root when parent exists but root is missing",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
 			},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
@@ -8401,7 +8400,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 		},
 		{
 			name: "Non-root when parent is root and is currently in-flight (popped)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
@@ -8422,7 +8421,7 @@ func TestPriorityQueue_AddCompositePodGroup(t *testing.T) {
 		},
 		{
 			name: "Root when another root is currently in-flight (popped)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").Obj(),
 			},
@@ -8499,7 +8498,7 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 	tests := []struct {
 		name                   string
 		initialCPGs            []*schedulingv1alpha3.CompositePodGroup
-		initialPodGroups       []*schedulingv1beta1.PodGroup
+		initialPodGroups       []*schedulingv1alpha3.PodGroup
 		initialPods            []*v1.Pod
 		cpgToUpdate            *schedulingv1alpha3.CompositePodGroup
 		expectedActiveQ        map[string][]string
@@ -8511,7 +8510,7 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").MinGroupCount(3).Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -8528,7 +8527,7 @@ func TestPriorityQueue_UpdateCompositePodGroup(t *testing.T) {
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 				st.MakeCompositePodGroup().Name("child-cpg").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -8602,7 +8601,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 	tests := []struct {
 		name                   string
 		initialCPGs            []*schedulingv1alpha3.CompositePodGroup
-		initialPodGroups       []*schedulingv1beta1.PodGroup
+		initialPodGroups       []*schedulingv1alpha3.PodGroup
 		initialPods            []*v1.Pod
 		beforeDelete           func(ctx context.Context, q *PriorityQueue)
 		cpgToDelete            *schedulingv1alpha3.CompositePodGroup
@@ -8616,7 +8615,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 				st.MakeCompositePodGroup().Name("child-cpg").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
@@ -8635,7 +8634,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 				st.MakeCompositePodGroup().Name("child-cpg").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
@@ -8653,7 +8652,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("child-cpg").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -8670,7 +8669,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 				st.MakeCompositePodGroup().Name("child-cpg").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
@@ -8692,7 +8691,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 				st.MakeCompositePodGroup().Name("child-cpg").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("child-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
@@ -8715,7 +8714,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -8737,7 +8736,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 				st.MakeCompositePodGroup().Name("mid-cpg").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("mid-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -8754,7 +8753,7 @@ func TestPriorityQueue_DeleteCompositePodGroup(t *testing.T) {
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 				st.MakeCompositePodGroup().Name("mid-cpg").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("mid-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
@@ -8827,10 +8826,10 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 		name                   string
 		disableCPGFeature      bool
 		initialCPGs            []*schedulingv1alpha3.CompositePodGroup
-		initialPodGroups       []*schedulingv1beta1.PodGroup
+		initialPodGroups       []*schedulingv1alpha3.PodGroup
 		initialPods            []*v1.Pod
 		beforeAdd              func(ctx context.Context, q *PriorityQueue)
-		pgToAdd                *schedulingv1beta1.PodGroup
+		pgToAdd                *schedulingv1alpha3.PodGroup
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
@@ -8854,7 +8853,7 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 		},
 		{
 			name: "Root when another root exists",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg2").Namespace("ns1").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -8897,7 +8896,7 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -8927,7 +8926,7 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -8948,7 +8947,7 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -8965,7 +8964,7 @@ func TestPriorityQueue_AddPodGroup_Hierarchical(t *testing.T) {
 		},
 		{
 			name: "Root when another root is currently in-flight (popped)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg2").Namespace("ns1").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -9053,16 +9052,16 @@ func TestPriorityQueue_UpdatePodGroup_Hierarchical(t *testing.T) {
 		name                   string
 		disableCPGFeature      bool
 		initialCPGs            []*schedulingv1alpha3.CompositePodGroup
-		initialPodGroups       []*schedulingv1beta1.PodGroup
+		initialPodGroups       []*schedulingv1alpha3.PodGroup
 		initialPods            []*v1.Pod
-		pgToUpdate             *schedulingv1beta1.PodGroup
+		pgToUpdate             *schedulingv1alpha3.PodGroup
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
 	}{
 		{
 			name: "Root when minCount is updated",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").MinCount(2).Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -9078,7 +9077,7 @@ func TestPriorityQueue_UpdatePodGroup_Hierarchical(t *testing.T) {
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -9092,7 +9091,7 @@ func TestPriorityQueue_UpdatePodGroup_Hierarchical(t *testing.T) {
 		{
 			name:              "Non-root when CPG feature is disabled",
 			disableCPGFeature: true,
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").MinCount(2).Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -9167,10 +9166,10 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 		name                   string
 		disableCPGFeature      bool
 		initialCPGs            []*schedulingv1alpha3.CompositePodGroup
-		initialPodGroups       []*schedulingv1beta1.PodGroup
+		initialPodGroups       []*schedulingv1alpha3.PodGroup
 		initialPods            []*v1.Pod
 		beforeDelete           func(ctx context.Context, q *PriorityQueue)
-		pgToDelete             *schedulingv1beta1.PodGroup
+		pgToDelete             *schedulingv1alpha3.PodGroup
 		expectedActiveQ        map[string][]string
 		expectedIncompletePods []string
 		expectedPendingPods    []string
@@ -9180,7 +9179,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
@@ -9195,7 +9194,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 		},
 		{
 			name: "Root with pods",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -9211,7 +9210,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
@@ -9232,7 +9231,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("root-cpg").Namespace("ns1").Obj(),
 			},
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
@@ -9252,7 +9251,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 		},
 		{
 			name: "Root when in-flight (popped)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -9268,7 +9267,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 		},
 		{
 			name: "Root with pending pods when in-flight (popped)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -9286,7 +9285,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 		},
 		{
 			name: "Root without pods",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").Obj(),
 			},
 			pgToDelete:             st.MakePodGroup().Name("pg1").Namespace("ns1").Obj(),
@@ -9297,7 +9296,7 @@ func TestPriorityQueue_DeletePodGroup_Hierarchical(t *testing.T) {
 		{
 			name:              "Non-root when CPG feature is disabled",
 			disableCPGFeature: true,
-			initialPodGroups: []*schedulingv1beta1.PodGroup{
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("ns1").ParentCompositePodGroup("root-cpg").Obj(),
 			},
 			initialPods: []*v1.Pod{
@@ -9435,7 +9434,7 @@ func newQueuedPodGroupInfoForLookup(namespace, name string, entityType fwk.Entit
 	}
 }
 
-func newSingleLevelPodGroupInfo(podInfo *framework.QueuedPodInfo, podGroup *schedulingv1beta1.PodGroup) *framework.QueuedPodGroupInfo {
+func newSingleLevelPodGroupInfo(podInfo *framework.QueuedPodInfo, podGroup *schedulingv1alpha3.PodGroup) *framework.QueuedPodGroupInfo {
 	pgName := *podInfo.Pod.Spec.SchedulingGroup.PodGroupName
 	key := fwk.PodGroupKey(podInfo.Pod.Namespace, pgName)
 	return &framework.QueuedPodGroupInfo{
@@ -10075,9 +10074,9 @@ func TestPreQueueingHint_PodGroupPreCheck(t *testing.T) {
 	pgName := "test-pg"
 	pod1 := st.MakePod().Name("pgpod1").Namespace("ns1").UID("pgpod1").Label("block", "").PodGroupName(pgName).Obj()
 	pod2 := st.MakePod().Name("pgpod2").Namespace("ns1").UID("pgpod2").Label("block", "").PodGroupName(pgName).Obj()
-	podGroup := &schedulingv1beta1.PodGroup{
+	podGroup := &schedulingv1alpha3.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: pgName, Namespace: "ns1", UID: "pg-uid"},
-		Spec:       schedulingv1beta1.PodGroupSpec{},
+		Spec:       schedulingv1alpha3.PodGroupSpec{},
 	}
 
 	preQueueingHintFn := func(logger klog.Logger, oldObj, newObj interface{}) (fwk.PreQueueingHintResult, error) {

--- a/pkg/scheduler/backend/queue/workload_forest.go
+++ b/pkg/scheduler/backend/queue/workload_forest.go
@@ -21,7 +21,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
@@ -35,7 +34,7 @@ import (
 // Outside of the scheduling queue, cache should be used as the source of truth.
 // This structure is not thread-safe and should be accessed only under the lock of the PriorityQueue.
 type workloadForest struct {
-	podGroups          map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+	podGroups          map[fwk.EntityKey]*schedulingv1alpha3.PodGroup
 	compositePodGroups map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
 	// children maps a parent CompositePodGroup key to its direct children keys (PodGroups or CompositePodGroups).
 	// As an invariant of this structure, a child-to-parent relationship is populated here regardless of whether
@@ -47,7 +46,7 @@ type workloadForest struct {
 
 func newWorkloadForest(isCompositePodGroupEnabled bool) *workloadForest {
 	return &workloadForest{
-		podGroups:                  make(map[fwk.EntityKey]*schedulingv1beta1.PodGroup),
+		podGroups:                  make(map[fwk.EntityKey]*schedulingv1alpha3.PodGroup),
 		compositePodGroups:         make(map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup),
 		children:                   make(map[fwk.EntityKey]sets.Set[fwk.EntityKey]),
 		isCompositePodGroupEnabled: isCompositePodGroupEnabled,
@@ -55,7 +54,7 @@ func newWorkloadForest(isCompositePodGroupEnabled bool) *workloadForest {
 }
 
 // addPodGroup adds a PodGroup to the forest.
-func (wf *workloadForest) addPodGroup(podGroup *schedulingv1beta1.PodGroup) {
+func (wf *workloadForest) addPodGroup(podGroup *schedulingv1alpha3.PodGroup) {
 	pgKey := podGroupKey(podGroup)
 	wf.podGroups[pgKey] = podGroup
 
@@ -72,12 +71,12 @@ func (wf *workloadForest) addPodGroup(podGroup *schedulingv1beta1.PodGroup) {
 }
 
 // updatePodGroup updates a PodGroup in the forest.
-func (wf *workloadForest) updatePodGroup(podGroup *schedulingv1beta1.PodGroup) {
+func (wf *workloadForest) updatePodGroup(podGroup *schedulingv1alpha3.PodGroup) {
 	wf.podGroups[podGroupKey(podGroup)] = podGroup
 }
 
 // deletePodGroup removes a PodGroup from the forest.
-func (wf *workloadForest) deletePodGroup(podGroup *schedulingv1beta1.PodGroup) {
+func (wf *workloadForest) deletePodGroup(podGroup *schedulingv1alpha3.PodGroup) {
 	pgKey := podGroupKey(podGroup)
 	delete(wf.podGroups, pgKey)
 
@@ -149,7 +148,7 @@ func (wf *workloadForest) getRootLookupInfoForPod(pod *v1.Pod) (*framework.Queue
 }
 
 // getRootLookupInfoForPodGroup returns the lookup info of the current root PodGroup or CompositePodGroup for a given PodGroup.
-func (wf *workloadForest) getRootLookupInfoForPodGroup(podGroup *schedulingv1beta1.PodGroup) (*framework.QueuedPodGroupInfo, bool) {
+func (wf *workloadForest) getRootLookupInfoForPodGroup(podGroup *schedulingv1alpha3.PodGroup) (*framework.QueuedPodGroupInfo, bool) {
 	podGroup, exists := wf.podGroups[podGroupKey(podGroup)]
 	if !exists {
 		return nil, false
@@ -204,8 +203,8 @@ func (wf *workloadForest) getRootLookupInfoForParentCPG(parentName, namespace st
 }
 
 // getLeafPodGroups returns all PodGroups that are leaf nodes in the subtree rooted at the given CompositePodGroup.
-func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *framework.QueuedPodGroupInfo) []*schedulingv1beta1.PodGroup {
-	var pgs []*schedulingv1beta1.PodGroup
+func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *framework.QueuedPodGroupInfo) []*schedulingv1alpha3.PodGroup {
+	var pgs []*schedulingv1alpha3.PodGroup
 	var key fwk.EntityKey
 	if rootLookupInfo.GetType() == fwk.PodGroupKeyType {
 		key = fwk.PodGroupKey(rootLookupInfo.GetNamespace(), rootLookupInfo.GetName())
@@ -250,7 +249,7 @@ func (wf *workloadForest) getLeafPodGroups(logger klog.Logger, rootLookupInfo *f
 }
 
 // getPodGroup returns the current PodGroup object for a given lookup.
-func (wf *workloadForest) getPodGroup(pgLookup *schedulingv1beta1.PodGroup) (*schedulingv1beta1.PodGroup, bool) {
+func (wf *workloadForest) getPodGroup(pgLookup *schedulingv1alpha3.PodGroup) (*schedulingv1alpha3.PodGroup, bool) {
 	podGroup, ok := wf.podGroups[podGroupKey(pgLookup)]
 	return podGroup, ok
 }
@@ -263,7 +262,7 @@ func (wf *workloadForest) getCompositePodGroup(cpgLookup *schedulingv1alpha3.Com
 
 // buildPodGroupInfoForPG constructs a PodGroupInfo representation for a given PodGroup,
 // using the provided visited set to detect cycles in the hierarchy.
-func (wf *workloadForest) buildPodGroupInfoForPG(logger klog.Logger, pg *schedulingv1beta1.PodGroup, visited sets.Set[fwk.EntityKey]) *framework.PodGroupInfo {
+func (wf *workloadForest) buildPodGroupInfoForPG(logger klog.Logger, pg *schedulingv1alpha3.PodGroup, visited sets.Set[fwk.EntityKey]) *framework.PodGroupInfo {
 	key := podGroupKey(pg)
 	if visited.Has(key) {
 		utilruntime.HandleErrorWithLogger(logger, nil, "cycle detected in composite pod group hierarchy", "pg-name", pg.Name, "namespace", pg.Namespace)
@@ -343,6 +342,6 @@ func (wf *workloadForest) buildQueuedPodGroupInfo(logger klog.Logger, rootLookup
 
 // podGroupHasParent checks whether the given PodGroup has a parent CompositePodGroup configured
 // and the CompositePodGroup feature is enabled.
-func (wf *workloadForest) podGroupHasParent(pg *schedulingv1beta1.PodGroup) bool {
+func (wf *workloadForest) podGroupHasParent(pg *schedulingv1alpha3.PodGroup) bool {
 	return wf.isCompositePodGroupEnabled && pg.Spec.ParentCompositePodGroupName != nil
 }

--- a/pkg/scheduler/backend/queue/workload_forest_test.go
+++ b/pkg/scheduler/backend/queue/workload_forest_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2/ktesting"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -41,15 +40,15 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		name                       string
 		isCompositePodGroupEnabled bool
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
-		podGroupsToAdd             []*schedulingv1beta1.PodGroup
-		wantPodGroups              map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+		podGroupsToAdd             []*schedulingv1alpha3.PodGroup
+		wantPodGroups              map[fwk.EntityKey]*schedulingv1alpha3.PodGroup
 		wantChildren               map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
 			name:                       "add single pod group",
 			isCompositePodGroupEnabled: true,
-			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:             []*schedulingv1alpha3.PodGroup{pg1},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg1"): pg1,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
@@ -57,8 +56,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		{
 			name:                       "add multiple pod groups",
 			isCompositePodGroupEnabled: true,
-			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg2},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:             []*schedulingv1alpha3.PodGroup{pg1, pg2},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg1"): pg1,
 				fwk.PodGroupKey("ns1", "pg2"): pg2,
 			},
@@ -67,8 +66,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		{
 			name:                       "add pod group with parent, parent not in children",
 			isCompositePodGroupEnabled: true,
-			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:             []*schedulingv1alpha3.PodGroup{pg3WithParent},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
@@ -78,8 +77,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		{
 			name:                       "add pod group with parent, parent already in children",
 			isCompositePodGroupEnabled: true,
-			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:             []*schedulingv1alpha3.PodGroup{pg3WithParent, pg4WithParent},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
 				fwk.PodGroupKey("ns1", "pg4"): pg4WithParent,
 			},
@@ -91,8 +90,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 			name:                       "add pod group with parent, parent already has composite pod group child",
 			isCompositePodGroupEnabled: true,
 			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpgChild},
-			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:             []*schedulingv1alpha3.PodGroup{pg3WithParent},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
@@ -102,8 +101,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		{
 			name:                       "add pod group with parent, feature disabled",
 			isCompositePodGroupEnabled: false,
-			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:             []*schedulingv1alpha3.PodGroup{pg3WithParent},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
@@ -111,8 +110,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		{
 			name:                       "add same pod group again, feature enabled",
 			isCompositePodGroupEnabled: true,
-			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg1},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:             []*schedulingv1alpha3.PodGroup{pg1, pg1},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg1"): pg1,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
@@ -120,8 +119,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		{
 			name:                       "add same pod group again, feature disabled",
 			isCompositePodGroupEnabled: false,
-			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg1, pg1},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:             []*schedulingv1alpha3.PodGroup{pg1, pg1},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg1"): pg1,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
@@ -129,8 +128,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		{
 			name:                       "add same pod group with parent again, feature enabled",
 			isCompositePodGroupEnabled: true,
-			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:             []*schedulingv1alpha3.PodGroup{pg3WithParent, pg3WithParent},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
@@ -140,8 +139,8 @@ func TestWorkloadForest_AddPodGroup(t *testing.T) {
 		{
 			name:                       "add same pod group with parent again, feature disabled",
 			isCompositePodGroupEnabled: false,
-			podGroupsToAdd:             []*schedulingv1beta1.PodGroup{pg3WithParent, pg3WithParent},
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			podGroupsToAdd:             []*schedulingv1alpha3.PodGroup{pg3WithParent, pg3WithParent},
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg3"): pg3WithParent,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
@@ -175,23 +174,23 @@ func TestWorkloadForest_UpdatePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		initialPodGroups []*schedulingv1beta1.PodGroup
-		podGroupToUpdate *schedulingv1beta1.PodGroup
-		want             map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+		initialPodGroups []*schedulingv1alpha3.PodGroup
+		podGroupToUpdate *schedulingv1alpha3.PodGroup
+		want             map[fwk.EntityKey]*schedulingv1alpha3.PodGroup
 	}{
 		{
 			name:             "update existing pod group",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
 			podGroupToUpdate: updatedPG1,
-			want: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			want: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg1"): updatedPG1,
 			},
 		},
 		{
 			name:             "update non-existent pod group adds it",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
 			podGroupToUpdate: pg2,
-			want: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			want: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg1"): pg1,
 				fwk.PodGroupKey("ns1", "pg2"): pg2,
 			},
@@ -224,18 +223,18 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 	tests := []struct {
 		name                       string
 		isCompositePodGroupEnabled bool
-		initialPodGroups           []*schedulingv1beta1.PodGroup
+		initialPodGroups           []*schedulingv1alpha3.PodGroup
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
-		podGroupToDelete           *schedulingv1beta1.PodGroup
-		wantPodGroups              map[fwk.EntityKey]*schedulingv1beta1.PodGroup
+		podGroupToDelete           *schedulingv1alpha3.PodGroup
+		wantPodGroups              map[fwk.EntityKey]*schedulingv1alpha3.PodGroup
 		wantChildren               map[fwk.EntityKey]sets.Set[fwk.EntityKey]
 	}{
 		{
 			name:                       "delete existing pod group",
 			isCompositePodGroupEnabled: true,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1, pg2},
 			podGroupToDelete:           pg1,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg2"): pg2,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
@@ -243,9 +242,9 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 		{
 			name:                       "delete non-existent pod group is no-op",
 			isCompositePodGroupEnabled: true,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1},
 			podGroupToDelete:           pg2,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg1"): pg1,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
@@ -253,26 +252,26 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 		{
 			name:                       "delete pod group with parent, where parent CPG does not exist in compositePodGroups (e.g. was just deleted)",
 			isCompositePodGroupEnabled: true,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg3WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			wantPodGroups:              map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{},
 			wantChildren:               map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:                       "delete pod group with parent, where parent CPG exists in compositePodGroups",
 			isCompositePodGroupEnabled: true,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg3WithParent},
 			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{st.MakeCompositePodGroup().Name("cpg1").Namespace("ns1").Obj()},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			wantPodGroups:              map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{},
 			wantChildren:               map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 		{
 			name:                       "delete pod group with parent, parent has other pod group children",
 			isCompositePodGroupEnabled: true,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent, pg4WithParent},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg3WithParent, pg4WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups: map[fwk.EntityKey]*schedulingv1beta1.PodGroup{
+			wantPodGroups: map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{
 				fwk.PodGroupKey("ns1", "pg4"): pg4WithParent,
 			},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
@@ -282,10 +281,10 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 		{
 			name:                       "delete pod group with parent, parent has other composite pod group children",
 			isCompositePodGroupEnabled: true,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg3WithParent},
 			initialCPGs:                []*schedulingv1alpha3.CompositePodGroup{cpgChild},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			wantPodGroups:              map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{},
 			wantChildren: map[fwk.EntityKey]sets.Set[fwk.EntityKey]{
 				fwk.CompositePodGroupKey("ns1", "cpg1"): sets.New(fwk.CompositePodGroupKey("ns1", "cpgChild")),
 			},
@@ -293,9 +292,9 @@ func TestWorkloadForest_DeletePodGroup(t *testing.T) {
 		{
 			name:                       "delete pod group with parent, feature disabled",
 			isCompositePodGroupEnabled: false,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithParent},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg3WithParent},
 			podGroupToDelete:           pg3WithParent,
-			wantPodGroups:              map[fwk.EntityKey]*schedulingv1beta1.PodGroup{},
+			wantPodGroups:              map[fwk.EntityKey]*schedulingv1alpha3.PodGroup{},
 			wantChildren:               map[fwk.EntityKey]sets.Set[fwk.EntityKey]{},
 		},
 	}
@@ -327,35 +326,35 @@ func TestWorkloadForest_GetPodGroup(t *testing.T) {
 
 	tests := []struct {
 		name                       string
-		initialPodGroups           []*schedulingv1beta1.PodGroup
-		podGroupLookup             *schedulingv1beta1.PodGroup
-		wantPodGroup               *schedulingv1beta1.PodGroup
+		initialPodGroups           []*schedulingv1alpha3.PodGroup
+		podGroupLookup             *schedulingv1alpha3.PodGroup
+		wantPodGroup               *schedulingv1alpha3.PodGroup
 		isCompositePodGroupEnabled bool
 	}{
 		{
 			name:                       "get existing pod group",
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1},
 			podGroupLookup:             pg1,
 			wantPodGroup:               pg1,
 			isCompositePodGroupEnabled: true,
 		},
 		{
 			name:                       "get non-existent pod group",
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{},
 			podGroupLookup:             pg1,
 			wantPodGroup:               nil,
 			isCompositePodGroupEnabled: true,
 		},
 		{
 			name:                       "get existing pod group (CPG=false)",
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1},
 			podGroupLookup:             pg1,
 			wantPodGroup:               pg1,
 			isCompositePodGroupEnabled: false,
 		},
 		{
 			name:                       "get non-existent pod group (CPG=false)",
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{},
 			podGroupLookup:             pg1,
 			wantPodGroup:               nil,
 			isCompositePodGroupEnabled: false,
@@ -431,7 +430,7 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		initialPGs   []*schedulingv1beta1.PodGroup
+		initialPGs   []*schedulingv1alpha3.PodGroup
 		cpgsToAdd    []*schedulingv1alpha3.CompositePodGroup
 		wantCPGs     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
 		wantChildren map[fwk.EntityKey]sets.Set[fwk.EntityKey]
@@ -476,7 +475,7 @@ func TestWorkloadForest_AddCompositePodGroup(t *testing.T) {
 		},
 		{
 			name:       "add composite pod group with parent, parent already has pod group child",
-			initialPGs: []*schedulingv1beta1.PodGroup{pgChild},
+			initialPGs: []*schedulingv1alpha3.PodGroup{pgChild},
 			cpgsToAdd:  []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
 			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
 				fwk.CompositePodGroupKey("ns1", "cpg3"): cpg3WithParent,
@@ -583,7 +582,7 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		initialPGs   []*schedulingv1beta1.PodGroup
+		initialPGs   []*schedulingv1alpha3.PodGroup
 		initialCPGs  []*schedulingv1alpha3.CompositePodGroup
 		cpgToDelete  *schedulingv1alpha3.CompositePodGroup
 		wantCPGs     map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup
@@ -605,7 +604,7 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 		},
 		{
 			name:        "delete composite pod group with parent, parent has other pod group child",
-			initialPGs:  []*schedulingv1beta1.PodGroup{pgChild},
+			initialPGs:  []*schedulingv1alpha3.PodGroup{pgChild},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent},
 			cpgToDelete: cpg3WithParent,
 			wantCPGs:    map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{},
@@ -626,7 +625,7 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 		},
 		{
 			name:        "delete composite pod group with parent, parent has both other pg and cpg children",
-			initialPGs:  []*schedulingv1beta1.PodGroup{pgChild},
+			initialPGs:  []*schedulingv1alpha3.PodGroup{pgChild},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg3WithParent, cpg4WithParent},
 			cpgToDelete: cpg3WithParent,
 			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
@@ -638,7 +637,7 @@ func TestWorkloadForest_DeleteCompositePodGroup(t *testing.T) {
 		},
 		{
 			name:        "delete mid cpg from root-mid-leaf hierarchy",
-			initialPGs:  []*schedulingv1beta1.PodGroup{pgLeaf},
+			initialPGs:  []*schedulingv1alpha3.PodGroup{pgLeaf},
 			initialCPGs: []*schedulingv1alpha3.CompositePodGroup{cpg1, cpgMid},
 			cpgToDelete: cpgMid,
 			wantCPGs: map[fwk.EntityKey]*schedulingv1alpha3.CompositePodGroup{
@@ -694,7 +693,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 
 	tests := []struct {
 		name                       string
-		initialPodGroups           []*schedulingv1beta1.PodGroup
+		initialPodGroups           []*schedulingv1alpha3.PodGroup
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
 		pod                        *v1.Pod
 		wantInfo                   *framework.QueuedPodGroupInfo
@@ -702,7 +701,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 	}{
 		{
 			name:             "pod belongs to existing standalone pod group",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
 			pod:              podWithPG1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
@@ -715,7 +714,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 		},
 		{
 			name:             "pod belongs to pod group with parent cpg",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg2WithParent},
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			pod:              podWithPG2,
 			wantInfo: &framework.QueuedPodGroupInfo{
@@ -729,14 +728,14 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 		},
 		{
 			name:                       "pod belongs to non-existent pod group",
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1},
 			pod:                        podWithNonExistentPG,
 			wantInfo:                   nil,
 			isCompositePodGroupEnabled: true,
 		},
 		{
 			name:             "pod belongs to existing standalone pod group (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
 			pod:              podWithPG1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
@@ -749,7 +748,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 		},
 		{
 			name:             "pod belongs to pod group with parent cpg (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg2WithParent},
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			pod:              podWithPG2,
 			wantInfo: &framework.QueuedPodGroupInfo{
@@ -763,7 +762,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 		},
 		{
 			name:                       "pod belongs to non-existent pod group (CPG=false)",
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1},
 			pod:                        podWithNonExistentPG,
 			wantInfo:                   nil,
 			isCompositePodGroupEnabled: false,
@@ -800,15 +799,15 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 
 	tests := []struct {
 		name                       string
-		initialPodGroups           []*schedulingv1beta1.PodGroup
+		initialPodGroups           []*schedulingv1alpha3.PodGroup
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
-		podGroup                   *schedulingv1beta1.PodGroup
+		podGroup                   *schedulingv1alpha3.PodGroup
 		wantInfo                   *framework.QueuedPodGroupInfo
 		isCompositePodGroupEnabled bool
 	}{
 		{
 			name:             "standalone pod group",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
 			podGroup:         pg1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
@@ -821,7 +820,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 		},
 		{
 			name:             "pod group with existing parent cpg",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg2WithParent},
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			podGroup:         pg2WithParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
@@ -835,21 +834,21 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 		},
 		{
 			name:                       "pod group with non-existent parent cpg",
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg3WithNonExistentParent},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg3WithNonExistentParent},
 			podGroup:                   pg3WithNonExistentParent,
 			wantInfo:                   nil,
 			isCompositePodGroupEnabled: true,
 		},
 		{
 			name:                       "non-existent pod group",
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{},
 			podGroup:                   pg1,
 			wantInfo:                   nil,
 			isCompositePodGroupEnabled: true,
 		},
 		{
 			name:             "standalone pod group (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
 			podGroup:         pg1,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
@@ -862,7 +861,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 		},
 		{
 			name:             "pod group with existing parent cpg (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg2WithParent},
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			podGroup:         pg2WithParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
@@ -876,7 +875,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 		},
 		{
 			name:             "pod group with non-existent parent cpg (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg3WithNonExistentParent},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg3WithNonExistentParent},
 			podGroup:         pg3WithNonExistentParent,
 			wantInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{
@@ -889,7 +888,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 		},
 		{
 			name:                       "non-existent pod group (CPG=false)",
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{},
 			podGroup:                   pg1,
 			wantInfo:                   nil,
 			isCompositePodGroupEnabled: false,
@@ -995,44 +994,44 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 
 	tests := []struct {
 		name                       string
-		initialPodGroups           []*schedulingv1beta1.PodGroup
+		initialPodGroups           []*schedulingv1alpha3.PodGroup
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
 		rootLookupInfo             *framework.QueuedPodGroupInfo
-		wantLeaves                 []*schedulingv1beta1.PodGroup
+		wantLeaves                 []*schedulingv1alpha3.PodGroup
 		isCompositePodGroupEnabled bool
 	}{
 		{
 			name:             "single pod group lookup",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
 			rootLookupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "pg1", Type: fwk.PodGroupKeyType},
 			},
-			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg1},
+			wantLeaves:                 []*schedulingv1alpha3.PodGroup{pg1},
 			isCompositePodGroupEnabled: true,
 		},
 		{
 			name:             "cpg with direct pod group child",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg2WithParent},
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			rootLookupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "cpg1", Type: fwk.CompositePodGroupKeyType},
 			},
-			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg2WithParent},
+			wantLeaves:                 []*schedulingv1alpha3.PodGroup{pg2WithParent},
 			isCompositePodGroupEnabled: true,
 		},
 		{
 			name:             "cpg with nested pod group child",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent, pg3WithParent},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg2WithParent, pg3WithParent},
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1, cpg2WithParent},
 			rootLookupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "cpg1", Type: fwk.CompositePodGroupKeyType},
 			},
-			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg2WithParent, pg3WithParent},
+			wantLeaves:                 []*schedulingv1alpha3.PodGroup{pg2WithParent, pg3WithParent},
 			isCompositePodGroupEnabled: true,
 		},
 		{
 			name:             "missing root",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{},
 			rootLookupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "missing", Type: fwk.CompositePodGroupKeyType},
 			},
@@ -1041,26 +1040,26 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 		},
 		{
 			name:             "single pod group lookup (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
 			rootLookupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "pg1", Type: fwk.PodGroupKeyType},
 			},
-			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg1},
+			wantLeaves:                 []*schedulingv1alpha3.PodGroup{pg1},
 			isCompositePodGroupEnabled: false,
 		},
 		{
 			name:             "pg with direct pod group child lookup (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg2WithParent},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg2WithParent},
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			rootLookupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "pg2", Type: fwk.PodGroupKeyType},
 			},
-			wantLeaves:                 []*schedulingv1beta1.PodGroup{pg2WithParent},
+			wantLeaves:                 []*schedulingv1alpha3.PodGroup{pg2WithParent},
 			isCompositePodGroupEnabled: false,
 		},
 		{
 			name:             "missing root (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{},
 			rootLookupInfo: &framework.QueuedPodGroupInfo{
 				PodGroupInfo: &framework.PodGroupInfo{Namespace: "ns1", Name: "missing", Type: fwk.CompositePodGroupKeyType},
 			},
@@ -1082,11 +1081,11 @@ func TestWorkloadForest_GetLeafPodGroups(t *testing.T) {
 			logger, _ := ktesting.NewTestContext(t)
 			gotLeaves := wf.getLeafPodGroups(logger, tt.rootLookupInfo)
 
-			wantMap := make(map[string]*schedulingv1beta1.PodGroup)
+			wantMap := make(map[string]*schedulingv1alpha3.PodGroup)
 			for _, l := range tt.wantLeaves {
 				wantMap[string(l.UID)] = l
 			}
-			gotMap := make(map[string]*schedulingv1beta1.PodGroup)
+			gotMap := make(map[string]*schedulingv1alpha3.PodGroup)
 			for _, l := range gotLeaves {
 				gotMap[string(l.UID)] = l
 			}
@@ -1103,14 +1102,14 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 
 	tests := []struct {
 		name                       string
-		initialPodGroups           []*schedulingv1beta1.PodGroup
-		pg                         *schedulingv1beta1.PodGroup
+		initialPodGroups           []*schedulingv1alpha3.PodGroup
+		pg                         *schedulingv1alpha3.PodGroup
 		wantInfo                   *framework.PodGroupInfo
 		isCompositePodGroupEnabled bool
 	}{
 		{
 			name:             "build info for existing pod group",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
 			pg:               pg1,
 			wantInfo: &framework.PodGroupInfo{
 				Namespace: "ns1",
@@ -1123,7 +1122,7 @@ func TestWorkloadForest_BuildPodGroupInfoForPG(t *testing.T) {
 		},
 		{
 			name:             "build info for existing pod group (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1},
 			pg:               pg1,
 			wantInfo: &framework.PodGroupInfo{
 				Namespace: "ns1",
@@ -1160,7 +1159,7 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 
 	tests := []struct {
 		name                       string
-		initialPodGroups           []*schedulingv1beta1.PodGroup
+		initialPodGroups           []*schedulingv1alpha3.PodGroup
 		initialCPGs                []*schedulingv1alpha3.CompositePodGroup
 		cpg                        *schedulingv1alpha3.CompositePodGroup
 		wantInfo                   *framework.PodGroupInfo
@@ -1168,7 +1167,7 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 	}{
 		{
 			name:             "build info for cpg with child pg",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1WithParent},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1WithParent},
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpg:              cpg1,
 			wantInfo: &framework.PodGroupInfo{
@@ -1190,7 +1189,7 @@ func TestWorkloadForest_BuildPodGroupInfoForCPG(t *testing.T) {
 		},
 		{
 			name:             "build info for cpg with child pg (CPG=false)",
-			initialPodGroups: []*schedulingv1beta1.PodGroup{pg1WithParent},
+			initialPodGroups: []*schedulingv1alpha3.PodGroup{pg1WithParent},
 			initialCPGs:      []*schedulingv1alpha3.CompositePodGroup{cpg1},
 			cpg:              cpg1,
 			wantInfo: &framework.PodGroupInfo{

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -24,7 +24,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -469,9 +468,9 @@ func (sched *Scheduler) addPodGroup(obj any) {
 	evt := fwk.ClusterEvent{Resource: fwk.PodGroup, ActionType: fwk.Add}
 	defer metrics.EventHandlingLatency.ObserveSince(time.Now(), evt.Label())()
 	logger := sched.logger
-	pg, ok := obj.(*schedulingv1beta1.PodGroup)
+	pg, ok := obj.(*schedulingv1alpha3.PodGroup)
 	if !ok {
-		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert to *v1beta1.PodGroup", "obj", obj)
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert to *v1alpha3.PodGroup", "obj", obj)
 		return
 	}
 
@@ -485,14 +484,14 @@ func (sched *Scheduler) updatePodGroup(oldObj, newObj any) {
 	evt := fwk.ClusterEvent{Resource: fwk.PodGroup, ActionType: fwk.Update}
 	defer metrics.EventHandlingLatency.ObserveSince(time.Now(), evt.Label())()
 	logger := sched.logger
-	oldPG, ok := oldObj.(*schedulingv1beta1.PodGroup)
+	oldPG, ok := oldObj.(*schedulingv1alpha3.PodGroup)
 	if !ok {
-		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert oldObj to *v1beta1.PodGroup", "oldObj", oldObj)
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert oldObj to *v1alpha3.PodGroup", "oldObj", oldObj)
 		return
 	}
-	newPG, ok := newObj.(*schedulingv1beta1.PodGroup)
+	newPG, ok := newObj.(*schedulingv1alpha3.PodGroup)
 	if !ok {
-		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert newObj to *v1beta1.PodGroup", "newObj", newObj)
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert newObj to *v1alpha3.PodGroup", "newObj", newObj)
 		return
 	}
 
@@ -511,19 +510,19 @@ func (sched *Scheduler) deletePodGroup(obj any) {
 	defer metrics.EventHandlingLatency.ObserveSince(time.Now(), evt.Label())()
 
 	logger := sched.logger
-	var pg *schedulingv1beta1.PodGroup
+	var pg *schedulingv1alpha3.PodGroup
 	switch t := obj.(type) {
-	case *schedulingv1beta1.PodGroup:
+	case *schedulingv1alpha3.PodGroup:
 		pg = t
 	case cache.DeletedFinalStateUnknown:
 		var ok bool
-		pg, ok = t.Obj.(*schedulingv1beta1.PodGroup)
+		pg, ok = t.Obj.(*schedulingv1alpha3.PodGroup)
 		if !ok {
-			utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert to *v1beta1.PodGroup", "obj", t.Obj)
+			utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert to *v1alpha3.PodGroup", "obj", t.Obj)
 			return
 		}
 	default:
-		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert to *v1beta1.PodGroup", "obj", t)
+		utilruntime.HandleErrorWithLogger(logger, nil, "Cannot convert to *v1alpha3.PodGroup", "obj", t)
 		return
 	}
 
@@ -659,7 +658,7 @@ func addAllEventHandlers(
 	handlers = append(handlers, handlerRegistration)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
-		if handlerRegistration, err = informerFactory.Scheduling().V1beta1().PodGroups().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		if handlerRegistration, err = informerFactory.Scheduling().V1alpha3().PodGroups().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc:    sched.addPodGroup,
 			UpdateFunc: sched.updatePodGroup,
 			DeleteFunc: sched.deletePodGroup,

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -30,7 +30,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -414,7 +413,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 				reflect.TypeFor[*resourceapi.ResourceSlice]():   true,
 				reflect.TypeFor[*resourceapi.DeviceTaintRule](): true,
 				reflect.TypeFor[*resourceapi.DeviceClass]():     true,
-				reflect.TypeFor[*schedulingapi.PodGroup]():      true,
+				reflect.TypeFor[*schedulingv1alpha3.PodGroup]():      true,
 			},
 			expectDynamicInformers: map[schema.GroupVersionResource]bool{},
 		},
@@ -543,7 +542,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 			expectedStaticInformers := make(map[reflect.Type]bool)
 			maps.Copy(expectedStaticInformers, tt.expectStaticInformers)
 			if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
-				expectedStaticInformers[reflect.TypeFor[*schedulingapi.PodGroup]()] = true
+				expectedStaticInformers[reflect.TypeFor[*schedulingv1alpha3.PodGroup]()] = true
 				if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) {
 					expectedStaticInformers[reflect.TypeFor[*schedulingv1alpha3.CompositePodGroup]()] = true
 				}
@@ -1409,7 +1408,7 @@ func TestAddPodGroup(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		podGroup *schedulingapi.PodGroup
+		podGroup *schedulingv1alpha3.PodGroup
 	}{
 		{
 			name:     "add valid pod group",
@@ -1450,9 +1449,9 @@ func TestUpdatePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		oldPodGroup    *schedulingapi.PodGroup
-		newPodGroup    *schedulingapi.PodGroup
-		expectPodGroup *schedulingapi.PodGroup
+		oldPodGroup    *schedulingv1alpha3.PodGroup
+		newPodGroup    *schedulingv1alpha3.PodGroup
+		expectPodGroup *schedulingv1alpha3.PodGroup
 	}{
 		{
 			name:           "update valid pod group",
@@ -1500,7 +1499,7 @@ func TestDeletePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		initPodGroup     *schedulingapi.PodGroup
+		initPodGroup     *schedulingv1alpha3.PodGroup
 		podGroupToDelete any
 	}{
 		{

--- a/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
+++ b/pkg/scheduler/framework/autoscaler_contract/lister_contract_test.go
@@ -24,7 +24,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/dynamic-resource-allocation/structured/schedulerapi"
@@ -102,7 +101,7 @@ func (c *shareListerContract) CompositePodGroups() fwk.CompositePodGroupLister {
 
 type podGroupListerContract struct{}
 
-func (c *podGroupListerContract) Get(_ string, _ string) (*schedulingapi.PodGroup, error) {
+func (c *podGroupListerContract) Get(_ string, _ string) (*schedulingv1alpha3.PodGroup, error) {
 	return nil, nil
 }
 

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -35,7 +35,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	"k8s.io/api/scheduling/v1alpha3"
-	"k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -212,7 +211,7 @@ func TestPostFilter(t *testing.T) {
 		pods                  []*v1.Pod
 		pdbs                  []*policy.PodDisruptionBudget
 		nodes                 []*v1.Node
-		podGroups             []*v1beta1.PodGroup
+		podGroups             []*v1alpha3.PodGroup
 		filteredNodesStatuses *framework.NodeToStatus
 		features              feature.Features
 		extender              fwk.Extender
@@ -1794,7 +1793,7 @@ func TestCustomSelection(t *testing.T) {
 		nodeNames          []string
 		pod                *v1.Pod
 		pods               []*v1.Pod
-		podGroups          []*v1beta1.PodGroup
+		podGroups          []*v1alpha3.PodGroup
 		compositePodGroups []*v1alpha3.CompositePodGroup
 		features           feature.Features
 		expected           map[string][]string
@@ -1928,7 +1927,7 @@ func TestCustomSelection(t *testing.T) {
 				st.MakePod().Name("v1").UID("v1").Namespace(v1.NamespaceDefault).Node("node1").Label("preemptible", "yes").PodGroupName("pg1").Priority(lowPriority).Req(largeRes).StartTime(epochTime).Obj(),
 				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node2").Label("preemptible", "yes").PodGroupName("pg1").Priority(lowPriority).Req(largeRes).StartTime(epochTime).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
 			},
 			features: feature.Features{EnableGenericWorkload: true},
@@ -1944,7 +1943,7 @@ func TestCustomSelection(t *testing.T) {
 				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node2").PodGroupName("pg1").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
 				st.MakePod().Name("v3").UID("v3").Namespace(v1.NamespaceDefault).Node("node1").Priority(midPriority).Req(largeRes).StartTime(epochTime).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
 			},
 			features: feature.Features{EnableGenericWorkload: true},
@@ -1959,7 +1958,7 @@ func TestCustomSelection(t *testing.T) {
 				st.MakePod().Name("v1").UID("v1").Namespace(v1.NamespaceDefault).Node("node1").Label("preemptible", "yes").PodGroupName("pg1").Priority(lowPriority).Req(largeRes).StartTime(epochTime).Obj(),
 				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node2").Label("preemptible", "yes").PodGroupName("pg2").Priority(lowPriority).Req(largeRes).StartTime(epochTime).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").Namespace(v1.NamespaceDefault).ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg2").UID("pg2").Namespace(v1.NamespaceDefault).ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 			},
@@ -1979,7 +1978,7 @@ func TestCustomSelection(t *testing.T) {
 				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node2").PodGroupName("pg2").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
 				st.MakePod().Name("v3").UID("v3").Namespace(v1.NamespaceDefault).Node("node1").Priority(midPriority).Req(largeRes).StartTime(epochTime).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").Namespace(v1.NamespaceDefault).ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg2").UID("pg2").Namespace(v1.NamespaceDefault).ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 			},
@@ -2184,7 +2183,7 @@ func TestCustomOrdering(t *testing.T) {
 		nodeNames          []string
 		preemptor          *v1.Pod
 		pods               []*v1.Pod
-		podGroups          []*v1beta1.PodGroup
+		podGroups          []*v1alpha3.PodGroup
 		compositePodGroups []*v1alpha3.CompositePodGroup
 		features           feature.Features
 		expectedPods       []string
@@ -2229,7 +2228,7 @@ func TestCustomOrdering(t *testing.T) {
 				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
 				st.MakePod().Name("v3").UID("v3").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
 			},
 			features: feature.Features{EnableGenericWorkload: true},
@@ -2246,7 +2245,7 @@ func TestCustomOrdering(t *testing.T) {
 				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-large").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
 				st.MakePod().Name("v3").UID("v3").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-large").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg-small").UID("pg-small").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
 				st.MakePodGroup().Name("pg-large").UID("pg-large").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
 			},
@@ -2263,7 +2262,7 @@ func TestCustomOrdering(t *testing.T) {
 				st.MakePod().Name("v1").UID("v1").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-a").Priority(lowPriority).Req(mediumRes).StartTime(epochTime1).Obj(),
 				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-z").Priority(lowPriority).Req(mediumRes).StartTime(epochTime).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg-a").UID("pg-a").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
 				st.MakePodGroup().Name("pg-z").UID("pg-z").Namespace(v1.NamespaceDefault).DisruptionModeAll().Obj(),
 			},
@@ -2281,7 +2280,7 @@ func TestCustomOrdering(t *testing.T) {
 				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg1").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
 				st.MakePod().Name("v3").UID("v3").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg2").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").Namespace(v1.NamespaceDefault).ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg2").UID("pg2").Namespace(v1.NamespaceDefault).ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 			},
@@ -2301,7 +2300,7 @@ func TestCustomOrdering(t *testing.T) {
 				st.MakePod().Name("v2").UID("v2").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-large1").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
 				st.MakePod().Name("v3").UID("v3").Namespace(v1.NamespaceDefault).Node("node1").PodGroupName("pg-large2").Priority(lowPriority).Req(smallRes).StartTime(epochTime).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg-small").UID("pg-small").Namespace(v1.NamespaceDefault).ParentCompositePodGroup("cpg-small").Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg-large1").UID("pg-large1").Namespace(v1.NamespaceDefault).ParentCompositePodGroup("cpg-large").Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg-large2").UID("pg-large2").Namespace(v1.NamespaceDefault).ParentCompositePodGroup("cpg-large").Priority(lowPriority).Obj(),
@@ -2421,7 +2420,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 		name                string
 		pod                 *v1.Pod
 		pods                []*v1.Pod
-		podGroups           []*v1beta1.PodGroup
+		podGroups           []*v1alpha3.PodGroup
 		compositePodGroups  []*v1alpha3.CompositePodGroup
 		nodes               []string
 		features            feature.Features
@@ -2474,7 +2473,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 				st.MakePod().Name("v1").UID("v1").Namespace("ns2").Node("node1").Priority(veryHighPriority).PodGroupName("pg1").Terminating().
 					Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").Namespace("ns2").Priority(lowPriority).Obj(),
 			},
 			nodes:    []string{"node1"},
@@ -2488,7 +2487,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 				st.MakePod().Name("v1").UID("v1").Namespace("ns2").Node("node1").Priority(veryHighPriority).PodGroupName("pg1").Terminating().
 					Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").Namespace("ns2").ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 			},
 			compositePodGroups: []*v1alpha3.CompositePodGroup{
@@ -2505,7 +2504,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 				st.MakePod().Name("v1").UID("v1").Namespace("ns2").Node("node1").Priority(veryHighPriority).PodGroupName("pg1").Terminating().
 					Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").Namespace("ns2").ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 			},
 			nodes:    []string{"node1"},
@@ -2530,7 +2529,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 				st.MakePod().Name("v1").UID("v1").Namespace("ns2").Node("node1").Priority(veryHighPriority).PodGroupName("leaf-pg").Terminating().
 					Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Obj(),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("leaf-pg").UID("leaf-pg").Namespace("ns2").ParentCompositePodGroup("child-cpg").Priority(veryHighPriority).Obj(),
 			},
 			compositePodGroups: []*v1alpha3.CompositePodGroup{
@@ -3052,7 +3051,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 		initPods                   []*v1.Pod
 		preemptor                  *v1.Pod
 		pdbs                       []*policy.PodDisruptionBudget
-		podGroups                  []*v1beta1.PodGroup
+		podGroups                  []*v1alpha3.PodGroup
 		registerPlugins            []tf.RegisterPluginFunc
 		features                   feature.Features
 		expectedPods               sets.Set[string]
@@ -3124,7 +3123,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			nodeNames: []string{"node1"},
 			mainNode:  "node1",
 			features:  feature.Features{EnableGenericWorkload: true},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -3140,7 +3139,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			nodeNames: []string{"node1"},
 			mainNode:  "node1",
 			features:  feature.Features{EnableGenericWorkload: true},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -3157,7 +3156,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			nodeNames: []string{"node1"},
 			mainNode:  "node1",
 			features:  feature.Features{EnableGenericWorkload: true},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -3173,7 +3172,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			nodeNames: []string{"node1"},
 			mainNode:  "node1",
 			features:  feature.Features{EnableGenericWorkload: true},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(highPriority).DisruptionModeAll().Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -3189,7 +3188,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			nodeNames: []string{"node1"},
 			mainNode:  "node1",
 			features:  feature.Features{EnableGenericWorkload: true},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -3212,7 +3211,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			nodeNames: []string{"node1"},
 			mainNode:  "node1",
 			features:  feature.Features{EnableGenericWorkload: true},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg-violating").Namespace(v1.NamespaceDefault).UID("pg-violating").Priority(lowPriority).DisruptionModeAll().Obj(),
 				st.MakePodGroup().Name("pg-non-violating").Namespace(v1.NamespaceDefault).UID("pg-non-violating").Priority(midPriority).DisruptionModeAll().Obj(),
 			},
@@ -3236,7 +3235,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			nodeNames: []string{"node1"},
 			mainNode:  "node1",
 			features:  feature.Features{EnableGenericWorkload: true},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg-violating").Namespace(v1.NamespaceDefault).UID("pg-violating").Priority(lowPriority).DisruptionModeSingle().Obj(),
 				st.MakePodGroup().Name("pg-non-violating").Namespace(v1.NamespaceDefault).UID("pg-non-violating").Priority(midPriority).DisruptionModeSingle().Obj(),
 			},
@@ -3285,7 +3284,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			registerPlugins: []tf.RegisterPluginFunc{
 				tf.RegisterPluginAsExtensions(interpodaffinity.Name, frameworkruntime.FactoryAdapter(feature.Features{}, interpodaffinity.New), "Filter", "PreFilter"),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -3305,7 +3304,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			registerPlugins: []tf.RegisterPluginFunc{
 				tf.RegisterPluginAsExtensions(interpodaffinity.Name, frameworkruntime.FactoryAdapter(feature.Features{}, interpodaffinity.New), "Filter", "PreFilter"),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -3325,7 +3324,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			registerPlugins: []tf.RegisterPluginFunc{
 				tf.RegisterPluginAsExtensions(interpodaffinity.Name, frameworkruntime.FactoryAdapter(feature.Features{}, interpodaffinity.New), "Filter", "PreFilter"),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -3345,7 +3344,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			registerPlugins: []tf.RegisterPluginFunc{
 				tf.RegisterPluginAsExtensions(podtopologyspread.Name, podTopologySpreadFunc, "PreFilter", "Filter"),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -3366,7 +3365,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			registerPlugins: []tf.RegisterPluginFunc{
 				tf.RegisterPluginAsExtensions(podtopologyspread.Name, podTopologySpreadFunc, "PreFilter", "Filter"),
 			},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -3385,7 +3384,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			nodeNames: []string{"node-a", "node-b"},
 			mainNode:  "node-a",
 			features:  feature.Features{EnableGenericWorkload: true},
-			podGroups: []*v1beta1.PodGroup{
+			podGroups: []*v1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace(v1.NamespaceDefault).UID("pg1").Priority(lowPriority).DisruptionModeAll().Obj(),
 			},
 			initPods: []*v1.Pod{
@@ -3715,7 +3714,7 @@ func TestPreEnqueue(t *testing.T) {
 				}
 			}
 
-			var allPgs []*v1beta1.PodGroup
+			var allPgs []*v1alpha3.PodGroup
 			var allCpgs []*v1alpha3.CompositePodGroup
 
 			if tt.pgInfo != nil {
@@ -3997,7 +3996,7 @@ func TestDefaultPreemption_PodGroupPostFilter_InvalidSnapshot(t *testing.T) {
 			testPods := []*v1.Pod{pod}
 			nodes := []*v1.Node{node}
 
-			var pg *v1beta1.PodGroup
+			var pg *v1alpha3.PodGroup
 			var cpg *v1alpha3.CompositePodGroup
 			var client *clientsetfake.Clientset
 			var cache internalcache.Cache
@@ -4008,7 +4007,7 @@ func TestDefaultPreemption_PodGroupPostFilter_InvalidSnapshot(t *testing.T) {
 				client = clientsetfake.NewClientset(pod, pg)
 				cache = internalcache.New(ctx, nil, true, false)
 				cache.AddPodGroup(pg)
-				snapshot = internalcache.NewTestSnapshotWithPodGroups(testPods, nodes, []*v1beta1.PodGroup{pg})
+				snapshot = internalcache.NewTestSnapshotWithPodGroups(testPods, nodes, []*v1alpha3.PodGroup{pg})
 			} else {
 				priorityVal := highPriority
 				cpg = &v1alpha3.CompositePodGroup{
@@ -4260,7 +4259,7 @@ func getCounterFromGatherer(g componentmetrics.Gatherer, name string, resultLabe
 }
 
 // newPGInfo creates a PodGroupInfo representing a standalone PodGroup.
-func newPGInfo(pg *v1beta1.PodGroup, pods ...*v1.Pod) *framework.PodGroupInfo {
+func newPGInfo(pg *v1alpha3.PodGroup, pods ...*v1.Pod) *framework.PodGroupInfo {
 	return &framework.PodGroupInfo{
 		Name:            pg.Name,
 		Namespace:       pg.Namespace,
@@ -4284,8 +4283,8 @@ func newCPGInfo(cpg *v1alpha3.CompositePodGroup, children []*framework.PodGroupI
 
 // extractGroups is an auxiliary method to extract all PodGroups and CompositePodGroups
 // API objects from a PodGroupInfo, useful for setting up tests.
-func extractGroups(pgInfo *framework.PodGroupInfo) ([]*v1beta1.PodGroup, []*v1alpha3.CompositePodGroup) {
-	var pgs []*v1beta1.PodGroup
+func extractGroups(pgInfo *framework.PodGroupInfo) ([]*v1alpha3.PodGroup, []*v1alpha3.CompositePodGroup) {
+	var pgs []*v1alpha3.PodGroup
 	var cpgs []*v1alpha3.CompositePodGroup
 
 	var traverse func(info *framework.PodGroupInfo)

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -28,7 +28,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	schedulingapi "k8s.io/api/scheduling/v1beta1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -37,7 +37,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	schedulingapi "k8s.io/api/scheduling/v1beta1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -4681,7 +4681,7 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 		tCtx.ExpectNoError(err, "create resource class")
 	}
 	for _, podGroup := range podGroups {
-		_, err := tc.client.SchedulingV1beta1().PodGroups(podGroup.Namespace).Create(tCtx, podGroup, metav1.CreateOptions{})
+		_, err := tc.client.SchedulingV1alpha3().PodGroups(podGroup.Namespace).Create(tCtx, podGroup, metav1.CreateOptions{})
 		tCtx.ExpectNoError(err, "create pod group")
 	}
 

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
@@ -112,7 +111,7 @@ func (pl *GangScheduling) isSchedulableAfterPodAdded(logger klog.Logger, pod *v1
 
 // isSchedulableAfterPodGroupUpdated triggers re-enqueueing of the group's pods if the minCount requirement has decreased.
 func (pl *GangScheduling) isSchedulableAfterPodGroupUpdated(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
-	oldPodGroup, newPodGroup, err := util.As[*schedulingapi.PodGroup](oldObj, newObj)
+	oldPodGroup, newPodGroup, err := util.As[*schedulingv1alpha3.PodGroup](oldObj, newObj)
 	if err != nil {
 		return fwk.Queue, err
 	}
@@ -144,7 +143,7 @@ func (pl *GangScheduling) isSchedulableAfterPodGroupUpdated(logger klog.Logger, 
 }
 
 func (pl *GangScheduling) isSchedulableAfterPodGroupAdded(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
-	_, addedPodGroup, err := util.As[*schedulingapi.PodGroup](oldObj, newObj)
+	_, addedPodGroup, err := util.As[*schedulingv1alpha3.PodGroup](oldObj, newObj)
 	if err != nil {
 		return fwk.Queue, err
 	}
@@ -362,7 +361,7 @@ func (pl *GangScheduling) Permit(ctx context.Context, state fwk.CycleState, pod 
 	namespace := pod.Namespace
 	schedulingGroup := pod.Spec.SchedulingGroup
 
-	var podGroup *schedulingapi.PodGroup
+	var podGroup *schedulingv1alpha3.PodGroup
 	var err error
 	var snapshot fwk.PodGroupManager
 
@@ -393,7 +392,7 @@ func (pl *GangScheduling) Permit(ctx context.Context, state fwk.CycleState, pod 
 	return pl.permitPodGroup(logger, pod, podGroup, podGroupState)
 }
 
-func (pl *GangScheduling) permitPodGroup(logger klog.Logger, pod *v1.Pod, podGroup *schedulingapi.PodGroup, podGroupState fwk.PodGroupState) (*fwk.Status, time.Duration) {
+func (pl *GangScheduling) permitPodGroup(logger klog.Logger, pod *v1.Pod, podGroup *schedulingv1alpha3.PodGroup, podGroupState fwk.PodGroupState) (*fwk.Status, time.Duration) {
 	if podGroup.Spec.SchedulingPolicy.Gang == nil {
 		return nil, 0
 	}

--- a/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
+++ b/pkg/scheduler/framework/plugins/gangscheduling/gangscheduling_test.go
@@ -24,7 +24,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -54,7 +53,7 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 		name                       string
 		pod                        *v1.Pod
 		newPod                     *v1.Pod
-		pgs                        []*schedulingv1beta1.PodGroup
+		pgs                        []*schedulingv1alpha3.PodGroup
 		cpgs                       []*schedulingv1alpha3.CompositePodGroup
 		expectedHint               fwk.QueueingHint
 		isCompositePodGroupEnabled bool
@@ -91,7 +90,7 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			name:   "add a newPod which doesn't match the pod's namespace",
 			pod:    st.MakePod().Name("p").PodGroupName("pg").Obj(),
 			newPod: st.MakePod().Namespace("foo").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg").Obj(),
 				st.MakePodGroup().Namespace("foo").Name("pg").Obj(),
 			},
@@ -102,7 +101,7 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			name:   "add a newPod which doesn't match the pod's namespace (CPG=false)",
 			pod:    st.MakePod().Name("p").PodGroupName("pg").Obj(),
 			newPod: st.MakePod().Namespace("foo").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg").Obj(),
 				st.MakePodGroup().Namespace("foo").Name("pg").Obj(),
 			},
@@ -113,7 +112,7 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			name:   "add a newPod which doesn't match the pod's pod group name",
 			pod:    st.MakePod().Name("p").PodGroupName("pg1").Obj(),
 			newPod: st.MakePod().PodGroupName("pg2").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Obj(),
 				st.MakePodGroup().Name("pg2").Obj(),
 			},
@@ -124,7 +123,7 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			name:   "add a newPod which doesn't match the pod's pod group name (CPG=false)",
 			pod:    st.MakePod().Name("p").PodGroupName("pg1").Obj(),
 			newPod: st.MakePod().PodGroupName("pg2").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Obj(),
 				st.MakePodGroup().Name("pg2").Obj(),
 			},
@@ -135,7 +134,7 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			name:   "add a newPod which belongs to a different scheduling group but matches the root CPG",
 			pod:    st.MakePod().Name("p1").PodGroupName("pg1").Obj(),
 			newPod: st.MakePod().Name("p2").PodGroupName("pg2").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Obj(),
 				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Obj(),
 			},
@@ -149,7 +148,7 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			name:   "add a newPod which belongs to a different scheduling group but matches the root CPG (CPG=false)",
 			pod:    st.MakePod().Name("p1").PodGroupName("pg1").Obj(),
 			newPod: st.MakePod().Name("p2").PodGroupName("pg2").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Obj(),
 				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Obj(),
 			},
@@ -163,7 +162,7 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			name:   "add a newPod which belongs to a different scheduling group and does not match the root CPG",
 			pod:    st.MakePod().Name("p1").PodGroupName("pg1").Obj(),
 			newPod: st.MakePod().Name("p2").PodGroupName("pg2").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root1").Obj(),
 				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root2").Obj(),
 			},
@@ -178,7 +177,7 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			name:   "add a newPod which belongs to a different scheduling group and does not match the root CPG (CPG=false)",
 			pod:    st.MakePod().Name("p1").PodGroupName("pg1").Obj(),
 			newPod: st.MakePod().Name("p2").PodGroupName("pg2").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root1").Obj(),
 				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root2").Obj(),
 			},
@@ -207,7 +206,7 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
 
 			for _, pg := range tc.pgs {
-				if err := informerFactory.Scheduling().V1beta1().PodGroups().Informer().GetStore().Add(pg); err != nil {
+				if err := informerFactory.Scheduling().V1alpha3().PodGroups().Informer().GetStore().Add(pg); err != nil {
 					t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
 				}
 			}
@@ -226,7 +225,7 @@ func Test_isSchedulableAfterPodAdded(t *testing.T) {
 
 			p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
 			if err == nil {
-				pgMap := make(map[string]*schedulingv1beta1.PodGroup)
+				pgMap := make(map[string]*schedulingv1alpha3.PodGroup)
 				for _, pg := range tc.pgs {
 					pgMap[pg.Name] = pg
 				}
@@ -254,8 +253,8 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 	tests := []struct {
 		name                       string
 		pod                        *v1.Pod
-		newPodGroup                *schedulingv1beta1.PodGroup
-		pgs                        []*schedulingv1beta1.PodGroup
+		newPodGroup                *schedulingv1alpha3.PodGroup
+		pgs                        []*schedulingv1alpha3.PodGroup
 		cpgs                       []*schedulingv1alpha3.CompositePodGroup
 		expectedHint               fwk.QueueingHint
 		isCompositePodGroupEnabled bool
@@ -278,7 +277,7 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 			name:        "add a pod group which doesn't match the pod's scheduling group name",
 			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
 			newPodGroup: st.MakePodGroup().Name("pg2").MinCount(1).WorkloadRef("t", "w").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Obj(),
 			},
 			expectedHint:               fwk.QueueSkip,
@@ -288,7 +287,7 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 			name:        "add a pod group which doesn't match the pod's scheduling group name (CPG=false)",
 			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
 			newPodGroup: st.MakePodGroup().Name("pg2").MinCount(1).WorkloadRef("t", "w").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Obj(),
 			},
 			expectedHint:               fwk.QueueSkip,
@@ -298,7 +297,7 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 			name:        "add a pod group which doesn't match the pod's scheduling group namespace",
 			pod:         st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
 			newPodGroup: st.MakePodGroup().Namespace("ns2").Name("pg").MinCount(1).WorkloadRef("t", "w").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Namespace("ns1").Name("pg").Obj(),
 			},
 			expectedHint:               fwk.QueueSkip,
@@ -308,7 +307,7 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 			name:        "add a pod group which doesn't match the pod's scheduling group namespace (CPG=false)",
 			pod:         st.MakePod().Namespace("ns1").Name("p").PodGroupName("pg").Obj(),
 			newPodGroup: st.MakePodGroup().Namespace("ns2").Name("pg").MinCount(1).WorkloadRef("t", "w").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Namespace("ns1").Name("pg").Obj(),
 			},
 			expectedHint:               fwk.QueueSkip,
@@ -318,7 +317,7 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 			name:        "add a pod group which doesn't match the pod's scheduling group but matches the root CPG",
 			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
 			newPodGroup: st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").MinCount(1).Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
@@ -331,7 +330,7 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 			name:        "add a pod group which doesn't match the pod's scheduling group but matches the root CPG (CPG=false)",
 			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
 			newPodGroup: st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").MinCount(1).Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
@@ -344,7 +343,7 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 			name:        "add a pod group which doesn't match the pod's scheduling group and doesn't match the root CPG",
 			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
 			newPodGroup: st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root2").MinCount(1).Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root1").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
@@ -358,7 +357,7 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 			name:        "add a pod group which doesn't match the pod's scheduling group and doesn't match the root CPG (CPG=false)",
 			pod:         st.MakePod().Name("p").PodGroupName("pg1").Obj(),
 			newPodGroup: st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root2").MinCount(1).Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root1").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
@@ -386,7 +385,7 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
 
 			for _, pg := range tc.pgs {
-				if err := informerFactory.Scheduling().V1beta1().PodGroups().Informer().GetStore().Add(pg); err != nil {
+				if err := informerFactory.Scheduling().V1alpha3().PodGroups().Informer().GetStore().Add(pg); err != nil {
 					t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
 				}
 			}
@@ -405,7 +404,7 @@ func Test_isSchedulableAfterPodGroupAdded(t *testing.T) {
 
 			p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
 			if err == nil {
-				pgMap := make(map[string]*schedulingv1beta1.PodGroup)
+				pgMap := make(map[string]*schedulingv1alpha3.PodGroup)
 				for _, pg := range tc.pgs {
 					pgMap[pg.Name] = pg
 				}
@@ -436,8 +435,8 @@ func Test_isSchedulableAfterPodGroupUpdated(t *testing.T) {
 	tests := []struct {
 		name                       string
 		pod                        *v1.Pod
-		oldPodGroup                *schedulingv1beta1.PodGroup
-		newPodGroup                *schedulingv1beta1.PodGroup
+		oldPodGroup                *schedulingv1alpha3.PodGroup
+		newPodGroup                *schedulingv1alpha3.PodGroup
 		expectedHint               fwk.QueueingHint
 		expectErr                  bool
 		isCompositePodGroupEnabled bool
@@ -572,7 +571,7 @@ func Test_isSchedulableAfterPodGroupUpdated(t *testing.T) {
 
 			p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
 			if err == nil {
-				pgMap := make(map[string]*schedulingv1beta1.PodGroup)
+				pgMap := make(map[string]*schedulingv1alpha3.PodGroup)
 				if tc.oldPodGroup != nil {
 					pgMap[tc.oldPodGroup.Name] = tc.oldPodGroup
 				}
@@ -618,14 +617,14 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 		pod                        *v1.Pod
 		newCPG                     *schedulingv1alpha3.CompositePodGroup
 		cpgs                       []*schedulingv1alpha3.CompositePodGroup
-		pgs                        []*schedulingv1beta1.PodGroup
+		pgs                        []*schedulingv1alpha3.PodGroup
 		expectedHint               fwk.QueueingHint
 		isCompositePodGroupEnabled bool
 	}{
 		{
 			name: "add a CPG which matches the pod's root CPG",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
 			},
 			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
@@ -635,7 +634,7 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 		{
 			name: "add a CPG which matches the pod's root CPG (CPG=false)",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
 			},
 			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
@@ -645,7 +644,7 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 		{
 			name: "add a CPG which matches the pod's root CPG",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-root").Obj(),
 			},
 			newCPG:                     st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj(),
@@ -655,7 +654,7 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 		{
 			name: "add a CPG which matches the pod's intermediate CPG but implies the same root",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
@@ -668,7 +667,7 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 		{
 			name: "add a CPG which matches the pod's intermediate CPG but implies the same root (CPG=false)",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
@@ -681,7 +680,7 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 		{
 			name: "add a CPG which matches the pod's intermediate CPG but implies the same root",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-sub").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
@@ -694,7 +693,7 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 		{
 			name: "add a CPG which does not match the pod's CPG hierarchy",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-1").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
@@ -708,7 +707,7 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 		{
 			name: "add a CPG which does not match the pod's CPG hierarchy (CPG=false)",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-1").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
@@ -722,7 +721,7 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 		{
 			name: "add a CPG which does not match the pod's CPG hierarchy",
 			pod:  st.MakePod().Namespace("default").Name("p").PodGroupName("pg").Obj(),
-			pgs: []*schedulingv1beta1.PodGroup{
+			pgs: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Namespace("default").Name("pg").ParentCompositePodGroup("cpg-1").Obj(),
 			},
 			cpgs: []*schedulingv1alpha3.CompositePodGroup{
@@ -754,7 +753,7 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 
 			// We need to wait for informers to sync
 			for _, pg := range tc.pgs {
-				if err := informerFactory.Scheduling().V1beta1().PodGroups().Informer().GetStore().Add(pg); err != nil {
+				if err := informerFactory.Scheduling().V1alpha3().PodGroups().Informer().GetStore().Add(pg); err != nil {
 					t.Fatalf("Failed to add podGroup %s to store: %v", pg.Name, err)
 				}
 			}
@@ -773,7 +772,7 @@ func Test_isSchedulableAfterCompositePodGroupAdded(t *testing.T) {
 
 			p, err := New(ctx, nil, fh, feature.NewSchedulerFeaturesFromGates(utilfeature.DefaultFeatureGate))
 			if err == nil {
-				pgMap := make(map[string]*schedulingv1beta1.PodGroup)
+				pgMap := make(map[string]*schedulingv1alpha3.PodGroup)
 				for _, pg := range tc.pgs {
 					pgMap[pg.Name] = pg
 				}
@@ -900,7 +899,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 		name                            string
 		pod                             *v1.Pod
 		initialPods                     []*v1.Pod
-		initialPodGroups                []*schedulingv1beta1.PodGroup
+		initialPodGroups                []*schedulingv1alpha3.PodGroup
 		initialCompositePodGroups       []*schedulingv1alpha3.CompositePodGroup
 		podsWaitingOnPermit             []*v1.Pod
 		isDuringPodGroupSchedulingCycle bool
@@ -915,7 +914,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			name:                       "non-gang pod succeeds immediately (CPG=false)",
 			pod:                        nonGangPod,
 			isCompositePodGroupEnabled: false,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           nil,
 		},
@@ -923,7 +922,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			name:                       "non-gang pod succeeds immediately (CPG=true)",
 			pod:                        nonGangPod,
 			isCompositePodGroupEnabled: true,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           nil,
 		},
@@ -931,7 +930,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			name:                       "basic policy pod succeeds immediately (CPG=false)",
 			pod:                        basicPolicyPod,
 			isCompositePodGroupEnabled: false,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           nil,
 		},
@@ -939,7 +938,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			name:                       "basic policy pod succeeds immediately (CPG=true)",
 			pod:                        basicPolicyPod,
 			isCompositePodGroupEnabled: true,
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{gangPodGroup1, gangPodGroup2, basicPodGroup},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           nil,
 		},
@@ -948,7 +947,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p1,
 			isCompositePodGroupEnabled: false,
 			initialPods:                []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, `waiting for pods's pod group "pg1" to appear in scheduling queue`),
 		},
 		{
@@ -956,7 +955,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p1,
 			isCompositePodGroupEnabled: true,
 			initialPods:                []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "failed to build hierarchy snapshot: pod group object not found in state for podgroup/ns1/pg1"),
 		},
 		{
@@ -964,7 +963,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p1,
 			isCompositePodGroupEnabled: false,
 			initialPods:                []*v1.Pod{p2, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{gangPodGroup1, gangPodGroup2},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
 		},
 		{
@@ -972,7 +971,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p1,
 			isCompositePodGroupEnabled: true,
 			initialPods:                []*v1.Pod{p2, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{gangPodGroup1, gangPodGroup2},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
 		},
 		{
@@ -980,7 +979,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p1,
 			isCompositePodGroupEnabled: false,
 			initialPods:                []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{gangPodGroup1, gangPodGroup2},
 			podsWaitingOnPermit:        []*v1.Pod{p2, p4, p5},
 			wantPreEnqueueStatus:       nil,
 			wantActivatedPods:          []*v1.Pod{p3},
@@ -991,7 +990,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p1,
 			isCompositePodGroupEnabled: true,
 			initialPods:                []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{gangPodGroup1, gangPodGroup2},
 			podsWaitingOnPermit:        []*v1.Pod{p2, p4, p5},
 			wantPreEnqueueStatus:       nil,
 			wantActivatedPods:          []*v1.Pod{p3},
@@ -1002,7 +1001,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p1,
 			isCompositePodGroupEnabled: false,
 			initialPods:                []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{gangPodGroup1, gangPodGroup2},
 			podsWaitingOnPermit:        []*v1.Pod{p2, p3, p4, p5},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           nil,
@@ -1013,7 +1012,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p1,
 			isCompositePodGroupEnabled: true,
 			initialPods:                []*v1.Pod{p2, p3, p4, p5},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{gangPodGroup1, gangPodGroup2},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{gangPodGroup1, gangPodGroup2},
 			podsWaitingOnPermit:        []*v1.Pod{p2, p3, p4, p5},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           nil,
@@ -1024,7 +1023,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p1CPG,
 			isCompositePodGroupEnabled: true,
 			initialPods:                []*v1.Pod{},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for composite pod group \"cpg-root\" tree to meet quorum"),
 		},
@@ -1033,7 +1032,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p1CPG,
 			isCompositePodGroupEnabled: false,
 			initialPods:                []*v1.Pod{},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           nil,
@@ -1043,7 +1042,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p6CPG,
 			isCompositePodGroupEnabled: true,
 			initialPods:                []*v1.Pod{p1CPG, p2CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for composite pod group \"cpg-root\" tree to meet quorum"),
 		},
@@ -1052,7 +1051,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p6CPG,
 			isCompositePodGroupEnabled: false,
 			initialPods:                []*v1.Pod{p1CPG, p2CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           nil,
@@ -1063,7 +1062,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			isCompositePodGroupEnabled: true,
 			initialPods:                []*v1.Pod{p1CPG, p2CPG, p6CPG},
 			podsWaitingOnPermit:        []*v1.Pod{p1CPG, p2CPG, p6CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           nil,
@@ -1073,7 +1072,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p4CPG,
 			isCompositePodGroupEnabled: false,
 			initialPods:                []*v1.Pod{p1CPG, p2CPG, p6CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
 		},
@@ -1082,7 +1081,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p2_1,
 			isCompositePodGroupEnabled: true,
 			initialPods:                []*v1.Pod{p1_1, p1_2},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgBasic1, pgBasic2},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pgBasic1, pgBasic2},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgBasicRoot},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           fwk.NewStatus(fwk.Wait, "waiting for composite pod group \"cpg-basic-root\" tree to meet quorum"),
@@ -1092,7 +1091,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p2_1,
 			isCompositePodGroupEnabled: false,
 			initialPods:                []*v1.Pod{p1_1, p1_2},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pgBasic1, pgBasic2},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pgBasic1, pgBasic2},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgBasicRoot},
 			wantPreEnqueueStatus:       fwk.NewStatus(fwk.UnschedulableAndUnresolvable, "waiting for minCount pods from a gang to appear in scheduling queue"),
 		},
@@ -1101,7 +1100,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p4CPG,
 			isCompositePodGroupEnabled: true,
 			initialPods:                []*v1.Pod{p1CPG, p2CPG, p6CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           fwk.NewStatus(fwk.Wait, "waiting for composite pod group \"cpg-root\" tree to meet quorum"),
@@ -1111,7 +1110,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			pod:                        p4CPG,
 			isCompositePodGroupEnabled: false,
 			initialPods:                []*v1.Pod{p1CPG, p2CPG, p6CPG},
-			initialPodGroups:           []*schedulingv1beta1.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
+			initialPodGroups:           []*schedulingv1alpha3.PodGroup{pg1, pg2, pg3, pg4, pg5, pg6, pg7},
 			initialCompositePodGroups:  []*schedulingv1alpha3.CompositePodGroup{cpgRoot, cpgSub1, cpgSub2, cpgSub3},
 			wantPreEnqueueStatus:       nil,
 			wantPermitStatus:           nil,
@@ -1129,7 +1128,7 @@ func TestGangSchedulingFlow(t *testing.T) {
 			cache := internalcache.New(ctx, nil, true, tt.isCompositePodGroupEnabled)
 
 			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(), 0)
-			podGroupInformer := informerFactory.Scheduling().V1beta1().PodGroups()
+			podGroupInformer := informerFactory.Scheduling().V1alpha3().PodGroups()
 			if tt.isCompositePodGroupEnabled {
 				informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
 			}
@@ -1778,9 +1777,9 @@ func TestPlacementFeasible(t *testing.T) {
 			} else {
 				pg := st.MakePodGroup().Namespace(namespace).Name(pgName).ParentCompositePodGroup("cpg-root").Obj()
 				if tc.minCount > 0 {
-					pg.Spec.SchedulingPolicy.Gang = &schedulingv1beta1.GangSchedulingPolicy{MinCount: tc.minCount}
+					pg.Spec.SchedulingPolicy.Gang = &schedulingv1alpha3.GangSchedulingPolicy{MinCount: tc.minCount}
 				} else {
-					pg.Spec.SchedulingPolicy.Basic = &schedulingv1beta1.BasicSchedulingPolicy{}
+					pg.Spec.SchedulingPolicy.Basic = &schedulingv1alpha3.BasicSchedulingPolicy{}
 				}
 				pgInfo.groupType = fwk.PodGroupKeyType
 				pgInfo.podGroup = pg
@@ -1788,7 +1787,7 @@ func TestPlacementFeasible(t *testing.T) {
 			}
 
 			informerFactory := informers.NewSharedInformerFactory(fake.NewClientset(objs...), 0)
-			informerFactory.Scheduling().V1beta1().PodGroups().Informer()
+			informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
 			if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) {
 				informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
 			}
@@ -1844,13 +1843,13 @@ type testPodGroupInfo struct {
 	groupType       fwk.EntityKeyType
 	unscheduledPods []*v1.Pod
 	cpg             *schedulingv1alpha3.CompositePodGroup
-	podGroup        *schedulingv1beta1.PodGroup
+	podGroup        *schedulingv1alpha3.PodGroup
 }
 
 func (t *testPodGroupInfo) GetNamespace() string                     { return t.namespace }
 func (t *testPodGroupInfo) GetName() string                          { return t.name }
 func (t *testPodGroupInfo) GetUnscheduledPods() []*v1.Pod            { return t.unscheduledPods }
-func (t *testPodGroupInfo) GetPodGroup() *schedulingv1beta1.PodGroup { return t.podGroup }
+func (t *testPodGroupInfo) GetPodGroup() *schedulingv1alpha3.PodGroup { return t.podGroup }
 func (t *testPodGroupInfo) GetType() fwk.EntityKeyType               { return t.groupType }
 func (t *testPodGroupInfo) GetKey() string {
 	return fmt.Sprintf("%s/%s/%s", t.groupType, t.namespace, t.name)
@@ -1864,7 +1863,7 @@ func (t *testPodGroupInfo) GetChildren() []fwk.PodGroupInfo {
 
 type mockPodGroupManager struct {
 	fwk.PodGroupManager
-	pgs  map[string]*schedulingv1beta1.PodGroup
+	pgs  map[string]*schedulingv1alpha3.PodGroup
 	cpgs map[string]*schedulingv1alpha3.CompositePodGroup
 }
 

--- a/pkg/scheduler/framework/plugins/helper/podgroup_test.go
+++ b/pkg/scheduler/framework/plugins/helper/podgroup_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -136,7 +135,7 @@ func TestGetPodGroupStates(t *testing.T) {
 
 	testCases := []struct {
 		name               string
-		podGroups          []*schedulingv1beta1.PodGroup
+		podGroups          []*schedulingv1alpha3.PodGroup
 		compositePodGroups []*schedulingv1alpha3.CompositePodGroup
 		rootEntityKey      fwk.EntityKey
 		faultyEntityKeys   []fwk.EntityKey
@@ -144,14 +143,14 @@ func TestGetPodGroupStates(t *testing.T) {
 	}{
 		{
 			name: "root is PodGroup",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			podGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("test").Obj(),
 			},
 			rootEntityKey: fwk.PodGroupKey("test", "pg1"),
 		},
 		{
 			name: "root is CompositePodGroup",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			podGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("test").ParentCompositePodGroup("cpg-root").Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("test").ParentCompositePodGroup("cpg-root").Obj(),
 			},
@@ -162,7 +161,7 @@ func TestGetPodGroupStates(t *testing.T) {
 		},
 		{
 			name:      "root is CompositePodGroup and has no leaves",
-			podGroups: []*schedulingv1beta1.PodGroup{},
+			podGroups: []*schedulingv1alpha3.PodGroup{},
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Namespace("test").Obj(),
 			},
@@ -170,7 +169,7 @@ func TestGetPodGroupStates(t *testing.T) {
 		},
 		{
 			name: "root is CompositePodGroup and one entity key is missing",
-			podGroups: []*schedulingv1beta1.PodGroup{
+			podGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg-leaf").Namespace("test").ParentCompositePodGroup("cpg-mid2").Obj(),
 			},
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
@@ -186,7 +185,7 @@ func TestGetPodGroupStates(t *testing.T) {
 		},
 		{
 			name:      "root is CompositePodGroup and multiple entity keys are missing",
-			podGroups: []*schedulingv1beta1.PodGroup{},
+			podGroups: []*schedulingv1alpha3.PodGroup{},
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Namespace("test").Obj(),
 				st.MakeCompositePodGroup().Name("cpg-mid1").Namespace("test").ParentCompositePodGroup("cpg-root").Obj(),
@@ -214,7 +213,7 @@ func TestGetPodGroupStates(t *testing.T) {
 				st.MakeCompositePodGroup().Name("cpg4").Namespace("test").ParentCompositePodGroup("cpg3").Obj(),
 				st.MakeCompositePodGroup().Name("cpg2.2").Namespace("test").ParentCompositePodGroup("cpg1").Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
+			podGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg-root").Namespace("test").ParentCompositePodGroup("cpg-root").Obj(),
 				st.MakePodGroup().Name("pg1").Namespace("test").ParentCompositePodGroup("cpg1").Obj(),
 				st.MakePodGroup().Name("pg2.1").Namespace("test").ParentCompositePodGroup("cpg2.1").Obj(),
@@ -266,7 +265,7 @@ func TestGetPodGroupStates_EarlyBreak(t *testing.T) {
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TopologyAwareWorkloadScheduling, true)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CompositePodGroup, true)
 
-	podGroups := []*schedulingv1beta1.PodGroup{
+	podGroups := []*schedulingv1alpha3.PodGroup{
 		st.MakePodGroup().Name("pg1").Namespace("test").ParentCompositePodGroup("cpg-root").Obj(),
 		st.MakePodGroup().Name("pg2").Namespace("test").ParentCompositePodGroup("cpg-root").Obj(),
 		st.MakePodGroup().Name("pg3").Namespace("test").ParentCompositePodGroup("cpg-root").Obj(),

--- a/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count_test.go
+++ b/pkg/scheduler/framework/plugins/podgrouppodscount/podgroup_pods_count_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -221,7 +220,7 @@ func TestScorePlacement(t *testing.T) {
 				})
 				_, tCtx := ktesting.NewTestContext(t)
 
-				pgs := []schedulingapi.PodGroup{}
+				pgs := []schedulingv1alpha3.PodGroup{}
 				cpgs := []schedulingv1alpha3.CompositePodGroup{}
 				pods := []*v1.Pod{}
 				alreadyAdded := sets.New[string]()
@@ -268,16 +267,16 @@ func TestScorePlacement(t *testing.T) {
 				}
 
 				cs := clientsetfake.NewClientset(
-					&schedulingapi.PodGroupList{Items: pgs},
+					&schedulingv1alpha3.PodGroupList{Items: pgs},
 					&schedulingv1alpha3.CompositePodGroupList{Items: cpgs},
 				)
 				informerFactory := informers.NewSharedInformerFactory(cs, 0)
-				_ = informerFactory.Scheduling().V1beta1().PodGroups().Informer()
+				_ = informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
 				_ = informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
 				informerFactory.StartWithContext(tCtx)
 				informerFactory.WaitForCacheSyncWithContext(tCtx)
 
-				pgPtrs := make([]*schedulingapi.PodGroup, len(pgs))
+				pgPtrs := make([]*schedulingv1alpha3.PodGroup, len(pgs))
 				cpgPtrs := make([]*schedulingv1alpha3.CompositePodGroup, len(cpgs))
 				for i := range pgs {
 					pgPtrs[i] = &pgs[i]
@@ -404,7 +403,7 @@ func TestNormalizePlacementScore(t *testing.T) {
 	}
 }
 
-func makePodGroupInfoFromPG(pg *schedulingapi.PodGroup) fwk.PodGroupInfo {
+func makePodGroupInfoFromPG(pg *schedulingv1alpha3.PodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
 		Name:      pg.Name,
 		Namespace: pg.Namespace,
@@ -423,7 +422,7 @@ func makePodGroupInfoFromCPG(cpg *schedulingv1alpha3.CompositePodGroup) fwk.PodG
 }
 
 func makePodGroup() fwk.PodGroupInfo {
-	return makePodGroupInfoFromPG(&schedulingapi.PodGroup{
+	return makePodGroupInfoFromPG(&schedulingv1alpha3.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "root",
 			Namespace: "default",

--- a/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
+++ b/pkg/scheduler/framework/plugins/topologyaware/topology_placement_test.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alphav3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
@@ -58,7 +57,7 @@ func TestGeneratePlacements(t *testing.T) {
 		wantStatus            fwk.Code
 	}{
 		"without constraint returns placement matching all nodes": {
-			podGroupInfo: makePodGroupInfoFromPG(&schedulingapi.PodGroup{}),
+			podGroupInfo: makePodGroupInfoFromPG(&schedulingv1alphav3.PodGroup{}),
 			placementNodes: []*v1.Node{
 				st.MakeNode().Name("node1").Obj(),
 				st.MakeNode().Name("node2").Label("foo", "bar").Obj(),
@@ -374,7 +373,7 @@ func TestGeneratePlacements(t *testing.T) {
 					nodes = append(nodes, *node)
 				}
 
-				pgs := []schedulingapi.PodGroup{}
+				pgs := []schedulingv1alphav3.PodGroup{}
 				cpgs := []schedulingv1alphav3.CompositePodGroup{}
 				pods := []*v1.Pod{}
 				alreadyAdded := sets.New[string]()
@@ -404,18 +403,18 @@ func TestGeneratePlacements(t *testing.T) {
 				}
 
 				cs := clientsetfake.NewClientset(
-					&schedulingapi.PodGroupList{Items: pgs},
+					&schedulingv1alphav3.PodGroupList{Items: pgs},
 					&schedulingv1alphav3.CompositePodGroupList{Items: cpgs},
 					&v1.NodeList{Items: nodes},
 				)
 				informerFactory := informers.NewSharedInformerFactory(cs, 0)
-				_ = informerFactory.Scheduling().V1beta1().PodGroups().Informer()
+				_ = informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
 				_ = informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
 				_ = informerFactory.Core().V1().Nodes().Informer()
 				informerFactory.StartWithContext(tCtx)
 				informerFactory.WaitForCacheSyncWithContext(tCtx)
 
-				pgPtrs := make([]*schedulingapi.PodGroup, len(pgs))
+				pgPtrs := make([]*schedulingv1alphav3.PodGroup, len(pgs))
 				cpgPtrs := make([]*schedulingv1alphav3.CompositePodGroup, len(cpgs))
 				nodePtrs := make([]*v1.Node, len(nodes))
 				for i := range pgs {
@@ -474,7 +473,7 @@ func TestGeneratePlacements(t *testing.T) {
 	}
 }
 
-func makePodGroupInfoFromPG(pg *schedulingapi.PodGroup) fwk.PodGroupInfo {
+func makePodGroupInfoFromPG(pg *schedulingv1alphav3.PodGroup) fwk.PodGroupInfo {
 	return &framework.PodGroupInfo{
 		Name:      pg.Name,
 		Namespace: pg.Namespace,

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -24,7 +24,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -502,7 +501,7 @@ func (p *podExecutorPreemptor) Type() string {
 
 // podGroupExecutorPreemptor is a wrapper around pod group used by preemption execution.
 type podGroupExecutorPreemptor struct {
-	pg   *schedulingv1beta1.PodGroup
+	pg   *schedulingv1alpha3.PodGroup
 	pods []*v1.Pod
 }
 

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -303,7 +302,7 @@ func TestPrepareCandidate(t *testing.T) {
 				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
 				Obj()
 
-		podGroupPreemptor = &schedulingv1beta1.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default", UID: "pg1"}}
+		podGroupPreemptor = &schedulingv1alpha3.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default", UID: "pg1"}}
 
 		errDeletePodFailed   = errors.New("delete pod failed")
 		errPatchStatusFailed = errors.New("patch pod status failed")
@@ -320,7 +319,7 @@ func TestPrepareCandidate(t *testing.T) {
 		nodeNames                  []string
 		candidate                  Candidate
 		preemptor                  *v1.Pod
-		preemptorPodGroup          *schedulingv1beta1.PodGroup
+		preemptorPodGroup          *schedulingv1alpha3.PodGroup
 		preemptorCompositePodGroup *schedulingv1alpha3.CompositePodGroup
 		testPods                   []*v1.Pod
 		// expectedDeletedPod is the pod name that is expected to be deleted.
@@ -898,7 +897,7 @@ func TestPrepareCandidateAsyncSetsPreemptingSets(t *testing.T) {
 				SchedulerName(defaultSchedulerName).Priority(highPriority).
 				Containers([]v1.Container{st.MakeContainer().Name("container1").Obj()}).
 				Obj()
-		preemptorPodGroup          = &schedulingv1beta1.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default", UID: "pg1"}}
+		preemptorPodGroup          = &schedulingv1alpha3.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default", UID: "pg1"}}
 		preemptorCompositePodGroup = &schedulingv1alpha3.CompositePodGroup{ObjectMeta: metav1.ObjectMeta{Name: "cpg1", Namespace: "default", UID: "cpg1"}}
 		testPods                   = []*v1.Pod{
 			victim1,
@@ -1121,7 +1120,7 @@ func TestAsyncPreemptionFailure(t *testing.T) {
 	tests := []struct {
 		name                                 string
 		victims                              []*v1.Pod
-		preemptorPodGroup                    *schedulingv1beta1.PodGroup
+		preemptorPodGroup                    *schedulingv1alpha3.PodGroup
 		preemptorCompositePodGroup           *schedulingv1alpha3.CompositePodGroup
 		preemptorPods                        []*v1.Pod
 		expectSuccessfulPreemption           bool
@@ -1198,7 +1197,7 @@ func TestAsyncPreemptionFailure(t *testing.T) {
 			victims: []*v1.Pod{
 				makeVictim(failVictimNamePrefix),
 			},
-			preemptorPodGroup:                    &schedulingv1beta1.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default"}},
+			preemptorPodGroup:                    &schedulingv1alpha3.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default"}},
 			preemptorPods:                        []*v1.Pod{makePod("pod1", highPriority), makePod("pod2", highPriority)},
 			expectSuccessfulPreemption:           false,
 			expectPreemptionAttemptForLastVictim: true,
@@ -1432,7 +1431,7 @@ func TestRemoveNominatedNodeName(t *testing.T) {
 
 func TestPreemptPod(t *testing.T) {
 	preemptorPod := st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()
-	preemptorPodGroup := &schedulingv1beta1.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"}}
+	preemptorPodGroup := &schedulingv1alpha3.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"}}
 	preemptorCompositePodGroup := &schedulingv1alpha3.CompositePodGroup{ObjectMeta: metav1.ObjectMeta{Name: "cpg", Namespace: "default"}}
 	preemptorPods := []*v1.Pod{st.MakePod().Name("p1").UID("p1").Priority(highPriority).Obj(), st.MakePod().Name("p2").UID("p2").Priority(highPriority).Obj()}
 
@@ -1561,7 +1560,7 @@ func TestPreemptPod(t *testing.T) {
 func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemption(t *testing.T) {
 	preemptorPod := st.MakePod().Name("p").UID("p").Priority(highPriority).Obj()
 	secondPreemptorPod := st.MakePod().Name("p2").UID("p2").Priority(highPriority).Obj()
-	preemptorPodGroup := &schedulingv1beta1.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg", UID: "pg"}}
+	preemptorPodGroup := &schedulingv1alpha3.PodGroup{ObjectMeta: metav1.ObjectMeta{Name: "pg", UID: "pg"}}
 	preemptorCompositePodGroup := &schedulingv1alpha3.CompositePodGroup{ObjectMeta: metav1.ObjectMeta{Name: "cpg", UID: "cpg"}}
 	waitingVictim := st.MakePod().Name("waiting-v").UID("waiting-v").Priority(midPriority).Node("node1").Obj()
 	preBindVictim := st.MakePod().Name("prebind-v").UID("prebind-v").Priority(midPriority).Node("node1").Obj()
@@ -1574,7 +1573,7 @@ func TestPrepareCandidateAsyncActivatesPreemptorAfterLastVictimInMemoryPreemptio
 		addVictimToPrebind          bool
 		addVictimToPrebindOnPreempt bool
 		addVictimToWaiting          bool
-		preemptorPodGroup           *schedulingv1beta1.PodGroup
+		preemptorPodGroup           *schedulingv1alpha3.PodGroup
 		preemptorCompositePodGroup  *schedulingv1alpha3.CompositePodGroup
 		preemptorPods               []*v1.Pod
 		wantPreemptorActivate       bool

--- a/pkg/scheduler/framework/preemption/podgrouppreemption.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption.go
@@ -26,7 +26,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
-	schedulingapi "k8s.io/api/scheduling/v1beta1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	policylisters "k8s.io/client-go/listers/policy/v1"

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -27,7 +27,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -101,10 +100,10 @@ type nodeCapacity struct {
 var _ fwk.FilterPlugin = &mockFilterPlugin{}
 
 type mockPodGroupLister struct {
-	podGroups map[string]*schedulingv1beta1.PodGroup
+	podGroups map[string]*schedulingv1alpha3.PodGroup
 }
 
-func (m *mockPodGroupLister) Get(namespace, name string) (*schedulingv1beta1.PodGroup, error) {
+func (m *mockPodGroupLister) Get(namespace, name string) (*schedulingv1alpha3.PodGroup, error) {
 	if pg, ok := m.podGroups[name]; ok {
 		return pg, nil
 	}
@@ -122,11 +121,11 @@ func (m *mockCompositePodGroupLister) Get(namespace, name string) (*schedulingv1
 	return nil, fmt.Errorf("composite pod group %s not found", name)
 }
 
-func makePodGroupPreemptor(pg *schedulingv1beta1.PodGroup, pods []*v1.Pod) *podGroupPreemptor {
-	return makePodGroupPreemptorWithPreemptionPolicy(pg, pods, schedulingv1beta1.PreemptLowerPriority)
+func makePodGroupPreemptor(pg *schedulingv1alpha3.PodGroup, pods []*v1.Pod) *podGroupPreemptor {
+	return makePodGroupPreemptorWithPreemptionPolicy(pg, pods, schedulingv1alpha3.PreemptLowerPriority)
 }
 
-func makePodGroupPreemptorWithPreemptionPolicy(pg *schedulingv1beta1.PodGroup, pods []*v1.Pod, policy schedulingv1beta1.PreemptionPolicy) *podGroupPreemptor {
+func makePodGroupPreemptorWithPreemptionPolicy(pg *schedulingv1alpha3.PodGroup, pods []*v1.Pod, policy schedulingv1alpha3.PreemptionPolicy) *podGroupPreemptor {
 	return &podGroupPreemptor{
 		priority:         util.PodGroupPriority(pg),
 		pods:             pods,
@@ -140,7 +139,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 		name                           string
 		nodes                          []*v1.Node
 		initPods                       []*v1.Pod
-		initPodGroups                  []*schedulingv1beta1.PodGroup
+		initPodGroups                  []*schedulingv1alpha3.PodGroup
 		preemptor                      *podGroupPreemptor
 		pdbs                           []*policy.PodDisruptionBudget
 		nodeCapacities                 []nodeCapacity
@@ -158,7 +157,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).Labels(map[string]string{"size": "1"}).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node1").Priority(lowPriority).Labels(map[string]string{"size": "1"}).PodGroupName("pg1").Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -183,7 +182,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("pg1").StartTime(metav1.Unix(1, 0)).Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node1").Priority(lowPriority).PodGroupName("pg1").StartTime(metav1.Unix(0, 0)).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -210,7 +209,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(lowPriority).Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -247,7 +246,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p4").UID("v4").Node("node4").Priority(midPriority).Obj(),
 				st.MakePod().Name("p5").UID("v5").Node("node5").Priority(highPriority).PodGroupName("pg3").StartTime(metav1.Unix(0, 0)).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeSingle().Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg3").UID("pg3").DisruptionModeSingle().Priority(highPriority).Obj(),
@@ -330,7 +329,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			preemptor: makePodGroupPreemptorWithPreemptionPolicy(
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{st.MakePod().Name("p-1").UID("p-1").Priority(highPriority).Obj()},
-				schedulingv1beta1.PreemptLowerPriority,
+				schedulingv1alpha3.PreemptLowerPriority,
 			),
 			nodeCapacities: []nodeCapacity{
 				{nodeName: "node1", capacity: 1},
@@ -353,11 +352,11 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).PodGroupName("pg2").Obj(),
 			},
 			preemptor: makePodGroupPreemptorWithPreemptionPolicy(
-				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).PreemptionPolicy(schedulingv1beta1.PreemptLowerPriority).Obj(),
+				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(),
 				[]*v1.Pod{
 					st.MakePod().Name("p-1").UID("p-1").Priority(highPriority).PreemptionPolicy(v1.PreemptNever).Obj(),
 				},
-				schedulingv1beta1.PreemptLowerPriority,
+				schedulingv1alpha3.PreemptLowerPriority,
 			),
 			nodeCapacities: []nodeCapacity{
 				{nodeName: "node1", capacity: 1},
@@ -377,7 +376,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("victim").UID("v1").Node("node2").Priority(lowPriority).Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
 				st.MakePod().Name("other-victim").UID("v2").Node("node1").Priority(lowPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{},
+			initPodGroups: []*schedulingv1alpha3.PodGroup{},
 			preemptor: makePodGroupPreemptor(
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
 				[]*v1.Pod{
@@ -408,7 +407,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
 				st.MakePod().Name("other-victim").UID("v2").Node("node1").Priority(lowPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Priority(highPriority).DisruptionModeAll().Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -441,7 +440,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
 				st.MakePod().Name("other-victim").UID("v2").Node("node1").Priority(lowPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Priority(highPriority).DisruptionModeSingle().Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -594,7 +593,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).PodGroupName("pg2").Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeSingle().Priority(lowPriority).Obj(),
 			},
@@ -608,7 +607,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				[]*v1.Pod{
 					st.MakePod().Name("p-1").UID("p-1").Priority(highPriority).Obj(),
 				},
-				schedulingv1beta1.PreemptLowerPriority,
+				schedulingv1alpha3.PreemptLowerPriority,
 			),
 			expectedVictims: []string{"p1"},
 			expectedStatus:  fwk.NewStatus(fwk.Success),
@@ -625,7 +624,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).PodGroupName("pg2").Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeSingle().Priority(lowPriority).Obj(),
 			},
@@ -634,7 +633,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				[]*v1.Pod{
 					st.MakePod().Name("p-1").UID("p-1").Priority(highPriority).PreemptionPolicy(v1.PreemptNever).Obj(),
 				},
-				schedulingv1beta1.PreemptLowerPriority,
+				schedulingv1alpha3.PreemptLowerPriority,
 			),
 			nodeCapacities: []nodeCapacity{
 				{nodeName: "node1", capacity: 1},
@@ -683,7 +682,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(lowPriority).Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -715,7 +714,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("g1-1").UID("g1").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("g1-2").UID("g2").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(lowPriority).Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -742,7 +741,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("g1-2").UID("g2").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(midPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(lowPriority).Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -770,7 +769,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("g1-2").UID("g2").Node("node1").PodGroupName("pg1").Priority(lowPriority).Obj(),
 				st.MakePod().Name("p1").UID("p1").Node("node1").Priority(lowPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(lowPriority).Obj(),
 			},
 			pdbs: []*policy.PodDisruptionBudget{
@@ -866,7 +865,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(highPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(highPriority).PodGroupName("pg1").Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(midPriority).Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -897,7 +896,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p1").UID("v1").Node("node1").Priority(lowPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(midPriority).Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -931,7 +930,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(highPriority).Obj(),
 				st.MakePod().Name("p4").UID("v4").Node("node4").Priority(highPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{},
+			initPodGroups: []*schedulingv1alpha3.PodGroup{},
 			preemptor: makePodGroupPreemptor(
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).MinCount(1).Obj(),
 				[]*v1.Pod{
@@ -974,7 +973,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("v2").UID("v2").Node("node2").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
 				st.MakePod().Name("v3").UID("v3").Node("node3").Namespace(v1.NamespaceDefault).Priority(lowPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Namespace(v1.NamespaceDefault).Priority(midPriority).DisruptionModeAll().MinCount(1).Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -1017,7 +1016,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("v3").UID("v3").Node("node3").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg2").Priority(highPriority).Obj(),
 				st.MakePod().Name("v4").UID("v4").Node("node4").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg2").Priority(highPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Namespace(v1.NamespaceDefault).Priority(midPriority).DisruptionModeAll().MinCount(2).Obj(),
 				st.MakePodGroup().Name("victim-pg2").UID("victim-pg2").Namespace(v1.NamespaceDefault).Priority(highPriority).DisruptionModeAll().MinCount(2).Obj(),
 			},
@@ -1065,7 +1064,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(highPriority).Obj(),
 				st.MakePod().Name("p4").UID("v4").Node("node4").Priority(highPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{},
+			initPodGroups: []*schedulingv1alpha3.PodGroup{},
 			preemptor: makePodGroupPreemptor(
 				st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).BasicPolicy().Obj(),
 				[]*v1.Pod{
@@ -1107,7 +1106,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("v2").UID("v2").Node("node2").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg").Priority(midPriority).Obj(),
 				st.MakePod().Name("v3").UID("v3").Node("node3").Namespace(v1.NamespaceDefault).Priority(lowPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Namespace(v1.NamespaceDefault).Priority(midPriority).DisruptionModeAll().MinCount(1).Obj(),
 			},
 			preemptor: makePodGroupPreemptor(
@@ -1150,7 +1149,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				st.MakePod().Name("v3").UID("v3").Node("node3").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg2").Priority(highPriority).Obj(),
 				st.MakePod().Name("v4").UID("v4").Node("node4").Namespace(v1.NamespaceDefault).PodGroupName("victim-pg2").Priority(highPriority).Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Namespace(v1.NamespaceDefault).Priority(midPriority).DisruptionModeAll().MinCount(2).Obj(),
 				st.MakePodGroup().Name("victim-pg2").UID("victim-pg2").Namespace(v1.NamespaceDefault).Priority(highPriority).DisruptionModeAll().MinCount(2).Obj(),
 			},
@@ -1285,7 +1284,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				return nil, fwk.NewStatus(fwk.Unschedulable)
 			}
 
-			podGroups := make(map[string]*schedulingv1beta1.PodGroup)
+			podGroups := make(map[string]*schedulingv1alpha3.PodGroup)
 			for _, pg := range tt.initPodGroups {
 				podGroups[pg.Name] = pg
 			}
@@ -1386,7 +1385,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain_NominatedNodes(t *testing.T) {
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
 
-	pgLister := &mockPodGroupLister{podGroups: make(map[string]*schedulingv1beta1.PodGroup)}
+	pgLister := &mockPodGroupLister{podGroups: make(map[string]*schedulingv1alpha3.PodGroup)}
 	domain, err := newDomainForWorkloadPreemption(logger, snapshot, pgLister, &mockCompositePodGroupLister{}, "test-domain")
 	if err != nil {
 		t.Fatalf("Failed to create domain: %v", err)
@@ -1437,8 +1436,8 @@ func TestPodGroupEvaluator_Preempt(t *testing.T) {
 		name               string
 		nodes              []*v1.Node
 		initPods           []*v1.Pod
-		initPodGroups      []*schedulingv1beta1.PodGroup
-		preemptorPodGroup  *schedulingv1beta1.PodGroup
+		initPodGroups      []*schedulingv1alpha3.PodGroup
+		preemptorPodGroup  *schedulingv1alpha3.PodGroup
 		preemptorPods      []*v1.Pod
 		expectedStatus     *fwk.Status
 		expectedNominating map[types.NamespacedName]*fwk.NominatingInfo
@@ -1470,7 +1469,7 @@ func TestPodGroupEvaluator_Preempt(t *testing.T) {
 			initPods: []*v1.Pod{
 				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(highPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Priority(lowPriority).DisruptionModeAll().Obj(),
 			},
 			preemptorPodGroup: st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
@@ -1492,7 +1491,7 @@ func TestPodGroupEvaluator_Preempt(t *testing.T) {
 			initPods: []*v1.Pod{
 				st.MakePod().Name("victim").UID("v1").Node("node1").Priority(highPriority).PodGroupName("victim-pg").Condition(v1.DisruptionTarget, v1.ConditionTrue, v1.PodReasonPreemptionByScheduler).Terminating().Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("victim-pg").UID("victim-pg").Priority(lowPriority).DisruptionModeSingle().Obj(),
 			},
 			preemptorPodGroup: st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).Obj(),
@@ -1518,7 +1517,7 @@ func TestPodGroupEvaluator_Preempt(t *testing.T) {
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).PodGroupName("pg2").Obj(),
 			},
-			preemptorPodGroup: st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			preemptorPodGroup: st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			preemptorPods: []*v1.Pod{
 				st.MakePod().Name("p-1").UID("p-1").Priority(highPriority).Obj(),
 				st.MakePod().Name("p-2").UID("p-2").Priority(highPriority).Obj(),
@@ -1537,11 +1536,11 @@ func TestPodGroupEvaluator_Preempt(t *testing.T) {
 				st.MakePod().Name("p2").UID("v2").Node("node2").Priority(lowPriority).PodGroupName("pg1").Obj(),
 				st.MakePod().Name("p3").UID("v3").Node("node3").Priority(lowPriority).PodGroupName("pg2").Obj(),
 			},
-			initPodGroups: []*schedulingv1beta1.PodGroup{
+			initPodGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeSingle().Priority(lowPriority).Obj(),
 			},
-			preemptorPodGroup: st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			preemptorPodGroup: st.MakePodGroup().Name("preemptor-pg").Priority(highPriority).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			preemptorPods: []*v1.Pod{
 				st.MakePod().Name("p-1").UID("p-1").Priority(highPriority).Obj(),
 				st.MakePod().Name("p-2").UID("p-2").Priority(highPriority).Obj(),
@@ -1585,7 +1584,7 @@ func TestPodGroupEvaluator_Preempt(t *testing.T) {
 			informerFactory.Start(ctx.Done())
 			informerFactory.WaitForCacheSync(ctx.Done())
 
-			podGroups := make(map[string]*schedulingv1beta1.PodGroup)
+			podGroups := make(map[string]*schedulingv1alpha3.PodGroup)
 			for _, pg := range tt.initPodGroups {
 				podGroups[pg.Name] = pg
 			}
@@ -1710,7 +1709,7 @@ func TestPodGroupPreemptionEvaluationDurationMetric(t *testing.T) {
 			informerFactory.Start(ctx.Done())
 			informerFactory.WaitForCacheSync(ctx.Done())
 
-			pgLister := &mockPodGroupLister{podGroups: make(map[string]*schedulingv1beta1.PodGroup)}
+			pgLister := &mockPodGroupLister{podGroups: make(map[string]*schedulingv1alpha3.PodGroup)}
 
 			pl := &PodGroupEvaluator{
 				Handle:           fh,

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -29,7 +29,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -664,7 +663,7 @@ func TestGetVictimsOnNode(t *testing.T) {
 		enableCompositePodGroup bool
 		nodes                   []*v1.Node
 		pods                    []*v1.Pod
-		podGroups               []*schedulingv1beta1.PodGroup
+		podGroups               []*schedulingv1alpha3.PodGroup
 		compositePodGroups      []*schedulingv1alpha3.CompositePodGroup
 		targetNode              string
 		expectedVictims         []*DomainVictim
@@ -732,7 +731,7 @@ func TestGetVictimsOnNode(t *testing.T) {
 				st.MakeNode().Name("node1").Obj(),
 				st.MakeNode().Name("node2").Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
+			podGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("default").Priority(midPriority).DisruptionModeAll().Obj(),
 			},
 			pods: []*v1.Pod{
@@ -768,7 +767,7 @@ func TestGetVictimsOnNode(t *testing.T) {
 				st.MakeNode().Name("node1").Obj(),
 				st.MakeNode().Name("node2").Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
+			podGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("default").Priority(midPriority).DisruptionModeSingle().Obj(),
 			},
 			pods: []*v1.Pod{
@@ -815,7 +814,7 @@ func TestGetVictimsOnNode(t *testing.T) {
 				st.MakeNode().Name("node1").Obj(),
 				st.MakeNode().Name("node2").Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
+			podGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg-all").Namespace("default").Priority(highPriority).DisruptionModeAll().Obj(),
 				st.MakePodGroup().Name("pg-single").Namespace("default").Priority(midPriority).DisruptionModeSingle().Obj(),
 			},
@@ -869,7 +868,7 @@ func TestGetVictimsOnNode(t *testing.T) {
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg1").Namespace("default").Priority(midPriority).DisruptionModeAll().Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
+			podGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("default").ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("default").ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 			},
@@ -902,7 +901,7 @@ func TestGetVictimsOnNode(t *testing.T) {
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg1").Namespace("default").Priority(midPriority).DisruptionModeSingle().Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
+			podGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("default").ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("default").ParentCompositePodGroup("cpg1").Priority(lowPriority).Obj(),
 			},
@@ -934,7 +933,7 @@ func TestGetVictimsOnNode(t *testing.T) {
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg1").Namespace("default").Priority(midPriority).DisruptionModeAll().Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
+			podGroups: []*schedulingv1alpha3.PodGroup{
 				st.MakePodGroup().Name("pg1").Namespace("default").ParentCompositePodGroup("cpg1").Priority(lowPriority).DisruptionModeSingle().Obj(),
 				st.MakePodGroup().Name("pg2").Namespace("default").ParentCompositePodGroup("cpg1").Priority(lowPriority).DisruptionModeSingle().Obj(),
 			},
@@ -1020,7 +1019,7 @@ func TestGetVictimsOnNode(t *testing.T) {
 				compositePodGroupSnapshot: cpgSnapshot,
 			}
 
-			_ = informerFactory.Scheduling().V1beta1().PodGroups().Informer()
+			_ = informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
 			_ = informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
 
 			informerFactory.Start(ctx.Done())

--- a/pkg/scheduler/framework/preemption/types.go
+++ b/pkg/scheduler/framework/preemption/types.go
@@ -22,7 +22,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
@@ -36,9 +35,9 @@ import (
 type podGroupPreemptor struct {
 	priority          int32
 	pods              []*v1.Pod
-	podGroup          *schedulingv1beta1.PodGroup
+	podGroup          *schedulingv1alpha3.PodGroup
 	compositePodGroup *schedulingv1alpha3.CompositePodGroup
-	preemptionPolicy  schedulingv1beta1.PreemptionPolicy
+	preemptionPolicy  schedulingv1alpha3.PreemptionPolicy
 }
 
 func newPodGroupPreemptor(pgInfo fwk.PodGroupInfo, enablePodGroupPreemptionPolicy bool) *podGroupPreemptor {
@@ -73,7 +72,7 @@ func (p *podGroupPreemptor) getObj() klog.KMetadata {
 	return p.podGroup
 }
 
-func resolvePreemptionPolicy(pg *schedulingv1beta1.PodGroup, pods []*v1.Pod, enablePodGroupPreemptionPolicy bool) schedulingv1beta1.PreemptionPolicy {
+func resolvePreemptionPolicy(pg *schedulingv1alpha3.PodGroup, pods []*v1.Pod, enablePodGroupPreemptionPolicy bool) schedulingv1alpha3.PreemptionPolicy {
 	if enablePodGroupPreemptionPolicy {
 		// If the PodGroup was created with PodGroupPreemptionPolicy feature disabled, the PreemptionPolicy field will be nil.
 		// In this case the default policy value should be returned.
@@ -83,29 +82,29 @@ func resolvePreemptionPolicy(pg *schedulingv1beta1.PodGroup, pods []*v1.Pod, ena
 	} else {
 		for _, pod := range pods {
 			if p := pod.Spec.PreemptionPolicy; p != nil && *p == v1.PreemptNever {
-				return schedulingv1beta1.PreemptNever
+				return schedulingv1alpha3.PreemptNever
 			}
 		}
 	}
-	return schedulingv1beta1.PreemptLowerPriority
+	return schedulingv1alpha3.PreemptLowerPriority
 }
 
-func resolveCompositePreemptionPolicy(cpg *schedulingv1alpha3.CompositePodGroup, pods []*v1.Pod, enablePodGroupPreemptionPolicy bool) schedulingv1beta1.PreemptionPolicy {
+func resolveCompositePreemptionPolicy(cpg *schedulingv1alpha3.CompositePodGroup, pods []*v1.Pod, enablePodGroupPreemptionPolicy bool) schedulingv1alpha3.PreemptionPolicy {
 	if enablePodGroupPreemptionPolicy {
 		if cpg.Spec.PreemptionPolicy != nil {
 			if *cpg.Spec.PreemptionPolicy == schedulingv1alpha3.PreemptLowerPriority {
-				return schedulingv1beta1.PreemptLowerPriority
+				return schedulingv1alpha3.PreemptLowerPriority
 			}
-			return schedulingv1beta1.PreemptNever
+			return schedulingv1alpha3.PreemptNever
 		}
 	} else {
 		for _, pod := range pods {
 			if p := pod.Spec.PreemptionPolicy; p != nil && *p == v1.PreemptNever {
-				return schedulingv1beta1.PreemptNever
+				return schedulingv1alpha3.PreemptNever
 			}
 		}
 	}
-	return schedulingv1beta1.PreemptLowerPriority
+	return schedulingv1alpha3.PreemptLowerPriority
 }
 
 // Priority returns the scheduling priority of the preemptor.
@@ -120,7 +119,7 @@ func (p *podGroupPreemptor) Members() []*v1.Pod {
 }
 
 // PodGroup returns a pod group connected with this preemptor.
-func (p *podGroupPreemptor) PodGroup() *schedulingv1beta1.PodGroup {
+func (p *podGroupPreemptor) PodGroup() *schedulingv1alpha3.PodGroup {
 	return p.podGroup
 }
 
@@ -130,7 +129,7 @@ func (p *podGroupPreemptor) CompositePodGroup() *schedulingv1alpha3.CompositePod
 }
 
 // PreemptionPolicy returns a preemption policy of this preemptor.
-func (p *podGroupPreemptor) PreemptionPolicy() schedulingv1beta1.PreemptionPolicy {
+func (p *podGroupPreemptor) PreemptionPolicy() schedulingv1alpha3.PreemptionPolicy {
 	return p.preemptionPolicy
 }
 
@@ -183,7 +182,7 @@ func getHighestAllAncestor(pod *v1.Pod, pgLister fwk.PodGroupLister, cpgLister f
 	var highestAllKey fwk.EntityKey
 	var hasAll bool
 
-	TraverseHierarchyUp(pod.Namespace, startKey, pgLister, cpgLister, func(key fwk.EntityKey, pg *schedulingv1beta1.PodGroup, cpg *schedulingv1alpha3.CompositePodGroup) bool {
+	TraverseHierarchyUp(pod.Namespace, startKey, pgLister, cpgLister, func(key fwk.EntityKey, pg *schedulingv1alpha3.PodGroup, cpg *schedulingv1alpha3.CompositePodGroup) bool {
 		if pg != nil {
 			if pg.Spec.DisruptionMode != nil && pg.Spec.DisruptionMode.All != nil {
 				highestAllKey = key

--- a/pkg/scheduler/framework/preemption/types_test.go
+++ b/pkg/scheduler/framework/preemption/types_test.go
@@ -25,7 +25,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -42,7 +41,7 @@ func TestGetHighestAllAncestor(t *testing.T) {
 	tests := []struct {
 		name               string
 		pod                *v1.Pod
-		podGroups          map[string]*schedulingv1beta1.PodGroup
+		podGroups          map[string]*schedulingv1alpha3.PodGroup
 		compositePodGroups map[string]*schedulingv1alpha3.CompositePodGroup
 		wantHighestAllKey  fwk.EntityKey
 		wantHasAll         bool
@@ -61,7 +60,7 @@ func TestGetHighestAllAncestor(t *testing.T) {
 		{
 			name: "pod group disruption mode single",
 			pod:  st.MakePod().Name("p1").Namespace("default").PodGroupName("pg1").Obj(),
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").Namespace("default").DisruptionModeSingle().Obj(),
 			},
 			wantHasAll: false,
@@ -69,7 +68,7 @@ func TestGetHighestAllAncestor(t *testing.T) {
 		{
 			name: "pod group disruption mode All",
 			pod:  st.MakePod().Name("p1").Namespace("default").PodGroupName("pg1").Obj(),
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").Namespace("default").DisruptionModeAll().Obj(),
 			},
 			wantHighestAllKey: fwk.PodGroupKey("default", "pg1"),
@@ -78,11 +77,11 @@ func TestGetHighestAllAncestor(t *testing.T) {
 		{
 			name: "parent CPG disruption mode All, child PG disruption mode single",
 			pod:  st.MakePod().Name("p1").Namespace("default").PodGroupName("pg1").Obj(),
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": {
 					ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default"},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						DisruptionMode:              &schedulingv1beta1.DisruptionMode{Single: &schedulingv1beta1.SingleDisruptionMode{}},
+					Spec: schedulingv1alpha3.PodGroupSpec{
+						DisruptionMode:              &schedulingv1alpha3.DisruptionMode{Single: &schedulingv1alpha3.SingleDisruptionMode{}},
 						ParentCompositePodGroupName: new("cpg1"),
 					},
 				},
@@ -101,11 +100,11 @@ func TestGetHighestAllAncestor(t *testing.T) {
 		{
 			name: "grandparent CPG disruption mode All, parent CPG disruption mode single, child PG disruption mode single",
 			pod:  st.MakePod().Name("p1").Namespace("default").PodGroupName("pg1").Obj(),
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": {
 					ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default"},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						DisruptionMode:              &schedulingv1beta1.DisruptionMode{Single: &schedulingv1beta1.SingleDisruptionMode{}},
+					Spec: schedulingv1alpha3.PodGroupSpec{
+						DisruptionMode:              &schedulingv1alpha3.DisruptionMode{Single: &schedulingv1alpha3.SingleDisruptionMode{}},
 						ParentCompositePodGroupName: new("cpg1"),
 					},
 				},
@@ -131,11 +130,11 @@ func TestGetHighestAllAncestor(t *testing.T) {
 		{
 			name: "highest All parent wins (both have disruption mode All)",
 			pod:  st.MakePod().Name("p1").Namespace("default").PodGroupName("pg1").Obj(),
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": {
 					ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default"},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						DisruptionMode:              &schedulingv1beta1.DisruptionMode{All: &schedulingv1beta1.AllDisruptionMode{}},
+					Spec: schedulingv1alpha3.PodGroupSpec{
+						DisruptionMode:              &schedulingv1alpha3.DisruptionMode{All: &schedulingv1alpha3.AllDisruptionMode{}},
 						ParentCompositePodGroupName: new("cpg1"),
 					},
 				},
@@ -160,11 +159,11 @@ func TestGetHighestAllAncestor(t *testing.T) {
 		{
 			name: "parent CPG missing from cache lister, child PG All returned",
 			pod:  st.MakePod().Name("p1").Namespace("default").PodGroupName("pg1").Obj(),
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": {
 					ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "default"},
-					Spec: schedulingv1beta1.PodGroupSpec{
-						DisruptionMode:              &schedulingv1beta1.DisruptionMode{All: &schedulingv1beta1.AllDisruptionMode{}},
+					Spec: schedulingv1alpha3.PodGroupSpec{
+						DisruptionMode:              &schedulingv1alpha3.DisruptionMode{All: &schedulingv1alpha3.AllDisruptionMode{}},
 						ParentCompositePodGroupName: new("cpg1"),
 					},
 				},
@@ -200,79 +199,79 @@ func TestNewPodGroupPreemptorResolvesPreemptionPolicy(t *testing.T) {
 
 	tests := []struct {
 		name                           string
-		pg                             *schedulingv1beta1.PodGroup
+		pg                             *schedulingv1alpha3.PodGroup
 		cpg                            *schedulingv1alpha3.CompositePodGroup
 		pods                           []*v1.Pod
 		enablePodGroupPreemptionPolicy bool
-		wantPolicy                     schedulingv1beta1.PreemptionPolicy
+		wantPolicy                     schedulingv1alpha3.PreemptionPolicy
 	}{
 		{
 			name:                           "PreemptionPolicy PreemptNever is resolved from PodGroup, ignoring policy in pod, with PodGroupPreemptionPolicy enabled",
-			pg:                             st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			pg:                             st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			pods:                           []*v1.Pod{preemptLowerPriorityPod},
 			enablePodGroupPreemptionPolicy: true,
-			wantPolicy:                     schedulingv1beta1.PreemptNever,
+			wantPolicy:                     schedulingv1alpha3.PreemptNever,
 		},
 		{
 			name:                           "PreemptionPolicy PreemptLowerPriority is resolved from PodGroup, ignoring different policies in pods, with PodGroupPreemptionPolicy enabled",
-			pg:                             st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1beta1.PreemptLowerPriority).Obj(),
+			pg:                             st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(),
 			pods:                           []*v1.Pod{preemptLowerPriorityPod, noPolicyPod},
 			enablePodGroupPreemptionPolicy: true,
-			wantPolicy:                     schedulingv1beta1.PreemptLowerPriority,
+			wantPolicy:                     schedulingv1alpha3.PreemptLowerPriority,
 		},
 		{
 			name:                           "PreemptionPolicy is resolved from pods with PodGroupPreemptionPolicy disabled",
-			pg:                             st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			pg:                             st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			pods:                           []*v1.Pod{preemptLowerPriorityPod},
 			enablePodGroupPreemptionPolicy: false,
-			wantPolicy:                     schedulingv1beta1.PreemptLowerPriority,
+			wantPolicy:                     schedulingv1alpha3.PreemptLowerPriority,
 		},
 		{
 			name:                           "PreemptionPolicy is resolved from pods when multiple pods have different policies, with PodGroupPreemptionPolicy disabled",
-			pg:                             st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1beta1.PreemptLowerPriority).Obj(),
+			pg:                             st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(),
 			pods:                           []*v1.Pod{preemptNeverPod, preemptLowerPriorityPod, noPolicyPod},
 			enablePodGroupPreemptionPolicy: false,
-			wantPolicy:                     schedulingv1beta1.PreemptNever,
+			wantPolicy:                     schedulingv1alpha3.PreemptNever,
 		},
 		{
 			name:       "PreemptionPolicy is resolved from pods when CompositePodGroup is active: PreemptLowerPriority when no pod is PreemptNever",
 			cpg:        st.MakeCompositePodGroup().Name("cpg1").Obj(),
 			pods:       []*v1.Pod{preemptLowerPriorityPod, noPolicyPod},
-			wantPolicy: schedulingv1beta1.PreemptLowerPriority,
+			wantPolicy: schedulingv1alpha3.PreemptLowerPriority,
 		},
 		{
 			name:       "PreemptionPolicy is resolved from pods when CompositePodGroup is active: PreemptNever when any pod is PreemptNever",
 			cpg:        st.MakeCompositePodGroup().Name("cpg1").Obj(),
 			pods:       []*v1.Pod{preemptNeverPod, preemptLowerPriorityPod},
-			wantPolicy: schedulingv1beta1.PreemptNever,
+			wantPolicy: schedulingv1alpha3.PreemptNever,
 		},
 		{
 			name:                           "PreemptionPolicy PreemptNever is resolved from CompositePodGroup, ignoring policy in pod, with PodGroupPreemptionPolicy enabled",
 			cpg:                            st.MakeCompositePodGroup().Name("cpg1").PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			pods:                           []*v1.Pod{preemptLowerPriorityPod},
 			enablePodGroupPreemptionPolicy: true,
-			wantPolicy:                     schedulingv1beta1.PreemptNever,
+			wantPolicy:                     schedulingv1alpha3.PreemptNever,
 		},
 		{
 			name:                           "PreemptionPolicy PreemptLowerPriority is resolved from CompositePodGroup, ignoring different policies in pods, with PodGroupPreemptionPolicy enabled",
 			cpg:                            st.MakeCompositePodGroup().Name("cpg1").PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(),
 			pods:                           []*v1.Pod{preemptLowerPriorityPod, preemptNeverPod},
 			enablePodGroupPreemptionPolicy: true,
-			wantPolicy:                     schedulingv1beta1.PreemptLowerPriority,
+			wantPolicy:                     schedulingv1alpha3.PreemptLowerPriority,
 		},
 		{
 			name:                           "PreemptionPolicy is resolved from pods when CompositePodGroup has policy but PodGroupPreemptionPolicy is disabled",
 			cpg:                            st.MakeCompositePodGroup().Name("cpg1").PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			pods:                           []*v1.Pod{preemptLowerPriorityPod, noPolicyPod},
 			enablePodGroupPreemptionPolicy: false,
-			wantPolicy:                     schedulingv1beta1.PreemptLowerPriority,
+			wantPolicy:                     schedulingv1alpha3.PreemptLowerPriority,
 		},
 		{
 			name:                           "PreemptionPolicy defaults to PreemptLowerPriority when CompositePodGroup has no policy set with PodGroupPreemptionPolicy enabled, even if pods are PreemptNever",
 			cpg:                            st.MakeCompositePodGroup().Name("cpg1").Obj(),
 			pods:                           []*v1.Pod{preemptNeverPod},
 			enablePodGroupPreemptionPolicy: true,
-			wantPolicy:                     schedulingv1beta1.PreemptLowerPriority,
+			wantPolicy:                     schedulingv1alpha3.PreemptLowerPriority,
 		},
 	}
 
@@ -297,7 +296,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 		name                    string
 		nodes                   []*v1.Node
 		pods                    []*v1.Pod
-		podGroups               map[string]*schedulingv1beta1.PodGroup
+		podGroups               map[string]*schedulingv1alpha3.PodGroup
 		compositePodGroups      map[string]*schedulingv1alpha3.CompositePodGroup
 		enableCompositePodGroup bool
 		domainName              string
@@ -340,7 +339,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1").UID("p1").Node("node1").PodGroupName("pg1").Priority(10).Obj(),
 				st.MakePod().Name("p2").UID("p2").Node("node2").PodGroupName("pg1").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(50).Obj(),
 			},
 			domainName: "test-domain",
@@ -358,7 +357,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1").UID("p1").Node("node1").PodGroupName("pg1").Priority(10).Obj(),
 				st.MakePod().Name("p2").UID("p2").Node("node2").PodGroupName("pg1").Priority(20).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().Priority(50).Obj(),
 			},
 			domainName: "test-domain",
@@ -379,7 +378,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p3").UID("p3").Node("node1").PodGroupName("pg2").Priority(20).Obj(),
 				st.MakePod().Name("p4").UID("p4").Node("node2").Priority(30).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().Priority(50).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeSingle().Priority(60).Obj(),
 			},
@@ -418,7 +417,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg2").UID("p1_pg2").Node("node1").PodGroupName("pg2").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg2").UID("p2_pg2").Node("node2").PodGroupName("pg2").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 			},
@@ -443,7 +442,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg2").UID("p1_pg2").Node("node1").PodGroupName("pg2").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg2").UID("p2_pg2").Node("node2").PodGroupName("pg2").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 			},
@@ -469,7 +468,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg2").UID("p1_pg2").Node("node1").PodGroupName("pg2").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg2").UID("p2_pg2").Node("node2").PodGroupName("pg2").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 			},
@@ -496,7 +495,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg2").UID("p1_pg2").Node("node1").PodGroupName("pg2").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg2").UID("p2_pg2").Node("node2").PodGroupName("pg2").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 			},
@@ -527,7 +526,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg4").UID("p1_pg4").Node("node1").PodGroupName("pg4").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg4").UID("p2_pg4").Node("node2").PodGroupName("pg4").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().ParentCompositePodGroup("cpg2").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg2").Priority(10).Obj(),
 				"pg3": st.MakePodGroup().Name("pg3").UID("pg3").DisruptionModeAll().ParentCompositePodGroup("cpg3").Priority(10).Obj(),
@@ -560,7 +559,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg4").UID("p1_pg4").Node("node1").PodGroupName("pg4").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg4").UID("p2_pg4").Node("node2").PodGroupName("pg4").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().ParentCompositePodGroup("cpg2").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg2").Priority(10).Obj(),
 				"pg3": st.MakePodGroup().Name("pg3").UID("pg3").DisruptionModeAll().ParentCompositePodGroup("cpg3").Priority(10).Obj(),
@@ -596,7 +595,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg4").UID("p1_pg4").Node("node1").PodGroupName("pg4").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg4").UID("p2_pg4").Node("node2").PodGroupName("pg4").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().ParentCompositePodGroup("cpg2").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg2").Priority(10).Obj(),
 				"pg3": st.MakePodGroup().Name("pg3").UID("pg3").DisruptionModeSingle().ParentCompositePodGroup("cpg3").Priority(10).Obj(),
@@ -633,7 +632,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg4").UID("p1_pg4").Node("node1").PodGroupName("pg4").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg4").UID("p2_pg4").Node("node2").PodGroupName("pg4").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().ParentCompositePodGroup("cpg2").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg2").Priority(10).Obj(),
 				"pg3": st.MakePodGroup().Name("pg3").UID("pg3").DisruptionModeSingle().ParentCompositePodGroup("cpg3").Priority(10).Obj(),
@@ -667,7 +666,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg2").UID("p1_pg2").Node("node1").PodGroupName("pg2").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg2").UID("p2_pg2").Node("node2").PodGroupName("pg2").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 			},
@@ -692,7 +691,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg2").UID("p1_pg2").Node("node1").PodGroupName("pg2").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg2").UID("p2_pg2").Node("node2").PodGroupName("pg2").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 			},
@@ -718,7 +717,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg2").UID("p1_pg2").Node("node1").PodGroupName("pg2").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg2").UID("p2_pg2").Node("node2").PodGroupName("pg2").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeSingle().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 			},
@@ -746,7 +745,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg2").UID("p1_pg2").Node("node1").PodGroupName("pg2").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg2").UID("p2_pg2").Node("node2").PodGroupName("pg2").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeSingle().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 			},
@@ -774,7 +773,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg2").UID("p1_pg2").Node("node1").PodGroupName("pg2").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg2").UID("p2_pg2").Node("node2").PodGroupName("pg2").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 			},
@@ -799,7 +798,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg2").UID("p1_pg2").Node("node1").PodGroupName("pg2").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg2").UID("p2_pg2").Node("node2").PodGroupName("pg2").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeSingle().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg1").Priority(10).Obj(),
 			},
@@ -830,7 +829,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 				st.MakePod().Name("p1_pg4").UID("p1_pg4").Node("node1").PodGroupName("pg4").Priority(10).Obj(),
 				st.MakePod().Name("p2_pg4").UID("p2_pg4").Node("node2").PodGroupName("pg4").Priority(10).Obj(),
 			},
-			podGroups: map[string]*schedulingv1beta1.PodGroup{
+			podGroups: map[string]*schedulingv1alpha3.PodGroup{
 				"pg1": st.MakePodGroup().Name("pg1").UID("pg1").DisruptionModeAll().ParentCompositePodGroup("cpg-mid1").Priority(10).Obj(),
 				"pg2": st.MakePodGroup().Name("pg2").UID("pg2").DisruptionModeAll().ParentCompositePodGroup("cpg-mid1").Priority(10).Obj(),
 				"pg3": st.MakePodGroup().Name("pg3").UID("pg3").DisruptionModeAll().ParentCompositePodGroup("cpg-mid2").Priority(10).Obj(),
@@ -859,7 +858,7 @@ func TestNewDomainForWorkloadPreemption(t *testing.T) {
 			})
 
 			logger, ctx := ktesting.NewTestContext(t)
-			var pgs []*schedulingv1beta1.PodGroup
+			var pgs []*schedulingv1alpha3.PodGroup
 			for _, pg := range tt.podGroups {
 				pgs = append(pgs, pg)
 			}
@@ -1154,7 +1153,7 @@ func TestNewDomainVictim(t *testing.T) {
 }
 
 type testPodGroupInfo struct {
-	pg   *schedulingv1beta1.PodGroup
+	pg   *schedulingv1alpha3.PodGroup
 	cpg  *schedulingv1alpha3.CompositePodGroup
 	pods []*v1.Pod
 }
@@ -1200,7 +1199,7 @@ func (t *testPodGroupInfo) GetUnscheduledPods() []*v1.Pod {
 	return t.pods
 }
 
-func (t *testPodGroupInfo) GetPodGroup() *schedulingv1beta1.PodGroup {
+func (t *testPodGroupInfo) GetPodGroup() *schedulingv1alpha3.PodGroup {
 	return t.pg
 }
 

--- a/pkg/scheduler/framework/preemption/util.go
+++ b/pkg/scheduler/framework/preemption/util.go
@@ -20,7 +20,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -105,14 +104,14 @@ func TraverseHierarchyUp(
 	startKey fwk.EntityKey,
 	pgLister fwk.PodGroupLister,
 	cpgLister fwk.CompositePodGroupLister,
-	visitFn func(key fwk.EntityKey, pg *schedulingv1beta1.PodGroup, cpg *schedulingv1alpha3.CompositePodGroup) (stop bool),
+	visitFn func(key fwk.EntityKey, pg *schedulingv1alpha3.PodGroup, cpg *schedulingv1alpha3.CompositePodGroup) (stop bool),
 ) {
 	if pgLister == nil || cpgLister == nil {
 		return
 	}
 	currentKey := startKey
 	visited := sets.New[fwk.EntityKey]()
-	for range schedulingv1beta1.WorkloadMaxTreeDepth {
+	for range schedulingv1alpha3.WorkloadMaxTreeDepth {
 		if visited.Has(currentKey) {
 			break
 		}
@@ -167,10 +166,10 @@ func GetPodPriority(p *v1.Pod, podGroupLister fwk.PodGroupLister, compositePodGr
 	}
 
 	startKey := fwk.PodGroupKey(p.Namespace, *p.Spec.SchedulingGroup.PodGroupName)
-	var lastPG *schedulingv1beta1.PodGroup
+	var lastPG *schedulingv1alpha3.PodGroup
 	var lastCPG *schedulingv1alpha3.CompositePodGroup
 
-	TraverseHierarchyUp(p.Namespace, startKey, podGroupLister, compositePodGroupLister, func(key fwk.EntityKey, pg *schedulingv1beta1.PodGroup, cpg *schedulingv1alpha3.CompositePodGroup) bool {
+	TraverseHierarchyUp(p.Namespace, startKey, podGroupLister, compositePodGroupLister, func(key fwk.EntityKey, pg *schedulingv1alpha3.PodGroup, cpg *schedulingv1alpha3.CompositePodGroup) bool {
 		if pg != nil {
 			lastPG = pg
 			lastCPG = nil

--- a/pkg/scheduler/framework/preemption/util_test.go
+++ b/pkg/scheduler/framework/preemption/util_test.go
@@ -25,7 +25,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fwk "k8s.io/kube-scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -674,7 +673,7 @@ func TestGetPodPriority(t *testing.T) {
 			name: "pod with PodGroup returns PodGroup priority instead of pod priority",
 			pod:  st.MakePod().Name("p2").Priority(10).PodGroupName("pg1").Obj(),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": st.MakePodGroup().Name("pg1").Priority(50).Obj(),
 				},
 			},
@@ -691,7 +690,7 @@ func TestGetPodPriority(t *testing.T) {
 		{
 			name:                    "pod with PodGroup but PodGroup not found in lister falls back to pod priority",
 			pod:                     st.MakePod().Name("p5").Priority(30).PodGroupName("missing-pg").Obj(),
-			podGroupLister:          &mockPodGroupLister{podGroups: map[string]*schedulingv1beta1.PodGroup{}},
+			podGroupLister:          &mockPodGroupLister{podGroups: map[string]*schedulingv1alpha3.PodGroup{}},
 			compositePodGroupLister: nil,
 			expectedPriority:        30,
 		},
@@ -706,10 +705,10 @@ func TestGetPodPriority(t *testing.T) {
 			name: "pod with PodGroup and parent CPG, returns CPG priority",
 			pod:  st.MakePod().Name("p7").Priority(10).PodGroupName("pg1").Obj(),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": {
 						ObjectMeta: metav1.ObjectMeta{Name: "pg1"},
-						Spec: schedulingv1beta1.PodGroupSpec{
+						Spec: schedulingv1alpha3.PodGroupSpec{
 							ParentCompositePodGroupName: new("cpg1"),
 						},
 					},
@@ -731,10 +730,10 @@ func TestGetPodPriority(t *testing.T) {
 			name: "pod with PodGroup and grandparent CPG, returns grandparent CPG priority",
 			pod:  st.MakePod().Name("p8").Priority(10).PodGroupName("pg1").Obj(),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": {
 						ObjectMeta: metav1.ObjectMeta{Name: "pg1"},
-						Spec: schedulingv1beta1.PodGroupSpec{
+						Spec: schedulingv1alpha3.PodGroupSpec{
 							ParentCompositePodGroupName: new("cpg1"),
 						},
 					},
@@ -762,7 +761,7 @@ func TestGetPodPriority(t *testing.T) {
 			name: "pod with PodGroup and parent CPG, but nil compositePodGroupLister, falls back to PodGroup priority",
 			pod:  st.MakePod().Name("p9").Priority(10).PodGroupName("pg1").Obj(),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": st.MakePodGroup().Name("pg1").Priority(50).ParentCompositePodGroup("cpg1").Obj(),
 				},
 			},
@@ -773,7 +772,7 @@ func TestGetPodPriority(t *testing.T) {
 			name: "pod with PodGroup and parent CPG, but parent CPG not found in lister, falls back to PodGroup priority",
 			pod:  st.MakePod().Name("p10").Priority(10).PodGroupName("pg1").Obj(),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": st.MakePodGroup().Name("pg1").Priority(50).ParentCompositePodGroup("cpg1").Obj(),
 				},
 			},
@@ -786,7 +785,7 @@ func TestGetPodPriority(t *testing.T) {
 			name: "pod with PodGroup, parent CPG and grandparent CPG, but grandparent CPG not found in lister, falls back to parent CPG priority",
 			pod:  st.MakePod().Name("p11").Priority(10).PodGroupName("pg1").Obj(),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": st.MakePodGroup().Name("pg1").Priority(50).ParentCompositePodGroup("cpg1").Obj(),
 				},
 			},
@@ -807,7 +806,7 @@ func TestGetPodPriority(t *testing.T) {
 			name: "pod with PodGroup, but PodGroup not found in lister and non-nil compositePodGroupLister, falls back to pod priority",
 			pod:  st.MakePod().Name("p12").Priority(50).PodGroupName("missing-pg").Obj(),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{},
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{},
 			},
 			compositePodGroupLister: &mockCompositePodGroupLister{
 				compositePodGroups: map[string]*schedulingv1alpha3.CompositePodGroup{},
@@ -848,7 +847,7 @@ func TestTraverseHierarchyUp(t *testing.T) {
 			name:     "nil compositePodGroupLister",
 			startKey: fwk.PodGroupKey(namespace, "pg1"),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": st.MakePodGroup().Name("pg1").Obj(),
 				},
 			},
@@ -858,7 +857,7 @@ func TestTraverseHierarchyUp(t *testing.T) {
 		{
 			name:                    "unsupported key type",
 			startKey:                fwk.PodKey(namespace, "p1"),
-			podGroupLister:          &mockPodGroupLister{podGroups: map[string]*schedulingv1beta1.PodGroup{}},
+			podGroupLister:          &mockPodGroupLister{podGroups: map[string]*schedulingv1alpha3.PodGroup{}},
 			compositePodGroupLister: &mockCompositePodGroupLister{compositePodGroups: map[string]*schedulingv1alpha3.CompositePodGroup{}},
 			expectedVisitedKeys:     nil,
 		},
@@ -866,7 +865,7 @@ func TestTraverseHierarchyUp(t *testing.T) {
 			name:     "single PG without parent CPG",
 			startKey: fwk.PodGroupKey(namespace, "pg1"),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": st.MakePodGroup().Namespace(namespace).Name("pg1").Obj(),
 				},
 			},
@@ -879,7 +878,7 @@ func TestTraverseHierarchyUp(t *testing.T) {
 			name:     "PG -> parent CPG -> grandparent CPG",
 			startKey: fwk.PodGroupKey(namespace, "pg1"),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": st.MakePodGroup().Namespace(namespace).Name("pg1").ParentCompositePodGroup("cpg1").Obj(),
 				},
 			},
@@ -905,7 +904,7 @@ func TestTraverseHierarchyUp(t *testing.T) {
 		{
 			name:           "start directly from CPG",
 			startKey:       fwk.CompositePodGroupKey(namespace, "cpg1"),
-			podGroupLister: &mockPodGroupLister{podGroups: map[string]*schedulingv1beta1.PodGroup{}},
+			podGroupLister: &mockPodGroupLister{podGroups: map[string]*schedulingv1alpha3.PodGroup{}},
 			compositePodGroupLister: &mockCompositePodGroupLister{
 				compositePodGroups: map[string]*schedulingv1alpha3.CompositePodGroup{
 					"cpg1": {
@@ -928,7 +927,7 @@ func TestTraverseHierarchyUp(t *testing.T) {
 			name:     "early stop via visitFn",
 			startKey: fwk.PodGroupKey(namespace, "pg1"),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": st.MakePodGroup().Namespace(namespace).Name("pg1").ParentCompositePodGroup("cpg1").Obj(),
 				},
 			},
@@ -955,7 +954,7 @@ func TestTraverseHierarchyUp(t *testing.T) {
 			name:     "cycle detection between CPGs",
 			startKey: fwk.PodGroupKey(namespace, "pg1"),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": st.MakePodGroup().Namespace(namespace).Name("pg1").ParentCompositePodGroup("cpg1").Obj(),
 				},
 			},
@@ -984,7 +983,7 @@ func TestTraverseHierarchyUp(t *testing.T) {
 		{
 			name:                    "missing PG in lister",
 			startKey:                fwk.PodGroupKey(namespace, "missing-pg"),
-			podGroupLister:          &mockPodGroupLister{podGroups: map[string]*schedulingv1beta1.PodGroup{}},
+			podGroupLister:          &mockPodGroupLister{podGroups: map[string]*schedulingv1alpha3.PodGroup{}},
 			compositePodGroupLister: &mockCompositePodGroupLister{compositePodGroups: map[string]*schedulingv1alpha3.CompositePodGroup{}},
 			expectedVisitedKeys:     nil,
 		},
@@ -992,7 +991,7 @@ func TestTraverseHierarchyUp(t *testing.T) {
 			name:     "missing parent CPG in lister stops gracefully",
 			startKey: fwk.PodGroupKey(namespace, "pg1"),
 			podGroupLister: &mockPodGroupLister{
-				podGroups: map[string]*schedulingv1beta1.PodGroup{
+				podGroups: map[string]*schedulingv1alpha3.PodGroup{
 					"pg1": st.MakePodGroup().Namespace(namespace).Name("pg1").ParentCompositePodGroup("missing-cpg").Obj(),
 				},
 			},
@@ -1006,7 +1005,7 @@ func TestTraverseHierarchyUp(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var visitedKeys []fwk.EntityKey
-			traverseFn := func(key fwk.EntityKey, pg *schedulingv1beta1.PodGroup, cpg *schedulingv1alpha3.CompositePodGroup) bool {
+			traverseFn := func(key fwk.EntityKey, pg *schedulingv1alpha3.PodGroup, cpg *schedulingv1alpha3.CompositePodGroup) bool {
 				visitedKeys = append(visitedKeys, key)
 				return key.Name == tt.stopAt
 			}

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -28,7 +28,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -1042,7 +1041,7 @@ func (pgqi *QueuedPodGroupInfo) SetFlushTimestamp(t time.Time) {
 }
 
 // AddPodGroup adds a pod group to the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) AddPodGroup(pg *schedulingv1beta1.PodGroup) {
+func (pgqi *QueuedPodGroupInfo) AddPodGroup(pg *schedulingv1alpha3.PodGroup) {
 	// We only add non-root pod groups to the hierarchy, because the root
 	// pod group is already present in the hierarchy.
 	if !utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) || pg.Spec.ParentCompositePodGroupName == nil {
@@ -1068,7 +1067,7 @@ func (pgqi *QueuedPodGroupInfo) AddPodGroup(pg *schedulingv1beta1.PodGroup) {
 }
 
 // UpdatePodGroup updates a pod group in the queued pod group info hierarchy.
-func (pgqi *QueuedPodGroupInfo) UpdatePodGroup(pg *schedulingv1beta1.PodGroup) {
+func (pgqi *QueuedPodGroupInfo) UpdatePodGroup(pg *schedulingv1alpha3.PodGroup) {
 	node, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, pg.Name)
 	if node != nil && node.GetPodGroup() != nil {
 		node.PodGroup = pg
@@ -1077,7 +1076,7 @@ func (pgqi *QueuedPodGroupInfo) UpdatePodGroup(pg *schedulingv1beta1.PodGroup) {
 
 // RemovePodGroup removes a pod group from the queued pod group info hierarchy.
 // It returns a slice of all pods within the hierarchy of the removed pod group.
-func (pgqi *QueuedPodGroupInfo) RemovePodGroup(pg *schedulingv1beta1.PodGroup) []*QueuedPodInfo {
+func (pgqi *QueuedPodGroupInfo) RemovePodGroup(pg *schedulingv1alpha3.PodGroup) []*QueuedPodInfo {
 	node, parent := findNodeAndParent(pgqi.PodGroupInfo, nil, pg.Name)
 	if node == nil {
 		return nil
@@ -1174,7 +1173,7 @@ func (pgqi *QueuedPodGroupInfo) deleteSubtreePods(curr *PodGroupInfo) []*QueuedP
 	return removedPods
 }
 
-func newQueuedPodGroupInfo(pg *schedulingv1beta1.PodGroup) *QueuedPodGroupInfo {
+func newQueuedPodGroupInfo(pg *schedulingv1alpha3.PodGroup) *QueuedPodGroupInfo {
 	return &QueuedPodGroupInfo{
 		PodGroupInfo: &PodGroupInfo{
 			Namespace: pg.Namespace,
@@ -1203,7 +1202,7 @@ type PodGroupInfo struct {
 	// Only leaf pod groups have unscheduled pods.
 	UnscheduledPods []*v1.Pod
 	// PodGroup is a PodGroup API object.
-	PodGroup *schedulingv1beta1.PodGroup
+	PodGroup *schedulingv1alpha3.PodGroup
 	// CompositePodGroup is a CompositePodGroup API object.
 	// It should be set only when CompositePodGroup feature is enabled.
 	CompositePodGroup *schedulingv1alpha3.CompositePodGroup
@@ -1241,7 +1240,7 @@ func (pgi *PodGroupInfo) GetUnscheduledPods() []*v1.Pod {
 	return pods
 }
 
-func (pgi *PodGroupInfo) GetPodGroup() *schedulingv1beta1.PodGroup {
+func (pgi *PodGroupInfo) GetPodGroup() *schedulingv1alpha3.PodGroup {
 	return pgi.PodGroup
 }
 

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -3538,7 +3537,7 @@ func TestPodGroupInfoGetChildrenSorting(t *testing.T) {
 		return &PodGroupInfo{
 			Name:      name,
 			Namespace: namespace,
-			PodGroup: &schedulingv1beta1.PodGroup{
+			PodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              name,
 					Namespace:         namespace,
@@ -3902,7 +3901,7 @@ func TestQueuedPodGroupInfo_AddPodGroup(t *testing.T) {
 	tests := []struct {
 		name       string
 		initialCPG *schedulingv1alpha3.CompositePodGroup
-		pgToAdd    *schedulingv1beta1.PodGroup
+		pgToAdd    *schedulingv1alpha3.PodGroup
 		verify     func(*testing.T, *QueuedPodGroupInfo)
 	}{
 		{
@@ -3973,7 +3972,7 @@ func TestQueuedPodGroupInfo_UpdatePodGroup(t *testing.T) {
 	tests := []struct {
 		name     string
 		setup    func() *QueuedPodGroupInfo
-		updatePG *schedulingv1beta1.PodGroup
+		updatePG *schedulingv1alpha3.PodGroup
 		verify   func(*testing.T, *QueuedPodGroupInfo)
 	}{
 		{
@@ -4055,7 +4054,7 @@ func TestQueuedPodGroupInfo_RemovePodGroup(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		removePG *schedulingv1beta1.PodGroup
+		removePG *schedulingv1alpha3.PodGroup
 		setup    func(*QueuedPodGroupInfo)
 		verify   func(*testing.T, *QueuedPodGroupInfo, []*QueuedPodInfo)
 	}{

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -197,8 +196,8 @@ func (mp *fakePlacementFeasiblePlugin) Permit(ctx context.Context, state fwk.Cyc
 func TestValidatePodGroup(t *testing.T) {
 	tests := []struct {
 		name                           string
-		podGroup                       *schedulingv1beta1.PodGroup
-		podGroups                      []*schedulingv1beta1.PodGroup
+		podGroup                       *schedulingv1alpha3.PodGroup
+		podGroups                      []*schedulingv1alpha3.PodGroup
 		compositePodGroup              *schedulingv1alpha3.CompositePodGroup
 		compositePodGroups             []*schedulingv1alpha3.CompositePodGroup
 		scheduledPods                  []*v1.Pod
@@ -325,7 +324,7 @@ func TestValidatePodGroup(t *testing.T) {
 		},
 		{
 			name:     "success when preemption policies match",
-			podGroup: st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			podGroup: st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg").PreemptionPolicy(v1.PreemptNever).Obj(),
 				st.MakePod().Name("p2").PodGroupName("pg").PreemptionPolicy(v1.PreemptNever).Obj(),
@@ -335,7 +334,7 @@ func TestValidatePodGroup(t *testing.T) {
 		},
 		{
 			name:     "failure when different preemption policies across pods",
-			podGroup: st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			podGroup: st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg").PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
 				st.MakePod().Name("p2").PodGroupName("pg").PreemptionPolicy(v1.PreemptNever).Obj(),
@@ -345,7 +344,7 @@ func TestValidatePodGroup(t *testing.T) {
 		},
 		{
 			name:     "failure when different preemption policies across pods and pod group",
-			podGroup: st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			podGroup: st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg").PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
 				st.MakePod().Name("p2").PodGroupName("pg").PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
@@ -355,7 +354,7 @@ func TestValidatePodGroup(t *testing.T) {
 		},
 		{
 			name:     "success when preemption policies between pods and podgroup do not match but PodGroupPreemptionPolicy is disabled",
-			podGroup: st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			podGroup: st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg").PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
 				st.MakePod().Name("p2").PodGroupName("pg").PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
@@ -365,7 +364,7 @@ func TestValidatePodGroup(t *testing.T) {
 		},
 		{
 			name:     "failure when preemption policies do not match across pods and PodGroupPreemptionPolicy is disabled",
-			podGroup: st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			podGroup: st.MakePodGroup().Name("pg").PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg").PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
 				st.MakePod().Name("p2").PodGroupName("pg").PreemptionPolicy(v1.PreemptNever).Obj(),
@@ -379,9 +378,9 @@ func TestValidatePodGroup(t *testing.T) {
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
-				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			podGroups: []*schedulingv1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
+				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			},
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg1").Priority(10).PreemptionPolicy(v1.PreemptNever).Obj(),
@@ -400,9 +399,9 @@ func TestValidatePodGroup(t *testing.T) {
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Priority(10).Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
-				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			podGroups: []*schedulingv1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
+				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			},
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg1").Priority(10).PreemptionPolicy(v1.PreemptNever).Obj(),
@@ -421,9 +420,9 @@ func TestValidatePodGroup(t *testing.T) {
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptLowerPriority).Obj(),
-				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptLowerPriority).Obj(),
+			podGroups: []*schedulingv1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(),
+				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(),
 			},
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg1").Priority(10).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
@@ -442,9 +441,9 @@ func TestValidatePodGroup(t *testing.T) {
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
-				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptLowerPriority).Obj(),
+			podGroups: []*schedulingv1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
+				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(),
 			},
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg1").Priority(10).PreemptionPolicy(v1.PreemptNever).Obj(),
@@ -463,9 +462,9 @@ func TestValidatePodGroup(t *testing.T) {
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptLowerPriority).Obj(),
-				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			podGroups: []*schedulingv1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(),
+				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			},
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg1").Priority(10).PreemptionPolicy(v1.PreemptLowerPriority).Obj(),
@@ -484,9 +483,9 @@ func TestValidatePodGroup(t *testing.T) {
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
-				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			podGroups: []*schedulingv1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
+				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			},
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg1").Priority(10).PreemptionPolicy(v1.PreemptNever).Obj(),
@@ -505,9 +504,9 @@ func TestValidatePodGroup(t *testing.T) {
 			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
 				st.MakeCompositePodGroup().Name("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
-				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptLowerPriority).Obj(), // different
+			podGroups: []*schedulingv1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
+				st.MakePodGroup().Name("pg2").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(), // different
 			},
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg1").Priority(10).PreemptionPolicy(v1.PreemptNever).Obj(),
@@ -527,8 +526,8 @@ func TestValidatePodGroup(t *testing.T) {
 				st.MakeCompositePodGroup().Name("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 				st.MakeCompositePodGroup().Name("cpg-nested").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-nested").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			podGroups: []*schedulingv1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-nested").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			},
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg1").Priority(10).PreemptionPolicy(v1.PreemptNever).Obj(),
@@ -547,8 +546,8 @@ func TestValidatePodGroup(t *testing.T) {
 				st.MakeCompositePodGroup().Name("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 				st.MakeCompositePodGroup().Name("cpg-nested").ParentCompositePodGroup("cpg-root").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptLowerPriority).Obj(), // different
 			},
-			podGroups: []*schedulingv1beta1.PodGroup{
-				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-nested").Priority(10).PreemptionPolicy(schedulingv1beta1.PreemptNever).Obj(),
+			podGroups: []*schedulingv1alpha3.PodGroup{
+				st.MakePodGroup().Name("pg1").ParentCompositePodGroup("cpg-nested").Priority(10).PreemptionPolicy(schedulingv1alpha3.PreemptNever).Obj(),
 			},
 			pods: []*v1.Pod{
 				st.MakePod().Name("p1").PodGroupName("pg1").Priority(10).PreemptionPolicy(v1.PreemptNever).Obj(),
@@ -577,7 +576,7 @@ func TestValidatePodGroup(t *testing.T) {
 				snapshot = internalcache.NewTestSnapshotWithCompositePodGroups(tt.scheduledPods, nil, tt.podGroups, tt.compositePodGroups)
 				podGroupInfo = buildHierarchicalQueuedPodGroupInfo(tt.compositePodGroup, tt.compositePodGroups, tt.podGroups, tt.pods)
 			} else {
-				snapshot = internalcache.NewTestSnapshotWithPodGroups(tt.scheduledPods, nil, []*schedulingv1beta1.PodGroup{tt.podGroup})
+				snapshot = internalcache.NewTestSnapshotWithPodGroups(tt.scheduledPods, nil, []*schedulingv1alpha3.PodGroup{tt.podGroup})
 				podGroupInfo = &framework.QueuedPodGroupInfo{
 					PodGroupInfo: &framework.PodGroupInfo{
 						Name:      tt.podGroup.Name,
@@ -629,7 +628,7 @@ func TestSkipPodGroupPodSchedule(t *testing.T) {
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 	qInfo3 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p3}}
 
-	testPodGroup := &schedulingv1beta1.PodGroup{
+	testPodGroup := &schedulingv1alpha3.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 	}
 
@@ -803,7 +802,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}
 
-	testPodGroup := &schedulingv1beta1.PodGroup{
+	testPodGroup := &schedulingv1alpha3.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 	}
 
@@ -1172,7 +1171,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 	p2 := st.MakePod().Name("p2").UID("p2").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
 	p3 := st.MakePod().Name("p3").UID("p3").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
 
-	testPodGroup := &schedulingv1beta1.PodGroup{
+	testPodGroup := &schedulingv1alpha3.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 	}
 
@@ -1574,13 +1573,13 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 	p2 := st.MakePod().Name("p2").Namespace("default").UID("p2").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
 	p3 := st.MakePod().Name("p3").Namespace("default").UID("p3").PodGroupName("pg").SchedulerName("test-scheduler").Obj()
 
-	testPodGroup := &schedulingv1beta1.PodGroup{
+	testPodGroup := &schedulingv1alpha3.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 	}
 
 	tests := []struct {
 		name             string
-		existingPodGroup *schedulingv1beta1.PodGroup
+		existingPodGroup *schedulingv1alpha3.PodGroup
 		// podResultsByPodName maps each pod name to its scheduling algorithm result.
 		// The final podResults slice is built in the order of UnscheduledPods after Pop,
 		// making the test independent of pod ordering within the pod group.
@@ -1705,9 +1704,9 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 		},
 		{
 			name: "Already Scheduled, successful cycle keeps condition",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
-				Status: schedulingv1beta1.PodGroupStatus{
+				Status: schedulingv1alpha3.PodGroupStatus{
 					Conditions: []metav1.Condition{{
 						Type:               schedulingapi.PodGroupInitiallyScheduled,
 						Status:             metav1.ConditionTrue,
@@ -1731,9 +1730,9 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 		},
 		{
 			name: "Already Scheduled, rejected cycle does not regress condition",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
-				Status: schedulingv1beta1.PodGroupStatus{
+				Status: schedulingv1alpha3.PodGroupStatus{
 					Conditions: []metav1.Condition{{
 						Type:               schedulingapi.PodGroupInitiallyScheduled,
 						Status:             metav1.ConditionTrue,
@@ -1759,9 +1758,9 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 		},
 		{
 			name: "Already Scheduled, error cycle does not regress condition",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
-				Status: schedulingv1beta1.PodGroupStatus{
+				Status: schedulingv1alpha3.PodGroupStatus{
 					Conditions: []metav1.Condition{{
 						Type:               schedulingapi.PodGroupInitiallyScheduled,
 						Status:             metav1.ConditionTrue,
@@ -1981,7 +1980,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 				}
 			}
 
-			updatedPodGroup, err := client.SchedulingV1beta1().PodGroups("default").Get(ctx, "pg", metav1.GetOptions{})
+			updatedPodGroup, err := client.SchedulingV1alpha3().PodGroups("default").Get(ctx, "pg", metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Failed to get PodGroup: %v", err)
 			}
@@ -1996,7 +1995,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 func TestUpdatePodGroupCondition(t *testing.T) {
 	tests := []struct {
 		name             string
-		existingPodGroup *schedulingv1beta1.PodGroup
+		existingPodGroup *schedulingv1alpha3.PodGroup
 		namespace        string
 		podGroupName     string
 		condition        *metav1.Condition
@@ -2007,7 +2006,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 	}{
 		{
 			name: "set Scheduled condition to True on empty status",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg1", Namespace: "ns1"},
 			},
 			namespace:    "ns1",
@@ -2027,7 +2026,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		},
 		{
 			name: "set Scheduled condition to False with Unschedulable reason",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg2", Namespace: "ns1"},
 			},
 			namespace:    "ns1",
@@ -2047,7 +2046,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		},
 		{
 			name: "set Scheduled condition to False with SchedulerError reason",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg3", Namespace: "ns1"},
 			},
 			namespace:    "ns1",
@@ -2067,9 +2066,9 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		},
 		{
 			name: "transition from Unschedulable to Scheduled",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg4", Namespace: "ns1"},
-				Status: schedulingv1beta1.PodGroupStatus{
+				Status: schedulingv1alpha3.PodGroupStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -2098,9 +2097,9 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		},
 		{
 			name: "transition from SchedulerError to Scheduled",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg-se-to-true", Namespace: "ns1"},
-				Status: schedulingv1beta1.PodGroupStatus{
+				Status: schedulingv1alpha3.PodGroupStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -2129,9 +2128,9 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		},
 		{
 			name: "do not regress Scheduled to Unschedulable",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg-true-to-unsched", Namespace: "ns1"},
-				Status: schedulingv1beta1.PodGroupStatus{
+				Status: schedulingv1alpha3.PodGroupStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -2161,9 +2160,9 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		},
 		{
 			name: "do not regress Scheduled to SchedulerError",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg-true-to-se", Namespace: "ns1"},
-				Status: schedulingv1beta1.PodGroupStatus{
+				Status: schedulingv1alpha3.PodGroupStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -2193,9 +2192,9 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		},
 		{
 			name: "transition from Unschedulable to SchedulerError preserves LastTransitionTime",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg-unsched-to-se", Namespace: "ns1"},
-				Status: schedulingv1beta1.PodGroupStatus{
+				Status: schedulingv1alpha3.PodGroupStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -2225,9 +2224,9 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		},
 		{
 			name: "transition from SchedulerError to Unschedulable preserves LastTransitionTime",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg-se-to-unsched", Namespace: "ns1"},
-				Status: schedulingv1beta1.PodGroupStatus{
+				Status: schedulingv1alpha3.PodGroupStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -2257,9 +2256,9 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		},
 		{
 			name: "Scheduled to Scheduled preserves LastTransitionTime",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg-true-to-true", Namespace: "ns1"},
-				Status: schedulingv1beta1.PodGroupStatus{
+				Status: schedulingv1alpha3.PodGroupStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -2289,7 +2288,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 		},
 		{
 			name: "ObservedGeneration is set from PodGroup generation",
-			existingPodGroup: &schedulingv1beta1.PodGroup{
+			existingPodGroup: &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg-gen", Namespace: "ns1", Generation: 7},
 			},
 			namespace:    "ns1",
@@ -2339,7 +2338,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			}
 			sched.updatePodGroupCondition(ctx, podGroupInfo.PodGroupInfo, tt.condition)
 
-			updatedPodGroup, err := client.SchedulingV1beta1().PodGroups(tt.namespace).Get(ctx, tt.podGroupName, metav1.GetOptions{})
+			updatedPodGroup, err := client.SchedulingV1alpha3().PodGroups(tt.namespace).Get(ctx, tt.podGroupName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("Failed to get PodGroup: %v", err)
 			}
@@ -2475,7 +2474,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 		st.MakeNode().Name("node2").Obj(),
 	}
 	podGroupPod := st.MakePod().Name("foo").UID("foo").PodGroupName("pg").Obj()
-	testPodGroup := &schedulingv1beta1.PodGroup{
+	testPodGroup := &schedulingv1alpha3.PodGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 	}
 
@@ -3057,7 +3056,7 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				for _, node := range nodes {
 					cache.AddNode(logger, node)
 				}
-				testPodGroup := &schedulingv1beta1.PodGroup{
+				testPodGroup := &schedulingv1alpha3.PodGroup{
 					ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 				}
 				cache.AddPodGroup(testPodGroup)
@@ -3227,7 +3226,7 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 			for _, node := range nodes {
 				cache.AddNode(logger, node)
 			}
-			testPodGroup := &schedulingv1beta1.PodGroup{
+			testPodGroup := &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: "default"},
 			}
 			cache.AddPodGroup(testPodGroup)
@@ -4561,7 +4560,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 		nodeInfoSnapshot: internalcache.NewTestSnapshotWithPodGroups(
 			[]*v1.Pod{st.MakePod().Name("p").Namespace("default").UID("p").PodGroupName("pg").Node("node1").SchedulerName("sched1").Obj()},
 			[]*v1.Node{st.MakeNode().Name("node1").Obj()},
-			[]*schedulingv1beta1.PodGroup{st.MakePodGroup().Name("pg").Namespace("default").UID("pg").Obj()},
+			[]*schedulingv1alpha3.PodGroup{st.MakePodGroup().Name("pg").Namespace("default").UID("pg").Obj()},
 		),
 		client: client,
 		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
@@ -4570,7 +4569,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 
 	sched.scheduleOnePodGroup(ctx, podGroupInfo)
 
-	pg, err := client.SchedulingV1beta1().PodGroups("default").Get(ctx, "pg", metav1.GetOptions{})
+	pg, err := client.SchedulingV1alpha3().PodGroups("default").Get(ctx, "pg", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to get PodGroup: %v", err)
 	}
@@ -4826,20 +4825,20 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 	ns := "default"
 
 	// Helper function to create PodGroups
-	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1beta1.PodGroup {
-		var policy schedulingv1beta1.PodGroupSchedulingPolicy
+	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1alpha3.PodGroup {
+		var policy schedulingv1alpha3.PodGroupSchedulingPolicy
 		if minCount > 0 {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Gang: &schedulingv1beta1.GangSchedulingPolicy{MinCount: minCount},
+			policy = schedulingv1alpha3.PodGroupSchedulingPolicy{
+				Gang: &schedulingv1alpha3.GangSchedulingPolicy{MinCount: minCount},
 			}
 		} else {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Basic: &schedulingv1beta1.BasicSchedulingPolicy{},
+			policy = schedulingv1alpha3.PodGroupSchedulingPolicy{
+				Basic: &schedulingv1alpha3.BasicSchedulingPolicy{},
 			}
 		}
-		pg := &schedulingv1beta1.PodGroup{
+		pg := &schedulingv1alpha3.PodGroup{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1beta1.PodGroupSpec{
+			Spec: schedulingv1alpha3.PodGroupSpec{
 				SchedulingPolicy:            policy,
 				ParentCompositePodGroupName: new(parentCPG),
 			},
@@ -5132,20 +5131,20 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 		return cpg
 	}
 
-	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1beta1.PodGroup {
-		var policy schedulingv1beta1.PodGroupSchedulingPolicy
+	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1alpha3.PodGroup {
+		var policy schedulingv1alpha3.PodGroupSchedulingPolicy
 		if minCount > 0 {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Gang: &schedulingv1beta1.GangSchedulingPolicy{MinCount: minCount},
+			policy = schedulingv1alpha3.PodGroupSchedulingPolicy{
+				Gang: &schedulingv1alpha3.GangSchedulingPolicy{MinCount: minCount},
 			}
 		} else {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Basic: &schedulingv1beta1.BasicSchedulingPolicy{},
+			policy = schedulingv1alpha3.PodGroupSchedulingPolicy{
+				Basic: &schedulingv1alpha3.BasicSchedulingPolicy{},
 			}
 		}
-		pg := &schedulingv1beta1.PodGroup{
+		pg := &schedulingv1alpha3.PodGroup{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1beta1.PodGroupSpec{
+			Spec: schedulingv1alpha3.PodGroupSpec{
 				SchedulingPolicy:            policy,
 				ParentCompositePodGroupName: new(parentCPG),
 			},
@@ -5364,20 +5363,20 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 		return cpg
 	}
 
-	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1beta1.PodGroup {
-		var policy schedulingv1beta1.PodGroupSchedulingPolicy
+	createPG := func(name string, minCount int32, parentCPG string) *schedulingv1alpha3.PodGroup {
+		var policy schedulingv1alpha3.PodGroupSchedulingPolicy
 		if minCount > 0 {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Gang: &schedulingv1beta1.GangSchedulingPolicy{MinCount: minCount},
+			policy = schedulingv1alpha3.PodGroupSchedulingPolicy{
+				Gang: &schedulingv1alpha3.GangSchedulingPolicy{MinCount: minCount},
 			}
 		} else {
-			policy = schedulingv1beta1.PodGroupSchedulingPolicy{
-				Basic: &schedulingv1beta1.BasicSchedulingPolicy{},
+			policy = schedulingv1alpha3.PodGroupSchedulingPolicy{
+				Basic: &schedulingv1alpha3.BasicSchedulingPolicy{},
 			}
 		}
-		pg := &schedulingv1beta1.PodGroup{
+		pg := &schedulingv1alpha3.PodGroup{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
-			Spec: schedulingv1beta1.PodGroupSpec{
+			Spec: schedulingv1alpha3.PodGroupSpec{
 				SchedulingPolicy:            policy,
 				ParentCompositePodGroupName: new(parentCPG),
 			},
@@ -5906,7 +5905,7 @@ func TestScorePlacementPodGroupAssignments(t *testing.T) {
 func buildHierarchicalQueuedPodGroupInfo(
 	rootCPG *schedulingv1alpha3.CompositePodGroup,
 	cpgs []*schedulingv1alpha3.CompositePodGroup,
-	pgs []*schedulingv1beta1.PodGroup,
+	pgs []*schedulingv1alpha3.PodGroup,
 	pods []*v1.Pod,
 ) *framework.QueuedPodGroupInfo {
 	cpgChildren := make(map[string][]*schedulingv1alpha3.CompositePodGroup)
@@ -5916,7 +5915,7 @@ func buildHierarchicalQueuedPodGroupInfo(
 			cpgChildren[parent] = append(cpgChildren[parent], cpg)
 		}
 	}
-	pgChildren := make(map[string][]*schedulingv1beta1.PodGroup)
+	pgChildren := make(map[string][]*schedulingv1alpha3.PodGroup)
 	for _, pg := range pgs {
 		if pg.Spec.ParentCompositePodGroupName != nil {
 			parent := *pg.Spec.ParentCompositePodGroupName

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -38,7 +38,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1041,7 +1041,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 		var gotNominatingInfo *fwk.NominatingInfo
 
 		var clientObjs []runtime.Object
-		var podGroup *schedulingv1beta1.PodGroup
+		var podGroup *schedulingv1alpha3.PodGroup
 		if scheduleAsPodGroup {
 			group := &v1.PodSchedulingGroup{
 				PodGroupName: new("pg"),
@@ -1056,7 +1056,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 				item.expectPodInUnschedulable = nil
 			}
 
-			podGroup = &schedulingv1beta1.PodGroup{
+			podGroup = &schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{Name: "pg", Namespace: item.sendPod.Namespace},
 			}
 			clientObjs = []runtime.Object{item.sendPod, podGroup}

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -25,7 +25,6 @@ import (
 	policy "k8s.io/api/policy/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1327,7 +1326,7 @@ func (wrapper *ResourceClaimWrapper) ReservedForPod(podName string, podUID types
 
 // ReservedForPodGroup sets that field of the inner object given information about one podgroup.
 func (wrapper *ResourceClaimWrapper) ReservedForPodGroup(podGroupName string, podGroupUID types.UID) *ResourceClaimWrapper {
-	return wrapper.ReservedFor(resourceapi.ResourceClaimConsumerReference{APIGroup: schedulingv1beta1.GroupName, Resource: "podgroups", Name: podGroupName, UID: podGroupUID})
+	return wrapper.ReservedFor(resourceapi.ResourceClaimConsumerReference{APIGroup: schedulingv1alpha3.GroupName, Resource: "podgroups", Name: podGroupName, UID: podGroupUID})
 }
 
 type ResourceSliceWrapper struct {
@@ -1590,7 +1589,7 @@ func (c *VolumeAttachmentWrapper) Attached(attached bool) *VolumeAttachmentWrapp
 }
 
 // PodGroupWrapper wraps a PodGroup inside.
-type PodGroupWrapper struct{ schedulingv1beta1.PodGroup }
+type PodGroupWrapper struct{ schedulingv1alpha3.PodGroup }
 
 // MakePodGroup creates a PodGroup wrapper.
 func MakePodGroup() *PodGroupWrapper {
@@ -1616,14 +1615,14 @@ func (wrapper *PodGroupWrapper) UID(uid types.UID) *PodGroupWrapper {
 }
 
 // Obj returns the inner PodGroup.
-func (wrapper *PodGroupWrapper) Obj() *schedulingv1beta1.PodGroup {
+func (wrapper *PodGroupWrapper) Obj() *schedulingv1alpha3.PodGroup {
 	return &wrapper.PodGroup
 }
 
 // MinCount sets the MinCount for the Gang scheduling policy.
 func (wrapper *PodGroupWrapper) MinCount(count int32) *PodGroupWrapper {
 	if wrapper.PodGroup.Spec.SchedulingPolicy.Gang == nil {
-		wrapper.PodGroup.Spec.SchedulingPolicy.Gang = &schedulingv1beta1.GangSchedulingPolicy{}
+		wrapper.PodGroup.Spec.SchedulingPolicy.Gang = &schedulingv1alpha3.GangSchedulingPolicy{}
 	}
 	wrapper.PodGroup.Spec.SchedulingPolicy.Gang.MinCount = count
 	return wrapper
@@ -1631,13 +1630,13 @@ func (wrapper *PodGroupWrapper) MinCount(count int32) *PodGroupWrapper {
 
 // BasicPolicy sets the PodGroup policy to Basic.
 func (wrapper *PodGroupWrapper) BasicPolicy() *PodGroupWrapper {
-	wrapper.PodGroup.Spec.SchedulingPolicy.Basic = &schedulingv1beta1.BasicSchedulingPolicy{}
+	wrapper.PodGroup.Spec.SchedulingPolicy.Basic = &schedulingv1alpha3.BasicSchedulingPolicy{}
 	return wrapper
 }
 
 // WorkloadRef sets appropriate WorkloadRef field of the inner PodGroup.
 func (wrapper *PodGroupWrapper) WorkloadRef(templateName, workloadName string) *PodGroupWrapper {
-	wrapper.PodGroup.Spec.WorkloadRef = &schedulingv1beta1.WorkloadReference{
+	wrapper.PodGroup.Spec.WorkloadRef = &schedulingv1alpha3.WorkloadReference{
 		TemplateName: templateName,
 		WorkloadName: workloadName,
 	}
@@ -1646,8 +1645,8 @@ func (wrapper *PodGroupWrapper) WorkloadRef(templateName, workloadName string) *
 
 // TopologyKey sets appropriate TopologyKey field in the SchedulingConstraints of the inner PodGroup.
 func (wrapper *PodGroupWrapper) TopologyKey(topologyKey string) *PodGroupWrapper {
-	wrapper.PodGroup.Spec.SchedulingConstraints = &schedulingv1beta1.PodGroupSchedulingConstraints{
-		Topology: []schedulingv1beta1.TopologyConstraint{
+	wrapper.PodGroup.Spec.SchedulingConstraints = &schedulingv1alpha3.PodGroupSchedulingConstraints{
+		Topology: []schedulingv1alpha3.TopologyConstraint{
 			{
 				Key: topologyKey,
 			},
@@ -1657,26 +1656,26 @@ func (wrapper *PodGroupWrapper) TopologyKey(topologyKey string) *PodGroupWrapper
 }
 
 // ResourceClaims adds resource claims to the inner PodGroup.
-func (wrapper *PodGroupWrapper) ResourceClaims(claims ...schedulingv1beta1.PodGroupResourceClaim) *PodGroupWrapper {
+func (wrapper *PodGroupWrapper) ResourceClaims(claims ...schedulingv1alpha3.PodGroupResourceClaim) *PodGroupWrapper {
 	wrapper.Spec.ResourceClaims = append(wrapper.Spec.ResourceClaims, claims...)
 	return wrapper
 }
 
 // ResourceClaimStatuses adds resource claim statuses to the inner PodGroup.
-func (wrapper *PodGroupWrapper) ResourceClaimStatuses(statuses ...schedulingv1beta1.PodGroupResourceClaimStatus) *PodGroupWrapper {
+func (wrapper *PodGroupWrapper) ResourceClaimStatuses(statuses ...schedulingv1alpha3.PodGroupResourceClaimStatus) *PodGroupWrapper {
 	wrapper.Status.ResourceClaimStatuses = append(wrapper.Status.ResourceClaimStatuses, statuses...)
 	return wrapper
 }
 
 // DisruptionModeAll sets the disruption mode of the inner PodGroup to All.
 func (wrapper *PodGroupWrapper) DisruptionModeAll() *PodGroupWrapper {
-	wrapper.PodGroup.Spec.DisruptionMode = &schedulingv1beta1.DisruptionMode{All: &schedulingv1beta1.AllDisruptionMode{}}
+	wrapper.PodGroup.Spec.DisruptionMode = &schedulingv1alpha3.DisruptionMode{All: &schedulingv1alpha3.AllDisruptionMode{}}
 	return wrapper
 }
 
 // DisruptionModeSingle sets the disruption mode of the inner PodGroup to Single.
 func (wrapper *PodGroupWrapper) DisruptionModeSingle() *PodGroupWrapper {
-	wrapper.PodGroup.Spec.DisruptionMode = &schedulingv1beta1.DisruptionMode{Single: &schedulingv1beta1.SingleDisruptionMode{}}
+	wrapper.PodGroup.Spec.DisruptionMode = &schedulingv1alpha3.DisruptionMode{Single: &schedulingv1alpha3.SingleDisruptionMode{}}
 	return wrapper
 }
 
@@ -1687,7 +1686,7 @@ func (wrapper *PodGroupWrapper) Priority(priority int32) *PodGroupWrapper {
 }
 
 // PreemptionPolicy sets the preemption policy of the inner PodGroup.
-func (wrapper *PodGroupWrapper) PreemptionPolicy(policy schedulingv1beta1.PreemptionPolicy) *PodGroupWrapper {
+func (wrapper *PodGroupWrapper) PreemptionPolicy(policy schedulingv1alpha3.PreemptionPolicy) *PodGroupWrapper {
 	wrapper.PodGroup.Spec.PreemptionPolicy = &policy
 	return wrapper
 }
@@ -1699,7 +1698,7 @@ func (wrapper *PodGroupWrapper) ParentCompositePodGroup(parent string) *PodGroup
 }
 
 // WorkloadWrapper wraps a Workload inside.
-type WorkloadWrapper struct{ schedulingv1beta1.Workload }
+type WorkloadWrapper struct{ schedulingv1alpha3.Workload }
 
 // MakeWorkload creates a Workload wrapper.
 func MakeWorkload() *WorkloadWrapper {
@@ -1707,7 +1706,7 @@ func MakeWorkload() *WorkloadWrapper {
 }
 
 // Obj returns the inner Workload.
-func (wrapper *WorkloadWrapper) Obj() *schedulingv1beta1.Workload {
+func (wrapper *WorkloadWrapper) Obj() *schedulingv1alpha3.Workload {
 	return &wrapper.Workload
 }
 
@@ -1724,14 +1723,14 @@ func (wrapper *WorkloadWrapper) Namespace(namespace string) *WorkloadWrapper {
 }
 
 // PodGroupTemplate appends the given PodGroupTemplate to the Workload spec.
-func (wrapper *WorkloadWrapper) PodGroupTemplate(t schedulingv1beta1.PodGroupTemplate) *WorkloadWrapper {
+func (wrapper *WorkloadWrapper) PodGroupTemplate(t schedulingv1alpha3.PodGroupTemplate) *WorkloadWrapper {
 	wrapper.Workload.Spec.PodGroupTemplates = append(wrapper.Workload.Spec.PodGroupTemplates, t)
 	return wrapper
 }
 
 // PodGroupTemplateWrapper wraps a PodGroupTemplate inside.
 type PodGroupTemplateWrapper struct {
-	schedulingv1beta1.PodGroupTemplate
+	schedulingv1alpha3.PodGroupTemplate
 }
 
 // MakePodGroupTemplate creates a PodGroupTemplate wrapper.
@@ -1740,7 +1739,7 @@ func MakePodGroupTemplate() *PodGroupTemplateWrapper {
 }
 
 // Obj returns the inner PodGroupTemplate.
-func (wrapper *PodGroupTemplateWrapper) Obj() schedulingv1beta1.PodGroupTemplate {
+func (wrapper *PodGroupTemplateWrapper) Obj() schedulingv1alpha3.PodGroupTemplate {
 	return wrapper.PodGroupTemplate
 }
 
@@ -1759,7 +1758,7 @@ func (wrapper *PodGroupTemplateWrapper) Priority(priority int32) *PodGroupTempla
 // MinCount sets the MinCount for the Gang scheduling policy.
 func (wrapper *PodGroupTemplateWrapper) MinCount(count int32) *PodGroupTemplateWrapper {
 	if wrapper.SchedulingPolicy.Gang == nil {
-		wrapper.SchedulingPolicy.Gang = &schedulingv1beta1.GangSchedulingPolicy{}
+		wrapper.SchedulingPolicy.Gang = &schedulingv1alpha3.GangSchedulingPolicy{}
 	}
 	wrapper.SchedulingPolicy.Gang.MinCount = count
 	return wrapper
@@ -1767,24 +1766,24 @@ func (wrapper *PodGroupTemplateWrapper) MinCount(count int32) *PodGroupTemplateW
 
 // BasicPolicy sets the PodGroup policy to Basic.
 func (wrapper *PodGroupTemplateWrapper) BasicPolicy() *PodGroupTemplateWrapper {
-	wrapper.SchedulingPolicy.Basic = &schedulingv1beta1.BasicSchedulingPolicy{}
+	wrapper.SchedulingPolicy.Basic = &schedulingv1alpha3.BasicSchedulingPolicy{}
 	return wrapper
 }
 
 // DisruptionModeAll sets the disruption mode of the inner PodGroupTemplate to All.
 func (wrapper *PodGroupTemplateWrapper) DisruptionModeAll() *PodGroupTemplateWrapper {
-	wrapper.PodGroupTemplate.DisruptionMode = &schedulingv1beta1.DisruptionMode{All: &schedulingv1beta1.AllDisruptionMode{}}
+	wrapper.PodGroupTemplate.DisruptionMode = &schedulingv1alpha3.DisruptionMode{All: &schedulingv1alpha3.AllDisruptionMode{}}
 	return wrapper
 }
 
 // DisruptionModeSingle sets the disruption mode of the inner PodGroupTemplate to Single.
 func (wrapper *PodGroupTemplateWrapper) DisruptionModeSingle() *PodGroupTemplateWrapper {
-	wrapper.PodGroupTemplate.DisruptionMode = &schedulingv1beta1.DisruptionMode{Single: &schedulingv1beta1.SingleDisruptionMode{}}
+	wrapper.PodGroupTemplate.DisruptionMode = &schedulingv1alpha3.DisruptionMode{Single: &schedulingv1alpha3.SingleDisruptionMode{}}
 	return wrapper
 }
 
 // CompositePodGroupTemplate appends the given CompositePodGroupTemplate to the Workload spec.
-func (wrapper *WorkloadWrapper) CompositePodGroupTemplate(t schedulingv1beta1.CompositePodGroupTemplate) *WorkloadWrapper {
+func (wrapper *WorkloadWrapper) CompositePodGroupTemplate(t schedulingv1alpha3.CompositePodGroupTemplate) *WorkloadWrapper {
 	wrapper.Workload.Spec.CompositePodGroupTemplates = append(wrapper.Workload.Spec.CompositePodGroupTemplates, t)
 	return wrapper
 }
@@ -1807,7 +1806,7 @@ func (wrapper *WorkloadWrapper) Children(children ...any) *WorkloadWrapper {
 
 // CompositePodGroupTemplateWrapper wraps a CompositePodGroupTemplate inside.
 type CompositePodGroupTemplateWrapper struct {
-	schedulingv1beta1.CompositePodGroupTemplate
+	schedulingv1alpha3.CompositePodGroupTemplate
 }
 
 // MakeCompositePodGroupTemplate creates a CompositePodGroupTemplate wrapper.
@@ -1816,7 +1815,7 @@ func MakeCompositePodGroupTemplate() *CompositePodGroupTemplateWrapper {
 }
 
 // Obj returns the inner CompositePodGroupTemplate.
-func (wrapper *CompositePodGroupTemplateWrapper) Obj() schedulingv1beta1.CompositePodGroupTemplate {
+func (wrapper *CompositePodGroupTemplateWrapper) Obj() schedulingv1alpha3.CompositePodGroupTemplate {
 	return wrapper.CompositePodGroupTemplate
 }
 
@@ -1850,13 +1849,13 @@ func (wrapper *CompositePodGroupTemplateWrapper) Children(children ...any) *Comp
 
 // MinGroupCount sets the policy to Gang with the given minGroupCount.
 func (wrapper *CompositePodGroupTemplateWrapper) MinGroupCount(minGroupCount int32) *CompositePodGroupTemplateWrapper {
-	wrapper.SchedulingPolicy.Gang = &schedulingv1beta1.CompositeGangSchedulingPolicy{MinGroupCount: minGroupCount}
+	wrapper.SchedulingPolicy.Gang = &schedulingv1alpha3.CompositeGangSchedulingPolicy{MinGroupCount: minGroupCount}
 	return wrapper
 }
 
 // BasicPolicy sets the policy to Basic.
 func (wrapper *CompositePodGroupTemplateWrapper) BasicPolicy() *CompositePodGroupTemplateWrapper {
-	wrapper.SchedulingPolicy.Basic = &schedulingv1beta1.CompositeBasicSchedulingPolicy{}
+	wrapper.SchedulingPolicy.Basic = &schedulingv1alpha3.CompositeBasicSchedulingPolicy{}
 	return wrapper
 }
 

--- a/pkg/scheduler/util/utils.go
+++ b/pkg/scheduler/util/utils.go
@@ -26,7 +26,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -156,26 +155,26 @@ func PatchPodStatus(ctx context.Context, cs kubernetes.Interface, name string, n
 // PatchPodGroupStatus calculates the delta bytes change from <old.Status> to <newStatus>,
 // and then submits a request to API server to patch the PodGroup status changes.
 func PatchPodGroupStatus(ctx context.Context, cs kubernetes.Interface, name string,
-	namespace string, oldStatus *schedulingv1beta1.PodGroupStatus,
-	newStatus *schedulingv1beta1.PodGroupStatus) error {
+	namespace string, oldStatus *schedulingv1alpha3.PodGroupStatus,
+	newStatus *schedulingv1alpha3.PodGroupStatus) error {
 	if newStatus == nil {
 		return nil
 	}
 
 	if oldStatus == nil {
-		oldStatus = &schedulingv1beta1.PodGroupStatus{}
+		oldStatus = &schedulingv1alpha3.PodGroupStatus{}
 	}
 
-	oldData, err := json.Marshal(schedulingv1beta1.PodGroup{Status: *oldStatus})
+	oldData, err := json.Marshal(schedulingv1alpha3.PodGroup{Status: *oldStatus})
 	if err != nil {
 		return err
 	}
 
-	newData, err := json.Marshal(schedulingv1beta1.PodGroup{Status: *newStatus})
+	newData, err := json.Marshal(schedulingv1alpha3.PodGroup{Status: *newStatus})
 	if err != nil {
 		return err
 	}
-	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, &schedulingv1beta1.PodGroup{})
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, &schedulingv1alpha3.PodGroup{})
 	if err != nil {
 		return fmt.Errorf("failed to create merge patch for podgroup %q/%q: %w", namespace, name, err)
 	}
@@ -185,7 +184,7 @@ func PatchPodGroupStatus(ctx context.Context, cs kubernetes.Interface, name stri
 	}
 
 	patchFn := func() error {
-		_, err := cs.SchedulingV1beta1().PodGroups(namespace).Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+		_, err := cs.SchedulingV1alpha3().PodGroups(namespace).Patch(ctx, name, types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
 		return err
 	}
 
@@ -274,7 +273,7 @@ func GetHostPorts(pod *v1.Pod) []v1.ContainerPort {
 }
 
 // PodGroupPriority returns priority of a given pod group.
-func PodGroupPriority(pg *schedulingv1beta1.PodGroup) int32 {
+func PodGroupPriority(pg *schedulingv1alpha3.PodGroup) int32 {
 	if pg.Spec.Priority != nil {
 		return *pg.Spec.Priority
 	}

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -368,24 +368,24 @@ func TestPatchPodGroupStatus(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		podGroup schedulingv1beta1.PodGroup
+		podGroup schedulingv1alpha3.PodGroup
 		client   *clientsetfake.Clientset
 		// validateErr checks if error returned from PatchPodGroupStatus is expected one or not.
 		// (true means error is expected one.)
 		validateErr    func(goterr error) bool
-		statusToUpdate *schedulingv1beta1.PodGroupStatus
+		statusToUpdate *schedulingv1alpha3.PodGroupStatus
 		nilOldStatus   bool
 	}{
 		{
 			name:   "Should update podgroup conditions successfully",
 			client: clientsetfake.NewClientset(),
-			podGroup: schedulingv1beta1.PodGroup{
+			podGroup: schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
 				},
 			},
-			statusToUpdate: &schedulingv1beta1.PodGroupStatus{
+			statusToUpdate: &schedulingv1alpha3.PodGroupStatus{
 				Conditions: []metav1.Condition{
 					{
 						Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -400,12 +400,12 @@ func TestPatchPodGroupStatus(t *testing.T) {
 		{
 			name:   "no-op when status is unchanged",
 			client: clientsetfake.NewClientset(),
-			podGroup: schedulingv1beta1.PodGroup{
+			podGroup: schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
 				},
-				Status: schedulingv1beta1.PodGroupStatus{
+				Status: schedulingv1alpha3.PodGroupStatus{
 					Conditions: []metav1.Condition{
 						{
 							Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -417,7 +417,7 @@ func TestPatchPodGroupStatus(t *testing.T) {
 					},
 				},
 			},
-			statusToUpdate: &schedulingv1beta1.PodGroupStatus{
+			statusToUpdate: &schedulingv1alpha3.PodGroupStatus{
 				Conditions: []metav1.Condition{
 					{
 						Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -432,7 +432,7 @@ func TestPatchPodGroupStatus(t *testing.T) {
 		{
 			name:   "nil newStatus returns nil",
 			client: clientsetfake.NewClientset(),
-			podGroup: schedulingv1beta1.PodGroup{
+			podGroup: schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
@@ -449,23 +449,23 @@ func TestPatchPodGroupStatus(t *testing.T) {
 				client.PrependReactor("patch", "podgroups", func(action clienttesting.Action) (bool, runtime.Object, error) {
 					defer func() { reqcount++ }()
 					if reqcount == 0 {
-						return true, &schedulingv1beta1.PodGroup{}, fmt.Errorf("connection refused: %w", syscall.ECONNREFUSED)
+						return true, &schedulingv1alpha3.PodGroup{}, fmt.Errorf("connection refused: %w", syscall.ECONNREFUSED)
 					}
 					if reqcount == 1 {
-						return false, &schedulingv1beta1.PodGroup{}, nil
+						return false, &schedulingv1alpha3.PodGroup{}, nil
 					}
 					return true, nil, errors.New("requests comes in more than three times.")
 				})
 
 				return client
 			}(),
-			podGroup: schedulingv1beta1.PodGroup{
+			podGroup: schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
 				},
 			},
-			statusToUpdate: &schedulingv1beta1.PodGroupStatus{
+			statusToUpdate: &schedulingv1alpha3.PodGroupStatus{
 				Conditions: []metav1.Condition{
 					{
 						Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -488,19 +488,19 @@ func TestPatchPodGroupStatus(t *testing.T) {
 					if reqcount >= 4 {
 						return true, nil, errors.New("requests comes in more than four times.")
 					}
-					return true, &schedulingv1beta1.PodGroup{}, fmt.Errorf("connection refused: %w", syscall.ECONNREFUSED)
+					return true, &schedulingv1alpha3.PodGroup{}, fmt.Errorf("connection refused: %w", syscall.ECONNREFUSED)
 				})
 
 				return client
 			}(),
-			podGroup: schedulingv1beta1.PodGroup{
+			podGroup: schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
 				},
 			},
 			validateErr: net.IsConnectionRefused,
-			statusToUpdate: &schedulingv1beta1.PodGroupStatus{
+			statusToUpdate: &schedulingv1alpha3.PodGroupStatus{
 				Conditions: []metav1.Condition{
 					{
 						Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -521,26 +521,26 @@ func TestPatchPodGroupStatus(t *testing.T) {
 				client.PrependReactor("patch", "podgroups", func(action clienttesting.Action) (bool, runtime.Object, error) {
 					defer func() { reqcount++ }()
 					if reqcount == 0 {
-						return true, &schedulingv1beta1.PodGroup{},
+						return true, &schedulingv1alpha3.PodGroup{},
 							apierrors.NewConflict(schema.GroupResource{
 								Resource: "podgroups"}, "pg1",
 								errors.New("the object has been modified"))
 					}
 					if reqcount == 1 {
-						return false, &schedulingv1beta1.PodGroup{}, nil
+						return false, &schedulingv1alpha3.PodGroup{}, nil
 					}
 					return true, nil, errors.New("requests comes in more than three times.")
 				})
 
 				return client
 			}(),
-			podGroup: schedulingv1beta1.PodGroup{
+			podGroup: schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
 				},
 			},
-			statusToUpdate: &schedulingv1beta1.PodGroupStatus{
+			statusToUpdate: &schedulingv1alpha3.PodGroupStatus{
 				Conditions: []metav1.Condition{
 					{
 						Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -555,13 +555,13 @@ func TestPatchPodGroupStatus(t *testing.T) {
 		{
 			name:   "nil oldStatus patches successfully",
 			client: clientsetfake.NewClientset(),
-			podGroup: schedulingv1beta1.PodGroup{
+			podGroup: schedulingv1alpha3.PodGroup{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns",
 					Name:      "pg1",
 				},
 			},
-			statusToUpdate: &schedulingv1beta1.PodGroupStatus{
+			statusToUpdate: &schedulingv1alpha3.PodGroupStatus{
 				Conditions: []metav1.Condition{
 					{
 						Type:               schedulingapi.PodGroupInitiallyScheduled,
@@ -583,7 +583,7 @@ func TestPatchPodGroupStatus(t *testing.T) {
 			defer cancel()
 
 			client := tc.client
-			_, err := client.SchedulingV1beta1().PodGroups(tc.podGroup.Namespace).Create(ctx, &tc.podGroup, metav1.CreateOptions{})
+			_, err := client.SchedulingV1alpha3().PodGroups(tc.podGroup.Namespace).Create(ctx, &tc.podGroup, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -603,7 +603,7 @@ func TestPatchPodGroupStatus(t *testing.T) {
 				return
 			}
 
-			retrievedPG, err := client.SchedulingV1beta1().PodGroups(tc.podGroup.Namespace).Get(ctx, tc.podGroup.Name, metav1.GetOptions{})
+			retrievedPG, err := client.SchedulingV1alpha3().PodGroups(tc.podGroup.Namespace).Get(ctx, tc.podGroup.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceclaim/resourceclaim.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceclaim/resourceclaim.go
@@ -31,7 +31,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
-	schedulingapi "k8s.io/api/scheduling/v1beta1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )

--- a/staging/src/k8s.io/kube-scheduler/framework/listers.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/listers.go
@@ -20,7 +20,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	resourceapi "k8s.io/api/resource/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingapi "k8s.io/api/scheduling/v1beta1"
+	schedulingapi "k8s.io/api/scheduling/v1alpha3"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/staging/src/k8s.io/kube-scheduler/framework/types.go
+++ b/staging/src/k8s.io/kube-scheduler/framework/types.go
@@ -23,7 +23,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
-	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -701,7 +700,7 @@ type PodGroupInfo interface {
 	// GetKey returns the key uniquely identifying the pod group.
 	GetKey() string
 	// GetPodGroup returns the PodGroup API object or nil if the group is a composite pod group.
-	GetPodGroup() *schedulingv1beta1.PodGroup
+	GetPodGroup() *schedulingv1alpha3.PodGroup
 	// GetCompositePodGroup returns the associated composite pod group or nil if the group is not a composite pod group.
 	// It should only be used when the CompositePodGroup feature gate is enabled.
 	GetCompositePodGroup() *schedulingv1alpha3.CompositePodGroup


### PR DESCRIPTION
Replaces all k8s.io/api/scheduling/v1beta1 references in pkg/scheduler with k8s.io/api/scheduling/v1alpha3, 
