### PR TITLE
apiserver/cacher: label terminated watchers with a reason

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -2045,11 +2045,13 @@
     endpoint: /metrics
 - name: terminated_watchers_total
   namespace: apiserver
-  help: Counter of watchers closed due to unresponsiveness broken by resource type.
+  help: Counter of watchers closed by the watch cache broken by resource type and
+    reason.
   type: Counter
   stabilityLevel: ALPHA
   labels:
   - group
+  - reason
   - resource
   componentEndpoints:
   - component: kube-apiserver

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -187,7 +187,7 @@ func (c *cacheWatcher) add(event *watchCacheEvent, timer *time.Timer) bool {
 		// This means that we couldn't send event to that watcher.
 		// Since we don't want to block on it infinitely,
 		// we simply terminate it.
-		metrics.TerminatedWatchersCounter.WithLabelValues(c.groupResource.Group, c.groupResource.Resource).Inc()
+		metrics.TerminatedWatchersCounter.WithLabelValues(c.groupResource.Group, c.groupResource.Resource, metrics.TerminationReasonUnresponsive).Inc()
 		// This means that we couldn't send event to that watcher.
 		// Since we don't want to block on it infinitely, we simply terminate it.
 
@@ -211,7 +211,7 @@ func (c *cacheWatcher) add(event *watchCacheEvent, timer *time.Timer) bool {
 			defer c.stateMutex.Unlock()
 			return c.state == cacheWatcherBookmarkReceived
 		}()
-		klog.V(1).Infof("Forcing %v watcher close due to unresponsiveness: %v. len(c.input) = %v, len(c.result) = %v, graceful = %v", c.groupResource.String(), c.identifier, len(c.input), len(c.result), graceful)
+		klog.V(1).Infof("Forcing %v watcher close due to unresponsiveness (reason = %v): %v. len(c.input) = %v, len(c.result) = %v, graceful = %v", c.groupResource.String(), metrics.TerminationReasonUnresponsive, c.identifier, len(c.input), len(c.result), graceful)
 		c.forget(graceful)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher_test.go
@@ -708,6 +708,51 @@ func TestBookmarkAfterResourceVersionWatchers(t *testing.T) {
 	}
 }
 
+// TestForceCloseIncrementsTerminatedWatchers verifies that force-closing an
+// unresponsive watcher increments the terminated watchers counter with
+// reason "unresponsive".
+func TestForceCloseIncrementsTerminatedWatchers(t *testing.T) {
+	registry := compbasemetrics.NewKubeRegistry()
+	if err := registry.Register(metrics.TerminatedWatchersCounter); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	filter := func(string, labels.Set, fields.Set, runtime.Object) bool { return true }
+	var w *cacheWatcher
+	forget := func(drainWatcher bool) {
+		w.setDrainInputBufferLocked(drainWatcher)
+		w.stopLocked()
+	}
+	// A watcher with a full input buffer (chanSize 1, one event already queued)
+	// and no processing goroutine, so any further add cannot succeed.
+	w = newCacheWatcher(1, filter, forget, storage.APIObjectVersioner{}, time.Now(), false, schema.GroupResource{Resource: "pods"}, metrics.NewNoopWatcherMetricsObservers(), nil, "")
+	if !w.nonblockingAdd(makeWatchCacheEvent(1)) {
+		t.Fatal("failed to fill the watcher's input buffer")
+	}
+
+	counter := metrics.TerminatedWatchersCounter.WithLabelValues("", "pods", metrics.TerminationReasonUnresponsive)
+	before, err := testutil.GetCounterMetricValue(counter)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// add() with a nil timer terminates the watcher immediately when the
+	// non-blocking send fails.
+	if w.add(makeWatchCacheEvent(2), nil) {
+		t.Fatal("expected add to fail and terminate the watcher")
+	}
+
+	after, err := testutil.GetCounterMetricValue(counter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after-before != 1 {
+		t.Errorf("expected terminated watchers counter (reason=%s) to increase by 1, got %v -> %v", metrics.TerminationReasonUnresponsive, before, after)
+	}
+	if !w.stopped {
+		t.Errorf("expected the watcher to be stopped")
+	}
+}
+
 func gatherWithoutBuckets(gatherer compbasemetrics.Gatherer) testutil.GathererFunc {
 	return func() ([]*testutil.MetricFamily, error) {
 		got, err := gatherer.Gather()

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/metrics/metrics.go
@@ -33,6 +33,13 @@ const (
 	subsystem = "watch_cache"
 )
 
+// Values of the "reason" label on TerminatedWatchersCounter.
+const (
+	// TerminationReasonUnresponsive: the watcher's input buffer was full
+	// and it did not drain within the dispatch time budget.
+	TerminationReasonUnresponsive = "unresponsive"
+)
+
 // DispatchPoint identifies a point in a watch event's dispatch lifecycle. The
 // duration between two points forms a labeled "stage" of the dispatch_duration
 // metric.
@@ -153,10 +160,10 @@ var (
 		&compbasemetrics.CounterOpts{
 			Namespace:      namespace,
 			Name:           "terminated_watchers_total",
-			Help:           "Counter of watchers closed due to unresponsiveness broken by resource type.",
+			Help:           "Counter of watchers closed by the watch cache broken by resource type and reason.",
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
-		[]string{"group", "resource"},
+		[]string{"group", "resource", "reason"},
 	)
 
 	watchCacheResourceVersion = compbasemetrics.NewGaugeVec(


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/sig api-machinery
/sig instrumentation

#### What this PR does / why we need it

`apiserver_terminated_watchers_total` gets a `reason` label. The only writer today, the force close of an unresponsive watcher in `cacheWatcher.add`, records `reason="unresponsive"`. The force close log line now names the reason too.

This PR is part of a small series that adds an alpha `WatchCacheStallResume` gate (KEP-6268). It depends on no other PR: it applies to master on its own and carries only its own commit. That series adds more termination reasons (`resource_expired`, `resource_expired_initial`), and dashboards need to tell them apart from the existing force close. The label is added ahead of the mechanism so the metric schema change is reviewed on its own.

The metric is ALPHA. Consumers that select an exact label set on this metric must account for the new label.

#### Which issue(s) this PR is related to

Related to kubernetes/kubernetes#116903 and kubernetes/kubernetes#109708. KEP: kubernetes/enhancements#6268, KEP PR: kubernetes/enhancements#6269.

#### Special notes for your reviewer

- Two lines change in `cache_watcher.go` (the metric label and the log line); the rest is the metric definition, a unit test that pins the label value, and the regenerated metrics documentation list.
- Follow-up PRs in this series: extract the interval streaming loop (no behavior change, kubernetes/kubernetes#141449), the `WatchCacheStallResume` gate and mechanism (kubernetes/kubernetes#141450), the stalled watchers gauge (kubernetes/kubernetes#141451), and an integration test (kubernetes/kubernetes#141452). The benchmark kubernetes/kubernetes#141475 (`BenchmarkSlowWatcherTax`, which measures the tax this series removes) is independent of this PR; kubernetes/kubernetes#141450 is the first PR that needs both.
- Split out of kubernetes/kubernetes#141228, which (closed) once this series is open.
- This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
The `apiserver_terminated_watchers_total` metric gained a `reason` label. Existing force closes of unresponsive watchers are recorded with `reason="unresponsive"`. Consumers that select an exact label set on this metric should account for the added label.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.

```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/6269
```
