### PR TITLE
kubelet: clean up terminated static pods from waiting queue

### DIFF
--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -1076,23 +1076,30 @@ func (p *podWorkers) allowStaticPodStart(fullname string, uid types.UID) bool {
 	waitingPods := p.waitingToStartStaticPodsByFullname[fullname]
 	// TODO: This is O(N) with respect to the number of updates to static pods
 	// with overlapping full names, and ideally would be O(1).
+	firstValidIndex := -1
 	for i, waitingUID := range waitingPods {
 		// has pod already terminated or been deleted?
 		status, ok := p.podSyncStatuses[waitingUID]
 		if !ok || status.IsTerminationRequested() || status.IsTerminated() {
 			continue
 		}
-		// another pod is next in line
-		if waitingUID != uid {
-			p.waitingToStartStaticPodsByFullname[fullname] = waitingPods[i:]
-			return false
-		}
-		// we are up next, remove ourselves
-		waitingPods = waitingPods[i+1:]
+		firstValidIndex = i
 		break
 	}
-	if len(waitingPods) != 0 {
-		p.waitingToStartStaticPodsByFullname[fullname] = waitingPods
+
+	if firstValidIndex == -1 {
+		delete(p.waitingToStartStaticPodsByFullname, fullname)
+		p.startedStaticPodsByFullname[fullname] = uid
+		return true
+	}
+
+	if waitingPods[firstValidIndex] != uid {
+		p.waitingToStartStaticPodsByFullname[fullname] = waitingPods[firstValidIndex:]
+		return false
+	}
+
+	if remaining := waitingPods[firstValidIndex+1:]; len(remaining) != 0 {
+		p.waitingToStartStaticPodsByFullname[fullname] = remaining
 	} else {
 		delete(p.waitingToStartStaticPodsByFullname, fullname)
 	}

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -2498,6 +2498,35 @@ func Test_allowPodStart(t *testing.T) {
 			allowedEver: true,
 		},
 		{
+			desc: "static pod when all waiting pods are terminated and a new valid static pod arrives",
+			pod:  newStaticPod("uid-0", "foo"),
+			podSyncStatuses: map[types.UID]*podSyncStatus{
+				"uid-0": {
+					fullname: "foo_",
+				},
+				"uid-2": {
+					fullname:      "foo_",
+					terminatingAt: time.Now(),
+				},
+				"uid-3": {
+					fullname:     "foo_",
+					terminatedAt: time.Now(),
+				},
+			},
+			waitingToStartStaticPodsByFullname: map[string][]types.UID{
+				"foo_": {
+					types.UID("uid-2"),
+					types.UID("uid-3"),
+				},
+			},
+			expectedStartedStaticPodsByFullname: map[string]types.UID{
+				"foo_": types.UID("uid-0"),
+			},
+			expectedWaitingToStartStaticPodsByFullname: make(map[string][]types.UID),
+			allowed:     true,
+			allowedEver: true,
+		},
+		{
 			desc: "static pod if there is no sync status for the pod should be denied",
 			pod:  newStaticPod("uid-0", "foo"),
 			podSyncStatuses: map[types.UID]*podSyncStatus{


### PR DESCRIPTION
 #### What type of PR is this?                                                                                                                                                         

/kind bug
             
#### What this PR does / why we need it:
    
In `kubelet/pod_workers.go`, `allowStaticPodStart` manages serialization for static pods sharing the same fullname via `waitingToStartStaticPodsByFullname` (`map[string][]types.UID`).
    
When iterating over `waitingPods`, if all preceding queued instances have already terminated or requested termination before `allowPodStart` runs, the loop skips them via `continue`.
  
If no valid pod is encountered before the loop finishes (e.g. when an unqueued replacement static pod arrives), `waitingPods` was left unmodified and written back to the map, leaving  orphaned UIDs in memory indefinitely.                                                                                                                                                   
  
This PR:
1. Identifies the first non-terminated static pod index in `waitingPods`.
2. Deletes the map key if no valid waiting pods remain (`firstValidIndex == -1`).
3. Correctly reslices `waitingPods` from `firstValidIndex + 1` when a pod starts, pruning both preceding terminated entries and the starting pod.
4. Adds a unit test case to `Test_allowPodStart` verifying map cleanup when all queued pods have terminated.
    
#### Which issue(s) this PR is related to:

N/A 
        
#### Special notes for your reviewer:
    
The change is isolated to static pod queue cleanup in `pkg/kubelet/pod_workers.go` and does not alter non-static pod paths. Unit tests added in `pkg/kubelet/pod_workers_test.go`.
                                                                                                                                                                                          
#### Does this PR introduce a user-facing change?
    
```release-note
NONE
```           
        
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
  
