### PR TITLE
Fix duplicate ServiceAccount storage construction

### DIFF
--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -125,6 +125,11 @@ func New(c Config, authorizer authorizer.UnconditionalAuthorizer) (*legacyProvid
 		authorizer:                       authorizer,
 	}
 
+	// When an issuer is configured, NewRESTStorage below builds a pod-aware
+	// serviceaccount storage. Tell the embedded generic config not to build its
+	// own, so the resource ends up with a single storage instance.
+	p.skipServiceAccount = c.ServiceAccountIssuer != nil
+
 	// create service node port repair controller
 	client, err := kubernetes.NewForConfig(c.LoopbackClientConfig)
 	if err != nil {
@@ -230,9 +235,10 @@ func (p *legacyProvider) NewRESTStorage(apiResourceConfigSource serverstorage.AP
 		return genericapiserver.APIGroupInfo{}, err
 	}
 
-	// potentially override the generic serviceaccount storage with one that supports pods
+	// The generic config skipped serviceaccounts (see New), so this provider owns
+	// the resource and builds the storage that supports pods.
 	var serviceAccountStorage *serviceaccountstore.REST
-	if p.ServiceAccountIssuer != nil {
+	if p.skipServiceAccount {
 		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, p.ServiceAccountIssuer, p.APIAudiences, p.Authorizer, p.ServiceAccountMaxExpiration, podStorage.Pod.Store, storage["secrets"].(rest.Getter), nodeStorage.Node.Store,
 			whClient.ValidatingWebhookConfigurations(), whClient.MutatingWebhookConfigurations(), p.ExtendExpiration, p.MaxExtendedExpiration)
 		if err != nil {
@@ -278,14 +284,8 @@ func (p *legacyProvider) NewRESTStorage(apiResourceConfigSource serverstorage.AP
 		}
 	}
 
-	// potentially override generic storage for service account (with pod support)
+	// serviceaccount storage with pod support, built above rather than by the generic config
 	if resource := "serviceaccounts"; serviceAccountStorage != nil && apiResourceConfigSource.ResourceEnabled(corev1.SchemeGroupVersion.WithResource(resource)) {
-		// don't leak go routines
-		storage[resource].Destroy()
-		if storage[resource+"/token"] != nil {
-			storage[resource+"/token"].Destroy()
-		}
-
 		storage[resource] = serviceAccountStorage
 		if serviceAccountStorage.Token != nil {
 			storage[resource+"/token"] = serviceAccountStorage.Token

--- a/pkg/registry/core/rest/storage_core_generic.go
+++ b/pkg/registry/core/rest/storage_core_generic.go
@@ -64,6 +64,12 @@ type GenericConfig struct {
 
 	LoopbackClientConfig *restclient.Config
 	Informers            informers.SharedInformerFactory
+
+	// skipServiceAccount, when true, skips building serviceaccount storage here.
+	// It is set by legacyProvider, which builds a pod-aware serviceaccount
+	// storage itself; without this the resource would get two storages, and
+	// therefore two cachers and two etcd watches, for the same GroupResource.
+	skipServiceAccount bool
 }
 
 func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, error) {
@@ -110,15 +116,17 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 	}
 
 	var serviceAccountStorage *serviceaccountstore.REST
-	if c.ServiceAccountIssuer != nil {
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.APIAudiences, authorizerfactory.NewAlwaysDenyAuthorizer(), c.ServiceAccountMaxExpiration, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), secretStorage.Store, newNotFoundGetter(schema.GroupResource{Resource: "nodes"}),
-			notFoundValidatingWebhookConfigurations{}, notFoundMutatingWebhookConfigurations{}, c.ExtendExpiration, c.MaxExtendedExpiration)
-	} else {
-		serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, authorizerfactory.NewAlwaysDenyAuthorizer(), 0, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), newNotFoundGetter(schema.GroupResource{Resource: "secrets"}), newNotFoundGetter(schema.GroupResource{Resource: "nodes"}),
-			notFoundValidatingWebhookConfigurations{}, notFoundMutatingWebhookConfigurations{}, false, c.MaxExtendedExpiration)
-	}
-	if err != nil {
-		return genericapiserver.APIGroupInfo{}, err
+	if !c.skipServiceAccount {
+		if c.ServiceAccountIssuer != nil {
+			serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, c.ServiceAccountIssuer, c.APIAudiences, authorizerfactory.NewAlwaysDenyAuthorizer(), c.ServiceAccountMaxExpiration, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), secretStorage.Store, newNotFoundGetter(schema.GroupResource{Resource: "nodes"}),
+				notFoundValidatingWebhookConfigurations{}, notFoundMutatingWebhookConfigurations{}, c.ExtendExpiration, c.MaxExtendedExpiration)
+		} else {
+			serviceAccountStorage, err = serviceaccountstore.NewREST(restOptionsGetter, nil, nil, authorizerfactory.NewAlwaysDenyAuthorizer(), 0, newNotFoundGetter(schema.GroupResource{Resource: "pods"}), newNotFoundGetter(schema.GroupResource{Resource: "secrets"}), newNotFoundGetter(schema.GroupResource{Resource: "nodes"}),
+				notFoundValidatingWebhookConfigurations{}, notFoundMutatingWebhookConfigurations{}, false, c.MaxExtendedExpiration)
+		}
+		if err != nil {
+			return genericapiserver.APIGroupInfo{}, err
+		}
 	}
 
 	storage := map[string]rest.Storage{}
@@ -141,7 +149,7 @@ func (c *GenericConfig) NewRESTStorage(apiResourceConfigSource serverstorage.API
 		storage[resource] = secretStorage
 	}
 
-	if resource := "serviceaccounts"; apiResourceConfigSource.ResourceEnabled(corev1.SchemeGroupVersion.WithResource(resource)) {
+	if resource := "serviceaccounts"; !c.skipServiceAccount && apiResourceConfigSource.ResourceEnabled(corev1.SchemeGroupVersion.WithResource(resource)) {
 		storage[resource] = serviceAccountStorage
 		if serviceAccountStorage.Token != nil {
 			storage[resource+"/token"] = serviceAccountStorage.Token


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:


Adds an unexported skipServiceAccount flag to `corerest.GenericConfig`. `legacyProvider` sets it in `New()` when a service account issuer is configured, so the generic core storage no longer builds serviceaccount storage that the legacy provider immediately replaces. The now-redundant `Destroy()` calls on the discarded storage are removed.

Behavior is unchanged: serviceaccounts and serviceaccounts/token are still served by the same pod-aware storage. The generic control plane is unaffected -- `NewCoreGenericConfig()` used standalone leaves the flag false.



trace:
<details>

```
I0817 01:32:05.704492 store.go:149] "etcd3.New" resource="serviceaccounts" resourcePrefix="/serviceaccounts"
    ...
    serviceaccount/storage.NewREST
        pkg/registry/core/serviceaccount/storage/storage.go:72
    rest.(*GenericConfig).NewRESTStorage
        pkg/registry/core/rest/storage_core_generic.go:114
    rest.(*legacyProvider).NewRESTStorage
        pkg/registry/core/rest/storage_core.go:160
    apiserver.(*Server).InstallAPIs
```
```
I0817 01:32:05.712420 store.go:149] "etcd3.New" resource="serviceaccounts" resourcePrefix="/serviceaccounts"
    ...
    serviceaccount/storage.NewREST
        pkg/registry/core/serviceaccount/storage/storage.go:72
    rest.(*legacyProvider).NewRESTStorage
        pkg/registry/core/rest/storage_core.go:241
    apiserver.(*Server).InstallAPIs
```

</details>

before:
```
2 "cacher.NewCacherFromConfig" group="" resource="serviceaccounts" resourcePrefix="/serviceaccounts"
2 "etcd3.New"                  group="" resource="serviceaccounts" resourcePrefix="/serviceaccounts"
```
after:
```
1 "cacher.NewCacherFromConfig" group="" resource="serviceaccounts" resourcePrefix="/serviceaccounts"
1 "etcd3.New"                  group="" resource="serviceaccounts" resourcePrefix="/serviceaccounts"
```

#### Which issue(s) this PR is related to:
part of #133877

#### Special notes for your reviewer:

this PR covers only the serviceaccounts half.
#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/cc @serathius 