### PR TITLE
Allocator pool buffer cap at 128KB

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/allocator.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/allocator.go
@@ -26,7 +26,7 @@ import (
 // Usage:
 //
 //	memoryAllocator := runtime.AllocatorPool.Get().(*runtime.Allocator)
-//	defer runtime.AllocatorPool.Put(memoryAllocator)
+//	defer runtime.PutAllocator(memoryAllocator)
 //
 // A note for future:
 //
@@ -36,6 +36,29 @@ var AllocatorPool = sync.Pool{
 	New: func() interface{} {
 		return &Allocator{}
 	},
+}
+
+// maxPooledBufferCapacity bounds the buffer capacity an Allocator may retain
+// while parked in AllocatorPool. An Allocator's buffer grows to the largest
+// object it has ever encoded and never shrinks, so without a bound a burst of
+// large responses leaves every pooled allocator holding a multi-megabyte
+// buffer for the lifetime of the process. Encodes larger than this bound still
+// work; their buffers are simply released to the GC instead of being pooled.
+const maxPooledBufferCapacity = 512 * 1024
+
+// PutAllocator returns a MemoryAllocator previously obtained from
+// AllocatorPool. Buffers that grew beyond maxPooledBufferCapacity are dropped
+// before pooling so that steady-state memory retained by the pool stays
+// bounded. Allocators of other types are ignored.
+func PutAllocator(m MemoryAllocator) {
+	a, ok := m.(*Allocator)
+	if !ok {
+		return
+	}
+	if cap(a.buf) > maxPooledBufferCapacity {
+		a.buf = nil
+	}
+	AllocatorPool.Put(a)
 }
 
 // Allocator knows how to allocate memory

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/allocator.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/allocator.go
@@ -44,7 +44,7 @@ var AllocatorPool = sync.Pool{
 // large responses leaves every pooled allocator holding a multi-megabyte
 // buffer for the lifetime of the process. Encodes larger than this bound still
 // work; their buffers are simply released to the GC instead of being pooled.
-const maxPooledBufferCapacity = 256 * 1024
+const maxPooledBufferCapacity = 128 * 1024
 
 // PutAllocator returns a MemoryAllocator previously obtained from
 // AllocatorPool. Buffers that grew beyond maxPooledBufferCapacity are dropped

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/allocator.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/allocator.go
@@ -44,7 +44,7 @@ var AllocatorPool = sync.Pool{
 // large responses leaves every pooled allocator holding a multi-megabyte
 // buffer for the lifetime of the process. Encodes larger than this bound still
 // work; their buffers are simply released to the GC instead of being pooled.
-const maxPooledBufferCapacity = 512 * 1024
+const maxPooledBufferCapacity = 256 * 1024
 
 // PutAllocator returns a MemoryAllocator previously obtained from
 // AllocatorPool. Buffers that grew beyond maxPooledBufferCapacity are dropped

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/allocator_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/allocator_test.go
@@ -57,6 +57,30 @@ func TestAllocatorNeverShrinks(t *testing.T) {
 	}
 }
 
+func TestPutAllocatorDropsOversizedBuffer(t *testing.T) {
+	target := &Allocator{}
+	target.Allocate(uint64(maxPooledBufferCapacity + 1))
+	PutAllocator(target)
+	if target.buf != nil {
+		t.Fatalf("expected the oversized buffer to be dropped before pooling, got capacity: %v", cap(target.buf))
+	}
+}
+
+func TestPutAllocatorKeepsSmallBuffer(t *testing.T) {
+	target := &Allocator{}
+	target.Allocate(uint64(maxPooledBufferCapacity / 2))
+	PutAllocator(target)
+	if cap(target.buf) < maxPooledBufferCapacity/2 {
+		t.Fatalf("expected the buffer to be retained, got capacity: %v", cap(target.buf))
+	}
+}
+
+func TestPutAllocatorIgnoresOtherAllocators(t *testing.T) {
+	// must not panic
+	PutAllocator(&SimpleAllocator{})
+	PutAllocator(nil)
+}
+
 func TestAllocatorZero(t *testing.T) {
 	target := &Allocator{}
 	initialSize := 1000000 // 1MB

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/allocator_put_bench_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/allocator_put_bench_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package responsewriters
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/protobuf"
+)
+
+// BenchmarkProtobufEncodeAllocatorPutStrategies quantifies the cost of
+// PutAllocator's buffer-capacity cap on the non-streaming protobuf encode
+// path (the one SerializeObject uses for single-object GET responses and
+// non-streamed LISTs, where the allocator buffer holds the entire serialized
+// response). It compares, on the same binary:
+//
+//   - Put=Uncapped: the pre-cap behavior (AllocatorPool.Put directly), where
+//     a pooled buffer grows to the largest response and is reused verbatim.
+//   - Put=Capped: the current behavior (PutAllocator), which drops buffers
+//     larger than the pool's capacity bound, so every over-cap encode pays a
+//     fresh buffer allocation.
+//   - Put=None: no pooling at all (SimpleAllocator), as a floor reference.
+//
+// The Uncapped→Capped delta on payloads above the cap is the CPU/alloc price
+// of the bounded pool; payloads below the cap must show no difference.
+func BenchmarkProtobufEncodeAllocatorPutStrategies(b *testing.B) {
+	// Non-streaming serializer: one Allocate for the whole response.
+	serializer := protobuf.NewSerializerWithOptions(nil, nil, protobuf.SerializerOptions{})
+
+	strategies := []struct {
+		name string
+		put  func(runtime.MemoryAllocator)
+	}{
+		{name: "Put=Uncapped", put: func(a runtime.MemoryAllocator) { runtime.AllocatorPool.Put(a) }},
+		{name: "Put=Capped", put: runtime.PutAllocator},
+		{name: "Put=None", put: nil},
+	}
+
+	for _, count := range []int{50, 500, 5_000} {
+		podList := benchmarkItems(b, count)
+		payloadSize := podList.Size()
+		b.Run(fmt.Sprintf("Pods=%d/PayloadKiB=%d", count, payloadSize/1024), func(b *testing.B) {
+			for _, strategy := range strategies {
+				b.Run(strategy.name, func(b *testing.B) {
+					b.ReportAllocs()
+					b.SetBytes(int64(payloadSize))
+					for b.Loop() {
+						var err error
+						if strategy.put == nil {
+							err = serializer.EncodeWithAllocator(podList, io.Discard, &runtime.SimpleAllocator{})
+						} else {
+							allocator := runtime.AllocatorPool.Get().(*runtime.Allocator)
+							err = serializer.EncodeWithAllocator(podList, io.Discard, allocator)
+							strategy.put(allocator)
+						}
+						if err != nil {
+							b.Fatalf("unexpected encode error: %v", err)
+						}
+					}
+				})
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -113,7 +113,7 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, hw http.Response
 		encoder = runtime.NewEncoderWithAllocator(encoderWithAllocator, memoryAllocator)
 	}
 	if memoryAllocator != nil {
-		defer runtime.AllocatorPool.Put(memoryAllocator)
+		defer runtime.PutAllocator(memoryAllocator)
 	}
 
 	err := encoder.Encode(object, w)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -371,7 +371,7 @@ func (s *WatchServer) HandleHTTP(w http.ResponseWriter, req *http.Request) {
 	req = req.WithContext(ctx)
 	defer func() {
 		if s.MemoryAllocator != nil {
-			runtime.AllocatorPool.Put(s.MemoryAllocator)
+			runtime.PutAllocator(s.MemoryAllocator)
 		}
 	}()
 
@@ -487,7 +487,7 @@ func (s *WatchServer) HandleWS(ws *websocket.Conn) {
 
 	defer func() {
 		if s.MemoryAllocator != nil {
-			runtime.AllocatorPool.Put(s.MemoryAllocator)
+			runtime.PutAllocator(s.MemoryAllocator)
 		}
 	}()
 

--- a/test/integration/apiserver/allocator_pool_test.go
+++ b/test/integration/apiserver/allocator_pool_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -81,14 +81,20 @@ func TestAllocatorPoolBufferCapacityBounded(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	const (
+		maxRounds         = 10
+		requestsPerRound  = 5
+		allocatorsToDrain = 64
+	)
+
 	// sync.Pool contents are cleared by GC. Disable GC so allocators returned
 	// to the pool by the serving path reliably survive until we drain and
 	// inspect them.
 	defer debug.SetGCPercent(debug.SetGCPercent(-1))
 
 	sawPooledSmallBuffer := false
-	for round := 0; round < 10 && !sawPooledSmallBuffer; round++ {
-		for i := 0; i < 5; i++ {
+	for round := 0; round < maxRounds && !sawPooledSmallBuffer; round++ {
+		for range requestsPerRound {
 			for _, name := range []string{"big", "small"} {
 				if _, err := pbClient.CoreV1().ConfigMaps("default").Get(tCtx, name, metav1.GetOptions{}); err != nil {
 					t.Fatalf("failed to get ConfigMap %q: %v", name, err)
@@ -99,8 +105,8 @@ func TestAllocatorPoolBufferCapacityBounded(t *testing.T) {
 		// Drain the pool. Allocators the serving path returned are eligible to
 		// be handed back to us; Get also returns fresh zero-capacity allocators
 		// once the pool is empty, which are harmless to inspect.
-		drained := make([]*k8sruntime.Allocator, 0, 64)
-		for i := 0; i < 64; i++ {
+		drained := make([]*k8sruntime.Allocator, 0, allocatorsToDrain)
+		for range allocatorsToDrain {
 			drained = append(drained, k8sruntime.AllocatorPool.Get().(*k8sruntime.Allocator))
 		}
 		for _, a := range drained {

--- a/test/integration/apiserver/allocator_pool_test.go
+++ b/test/integration/apiserver/allocator_pool_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"runtime/debug"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+// maxPooledBufferCapacity mirrors the unexported bound in
+// k8s.io/apimachinery/pkg/runtime/allocator.go. If the bound there changes,
+// update this constant.
+const maxPooledBufferCapacity = 512 * 1024
+
+// TestAllocatorPoolBufferCapacityBounded verifies end to end that serving
+// protobuf responses larger than maxPooledBufferCapacity does not leave
+// oversized encode buffers parked in runtime.AllocatorPool. Before the cap was
+// introduced, every allocator that ever encoded a large object kept its grown
+// buffer for the life of the process; on a GKE control plane this pinned
+// ~49MB of heap.
+//
+// The test server runs in-process, so the pool under test is shared with the
+// serving path. The test drives GETs of a ConfigMap well above the cap and a
+// ConfigMap well below it through the real protobuf serialization stack
+// (SerializeObject only uses AllocatorPool for encoders that implement
+// EncoderWithAllocator, which protobuf does and JSON does not), then drains
+// the pool and inspects the retained buffer capacities:
+//
+//   - No drained allocator may retain more than maxPooledBufferCapacity.
+//   - At least one drained allocator must retain a buffer at least as large
+//     as the small ConfigMap's payload, proving the pool is still actually
+//     reusing buffers for sub-cap responses (i.e. the invariant above is not
+//     passing vacuously because pooling broke entirely).
+func TestAllocatorPoolBufferCapacityBounded(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	client, kubeConfig, tearDownFn := framework.StartTestServer(tCtx, t, framework.TestServerSetup{})
+	defer tearDownFn()
+
+	const (
+		bigPayload   = 900 * 1024 // well above maxPooledBufferCapacity, under the 1MiB ConfigMap limit
+		smallPayload = 64 * 1024  // well below maxPooledBufferCapacity
+	)
+
+	for name, size := range map[string]int{"big": bigPayload, "small": smallPayload} {
+		cm := &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Data:       map[string]string{"blob": strings.Repeat("x", size)},
+		}
+		if _, err := client.CoreV1().ConfigMaps("default").Create(tCtx, cm, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("failed to create ConfigMap %q: %v", name, err)
+		}
+	}
+
+	pbConfig := restclient.CopyConfig(kubeConfig)
+	pbConfig.ContentType = "application/vnd.kubernetes.protobuf"
+	pbClient, err := clientset.NewForConfig(pbConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// sync.Pool contents are cleared by GC. Disable GC so allocators returned
+	// to the pool by the serving path reliably survive until we drain and
+	// inspect them.
+	defer debug.SetGCPercent(debug.SetGCPercent(-1))
+
+	sawPooledSmallBuffer := false
+	for round := 0; round < 10 && !sawPooledSmallBuffer; round++ {
+		for i := 0; i < 5; i++ {
+			for _, name := range []string{"big", "small"} {
+				if _, err := pbClient.CoreV1().ConfigMaps("default").Get(tCtx, name, metav1.GetOptions{}); err != nil {
+					t.Fatalf("failed to get ConfigMap %q: %v", name, err)
+				}
+			}
+		}
+
+		// Drain the pool. Allocators the serving path returned are eligible to
+		// be handed back to us; Get also returns fresh zero-capacity allocators
+		// once the pool is empty, which are harmless to inspect.
+		drained := make([]*k8sruntime.Allocator, 0, 64)
+		for i := 0; i < 64; i++ {
+			drained = append(drained, k8sruntime.AllocatorPool.Get().(*k8sruntime.Allocator))
+		}
+		for _, a := range drained {
+			// Allocate(0) exposes the retained buffer without growing it.
+			retained := cap(a.Allocate(0))
+			if retained > maxPooledBufferCapacity {
+				t.Fatalf("AllocatorPool retained a buffer of %d bytes, want at most %d: encode buffers above the cap must be dropped, not pooled", retained, maxPooledBufferCapacity)
+			}
+			if retained >= smallPayload {
+				sawPooledSmallBuffer = true
+			}
+		}
+		for _, a := range drained {
+			k8sruntime.PutAllocator(a)
+		}
+	}
+
+	if !sawPooledSmallBuffer {
+		t.Fatalf("never drained an allocator retaining at least %d bytes; the pool does not appear to be reusing buffers for sub-cap responses, so this test has lost its signal", smallPayload)
+	}
+}


### PR DESCRIPTION
Bound the buffer capacity retained by runtime.AllocatorPool (at 128 KB) so a burst of large protobuf responses no longer pins multi-megabyte encode buffers in memory for the life of the apiserver process (observed pinning ~49MB of heap on a k8s control plane).

* Add `runtime.PutAllocator`, which drops buffers grown beyond 128KiB before returning an allocator to the pool, and use it at all pool put sites (SerializeObject, watch handlers)
* Add an integration test verifying end-to-end that oversized buffers are not pooled while sub-cap buffers are still reused
* Add a benchmark comparing uncapped, capped, and unpooled put strategies across payload sizes to quantify the cost of the cap

/kind feature

```release-note
NONE
```