### PR TITLE
Gate webhook authorizer cache on actual key size

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -50,8 +50,11 @@ import (
 )
 
 const (
-	// The maximum length of requester-controlled attributes to allow caching.
-	maxControlledAttrCacheSize = 10000
+	// maxCacheKeySize is the maximum length of the JSON-serialized
+	// SubjectAccessReviewSpec that may be used as a webhook response cache key.
+	// Oversized keys would let a requester bloat the shared LRU cache and evict
+	// legitimate entries (cache-poisoning DoS), so such requests bypass the cache.
+	maxCacheKeySize = 10000
 )
 
 // DefaultRetryBackoff returns the default backoff parameters for webhook retry.
@@ -272,7 +275,7 @@ func (w *WebhookAuthorizer) Authorize(ctx context.Context, attr authorizer.Attri
 		}
 
 		r.Status = result.Status
-		if shouldCache(attr) {
+		if shouldCache(key) {
 			if r.Status.Allowed {
 				w.responseCache.Add(string(key), r.Status, w.authorizedTTL)
 			} else {
@@ -535,18 +538,13 @@ func (t *subjectAccessReviewV1beta1ClientGW) Create(ctx context.Context, subject
 	return subjectAccessReview, statusCode, err
 }
 
-// shouldCache determines whether it is safe to cache the given request attributes. If the
-// requester-controlled attributes are too large, this may be a DoS attempt, so we skip the cache.
-func shouldCache(attr authorizer.Attributes) bool {
-	controlledAttrSize := int64(len(attr.GetNamespace())) +
-		int64(len(attr.GetVerb())) +
-		int64(len(attr.GetAPIGroup())) +
-		int64(len(attr.GetAPIVersion())) +
-		int64(len(attr.GetResource())) +
-		int64(len(attr.GetSubresource())) +
-		int64(len(attr.GetName())) +
-		int64(len(attr.GetPath()))
-	return controlledAttrSize < maxControlledAttrCacheSize
+// shouldCache guards the webhook response cache against DoS via oversized keys.
+// The cache key is the JSON-serialized SubjectAccessReviewSpec, so the size limit
+// must apply to the actual key. Measuring only a subset of fields leaves any
+// requester-controlled input outside the check (e.g. fieldSelector/labelSelector
+// requirements) free to bloat the cache and evict legitimate entries.
+func shouldCache(key []byte) bool {
+	return int64(len(key)) < maxCacheKeySize
 }
 
 func v1beta1StatusToV1Status(in *authorizationv1beta1.SubjectAccessReviewStatus) authorizationv1.SubjectAccessReviewStatus {

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package webhook
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -289,5 +292,72 @@ func Test_resourceAttributesFrom(t *testing.T) {
 				t.Errorf("resourceAttributesFrom() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_shouldCache(t *testing.T) {
+	smallSpec := authorizationv1.SubjectAccessReviewSpec{
+		User: "alice",
+		ResourceAttributes: &authorizationv1.ResourceAttributes{
+			Verb: "list", Resource: "pods",
+		},
+	}
+	smallKey, err := json.Marshal(smallSpec)
+	if err != nil {
+		t.Fatalf("marshal small spec: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		key  []byte
+		want bool
+	}{
+		{"empty", nil, true},
+		{"small legitimate", smallKey, true},
+		{"just under limit", bytes.Repeat([]byte("a"), maxCacheKeySize-1), true},
+		{"at limit", bytes.Repeat([]byte("a"), maxCacheKeySize), false},
+		{"over limit", bytes.Repeat([]byte("a"), maxCacheKeySize+1), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldCache(tc.key); got != tc.want {
+				t.Fatalf("shouldCache(key len=%d) = %v, want %v", len(tc.key), got, tc.want)
+			}
+		})
+	}
+}
+
+// Test_shouldCache_rejectsLargeFieldSelectorFromAttributes reproduces the cache-poisoning
+// DoS path: a requester-controlled fieldSelector with thousands of terms produces a SAR
+// spec whose JSON key far exceeds maxCacheKeySize, yet the scalar-field check
+// used to pass because selector requirements were not counted. The fix measures the key.
+func Test_shouldCache_rejectsLargeFieldSelectorFromAttributes(t *testing.T) {
+	reqs := make(fields.Requirements, 5000)
+	for i := range reqs {
+		reqs[i] = fields.Requirement{
+			Field:    "spec.nodeName",
+			Operator: selection.Equals,
+			Value:    fmt.Sprintf("node-%04d", i),
+		}
+	}
+	attr := authorizer.AttributesRecord{
+		Verb:                      "list",
+		Resource:                  "pods",
+		FieldSelectorRequirements: reqs,
+	}
+
+	spec := authorizationv1.SubjectAccessReviewSpec{
+		User:               "alice",
+		ResourceAttributes: resourceAttributesFrom(attr),
+	}
+	key, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if len(key) <= maxCacheKeySize {
+		t.Fatalf("test premise broken: key is only %d bytes, need > %d to exercise the gate", len(key), maxCacheKeySize)
+	}
+	if shouldCache(key) {
+		t.Fatalf("shouldCache returned true for %d-byte fieldSelector key; cache would be poisoned", len(key))
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Fixes a cache-poisoning DoS in the webhook authorizer. The response cache key is `json.Marshal(SubjectAccessReviewSpec)`, which since `92e3445e9d7` includes the full `fieldSelector`/`labelSelector` requirements parsed from the request URL. The `shouldCache` gate, however, only measured 8 scalar fields (namespace/verb/group/version/resource/subresource/name/path) and did not account for the selector requirements — so a requester could send legal list/watch/deletecollection requests with thousands of selector terms, pass the gate (tiny scalar fields), and store a ~250 KB key in the shared 8192-entry LRU cache. 8192 such distinct keys evict every legitimate entry, collapsing the cache hit ratio to zero and hammering the external webhook on every subsequent request; with `failurePolicy: Deny` this escalates to cluster-wide API unavailability.

The fix measures the actual cache key (`len(key)`), restoring the invariant that existed before `e23c15a0f34` (2019) replaced `len(key)` with a scalar-field approximation. The `key` is already computed at `webhook.go:220`, so the fix is zero extra cost. The `maxControlledAttrCacheSize` constant is renamed to `maxCacheKeySize` with an updated comment, since it now bounds the whole key rather than a subset of requester-controlled attributes.

#### Which issue(s) this PR is related to:

Fixes #141457

#### Special notes for your reviewer:

- The regression was introduced by `92e3445e9d7` (selector requirements added to the SAR spec / cache key) and became unconditional when the `AuthorizeWithSelectors` feature gate was removed in `b2e27e89867`. Backport candidates: every supported release carrying `resourceAttributesFrom` with selector injection plus the scalar-only `shouldCache`.
- `shouldCache` has a single call site (`webhook.go:275`); the signature change from `authorizer.Attributes` to `[]byte` has no external callers (package-private function, grep-verified).
- Behavior of the existing `TestV1WebhookCache` / `TestV1beta1WebhookCache` `ridiculous_*` cases is preserved: they stuff 5 scalar fields with 2000 chars each (~10 KB), which makes `len(key)` exceed the limit just as the old scalar sum did.
- The optional parse-layer hardening (cap selector requirements count/total length in `requestinfo.go` or `fieldSelectorToAuthorizationAPI`) is intentionally left out to keep this PR minimal and focused; it benefits non-webhook authorizers too and warrants a separate PR.

#### Does this PR introduce a user-facing change?

```release-note
The webhook authorizer response cache now gates on the size of the serialized SubjectAccessReviewSpec key rather than a subset of scalar attribute fields, preventing a cache-poisoning denial of service where a requester could fill the shared LRU cache with oversized keys (e.g. via large fieldSelector/labelSelector query parameters) and evict legitimate entries. Clusters using webhook authorization (OPA / Kyverno / RBAC-proxy / custom) should upgrade.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
