### PR TITLE
Wait for podcertificate server and client deployment

### DIFF
--- a/test/e2e/auth/projected_podcertificate.go
+++ b/test/e2e/auth/projected_podcertificate.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epodoutput "k8s.io/kubernetes/test/e2e/framework/pod/output"
+	testutils "k8s.io/kubernetes/test/utils"
 	"k8s.io/kubernetes/test/utils/hermeticpodcertificatesigner"
 	imageutils "k8s.io/kubernetes/test/utils/image" // Import imageutils
 	admissionapi "k8s.io/pod-security-admission/api"
@@ -104,6 +105,12 @@ var _ = SIGDescribe("Projected PodCertificate",
 			if err != nil {
 				framework.Failf("failed to create client deployment: %v", err)
 			}
+
+			ginkgo.By("Waiting for server deployment to complete...")
+			framework.ExpectNoError(testutils.WaitForDeploymentComplete(f.ClientSet, serverDeployment, framework.Logf, time.Second, time.Minute))
+
+			ginkgo.By("Waiting for client deployment to complete...")
+			framework.ExpectNoError(testutils.WaitForDeploymentComplete(f.ClientSet, clientDeployment, framework.Logf, time.Second, time.Minute))
 
 			ginkgo.By("Waiting for mTLS connection to be built...")
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

Waits for the server and client deployments to be healthy before starting the 30-second poll for pod logs.

#### Which issue(s) this PR is related to:

Fixes #141402

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/sig auth
/cc @ahmedtd @yt2985 