### PR TITLE
sets: optimize SymmetricDifference with a single-allocation dual pass

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/set.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/set.go
@@ -131,7 +131,18 @@ func (s1 Set[T]) Difference(s2 Set[T]) Set[T] {
 // s1.SymmetricDifference(s2) = {a3, a4, a5}
 // s2.SymmetricDifference(s1) = {a3, a4, a5}
 func (s1 Set[T]) SymmetricDifference(s2 Set[T]) Set[T] {
-	return s1.Difference(s2).Union(s2.Difference(s1))
+	result := New[T]()
+	for key := range s1 {
+		if !s2.Has(key) {
+			result.Insert(key)
+		}
+	}
+	for key := range s2 {
+		if !s1.Has(key) {
+			result.Insert(key)
+		}
+	}
+	return result
 }
 
 // Union returns a new set which includes items in either s1 or s2.

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/set_generic_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/set_generic_test.go
@@ -194,15 +194,52 @@ func TestSetDifference(t *testing.T) {
 }
 
 func TestSetSymmetricDifference(t *testing.T) {
-	a := sets.New("1", "2", "3")
-	b := sets.New("1", "2", "4", "5")
-	c := a.SymmetricDifference(b)
-	d := b.SymmetricDifference(a)
-	if !c.Equal(sets.New("3", "4", "5")) {
-		t.Errorf("Unexpected contents: %#v", sets.List(c))
+	tests := []struct {
+		s1       sets.Set[string]
+		s2       sets.Set[string]
+		expected sets.Set[string]
+	}{
+		{
+			s1:       sets.New("1", "2", "3"),
+			s2:       sets.New("1", "2", "4", "5"),
+			expected: sets.New("3", "4", "5"),
+		},
+		{
+			s1:       sets.New("1", "2", "3"),
+			s2:       sets.New("1", "2", "3"),
+			expected: sets.New[string](),
+		},
+		{
+			s1:       sets.New("1", "2"),
+			s2:       sets.New("3", "4"),
+			expected: sets.New("1", "2", "3", "4"),
+		},
+		{
+			s1:       sets.New("1", "2"),
+			s2:       sets.New[string](),
+			expected: sets.New("1", "2"),
+		},
+		{
+			s1:       sets.New[string](),
+			s2:       sets.New("1", "2"),
+			expected: sets.New("1", "2"),
+		},
+		{
+			s1:       sets.New[string](),
+			s2:       sets.New[string](),
+			expected: sets.New[string](),
+		},
 	}
-	if !d.Equal(sets.New("3", "4", "5")) {
-		t.Errorf("Unexpected contents: %#v", sets.List(d))
+
+	for i, tc := range tests {
+		c := tc.s1.SymmetricDifference(tc.s2)
+		d := tc.s2.SymmetricDifference(tc.s1)
+		if !c.Equal(tc.expected) {
+			t.Errorf("[%d] Unexpected contents for s1.SymmetricDifference(s2): expected %#v, got %#v", i, sets.List(tc.expected), sets.List(c))
+		}
+		if !d.Equal(tc.expected) {
+			t.Errorf("[%d] Unexpected contents for s2.SymmetricDifference(s1): expected %#v, got %#v", i, sets.List(tc.expected), sets.List(d))
+		}
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`Set[T].SymmetricDifference` in `k8s.io/apimachinery/pkg/util/sets` was implemented as:

```go
func (s1 Set[T]) SymmetricDifference(s2 Set[T]) Set[T] {
	return s1.Difference(s2).Union(s2.Difference(s1))
}
```

This composition creates 3 separate heap map allocations (`s1.Difference(s2)`, `s2.Difference(s1)`, and `Union.Clone()`), discarding the first two to GC and triggering hash map growth/rehashing when inserting into the union map.

This PR:

1. Optimizes `Set[T].SymmetricDifference` to compute the result directly into a single allocated map via a dual linear scan over `s1` and `s2`.
2. Expands `TestSetSymmetricDifference` in `set_generic_test.go` into a table-driven test covering disjoint, identical, overlapping, and empty set edge cases.

#### Benchmark Results

Ran:

```bash
go test -run=^$ -bench=BenchmarkStringSet/symmetric-difference -benchmem -count=5 ./staging/src/k8s.io/apimachinery/pkg/util/sets
```

on `master` and `perf/sets-symmetric-difference`:

goarch: amd64
pkg: k8s.io/apimachinery/pkg/util/sets
cpu: 12th Gen Intel(R) Core(TM) i3-1215U

| Benchmark | master (5-Run Avg) | perf/sets-symmetric-difference (5-Run Avg) | Delta |
|---|---:|---:|---:|
| `symmetric-difference-20` | 13,956 ns/op (6,076 B/op, 19 allocs/op) | 8,661 ns/op (3,457 B/op, 8 allocs/op) | -37.9% time, -43.1% RAM, -57.9% allocs |
| `symmetric-difference-50` | 34,299 ns/op (12,271 B/op, 23 allocs/op) | 22,855 ns/op (6,937 B/op, 10 allocs/op) | -33.4% time, -43.5% RAM, -56.5% allocs |
| `symmetric-difference-100` | 63,126 ns/op (23,962 B/op, 27 allocs/op) | 39,943 ns/op (13,486 B/op, 12 allocs/op) | -36.7% time, -43.7% RAM, -55.6% allocs |
| `symmetric-difference-500` | 380,394 ns/op (190,351 B/op, 42 allocs/op) | 277,416 ns/op (108,828 B/op, 21 allocs/op) | -27.1% time, -42.8% RAM, -50.0% allocs |
| `symmetric-difference-1000` | 840,501 ns/op (380,782 B/op, 58 allocs/op) | 591,342 ns/op (217,888 B/op, 30 allocs/op) | -29.6% time, -42.8% RAM, -48.3% allocs |

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Zero API or behavioral changes. All existing and newly added table tests pass.

#### Does this PR introduce a user-facing change?

NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.: