### PR TITLE
apiserver/cacher: extract the interval streaming loop

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cache_watcher.go
@@ -447,6 +447,40 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) (builtAt, sen
 	return builtAt, sentAt
 }
 
+// streamInterval sends every event of cacheInterval to the result channel,
+// advancing *resourceVersion to the highest resourceVersion of any event the
+// interval yielded (including events the watcher's filter drops). It returns
+// the number of events the interval yielded. A non-nil error means the
+// interval has been invalidated (the watch cache history moved past it) and
+// can no longer serve events; the returned count is then meaningless.
+func (c *cacheWatcher) streamInterval(cacheInterval *watchCacheInterval, resourceVersion *uint64) (int, error) {
+	eventCount := 0
+	for {
+		event, err := cacheInterval.Next()
+		if err != nil {
+			return eventCount, err
+		}
+		if event == nil {
+			return eventCount, nil
+		}
+		c.sendWatchCacheEvent(event)
+
+		// With some events already sent, update resourceVersion so that
+		// events that were buffered and not yet processed won't be delivered
+		// to this watcher second time causing going back in time.
+		//
+		// There is one case where events are not necessary ordered by
+		// resourceVersion, being a case of watching from resourceVersion=0,
+		// which at the beginning returns the state of each objects.
+		// For the purpose of it, we need to max it with the resource version
+		// that we have so far.
+		if event.ResourceVersion > *resourceVersion {
+			*resourceVersion = event.ResourceVersion
+		}
+		eventCount++
+	}
+}
+
 func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watchCacheInterval, resourceVersion uint64) {
 	defer utilruntime.HandleCrashWithContext(ctx)
 	defer close(c.result)
@@ -475,45 +509,24 @@ func (c *cacheWatcher) processInterval(ctx context.Context, cacheInterval *watch
 		resourceVersion = cacheInterval.resourceVersion
 	}
 
-	initEventCount := 0
-	for {
-		event, err := cacheInterval.Next()
-		if err != nil {
-			// An error indicates that the cache interval
-			// has been invalidated and can no longer serve
-			// events.
-			//
-			// Initially we considered sending an "out-of-history"
-			// Error event in this case, but because historically
-			// such events weren't sent out of the watchCache, we
-			// decided not to. This is still ok, because on watch
-			// closure, the watcher will try to re-instantiate the
-			// watch and then will get an explicit "out-of-history"
-			// window. There is potential for optimization, but for
-			// now, in order to be on the safe side and not break
-			// custom clients, the cost of it is something that we
-			// are fully accepting.
-			klog.Warningf("couldn't retrieve watch event to serve: %#v", err)
-			return
-		}
-		if event == nil {
-			break
-		}
-		c.sendWatchCacheEvent(event)
-
-		// With some events already sent, update resourceVersion so that
-		// events that were buffered and not yet processed won't be delivered
-		// to this watcher second time causing going back in time.
+	initEventCount, err := c.streamInterval(cacheInterval, &resourceVersion)
+	if err != nil {
+		// An error indicates that the cache interval
+		// has been invalidated and can no longer serve
+		// events.
 		//
-		// There is one case where events are not necessary ordered by
-		// resourceVersion, being a case of watching from resourceVersion=0,
-		// which at the beginning returns the state of each objects.
-		// For the purpose of it, we need to max it with the resource version
-		// that we have so far.
-		if event.ResourceVersion > resourceVersion {
-			resourceVersion = event.ResourceVersion
-		}
-		initEventCount++
+		// Initially we considered sending an "out-of-history"
+		// Error event in this case, but because historically
+		// such events weren't sent out of the watchCache, we
+		// decided not to. This is still ok, because on watch
+		// closure, the watcher will try to re-instantiate the
+		// watch and then will get an explicit "out-of-history"
+		// window. There is potential for optimization, but for
+		// now, in order to be on the safe side and not break
+		// custom clients, the cost of it is something that we
+		// are fully accepting.
+		klog.Warningf("couldn't retrieve watch event to serve: %#v", err)
+		return
 	}
 
 	if initEventCount > 0 {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it

Extracts the loop that streams one `watchCacheInterval` into the watcher result channel out of `cacheWatcher.processInterval` into a new `streamInterval` function. No behavior change.

This is preparation for the `WatchCacheStallResume` gate (KEP-6268): a stalled watcher will replay missed history through the same loop, so the loop needs one home.

This is part of a small series. It depends on no other PR: it applies to master on its own and carries only its own commit. It does not depend on the benchmark kubernetes/kubernetes#141475 (merged).

#### Which issue(s) this PR is related to

KEP: kubernetes/enhancements#6268, KEP PR: kubernetes/enhancements#6269.

#### Special notes for your reviewer

- Pure move. `processInterval` keeps its contract; the loop body is unchanged apart from taking the interval and the position as parameters and returning the number of events the interval yielded.
- This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.

```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/6269
```
