### PR TITLE
scheduler: replace pkg/apis/core/validation dependency with local const

### DIFF
--- a/pkg/scheduler/.import-restrictions
+++ b/pkg/scheduler/.import-restrictions
@@ -4,8 +4,6 @@ rules:
     allowedPrefixes: [ "" ]
   - selectorRegexp: ^k8s[.]io/kubernetes/pkg/apis/core/v1/helper$
     allowedPrefixes: [ "" ]
-  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/apis/core/validation$
-    allowedPrefixes: [ "" ]
   - selectorRegexp: ^k8s[.]io/kubernetes/pkg/apis/scheduling$
     allowedPrefixes: [ "" ]
   - selectorRegexp: ^k8s[.]io/kubernetes/pkg/controller$

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -36,7 +36,6 @@ import (
 	extenderv1 "k8s.io/kube-scheduler/extender/v1"
 	fwk "k8s.io/kube-scheduler/framework"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
-	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
@@ -56,6 +55,10 @@ const (
 	// to ensure that a certain minimum of nodes are checked for feasibility.
 	// This in turn helps ensure a minimum level of spreading.
 	minFeasibleNodesPercentageToFind = 5
+	// noteLengthLimit is a local copy of NoteLengthLimit in k8s.io/kubernetes/pkg/apis/core/validation, which the API
+	// server enforces on notes the scheduler records. A local copy is safe because API validation limits will never
+	// become lower than an already released version.
+	noteLengthLimit = 1024
 )
 
 // ScheduleOne does the entire scheduling workflow for a single scheduling entity (either a pod or a pod group).
@@ -845,14 +848,13 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk fram
 	}
 }
 
-// truncateMessage truncates a message if it hits the NoteLengthLimit.
+// truncateMessage truncates a message if it hits the noteLengthLimit.
 func truncateMessage(message string) string {
-	max := validation.NoteLengthLimit
-	if len(message) <= max {
+	if len(message) <= noteLengthLimit {
 		return message
 	}
 	suffix := " ..."
-	return message[:max-len(suffix)] + suffix
+	return message[:noteLengthLimit-len(suffix)] + suffix
 }
 
 func updatePod(ctx context.Context, client clientset.Interface, apiCacher fwk.APICacher, pod *v1.Pod, condition *v1.PodCondition, nominatingInfo *fwk.NominatingInfo) error {


### PR DESCRIPTION
pkg/scheduler only uses k8s.io/kubernetes/pkg/apis/core/validation for NoteLengthLimit, for which a local copy remains safe even if stale.

Part of removal of k/k imports in pkg/scheduler to support move to staging.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Removes the `k8s.io/kubernetes/pkg/apis/core/validation` dependency in `pkg/scheduler`. The only usage was that of a const `NoteLengthLimit`. This replaces it with a local const, which is safe as validation can only tighten compared to a released version, so the value will never become invalid, even if stale.

Part of #141411 which requires there be no `k8s.io/kubernetes` dependencies from `pkg/scheduler`.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes #141410.

#### Special notes for your reviewer:

Depends on #141415. Once merged, will rebase and add removal of the `pkg/apis/core/validation` entry from `pkg/scheduler/.import-restrictions`. Holding until then.
/hold

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```