### PR TITLE
test/scheduler_perf: add starvation benchmark workloads for async sch…

### DIFF
--- a/test/integration/scheduler_perf/starvation/performance-config.yaml
+++ b/test/integration/scheduler_perf/starvation/performance-config.yaml
@@ -1,14 +1,17 @@
-- name: StarvationIndependent
+- name: StarvationIndependent_NoChurn
+  schedulerConfigPath: scheduler-config-qps100.yaml
+  featureGates:
+    SchedulerAsyncAPICalls: true
   metricsCollectorConfig:
     metrics:
-      scheduler_queue_incoming_pods_total:
-      - label: event
-        values: [ScheduleAttemptFailure, AssignedPodAdd, BackoffComplete, UnscheduledPodAdd, ForceActivate]
-      - label: queue
-        values: [active, backoff, unschedulable]
       scheduler_scheduling_attempt_duration_seconds:
       - label: result
         values: [scheduled, unschedulable, error]
+      scheduler_async_api_call_execution_duration_seconds:
+      - label: call_type
+        values: [binding, pod_status_patch]
+      - label: result
+        values: [success, error]
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -16,15 +19,7 @@
   - opcode: createNamespaces
     prefix: starvation
     count: 1
-  # Start churn generator to continuously generate PodAdd/PodDelete events
-  - opcode: churn
-    mode: recreate
-    number: 600
-    intervalMilliseconds: 1000
-    namespace: starvation-0
-    templatePaths:
-    - templates/churn-pod.yaml
-  # Inject massive batch of independent, high-priority, unschedulable pods
+  # Inject unschedulable high-priority cloggers (if any)
   - opcode: createPods
     countParam: $cloggerPods
     podTemplatePath: templates/clogger-pod.yaml
@@ -44,31 +39,33 @@
     namespace: starvation-0
   - opcode: stopCollectingMetrics
   workloads:
-  - name: 10Nodes_100Cloggers
+  - name: 1000Nodes_20Cloggers_1000Schedulable_0Churn_QPS100
     labels: [integration-test, short]
     params:
-      initNodes: 10
-      cloggerPods: 100
-      starvationProne: 50
-  - name: 10000Nodes_10000Cloggers
-    labels: [performance]
+      initNodes: 1000
+      cloggerPods: 20
+      starvationProne: 1000
+  - name: 1000Nodes_0Cloggers_1000Schedulable_0Churn_QPS100
+    labels: [integration-test, short]
     params:
-      initNodes: 10000
-      cloggerPods: 10000
-      starvationProne: 500
-- name: StarvationPodGroup
+      initNodes: 1000
+      cloggerPods: 0
+      starvationProne: 1000
+
+- name: StarvationIndependent_200Churn
+  schedulerConfigPath: scheduler-config-qps100.yaml
   featureGates:
-    GenericWorkload: true
+    SchedulerAsyncAPICalls: true
   metricsCollectorConfig:
     metrics:
-      scheduler_queue_incoming_pods_total:
-      - label: event
-        values: [ScheduleAttemptFailure, AssignedPodAdd, BackoffComplete, UnscheduledPodAdd, ForceActivate]
-      - label: queue
-        values: [active, backoff, unschedulable]
       scheduler_scheduling_attempt_duration_seconds:
       - label: result
         values: [scheduled, unschedulable, error]
+      scheduler_async_api_call_execution_duration_seconds:
+      - label: call_type
+        values: [binding, pod_status_patch]
+      - label: result
+        values: [success, error]
   workloadTemplate:
   - opcode: createNodes
     countParam: $initNodes
@@ -76,26 +73,18 @@
   - opcode: createNamespaces
     prefix: starvation
     count: 1
-  # Create the single PodGroup podgroup-0 using Basic scheduling policy under the Workload API
-  # and wait for the scheduler's informer cache to reflect the newly created PodGroup object
-  - opcode: createPodGroups
-    namespace: starvation-0
-    templatePath: templates/podgroup.yaml
-    countParam: $initPodGroups
-    templateParams:
-      minCount: $cloggerPods
   # Start churn generator to continuously generate PodAdd/PodDelete events
   - opcode: churn
     mode: recreate
-    number: 600
+    number: 200
     intervalMilliseconds: 1000
     namespace: starvation-0
     templatePaths:
     - templates/churn-pod.yaml
-  # Inject massive batch of podgroup-managed, high-priority, unschedulable pods
+  # Inject unschedulable high-priority cloggers
   - opcode: createPods
     countParam: $cloggerPods
-    podTemplatePath: templates/clogger-podgroup-pod.yaml
+    podTemplatePath: templates/clogger-pod.yaml
     namespace: starvation-0
     skipWaitToCompletion: true
   # Wait until all unschedulable cloggers are attempted by the scheduler
@@ -112,17 +101,9 @@
     namespace: starvation-0
   - opcode: stopCollectingMetrics
   workloads:
-  - name: 10Nodes_100Cloggers_Podgroup
+  - name: 1000Nodes_20Cloggers_1000Schedulable_200Churn_QPS100
     labels: [integration-test, short]
     params:
-      initNodes: 10
-      initPodGroups: 1
-      cloggerPods: 100
-      starvationProne: 50
-  - name: 10000Nodes_10000Cloggers_Podgroup
-    labels: [performance]
-    params:
-      initNodes: 10000
-      initPodGroups: 1
-      cloggerPods: 10000
-      starvationProne: 500
+      initNodes: 1000
+      cloggerPods: 20
+      starvationProne: 1000

--- a/test/integration/scheduler_perf/starvation/scheduler-config-qps100.yaml
+++ b/test/integration/scheduler_perf/starvation/scheduler-config-qps100.yaml
@@ -1,0 +1,5 @@
+apiVersion: kubescheduler.config.k8s.io/v1
+kind: KubeSchedulerConfiguration
+clientConnection:
+  qps: 100
+  burst: 100

--- a/test/integration/scheduler_perf/starvation/templates/victim-pod.yaml
+++ b/test/integration/scheduler_perf/starvation/templates/victim-pod.yaml
@@ -2,8 +2,22 @@ apiVersion: v1
 kind: Pod
 metadata:
   generateName: pod-victim-
+  labels:
+    app: victim-app
 spec:
   priority: 0
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - victim-app
+          topologyKey: kubernetes.io/hostname
   containers:
   - image: registry.k8s.io/pause:3.10.1
     name: pause


### PR DESCRIPTION
Add declarative performance-config benchmark suites and pod templates for evaluating scheduler async API dispatching under stable conditions:

1. 1000Nodes_20Cloggers_1000Schedulable_0Churn_QPS100: 1k nodes, 1k pods, 20 unschedulable cloggers, 0 churn.
2. 1000Nodes_0Cloggers_1000Schedulable_0Churn_QPS100: 1k nodes, 1k pods, 0 cloggers, 0 churn (100% schedulable baseline).
3. 1000Nodes_20Cloggers_1000Schedulable_200Churn_QPS100: 1k nodes, 1k pods, 20 cloggers, 200 churn/s.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
