### PR TITLE
Make maxBatchAge configurable in tests

### DIFF
--- a/pkg/scheduler/framework/runtime/batch.go
+++ b/pkg/scheduler/framework/runtime/batch.go
@@ -41,9 +41,10 @@ type batchHandle interface {
 // OpportunisticBatching caches results from filtering and scoring when possible to optimize
 // scheduling of common pods.
 type OpportunisticBatch struct {
-	state     *batchState
-	lastCycle schedulingCycle
-	handle    batchHandle
+	state       *batchState
+	lastCycle   schedulingCycle
+	handle      batchHandle
+	maxBatchAge time.Duration
 
 	// Used primarily for tests, count the total pods we
 	// have successfully batched.
@@ -65,7 +66,8 @@ type schedulingCycle struct {
 }
 
 const (
-	maxBatchAge = 500 * time.Millisecond
+	// DefaultMaxBatchAge defines the default maximum duration a batch state is considered valid.
+	DefaultMaxBatchAge = 500 * time.Millisecond
 )
 
 // GetNodeHint provides a hint for the pod based on filtering a scoring results of previous cycles. Caching works only for consecutive pods
@@ -213,7 +215,7 @@ func (b *OpportunisticBatch) batchStateCompatible(ctx context.Context, pod *v1.P
 	// If the state is too old, throw the state away. This is to avoid
 	// cases where we either have huge numbers of compatible pods in a
 	// row or we have a long wait between pods.
-	if time.Now().After((b.state.creationTime.Add(maxBatchAge))) {
+	if time.Now().After(b.state.creationTime.Add(b.maxBatchAge)) {
 		b.logUnusableState(logger, cycleCount, metrics.BatchFlushExpired)
 		return false
 	}
@@ -319,9 +321,10 @@ func (b *OpportunisticBatch) stateEmpty() bool {
 	return b.state == nil || b.state.sortedNodes == nil || b.state.sortedNodes.Len() == 0
 }
 
-func newOpportunisticBatch(h batchHandle, genericWorkloadEnabled bool) *OpportunisticBatch {
+func newOpportunisticBatch(h batchHandle, genericWorkloadEnabled bool, maxBatchAge time.Duration) *OpportunisticBatch {
 	return &OpportunisticBatch{
 		handle:                 h,
 		genericWorkloadEnabled: genericWorkloadEnabled,
+		maxBatchAge:            maxBatchAge,
 	}
 }

--- a/pkg/scheduler/framework/runtime/batch_test.go
+++ b/pkg/scheduler/framework/runtime/batch_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
@@ -368,7 +369,7 @@ func TestBatchBasic(t *testing.T) {
 			}
 
 			signature := fwk.PodSignature(tt.firstSig)
-			batch := newOpportunisticBatch(testFwk, tt.genericWorkloadEnabled)
+			batch := newOpportunisticBatch(testFwk, tt.genericWorkloadEnabled, time.Minute)
 			state := framework.NewCycleState()
 
 			// Run the first "pod" through
@@ -599,7 +600,7 @@ func TestBatchRescore(t *testing.T) {
 			// First pod: non-blocking, chosen node is n2, n1 left as other candidate.
 			pod1 := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID(nonBlockingPodID("1"))}}
 			sig := fwk.PodSignature("sig")
-			batch := newOpportunisticBatch(testFwk, false)
+			batch := newOpportunisticBatch(testFwk, false, time.Minute)
 
 			cachedNodes := framework.NewSortedScoredNodes([]fwk.NodePluginScores{
 				{Name: "n1", RawScores: []fwk.PluginScore{{Name: "configurableScore", Score: n1CachedScore}}},
@@ -662,7 +663,7 @@ func TestBatchRescoreChain(t *testing.T) {
 	}
 
 	sig := fwk.PodSignature("sig")
-	batch := newOpportunisticBatch(testFwk, false)
+	batch := newOpportunisticBatch(testFwk, false, time.Minute)
 
 	// Pod1: n2 chosen, n1 is stored as the only other candidate.
 	pod1 := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: types.UID(nonBlockingPodID("1"))}}

--- a/pkg/scheduler/framework/runtime/framework.go
+++ b/pkg/scheduler/framework/runtime/framework.go
@@ -169,6 +169,7 @@ type frameworkOptions struct {
 	podsInPreBind          *podsInPreBindMap
 	apiDispatcher          *apidispatcher.APIDispatcher
 	podGroupManager        fwk.PodGroupManager
+	maxBatchAge            time.Duration
 	logger                 *klog.Logger
 }
 
@@ -320,11 +321,19 @@ func WithLogger(logger klog.Logger) Option {
 	}
 }
 
+// WithMaxBatchAge sets maxBatchAge for OpportunisticBatch.
+func WithMaxBatchAge(maxBatchAge time.Duration) Option {
+	return func(o *frameworkOptions) {
+		o.maxBatchAge = maxBatchAge
+	}
+}
+
 // defaultFrameworkOptions are applied when no option corresponding to those fields exist.
 func defaultFrameworkOptions(stopCh <-chan struct{}) frameworkOptions {
 	return frameworkOptions{
 		metricsRecorder: metrics.NewMetricsAsyncRecorder(1000, time.Second, stopCh),
 		parallelizer:    parallelize.NewParallelizer(parallelize.DefaultParallelism),
+		maxBatchAge:     DefaultMaxBatchAge,
 	}
 }
 
@@ -368,7 +377,7 @@ func NewFramework(ctx context.Context, r Registry, profile *config.KubeScheduler
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.OpportunisticBatching) {
-		f.batch = newOpportunisticBatch(f, utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload))
+		f.batch = newOpportunisticBatch(f, utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload), options.maxBatchAge)
 	}
 
 	if len(f.extenders) > 0 {

--- a/pkg/scheduler/framework_init.go
+++ b/pkg/scheduler/framework_init.go
@@ -201,6 +201,7 @@ func NewFrameworkMap(ctx context.Context, c *FrameworkComponents, recorderFactor
 		frameworkruntime.WithAPIDispatcher(c.apiDispatcher),
 		frameworkruntime.WithSharedCSIManager(csiManager),
 		frameworkruntime.WithPodGroupManager(c.cache),
+		frameworkruntime.WithMaxBatchAge(c.options.maxBatchAge),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("initializing profiles: %w", err)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -131,6 +131,7 @@ type schedulerOptions struct {
 	podInitialBackoffSeconds          int64
 	podMaxBackoffSeconds              int64
 	podMaxInUnschedulablePodsDuration time.Duration
+	maxBatchAge                       time.Duration
 	// Contains out-of-tree plugins to be merged with the in-tree registry.
 	frameworkOutOfTreeRegistry frameworkruntime.Registry
 	profiles                   []schedulerapi.KubeSchedulerProfile
@@ -228,6 +229,13 @@ func WithPodMaxInUnschedulablePodsDuration(duration time.Duration) Option {
 	}
 }
 
+// WithMaxBatchAge sets maxBatchAge for OpportunisticBatching, the default value is 500ms.
+func WithMaxBatchAge(maxBatchAge time.Duration) Option {
+	return func(o *schedulerOptions) {
+		o.maxBatchAge = maxBatchAge
+	}
+}
+
 // WithExtenders sets extenders for the Scheduler
 func WithExtenders(e ...schedulerapi.Extender) Option {
 	return func(o *schedulerOptions) {
@@ -258,6 +266,7 @@ var defaultSchedulerOptions = schedulerOptions{
 	podInitialBackoffSeconds:          int64(internalqueue.DefaultPodInitialBackoffDuration.Seconds()),
 	podMaxBackoffSeconds:              int64(internalqueue.DefaultPodMaxBackoffDuration.Seconds()),
 	podMaxInUnschedulablePodsDuration: internalqueue.DefaultPodMaxInUnschedulablePodsDuration,
+	maxBatchAge:                       frameworkruntime.DefaultMaxBatchAge,
 	parallelism:                       int32(parallelize.DefaultParallelism),
 	// Ideally we would statically set the default profile here, but we can't because
 	// creating the default profile may require testing feature gates, which may get

--- a/test/integration/scheduler/batch/batch_test.go
+++ b/test/integration/scheduler/batch/batch_test.go
@@ -18,7 +18,6 @@ package batch
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -26,21 +25,15 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/informers"
-	restclient "k8s.io/client-go/rest"
 	kubeschedulerconfigv1 "k8s.io/kube-scheduler/config/v1"
 	fwk "k8s.io/kube-scheduler/framework"
-	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/pkg/scheduler"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	kubeschedulerscheme "k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/names"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
-	"k8s.io/kubernetes/test/integration/framework"
-
-	"k8s.io/kubernetes/pkg/scheduler"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testutil "k8s.io/kubernetes/test/integration/util"
-	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 )
 
 type podDef struct {
@@ -395,20 +388,77 @@ func TestBatchScenarios(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			finalPods, batched := runScenario(t, tt, true)
+			profiles, registry := initSchedulerProfiles(t)
+			testCtx := testutil.InitTestSchedulerWithNS(t, "batch",
+				scheduler.WithProfiles(profiles...),
+				scheduler.WithFrameworkOutOfTreeRegistry(registry),
+				scheduler.WithMaxBatchAge(time.Minute),
+			)
+
+			getter, ok := testCtx.Scheduler.Profiles["default-scheduler"].(interface {
+				TotalBatchedPods() int64
+			})
+			if !ok {
+				t.Fatal("Profile default-scheduler does not implement batchGetter")
+			}
+			cs := testCtx.ClientSet
+
+			for _, n := range tt.nodes {
+				_, err := testutil.CreateNode(cs, newNode(&n))
+				if err != nil {
+					t.Fatal("Failed adding node", "node", n, err)
+				}
+			}
+
+			finalPods := []*v1.Pod{}
+			batched := []bool{}
+			for _, pd := range tt.pods {
+				prevBatched := getter.TotalBatchedPods()
+
+				p := newPod(&pd, testCtx.NS.Name)
+				createdPod, err := cs.CoreV1().Pods(p.Namespace).Create(testCtx.Ctx, p, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("Failed to create pod %s/%s, error: %v",
+						p.Namespace, p.Name, err)
+				}
+
+				if err := testutil.WaitForPodToScheduleWithTimeout(testCtx.Ctx, cs, createdPod, 5*time.Second); err != nil {
+					if !pd.expectUnschedulable {
+						t.Errorf("Failed to schedule pod %s/%s on the node, err: %v",
+							p.Namespace, p.Name, err)
+					} else {
+						break
+					}
+				}
+
+				if pd.expectUnschedulable {
+					t.Fatalf("Expected pod to be unschedulable but it was scheduled")
+				}
+
+				finalPod, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx.Ctx, p.Name, metav1.GetOptions{})
+				if err != nil {
+					t.Fatalf("Failed to get pod %v", err)
+				}
+				finalPods = append(finalPods, finalPod)
+
+				currBatched := getter.TotalBatchedPods()
+
+				batched = append(batched, currBatched > prevBatched)
+			}
+
 			for i, p := range finalPods {
 				if p.Spec.NodeName != tt.pods[i].expectedNode {
-					t.Fatalf("Invalid node '%s' for pod '%s'. Expected '%s'", p.Spec.NodeName, p.Name, tt.pods[i].expectedNode)
+					t.Fatalf("Invalid node %q for pod %q. Expected %q", p.Spec.NodeName, p.Name, tt.pods[i].expectedNode)
 				}
 				if batched[i] != tt.pods[i].expectBatched {
-					t.Fatalf("Expected pod %s batched %t, actually %t", p.Name, tt.pods[i].expectBatched, batched[i])
+					t.Fatalf("Expected pod %q batched %t, actually %t", p.Name, tt.pods[i].expectBatched, batched[i])
 				}
 			}
 		})
 	}
 }
 
-func newPod(d *podDef) *v1.Pod {
+func newPod(d *podDef, ns string) *v1.Pod {
 	aff := &v1.NodeAffinity{}
 	if len(d.nodeAffinity) > 0 {
 		for i, node := range d.nodeAffinity {
@@ -431,7 +481,7 @@ func newPod(d *podDef) *v1.Pod {
 	ret := testutil.InitPausePod(&testutil.PausePodConfig{
 		Name:      d.name,
 		Affinity:  &v1.Affinity{NodeAffinity: aff},
-		Namespace: "default",
+		Namespace: ns,
 		Resources: &v1.ResourceRequirements{
 			Requests: v1.ResourceList{
 				v1.ResourceCPU:    *(resource.NewQuantity(10, resource.DecimalSI)),
@@ -509,7 +559,7 @@ var _ fwk.FilterPlugin = &testPluginEmptySign{}
 var _ fwk.SignPlugin = &testPluginEmptySign{}
 
 func (pl *testPluginEmptySign) Name() string {
-	return "nosign"
+	return "emptysign"
 }
 
 func (pl *testPluginEmptySign) Filter(ctx context.Context, state fwk.CycleState, pod *v1.Pod, nodeInfo fwk.NodeInfo) *fwk.Status {
@@ -524,17 +574,10 @@ func newEmptySignPlugin(_ context.Context, injArgs runtime.Object, f fwk.Handle)
 	return &testPluginEmptySign{}, nil
 }
 
-// To access the test-only field in the framework
-type batchGetter interface {
-	TotalBatchedPods() int64
-}
-
-func runScenario(t *testing.T, tt *scenario, batch bool) ([]*v1.Pod, []bool) {
-	tCtx := ktesting.Init(t)
-
+func initSchedulerProfiles(t *testing.T) ([]config.KubeSchedulerProfile, frameworkruntime.Registry) {
 	cfg, err := newDefaultComponentConfig()
 	if err != nil {
-		tCtx.Fatalf("Error creating default component config: %v", err)
+		t.Fatalf("Error creating default component config: %v", err)
 	}
 
 	newProfile := cfg.Profiles[0].DeepCopy()
@@ -551,125 +594,10 @@ func runScenario(t *testing.T, tt *scenario, batch bool) ([]*v1.Pod, []bool) {
 	newProfile.Plugins.Filter.Enabled = append(newProfile.Plugins.Filter.Enabled, config.Plugin{Name: "emptysign"})
 	cfg.Profiles = append(cfg.Profiles, *newProfile)
 
-	scheduler, _, testCtx := mustSetupCluster(tCtx, cfg, frameworkruntime.Registry{
+	registry := frameworkruntime.Registry{
 		"nosign":    newNoSignPlugin,
 		"emptysign": newEmptySignPlugin,
-	})
-
-	getter := scheduler.Profiles["default-scheduler"].(batchGetter)
-
-	cs := testCtx.Client()
-
-	// Add nodes.
-	for _, n := range tt.nodes {
-		_, err := testutil.CreateNode(cs, newNode(&n))
-		if err != nil {
-			t.Fatal("Failed adding node", "node", n, err)
-		}
 	}
 
-	finalPods := []*v1.Pod{}
-	batched := []bool{}
-	for _, pd := range tt.pods {
-		prevBatched := getter.TotalBatchedPods()
-
-		p := newPod(&pd)
-		createdPod, err := cs.CoreV1().Pods(p.Namespace).Create(testCtx, p, metav1.CreateOptions{})
-		if err != nil {
-			t.Fatalf("Failed to create pod %s/%s, error: %v",
-				p.Namespace, p.Name, err)
-		}
-
-		if err := testutil.WaitForPodToScheduleWithTimeout(testCtx, cs, createdPod, 5*time.Second); err != nil {
-			if !pd.expectUnschedulable {
-				t.Errorf("Failed to schedule pod %s/%s on the node, err: %v",
-					p.Namespace, p.Name, err)
-			} else {
-				break
-			}
-		}
-
-		if pd.expectUnschedulable {
-			t.Fatalf("Expected pod to be unschedulable but it was scheduled")
-		}
-
-		finalPod, err := cs.CoreV1().Pods(p.Namespace).Get(testCtx, p.Name, metav1.GetOptions{})
-		if err != nil {
-			t.Fatalf("Failed to get pod %v", err)
-		}
-		finalPods = append(finalPods, finalPod)
-
-		currBatched := getter.TotalBatchedPods()
-
-		batched = append(batched, currBatched > prevBatched)
-	}
-
-	return finalPods, batched
-}
-
-// mustSetupCluster starts the following components:
-// - k8s api server
-// - scheduler
-// - some of the kube-controller-manager controllers
-//
-// It returns regular and dynamic clients, and destroyFunc which should be used to
-// remove resources after finished.
-// Notes on rate limiter:
-//   - client rate limit is set to 5000.
-func mustSetupCluster(tCtx ktesting.TContext, config *config.KubeSchedulerConfiguration, outOfTreePluginRegistry frameworkruntime.Registry) (*scheduler.Scheduler, informers.SharedInformerFactory, ktesting.TContext) {
-	var runtimeConfig []string
-	customFlags := []string{
-		// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
-		"--disable-admission-plugins=ServiceAccount,TaintNodesByCondition,Priority",
-		"--runtime-config=" + strings.Join(runtimeConfig, ","),
-	}
-	serverOpts := apiservertesting.NewDefaultTestServerOptions()
-	// Timeout sufficiently long to handle deleting pods of the largest test cases.
-	serverOpts.RequestTimeout = 10 * time.Minute
-	server, err := apiservertesting.StartTestServer(tCtx, serverOpts, customFlags, framework.SharedEtcd())
-	if err != nil {
-		tCtx.Fatalf("start apiserver: %v", err)
-	}
-	// Cleanup will be in reverse order: first the clients by canceling the
-	// child context, then the server.
-	tCtx.Cleanup(server.TearDownFn)
-	tCtx = tCtx.WithCancel()
-	tCtx.Cleanup(func() {
-		tCtx.Cancel("test is done")
-	})
-
-	// TODO: client connection configuration, such as QPS or Burst is configurable in theory, this could be derived from the `config`, need to
-	// support this when there is any testcase that depends on such configuration.
-	cfg := restclient.CopyConfig(server.ClientConfig)
-	cfg.QPS = 5000.0
-	cfg.Burst = 5000
-
-	// use default component config if config here is nil
-	if config == nil {
-		var err error
-		config, err = newDefaultComponentConfig()
-		if err != nil {
-			tCtx.Fatalf("Error creating default component config: %v", err)
-		}
-	}
-
-	tCtx = tCtx.WithRESTConfig(cfg)
-
-	// Not all config options will be effective but only those mostly related with scheduler performance will
-	// be applied to start a scheduler, most of them are defined in `scheduler.schedulerOptions`.
-	scheduler, informerFactory := testutil.StartScheduler(tCtx, config, outOfTreePluginRegistry)
-	testutil.StartFakePVController(tCtx, tCtx.Client(), informerFactory)
-	runGC := testutil.CreateGCController(tCtx, tCtx, *cfg, informerFactory)
-	runNS := testutil.CreateNamespaceController(tCtx, tCtx, *cfg, informerFactory)
-
-	runResourceClaimController := func() {}
-
-	informerFactory.Start(tCtx.Done())
-	informerFactory.WaitForCacheSync(tCtx.Done())
-	go runGC()
-	go runNS()
-	go runResourceClaimController()
-
-	return scheduler, informerFactory, tCtx
-
+	return cfg.Profiles, registry
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/kind flake

#### What this PR does / why we need it:

This PR makes the `maxBatchAge` configurable and sets it to 1 minute in the tests. Without this fix, the `pull-kubernetes-integration-master` job is failing, because the race detection overhead and testing parallelism makes the scheduling much slower than usual.

This PR also refactors the integration tests for batching, reducing creation of unnecessary components and follows the setup that we have for other scheduler tests.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Generative AI was used in the PR preparation. Changes were carefully reviewed before pushing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
