### PR TITLE
Set the timeAdded of node taints at admission

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -12856,7 +12856,7 @@
         },
         "timeAdded": {
           "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.Time",
-          "description": "TimeAdded represents the time at which the taint was added."
+          "description": "TimeAdded represents the time at which the taint was added. It is populated at admission time by the NodeTaintTimeAddedDefaulting admission controller when it is not set: taints which have no counterpart with the same key and effect in the existing node get the current time, all other taints keep the time they already had."
         },
         "value": {
           "description": "The taint value corresponding to the taint key.",

--- a/api/openapi-spec/v3/api__v1_openapi.json
+++ b/api/openapi-spec/v3/api__v1_openapi.json
@@ -8046,7 +8046,7 @@
                 "$ref": "#/components/schemas/io.k8s.apimachinery.pkg.apis.meta.v1.Time"
               }
             ],
-            "description": "TimeAdded represents the time at which the taint was added."
+            "description": "TimeAdded represents the time at which the taint was added. It is populated at admission time by the NodeTaintTimeAddedDefaulting admission controller when it is not set: taints which have no counterpart with the same key and effect in the existing node get the current time, all other taints keep the time they already had."
           },
           "value": {
             "description": "The taint value corresponding to the taint key.",

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3825,6 +3825,10 @@ type Taint struct {
 	// Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 	Effect TaintEffect
 	// TimeAdded represents the time at which the taint was added.
+	// It is populated at admission time by the NodeTaintTimeAddedDefaulting
+	// admission controller when it is not set: taints which have no counterpart with the
+	// same key and effect in the existing node get the current time, all other
+	// taints keep the time they already had.
 	// +optional
 	TimeAdded *metav1.Time
 }

--- a/pkg/controlplane/apiserver/samples/generic/server/admission_test.go
+++ b/pkg/controlplane/apiserver/samples/generic/server/admission_test.go
@@ -24,7 +24,8 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/limitranger"
 	"k8s.io/kubernetes/plugin/pkg/admission/network/defaultingressclass"
 	"k8s.io/kubernetes/plugin/pkg/admission/nodedeclaredfeatures"
-	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
+	"k8s.io/kubernetes/plugin/pkg/admission/nodetaintcondition"
+	"k8s.io/kubernetes/plugin/pkg/admission/nodetainttimeadded"
 	"k8s.io/kubernetes/plugin/pkg/admission/podresize"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtopologylabels"
 	podpriority "k8s.io/kubernetes/plugin/pkg/admission/priority"
@@ -43,7 +44,8 @@ var intentionallyOffPlugins = sets.New[string](
 	storageobjectinuseprotection.PluginName, // StorageObjectInUseProtection
 	podgroupprotection.PluginName,           // PodGroupProtection
 	podpriority.PluginName,                  // Priority
-	nodetaint.PluginName,                    // TaintNodesByCondition
+	nodetaintcondition.PluginName,           // TaintNodesByCondition
+	nodetainttimeadded.PluginName,           // NodeTaintTimeAddedDefaulting
 	runtimeclass.PluginName,                 // RuntimeClass
 	defaultingressclass.PluginName,          // DefaultIngressClass
 	podsecurity.PluginName,                  // PodSecurity

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -32932,7 +32932,7 @@ func schema_k8sio_api_core_v1_Taint(ref common.ReferenceCallback) common.OpenAPI
 					},
 					"timeAdded": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TimeAdded represents the time at which the taint was added.",
+							Description: "TimeAdded represents the time at which the taint was added. It is populated at admission time by the NodeTaintTimeAddedDefaulting admission controller when it is not set: taints which have no counterpart with the same key and effect in the existing node get the current time, all other taints keep the time they already had.",
 							Ref:         ref(metav1.Time{}.OpenAPIModelName()),
 						},
 					},

--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -46,7 +46,8 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/network/denyserviceexternalips"
 	"k8s.io/kubernetes/plugin/pkg/admission/nodedeclaredfeatures"
 	"k8s.io/kubernetes/plugin/pkg/admission/noderestriction"
-	"k8s.io/kubernetes/plugin/pkg/admission/nodetaint"
+	"k8s.io/kubernetes/plugin/pkg/admission/nodetaintcondition"
+	"k8s.io/kubernetes/plugin/pkg/admission/nodetainttimeadded"
 	"k8s.io/kubernetes/plugin/pkg/admission/podnodeselector"
 	"k8s.io/kubernetes/plugin/pkg/admission/podresize"
 	"k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction"
@@ -78,7 +79,8 @@ var AllOrderedPlugins = []string{
 	limitranger.PluginName,                  // LimitRanger
 	serviceaccount.PluginName,               // ServiceAccount
 	noderestriction.PluginName,              // NodeRestriction
-	nodetaint.PluginName,                    // TaintNodesByCondition
+	nodetaintcondition.PluginName,           // TaintNodesByCondition
+	nodetainttimeadded.PluginName,           // NodeTaintTimeAddedDefaulting
 	alwayspullimages.PluginName,             // AlwaysPullImages
 	imagepolicy.PluginName,                  // ImagePolicyWebhook
 	podsecurity.PluginName,                  // PodSecurity
@@ -139,7 +141,8 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	autoprovision.Register(plugins)
 	exists.Register(plugins)
 	noderestriction.Register(plugins)
-	nodetaint.Register(plugins)
+	nodetaintcondition.Register(plugins)
+	nodetainttimeadded.Register(plugins)
 	podnodeselector.Register(plugins)
 	podtolerationrestriction.Register(plugins)
 	runtimeclass.Register(plugins)
@@ -175,7 +178,8 @@ func DefaultOffAdmissionPlugins() sets.Set[string] {
 		storageobjectinuseprotection.PluginName, // StorageObjectInUseProtection
 		podgroupprotection.PluginName,           // PodGroupProtection
 		podpriority.PluginName,                  // Priority
-		nodetaint.PluginName,                    // TaintNodesByCondition
+		nodetaintcondition.PluginName,           // TaintNodesByCondition
+		nodetainttimeadded.PluginName,           // NodeTaintTimeAddedDefaulting
 		runtimeclass.PluginName,                 // RuntimeClass
 		certapproval.PluginName,                 // CertificateApproval
 		certsigning.PluginName,                  // CertificateSigning

--- a/plugin/pkg/admission/nodetaintcondition/admission.go
+++ b/plugin/pkg/admission/nodetaintcondition/admission.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package nodetaint
+package nodetaintcondition
 
 import (
 	"context"

--- a/plugin/pkg/admission/nodetaintcondition/admission_test.go
+++ b/plugin/pkg/admission/nodetaintcondition/admission_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package nodetaint
+package nodetaintcondition
 
 import (
 	"context"

--- a/plugin/pkg/admission/nodetainttimeadded/admission.go
+++ b/plugin/pkg/admission/nodetainttimeadded/admission.go
@@ -1,0 +1,121 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodetainttimeadded
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+const (
+	// PluginName is the name of the plugin.
+	PluginName = "NodeTaintTimeAddedDefaulting"
+)
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return NewPlugin(), nil
+	})
+}
+
+// NewPlugin creates a new NodeTaintTimeAddedDefaulting admission plugin.
+// This plugin sets the timeAdded of the node taints which don't have it set.
+func NewPlugin() *Plugin {
+	return &Plugin{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}
+}
+
+// Plugin holds state for and implements the admission plugin.
+type Plugin struct {
+	*admission.Handler
+}
+
+var (
+	_ = admission.Interface(&Plugin{})
+)
+
+var (
+	nodeResource = api.Resource("nodes")
+)
+
+// Admit sets the timeAdded of the node taints which don't have it set. Taints
+// are unique by key and effect, so a taint counts as newly added when there is
+// no taint with the same key and effect on the node which is being updated: it
+// gets the current time. The taints which already existed keep the timeAdded
+// they had, which stops clients that read a node, change its taints and write
+// it back from resetting the timestamps of the taints they did not touch. A
+// timeAdded provided by the client is never overwritten.
+func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	// Our job is just to timestamp node taints.
+	if a.GetResource().GroupResource() != nodeResource || a.GetSubresource() != "" {
+		return nil
+	}
+
+	node, ok := a.GetObject().(*api.Node)
+	if !ok {
+		return admission.NewForbidden(a, fmt.Errorf("unexpected type %T", a.GetObject()))
+	}
+
+	var oldNode *api.Node
+	if a.GetOperation() == admission.Update {
+		oldNode, ok = a.GetOldObject().(*api.Node)
+		if !ok {
+			return admission.NewForbidden(a, fmt.Errorf("unexpected type %T", a.GetOldObject()))
+		}
+	}
+
+	var now *metav1.Time
+	for i := range node.Spec.Taints {
+		taint := &node.Spec.Taints[i]
+		if taint.TimeAdded != nil {
+			continue
+		}
+		if oldTaint := findTaint(oldNode, *taint); oldTaint != nil && oldTaint.TimeAdded != nil {
+			taint.TimeAdded = oldTaint.TimeAdded.DeepCopy()
+			continue
+		}
+		if now == nil {
+			// Truncate to seconds because sub-second resolution does not
+			// survive round-tripping through the API.
+			now = &metav1.Time{Time: time.Now().Truncate(time.Second)}
+		}
+		taint.TimeAdded = now.DeepCopy()
+	}
+	return nil
+}
+
+// findTaint returns the taint of the node which matches the given taint by key
+// and effect, if there is one.
+func findTaint(node *api.Node, taint api.Taint) *api.Taint {
+	if node == nil {
+		return nil
+	}
+	for i := range node.Spec.Taints {
+		if node.Spec.Taints[i].MatchTaint(taint) {
+			return &node.Spec.Taints[i]
+		}
+	}
+	return nil
+}

--- a/plugin/pkg/admission/nodetainttimeadded/admission_test.go
+++ b/plugin/pkg/admission/nodetainttimeadded/admission_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodetainttimeadded
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/authentication/user"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+var (
+	mynode   = &user.DefaultInfo{Name: "system:node:mynode", Groups: []string{"system:nodes"}}
+	nodeGVR  = api.Resource("nodes").WithVersion("v1")
+	nodeKind = api.Kind("Node").WithVersion("v1")
+	podGVR   = api.Resource("pods").WithVersion("v1")
+	podKind  = api.Kind("Pod").WithVersion("v1")
+)
+
+func TestHandles(t *testing.T) {
+	p := NewPlugin()
+	tests := map[admission.Operation]bool{
+		admission.Create:  true,
+		admission.Update:  true,
+		admission.Delete:  false,
+		admission.Connect: false,
+	}
+	for op, expected := range tests {
+		result := p.Handles(op)
+		if result != expected {
+			t.Errorf("Unexpected result for operation %s: %v\n", op, result)
+		}
+	}
+}
+
+func Test_taintTimeAdded(t *testing.T) {
+	oldTime := metav1.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	clientTime := metav1.Date(2025, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	nodeWithTaints := func(taints ...api.Taint) api.Node {
+		return api.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "mynode"},
+			Spec:       api.NodeSpec{Taints: taints},
+		}
+	}
+	taint := func(key string, effect api.TaintEffect, timeAdded *metav1.Time) api.Taint {
+		return api.Taint{Key: key, Effect: effect, TimeAdded: timeAdded}
+	}
+
+	tests := []struct {
+		name        string
+		node        api.Node
+		oldNode     api.Node
+		operation   admission.Operation
+		options     runtime.Object
+		subresource string
+		check       func(t *testing.T, taints []api.Taint)
+	}{
+		{
+			name: "create, timeAdded is defaulted for every effect",
+			node: nodeWithTaints(
+				taint("no-schedule", api.TaintEffectNoSchedule, nil),
+				taint("prefer-no-schedule", api.TaintEffectPreferNoSchedule, nil),
+				taint("no-execute", api.TaintEffectNoExecute, nil),
+			),
+			operation: admission.Create,
+			options:   &metav1.CreateOptions{},
+			check: func(t *testing.T, taints []api.Taint) {
+				for _, taint := range taints {
+					expectTimeAddedNow(t, taint)
+				}
+			},
+		},
+		{
+			name:      "create, timeAdded set by the client is kept",
+			node:      nodeWithTaints(taint("no-schedule", api.TaintEffectNoSchedule, &clientTime)),
+			operation: admission.Create,
+			options:   &metav1.CreateOptions{},
+			check: func(t *testing.T, taints []api.Taint) {
+				expectTimeAdded(t, taints[0], clientTime)
+			},
+		},
+		{
+			name:      "update, timeAdded is defaulted for a taint which was just added",
+			oldNode:   nodeWithTaints(),
+			node:      nodeWithTaints(taint("no-schedule", api.TaintEffectNoSchedule, nil)),
+			operation: admission.Update,
+			options:   &metav1.UpdateOptions{},
+			check: func(t *testing.T, taints []api.Taint) {
+				expectTimeAddedNow(t, taints[0])
+			},
+		},
+		{
+			name:      "update, timeAdded of an existing taint is carried over",
+			oldNode:   nodeWithTaints(taint("no-schedule", api.TaintEffectNoSchedule, &oldTime)),
+			node:      nodeWithTaints(taint("no-schedule", api.TaintEffectNoSchedule, nil)),
+			operation: admission.Update,
+			options:   &metav1.UpdateOptions{},
+			check: func(t *testing.T, taints []api.Taint) {
+				expectTimeAdded(t, taints[0], oldTime)
+			},
+		},
+		{
+			name:      "update, timeAdded is defaulted again when the effect changes",
+			oldNode:   nodeWithTaints(taint("spot", api.TaintEffectNoSchedule, &oldTime)),
+			node:      nodeWithTaints(taint("spot", api.TaintEffectNoExecute, nil)),
+			operation: admission.Update,
+			options:   &metav1.UpdateOptions{},
+			check: func(t *testing.T, taints []api.Taint) {
+				expectTimeAddedNow(t, taints[0])
+			},
+		},
+		{
+			name:      "update, timeAdded set by the client is kept",
+			oldNode:   nodeWithTaints(taint("no-schedule", api.TaintEffectNoSchedule, &oldTime)),
+			node:      nodeWithTaints(taint("no-schedule", api.TaintEffectNoSchedule, &clientTime)),
+			operation: admission.Update,
+			options:   &metav1.UpdateOptions{},
+			check: func(t *testing.T, taints []api.Taint) {
+				expectTimeAdded(t, taints[0], clientTime)
+			},
+		},
+		{
+			name:        "update of a subresource is ignored",
+			oldNode:     nodeWithTaints(taint("no-schedule", api.TaintEffectNoSchedule, &oldTime)),
+			node:        nodeWithTaints(taint("no-schedule", api.TaintEffectNoSchedule, nil)),
+			operation:   admission.Update,
+			options:     &metav1.UpdateOptions{},
+			subresource: "status",
+			check: func(t *testing.T, taints []api.Taint) {
+				if taints[0].TimeAdded != nil {
+					t.Errorf("expected timeAdded to be unset, got %v", taints[0].TimeAdded)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attributes := admission.NewAttributesRecord(&tt.node, &tt.oldNode, nodeKind, tt.node.Namespace, tt.node.Name, nodeGVR, tt.subresource, tt.operation, tt.options, false, mynode)
+			if err := NewPlugin().Admit(context.TODO(), attributes, nil); err != nil {
+				t.Fatalf("Admit() error = %v", err)
+			}
+			node, _ := attributes.GetObject().(*api.Node)
+			tt.check(t, node.Spec.Taints)
+		})
+	}
+}
+
+func Test_otherResourcesAreIgnored(t *testing.T) {
+	pod := &api.Pod{ObjectMeta: metav1.ObjectMeta{Name: "mypod", Namespace: "default"}}
+	attributes := admission.NewAttributesRecord(pod, nil, podKind, pod.Namespace, pod.Name, podGVR, "", admission.Create, &metav1.CreateOptions{}, false, mynode)
+	if err := NewPlugin().Admit(context.TODO(), attributes, nil); err != nil {
+		t.Fatalf("Admit() error = %v", err)
+	}
+}
+
+// expectTimeAdded fails the test if timeAdded does not match the given time.
+func expectTimeAdded(t *testing.T, taint api.Taint, want metav1.Time) {
+	t.Helper()
+	if taint.TimeAdded == nil {
+		t.Fatalf("taint %q: expected timeAdded %v, got nil", taint.Key, want)
+	}
+	if !taint.TimeAdded.Equal(&want) {
+		t.Errorf("taint %q: expected timeAdded %v, got %v", taint.Key, want, taint.TimeAdded)
+	}
+}
+
+// expectTimeAddedNow fails the test if timeAdded is not close to the current
+// time, truncated to seconds because that is all which survives round-tripping.
+func expectTimeAddedNow(t *testing.T, taint api.Taint) {
+	t.Helper()
+	if taint.TimeAdded == nil {
+		t.Fatalf("taint %q: expected timeAdded to be defaulted, got nil", taint.Key)
+	}
+	if delta := time.Since(taint.TimeAdded.Time); delta < -time.Minute || delta > time.Minute {
+		t.Errorf("taint %q: expected timeAdded close to the current time, got %v", taint.Key, taint.TimeAdded)
+	}
+	if truncated := taint.TimeAdded.Truncate(time.Second); !taint.TimeAdded.Time.Equal(truncated) {
+		t.Errorf("taint %q: expected timeAdded truncated to seconds, got %v", taint.Key, taint.TimeAdded)
+	}
+}

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -6939,6 +6939,10 @@ message Taint {
   optional string effect = 3;
 
   // TimeAdded represents the time at which the taint was added.
+  // It is populated at admission time by the NodeTaintTimeAddedDefaulting
+  // admission controller when it is not set: taints which have no counterpart with the
+  // same key and effect in the existing node get the current time, all other
+  // taints keep the time they already had.
   // +optional
   optional .k8s.io.apimachinery.pkg.apis.meta.v1.Time timeAdded = 4;
 }

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4277,6 +4277,10 @@ type Taint struct {
 	// Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 	Effect TaintEffect `json:"effect" protobuf:"bytes,3,opt,name=effect,casttype=TaintEffect"`
 	// TimeAdded represents the time at which the taint was added.
+	// It is populated at admission time by the NodeTaintTimeAddedDefaulting
+	// admission controller when it is not set: taints which have no counterpart with the
+	// same key and effect in the existing node get the current time, all other
+	// taints keep the time they already had.
 	// +optional
 	TimeAdded *metav1.Time `json:"timeAdded,omitempty" protobuf:"bytes,4,opt,name=timeAdded"`
 }

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -2754,7 +2754,7 @@ var map_Taint = map[string]string{
 	"key":       "Required. The taint key to be applied to a node.",
 	"value":     "The taint value corresponding to the taint key.",
 	"effect":    "Required. The effect of the taint on pods that do not tolerate the taint. Valid effects are NoSchedule, PreferNoSchedule and NoExecute.",
-	"timeAdded": "TimeAdded represents the time at which the taint was added.",
+	"timeAdded": "TimeAdded represents the time at which the taint was added. It is populated at admission time by the NodeTaintTimeAddedDefaulting admission controller when it is not set: taints which have no counterpart with the same key and effect in the existing node get the current time, all other taints keep the time they already had.",
 }
 
 func (Taint) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/client-go/applyconfigurations/core/v1/taint.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/core/v1/taint.go
@@ -38,6 +38,10 @@ type TaintApplyConfiguration struct {
 	// Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 	Effect *corev1.TaintEffect `json:"effect,omitempty"`
 	// TimeAdded represents the time at which the taint was added.
+	// It is populated at admission time by the NodeTaintTimeAddedDefaulting
+	// admission controller when it is not set: taints which have no counterpart with the
+	// same key and effect in the existing node get the current time, all other
+	// taints keep the time they already had.
 	TimeAdded *metav1.Time `json:"timeAdded,omitempty"`
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

`Taint.TimeAdded` is only ever set by the node lifecycle controller, and only for the not-ready and unreachable taints. Taints added any other way - kubelet `--register-with-taints`, `kubectl taint`, cloud providers, out-of-tree controllers, etc have no `timeAdded`, so there is no way to tell when a taint started to apply.

This PR adds a new `NodeTaintTimeAddedDefaulting` admission plugin so that on Node update or create:
- a taint with no counterpart with the same key and effect in the existing node gets the current time, truncated to seconds because that is the resolution which survives round-tripping
- a taint which already existed keeps its `timeAdded`, so clients doing read-modify-write on `spec.taints` don't reset timestamps they never touched
- a value provided by the client is never overwritten

The plugin is executed right after `TaintNodesByCondition` so the not-ready taint added there gets a timestamp too. 

#### Which issue(s) this PR is related to:

- https://github.com/kubernetes/kubernetes/issues/40586 - agreed in 1.6 that `timeAdded` should be set for all taints, never implemented
- https://github.com/kubernetes/kubernetes/pull/128469 - earlier attempt inside the condition plugin, `CREATE` only, withdrawn by its author
- See also https://github.com/kubernetes/kubernetes/issues/42394 and https://github.com/kubernetes/kubernetes/issues/113044

#### Special notes for your reviewer:

- `NodeTaintTimeAddedDefaulting` is a new plugin name, which is user-facing configuration, and it is on by default, so clusters get the behaviour as soon as they run the new apiserver.

#### Does this PR introduce a user-facing change?

```release-note
Add a new NodeTaintTimeAddedDefaulting admission plugin, enabled by default, which sets the `timeAdded` field of node taints which do not have it, on create and update, for every taint effect. Values already stored on the node and values provided by the client are preserved.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

