### PR TITLE
kubelet: propagate context through Cache and GeneratePodStatus

### DIFF
--- a/pkg/kubelet/container/cache.go
+++ b/pkg/kubelet/container/cache.go
@@ -17,6 +17,7 @@ limitations under the License.
 package container
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -52,10 +53,10 @@ type Cache interface {
 // methods to retrieve the PodStatus: the non-blocking Get() and the blocking
 // GetNewerThan() method.
 type ROCache interface {
-	Get(types.UID) (*PodStatus, error)
+	Get(context.Context, types.UID) (*PodStatus, error)
 	// GetNewerThan is a blocking call that only returns the status
 	// when it is newer than the given time.
-	GetNewerThan(types.UID, time.Time) (*PodStatus, error)
+	GetNewerThan(context.Context, types.UID, time.Time) (*PodStatus, error)
 }
 
 type data struct {
@@ -98,14 +99,14 @@ func NewCache() Cache {
 
 // Get returns the PodStatus for the pod; callers are expected not to
 // modify the objects returned.
-func (c *cache) Get(id types.UID) (*PodStatus, error) {
+func (c *cache) Get(_ context.Context, id types.UID) (*PodStatus, error) {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 	d := c.get(id)
 	return d.status, d.err
 }
 
-func (c *cache) GetNewerThan(id types.UID, minTime time.Time) (*PodStatus, error) {
+func (c *cache) GetNewerThan(ctx context.Context, id types.UID, minTime time.Time) (*PodStatus, error) {
 	ch := c.subscribe(id, minTime)
 	d := <-ch
 	return d.status, d.err

--- a/pkg/kubelet/container/cache_test.go
+++ b/pkg/kubelet/container/cache_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func newTestCache() *cache {
@@ -132,6 +133,7 @@ func TestGetPodNewerThanWhenPodDoesNotExist(t *testing.T) {
 }
 
 func TestCacheSetAndGet(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	cache := NewCache()
 	cases := []struct {
 		numContainers int
@@ -146,34 +148,36 @@ func TestCacheSetAndGet(t *testing.T) {
 		cache.Set(podID, status, c.error, time.Time{})
 		// Read back the status and error stored in cache and make sure they
 		// match the original ones.
-		actualStatus, actualErr := cache.Get(podID)
+		actualStatus, actualErr := cache.Get(tCtx, podID)
 		assert.Equal(t, status, actualStatus, "test[%d]", i)
 		assert.Equal(t, c.error, actualErr, "test[%d]", i)
 	}
 }
 
 func TestCacheGetPodDoesNotExist(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	cache := NewCache()
 	podID, status := getTestPodIDAndStatus(0)
 	// If the pod does not exist in cache, cache should return an status
 	// object with id filled.
-	actualStatus, actualErr := cache.Get(podID)
+	actualStatus, actualErr := cache.Get(tCtx, podID)
 	assert.Equal(t, status, actualStatus)
 	assert.NoError(t, actualErr)
 }
 
 func TestDelete(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	cache := &cache{pods: map[types.UID]*data{}}
 	// Write a new pod status into the cache.
 	podID, status := getTestPodIDAndStatus(3)
 	cache.Set(podID, status, nil, time.Time{})
-	actualStatus, actualErr := cache.Get(podID)
+	actualStatus, actualErr := cache.Get(tCtx, podID)
 	assert.Equal(t, status, actualStatus)
 	assert.NoError(t, actualErr)
 	// Delete the pod from cache, and verify that we get an empty status.
 	cache.Delete(podID)
 	expectedStatus := &PodStatus{ID: podID}
-	actualStatus, actualErr = cache.Get(podID)
+	actualStatus, actualErr = cache.Get(tCtx, podID)
 	assert.Equal(t, expectedStatus, actualStatus)
 	assert.NoError(t, actualErr)
 }
@@ -212,6 +216,7 @@ func TestRegisterNotification(t *testing.T) {
 }
 
 func TestGetNewerThan(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	podID := types.UID("test-pod")
 	status := &PodStatus{ID: podID}
 
@@ -265,7 +270,7 @@ func TestGetNewerThan(t *testing.T) {
 				// First call to GetNewerThan - should block initially.
 				resCh := make(chan *PodStatus, 1)
 				go func() {
-					s, err := c.GetNewerThan(podID, minTime)
+					s, err := c.GetNewerThan(tCtx, podID, minTime)
 					assert.NoError(t, err)
 					resCh <- s
 				}()
@@ -284,7 +289,7 @@ func TestGetNewerThan(t *testing.T) {
 				// Verify a subsequent call returns immediately.
 				resCh2 := make(chan *PodStatus, 1)
 				go func() {
-					s, err := c.GetNewerThan(podID, minTime)
+					s, err := c.GetNewerThan(tCtx, podID, minTime)
 					assert.NoError(t, err)
 					resCh2 <- s
 				}()

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -132,7 +132,7 @@ type Runtime interface {
 	// and store the resulting archive to the checkpoint directory.
 	CheckpointContainer(ctx context.Context, options *runtimeapi.CheckpointContainerRequest) error
 	// Generate pod status from the CRI event
-	GeneratePodStatus(event *runtimeapi.ContainerEventResponse) *PodStatus
+	GeneratePodStatus(ctx context.Context, event *runtimeapi.ContainerEventResponse) *PodStatus
 	// ListMetricDescriptors gets the descriptors for the metrics that will be returned in ListPodSandboxMetrics.
 	// This list should be static at startup: either the client and server restart together when
 	// adding or removing metrics descriptors, or they should not change.

--- a/pkg/kubelet/container/testing/fake_cache.go
+++ b/pkg/kubelet/container/testing/fake_cache.go
@@ -32,16 +32,16 @@ func NewFakeCache(runtime container.Runtime) container.Cache {
 	return &fakeCache{runtime: runtime}
 }
 
-func (c *fakeCache) Get(id types.UID) (*container.PodStatus, error) {
-	pod, err := c.runtime.GetPod(context.TODO(), id)
+func (c *fakeCache) Get(ctx context.Context, id types.UID) (*container.PodStatus, error) {
+	pod, err := c.runtime.GetPod(ctx, id)
 	if err != nil {
 		pod = &container.Pod{ID: id}
 	}
-	return c.runtime.GetPodStatus(context.TODO(), pod)
+	return c.runtime.GetPodStatus(ctx, pod)
 }
 
-func (c *fakeCache) GetNewerThan(id types.UID, minTime time.Time) (*container.PodStatus, error) {
-	return c.Get(id)
+func (c *fakeCache) GetNewerThan(ctx context.Context, id types.UID, minTime time.Time) (*container.PodStatus, error) {
+	return c.Get(ctx, id)
 }
 
 func (c *fakeCache) Set(id types.UID, status *container.PodStatus, err error, timestamp time.Time) (updated bool) {

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -316,7 +316,7 @@ func (f *FakeRuntime) KillContainerInPod(container v1.Container, pod *v1.Pod) er
 	return f.Err
 }
 
-func (f *FakeRuntime) GeneratePodStatus(event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
+func (f *FakeRuntime) GeneratePodStatus(_ context.Context, event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
 	f.Lock()
 	defer f.Unlock()
 

--- a/pkg/kubelet/container/testing/mocks.go
+++ b/pkg/kubelet/container/testing/mocks.go
@@ -302,16 +302,16 @@ func (_c *MockRuntime_GarbageCollect_Call) RunAndReturn(run func(ctx context.Con
 }
 
 // GeneratePodStatus provides a mock function for the type MockRuntime
-func (_mock *MockRuntime) GeneratePodStatus(event *v1.ContainerEventResponse) *container.PodStatus {
-	ret := _mock.Called(event)
+func (_mock *MockRuntime) GeneratePodStatus(ctx context.Context, event *v1.ContainerEventResponse) *container.PodStatus {
+	ret := _mock.Called(ctx, event)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GeneratePodStatus")
 	}
 
 	var r0 *container.PodStatus
-	if returnFunc, ok := ret.Get(0).(func(*v1.ContainerEventResponse) *container.PodStatus); ok {
-		r0 = returnFunc(event)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *v1.ContainerEventResponse) *container.PodStatus); ok {
+		r0 = returnFunc(ctx, event)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*container.PodStatus)
@@ -326,19 +326,25 @@ type MockRuntime_GeneratePodStatus_Call struct {
 }
 
 // GeneratePodStatus is a helper method to define mock.On call
+//   - ctx context.Context
 //   - event *v1.ContainerEventResponse
-func (_e *MockRuntime_Expecter) GeneratePodStatus(event interface{}) *MockRuntime_GeneratePodStatus_Call {
-	return &MockRuntime_GeneratePodStatus_Call{Call: _e.mock.On("GeneratePodStatus", event)}
+func (_e *MockRuntime_Expecter) GeneratePodStatus(ctx interface{}, event interface{}) *MockRuntime_GeneratePodStatus_Call {
+	return &MockRuntime_GeneratePodStatus_Call{Call: _e.mock.On("GeneratePodStatus", ctx, event)}
 }
 
-func (_c *MockRuntime_GeneratePodStatus_Call) Run(run func(event *v1.ContainerEventResponse)) *MockRuntime_GeneratePodStatus_Call {
+func (_c *MockRuntime_GeneratePodStatus_Call) Run(run func(ctx context.Context, event *v1.ContainerEventResponse)) *MockRuntime_GeneratePodStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 *v1.ContainerEventResponse
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(*v1.ContainerEventResponse)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *v1.ContainerEventResponse
+		if args[1] != nil {
+			arg1 = args[1].(*v1.ContainerEventResponse)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -349,7 +355,7 @@ func (_c *MockRuntime_GeneratePodStatus_Call) Return(podStatus *container.PodSta
 	return _c
 }
 
-func (_c *MockRuntime_GeneratePodStatus_Call) RunAndReturn(run func(event *v1.ContainerEventResponse) *container.PodStatus) *MockRuntime_GeneratePodStatus_Call {
+func (_c *MockRuntime_GeneratePodStatus_Call) RunAndReturn(run func(ctx context.Context, event *v1.ContainerEventResponse) *container.PodStatus) *MockRuntime_GeneratePodStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -80,7 +80,7 @@ type ImageGCManager interface {
 	// Start async garbage collection of images.
 	Start(ctx context.Context)
 
-	GetImageList() ([]container.Image, error)
+	GetImageList(ctx context.Context) ([]container.Image, error)
 
 	// Delete all unused images.
 	DeleteUnusedImages(ctx context.Context) error
@@ -237,7 +237,7 @@ func (im *realImageGCManager) Start(ctx context.Context) {
 }
 
 // Get a list of images on this node
-func (im *realImageGCManager) GetImageList() ([]container.Image, error) {
+func (im *realImageGCManager) GetImageList(_ context.Context) ([]container.Image, error) {
 	return im.imageCache.get(), nil
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -3251,7 +3251,7 @@ func (kl *Kubelet) HandlePodReconcile(ctx context.Context, pods []*v1.Pod) {
 		// been evicted, so if this is about minimizing the time to react to an eviction we
 		// can do better. If it's about preserving pod status info we can also do better.
 		if eviction.PodIsEvicted(pod.Status) {
-			if podStatus, err := kl.podCache.Get(pod.UID); err == nil {
+			if podStatus, err := kl.podCache.Get(ctx, pod.UID); err == nil {
 				kl.containerDeletor.deleteContainersInPod(logger, "", podStatus, true)
 			}
 		}
@@ -3449,7 +3449,7 @@ func (kl *Kubelet) ListenAndServePods(ctx context.Context) {
 
 // Delete the eligible dead container instances in a pod. Depending on the configuration, the latest dead containers may be kept around.
 func (kl *Kubelet) cleanUpContainersInPod(ctx context.Context, podID types.UID, exitedContainerID string) {
-	if podStatus, err := kl.podCache.Get(podID); err == nil {
+	if podStatus, err := kl.podCache.Get(ctx, podID); err == nil {
 		// When an evicted or deleted pod has already synced, all containers can be removed.
 		removeAll := kl.podWorkers.ShouldPodContentBeRemoved(podID)
 		kl.containerDeletor.deleteContainersInPod(klog.FromContext(ctx), exitedContainerID, podStatus, removeAll)

--- a/pkg/kubelet/kubelet_server_journal_test.go
+++ b/pkg/kubelet/kubelet_server_journal_test.go
@@ -18,7 +18,6 @@ package kubelet
 
 import (
 	"bytes"
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -33,6 +32,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -302,7 +302,7 @@ func Test_nodeLogQuery_validate(t *testing.T) {
 }
 
 func Test_heuristicsCopyFileLogs(t *testing.T) {
-	ctx := context.TODO()
+	tCtx := ktesting.Init(t)
 	buf := &bytes.Buffer{}
 
 	dir, err := os.MkdirTemp("", "logs")
@@ -312,14 +312,14 @@ func Test_heuristicsCopyFileLogs(t *testing.T) {
 	defer func() { _ = os.RemoveAll(dir) }()
 
 	// Check missing logs
-	heuristicsCopyFileLogs(ctx, buf, dir, "service.log")
+	heuristicsCopyFileLogs(tCtx, buf, dir, "service.log")
 	if !strings.Contains(buf.String(), "log not found for service.log") {
 		t.Fail()
 	}
 	buf.Reset()
 
 	// Check missing service logs
-	heuristicsCopyFileLogs(ctx, buf, dir, "service")
+	heuristicsCopyFileLogs(tCtx, buf, dir, "service")
 	if !strings.Contains(buf.String(), "log not found for service") {
 		t.Fail()
 	}
@@ -329,14 +329,14 @@ func Test_heuristicsCopyFileLogs(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "service.log"), []byte("valid logs"), 0o444); err != nil {
 		t.Fatal(err)
 	}
-	heuristicsCopyFileLogs(ctx, buf, dir, "service.log")
+	heuristicsCopyFileLogs(tCtx, buf, dir, "service.log")
 	if buf.String() != "valid logs" {
 		t.Fail()
 	}
 	buf.Reset()
 
 	// Check service logs
-	heuristicsCopyFileLogs(ctx, buf, dir, "service")
+	heuristicsCopyFileLogs(tCtx, buf, dir, "service")
 	if buf.String() != "valid logs" {
 		t.Fail()
 	}
@@ -346,7 +346,7 @@ func Test_heuristicsCopyFileLogs(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(dir, "service"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	heuristicsCopyFileLogs(ctx, buf, dir, "service")
+	heuristicsCopyFileLogs(tCtx, buf, dir, "service")
 	if buf.String() != "valid logs" {
 		t.Fail()
 	}
@@ -356,7 +356,7 @@ func Test_heuristicsCopyFileLogs(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "service", "service.log"), []byte("error"), 0o444); err != nil {
 		t.Fatal(err)
 	}
-	heuristicsCopyFileLogs(ctx, buf, dir, "service")
+	heuristicsCopyFileLogs(tCtx, buf, dir, "service")
 	if buf.String() != "valid logs" {
 		t.Fail()
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -147,9 +147,8 @@ type fakeImageGCManager struct {
 	images.ImageGCManager
 }
 
-func (f *fakeImageGCManager) GetImageList() ([]kubecontainer.Image, error) {
-	// ImageGCManager interface does not accept a context parameter.
-	return f.fakeImageService.ListImages(context.TODO())
+func (f *fakeImageGCManager) GetImageList(ctx context.Context) ([]kubecontainer.Image, error) {
+	return f.fakeImageService.ListImages(ctx)
 }
 
 type TestKubelet struct {

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1049,14 +1049,12 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 		var err error
 		// At upsizing, limits should expand prior to requests in order to keep "requests <= limits".
 		if newPodCgLimValue > currPodCgLimValue {
-			// TODO: Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
+			if err = setPodCgroupConfig(logger, rName, true); err != nil {
 				return err
 			}
 		}
 		if newPodCgReqValue > currPodCgReqValue {
-			// TODO: Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, false); err != nil {
+			if err = setPodCgroupConfig(logger, rName, false); err != nil {
 				return err
 			}
 		}
@@ -1069,14 +1067,12 @@ func (m *kubeGenericRuntimeManager) doPodResizeAction(ctx context.Context, pod *
 
 		// At downsizing, requests should shrink prior to limits in order to keep "requests <= limits".
 		if newPodCgReqValue < currPodCgReqValue {
-			// TODO: Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, false); err != nil {
+			if err = setPodCgroupConfig(logger, rName, false); err != nil {
 				return err
 			}
 		}
 		if newPodCgLimValue < currPodCgLimValue {
-			// TODO(#127825): Pass logger from context once contextual logging migration is complete
-			if err = setPodCgroupConfig(klog.TODO(), rName, true); err != nil {
+			if err = setPodCgroupConfig(logger, rName, true); err != nil {
 				return err
 			}
 		}
@@ -2140,8 +2136,7 @@ func (m *kubeGenericRuntimeManager) killPodWithSyncResult(ctx context.Context, p
 	return
 }
 
-func (m *kubeGenericRuntimeManager) GeneratePodStatus(event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
-	ctx := context.TODO() // This context will be passed as parameter in the future
+func (m *kubeGenericRuntimeManager) GeneratePodStatus(ctx context.Context, event *runtimeapi.ContainerEventResponse) *kubecontainer.PodStatus {
 	podUID := kubetypes.UID(event.PodSandboxStatus.Metadata.Uid)
 	podIPs := m.determinePodSandboxIPs(ctx, event.PodSandboxStatus.Metadata.Namespace, event.PodSandboxStatus.Metadata.Name, event.PodSandboxStatus)
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -51,7 +51,6 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	apitest "k8s.io/cri-api/pkg/apis/testing"
 	crierror "k8s.io/cri-api/pkg/errors"
-	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
@@ -4862,8 +4861,7 @@ func TestDoPodResizeAction(t *testing.T) {
 				CPUQuota:  ptr.To(cm.MilliCPUToQuota(podCPULimit, cm.QuotaPeriod)),
 			}, nil).Maybe()
 			if tc.expectPodCgroupUpdates > 0 {
-				// TODO: Update to use proper logger once contextual logging migration is complete
-				call := mockPCM.EXPECT().SetPodCgroupConfig(klog.TODO(), mock.Anything, mock.Anything)
+				call := mockPCM.EXPECT().SetPodCgroupConfig(logger, mock.Anything, mock.Anything)
 				if tc.injectPodUpdateCgroupsError != nil {
 					call.Return(tc.injectPodUpdateCgroupsError).Times(1)
 				} else {

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -388,12 +388,12 @@ func DaemonEndpoints(daemonEndpoints *v1.NodeDaemonEndpoints) Setter {
 // imageListFunc is expected to return a list of images sorted in descending order by image size.
 // nodeStatusMaxImages is ignored if set to -1.
 func Images(nodeStatusMaxImages int32,
-	imageListFunc func() ([]kubecontainer.Image, error), // typically Kubelet.imageManager.GetImageList
+	imageListFunc func(context.Context) ([]kubecontainer.Image, error), // typically Kubelet.imageManager.GetImageList
 ) Setter {
 	return func(ctx context.Context, node *v1.Node) error {
 		// Update image list of this node
 		var imagesOnNode []v1.ContainerImage
-		containerImages, err := imageListFunc()
+		containerImages, err := imageListFunc(ctx)
 		if err != nil {
 			node.Status.Images = imagesOnNode
 			return fmt.Errorf("error getting image list: %v", err)

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -1157,7 +1157,7 @@ func TestImages(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.desc, func(t *testing.T) {
 			ctx := ktesting.Init(t)
-			imageListFunc := func() ([]kubecontainer.Image, error) {
+			imageListFunc := func(_ context.Context) ([]kubecontainer.Image, error) {
 				// today, imageListFunc is expected to return a sorted list,
 				// but we may choose to sort in the setter at some future point
 				// (e.g. if the image cache stopped sorting for us)

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -483,12 +483,12 @@ func computeEvents(logger klog.Logger, oldPod, newPod *kubecontainer.Pod, cid *k
 
 // getPodIP preserves an older cached status' pod IP if the new status has no pod IPs
 // and its sandboxes have exited
-func (g *GenericPLEG) getPodIPs(pid types.UID, status *kubecontainer.PodStatus) []string {
+func (g *GenericPLEG) getPodIPs(ctx context.Context, pid types.UID, status *kubecontainer.PodStatus) []string {
 	if len(status.IPs) != 0 {
 		return status.IPs
 	}
 
-	oldStatus, err := g.cache.Get(pid)
+	oldStatus, err := g.cache.Get(ctx, pid)
 	if err != nil || len(oldStatus.IPs) == 0 {
 		return nil
 	}
@@ -537,7 +537,7 @@ func (g *GenericPLEG) updateCache(ctx context.Context, pod *kubecontainer.Pod, p
 		// When a pod is torn down, kubelet may race with PLEG and retrieve
 		// a pod status after network teardown, but the kubernetes API expects
 		// the completed pod's IP to be available after the pod is dead.
-		status.IPs = g.getPodIPs(pid, status)
+		status.IPs = g.getPodIPs(ctx, pid, status)
 	}
 
 	g.cache.Set(pod.ID, status, err, timestamp)

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -387,7 +387,7 @@ func TestRelistWithCache(t *testing.T) {
 	}
 	for i, c := range cases {
 		testStr := fmt.Sprintf("test[%d]", i)
-		actualStatus, actualErr := pleg.cache.Get(c.pod.ID)
+		actualStatus, actualErr := pleg.cache.Get(tCtx, c.pod.ID)
 		assert.Equal(t, c.status, actualStatus, testStr)
 		assert.Equal(t, c.error, actualErr, testStr)
 	}
@@ -408,7 +408,7 @@ func TestRelistWithCache(t *testing.T) {
 	}
 	for i, c := range cases {
 		testStr := fmt.Sprintf("test[%d]", i)
-		actualStatus, actualErr := pleg.cache.Get(c.pod.ID)
+		actualStatus, actualErr := pleg.cache.Get(tCtx, c.pod.ID)
 		assert.Equal(t, c.status, actualStatus, testStr)
 		assert.Equal(t, c.error, actualErr, testStr)
 	}
@@ -430,7 +430,7 @@ func TestRemoveCacheEntry(t *testing.T) {
 	// removed after relisting.
 	runtimeMock.EXPECT().GetPods(mock.Anything, true).Return([]*kubecontainer.Pod{}, nil).Times(1)
 	pleg.Relist(tCtx)
-	actualStatus, actualErr := pleg.cache.Get(pods[0].ID)
+	actualStatus, actualErr := pleg.cache.Get(tCtx, pods[0].ID)
 	assert.Equal(t, &kubecontainer.PodStatus{ID: pods[0].ID}, actualStatus)
 	assert.NoError(t, actualErr)
 }
@@ -615,11 +615,11 @@ func TestReinspect(t *testing.T) {
 			}
 
 			if tc.expectStatus {
-				actualStatus, actualErr := pleg.cache.Get(podID)
+				actualStatus, actualErr := pleg.cache.Get(tCtx, podID)
 				assert.Equal(t, expectedStatus, actualStatus)
 				assert.Equal(t, tc.updateCacheError, actualErr)
 			} else if tc.podDeleted {
-				actualStatus, _ := pleg.cache.Get(podID)
+				actualStatus, _ := pleg.cache.Get(tCtx, podID)
 				// If deleted, Get returns an empty status with the ID
 				assert.Equal(t, &kubecontainer.PodStatus{ID: podID}, actualStatus)
 			}
@@ -656,7 +656,7 @@ func TestUpdateCacheUsesPodTimestampWhenEventedPLEGIsEnabled(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, expectedStatus, status)
 
-	cachedStatus, cachedErr := cache.Get(podID)
+	cachedStatus, cachedErr := cache.Get(ctx, podID)
 	require.NoError(t, cachedErr)
 	assert.Equal(t, expectedStatus, cachedStatus)
 }
@@ -772,7 +772,7 @@ func TestRelistIPChange(t *testing.T) {
 
 		pleg.Relist(tCtx)
 		actualEvents := getEventsFromChannel(ch)
-		actualStatus, actualErr := pleg.cache.Get(pod.ID)
+		actualStatus, actualErr := pleg.cache.Get(tCtx, pod.ID)
 		assert.Equal(t, status, actualStatus, tc.name)
 		assert.NoError(t, actualErr, tc.name)
 		assert.Exactly(t, []*PodLifecycleEvent{event}, actualEvents)
@@ -793,7 +793,7 @@ func TestRelistIPChange(t *testing.T) {
 
 		pleg.Relist(tCtx)
 		actualEvents = getEventsFromChannel(ch)
-		actualStatus, actualErr = pleg.cache.Get(pod.ID)
+		actualStatus, actualErr = pleg.cache.Get(tCtx, pod.ID)
 		// Must copy status to compare since its pointer gets passed through all
 		// the way to the event
 		statusCopy := *status
@@ -983,9 +983,10 @@ func TestWorkerLoop(t *testing.T) {
 }
 
 func getNewerThanAsync(t *testing.T, cache kubecontainer.ROCache, podID types.UID, minTime time.Time) <-chan *kubecontainer.PodStatus {
+	tCtx := ktesting.Init(t)
 	resCh := make(chan *kubecontainer.PodStatus, 1)
 	go func() {
-		s, err := cache.GetNewerThan(podID, minTime)
+		s, err := cache.GetNewerThan(tCtx, podID, minTime)
 		assert.NoError(t, err)
 		resCh <- s
 	}()

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -804,7 +804,7 @@ func (p *podWorkers) UpdatePod(ctx context.Context, options UpdatePodOptions) {
 			// Check to see if the pod is not running and the pod is terminal; if this succeeds then record in the podWorker that it is terminated.
 			// This is needed because after a kubelet restart, we need to ensure terminal pods will NOT be considered active in Pod Admission. See http://issues.k8s.io/105523
 			// However, `filterOutInactivePods`, considers pods that are actively terminating as active. As a result, `IsPodKnownTerminated()` needs to return true and thus `terminatedAt` needs to be set.
-			if statusCache, err := p.podCache.Get(uid); err == nil {
+			if statusCache, err := p.podCache.Get(ctx, uid); err == nil {
 				if isPodStatusCacheTerminal(statusCache) {
 					// At this point we know:
 					// (1) The pod is terminal based on the config source.
@@ -1285,7 +1285,7 @@ func (p *podWorkers) podWorkerLoop(parentCtx context.Context, podUID types.UID, 
 				//  Improving this latency also reduces the possibility that a terminated
 				//  container's status is garbage collected before we have a chance to update the
 				//  API server (thus losing the exit code).
-				status, err = p.podCache.GetNewerThan(update.Options.Pod.UID, lastSyncTime)
+				status, err = p.podCache.GetNewerThan(ctx, update.Options.Pod.UID, lastSyncTime)
 
 				if err != nil {
 					// This is the legacy event thrown by manage pod loop all other events are now dispatched

--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -79,7 +79,7 @@ func (f *fakePodWorkers) UpdatePod(ctx context.Context, options UpdatePodOptions
 	default:
 		return
 	}
-	status, err := f.cache.Get(uid)
+	status, err := f.cache.Get(ctx, uid)
 	if err != nil {
 		f.t.Errorf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Add a context.Context parameter to `container.Cache.Get/GetNewerThan `and `Runtime.GeneratePodStatus,` and thread the caller's context through `kubelet`, `pod_workers`, `PLEG`, and the `kuberuntime` manager instead of using `context.TODO()/klog.TODO()`. Update tests to obtain contexts via `ktesting.Init`.

#### Which issue(s) this PR is related to:

Ref: https://github.com/kubernetes/kubernetes/issues/130069

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node
/wg structured-logging
/area logging
/priority important-longterm