### PR TITLE
kubelet/cm: add unit tests for ResourceConfig CPU and memory helpers

### DIFF
--- a/pkg/kubelet/cm/helpers_linux_test.go
+++ b/pkg/kubelet/cm/helpers_linux_test.go
@@ -1446,3 +1446,188 @@ func TestCPUSharesEqualAfterV2RoundTrip(t *testing.T) {
 		})
 	}
 }
+
+// quantityEqual compares two optional quantities, treating nil as "unset".
+func quantityEqual(expected, actual *resource.Quantity) bool {
+	if expected == nil || actual == nil {
+		return expected == nil && actual == nil
+	}
+	return expected.Cmp(*actual) == 0
+}
+
+func quantityString(q *resource.Quantity) string {
+	if q == nil {
+		return "<nil>"
+	}
+	return q.String()
+}
+
+// Note: these helpers dereference individual ResourceConfig fields after only
+// checking that the config itself is non-nil, so a config carrying nil fields
+// is not a valid input and is intentionally left uncovered here.
+func TestCPURequestsFromConfig(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   *ResourceConfig
+		expected *resource.Quantity
+	}{
+		{
+			name:     "nil config yields no request",
+			config:   nil,
+			expected: nil,
+		},
+		{
+			name:     "zero shares yields no request",
+			config:   &ResourceConfig{CPUShares: ptr.To[uint64](0)},
+			expected: nil,
+		},
+		{
+			// Shares below MinShares convert to 0 milliCPU, which is not a
+			// meaningful request.
+			name:     "shares below MinShares yields no request",
+			config:   &ResourceConfig{CPUShares: ptr.To[uint64](1)},
+			expected: nil,
+		},
+		{
+			name:     "MinShares rounds up to 2m",
+			config:   &ResourceConfig{CPUShares: ptr.To[uint64](MinShares)},
+			expected: resource.NewMilliQuantity(2, resource.DecimalSI),
+		},
+		{
+			// cgroup v2 readback granularity: 102 shares maps back to 100m.
+			name:     "lossy v2 readback shares",
+			config:   &ResourceConfig{CPUShares: ptr.To[uint64](102)},
+			expected: resource.NewMilliQuantity(100, resource.DecimalSI),
+		},
+		{
+			name:     "one CPU worth of shares",
+			config:   &ResourceConfig{CPUShares: ptr.To[uint64](SharesPerCPU)},
+			expected: resource.NewMilliQuantity(1000, resource.DecimalSI),
+		},
+		{
+			name:     "two CPUs worth of shares",
+			config:   &ResourceConfig{CPUShares: ptr.To[uint64](2 * SharesPerCPU)},
+			expected: resource.NewMilliQuantity(2000, resource.DecimalSI),
+		},
+		{
+			name:     "MaxShares",
+			config:   &ResourceConfig{CPUShares: ptr.To[uint64](MaxShares)},
+			expected: resource.NewMilliQuantity(256000, resource.DecimalSI),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := CPURequestsFromConfig(testCase.config)
+			if !quantityEqual(testCase.expected, actual) {
+				t.Errorf("expected cpu request %v, got %v", quantityString(testCase.expected), quantityString(actual))
+			}
+		})
+	}
+}
+
+func TestCPULimitsFromConfig(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   *ResourceConfig
+		expected *resource.Quantity
+	}{
+		{
+			name:     "nil config yields no limit",
+			config:   nil,
+			expected: nil,
+		},
+		{
+			name:     "zero period yields no limit",
+			config:   &ResourceConfig{CPUQuota: ptr.To[int64](100000), CPUPeriod: ptr.To[uint64](0)},
+			expected: nil,
+		},
+		{
+			// -1 is the cgroup representation of an unlimited quota.
+			name:     "unlimited quota yields no limit",
+			config:   &ResourceConfig{CPUQuota: ptr.To[int64](-1), CPUPeriod: ptr.To[uint64](QuotaPeriod)},
+			expected: nil,
+		},
+		{
+			name:     "zero quota yields no limit",
+			config:   &ResourceConfig{CPUQuota: ptr.To[int64](0), CPUPeriod: ptr.To[uint64](QuotaPeriod)},
+			expected: nil,
+		},
+		{
+			name:     "full quota over default period",
+			config:   &ResourceConfig{CPUQuota: ptr.To[int64](100000), CPUPeriod: ptr.To[uint64](QuotaPeriod)},
+			expected: resource.NewMilliQuantity(1000, resource.DecimalSI),
+		},
+		{
+			name:     "partial quota over default period",
+			config:   &ResourceConfig{CPUQuota: ptr.To[int64](20000), CPUPeriod: ptr.To[uint64](QuotaPeriod)},
+			expected: resource.NewMilliQuantity(200, resource.DecimalSI),
+		},
+		{
+			name:     "minimum quota over default period",
+			config:   &ResourceConfig{CPUQuota: ptr.To[int64](MinQuotaPeriod), CPUPeriod: ptr.To[uint64](QuotaPeriod)},
+			expected: resource.NewMilliQuantity(MinMilliCPULimit, resource.DecimalSI),
+		},
+		{
+			// A custom period must scale the quota, not be assumed to be QuotaPeriod.
+			name:     "quota over custom period",
+			config:   &ResourceConfig{CPUQuota: ptr.To[int64](10000), CPUPeriod: ptr.To[uint64](50000)},
+			expected: resource.NewMilliQuantity(200, resource.DecimalSI),
+		},
+		{
+			name:     "quota exceeding one CPU",
+			config:   &ResourceConfig{CPUQuota: ptr.To[int64](250000), CPUPeriod: ptr.To[uint64](QuotaPeriod)},
+			expected: resource.NewMilliQuantity(2500, resource.DecimalSI),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := CPULimitsFromConfig(testCase.config)
+			if !quantityEqual(testCase.expected, actual) {
+				t.Errorf("expected cpu limit %v, got %v", quantityString(testCase.expected), quantityString(actual))
+			}
+		})
+	}
+}
+
+func TestMemoryLimitsFromConfig(t *testing.T) {
+	testCases := []struct {
+		name     string
+		config   *ResourceConfig
+		expected *resource.Quantity
+	}{
+		{
+			name:     "nil config yields no limit",
+			config:   nil,
+			expected: nil,
+		},
+		{
+			name:     "zero memory yields no limit",
+			config:   &ResourceConfig{Memory: ptr.To[int64](0)},
+			expected: nil,
+		},
+		{
+			// -1 is the cgroup representation of unlimited memory.
+			name:     "negative memory yields no limit",
+			config:   &ResourceConfig{Memory: ptr.To[int64](-1)},
+			expected: nil,
+		},
+		{
+			name:     "single byte limit",
+			config:   &ResourceConfig{Memory: ptr.To[int64](1)},
+			expected: resource.NewQuantity(1, resource.BinarySI),
+		},
+		{
+			name:     "one gibibyte limit",
+			config:   &ResourceConfig{Memory: ptr.To[int64](1024 * 1024 * 1024)},
+			expected: resource.NewQuantity(1024*1024*1024, resource.BinarySI),
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := MemoryLimitsFromConfig(testCase.config)
+			if !quantityEqual(testCase.expected, actual) {
+				t.Errorf("expected memory limit %v, got %v", quantityString(testCase.expected), quantityString(actual))
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`CPURequestsFromConfig`, `CPULimitsFromConfig` and `MemoryLimitsFromConfig` had
no unit tests. They convert a cgroup `ResourceConfig` back into API quantities,
where "unset" and "unlimited" are different results, so the edges seemed worth
pinning down before someone changes the rounding.

Table-driven, and the cases I cared about are: shares below `MinShares`, which
convert to 0 milliCPU and so produce no request at all; the cgroup v2 readback
where 102 shares comes back as 100m; a `-1` quota meaning unlimited; and a
non-default CFS period, so the period isn't assumed to be `QuotaPeriod`.

Takes `pkg/kubelet/cm` from 25.5% to 26.9%.

#### Which issue(s) this PR is related to:

xref #109717

#### Special notes for your reviewer:

These helpers check `podConfig != nil` and then dereference a field, e.g.
`*podConfig.CPUShares`. So a non-nil config with a nil field panics. Current
callers look like they always set those fields, so it's latent, and I left it
alone to keep this test-only. A comment in the test file notes why that input
isn't covered. Can file a separate issue if you'd like it fixed.

/sig node

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
