### PR TITLE
Lock down k8s.io/kubernetes imports in pkg/scheduler

### DIFF
--- a/pkg/scheduler/.import-restrictions
+++ b/pkg/scheduler/.import-restrictions
@@ -1,0 +1,28 @@
+rules:
+  # Allow only specific k8s.io/kubernetes dependencies currently used
+  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/api/v1/pod$
+    allowedPrefixes: [ "" ]
+  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/apis/core/v1/helper$
+    allowedPrefixes: [ "" ]
+  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/apis/core/validation$
+    allowedPrefixes: [ "" ]
+  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/apis/scheduling$
+    allowedPrefixes: [ "" ]
+  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/controller$
+    allowedPrefixes: [ "" ]
+  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/controller/volume/persistentvolume/testing$
+    allowedPrefixes: [ "" ]
+  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/features$
+    allowedPrefixes: [ "" ]
+  - selectorRegexp: ^k8s[.]io/kubernetes/test/utils/image$
+    allowedPrefixes: [ "" ]
+  - selectorRegexp: ^k8s[.]io/kubernetes/test/utils/ktesting($|/)
+    allowedPrefixes: [ "" ]
+
+  # Allow internal pkg/scheduler packages and subpackages
+  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/scheduler($|/)
+    allowedPrefixes: [ "" ]
+
+  # Forbid any other k8s.io/kubernetes imports
+  - selectorRegexp: ^k8s[.]io/kubernetes
+    forbiddenPrefixes: [ "" ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

This PR prevents silently expanding the k8s.io/kubernetes dependencies in scheduler package.

We will want the import allowlist to gradually shrink, until we are able to move the scheduler package into the staging repo as mentioned in #141411

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #141403

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
