### PR TITLE
kubelet: don't let podActions alias the pod spec's volumes

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -857,23 +857,36 @@ func (m *kubeGenericRuntimeManager) computeVolumeResizeAction(ctx context.Contex
 			if !allocation.VolHasMemoryBackedEmptyDirSizeLimit(&vol) {
 				continue
 			}
+			// vol is only a shallow copy, so vol.EmptyDir still points at the
+			// pod spec's EmptyDirVolumeSource and vol.EmptyDir.SizeLimit at a
+			// resource.Quantity that every other reader of the pod shares (the
+			// volume manager's populator, for one). Several of the methods that
+			// look like reads write to the quantity: String() fills in the
+			// cached string, and Cmp() calls AsDec() on its receiver if either
+			// side is in inf.Dec form. Both happen to this SizeLimit - it is
+			// compared below, logged as part of podActions in SyncPod, logged
+			// by the emptyDir plugin during the resize, and stored in and
+			// logged by the actuated state. Work off a copy throughout so none
+			// of that can reach the pod spec.
+			volCopy := *vol.DeepCopy()
+
 			actuatedSize := m.getActuatedEmptyDirVolumeLimit(logger, pod, vol.Name)
-			desiredSize := vol.EmptyDir.SizeLimit
+			desiredSize := volCopy.EmptyDir.SizeLimit
 
 			if actuatedSize == nil {
 				// If the actuation checkpoint is missing, force a sync to apply
 				// the limit and write the checkpoint. We treat it as an upsize
 				// (safer order) to ensure cgroup limits are expanded first.
-				changes.VolumesToUpsize = append(changes.VolumesToUpsize, vol)
+				changes.VolumesToUpsize = append(changes.VolumesToUpsize, volCopy)
 				continue
 			}
 
 			// Compare current (actuated) size with new size
 			cmp := desiredSize.Cmp(*actuatedSize)
 			if cmp > 0 {
-				changes.VolumesToUpsize = append(changes.VolumesToUpsize, vol)
+				changes.VolumesToUpsize = append(changes.VolumesToUpsize, volCopy)
 			} else if cmp < 0 {
-				changes.VolumesToDownsize = append(changes.VolumesToDownsize, vol)
+				changes.VolumesToDownsize = append(changes.VolumesToDownsize, volCopy)
 			}
 		}
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -5152,6 +5152,86 @@ func TestComputeVolumeResizeAction(t *testing.T) {
 	}
 }
 
+// TestComputeVolumeResizeActionCopiesVolumes verifies that the volumes recorded
+// in podActions do not alias the pod spec. They are handed to code that calls
+// resource.Quantity.String() on their SizeLimit - the podActions log line in
+// SyncPod, the emptyDir plugin and the actuated state - and String() writes the
+// quantity's cached string, which would be a data race against everything else
+// reading the pod.
+func TestComputeVolumeResizeActionCopiesVolumes(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.InPlacePodVerticalScalingMemoryBackedVolumes, true)
+
+	_, _, m, err := createTestRuntimeManager(tCtx)
+	require.NoError(t, err)
+
+	// "128Mi" is not in the canonical form that ParseQuantity caches, so this
+	// quantity starts out with an empty string cache and String() will write to
+	// it.
+	sizeLimit := resource.MustParse("128Mi")
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: "test-pod-uid"},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{{
+				Name: "mem-vol",
+				VolumeSource: v1.VolumeSource{
+					EmptyDir: &v1.EmptyDirVolumeSource{
+						Medium:    v1.StorageMediumMemory,
+						SizeLimit: &sizeLimit,
+					},
+				},
+			}},
+		},
+	}
+	require.NoError(t, m.actuatedState.SetEmptyDirVolumeLimit(pod.UID, "mem-vol", resource.NewQuantity(1, resource.BinarySI)))
+
+	var changes podActions
+	m.computeVolumeResizeAction(tCtx, pod, &changes)
+
+	require.Len(t, changes.VolumesToUpsize, 1)
+	upsize := changes.VolumesToUpsize[0]
+	assert.Equal(t, "mem-vol", upsize.Name)
+	require.NotNil(t, upsize.EmptyDir)
+	require.NotNil(t, upsize.EmptyDir.SizeLimit)
+	assert.Equal(t, sizeLimit.Value(), upsize.EmptyDir.SizeLimit.Value())
+
+	assert.NotSame(t, pod.Spec.Volumes[0].EmptyDir, upsize.EmptyDir,
+		"podActions must not alias the pod spec's EmptyDirVolumeSource")
+	assert.NotSame(t, pod.Spec.Volumes[0].EmptyDir.SizeLimit, upsize.EmptyDir.SizeLimit,
+		"podActions must not alias the pod spec's SizeLimit quantity")
+
+	// Reproduce the reported race: logging podActions while another goroutine
+	// reads the pod spec, as the volume manager's populator does. Formatting
+	// only ever reaches the copy, so -race stays quiet. Nothing may call
+	// String() before this point, or the first call - the one that writes the
+	// cached string - happens before the reader starts.
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		zero := resource.Quantity{}
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				// Mirrors updateEmptyDirVolumeLimitsFromAllocation: the
+				// dereference copies the whole quantity, cached string
+				// included.
+				zero.Cmp(*pod.Spec.Volumes[0].EmptyDir.SizeLimit)
+			}
+		}
+	}()
+	for range 1000 {
+		_ = changes.String()
+	}
+	close(stop)
+	<-done
+
+	assert.Contains(t, changes.String(), "mem-vol")
+	assert.Equal(t, sizeLimit.Value(), pod.Spec.Volumes[0].EmptyDir.SizeLimit.Value())
+}
+
 func TestDoPodResizeAction_Volumes(t *testing.T) {
 	if goruntime.GOOS != "linux" {
 		t.Skip("unsupported OS")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

`computeVolumeResizeAction` records `v1.Volume` values from the pod spec into `podActions.VolumesToUpsize`/`VolumesToDownsize`. The range variable is only a shallow copy, so `vol.EmptyDir` — and with it the `SizeLimit` `*resource.Quantity` — remains shared with every other reader of the pod.

`resource.Quantity.String()` lazily populates the quantity's cached string, i.e. it **writes** to the quantity. Three consumers of these recorded volumes do exactly that:

| site | what it formats |
| --- | --- |
| `kuberuntime_manager.go` `SyncPod` | `logger.V(3).Info("computePodActions got for pod", "podActions", …)` → `podActions.String()` → `EmptyDirVolumeSource.String()` |
| `pkg/volume/emptydir/empty_dir_linux.go` | `klog.V(2).InfoS("Resizing emptyDir volume", …, "newSize", newSize)` |
| `pkg/kubelet/allocation/state/state_mem.go` | `SetEmptyDirVolumeLimit` stores the `*Quantity` and logs `"limit", limit` |

Concurrently, the volume manager's populator reads the same pod via `allocatedPodManager.GetPods()` → `updateEmptyDirVolumeLimitsFromAllocation` → `alloc.Cmp(*vol.EmptyDir.SizeLimit)`, which is the race reported by the kind race job:

```
Write: resource.(*Quantity).String  ← v1.(*EmptyDirVolumeSource).String
                                    ← kuberuntime.podActions.String ← klog ← SyncPod
Read:  allocation.updateEmptyDirVolumeLimitsFromAllocation
                                    ← allocatedPodManager.GetPods ← desiredStateOfWorldPopulator
```

Note that the shared quantity is the one decoded from the API object, not a copy made by the allocation manager: `ParseQuantity` only caches the literal when it is already in canonical form, so common `sizeLimit` values (`128Mi`, `512Mi`, `8Gi`, `1.5Gi`, …) arrive with an empty string cache and are still waiting to be mutated by the first `String()` call.

This PR records a copy of the volume instead. That keeps the full volume specs in the logs and covers all three consumers at once, rather than removing one log line at a time.

#### Which issue(s) this PR fixes:

Fixes #141404

#### Special notes for your reviewer:

The added unit test reproduces the reported race: with the copy removed it fails both the aliasing assertions and, under `-race`, reproduces the `WARNING: DATA RACE` from the CI job.

Remaining aliasing that this PR does not address, since it is no longer reachable from the pod spec once the volume is copied: `stateMemory.SetEmptyDirVolumeLimit` stores the caller's `*resource.Quantity` verbatim and logs it. Happy to harden that separately if you'd like.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
