### PR TITLE
[conformance] extend pod lifecycle test to cover PodReadyToStartContainers

### DIFF
--- a/test/e2e/common/node/pods.go
+++ b/test/e2e/common/node/pods.go
@@ -1026,9 +1026,9 @@ var _ = SIGDescribe("Pods", func() {
 			framework.ExpectNoError(err, "failed to unmarshal JSON bytes to a Pod object type")
 			podStatusUpdated := podStatus
 			podStatusFieldPatchCount := 0
-			podStatusFieldPatchCountTotal := 2
+			podStatusFieldPatchCountTotal := 3
 			for pos, cond := range podStatusUpdated.Status.Conditions {
-				if (cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue) || (cond.Type == v1.ContainersReady && cond.Status == v1.ConditionTrue) {
+				if (cond.Type == v1.PodReady && cond.Status == v1.ConditionTrue) || (cond.Type == v1.ContainersReady && cond.Status == v1.ConditionTrue) || (cond.Type == v1.PodReadyToStartContainers && cond.Status == v1.ConditionTrue) {
 					podStatusUpdated.Status.Conditions[pos].Status = v1.ConditionFalse
 					podStatusFieldPatchCount++
 				}
@@ -1041,9 +1041,9 @@ var _ = SIGDescribe("Pods", func() {
 
 		ginkgo.By("check the Pod again to ensure its Ready conditions are False")
 		podStatusFieldPatchCount := 0
-		podStatusFieldPatchCountTotal := 2
+		podStatusFieldPatchCountTotal := 3
 		for _, cond := range podStatusUpdate.Status.Conditions {
-			if (cond.Type == v1.PodReady && cond.Status == v1.ConditionFalse) || (cond.Type == v1.ContainersReady && cond.Status == v1.ConditionFalse) {
+			if (cond.Type == v1.PodReady && cond.Status == v1.ConditionFalse) || (cond.Type == v1.ContainersReady && cond.Status == v1.ConditionFalse) || (cond.Type == v1.PodReadyToStartContainers && cond.Status == v1.ConditionFalse) {
 				podStatusFieldPatchCount++
 			}
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

extending the existing [conformance test](https://github.com/kubernetes/kubernetes/blob/b3bc2ac58fa173967f27ade80f28cc5015b8c1c3/test/e2e/common/node/pods.go#L902-L909) to cover `PodReadyToStartContainers` pod status condition (GA in v1.37)

ref: [part of KEP-3085](https://github.com/kubernetes/enhancements/blob/552c48ba8adf5b77b2c12c7bef04c47748136898/keps/sig-node/3085-pod-conditions-for-starting-completition-of-sandbox-creation/README.md?plain=1#L1057-L1059)

> Testing updates of Pod conditions in the Conformance Test `Pods, completes the lifecycle of a Pod and the PodStatus` will be enhanced to cover resetting the new pod sandbox conditions.

#### Which issue(s) this PR is related to:

KEP: https://github.com/kubernetes/enhancements/issues/4138

#### Does this PR introduce a user-facing change?

```release-note
Conformance test `Pods, completes the lifecycle of a Pod and the PodStatus` now cover resetting the `PodReadyToStartContainers` condition
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/issues/4138
```