### PR TITLE
device-plugin: skip DRA resources in GetDeviceRunContainerOptions

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -984,6 +984,12 @@ func (m *ManagerImpl) GetDeviceRunContainerOptions(ctx context.Context, pod *v1.
 	needsReAllocate := false
 	for k, v := range container.Resources.Limits {
 		resource := string(k)
+		// A DRA-backed extended resource won't have device plugin state.
+		// We need to detect that and skip, because an earlier
+		// device-plugin resource with the same name may still be cached.
+		if utilfeature.DefaultFeatureGate.Enabled(features.DRAExtendedResource) && isDRAExtendedResource(pod, container.Name, resource) {
+			continue
+		}
 		if !m.isDevicePluginResource(resource) || v.Value() == 0 {
 			continue
 		}

--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -2260,6 +2260,132 @@ func TestAdmitPodWithDRAResources(t *testing.T) {
 	}
 }
 
+func TestIsDRAExtendedResource(t *testing.T) {
+	containerName := "container1"
+	resourceName := "domain1.com/resource1"
+	podWithMapping := &v1.Pod{
+		Status: v1.PodStatus{
+			ExtendedResourceClaimStatus: &v1.PodExtendedResourceClaimStatus{
+				RequestMappings: []v1.ContainerExtendedResourceRequest{
+					{
+						ContainerName: containerName,
+						ResourceName:  resourceName,
+					},
+				},
+			},
+		},
+	}
+
+	testCases := map[string]struct {
+		pod           *v1.Pod
+		containerName string
+		resourceName  string
+		expected      bool
+	}{
+		"resource mapped to the container": {
+			pod:           podWithMapping,
+			containerName: containerName,
+			resourceName:  resourceName,
+			expected:      true,
+		},
+		"resource mapped to a different container": {
+			pod:           podWithMapping,
+			containerName: "container2",
+			resourceName:  resourceName,
+			expected:      false,
+		},
+		"resource not mapped": {
+			pod:           podWithMapping,
+			containerName: containerName,
+			resourceName:  "domain1.com/resource2",
+			expected:      false,
+		},
+		"pod without extended resource claim status": {
+			pod:           &v1.Pod{},
+			containerName: containerName,
+			resourceName:  resourceName,
+			expected:      false,
+		},
+	}
+
+	for description, test := range testCases {
+		t.Run(description, func(t *testing.T) {
+			require.Equal(t, test.expected, isDRAExtendedResource(test.pod, test.containerName, test.resourceName))
+		})
+	}
+}
+
+// TestGetDeviceRunContainerOptionsWithDRAResourceAndStaleDevicePluginState verifies
+// that a DRA-backed extended resource is not mistaken for a device plugin resource
+// when the device manager still holds allocated devices under the same name.
+func TestGetDeviceRunContainerOptionsWithDRAResourceAndStaleDevicePluginState(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	testCases := map[string]struct {
+		enableFeatureGate bool
+		checkError        func(t require.TestingT, err error, msgAndArgs ...interface{})
+	}{
+		"DRAExtendedResource enabled": {
+			enableFeatureGate: true,
+			checkError:        require.NoError,
+		},
+		"DRAExtendedResource disabled": {
+			enableFeatureGate: false,
+			checkError:        require.Error,
+		},
+	}
+
+	containerName := "container1"
+	resourceName := "domain1.com/resource1"
+
+	for description, test := range testCases {
+		t.Run(description, func(t *testing.T) {
+			if !test.enableFeatureGate {
+				featuregatetesting.SetFeatureGateEmulationVersionDuringTest(t, utilfeature.DefaultFeatureGate, version.MustParse("1.36"))
+			}
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DRAExtendedResource, test.enableFeatureGate)
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID: uuid.NewUUID(),
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: containerName,
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceName(resourceName): resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+				Status: v1.PodStatus{
+					ExtendedResourceClaimStatus: &v1.PodExtendedResourceClaimStatus{
+						RequestMappings: []v1.ContainerExtendedResourceRequest{
+							{
+								ContainerName: containerName,
+								ResourceName:  resourceName,
+							},
+						},
+					},
+				},
+			}
+
+			testManager := &ManagerImpl{
+				endpoints:  make(map[string]endpointInfo),
+				podDevices: newPodDevices(),
+				allocatedDevices: map[string]sets.Set[string]{
+					resourceName: sets.New("Dev"),
+				},
+			}
+
+			_, err := testManager.GetDeviceRunContainerOptions(tCtx, pod, &pod.Spec.Containers[0])
+			test.checkError(t, err)
+		})
+	}
+}
+
 // TestEndpointSyncOnDisconnect verifies that when a device plugin disconnects,
 // the device manager correctly updates its internal state by marking all
 // devices from that endpoint as unhealthy. It ensures that the healthyDevices


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

When a DRA-backed extended resource reuses a name previously handled by a device plugin resource, cached kubelet allocation state can incorrectly trigger legacy device-plugin handling, preventing the container from starting.

This fix makes `GetDeviceRunContainerOptions` skip device-plugin handling for DRA pod+container+resource request mappings.

This change has no effect upon existing device-plugin handling, all UT coverage is net new to validate that DRA resources are skipped.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
device-plugin: skip DRA resources in GetDeviceRunContainerOptions
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
