### PR TITLE
scheduler: remove redundant conditional branch in getEntityFromAnyQueue

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -2144,9 +2144,6 @@ func (p *PriorityQueue) getEntityFromAnyQueue(unlockedActiveQ unlockedActiveQueu
 		return existing
 	}
 	if existing = p.unschedulableEntities.get(entityLookup); existing != nil {
-		if existing.Gated() {
-			return existing
-		}
 		return existing
 	}
 	return nil


### PR DESCRIPTION
#### What type of PR is this?
    
/kind cleanup
    
#### What this PR does / why we need it:
    
In `pkg/scheduler/backend/queue/scheduling_queue.go`, `getEntityFromAnyQueue` contained a redundant conditional check when looking up entities in `unschedulableEntities`:
                                                                                                                                                                                          
 ```go
    if existing = p.unschedulableEntities.get(entityLookup); existing != nil {
        if existing.Gated() {
            return existing  
        }
        return existing
    }
```
      
Since both branches execute return existing, the if existing.Gated() check is redundant. This PR cleans up the redundant branch to directly return existing.
  
#### Which issue(s) this PR is related to:
  
N/A 
      
#### Special notes for your reviewer:
  
Trivial dead-code cleanup in pkg/scheduler/backend/queue/scheduling_queue.go. All scheduler queue unit tests pass.
  
#### Does this PR introduce a user-facing change?
  
NONE
        
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
