### PR TITLE
kubectl describe: render byte resources as bytes, not millibytes

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -562,22 +562,22 @@ func describeLimitRangeSpec(spec corev1.LimitRangeSpec, prefix string, w PrefixW
 
 			maxQuantity, maxQuantityFound := maxResources[k]
 			if maxQuantityFound {
-				maxValue = maxQuantity.String()
+				maxValue = formatResourceQuantity(k, maxQuantity)
 			}
 
 			minQuantity, minQuantityFound := minResources[k]
 			if minQuantityFound {
-				minValue = minQuantity.String()
+				minValue = formatResourceQuantity(k, minQuantity)
 			}
 
 			defaultLimitQuantity, defaultLimitQuantityFound := defaultLimitResources[k]
 			if defaultLimitQuantityFound {
-				defaultLimitValue = defaultLimitQuantity.String()
+				defaultLimitValue = formatResourceQuantity(k, defaultLimitQuantity)
 			}
 
 			defaultRequestQuantity, defaultRequestQuantityFound := defaultRequestResources[k]
 			if defaultRequestQuantityFound {
-				defaultRequestValue = defaultRequestQuantity.String()
+				defaultRequestValue = formatResourceQuantity(k, defaultRequestQuantity)
 			}
 
 			ratioQuantity, ratioQuantityFound := ratio[k]
@@ -642,7 +642,8 @@ func DescribeResourceQuotas(quotas *corev1.ResourceQuotaList, w PrefixWriter) {
 		for _, resource := range resources {
 			hardQuantity := q.Status.Hard[resource]
 			usedQuantity := q.Status.Used[resource]
-			w.Write(LEVEL_1, "%s\t%s\t%s\n", string(resource), usedQuantity.String(), hardQuantity.String())
+			w.Write(LEVEL_1, "%s\t%s\t%s\n", string(resource),
+				formatResourceQuantity(resource, usedQuantity), formatResourceQuantity(resource, hardQuantity))
 		}
 	}
 }
@@ -736,7 +737,8 @@ func describeQuota(resourceQuota *corev1.ResourceQuota) (string, error) {
 			if hardQuantity.Format != usedQuantity.Format {
 				usedQuantity = *resource.NewQuantity(usedQuantity.Value(), hardQuantity.Format)
 			}
-			w.Write(LEVEL_0, msg, resourceName, usedQuantity.String(), hardQuantity.String())
+			w.Write(LEVEL_0, msg, resourceName,
+				formatResourceQuantity(resourceName, usedQuantity), formatResourceQuantity(resourceName, hardQuantity))
 		}
 		return nil
 	})
@@ -1892,6 +1894,26 @@ func describeContainerCommand(container corev1.Container, w PrefixWriter) {
 	}
 }
 
+// isByteSizedResource returns true for resources that are measured in bytes.
+func isByteSizedResource(name corev1.ResourceName) bool {
+	return name == corev1.ResourceMemory ||
+		name == corev1.ResourceStorage ||
+		name == corev1.ResourceEphemeralStorage ||
+		kubectlresourcehelper.IsHugePageResourceName(name)
+}
+
+// formatResourceQuantity renders a quantity, rounding byte-sized resources up to
+// whole bytes. A request of "0.1Gi" is stored as "107374182400m" because it is not
+// a whole number of bytes, and a fractional byte is not meaningful to display.
+// Quantities that are already whole bytes and resources not measured in bytes are
+// rendered unchanged.
+func formatResourceQuantity(name corev1.ResourceName, quantity resource.Quantity) string {
+	if _, exact := quantity.AsScale(0); exact || !isByteSizedResource(name) {
+		return quantity.String()
+	}
+	return resource.NewQuantity(quantity.Value(), quantity.Format).String()
+}
+
 func describeResources(resources *corev1.ResourceRequirements, w PrefixWriter, level int) {
 	if resources == nil {
 		return
@@ -1902,7 +1924,7 @@ func describeResources(resources *corev1.ResourceRequirements, w PrefixWriter, l
 	}
 	for _, name := range SortedResourceNames(resources.Limits) {
 		quantity := resources.Limits[name]
-		w.Write(level+1, "%s:\t%s\n", name, quantity.String())
+		w.Write(level+1, "%s:\t%s\n", name, formatResourceQuantity(name, quantity))
 	}
 
 	if len(resources.Requests) > 0 {
@@ -1910,7 +1932,7 @@ func describeResources(resources *corev1.ResourceRequirements, w PrefixWriter, l
 	}
 	for _, name := range SortedResourceNames(resources.Requests) {
 		quantity := resources.Requests[name]
-		w.Write(level+1, "%s:\t%s\n", name, quantity.String())
+		w.Write(level+1, "%s:\t%s\n", name, formatResourceQuantity(name, quantity))
 	}
 }
 
@@ -3544,7 +3566,7 @@ func describeNode(node *corev1.Node, nodeNonTerminatedPodsList *corev1.PodList, 
 			sort.Sort(SortableResourceNames(resources))
 			for _, resource := range resources {
 				value := resourceList[resource]
-				w.Write(LEVEL_0, "  %s:\t%s\n", resource, value.String())
+				w.Write(LEVEL_0, "  %s:\t%s\n", resource, formatResourceQuantity(resource, value))
 			}
 		}
 
@@ -4073,7 +4095,9 @@ func describeNodeResource(nodeNonTerminatedPodsList *corev1.PodList, node *corev
 		fractionMemoryLimit := float64(memoryLimit.Value()) / float64(allocatable.Memory().Value()) * 100
 		w.Write(LEVEL_1, "%s\t%s\t\t%s (%d%%)\t%s (%d%%)\t%s (%d%%)\t%s (%d%%)\t%s\n", pod.Namespace, pod.Name,
 			cpuReq.String(), int64(fractionCpuReq), cpuLimit.String(), int64(fractionCpuLimit),
-			memoryReq.String(), int64(fractionMemoryReq), memoryLimit.String(), int64(fractionMemoryLimit), translateTimestampSince(pod.CreationTimestamp))
+			formatResourceQuantity(corev1.ResourceMemory, memoryReq), int64(fractionMemoryReq),
+			formatResourceQuantity(corev1.ResourceMemory, memoryLimit), int64(fractionMemoryLimit),
+			translateTimestampSince(pod.CreationTimestamp))
 	}
 
 	w.Write(LEVEL_0, "Allocated resources:\n  (Total limits may be over 100 percent, i.e., overcommitted.)\n")
@@ -4103,9 +4127,13 @@ func describeNodeResource(nodeNonTerminatedPodsList *corev1.PodList, node *corev
 	w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
 		corev1.ResourceCPU, cpuReqs.String(), int64(fractionCpuReqs), cpuLimits.String(), int64(fractionCpuLimits))
 	w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
-		corev1.ResourceMemory, memoryReqs.String(), int64(fractionMemoryReqs), memoryLimits.String(), int64(fractionMemoryLimits))
+		corev1.ResourceMemory,
+		formatResourceQuantity(corev1.ResourceMemory, memoryReqs), int64(fractionMemoryReqs),
+		formatResourceQuantity(corev1.ResourceMemory, memoryLimits), int64(fractionMemoryLimits))
 	w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
-		corev1.ResourceEphemeralStorage, ephemeralstorageReqs.String(), int64(fractionEphemeralStorageReqs), ephemeralstorageLimits.String(), int64(fractionEphemeralStorageLimits))
+		corev1.ResourceEphemeralStorage,
+		formatResourceQuantity(corev1.ResourceEphemeralStorage, ephemeralstorageReqs), int64(fractionEphemeralStorageReqs),
+		formatResourceQuantity(corev1.ResourceEphemeralStorage, ephemeralstorageLimits), int64(fractionEphemeralStorageLimits))
 
 	extResources := make([]string, 0, len(allocatable))
 	hugePageResources := make([]string, 0, len(allocatable))
@@ -4121,7 +4149,8 @@ func describeNodeResource(nodeNonTerminatedPodsList *corev1.PodList, node *corev
 	sort.Strings(hugePageResources)
 
 	for _, resource := range hugePageResources {
-		hugePageSizeRequests, hugePageSizeLimits, hugePageSizeAllocable := reqs[corev1.ResourceName(resource)], limits[corev1.ResourceName(resource)], allocatable[corev1.ResourceName(resource)]
+		hugePageName := corev1.ResourceName(resource)
+		hugePageSizeRequests, hugePageSizeLimits, hugePageSizeAllocable := reqs[hugePageName], limits[hugePageName], allocatable[hugePageName]
 		fractionHugePageSizeRequests := float64(0)
 		fractionHugePageSizeLimits := float64(0)
 		if hugePageSizeAllocable.Value() != 0 {
@@ -4129,7 +4158,9 @@ func describeNodeResource(nodeNonTerminatedPodsList *corev1.PodList, node *corev
 			fractionHugePageSizeLimits = float64(hugePageSizeLimits.Value()) / float64(hugePageSizeAllocable.Value()) * 100
 		}
 		w.Write(LEVEL_1, "%s\t%s (%d%%)\t%s (%d%%)\n",
-			resource, hugePageSizeRequests.String(), int64(fractionHugePageSizeRequests), hugePageSizeLimits.String(), int64(fractionHugePageSizeLimits))
+			resource,
+			formatResourceQuantity(hugePageName, hugePageSizeRequests), int64(fractionHugePageSizeRequests),
+			formatResourceQuantity(hugePageName, hugePageSizeLimits), int64(fractionHugePageSizeLimits))
 	}
 
 	for _, ext := range extResources {

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -1024,7 +1024,7 @@ func printHostPathVolumeSource(hostPath *corev1.HostPathVolumeSource, w PrefixWr
 func printEmptyDirVolumeSource(emptyDir *corev1.EmptyDirVolumeSource, w PrefixWriter) {
 	var sizeLimit string
 	if emptyDir.SizeLimit != nil && emptyDir.SizeLimit.Cmp(resource.Quantity{}) > 0 {
-		sizeLimit = fmt.Sprintf("%v", emptyDir.SizeLimit)
+		sizeLimit = formatResourceQuantity(corev1.ResourceStorage, *emptyDir.SizeLimit)
 	} else {
 		sizeLimit = "<unset>"
 	}
@@ -1906,9 +1906,13 @@ func isByteSizedResource(name corev1.ResourceName) bool {
 // whole bytes. A request of "0.1Gi" is stored as "107374182400m" because it is not
 // a whole number of bytes, and a fractional byte is not meaningful to display.
 // Quantities that are already whole bytes and resources not measured in bytes are
-// rendered unchanged.
+// rendered unchanged, as are negative quantities, which are rejected by API
+// validation for every resource this applies to.
 func formatResourceQuantity(name corev1.ResourceName, quantity resource.Quantity) string {
-	if _, exact := quantity.AsScale(0); exact || !isByteSizedResource(name) {
+	if quantity.Sign() <= 0 || !isByteSizedResource(name) {
+		return quantity.String()
+	}
+	if _, exact := quantity.AsScale(0); exact {
 		return quantity.String()
 	}
 	return resource.NewQuantity(quantity.Value(), quantity.Format).String()

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -1761,12 +1761,11 @@ func printPersistentVolumeClaim(w PrefixWriter, pvc *corev1.PersistentVolumeClai
 	if isFullPVC {
 		w.Write(LEVEL_0, "Finalizers:\t%v\n", pvc.ObjectMeta.Finalizers)
 	}
-	storage := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
 	capacity := ""
 	accessModes := ""
 	if pvc.Spec.VolumeName != "" {
 		accessModes = storageutil.GetAccessModesAsString(pvc.Status.AccessModes)
-		storage = pvc.Status.Capacity[corev1.ResourceStorage]
+		storage := pvc.Status.Capacity[corev1.ResourceStorage]
 		capacity = formatResourceQuantity(corev1.ResourceStorage, storage)
 	}
 	w.Write(LEVEL_0, "Capacity:\t%s\n", capacity)

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -1578,7 +1578,7 @@ func describePersistentVolume(pv *corev1.PersistentVolume, events *corev1.EventL
 			w.Write(LEVEL_0, "VolumeMode:\t%v\n", *pv.Spec.VolumeMode)
 		}
 		storage := pv.Spec.Capacity[corev1.ResourceStorage]
-		w.Write(LEVEL_0, "Capacity:\t%s\n", storage.String())
+		w.Write(LEVEL_0, "Capacity:\t%s\n", formatResourceQuantity(corev1.ResourceStorage, storage))
 		printVolumeNodeAffinity(w, pv.Spec.NodeAffinity)
 		w.Write(LEVEL_0, "Message:\t%s\n", pv.Status.Message)
 		w.Write(LEVEL_0, "Source:\n")
@@ -1767,7 +1767,7 @@ func printPersistentVolumeClaim(w PrefixWriter, pvc *corev1.PersistentVolumeClai
 	if pvc.Spec.VolumeName != "" {
 		accessModes = storageutil.GetAccessModesAsString(pvc.Status.AccessModes)
 		storage = pvc.Status.Capacity[corev1.ResourceStorage]
-		capacity = storage.String()
+		capacity = formatResourceQuantity(corev1.ResourceStorage, storage)
 	}
 	w.Write(LEVEL_0, "Capacity:\t%s\n", capacity)
 	w.Write(LEVEL_0, "Access Modes:\t%s\n", accessModes)
@@ -2154,7 +2154,7 @@ func describeVolumeClaimTemplates(templates []corev1.PersistentVolumeClaim, w Pr
 		printLabelsMultilineWithIndent(w, "  ", "Labels", "\t", pvc.Labels, sets.New[string]())
 		printLabelsMultilineWithIndent(w, "  ", "Annotations", "\t", pvc.Annotations, sets.New[string]())
 		if capacity, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
-			w.Write(LEVEL_1, "Capacity:\t%s\n", capacity.String())
+			w.Write(LEVEL_1, "Capacity:\t%s\n", formatResourceQuantity(corev1.ResourceStorage, capacity))
 		} else {
 			w.Write(LEVEL_1, "Capacity:\t%s\n", "<default>")
 		}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -1487,6 +1487,15 @@ func TestDescribeResources(t *testing.T) {
 			},
 			expectedElements: map[string]int{"cpu": 1, "memory": 1, "Requests": 1, "1k": 1, "100Mi": 1},
 		},
+		{
+			resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1m"),
+					corev1.ResourceMemory: resource.MustParse("0.1Gi"),
+				},
+			},
+			expectedElements: map[string]int{"cpu": 1, "memory": 1, "Requests": 1, "1m": 1, "107374183": 1},
+		},
 	}
 
 	for i, testCase := range testCases {
@@ -1507,6 +1516,97 @@ func TestDescribeResources(t *testing.T) {
 
 			if !reflect.DeepEqual(gotElements, testCase.expectedElements) {
 				t.Errorf("Expected %v, got %v in output string: %q", testCase.expectedElements, gotElements, output)
+			}
+		})
+	}
+}
+
+func TestFormatResourceQuantity(t *testing.T) {
+	testCases := []struct {
+		name     string
+		resource corev1.ResourceName
+		quantity string
+		expected string
+	}{
+		{
+			name:     "fractional memory is rounded up to whole bytes",
+			resource: corev1.ResourceMemory,
+			quantity: "0.1Gi",
+			expected: "107374183",
+		},
+		{
+			name:     "memory already stored in millibytes is rounded up to whole bytes",
+			resource: corev1.ResourceMemory,
+			quantity: "107374182400m",
+			expected: "107374183",
+		},
+		{
+			name:     "sub-byte memory is rounded up to one byte",
+			resource: corev1.ResourceMemory,
+			quantity: "1m",
+			expected: "1",
+		},
+		{
+			name:     "whole memory is unchanged",
+			resource: corev1.ResourceMemory,
+			quantity: "10Gi",
+			expected: "10Gi",
+		},
+		{
+			name:     "decimal memory suffix is preserved",
+			resource: corev1.ResourceMemory,
+			quantity: "500M",
+			expected: "500M",
+		},
+		{
+			name:     "zero memory is unchanged",
+			resource: corev1.ResourceMemory,
+			quantity: "0",
+			expected: "0",
+		},
+		{
+			name:     "fractional ephemeral storage is rounded up to whole bytes",
+			resource: corev1.ResourceEphemeralStorage,
+			quantity: "0.1Gi",
+			expected: "107374183",
+		},
+		{
+			name:     "fractional storage is rounded up to whole bytes",
+			resource: corev1.ResourceStorage,
+			quantity: "0.1Gi",
+			expected: "107374183",
+		},
+		{
+			name:     "fractional hugepages are rounded up to whole bytes",
+			resource: corev1.ResourceName("hugepages-2Mi"),
+			quantity: "0.1Gi",
+			expected: "107374183",
+		},
+		{
+			name:     "cpu milli-units are preserved",
+			resource: corev1.ResourceCPU,
+			quantity: "100m",
+			expected: "100m",
+		},
+		{
+			name:     "fractional cpu is preserved",
+			resource: corev1.ResourceCPU,
+			quantity: "0.1",
+			expected: "100m",
+		},
+		{
+			name:     "non-byte resources are unchanged",
+			resource: corev1.ResourcePods,
+			quantity: "110",
+			expected: "110",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := formatResourceQuantity(testCase.resource, resource.MustParse(testCase.quantity))
+			if got != testCase.expected {
+				t.Errorf("expected %q, got %q", testCase.expected, got)
 			}
 		})
 	}
@@ -6444,6 +6544,64 @@ func TestDescribeNode(t *testing.T) {
 		if !strings.Contains(out, expected) {
 			t.Errorf("expected to find %q in output: %q", expected, out)
 		}
+	}
+}
+
+// TestDescribeNodeWithFractionalMemory verifies that a memory request that is not
+// a whole number of bytes is never rendered in millibytes, neither in the per-pod
+// table nor in the Allocated resources summary.
+func TestDescribeNodeWithFractionalMemory(t *testing.T) {
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bar",
+			UID:  "uid",
+		},
+		Status: corev1.NodeStatus{
+			Capacity:    getResourceList("8", "24Gi"),
+			Allocatable: getResourceList("4", "12Gi"),
+		},
+	}
+	fake := fake.NewClientset(
+		node,
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-with-fractional-memory",
+				Namespace: "foo",
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind: "Pod",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "cpu-mem",
+						Image: "image:latest",
+						Resources: corev1.ResourceRequirements{
+							Requests: getResourceList("1m", "0.1Gi"),
+							Limits:   getResourceList("2", "0.1Gi"),
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+			},
+		},
+	)
+	c := &describeClient{T: t, Namespace: "foo", Interface: fake}
+	d := NodeDescriber{c}
+	out, err := d.Describe("foo", "bar", DescriberSettings{ShowEvents: false})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(out, "107374182400m") {
+		t.Errorf("expected no millibyte memory value in output: %q", out)
+	}
+	// Once each for the pod's requests and limits in the per-pod table, and
+	// once each for the requests and limits rows of Allocated resources.
+	if got := strings.Count(out, "107374183"); got != 4 {
+		t.Errorf("expected 4 occurrences of %q, got %d in output: %q", "107374183", got, out)
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -2503,6 +2503,23 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 			expectedElements:   []string{"EndpointsNamespace", "glusterfsendpointname"},
 			unexpectedElements: []string{"VolumeMode", "Filesystem"},
 		},
+		{
+			name:   "fractional storage capacity",
+			plugin: "hostpath",
+			pv: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "bar"},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{Type: new(corev1.HostPathType)},
+					},
+					Capacity: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("0.1Gi"),
+					},
+				},
+			},
+			expectedElements:   []string{"Capacity:", "107374183"},
+			unexpectedElements: []string{"107374182400m"},
+		},
 	}
 
 	for _, test := range testCases {
@@ -2757,6 +2774,24 @@ func TestPersistentVolumeClaimDescriber(t *testing.T) {
 			unexpectedElements: []string{"Events"},
 			describerSettings:  &DescriberSettings{ShowEvents: false},
 		},
+		{
+			name: "fractional storage capacity",
+			pvc: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeName:       "volume1",
+					StorageClassName: &goldClassName,
+				},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Phase: corev1.ClaimBound,
+					Capacity: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("0.1Gi"),
+					},
+				},
+			},
+			expectedElements:   []string{"Capacity:", "107374183"},
+			unexpectedElements: []string{"107374182400m"},
+		},
 	}
 
 	for _, test := range testCases {
@@ -2789,6 +2824,34 @@ func TestPersistentVolumeClaimDescriber(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestDescribeVolumeClaimTemplates(t *testing.T) {
+	templates := []corev1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("0.1Gi"),
+					},
+				},
+			},
+		},
+	}
+
+	out := new(bytes.Buffer)
+	writer := NewPrefixWriter(out)
+	describeVolumeClaimTemplates(templates, writer)
+	writer.Flush()
+	output := out.String()
+
+	if !strings.Contains(output, "107374183") {
+		t.Errorf("expected to find %q in output: %q", "107374183", output)
+	}
+	if strings.Contains(output, "107374182400m") {
+		t.Errorf("unexpected to find %q in output: %q", "107374182400m", output)
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe_test.go
@@ -1600,6 +1600,24 @@ func TestFormatResourceQuantity(t *testing.T) {
 			quantity: "110",
 			expected: "110",
 		},
+		{
+			name:     "large binary suffix is preserved",
+			resource: corev1.ResourceStorage,
+			quantity: "1Pi",
+			expected: "1Pi",
+		},
+		{
+			name:     "exponent notation is preserved",
+			resource: corev1.ResourceStorage,
+			quantity: "1e3",
+			expected: "1e3",
+		},
+		{
+			name:     "negative memory is left untouched",
+			resource: corev1.ResourceMemory,
+			quantity: "-107374182400m",
+			expected: "-107374182400m",
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -2822,6 +2840,52 @@ func TestPersistentVolumeClaimDescriber(t *testing.T) {
 				if strings.Contains(str, unexpected) {
 					t.Errorf("unexpected to find %q in output: %q", unexpected, str)
 				}
+			}
+		})
+	}
+}
+
+func TestPrintEmptyDirVolumeSource(t *testing.T) {
+	fractional := resource.MustParse("0.1Gi")
+	whole := resource.MustParse("1Gi")
+
+	testCases := []struct {
+		name       string
+		sizeLimit  *resource.Quantity
+		expected   string
+		unexpected string
+	}{
+		{
+			name:       "fractional size limit is rounded up to whole bytes",
+			sizeLimit:  &fractional,
+			expected:   "107374183",
+			unexpected: "107374182400m",
+		},
+		{
+			name:      "whole size limit is unchanged",
+			sizeLimit: &whole,
+			expected:  "1Gi",
+		},
+		{
+			name:      "unset size limit",
+			sizeLimit: nil,
+			expected:  "<unset>",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			writer := NewPrefixWriter(out)
+			printEmptyDirVolumeSource(&corev1.EmptyDirVolumeSource{SizeLimit: test.sizeLimit}, writer)
+			writer.Flush()
+			output := out.String()
+
+			if !strings.Contains(output, test.expected) {
+				t.Errorf("expected to find %q in output: %q", test.expected, output)
+			}
+			if test.unexpected != "" && strings.Contains(output, test.unexpected) {
+				t.Errorf("unexpected to find %q in output: %q", test.unexpected, output)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A memory value such as `0.1Gi` is not representable as a whole number of bytes, because 10 does not divide a power of 2:

```
0.1 * 1024 * 1024 * 1024 * 1000 = 107374182400
```

The API server therefore stores the quantity as `107374182400m`. `describe` rendered quantities with `Quantity.String()`, which faithfully reproduced that millibyte form, so users saw output like this in `describe node` and `describe pod`:

```
  Namespace  Name                        CPU Requests  CPU Limits  Memory Requests     Memory Limits
  foo        pod-with-fractional-memory  1m (0%)       2 (50%)     107374182400m (0%)  107374182400m (0%)
```

A fractional byte has no physical meaning, so this is never useful to read.

This PR adds a `formatResourceQuantity` helper that rounds byte-sized resources up to whole bytes before rendering. The same output now reads:

```
  Namespace  Name                        CPU Requests  CPU Limits  Memory Requests  Memory Limits
  foo        pod-with-fractional-memory  1m (0%)       2 (50%)     107374183 (0%)   107374183 (0%)
```

Two properties keep this safe:

* `Quantity.AsScale(0)` reports whether a quantity is already exact at whole-byte scale, so any integral value (`10Gi`, `500M`, `0`) is passed straight to `Quantity.String()` and renders exactly as it does today.
* The helper only applies to resources measured in bytes (memory, storage, ephemeral-storage and hugepages). CPU is untouched, since milli-units are meaningful there, as are `pods`, `count/*` and extended resources.

`Quantity.Value()` rounds up, away from zero, which is the correct direction for a request or a limit.

The helper is applied at every place `describe` renders a `ResourceList`, so the behaviour is consistent across commands: container requests and limits, node `Capacity` and `Allocatable`, the non-terminated pods table, the `Allocated resources` summary including ephemeral-storage and hugepages, ResourceQuota used and hard, and LimitRange min, max and defaults.

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubectl#1597

#### Special notes for your reviewer:

An earlier attempt at this fix, #141171, was closed without merging because its author had not signed the CLA. No technical feedback was given on it. I picked the issue up after checking with the previous assignees on kubernetes/kubectl#1597.

Compared to that attempt, this PR also covers node `Capacity` and `Allocatable`, ResourceQuota and LimitRange, which render the same user supplied quantities and had the same problem.

Tests added:

* `TestFormatResourceQuantity` covers the rounding behaviour directly, including the cases that must stay unchanged (`10Gi`, `500M`, `0`, CPU and non byte resources).
* `TestDescribeNodeWithFractionalMemory` is a regression test on the rendered node output, asserting that no millibyte memory value survives into the per-pod table or the `Allocated resources` summary.
* `TestDescribeResources` gains a fractional memory case.

#### Does this PR introduce a user-facing change?

```release-note
kubectl describe now renders memory, storage, ephemeral-storage and hugepages values that are not a whole number of bytes as a byte count rather than in millibytes. A request of `0.1Gi`, stored by the API server as `107374182400m`, is now shown as `107374183`.
```
