### PR TITLE
pod-security-admission: re-evaluate on seccomp/AppArmor annotation

### DIFF
--- a/staging/src/k8s.io/pod-security-admission/admission/admission.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission.go
@@ -662,12 +662,36 @@ func isSignificantPodUpdate(pod, oldPod *corev1.Pod) bool {
 			return true
 		}
 	}
-	return false
+	return podSecurityAnnotationsChanged(pod.Annotations, oldPod.Annotations)
 }
 
 // isSignificantContainerUpdate determines whether a container update should trigger a policy evaluation.
 func isSignificantContainerUpdate(container, oldContainer *corev1.Container) bool {
 	return container.Image != oldContainer.Image
+}
+
+// podSecurityAnnotationsChanged reports whether any seccomp or AppArmor annotation
+// that is read by the pod security policy has changed between two annotations.
+func podSecurityAnnotationsChanged(newAnnotations, oldAnnotations map[string]string) bool {
+	for k, v := range newAnnotations {
+		if isSecurityAnnotationKey(k) && v != oldAnnotations[k] {
+			return true
+		}
+	}
+	for k, v := range oldAnnotations {
+		if isSecurityAnnotationKey(k) && newAnnotations[k] != v {
+			return true
+		}
+	}
+	return false
+}
+
+// isSecurityAnnotationKey returns true if the key is an annotation that the
+// pod security policy reads for seccomp or AppArmor enforcement.
+func isSecurityAnnotationKey(key string) bool {
+	return key == corev1.SeccompPodAnnotationKey ||
+		strings.HasPrefix(key, corev1.SeccompContainerAnnotationKeyPrefix) ||
+		strings.HasPrefix(key, corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix)
 }
 
 func (a *Admission) exemptNamespace(namespace string) bool {

--- a/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
+++ b/staging/src/k8s.io/pod-security-admission/admission/admission_test.go
@@ -1268,3 +1268,60 @@ func (a *testAttributes) GetOldObject() (runtime.Object, error) {
 		return a.AttributesRecord.GetOldObject()
 	}
 }
+
+// TestIsSignificantPodUpdateSecurityAnnotations asserts that a pod update whose only
+// change is a seccomp or AppArmor annotation is significant, so the change is
+// re-evaluated against the pod security policy instead of being admitted
+// without evaluation.
+func TestIsSignificantPodUpdateSecurityAnnotations(t *testing.T) {
+	const testContainer = "test-container"
+
+	basePod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-pod",
+				Namespace:   "test-ns",
+				Annotations: map[string]string{},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: testContainer, Image: "image:1"}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*corev1.Pod)
+	}{
+		{
+			name: "apparmor annotation change",
+			mutate: func(p *corev1.Pod) {
+				p.Annotations[corev1.DeprecatedAppArmorBetaContainerAnnotationKeyPrefix+testContainer] = "unconfined"
+			},
+		},
+		{
+			name: "seccomp pod annotation change",
+			mutate: func(p *corev1.Pod) {
+				p.Annotations[corev1.SeccompPodAnnotationKey] = "unconfined"
+			},
+		},
+		{
+			name: "seccomp container annotation change",
+			mutate: func(p *corev1.Pod) {
+				p.Annotations[corev1.SeccompContainerAnnotationKeyPrefix+testContainer] = "unconfined"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldPod := basePod()
+			newPod := oldPod.DeepCopy()
+			tt.mutate(newPod)
+
+			if !isSignificantPodUpdate(newPod, oldPod) {
+				t.Errorf("expected annotation-only update to be significant, got insignificant")
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig auth

#### What this PR does / why we need it:

`isSignificantPodUpdate` decides whether a pod UPDATE gets re-evaluated against
the namespace's Pod Security policy. It compares only container counts and
container images, so an update whose only change is a seccomp or AppArmor
annotation is treated as insignificant and admitted without re-evaluation, even though
the policy checks read exactly those annotations
(`check_appArmorProfile.go:116-120`, `check_seccompProfile_baseline.go:34-49,82`).
An annotation-only update can therefore admit a pod that violates the
namespace's enforced level.

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

- The added test (`TestIsSignificantPodUpdateSecurityAnnotations`) covers three
cases: pod-level seccomp annotation, container seccomp annotation, and
container AppArmor annotation.

- This PR was written in part with the assistance of generative AI, per the [Kubernetes AI policy](https://kubernetes.io/blog/2026/06/26/open-source-maintainership-in-the-age-of-ai/).

#### Does this PR introduce a user-facing change?

```release-note
Fix PodSecurity admission skipping policy re-evaluation for pod updates that change only seccomp or AppArmor annotations.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
