### PR TITLE
kubelet: invalidate name-keyed ClusterTrustBundle cache entries

### DIFF
--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
@@ -206,13 +206,24 @@ func newInformerManager[T clusterTrustBundle](ctx context.Context, handlers clus
 }
 
 func (m *InformerManager[T]) dropCacheFor(ctb *T) {
+	// A ClusterTrustBundle that has a signer name is still reachable by name, so
+	// a change to it has to invalidate both kinds of cache entry. The name sweep
+	// is therefore unconditional. It cannot over-match a signer-keyed entry,
+	// because those are stored with an empty ctbName and an object's name is
+	// never empty.
+	ctbName := m.ctbHandlers.GetName(ctb)
+	m.normalizationCache.RemoveAll(func(key any) bool {
+		return key.(cacheKeyType).ctbName == ctbName
+	})
+
+	// The signer sweep stays guarded. GetSignerName returns "" for a bundle with
+	// no signer, and every name-keyed entry is stored with an empty signerName,
+	// so an unguarded sweep would match all of them. That would still project
+	// correct content, since entries are refilled from the lister, but it would
+	// needlessly evict unrelated entries.
 	if ctbSignerName := m.ctbHandlers.GetSignerName(ctb); ctbSignerName != "" {
 		m.normalizationCache.RemoveAll(func(key any) bool {
 			return key.(cacheKeyType).signerName == ctbSignerName
-		})
-	} else {
-		m.normalizationCache.RemoveAll(func(key any) bool {
-			return key.(cacheKeyType).ctbName == m.ctbHandlers.GetName(ctb)
 		})
 	}
 }

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
@@ -206,21 +206,11 @@ func newInformerManager[T clusterTrustBundle](ctx context.Context, handlers clus
 }
 
 func (m *InformerManager[T]) dropCacheFor(ctb *T) {
-	// A ClusterTrustBundle that has a signer name is still reachable by name, so
-	// a change to it has to invalidate both kinds of cache entry. The name sweep
-	// is therefore unconditional. It cannot over-match a signer-keyed entry,
-	// because those are stored with an empty ctbName and an object's name is
-	// never empty.
 	ctbName := m.ctbHandlers.GetName(ctb)
 	m.normalizationCache.RemoveAll(func(key any) bool {
 		return key.(cacheKeyType).ctbName == ctbName
 	})
 
-	// The signer sweep stays guarded. GetSignerName returns "" for a bundle with
-	// no signer, and every name-keyed entry is stored with an empty signerName,
-	// so an unguarded sweep would match all of them. That would still project
-	// correct content, since entries are refilled from the lister, but it would
-	// needlessly evict unrelated entries.
 	if ctbSignerName := m.ctbHandlers.GetSignerName(ctb); ctbSignerName != "" {
 		m.normalizationCache.RemoveAll(func(key any) bool {
 			return key.(cacheKeyType).signerName == ctbSignerName

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
@@ -67,6 +67,7 @@ func TestBeforeSynced(t *testing.T) {
 
 type testClient[T clusterTrustBundle] interface {
 	Create(context.Context, *T, metav1.CreateOptions) (*T, error)
+	Update(context.Context, *T, metav1.UpdateOptions) (*T, error)
 	Delete(context.Context, string, metav1.DeleteOptions) error
 }
 
@@ -263,6 +264,144 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](tCtx ktesting.TConte
 			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
 		}
 	}()
+}
+
+func TestGetTrustAnchorsByNameCachingSignedBundle(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	tCtx.SyncTest("v1alpha1", func(tCtx ktesting.TContext) {
+		testGetTrustAnchorsByNameCachingSignedBundle(tCtx, alphaFunctionsBundle)
+	})
+	tCtx.SyncTest("v1beta1", func(tCtx ktesting.TContext) {
+		testGetTrustAnchorsByNameCachingSignedBundle(tCtx, betaFunctionsBundle)
+	})
+	tCtx.SyncTest("v1", func(tCtx ktesting.TContext) {
+		testGetTrustAnchorsByNameCachingSignedBundle(tCtx, gaFunctionsBundle)
+	})
+}
+
+// testGetTrustAnchorsByNameCachingSignedBundle covers a ClusterTrustBundle that
+// carries a signer name but is read by name, which is what a pod does when it
+// projects a signer-linked bundle through clusterTrustBundle.name. Such an
+// object lands in the cache under a name key, and the update below has to
+// invalidate that entry just as it would for a bundle with no signer.
+func testGetTrustAnchorsByNameCachingSignedBundle[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
+
+	ctb1 := b.ctbConstructor("foo", "foo.bar/a", nil, mustMakeRoot(t, "root1"))
+	ctb2 := b.ctbConstructor("foo", "foo.bar/a", nil, mustMakeRoot(t, "root2"))
+
+	kc := fake.NewSimpleClientset(b.ctbToObj(ctb1))
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(kc, 0)
+
+	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
+
+	informerFactory.Start(tCtx.Done())
+	ctbInformer := b.informerGetter(informerFactory)
+	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
+		t.Fatalf("Timed out waiting for informer to sync")
+	}
+
+	func() {
+		t.Log("foo should yield the first certificate, and leave it in the cache under a name key")
+		gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
+		if err != nil {
+			t.Fatalf("Got error while calling GetTrustAnchorsByName: %v", err)
+		}
+
+		wantBundle := b.ctbTrustBundle(ctb1)
+
+		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
+			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
+		}
+	}()
+
+	client := b.clientGetter(kc)
+	if _, err := client.Update(tCtx, ctb2, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Error while updating the CTB: %v", err)
+	}
+
+	// As above, long enough for the informer to notice the update and much less
+	// than the 5 minute cache TTL, so that passing here means the event dropped
+	// the entry rather than the entry expiring on its own.
+	time.Sleep(5 * time.Second)
+
+	func() {
+		t.Log("foo should yield the new certificate")
+		gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
+		if err != nil {
+			t.Fatalf("Got error while calling GetTrustAnchorsByName: %v", err)
+		}
+
+		wantBundle := b.ctbTrustBundle(ctb2)
+		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
+			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
+		}
+	}()
+}
+
+func TestDropCacheForKeepsUnrelatedEntries(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	tCtx.SyncTest("v1alpha1", func(tCtx ktesting.TContext) {
+		testDropCacheForKeepsUnrelatedEntries(tCtx, alphaFunctionsBundle)
+	})
+	tCtx.SyncTest("v1beta1", func(tCtx ktesting.TContext) {
+		testDropCacheForKeepsUnrelatedEntries(tCtx, betaFunctionsBundle)
+	})
+	tCtx.SyncTest("v1", func(tCtx ktesting.TContext) {
+		testDropCacheForKeepsUnrelatedEntries(tCtx, gaFunctionsBundle)
+	})
+}
+
+// testDropCacheForKeepsUnrelatedEntries is why the signer sweep in dropCacheFor
+// stays conditional. GetSignerName returns "" for a bundle with no signer, and
+// name-keyed entries are stored with an empty signerName, so sweeping on signer
+// name unconditionally would match every name-keyed entry in the cache,
+// including entries belonging to unrelated ClusterTrustBundles.
+func testDropCacheForKeepsUnrelatedEntries[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
+	defer tCtx.Cancel("test completed")
+	t := tCtx.TB()
+
+	ctb1 := b.ctbConstructor("ctb1", "", nil, mustMakeRoot(t, "root1"))
+	ctb2 := b.ctbConstructor("ctb2", "", nil, mustMakeRoot(t, "root2"))
+
+	kc := fake.NewSimpleClientset(b.ctbToObj(ctb1), b.ctbToObj(ctb2))
+
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(kc, 0)
+
+	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
+
+	informerFactory.Start(tCtx.Done())
+	ctbInformer := b.informerGetter(informerFactory)
+	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
+		t.Fatalf("Timed out waiting for informer to sync")
+	}
+
+	m, ok := ctbManager.(*InformerManager[T])
+	if !ok {
+		t.Fatalf("Got a %T, wanted an *InformerManager", ctbManager)
+	}
+
+	// The informer hands its initial adds to the event handler asynchronously,
+	// and each one calls dropCacheFor. Let those drain first, so that what the
+	// assertions below see is the effect of the explicit call and nothing else.
+	time.Sleep(1 * time.Second)
+
+	for _, name := range []string{"ctb1", "ctb2"} {
+		if _, err := m.GetTrustAnchorsByName(tCtx, name, false); err != nil {
+			t.Fatalf("Error while calling GetTrustAnchorsByName(%q): %v", name, err)
+		}
+	}
+
+	m.dropCacheFor(ctb1)
+
+	if _, ok := m.normalizationCache.Get(cacheKeyType{ctbName: "ctb1"}); ok {
+		t.Errorf("Cache entry for ctb1 survived dropCacheFor(ctb1), wanted it dropped")
+	}
+	if _, ok := m.normalizationCache.Get(cacheKeyType{ctbName: "ctb2"}); !ok {
+		t.Errorf("Cache entry for the unrelated ctb2 was dropped by dropCacheFor(ctb1), wanted it kept")
+	}
 }
 
 func TestGetTrustAnchorsBySignerName(t *testing.T) {

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
@@ -279,11 +279,6 @@ func TestGetTrustAnchorsByNameCachingSignedBundle(t *testing.T) {
 	})
 }
 
-// testGetTrustAnchorsByNameCachingSignedBundle covers a ClusterTrustBundle that
-// carries a signer name but is read by name, which is what a pod does when it
-// projects a signer-linked bundle through clusterTrustBundle.name. Such an
-// object lands in the cache under a name key, and the update below has to
-// invalidate that entry just as it would for a bundle with no signer.
 func testGetTrustAnchorsByNameCachingSignedBundle[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
 	defer tCtx.Cancel("test completed")
 	t := tCtx.TB()
@@ -303,42 +298,35 @@ func testGetTrustAnchorsByNameCachingSignedBundle[T clusterTrustBundle](tCtx kte
 		t.Fatalf("Timed out waiting for informer to sync")
 	}
 
-	func() {
-		t.Log("foo should yield the first certificate, and leave it in the cache under a name key")
-		gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
-		if err != nil {
-			t.Fatalf("Got error while calling GetTrustAnchorsByName: %v", err)
-		}
+	t.Log("foo should yield the first certificate")
+	gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
+	if err != nil {
+		t.Fatalf("Got error while calling GetTrustAnchorsByName: %v", err)
+	}
 
-		wantBundle := b.ctbTrustBundle(ctb1)
+	wantBundle := b.ctbTrustBundle(ctb1)
 
-		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
-			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
-		}
-	}()
+	if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
+		t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
+	}
 
 	client := b.clientGetter(kc)
 	if _, err := client.Update(tCtx, ctb2, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("Error while updating the CTB: %v", err)
 	}
 
-	// As above, long enough for the informer to notice the update and much less
-	// than the 5 minute cache TTL, so that passing here means the event dropped
-	// the entry rather than the entry expiring on its own.
-	time.Sleep(5 * time.Second)
+	tCtx.Wait()
 
-	func() {
-		t.Log("foo should yield the new certificate")
-		gotBundle, err := ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
-		if err != nil {
-			t.Fatalf("Got error while calling GetTrustAnchorsByName: %v", err)
-		}
+	t.Log("foo should yield the new certificate")
+	gotBundle, err = ctbManager.GetTrustAnchorsByName(tCtx, "foo", false)
+	if err != nil {
+		t.Fatalf("Got error while calling GetTrustAnchorsByName: %v", err)
+	}
 
-		wantBundle := b.ctbTrustBundle(ctb2)
-		if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
-			t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
-		}
-	}()
+	wantBundle = b.ctbTrustBundle(ctb2)
+	if diff := diffBundles(gotBundle, []byte(wantBundle)); diff != "" {
+		t.Fatalf("Bad bundle; diff (-got +want)\n%s", diff)
+	}
 }
 
 func TestDropCacheForKeepsUnrelatedEntries(t *testing.T) {
@@ -354,11 +342,6 @@ func TestDropCacheForKeepsUnrelatedEntries(t *testing.T) {
 	})
 }
 
-// testDropCacheForKeepsUnrelatedEntries is why the signer sweep in dropCacheFor
-// stays conditional. GetSignerName returns "" for a bundle with no signer, and
-// name-keyed entries are stored with an empty signerName, so sweeping on signer
-// name unconditionally would match every name-keyed entry in the cache,
-// including entries belonging to unrelated ClusterTrustBundles.
 func testDropCacheForKeepsUnrelatedEntries[T clusterTrustBundle](tCtx ktesting.TContext, b testingFunctionBundle[T]) {
 	defer tCtx.Cancel("test completed")
 	t := tCtx.TB()
@@ -383,10 +366,7 @@ func testDropCacheForKeepsUnrelatedEntries[T clusterTrustBundle](tCtx ktesting.T
 		t.Fatalf("Got a %T, wanted an *InformerManager", ctbManager)
 	}
 
-	// The informer hands its initial adds to the event handler asynchronously,
-	// and each one calls dropCacheFor. Let those drain first, so that what the
-	// assertions below see is the effect of the explicit call and nothing else.
-	time.Sleep(1 * time.Second)
+	tCtx.Wait()
 
 	for _, name := range []string{"ctb1", "ctb2"} {
 		if _, err := m.GetTrustAnchorsByName(tCtx, name, false); err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

kubelet caches normalized trust anchors from ClusterTrustBundles. When a bundle
changes, `dropCacheFor` clears the cache entries for it. Right now it does that
with an if/else:

- bundle has a `spec.signerName` -> clear only the entries keyed by signer name
- bundle has no signer name -> clear only the entries keyed by object name

The problem is that a bundle with a signer name can still be read by name. A pod
is allowed to mount it with `clusterTrustBundle.name`, and that read stores a
cache entry keyed by name. The if/else never clears that entry, so no event ever
clears it. It stays in the cache until the 5 minute TTL runs out.

For those 5 minutes kubelet keeps writing the old trust anchors into the
projected volume of a running pod. A pod that starts during that window gets the
old anchors too, because the cache is per node. If the projected `ca.crt` is the
only trust store the pod has, then the pod trusts a CA the cluster already
removed, and cannot verify the CA the cluster just published.

The fix is to always clear by name. The signer clear stays inside an if, and
that part matters: `GetSignerName` returns `""` for a bundle with no signer, and
name-keyed entries are stored with an empty signer name. So clearing by signer
without the if would match every name-keyed entry in the cache, including
entries that belong to other bundles.

The existing `TestGetTrustAnchorsByNameCaching` creates its bundle with an empty
signer name, so it only ever tested the else branch. That is why this was not
caught. Two tests are added:

- `TestGetTrustAnchorsByNameCachingSignedBundle` - bundle with a signer name,
  read by name, then updated. It fails on master and passes with this change, on
  v1alpha1, v1beta1 and v1.
- `TestDropCacheForKeepsUnrelatedEntries` - checks that `dropCacheFor` does not
  drop entries of other bundles. This one passes on master too. It is there so
  that the if around the signer clear is not removed later.

#### Which issue(s) this PR is related to:

Fixes #141439

#### Special notes for your reviewer:

I tested this on 4 kind clusters, 3 minor versions, on both the v1beta1 and the
v1 manager. One pod mounts the same bundle 3 ways at the same time, each in its
own volume so that a failure in one does not hide the others:

| arm | mounted as | bundle | time until the pod sees the new anchors |
| --- | --- | --- | --- |
| 1 | by `name` | has `signerName` | 290-374 s |
| 2 | by `signerName` | has `signerName` | 0-95 s |
| 3 | by `name` | no `signerName` | 0-95 s |

Arm 1 minus arm 2 is 296 s, 290 s, 299 s and 300 s over the 4 runs. That is the
cache TTL. In one run I set `syncFrequency` to `10s`. The other 2 arms then
converged in under 10 s, but arm 1 still took 299-310 s. So the delay is the
cache, not the pod sync loop. The reproducer and the full numbers are in the
issue.

Note that arm 3 also passes on master, since it is the else branch. It is there
as a control, not as a second failing case.

One more thing worth knowing: `AddFunc`, `UpdateFunc` and `DeleteFunc` all call
`dropCacheFor`. So creating or deleting a bundle with a signer name leaves stale
name-keyed entries as well, not just updating one.

This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?

```release-note
kubelet now clears name-keyed ClusterTrustBundle cache entries when a ClusterTrustBundle that has a `spec.signerName` changes. Before this, a pod that projected such a bundle by name could get stale trust anchors for up to 5 minutes after the object was updated.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/tree/96321bd03d0bfda6d4ed19374bfe21de75d26fb1/keps/sig-auth/3257-cluster-trust-bundles
```
