### PR TITLE
fix: reject empty deviceSelector in DeviceTaintRule validation

### DIFF
--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1906,6 +1906,10 @@ func validateDeviceTaintSelector(filter, oldFilter *resource.DeviceTaintSelector
 	if filter == nil {
 		return allErrs
 	}
+	if filter.Driver == nil && filter.Pool == nil && filter.Device == nil {
+		allErrs = append(allErrs, field.Required(fldPath, "at least one of driver, pool, or device must be specified"))
+		return allErrs
+	}
 	if filter.Driver != nil {
 		allErrs = append(allErrs, validateDriverName(*filter.Driver, fldPath.Child("driver"))...)
 	}

--- a/pkg/apis/resource/validation/validation_devicetaintrule_test.go
+++ b/pkg/apis/resource/validation/validation_devicetaintrule_test.go
@@ -248,6 +248,14 @@ func TestValidateDeviceTaint(t *testing.T) {
 				return claim
 			}(),
 		},
+		"empty-device-selector": {
+			wantFailures: field.ErrorList{field.Required(field.NewPath("spec", "deviceSelector"), "at least one of driver, pool, or device must be specified")},
+			taintRule: func() *resourceapi.DeviceTaintRule {
+				claim := testDeviceTaintRule(goodName, validDeviceTaintRuleSpec)
+				claim.Spec.DeviceSelector = &resourceapi.DeviceTaintSelector{}
+				return claim
+			}(),
+		},
 	}
 
 	for name, scenario := range scenarios {


### PR DESCRIPTION
### Which problem is this PR solving?

Fixes #141422

A `DeviceTaintRule` created with an empty `deviceSelector: {}` (all three fields nil) currently passes validation and matches every device in the cluster, causing silent eviction of all pods using DRA devices. This is a safety issue: an empty selector should not be equivalent to selecting everything.

### What this PR does

Adds a validation check in `validateDeviceTaintSelector` to reject a `DeviceTaintSelector` where none of `driver`, `pool`, or `device` are specified. At least one of these fields must be set for the selector to be meaningful.

### Release note

```release-note
A `DeviceTaintRule` with an empty `deviceSelector` (all fields omitted) is now rejected at admission time. The selector must specify at least one of `driver`, `pool`, or `device`.
```