### PR TITLE
client-go: use stable hashes for exec auth cache keys

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -50,7 +50,6 @@ import (
 	"k8s.io/client-go/util/connrotation"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
-	"k8s.io/utils/dump"
 )
 
 const execInfoEnv = "KUBERNETES_EXEC_INFO"
@@ -78,46 +77,6 @@ var (
 		clientauthenticationv1.SchemeGroupVersion.String():      clientauthenticationv1.SchemeGroupVersion,
 	}
 )
-
-func newCache() *cache {
-	return &cache{m: make(map[string]*Authenticator)}
-}
-
-func cacheKey(conf *api.ExecConfig, cluster *clientauthentication.Cluster) string {
-	key := struct {
-		conf    *api.ExecConfig
-		cluster *clientauthentication.Cluster
-	}{
-		conf:    conf,
-		cluster: cluster,
-	}
-	return dump.Pretty(key)
-}
-
-type cache struct {
-	mu sync.Mutex
-	m  map[string]*Authenticator
-}
-
-func (c *cache) get(s string) (*Authenticator, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	a, ok := c.m[s]
-	return a, ok
-}
-
-// put inserts an authenticator into the cache. If an authenticator is already
-// associated with the key, the first one is returned instead.
-func (c *cache) put(s string, a *Authenticator) *Authenticator {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	existing, ok := c.m[s]
-	if ok {
-		return existing
-	}
-	c.m[s] = a
-	return a
-}
 
 // sometimes rate limits how often a function f() is called. Specifically, Do()
 // will run the provided function f() up to threshold times every interval
@@ -164,7 +123,10 @@ func GetAuthenticator(config *api.ExecConfig, cluster *clientauthentication.Clus
 }
 
 func newAuthenticator(c *cache, isTerminalFunc func(int) bool, config *api.ExecConfig, cluster *clientauthentication.Cluster) (*Authenticator, error) {
-	key := cacheKey(config, cluster)
+	key, err := newCacheKey(config, cluster)
+	if err != nil {
+		return nil, fmt.Errorf("creating exec plugin cache key: %w", err)
+	}
 	if a, ok := c.get(key); ok {
 		return a, nil
 	}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_cache.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_cache.go
@@ -1,0 +1,208 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/pkg/apis/clientauthentication"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// cacheKey is a stable hash of the configuration used to initialize an
+// authenticator.
+type cacheKey [sha256.Size]byte
+
+// newCacheKey returns a stable cache key for an exec configuration and cluster.
+// The configuration is hashed to avoid retaining potentially sensitive values
+// such as arguments and environment variables in the cache key.
+func newCacheKey(conf *api.ExecConfig, cluster *clientauthentication.Cluster) (cacheKey, error) {
+	return newCacheKeyData(conf, cluster).key()
+}
+
+func newCacheKeyData(conf *api.ExecConfig, cluster *clientauthentication.Cluster) cacheKeyData {
+	return cacheKeyData{
+		ExecConfig: newExecConfigCacheKeyData(conf),
+		Cluster:    newClusterCacheKeyData(cluster),
+	}
+}
+
+type cacheKeyData struct {
+	ExecConfig execConfigCacheKeyData `json:"execConfig"`
+	Cluster    *clusterCacheKeyData   `json:"cluster,omitempty"`
+}
+
+// key returns the SHA-256 digest of the cache identity data.
+//
+// JSON encoding preserves values omitted by String and GoString and provides
+// stable map ordering, while hashing avoids retaining potentially sensitive
+// values in the cache key.
+func (d cacheKeyData) key() (cacheKey, error) {
+	data, err := json.Marshal(d)
+	if err != nil {
+		// Avoid returning the original marshal error, which may include values
+		// from custom marshalers and therefore expose sensitive configuration.
+		if typeErr, ok := errors.AsType[*json.UnsupportedTypeError](err); ok {
+			return cacheKey{}, fmt.Errorf("cannot marshal unsupported type %s", typeErr.Type)
+		}
+		if _, ok := errors.AsType[*json.UnsupportedValueError](err); ok {
+			return cacheKey{}, errors.New("cannot marshal unsupported value")
+		}
+		if marshalerErr, ok := errors.AsType[*json.MarshalerError](err); ok {
+			return cacheKey{}, fmt.Errorf("cannot marshal type %s", marshalerErr.Type)
+		}
+		return cacheKey{}, errors.New("cannot marshal cache key")
+	}
+
+	return sha256.Sum256(data), nil
+}
+
+func newExecConfigCacheKeyData(conf *api.ExecConfig) execConfigCacheKeyData {
+	return execConfigCacheKeyData{
+		Command:                 conf.Command,
+		Args:                    conf.Args,
+		Env:                     conf.Env,
+		APIVersion:              conf.APIVersion,
+		InstallHint:             conf.InstallHint,
+		ProvideClusterInfo:      conf.ProvideClusterInfo,
+		Config:                  newObjectCacheKeyData(conf.Config),
+		InteractiveMode:         conf.InteractiveMode,
+		StdinUnavailable:        conf.StdinUnavailable,
+		StdinUnavailableMessage: conf.StdinUnavailableMessage,
+		PluginPolicy:            newPluginPolicyCacheKeyData(conf.PluginPolicy),
+	}
+}
+
+// Fields from [api.ExecConfig] that affect authenticator identity.
+type execConfigCacheKeyData struct {
+	Command                 string                   `json:"command"`
+	Args                    []string                 `json:"args"`
+	Env                     []api.ExecEnvVar         `json:"env"`
+	APIVersion              string                   `json:"apiVersion"`
+	InstallHint             string                   `json:"installHint"`
+	ProvideClusterInfo      bool                     `json:"provideClusterInfo"`
+	Config                  *objectCacheKeyData      `json:"config,omitempty"`
+	InteractiveMode         api.ExecInteractiveMode  `json:"interactiveMode"`
+	StdinUnavailable        bool                     `json:"stdinUnavailable"`
+	StdinUnavailableMessage string                   `json:"stdinUnavailableMessage"`
+	PluginPolicy            pluginPolicyCacheKeyData `json:"pluginPolicy"`
+}
+
+func newPluginPolicyCacheKeyData(policy api.PluginPolicy) pluginPolicyCacheKeyData {
+	allowlist := make([]allowlistEntryCacheKeyData, len(policy.Allowlist))
+	for i, entry := range policy.Allowlist {
+		allowlist[i] = allowlistEntryCacheKeyData{
+			Command: entry.Command,
+		}
+	}
+
+	return pluginPolicyCacheKeyData{
+		PolicyType: policy.PolicyType,
+		Allowlist:  allowlist,
+	}
+}
+
+// pluginPolicyCacheKeyData is the representation of api.PluginPolicy used when
+// computing an exec credential cache key. It includes fields that are
+// intentionally excluded from JSON serialization on api.PluginPolicy.
+type pluginPolicyCacheKeyData struct {
+	PolicyType api.PolicyType
+	Allowlist  []allowlistEntryCacheKeyData
+}
+
+// allowlistEntryCacheKeyData is the representation of api.AllowlistEntry used
+// when computing an exec credential cache key. It includes fields that are
+// intentionally excluded from JSON serialization on api.AllowlistEntry.
+type allowlistEntryCacheKeyData struct {
+	Command string
+}
+
+func newClusterCacheKeyData(cluster *clientauthentication.Cluster) *clusterCacheKeyData {
+	if cluster == nil {
+		return nil
+	}
+
+	return &clusterCacheKeyData{
+		Server:                   cluster.Server,
+		TLSServerName:            cluster.TLSServerName,
+		InsecureSkipTLSVerify:    cluster.InsecureSkipTLSVerify,
+		CertificateAuthorityData: cluster.CertificateAuthorityData,
+		ProxyURL:                 cluster.ProxyURL,
+		DisableCompression:       cluster.DisableCompression,
+		Config:                   newObjectCacheKeyData(cluster.Config),
+	}
+}
+
+// Fields from [clientauthentication.Cluster] that affect authenticator identity.
+type clusterCacheKeyData struct {
+	Server                   string `json:"server"`
+	TLSServerName            string `json:"tlsServerName"`
+	InsecureSkipTLSVerify    bool   `json:"insecureSkipTLSVerify"`
+	CertificateAuthorityData []byte `json:"certificateAuthorityData"`
+	ProxyURL                 string `json:"proxyURL"`
+	DisableCompression       bool   `json:"disableCompression"`
+
+	Config *objectCacheKeyData `json:"config,omitempty"`
+}
+
+func newObjectCacheKeyData(obj runtime.Object) *objectCacheKeyData {
+	if obj == nil {
+		return nil
+	}
+	return &objectCacheKeyData{Object: obj}
+}
+
+// objectCacheKeyData defines the observable runtime.Object state that
+// participates in cache identity. JSON-visible state is included; unexported
+// runtime state is intentionally ignored.
+type objectCacheKeyData struct {
+	Object runtime.Object `json:"object"`
+}
+
+func newCache() *cache {
+	return &cache{m: make(map[cacheKey]*Authenticator)}
+}
+
+type cache struct {
+	mu sync.Mutex
+	m  map[cacheKey]*Authenticator
+}
+
+func (c *cache) get(s cacheKey) (*Authenticator, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	a, ok := c.m[s]
+	return a, ok
+}
+
+// put inserts an authenticator into the cache. If an authenticator is already
+// associated with the key, the first one is returned instead.
+func (c *cache) put(s cacheKey, a *Authenticator) *Authenticator {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	existing, ok := c.m[s]
+	if ok {
+		return existing
+	}
+	c.m[s] = a
+	return a
+}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_cache_internal_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_cache_internal_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/client-go/pkg/apis/clientauthentication"
+	"k8s.io/client-go/tools/clientcmd/api"
+)
+
+// TestCacheKeyFields verifies that every ExecConfig and Cluster field has been
+// considered for cache identity. When either source type changes, update
+// execConfigCacheKeyData or clusterCacheKeyData to include identity-relevant
+// fields, or add intentionally excluded fields to the corresponding skipped
+// list.
+func TestCacheKeyFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   reflect.Type
+		included reflect.Type
+		skipped  []string
+	}{
+		{
+			name:     "ExecConfig",
+			source:   reflect.TypeFor[api.ExecConfig](),
+			included: reflect.TypeFor[execConfigCacheKeyData](),
+			skipped:  []string{
+				// "ExampleExcludedField", // Example of a field intentionally excluded from cache identity.
+			},
+		},
+		{
+			name:     "Cluster",
+			source:   reflect.TypeFor[clientauthentication.Cluster](),
+			included: reflect.TypeFor[clusterCacheKeyData](),
+			skipped:  []string{
+				// "ExampleExcludedField", // Example of a field intentionally excluded from cache identity.
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			classified := make(map[string]struct{}, tc.included.NumField()+len(tc.skipped))
+
+			for field := range tc.included.Fields() {
+				classified[field.Name] = struct{}{}
+			}
+			for _, field := range tc.skipped {
+				if _, ok := classified[field]; ok {
+					t.Fatalf("field %q is both included and skipped", field)
+				}
+				classified[field] = struct{}{}
+			}
+
+			for field := range tc.source.Fields() {
+				if _, ok := classified[field.Name]; !ok {
+					t.Errorf("field %q has not been considered for cache identity", field.Name)
+					continue
+				}
+				delete(classified, field.Name)
+			}
+
+			for field := range classified {
+				t.Errorf("classified field %q does not exist", field)
+			}
+		})
+	}
+}
+
+// TestCacheKeyPluginPolicy verifies that fields intentionally excluded from
+// PluginPolicy's JSON representation still contribute to the cache key.
+func TestCacheKeyPluginPolicy(t *testing.T) {
+	conf1 := &api.ExecConfig{
+		PluginPolicy: api.PluginPolicy{
+			PolicyType: api.PluginPolicyAllowlist,
+			Allowlist: []api.AllowlistEntry{
+				{Command: "foo"},
+			},
+		},
+	}
+	conf2 := conf1.DeepCopy()
+	conf2.PluginPolicy.Allowlist[0].Command = "bar"
+
+	if makeCacheKey(t, conf1, nil) == makeCacheKey(t, conf2, nil) {
+		t.Fatal("expected different cache keys for different plugin allowlists")
+	}
+}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_cache_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_cache_test.go
@@ -104,3 +104,100 @@ func TestExecTLSCache(t *testing.T) {
 		t.Fatal("expected different TLS config for non-matching exec config via rest config")
 	}
 }
+
+// TestExecTLSCacheWithDifferentPluginPolicy verifies that exec configurations
+// with different plugin policies do not share cached TLS configuration.
+func TestExecTLSCacheWithDifferentPluginPolicy(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	newConfig := func(policyType clientcmdapi.PolicyType) *rest.Config {
+		return &rest.Config{
+			Host: "https://localhost",
+			ExecProvider: &clientcmdapi.ExecConfig{
+				Command:         "./testdata/test-plugin.sh",
+				APIVersion:      "client.authentication.k8s.io/v1",
+				InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
+				PluginPolicy: clientcmdapi.PluginPolicy{
+					PolicyType: policyType,
+				},
+			},
+		}
+	}
+
+	client1 := clientset.NewForConfigOrDie(newConfig(clientcmdapi.PluginPolicyAllowAll))
+	client2 := clientset.NewForConfigOrDie(newConfig(clientcmdapi.PluginPolicyDenyAll))
+
+	_, _ = client1.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	_, _ = client2.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+
+	rt1 := client1.RESTClient().(*rest.RESTClient).Client.Transport
+	rt2 := client2.RESTClient().(*rest.RESTClient).Client.Transport
+
+	tlsConfig1, err := utilnet.TLSClientConfig(rt1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsConfig2, err := utilnet.TLSClientConfig(rt2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tlsConfig1 == nil || tlsConfig2 == nil {
+		t.Fatal("expected non-nil TLS configs")
+	}
+
+	if tlsConfig1 == tlsConfig2 {
+		t.Fatal("expected different TLS configs for different plugin policies")
+	}
+}
+
+// TestExecTLSCacheWithDifferentPluginAllowlist verifies that exec configurations
+// with different plugin allowlist entries do not share cached TLS configuration.
+func TestExecTLSCacheWithDifferentPluginAllowlist(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	newConfig := func(command string) *rest.Config {
+		return &rest.Config{
+			Host: "https://localhost",
+			ExecProvider: &clientcmdapi.ExecConfig{
+				Command:         "./testdata/test-plugin.sh",
+				APIVersion:      "client.authentication.k8s.io/v1",
+				InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
+				PluginPolicy: clientcmdapi.PluginPolicy{
+					PolicyType: clientcmdapi.PluginPolicyAllowlist,
+					Allowlist: []clientcmdapi.AllowlistEntry{
+						{Command: command},
+					},
+				},
+			},
+		}
+	}
+
+	client1 := clientset.NewForConfigOrDie(newConfig("testdata/test-plugin.sh"))
+	client2 := clientset.NewForConfigOrDie(newConfig("testdata/other-plugin.sh"))
+
+	_, _ = client1.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	_, _ = client2.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+
+	rt1 := client1.RESTClient().(*rest.RESTClient).Client.Transport
+	rt2 := client2.RESTClient().(*rest.RESTClient).Client.Transport
+
+	tlsConfig1, err := utilnet.TLSClientConfig(rt1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsConfig2, err := utilnet.TLSClientConfig(rt2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if tlsConfig1 == nil || tlsConfig2 == nil {
+		t.Fatal("expected non-nil TLS configs")
+	}
+
+	if tlsConfig1 == tlsConfig2 {
+		t.Fatal("expected different TLS configs for different plugin allowlists")
+	}
+}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_cache_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_cache_test.go
@@ -18,6 +18,7 @@ package exec_test // separate package to prevent circular import
 
 import (
 	"context"
+	"crypto/tls"
 	"testing"
 	"time"
 
@@ -102,6 +103,58 @@ func TestExecTLSCache(t *testing.T) {
 
 	if tlsConfig1 == tlsConfig3 {
 		t.Fatal("expected different TLS config for non-matching exec config via rest config")
+	}
+}
+
+// TestExecTLSCacheWithMapConfig verifies that equivalent exec configs containing
+// maps produce stable cache keys and share a cached authenticator.
+func TestExecTLSCacheWithMapConfig(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	newConfig := func() *rest.Config {
+		execConfig := &clientcmdapi.ExecConfig{
+			Command:         "./testdata/test-plugin.sh",
+			APIVersion:      "client.authentication.k8s.io/v1",
+			InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
+			Config: &clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"a": {Server: "https://a.example.com"},
+					"b": {Server: "https://b.example.com"},
+					"c": {Server: "https://c.example.com"},
+				},
+			},
+		}
+
+		return &rest.Config{
+			Host:         "https://localhost",
+			ExecProvider: execConfig,
+		}
+	}
+
+	var expected *tls.Config
+
+	for range 100 {
+		client := clientset.NewForConfigOrDie(newConfig())
+
+		_, _ = client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+
+		rt := client.RESTClient().(*rest.RESTClient).Client.Transport
+		tlsConfig, err := utilnet.TLSClientConfig(rt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tlsConfig == nil {
+			t.Fatal("expected non-nil TLS config")
+		}
+
+		if expected == nil {
+			expected = tlsConfig
+			continue
+		}
+		if expected != tlsConfig {
+			t.Fatal("expected the same TLS config for equivalent exec configs containing maps")
+		}
 	}
 }
 

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
@@ -110,6 +110,16 @@ func init() {
 	validCert = &cert
 }
 
+func makeCacheKey(t *testing.T, conf *api.ExecConfig, cluster *clientauthentication.Cluster) cacheKey {
+	t.Helper()
+
+	k, err := newCacheKey(conf, cluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return k
+}
+
 func TestCacheKey(t *testing.T) {
 	c1 := &api.ExecConfig{
 		Command: "foo-bar",
@@ -260,13 +270,13 @@ func TestCacheKey(t *testing.T) {
 		StdinUnavailable: true,
 	}
 
-	key1 := cacheKey(c1, c1c)
-	key2 := cacheKey(c2, c2c)
-	key3 := cacheKey(c3, c3c)
-	key4 := cacheKey(c4, c4c)
-	key5 := cacheKey(c5, c5c)
-	key6 := cacheKey(c6, nil)
-	key7 := cacheKey(c7, nil)
+	key1 := makeCacheKey(t, c1, c1c)
+	key2 := makeCacheKey(t, c2, c2c)
+	key3 := makeCacheKey(t, c3, c3c)
+	key4 := makeCacheKey(t, c4, c4c)
+	key5 := makeCacheKey(t, c5, c5c)
+	key6 := makeCacheKey(t, c6, nil)
+	key7 := makeCacheKey(t, c7, nil)
 	if key1 != key2 {
 		t.Error("key1 and key2 didn't match")
 	}


### PR DESCRIPTION
The exec authenticator cache currently uses dump.Pretty to serialize its
configuration as the cache key. Pretty-printing does not sort map keys, so
equivalent configurations containing maps can produce different keys and miss
the cache.

Define the fields that participate in authenticator identity explicitly and
serialize that representation as JSON before hashing it with SHA-256. This
provides deterministic map ordering while avoiding retention of potentially
sensitive exec arguments and environment variables in the cache key.

Runtime objects contribute their JSON-visible state to the identity while
unexported runtime state is intentionally ignored. Add a test that requires new
ExecConfig and Cluster fields to be explicitly considered for inclusion in or
exclusion from the cache identity.

Sanitize JSON encoding errors so configuration values are not inadvertently
returned through errors.


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
