### PR TITLE
[release-1.35] build(test): pin agnhost base image and set GOTOOLCHAIN

### DIFF
--- a/test/images/agnhost/Dockerfile
+++ b/test/images/agnhost/Dockerfile
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASEIMAGE
-ARG GOLANG_VERSION
+# If we ever move agnhost away from alpine, we may need changes to
+# test/e2e/network/dns.go, which assumes that agnhost's `dig` binary
+# is linked against musl libc.
+ARG BASEIMAGE=alpine
 
-FROM golang:$GOLANG_VERSION AS preparer
+# latest as of 2026-05-08
+FROM golang@sha256:efaccb5b497e90df3ebe5216cc25cd9f98e73874e2d638b56e38d4a3f098c41c AS preparer
+
+ARG GOLANG_VERSION
+ARG GOTOOLCHAIN=go${GOLANG_VERSION}
 
 RUN go install github.com/google/go-containerregistry/cmd/crane@latest && \
     apt-get update && apt-get install -y jq


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This is a manual backport of commit `2092df7cf309bb993f3e438ed9e8735506570144` from `master` to `release-1.35`.

It pins the base `golang` image digest and sets `ARG GOTOOLCHAIN=go${GOLANG_VERSION}` in `test/images/agnhost/Dockerfile` to allow `agnhost` builds to succeed before new official golang base images are published on Docker Hub following `.go-version` bumps.

#### Which issue(s) this PR fixes:
Ref #141396

#### Special notes for your reviewer:
Clean backport of `2092df7cf309bb993f3e438ed9e8735506570144`. Verified locally via build test.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
