### PR TITLE
Extend integration tests coverage for the CompositePodGroup API

### DIFF
--- a/test/integration/scheduler/podgroup/cpg_test.go
+++ b/test/integration/scheduler/podgroup/cpg_test.go
@@ -25,6 +25,7 @@ import (
 	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
@@ -37,11 +38,11 @@ import (
 // _ to avoid unused import
 var _ = time.Second
 
-func makeTestPods(pgName string, reqCPUs ...string) []*v1.Pod {
+func makeTestPodsWithPriority(pgName string, priority int32, reqCPUs ...string) []*v1.Pod {
 	var pods []*v1.Pod
 	for i, cpu := range reqCPUs {
 		pod := st.MakePod().Name(fmt.Sprintf("%s-pod-%d", pgName, i)).
-			PodGroupName(pgName).Priority(100).Obj()
+			PodGroupName(pgName).Priority(priority).Obj()
 
 		pod.Spec.Containers = []v1.Container{{
 			Name:  "container",
@@ -56,6 +57,10 @@ func makeTestPods(pgName string, reqCPUs ...string) []*v1.Pod {
 		pods = append(pods, pod)
 	}
 	return pods
+}
+
+func makeTestPods(pgName string, reqCPUs ...string) []*v1.Pod {
+	return makeTestPodsWithPriority(pgName, 100, reqCPUs...)
 }
 
 func concatPods(podSlices ...[]*v1.Pod) []*v1.Pod {
@@ -634,6 +639,234 @@ func TestCPGScheduling(t *testing.T) {
 						makeTestPods("sub-pg1", "1", "1"),
 						makeTestPods("sub-pg2", "1", "1"),
 					)),
+				},
+			},
+		},
+		{
+			name: "TestCPGAtomicCacheRollbackOnGangQuorumFailure",
+			// TestCPGAtomicCacheRollbackOnGangQuorumFailure verifies that when a Gang CompositePodGroup
+			// fails to satisfy its minGroupCount quorum across multiple subtrees, all tentative
+			// in-memory assumptions made in the scheduler cache are cleanly rolled back, allowing
+			// subsequent workloads to claim the resources on those nodes immediately.
+			//
+			// Setup:
+			//   node1: 2 CPU
+			//   node2: 1 CPU
+			//
+			// CPG Tree:
+			//   cpg-root (Gang, MinGroup: 2)
+			//    /        \
+			//   pg1       pg2
+			// (needs 2) (needs 2)
+			//
+			// pg1 fits on node1, but pg2 fails on node2. Quorum of 2 groups is unmet.
+			// Tentative assumption of pg1 on node1 must be rolled back.
+			// A standalone pod requiring 2 CPU should then successfully schedule on node1.
+			steps: []stepsframework.Step{
+				{
+					Name: "Create Nodes",
+					CreateNodes: []*v1.Node{
+						st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Obj(),
+						st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+					},
+				},
+				{
+					Name: "Create Workload",
+					CreateWorkloads: []*schedulingapi.Workload{
+						st.MakeWorkload().Name("workload-cpg-rollback").
+							Children(
+								st.MakeCompositePodGroupTemplate().Name("root-t").MinGroupCount(2).Priority(100).Children(
+									st.MakePodGroupTemplate().Name("gang-t").MinCount(2).Priority(100),
+								),
+							).Obj(),
+					},
+				},
+				{
+					Name:                    "Create root CPG",
+					CreateCompositePodGroup: st.MakeCompositePodGroup().Name("cpg-root").WorkloadRef("workload-cpg-rollback", "root-t").MinGroupCount(2).Priority(100).Obj(),
+				},
+				{
+					Name:           "Create pg1",
+					CreatePodGroup: st.MakePodGroup().Name("pg1").WorkloadRef("workload-cpg-rollback", "gang-t").ParentCompositePodGroup("cpg-root").Priority(100).MinCount(2).Obj(),
+				},
+				{
+					Name:           "Create pg2",
+					CreatePodGroup: st.MakePodGroup().Name("pg2").WorkloadRef("workload-cpg-rollback", "gang-t").ParentCompositePodGroup("cpg-root").Priority(100).MinCount(2).Obj(),
+				},
+				{
+					Name: "Create pods for both groups",
+					CreatePods: concatPods(
+						makeTestPods("pg1", "1", "1"),
+						makeTestPods("pg2", "1", "1"),
+					),
+				},
+				{
+					Name: "Verify all CPG pods remain unschedulable due to unmet root gang quorum",
+					WaitForPodsUnschedulable: podNames(concatPods(
+						makeTestPods("pg1", "1", "1"),
+						makeTestPods("pg2", "1", "1"),
+					)),
+				},
+				{
+					Name: "Create standalone pod requiring all 2 CPU on node1",
+					CreatePods: []*v1.Pod{
+						st.MakePod().Name("standalone-pod").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").Obj(),
+					},
+				},
+				{
+					Name:                 "Verify standalone pod schedules on node1, confirming cache rollback",
+					WaitForPodsScheduled: []string{"standalone-pod"},
+				},
+				{
+					Name: "Verify standalone pod is assigned to node1",
+					VerifyAssignments: &stepsframework.VerifyAssignments{
+						Pods:  []string{"standalone-pod"},
+						Nodes: sets.New("node1"),
+					},
+				},
+			},
+		},
+		{
+			name: "TestCPGHierarchyValidationMismatchedPriority",
+			// TestCPGHierarchyValidationMismatchedPriority verifies that when a pod in a child
+			// PodGroup has a priority that does not match the root CompositePodGroup, the
+			// scheduler validation detects the mismatch and rejects the scheduling attempt.
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create Node",
+					CreateNodes: []*v1.Node{st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "20"}).Obj()},
+				},
+				{
+					Name: "Create Workload",
+					CreateWorkloads: []*schedulingapi.Workload{
+						st.MakeWorkload().Name("workload-cpg-mismatched-prio").
+							Children(
+								st.MakeCompositePodGroupTemplate().Name("root-t").BasicPolicy().Priority(100).Children(
+									st.MakePodGroupTemplate().Name("basic-t1").BasicPolicy().Priority(100),
+									st.MakePodGroupTemplate().Name("basic-t2").BasicPolicy().Priority(100),
+								),
+							).Obj(),
+					},
+				},
+				{
+					Name:                    "Create root CPG with Priority 100",
+					CreateCompositePodGroup: st.MakeCompositePodGroup().Name("cpg-root").WorkloadRef("workload-cpg-mismatched-prio", "root-t").BasicPolicy().Priority(100).Obj(),
+				},
+				{
+					Name:           "Create pg1 with Priority 100",
+					CreatePodGroup: st.MakePodGroup().Name("pg1").WorkloadRef("workload-cpg-mismatched-prio", "basic-t1").ParentCompositePodGroup("cpg-root").Priority(100).BasicPolicy().Obj(),
+				},
+				{
+					Name:           "Create pg2 with Priority 100",
+					CreatePodGroup: st.MakePodGroup().Name("pg2").WorkloadRef("workload-cpg-mismatched-prio", "basic-t2").ParentCompositePodGroup("cpg-root").Priority(100).BasicPolicy().Obj(),
+				},
+				{
+					Name: "Create pods with priority 50 (mismatched with root CPG priority 100)",
+					CreatePods: concatPods(
+						makeTestPodsWithPriority("pg1", 50, "1", "1"),
+						makeTestPodsWithPriority("pg2", 50, "1", "1"),
+					),
+				},
+				{
+					Name:                       "Verify pods get scheduling error due to priority validation rejection",
+					WaitForPodsSchedulingError: []string{"pg1-pod-0", "pg1-pod-1", "pg2-pod-0", "pg2-pod-1"},
+				},
+			},
+		},
+		{
+			name: "TestCPG3LevelMixedGangAndBasicSubtrees",
+			// TestCPG3LevelMixedGangAndBasicSubtrees tests a 3-level hierarchy with a Basic root CPG,
+			// one Gang intermediate CPG (minGroupCount=2 with 2 Gang child PGs), and one Basic
+			// intermediate CPG (with 2 Basic child PGs).
+			//
+			// Tree structure:
+			//
+			//	                    cpg-root (Basic)
+			//	            /                              \
+			//	   cpg-gang-mid (Gang, Min: 2)       cpg-basic-mid (Basic)
+			//	   /                       \          /                 \
+			//	 pg-g1                   pg-g2      pg-b1             pg-b2
+			//	  (F)                     (F)        (S)               (S)
+			//
+			// [Gang, Min: 2]       [Gang, Min: 2]     [Basic]           [Basic]
+			// (needs 2 CPU)        (needs 2 CPU)      (needs 1 CPU)     (needs 1 CPU)
+			//
+			// (S) = Success (scheduled on node1)
+			// (F) = Fail (unschedulable due to gang quorum failure)
+			//
+			// Cluster capacity fits the Basic branch (2 CPU) but cannot satisfy the Gang branch quorum (4 CPU).
+			// The scheduler rolls back tentative placements for the Gang branch and successfully schedules
+			// the Basic branch.
+			steps: []stepsframework.Step{
+				{
+					Name: "Create nodes with total capacity 3 CPU",
+					CreateNodes: []*v1.Node{
+						st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Obj(),
+						st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj(),
+					},
+				},
+				{
+					Name: "Create Workload with mixed Gang and Basic subtrees",
+					CreateWorkloads: []*schedulingapi.Workload{
+						st.MakeWorkload().Name("workload-mixed-subtrees").
+							Children(
+								st.MakeCompositePodGroupTemplate().Name("root-t").BasicPolicy().Priority(100).Children(
+									st.MakeCompositePodGroupTemplate().Name("gang-mid-t").MinGroupCount(2).Priority(100).Children(
+										st.MakePodGroupTemplate().Name("gang-t1").MinCount(2).Priority(100),
+										st.MakePodGroupTemplate().Name("gang-t2").MinCount(2).Priority(100),
+									),
+									st.MakeCompositePodGroupTemplate().Name("basic-mid-t").BasicPolicy().Priority(100).Children(
+										st.MakePodGroupTemplate().Name("basic-t1").BasicPolicy().Priority(100),
+										st.MakePodGroupTemplate().Name("basic-t2").BasicPolicy().Priority(100),
+									),
+								),
+							).Obj(),
+					},
+				},
+				{
+					Name:                    "Create root CPG (Basic)",
+					CreateCompositePodGroup: st.MakeCompositePodGroup().Name("cpg-root").WorkloadRef("workload-mixed-subtrees", "root-t").BasicPolicy().Priority(100).Obj(),
+				},
+				{
+					Name:                    "Create gang intermediate CPG",
+					CreateCompositePodGroup: st.MakeCompositePodGroup().Name("cpg-gang-mid").WorkloadRef("workload-mixed-subtrees", "gang-mid-t").ParentCompositePodGroup("cpg-root").MinGroupCount(2).Priority(100).Obj(),
+				},
+				{
+					Name:                    "Create basic intermediate CPG",
+					CreateCompositePodGroup: st.MakeCompositePodGroup().Name("cpg-basic-mid").WorkloadRef("workload-mixed-subtrees", "basic-mid-t").ParentCompositePodGroup("cpg-root").BasicPolicy().Priority(100).Obj(),
+				},
+				{
+					Name:           "Create gang leaf pg-g1",
+					CreatePodGroup: st.MakePodGroup().Name("pg-g1").WorkloadRef("workload-mixed-subtrees", "gang-t1").ParentCompositePodGroup("cpg-gang-mid").MinCount(2).Priority(100).Obj(),
+				},
+				{
+					Name:           "Create gang leaf pg-g2",
+					CreatePodGroup: st.MakePodGroup().Name("pg-g2").WorkloadRef("workload-mixed-subtrees", "gang-t2").ParentCompositePodGroup("cpg-gang-mid").MinCount(2).Priority(100).Obj(),
+				},
+				{
+					Name:           "Create basic leaf pg-b1",
+					CreatePodGroup: st.MakePodGroup().Name("pg-b1").WorkloadRef("workload-mixed-subtrees", "basic-t1").ParentCompositePodGroup("cpg-basic-mid").BasicPolicy().Priority(100).Obj(),
+				},
+				{
+					Name:           "Create basic leaf pg-b2",
+					CreatePodGroup: st.MakePodGroup().Name("pg-b2").WorkloadRef("workload-mixed-subtrees", "basic-t2").ParentCompositePodGroup("cpg-basic-mid").BasicPolicy().Priority(100).Obj(),
+				},
+				{
+					Name: "Create pods: gang pods need 4 CPU total (exceeds cluster capacity 3 CPU), basic pods need 2 CPU total (fits on node1)",
+					CreatePods: concatPods(
+						makeTestPods("pg-g1", "1", "1"),
+						makeTestPods("pg-g2", "1", "1"),
+						makeTestPods("pg-b1", "1"),
+						makeTestPods("pg-b2", "1"),
+					),
+				},
+				{
+					Name:                 "Verify Basic subtree pods are scheduled successfully",
+					WaitForPodsScheduled: []string{"pg-b1-pod-0", "pg-b2-pod-0"},
+				},
+				{
+					Name:                     "Verify Gang subtree pods remain unschedulable due to quorum failure",
+					WaitForPodsUnschedulable: []string{"pg-g1-pod-0", "pg-g1-pod-1", "pg-g2-pod-0", "pg-g2-pod-1"},
 				},
 			},
 		},

--- a/test/integration/scheduler/podgroup/queueing_test.go
+++ b/test/integration/scheduler/podgroup/queueing_test.go
@@ -43,10 +43,31 @@ func TestCPGQueueing(t *testing.T) {
 	pg2_1 := st.MakePodGroup().Name("pg2-1").WorkloadRef("w2", "pg-t2-1").MinCount(2).ParentCompositePodGroup("cpg-root2").Obj()
 	pg2_2 := st.MakePodGroup().Name("pg2-2").WorkloadRef("w2", "pg-t2-2").MinCount(2).ParentCompositePodGroup("cpg-root2").Obj()
 
+	taintedNode := st.MakeNode().Name("tainted-node").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "8"}).Taints([]v1.Taint{{Key: "dedicated", Value: "special", Effect: v1.TaintEffectNoSchedule}}).Obj()
+
 	p2_1 := st.MakePod().Name("p2-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg2-1").Obj()
 	p2_2 := st.MakePod().Name("p2-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg2-1").Obj()
 	p2_3 := st.MakePod().Name("p2-3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg2-2").Obj()
 	p2_4 := st.MakePod().Name("p2-4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg2-2").Obj()
+
+	blockingPod := st.MakePod().Name("blocking-pod").Req(map[v1.ResourceName]string{v1.ResourceCPU: "8"}).Container("image").Obj()
+
+	cpgRoot3 := st.MakeCompositePodGroup().Name("cpg-root3").WorkloadRef("w3", "cpg-t3").MinGroupCount(3).Obj()
+	pg3_1 := st.MakePodGroup().Name("pg3-1").WorkloadRef("w3", "pg-t3-1").MinCount(2).ParentCompositePodGroup("cpg-root3").Obj()
+	pg3_2 := st.MakePodGroup().Name("pg3-2").WorkloadRef("w3", "pg-t3-2").MinCount(2).ParentCompositePodGroup("cpg-root3").Obj()
+	pg3_3 := st.MakePodGroup().Name("pg3-3").WorkloadRef("w3", "pg-t3-3").MinCount(2).ParentCompositePodGroup("cpg-root3").Obj()
+	pg3_4 := st.MakePodGroup().Name("pg3-4").WorkloadRef("w3", "pg-t3-4").MinCount(2).ParentCompositePodGroup("cpg-root3").Obj()
+	p3_1 := st.MakePod().Name("p3-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg3-1").Obj()
+	p3_2 := st.MakePod().Name("p3-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg3-1").Obj()
+	p3_3 := st.MakePod().Name("p3-3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg3-2").Obj()
+	p3_4 := st.MakePod().Name("p3-4").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg3-2").Obj()
+	p3_5 := st.MakePod().Name("p3-5").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg3-3").Obj()
+	p3_6 := st.MakePod().Name("p3-6").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg3-3").Obj()
+	p3_7 := st.MakePod().Name("p3-7").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg3-4").Obj()
+	p3_8 := st.MakePod().Name("p3-8").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg3-4").Obj()
+
+	// cpgRootCyclic forms a dependency cycle with cpgMid (cpg-root -> cpg-mid -> cpg-root) to test hierarchy loop detection.
+	cpgRootCyclic := st.MakeCompositePodGroup().Name("cpg-root").WorkloadRef("w1", "cpg-t").MinGroupCount(1).ParentCompositePodGroup("cpg-mid").Obj()
 
 	tests := []struct {
 		name  string
@@ -226,6 +247,330 @@ func TestCPGQueueing(t *testing.T) {
 				{
 					Name:                 "Verify pod gets scheduled after PodGroup MinCount is reduced",
 					WaitForPodsScheduled: []string{"p1"},
+				},
+			},
+		},
+		{
+			name: "Node update (taint removal) triggers queueing hint for complete CPG tree from unschedulableQ",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create initial tainted node",
+					CreateNodes: []*v1.Node{taintedNode},
+				},
+				{
+					Name:                    "Create root CPG",
+					CreateCompositePodGroup: cpgRoot,
+				},
+				{
+					Name:                    "Create intermediate CPG",
+					CreateCompositePodGroup: cpgMid,
+				},
+				{
+					Name:           "Create PodGroup",
+					CreatePodGroup: pg1,
+				},
+				{
+					Name:       "Create member pods while node is tainted",
+					CreatePods: []*v1.Pod{p1, p2},
+				},
+				{
+					Name:                     "Verify pods are unschedulable (taint mismatch) and move to unschedulableQ",
+					WaitForPodsUnschedulable: []string{"p1", "p2"},
+				},
+				{
+					Name: "Remove taint from node",
+					UpdateNode: &stepsframework.UpdateNode{
+						NodeName: "tainted-node",
+						ModifyFn: func(n *v1.Node) {
+							n.Spec.Taints = nil
+						},
+					},
+				},
+				{
+					Name:                 "Verify pods get scheduled successfully after taint is removed",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+			},
+		},
+		{
+			name: "Intermediate CPG creation triggers queueing hint for incomplete CPG hierarchy",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create initial node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                    "Create root CPG",
+					CreateCompositePodGroup: cpgRoot,
+				},
+				{
+					Name:           "Create leaf PodGroup referencing missing intermediate CPG",
+					CreatePodGroup: pg1,
+				},
+				{
+					Name:       "Create member pods",
+					CreatePods: []*v1.Pod{p1, p2},
+				},
+				{
+					Name:                                "Verify pods are buffered in incompletePodGroupPods due to missing intermediate CPG",
+					WaitForPodsInIncompletePodGroupPods: []string{"p1", "p2"},
+				},
+				{
+					Name:                    "Create the missing intermediate CPG",
+					CreateCompositePodGroup: cpgMid,
+				},
+				{
+					Name:                 "Verify pods get scheduled successfully after intermediate CPG completes the tree",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+			},
+		},
+		{
+			name: "Pod deletion triggers queueing hint for complete CPG tree from unschedulableQ",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create initial node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:       "Create blocking pod consuming entire node capacity",
+					CreatePods: []*v1.Pod{blockingPod},
+				},
+				{
+					Name:                 "Wait for blocking pod to be scheduled",
+					WaitForPodsScheduled: []string{"blocking-pod"},
+				},
+				{
+					Name:                    "Create root CPG",
+					CreateCompositePodGroup: cpgRoot2,
+				},
+				{
+					Name:           "Create first leaf PodGroup",
+					CreatePodGroup: pg2_1,
+				},
+				{
+					Name:           "Create second leaf PodGroup",
+					CreatePodGroup: pg2_2,
+				},
+				{
+					Name:       "Create member pods for CPG tree",
+					CreatePods: []*v1.Pod{p2_1, p2_2, p2_3, p2_4},
+				},
+				{
+					Name:                     "Verify CPG member pods are unschedulable due to saturated node",
+					WaitForPodsUnschedulable: []string{"p2-1", "p2-2", "p2-3", "p2-4"},
+				},
+				{
+					Name:       "Delete blocking pod to free node capacity",
+					DeletePods: []string{"blocking-pod"},
+				},
+				{
+					Name:                 "Verify CPG member pods are scheduled after blocking pod deletion",
+					WaitForPodsScheduled: []string{"p2-1", "p2-2", "p2-3", "p2-4"},
+				},
+			},
+		},
+		{
+			name: "Intermediate CPG deletion transitions child pods to incompletePodGroupPods",
+			steps: []stepsframework.Step{
+				{
+					Name:                    "Create root CPG",
+					CreateCompositePodGroup: cpgRoot,
+				},
+				{
+					Name:                    "Create intermediate CPG",
+					CreateCompositePodGroup: cpgMid,
+				},
+				{
+					Name:           "Create leaf PodGroup",
+					CreatePodGroup: pg1,
+				},
+				{
+					Name:       "Create member pods",
+					CreatePods: []*v1.Pod{p1, p2},
+				},
+				{
+					Name:                 "Verify pods are in activeQ",
+					WaitForPodsInActiveQ: []string{"p1", "p2"},
+				},
+				{
+					Name:                    "Delete intermediate CPG",
+					DeleteCompositePodGroup: "cpg-mid",
+				},
+				{
+					Name:                                "Verify pods transition to incompletePodGroupPods due to broken hierarchy",
+					WaitForPodsInIncompletePodGroupPods: []string{"p1", "p2"},
+				},
+				{
+					Name:                    "Re-create intermediate CPG",
+					CreateCompositePodGroup: cpgMid,
+				},
+				{
+					Name:                 "Verify pods transition back to activeQ",
+					WaitForPodsInActiveQ: []string{"p1", "p2"},
+				},
+				{
+					Name:        "Create node to allow scheduling",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                 "Verify pods are scheduled",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+			},
+		},
+		{
+			name: "Root CPG deletion transitions descendant pods from unschedulableQ to incompletePodGroupPods",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                    "Create root CPG requiring 2 child groups",
+					CreateCompositePodGroup: cpgRoot2,
+				},
+				{
+					Name:           "Create first leaf PodGroup",
+					CreatePodGroup: pg2_1,
+				},
+				{
+					Name:       "Create pods for first leaf group",
+					CreatePods: []*v1.Pod{p2_1, p2_2},
+				},
+				{
+					Name:                               "Verify pods are in unschedulableEntities because root CPG requires 2 groups",
+					WaitForPodsInUnschedulableEntities: []string{"p2-1", "p2-2"},
+				},
+				{
+					Name:                    "Delete root CPG",
+					DeleteCompositePodGroup: "cpg-root2",
+				},
+				{
+					Name:                                "Verify pods transition to incompletePodGroupPods after root CPG deletion",
+					WaitForPodsInIncompletePodGroupPods: []string{"p2-1", "p2-2"},
+				},
+				{
+					Name:                    "Re-create root CPG",
+					CreateCompositePodGroup: cpgRoot2,
+				},
+				{
+					Name:                               "Verify pods transition back to unschedulableEntities as tree is restored",
+					WaitForPodsInUnschedulableEntities: []string{"p2-1", "p2-2"},
+				},
+				{
+					Name:           "Create second leaf PodGroup under root CPG",
+					CreatePodGroup: pg2_2,
+				},
+				{
+					Name:       "Create pods for second leaf group, satisfying quorum",
+					CreatePods: []*v1.Pod{p2_3, p2_4},
+				},
+				{
+					Name:                 "Verify all pods are scheduled after quorum is satisfied",
+					WaitForPodsScheduled: []string{"p2-1", "p2-2", "p2-3", "p2-4"},
+				},
+			},
+		},
+		{
+			name: "Leaf PodGroup deletion in multi-branch CPG preserves sibling subtree in unschedulableQ",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                    "Create root CPG requiring 3 child groups",
+					CreateCompositePodGroup: cpgRoot3,
+				},
+				{
+					Name:           "Create first leaf PodGroup",
+					CreatePodGroup: pg3_1,
+				},
+				{
+					Name:           "Create second leaf PodGroup",
+					CreatePodGroup: pg3_2,
+				},
+				{
+					Name:       "Create pods for first two leaf groups",
+					CreatePods: []*v1.Pod{p3_1, p3_2, p3_3, p3_4},
+				},
+				{
+					Name:                               "Verify all pods are in unschedulableEntities because root CPG requires 3 groups",
+					WaitForPodsInUnschedulableEntities: []string{"p3-1", "p3-2", "p3-3", "p3-4"},
+				},
+				{
+					Name:           "Delete first leaf PodGroup",
+					DeletePodGroup: "pg3-1",
+				},
+				{
+					Name:                                "Verify deleted group pods transition to incompletePodGroupPods",
+					WaitForPodsInIncompletePodGroupPods: []string{"p3-1", "p3-2"},
+				},
+				{
+					Name:                               "Verify sibling group pods remain in unschedulableEntities",
+					WaitForPodsInUnschedulableEntities: []string{"p3-3", "p3-4"},
+				},
+				{
+					Name:           "Create third leaf PodGroup",
+					CreatePodGroup: pg3_3,
+				},
+				{
+					Name:       "Create pods for third leaf group",
+					CreatePods: []*v1.Pod{p3_5, p3_6},
+				},
+				{
+					Name:           "Create fourth leaf PodGroup",
+					CreatePodGroup: pg3_4,
+				},
+				{
+					Name:       "Create pods for fourth leaf group, completing 3 groups under root CPG",
+					CreatePods: []*v1.Pod{p3_7, p3_8},
+				},
+				{
+					Name:                 "Verify remaining groups are scheduled after quorum of 3 is satisfied",
+					WaitForPodsScheduled: []string{"p3-3", "p3-4", "p3-5", "p3-6", "p3-7", "p3-8"},
+				},
+			},
+		},
+		{
+			name: "Cyclic CPG hierarchy loop protection buffers pods in incompletePodGroupPods until cycle is broken",
+			steps: []stepsframework.Step{
+				{
+					Name:        "Create node",
+					CreateNodes: []*v1.Node{node},
+				},
+				{
+					Name:                    "Create CPG mid referencing root CPG",
+					CreateCompositePodGroup: cpgMid,
+				},
+				{
+					Name:                    "Create root CPG referencing mid CPG (forming cyclic dependency)",
+					CreateCompositePodGroup: cpgRootCyclic,
+				},
+				{
+					Name:           "Create leaf PodGroup referencing mid CPG",
+					CreatePodGroup: pg1,
+				},
+				{
+					Name:       "Create member pods",
+					CreatePods: []*v1.Pod{p1, p2},
+				},
+				{
+					Name:                                "Verify pods are held in incompletePodGroupPods due to detected cyclic hierarchy",
+					WaitForPodsInIncompletePodGroupPods: []string{"p1", "p2"},
+				},
+				{
+					Name:                    "Delete cyclic root CPG",
+					DeleteCompositePodGroup: "cpg-root",
+				},
+				{
+					Name:                    "Re-create root CPG without parent, establishing it as legitimate root CPG",
+					CreateCompositePodGroup: cpgRoot,
+				},
+				{
+					Name:                 "Verify pods are scheduled after cycle is broken and hierarchy is resolved",
+					WaitForPodsScheduled: []string{"p1", "p2"},
 				},
 			},
 		},

--- a/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
+++ b/test/integration/scheduler/podgroup/stepsframework/stepsframework.go
@@ -70,6 +70,11 @@ type UpdatePod struct {
 	ModifyFn func(*v1.Pod)
 }
 
+type UpdateNode struct {
+	NodeName string
+	ModifyFn func(*v1.Node)
+}
+
 // Step is allowing us to create a test in a more readable way.
 // We can create test as a flow of steps, each step is an operation that will be performed on the cluster.
 // Every Step should have a Name, that is used to identify the step and one operation.
@@ -145,6 +150,8 @@ type Step struct {
 	CreateCompositePodGroup *schedulingv1alpha3.CompositePodGroup
 	// UpdateCompositePodGroup is used to update an existing composite pod group and wait for it to propagate.
 	UpdateCompositePodGroup *schedulingv1alpha3.CompositePodGroup
+	// DeleteCompositePodGroup is used to delete a composite pod group by name and wait for it to propagate.
+	DeleteCompositePodGroup string
 	// CreatePods is use to create pods in the cluster.
 	CreatePods []*v1.Pod
 	// CreatePodsInOrder is use to create pods in the cluster and have them enqueued by the scheduler in the specified order.
@@ -163,6 +170,8 @@ type Step struct {
 	// queue-level barrier so a following step can rely on the scheduler reading
 	// the nominated node during the placement cycle.
 	WaitForPodsNominated map[string]string
+	// UpdateNode is used to mutate any field of the node.
+	UpdateNode *UpdateNode
 	// WaitForPodsInActiveQ is used to check if the pods are present in ActiveQ.
 	WaitForPodsInActiveQ []string
 	// WaitForPodsInUnschedulableEntities is use to wait for pods to be in unschedulableEntities.
@@ -436,6 +445,36 @@ func deletePodGroup(testCtx *testutils.TestContext, ns string, pgName string) er
 	return nil
 }
 
+func deleteCompositePodGroup(testCtx *testutils.TestContext, ns string, cpgName string) error {
+	cs := testCtx.ClientSet
+	cpg, err := cs.SchedulingV1alpha3().CompositePodGroups(ns).Get(testCtx.Ctx, cpgName, metav1.GetOptions{})
+	if err == nil && len(cpg.Finalizers) > 0 {
+		cpg.Finalizers = nil
+		if _, err = cs.SchedulingV1alpha3().CompositePodGroups(ns).Update(testCtx.Ctx, cpg, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to clear finalizers of composite pod group %s: %w", cpgName, err)
+		}
+	}
+	if err := cs.SchedulingV1alpha3().CompositePodGroups(ns).Delete(testCtx.Ctx, cpgName, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("failed to delete composite pod group %s: %w", cpgName, err)
+	}
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+		func(_ context.Context) (bool, error) {
+			_, err := testCtx.InformerFactory.Scheduling().V1alpha3().CompositePodGroups().Lister().CompositePodGroups(ns).Get(cpgName)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return true, nil
+				}
+				return false, err
+			}
+			return false, nil
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to wait for composite pod group %s deletion to propagate: %w", cpgName, err)
+	}
+	return nil
+}
+
 func createWorkloads(testCtx *testutils.TestContext, ns string, wls []*schedulingapi.Workload) error {
 	cs := testCtx.ClientSet
 	for _, wl := range wls {
@@ -451,8 +490,25 @@ func createWorkloads(testCtx *testutils.TestContext, ns string, wls []*schedulin
 func deletePods(testCtx *testutils.TestContext, ns string, podNames []string) error {
 	cs := testCtx.ClientSet
 	for _, podName := range podNames {
-		if err := cs.CoreV1().Pods(ns).Delete(testCtx.Ctx, podName, metav1.DeleteOptions{}); err != nil {
+		if err := cs.CoreV1().Pods(ns).Delete(testCtx.Ctx, podName, metav1.DeleteOptions{GracePeriodSeconds: new(int64)}); err != nil {
 			return fmt.Errorf("failed to delete pod %s: %w", podName, err)
+		}
+	}
+	for _, podName := range podNames {
+		err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, wait.ForeverTestTimeout, false,
+			func(_ context.Context) (bool, error) {
+				_, err := testCtx.InformerFactory.Core().V1().Pods().Lister().Pods(ns).Get(podName)
+				if err != nil {
+					if apierrors.IsNotFound(err) {
+						return true, nil
+					}
+					return false, err
+				}
+				return false, nil
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to wait for pod %s deletion to propagate: %w", podName, err)
 		}
 	}
 	return nil
@@ -507,6 +563,20 @@ func waitForPodsNominated(testCtx *testutils.TestContext, nominated map[string]s
 		})
 	if err != nil {
 		return fmt.Errorf("failed to wait for pods %v to be nominated in the scheduling queue: %w", nominated, err)
+	}
+	return nil
+}
+
+func updateNode(testCtx *testutils.TestContext, update *UpdateNode) error {
+	cs := testCtx.ClientSet
+	node, err := cs.CoreV1().Nodes().Get(testCtx.Ctx, update.NodeName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get node %s for update: %w", update.NodeName, err)
+	}
+	update.ModifyFn(node)
+	_, err = cs.CoreV1().Nodes().Update(testCtx.Ctx, node, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to update node %s: %w", update.NodeName, err)
 	}
 	return nil
 }
@@ -731,6 +801,8 @@ func RunSteps(testCtx *testutils.TestContext, t *testing.T, ns string, steps []S
 			err = createCompositePodGroup(testCtx, ns, step.CreateCompositePodGroup)
 		case step.UpdateCompositePodGroup != nil:
 			err = updateCompositePodGroup(testCtx, ns, step.UpdateCompositePodGroup)
+		case step.DeleteCompositePodGroup != "":
+			err = deleteCompositePodGroup(testCtx, ns, step.DeleteCompositePodGroup)
 		case step.CreatePodGroup != nil:
 			err = createPodGroup(testCtx, ns, step.CreatePodGroup)
 		case step.UpdatePodGroup != nil:
@@ -747,6 +819,8 @@ func RunSteps(testCtx *testutils.TestContext, t *testing.T, ns string, steps []S
 			err = updatePodStatus(testCtx, ns, step.UpdatePodStatus)
 		case step.WaitForPodsNominated != nil:
 			err = waitForPodsNominated(testCtx, step.WaitForPodsNominated)
+		case step.UpdateNode != nil:
+			err = updateNode(testCtx, step.UpdateNode)
 		case step.WaitForPodsInActiveQ != nil:
 			err = waitForPodsInActiveQ(testCtx, step.WaitForPodsInActiveQ)
 		case step.WaitForPodsInUnschedulableEntities != nil:

--- a/test/integration/scheduler/podgroup/topology_aware_scheduling/cpg_tas_test.go
+++ b/test/integration/scheduler/podgroup/topology_aware_scheduling/cpg_tas_test.go
@@ -938,6 +938,452 @@ func TestCPGTopologyAwareScheduling(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "CPG schedules on a single rack, choosing placement with highest allocation percentage (NodeResourcesFit placement scoring)",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create nodes in two racks, each rack with 4 CPU capacity",
+					CreateNodes: []*v1.Node{
+						makeNode("node1-z1-r1", "rack-1", "zone-1"),
+						makeNode("node2-z1-r1", "rack-1", "zone-1"),
+						makeNode("node3-z1-r2", "rack-2", "zone-1"),
+						makeNode("node4-z1-r2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					Name: "Create a preexisting pod consuming 1 CPU on rack-1 leaving 3 CPU free",
+					CreatePods: []*v1.Pod{
+						makeAssignedPod("existing", "node1-z1-r1", "1"),
+					},
+				},
+				{
+					Name:                    "Create root CompositePodGroup (Gang minGroupCount=2, TopologyKey=rack)",
+					CreateCompositePodGroup: makeGangCompositePodGroup("cpg-root", "", "rack", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg1 (Gang minCount=1, Parent=cpg-root)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg1", "cpg-root", "", 1),
+				},
+				{
+					Name:           "Create child PodGroup pg2 (Gang minCount=2, Parent=cpg-root)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg2", "cpg-root", "", 2),
+				},
+				{
+					Name: "Create pods for pg1 (1 pod) and pg2 (2 pods), requiring 3 CPU total",
+					CreatePods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg2"),
+						makePod("p3", "pg2"),
+					},
+				},
+				{
+					Name:                 "Verify all pods in the composite group are scheduled",
+					WaitForPodsScheduled: []string{"p1", "p2", "p3"},
+				},
+				{
+					Name: "Verify all pods scheduled on rack-1 due to highest allocation percentage scoring",
+					VerifyAssignments: &stepsframework.VerifyAssignments{
+						Pods:  []string{"p1", "p2", "p3"},
+						Nodes: sets.New("node1-z1-r1", "node2-z1-r1"),
+					},
+				},
+			},
+		},
+		{
+			name: "CPG schedules on a single rack, choosing placement that accommodates more descendant pods (PodGroupPodsCount placement scoring)",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create nodes in two racks, each rack with 4 CPU capacity",
+					CreateNodes: []*v1.Node{
+						makeNode("node1-z1-r1", "rack-1", "zone-1"),
+						makeNode("node2-z1-r1", "rack-1", "zone-1"),
+						makeNode("node3-z1-r2", "rack-2", "zone-1"),
+						makeNode("node4-z1-r2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					Name: "Create a preexisting pod consuming 1 CPU on rack-1 leaving only 3 CPU free",
+					CreatePods: []*v1.Pod{
+						makeAssignedPod("existing", "node1-z1-r1", "1"),
+					},
+				},
+				{
+					Name:           "Create child PodGroup pg1 (Gang minCount=2, Parent=cpg-root)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg1", "cpg-root", "", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg2 (Gang minCount=2, Parent=cpg-root)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg2", "cpg-root", "", 2),
+				},
+				{
+					Name: "Create 4 pods across pg1 and pg2 requiring 4 CPU total",
+					CreatePods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg2"),
+						makePod("p4", "pg2"),
+					},
+				},
+				{
+					Name:                    "Create root CompositePodGroup (Gang minGroupCount=1, TopologyKey=rack)",
+					CreateCompositePodGroup: makeGangCompositePodGroup("cpg-root", "", "rack", 1),
+				},
+				{
+					Name:                 "Verify all 4 pods are scheduled",
+					WaitForPodsScheduled: []string{"p1", "p2", "p3", "p4"},
+				},
+				{
+					Name: "Verify all pods scheduled on rack-2 which fits all 4 pods",
+					VerifyAssignments: &stepsframework.VerifyAssignments{
+						Pods:  []string{"p1", "p2", "p3", "p4"},
+						Nodes: sets.New("node3-z1-r2", "node4-z1-r2"),
+					},
+				},
+			},
+		},
+		{
+			name: "CPG with minGroupCount < total children schedules satisfying subset on a single rack",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create nodes in two racks, each rack with 4 CPU capacity",
+					CreateNodes: []*v1.Node{
+						makeNode("node1-z1-r1", "rack-1", "zone-1"),
+						makeNode("node2-z1-r1", "rack-1", "zone-1"),
+						makeNode("node3-z1-r2", "rack-2", "zone-1"),
+						makeNode("node4-z1-r2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					Name: "Occupy rack-2 completely with preexisting pods",
+					CreatePods: []*v1.Pod{
+						makeAssignedPod("existing1", "node3-z1-r2", "2"),
+						makeAssignedPod("existing2", "node4-z1-r2", "2"),
+					},
+				},
+				{
+					Name:                    "Create root CompositePodGroup (Gang minGroupCount=2, TopologyKey=rack)",
+					CreateCompositePodGroup: makeGangCompositePodGroup("cpg-root", "", "rack", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg1 (Gang minCount=2, Parent=cpg-root)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg1", "cpg-root", "", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg2 (Gang minCount=2, Parent=cpg-root)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg2", "cpg-root", "", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg3 (Gang minCount=2, Parent=cpg-root)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg3", "cpg-root", "", 2),
+				},
+				{
+					Name: "Create pods for pg1, pg2, and pg3 (6 pods total)",
+					CreatePods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg2"),
+						makePod("p4", "pg2"),
+						makePod("p5", "pg3"),
+						makePod("p6", "pg3"),
+					},
+				},
+				{
+					Name:                 "Verify pods for pg1 and pg2 are scheduled",
+					WaitForPodsScheduled: []string{"p1", "p2", "p3", "p4"},
+				},
+				{
+					Name:                     "Verify pods for pg3 remain unschedulable",
+					WaitForPodsUnschedulable: []string{"p5", "p6"},
+				},
+				{
+					Name: "Verify scheduled pods are on rack-1",
+					VerifyAssignments: &stepsframework.VerifyAssignments{
+						Pods:  []string{"p1", "p2", "p3", "p4"},
+						Nodes: sets.New("node1-z1-r1", "node2-z1-r1"),
+					},
+				},
+			},
+		},
+		{
+			name: "basic CPG schedules available pods on a single rack and continues scheduling as resources become available",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create nodes in rack-1 with 4 CPU total capacity",
+					CreateNodes: []*v1.Node{
+						makeNode("node1-z1-r1", "rack-1", "zone-1"),
+						makeNode("node2-z1-r1", "rack-1", "zone-1"),
+					},
+				},
+				{
+					Name: "Create a preexisting pod consuming 2 CPU on node1 leaving only 2 CPU on node2",
+					CreatePods: []*v1.Pod{
+						makeAssignedPod("existing", "node1-z1-r1", "2"),
+					},
+				},
+				{
+					Name:                    "Create root CompositePodGroup (Basic policy, TopologyKey=rack)",
+					CreateCompositePodGroup: makeBasicCompositePodGroup("cpg-root", "", "rack"),
+				},
+				{
+					Name:           "Create child PodGroup pg1 (Basic policy, Parent=cpg-root)",
+					CreatePodGroup: makeBasicPodGroupWithParent("pg1", "cpg-root", ""),
+				},
+				{
+					Name:           "Create child PodGroup pg2 (Basic policy, Parent=cpg-root)",
+					CreatePodGroup: makeBasicPodGroupWithParent("pg2", "cpg-root", ""),
+				},
+				{
+					Name: "Create pods for pg1 and pg2 (4 pods total)",
+					CreatePods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg2"),
+						makePod("p4", "pg2"),
+					},
+				},
+				{
+					Name:                 "Verify pods for pg1 are scheduled on the available node",
+					WaitForPodsScheduled: []string{"p1", "p2"},
+				},
+				{
+					Name:                     "Verify pods for pg2 remain unschedulable",
+					WaitForPodsUnschedulable: []string{"p3", "p4"},
+				},
+				{
+					Name:       "Delete the preexisting pod to free up resources on rack-1",
+					DeletePods: []string{"existing"},
+				},
+				{
+					Name:                 "Verify pods for pg2 are now scheduled",
+					WaitForPodsScheduled: []string{"p3", "p4"},
+				},
+				{
+					Name: "Verify all pods across pg1 and pg2 are scheduled on rack-1",
+					VerifyAssignments: &stepsframework.VerifyAssignments{
+						Pods:  []string{"p1", "p2", "p3", "p4"},
+						Nodes: sets.New("node1-z1-r1", "node2-z1-r1"),
+					},
+				},
+			},
+		},
+		{
+			name: "two CPG hierarchies schedule consecutively, each on a separate rack",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create nodes in two racks, each rack with 4 CPU capacity",
+					CreateNodes: []*v1.Node{
+						makeNode("node1-z1-r1", "rack-1", "zone-1"),
+						makeNode("node2-z1-r1", "rack-1", "zone-1"),
+						makeNode("node3-z1-r2", "rack-2", "zone-1"),
+						makeNode("node4-z1-r2", "rack-2", "zone-1"),
+					},
+				},
+				{
+					Name:                    "Create first CompositePodGroup cpg-root1 (Gang minGroupCount=2, TopologyKey=rack)",
+					CreateCompositePodGroup: makeGangCompositePodGroup("cpg-root1", "", "rack", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg1-1 (Gang minCount=2, Parent=cpg-root1)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg1-1", "cpg-root1", "", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg1-2 (Gang minCount=2, Parent=cpg-root1)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg1-2", "cpg-root1", "", 2),
+				},
+				{
+					Name: "Create pods for cpg-root1",
+					CreatePods: []*v1.Pod{
+						makePod("p1-1", "pg1-1"),
+						makePod("p1-2", "pg1-1"),
+						makePod("p1-3", "pg1-2"),
+						makePod("p1-4", "pg1-2"),
+					},
+				},
+				{
+					Name:                 "Verify all pods for cpg-root1 are scheduled",
+					WaitForPodsScheduled: []string{"p1-1", "p1-2", "p1-3", "p1-4"},
+				},
+				{
+					Name: "Verify all pods for cpg-root1 are assigned in a single rack",
+					VerifyAssignedInOneDomain: &stepsframework.VerifyAssignedInOneDomain{
+						Pods:        []string{"p1-1", "p1-2", "p1-3", "p1-4"},
+						TopologyKey: "rack",
+					},
+				},
+				{
+					Name:                    "Create second CompositePodGroup cpg-root2 (Gang minGroupCount=2, TopologyKey=rack)",
+					CreateCompositePodGroup: makeGangCompositePodGroup("cpg-root2", "", "rack", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg2-1 (Gang minCount=2, Parent=cpg-root2)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg2-1", "cpg-root2", "", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg2-2 (Gang minCount=2, Parent=cpg-root2)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg2-2", "cpg-root2", "", 2),
+				},
+				{
+					Name: "Create pods for cpg-root2",
+					CreatePods: []*v1.Pod{
+						makePod("p2-1", "pg2-1"),
+						makePod("p2-2", "pg2-1"),
+						makePod("p2-3", "pg2-2"),
+						makePod("p2-4", "pg2-2"),
+					},
+				},
+				{
+					Name:                 "Verify all pods for cpg-root2 are scheduled",
+					WaitForPodsScheduled: []string{"p2-1", "p2-2", "p2-3", "p2-4"},
+				},
+				{
+					Name: "Verify all pods for cpg-root2 are assigned in a single rack",
+					VerifyAssignedInOneDomain: &stepsframework.VerifyAssignedInOneDomain{
+						Pods:        []string{"p2-1", "p2-2", "p2-3", "p2-4"},
+						TopologyKey: "rack",
+					},
+				},
+			},
+		},
+		{
+			name: "two CPG hierarchies schedule consecutively, second remains pending when no additional rack is available",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create nodes in a single rack with 4 CPU capacity",
+					CreateNodes: []*v1.Node{
+						makeNode("node1-z1-r1", "rack-1", "zone-1"),
+						makeNode("node2-z1-r1", "rack-1", "zone-1"),
+					},
+				},
+				{
+					Name:                    "Create first CompositePodGroup cpg-root1 (Gang minGroupCount=2, TopologyKey=rack)",
+					CreateCompositePodGroup: makeGangCompositePodGroup("cpg-root1", "", "rack", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg1-1 (Gang minCount=2, Parent=cpg-root1)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg1-1", "cpg-root1", "", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg1-2 (Gang minCount=2, Parent=cpg-root1)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg1-2", "cpg-root1", "", 2),
+				},
+				{
+					Name: "Create pods for cpg-root1",
+					CreatePods: []*v1.Pod{
+						makePod("p1-1", "pg1-1"),
+						makePod("p1-2", "pg1-1"),
+						makePod("p1-3", "pg1-2"),
+						makePod("p1-4", "pg1-2"),
+					},
+				},
+				{
+					Name:                 "Verify all pods for cpg-root1 are scheduled",
+					WaitForPodsScheduled: []string{"p1-1", "p1-2", "p1-3", "p1-4"},
+				},
+				{
+					Name:                    "Create second CompositePodGroup cpg-root2 (Gang minGroupCount=2, TopologyKey=rack)",
+					CreateCompositePodGroup: makeGangCompositePodGroup("cpg-root2", "", "rack", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg2-1 (Gang minCount=2, Parent=cpg-root2)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg2-1", "cpg-root2", "", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg2-2 (Gang minCount=2, Parent=cpg-root2)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg2-2", "cpg-root2", "", 2),
+				},
+				{
+					Name: "Create pods for cpg-root2",
+					CreatePods: []*v1.Pod{
+						makePod("p2-1", "pg2-1"),
+						makePod("p2-2", "pg2-1"),
+						makePod("p2-3", "pg2-2"),
+						makePod("p2-4", "pg2-2"),
+					},
+				},
+				{
+					Name:                     "Verify pods for cpg-root2 remain unschedulable",
+					WaitForPodsUnschedulable: []string{"p2-1", "p2-2", "p2-3", "p2-4"},
+				},
+			},
+		},
+		{
+			name: "CPG hierarchy with mixed sub-CPG and direct child PGs and different topology constraints",
+			steps: []stepsframework.Step{
+				{
+					Name: "Create nodes across zones and racks",
+					CreateNodes: []*v1.Node{
+						makeNode("node1-z1-r1", "rack-1", "zone-1"),
+						makeNode("node2-z1-r1", "rack-1", "zone-1"),
+						makeNode("node3-z1-r2", "rack-2", "zone-1"),
+						makeNode("node4-z1-r2", "rack-2", "zone-1"),
+						makeNode("node5-z2-r1", "rack-1", "zone-2"),
+						makeNode("node6-z2-r2", "rack-2", "zone-2"),
+					},
+				},
+				{
+					Name:                    "Create root CompositePodGroup (Gang minGroupCount=3, TopologyKey=zone)",
+					CreateCompositePodGroup: makeGangCompositePodGroup("cpg-root", "", "zone", 3),
+				},
+				{
+					Name:                    "Create sub CompositePodGroup cpg-sub1 (Gang minGroupCount=2, TopologyKey=rack, Parent=cpg-root)",
+					CreateCompositePodGroup: makeGangCompositePodGroup("cpg-sub1", "cpg-root", "rack", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg1 (Gang minCount=2, without topology constraints, Parent=cpg-sub1)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg1", "cpg-sub1", "", 2),
+				},
+				{
+					Name:           "Create child PodGroup pg2 (Gang minCount=2, without topology constraints, Parent=cpg-sub1)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg2", "cpg-sub1", "", 2),
+				},
+				{
+					Name:           "Create direct child PodGroup pg3 (Gang minCount=2, TopologyKey=rack, Parent=cpg-root)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg3", "cpg-root", "rack", 2),
+				},
+				{
+					Name:           "Create direct child PodGroup pg4 (Gang minCount=2, without topology constraints, Parent=cpg-root)",
+					CreatePodGroup: makeGangPodGroupWithParent("pg4", "cpg-root", "", 2),
+				},
+				{
+					Name: "Create all pods across pg1, pg2, pg3, and pg4 (8 pods total)",
+					CreatePods: []*v1.Pod{
+						makePod("p1", "pg1"),
+						makePod("p2", "pg1"),
+						makePod("p3", "pg2"),
+						makePod("p4", "pg2"),
+						makePod("p5", "pg3"),
+						makePod("p6", "pg3"),
+						makePod("p7", "pg4"),
+						makePod("p8", "pg4"),
+					},
+				},
+				{
+					Name:                 "Verify all 8 pods across all child groups are scheduled",
+					WaitForPodsScheduled: []string{"p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"},
+				},
+				{
+					Name: "Verify all pods are assigned in the same zone",
+					VerifyAssignedInOneDomain: &stepsframework.VerifyAssignedInOneDomain{
+						Pods:        []string{"p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"},
+						TopologyKey: "zone",
+					},
+				},
+				{
+					Name: "Verify cpg-sub1 pods are assigned in the same rack",
+					VerifyAssignedInOneDomain: &stepsframework.VerifyAssignedInOneDomain{
+						Pods:        []string{"p1", "p2", "p3", "p4"},
+						TopologyKey: "rack",
+					},
+				},
+				{
+					Name: "Verify pg3 pods are assigned in the same rack",
+					VerifyAssignedInOneDomain: &stepsframework.VerifyAssignedInOneDomain{
+						Pods:        []string{"p5", "p6"},
+						TopologyKey: "rack",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/integration/scheduler/preemption/podgroup/podgrouppreemption_test.go
+++ b/test/integration/scheduler/preemption/podgroup/podgrouppreemption_test.go
@@ -2322,6 +2322,204 @@ func TestCompositePodGroupPreemption(t *testing.T) {
 			expectedPodsPreemptedByWAP:    2,
 			removeCPGNameBeforePreemption: "cpg-victim",
 		},
+		{
+			name: "CPG Tie-Breaking: Standalone Pod chosen over CompositePodGroup",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("cpg-victim").Namespace("default").Priority(10).BasicPolicy().DisruptionModeAll().WorkloadRef("wl1", "t1").Obj(),
+			},
+			podGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg-victim").Namespace("default").Priority(10).MinCount(1).ParentCompositePodGroup("cpg-victim").WorkloadRef("t1", "wl1").Obj(),
+				st.MakePodGroup().Name("pg-preemptor").Namespace("default").Priority(100).MinCount(1).WorkloadRef("t1", "wl2").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				// Standalone Pod (Rank 1)
+				st.MakePod().Name("low-standalone").Req(map[v1.ResourceName]string{v1.ResourceCPU: "500m"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
+				// CPG Child PG Pod (Rank 3)
+				st.MakePod().Name("low-cpg").Req(map[v1.ResourceName]string{v1.ResourceCPU: "500m"}).Container("image").PodGroupName("pg-victim").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("high-preemptor").Req(map[v1.ResourceName]string{v1.ResourceCPU: "500m"}).Container("image").PodGroupName("pg-preemptor").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:              []string{"high-preemptor", "low-cpg"},
+			expectedPreempted:              []string{"low-standalone"},
+			expectedPodsPreemptedByWAP:     1,
+			enablePodGroupPreemptionPolicy: false,
+		},
+		{
+			name: "CPG Tie-Breaking: Standalone Pod and PodGroup chosen over CompositePodGroup",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "3", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("cpg-victim").Namespace("default").Priority(10).MinGroupCount(1).DisruptionModeAll().WorkloadRef("wl1", "t1").Obj(),
+			},
+			podGroups: []*schedulingv1beta1.PodGroup{
+				// Workload 1: A standalone PodGroup (Rank 2)
+				st.MakePodGroup().Name("pg-victim-standalone").Namespace("default").Priority(10).MinCount(1).WorkloadRef("t1", "wl2").Obj(),
+				// Workload 2: A PodGroup under a CompositePodGroup (Rank 3)
+				st.MakePodGroup().Name("pg-victim-child").Namespace("default").Priority(10).MinCount(1).ParentCompositePodGroup("cpg-victim").WorkloadRef("t1", "wl1").Obj(),
+				// Preemptor Workload
+				st.MakePodGroup().Name("pg-preemptor").Namespace("default").Priority(100).MinCount(1).WorkloadRef("t1", "wl3").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				// Standalone Pod (Rank 1)
+				st.MakePod().Name("low-standalone").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
+				// Standalone PG Pod (Rank 2)
+				st.MakePod().Name("low-pg").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-victim-standalone").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
+				// CPG Child PG Pod (Rank 3)
+				st.MakePod().Name("low-cpg").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-victim-child").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("high-preemptor").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg-preemptor").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			// The scheduler needs 2 CPU. It evaluates three candidates of equal priority (10):
+			// Rank 1 (low-standalone) < Rank 2 (low-pg) < Rank 3 (low-cpg).
+			// It preempts low-standalone (Rank 1) and low-pg (Rank 2), reprieving low-cpg (Rank 3).
+			expectedScheduled:              []string{"high-preemptor", "low-cpg"},
+			expectedPreempted:              []string{"low-standalone", "low-pg"},
+			expectedPodsPreemptedByWAP:     2,
+			enablePodGroupPreemptionPolicy: false,
+		},
+		{
+			name: "CPG Tie-Breaking: Smaller CompositePodGroup chosen over Larger CompositePodGroup",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("cpg-small").Namespace("default").Priority(10).BasicPolicy().DisruptionModeAll().WorkloadRef("wl1", "t1").Obj(),
+				st.MakeCompositePodGroup().Name("cpg-large").Namespace("default").Priority(10).BasicPolicy().DisruptionModeAll().WorkloadRef("wl2", "t1").Obj(),
+			},
+			podGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg-small").Namespace("default").Priority(10).MinCount(1).ParentCompositePodGroup("cpg-small").WorkloadRef("t1", "wl1").Obj(),
+				st.MakePodGroup().Name("pg-large").Namespace("default").Priority(10).MinCount(3).ParentCompositePodGroup("cpg-large").WorkloadRef("t1", "wl2").Obj(),
+				st.MakePodGroup().Name("pg-preemptor").Namespace("default").Priority(100).MinCount(1).WorkloadRef("t1", "wl3").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("low-small-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-small").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
+				st.MakePod().Name("low-large-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-large").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
+				st.MakePod().Name("low-large-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-large").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
+				st.MakePod().Name("low-large-3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-large").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("high-preemptor").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-preemptor").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:              []string{"high-preemptor", "low-large-1", "low-large-2", "low-large-3"},
+			expectedPreempted:              []string{"low-small-1"},
+			expectedPodsPreemptedByWAP:     1,
+			enablePodGroupPreemptionPolicy: false,
+		},
+		{
+			name: "Multi-Branch Subtree Isolation with Mixed Disruption Modes",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Label("kubernetes.io/hostname", "node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Label("kubernetes.io/hostname", "node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("cpg-root").Namespace("default").Priority(10).BasicPolicy().DisruptionModeSingle().WorkloadRef("wl1", "t1").Obj(),
+				st.MakeCompositePodGroup().Name("cpg-branch-a").Namespace("default").Priority(10).BasicPolicy().DisruptionModeAll().ParentCompositePodGroup("cpg-root").WorkloadRef("wl1", "t1").Obj(),
+				st.MakeCompositePodGroup().Name("cpg-branch-b").Namespace("default").Priority(10).BasicPolicy().DisruptionModeSingle().ParentCompositePodGroup("cpg-root").WorkloadRef("wl1", "t1").Obj(),
+			},
+			podGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg-a1").Namespace("default").Priority(10).MinCount(1).DisruptionModeSingle().ParentCompositePodGroup("cpg-branch-a").WorkloadRef("t1", "wl1").Obj(),
+				st.MakePodGroup().Name("pg-a2").Namespace("default").Priority(10).MinCount(1).DisruptionModeSingle().ParentCompositePodGroup("cpg-branch-a").WorkloadRef("t1", "wl1").Obj(),
+				st.MakePodGroup().Name("pg-b1").Namespace("default").Priority(10).MinCount(1).DisruptionModeSingle().ParentCompositePodGroup("cpg-branch-b").WorkloadRef("t1", "wl1").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("low-a1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-a1").Node("node1").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("low-a2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-a2").Node("node2").ZeroTerminationGracePeriod().Priority(10).Obj(),
+				st.MakePod().Name("low-b1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-b1").Node("node2").ZeroTerminationGracePeriod().Priority(10).Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("high-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").NodeSelector(map[string]string{"kubernetes.io/hostname": "node1"}).ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:              []string{"high-1", "low-b1"},
+			expectedPreempted:              []string{"low-a1", "low-a2"},
+			expectedPodsPreemptedByWAP:     2,
+			enablePodGroupPreemptionPolicy: false,
+		},
+		{
+			name: "Intermediate Parent CPG Deletion Fallback",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("cpg-grandparent").Namespace("default").Priority(100).BasicPolicy().WorkloadRef("wl1", "t1").Obj(),
+				st.MakeCompositePodGroup().Name("cpg-parent").Namespace("default").Priority(100).BasicPolicy().ParentCompositePodGroup("cpg-grandparent").WorkloadRef("wl1", "t1").Obj(),
+			},
+			podGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg-child").Namespace("default").Priority(20).MinCount(2).ParentCompositePodGroup("cpg-parent").WorkloadRef("t1", "wl1").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("low-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-child").ZeroTerminationGracePeriod().Priority(20).Node("node1").Obj(),
+				st.MakePod().Name("low-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-child").ZeroTerminationGracePeriod().Priority(20).Node("node1").Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("high-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").ZeroTerminationGracePeriod().Priority(50).Obj(),
+			},
+			expectedScheduled:             []string{"high-1"},
+			expectedPreempted:             []string{"low-1", "low-2"},
+			expectedPodsPreemptedByWAP:    2,
+			removeCPGNameBeforePreemption: "cpg-parent",
+		},
+		{
+			name: "Multi-Branch Preemptor with Gang and Basic Subtrees across Multiple Nodes",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Label("kubernetes.io/hostname", "node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Label("kubernetes.io/hostname", "node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("cpg-preemptor").Namespace("default").Priority(100).BasicPolicy().WorkloadRef("wl-preempt", "t1").Obj(),
+				st.MakeCompositePodGroup().Name("cpg-gang-branch").Namespace("default").Priority(100).MinGroupCount(1).ParentCompositePodGroup("cpg-preemptor").WorkloadRef("wl-preempt", "t1").Obj(),
+			},
+			podGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg-gang").Namespace("default").Priority(100).MinCount(2).ParentCompositePodGroup("cpg-gang-branch").WorkloadRef("t1", "wl-preempt").Obj(),
+				st.MakePodGroup().Name("pg-basic").Namespace("default").Priority(100).BasicPolicy().ParentCompositePodGroup("cpg-preemptor").WorkloadRef("t1", "wl-preempt").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("low-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1500m"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
+				st.MakePod().Name("low-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1500m"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Node("node2").Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("gang-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-gang").NodeSelector(map[string]string{"kubernetes.io/hostname": "node1"}).ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("gang-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-gang").NodeSelector(map[string]string{"kubernetes.io/hostname": "node2"}).ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("basic-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg-basic").NodeSelector(map[string]string{"kubernetes.io/hostname": "node1"}).ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:              []string{"gang-1", "gang-2", "basic-1"},
+			expectedPreempted:              []string{"low-1", "low-2"},
+			expectedPodsPreemptedByWAP:     2,
+			enablePodGroupPreemptionPolicy: false,
+			tempRemoveCPG:                  true,
+		},
+		{
+			name: "CPG Gang Quorum Preemption Infeasibility aborts cleanly without evictions",
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "2", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+			},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("cpg-preemptor").Namespace("default").Priority(100).MinGroupCount(1).WorkloadRef("wl-preempt", "t1").Obj(),
+			},
+			podGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg-gang").Namespace("default").Priority(100).MinCount(3).ParentCompositePodGroup("cpg-preemptor").WorkloadRef("t1", "wl-preempt").Obj(),
+			},
+			initialPods: []*v1.Pod{
+				st.MakePod().Name("low-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Node("node1").Obj(),
+				st.MakePod().Name("low-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").ZeroTerminationGracePeriod().Priority(10).Node("node2").Obj(),
+			},
+			preemptorPods: []*v1.Pod{
+				st.MakePod().Name("high-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg-gang").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("high-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg-gang").ZeroTerminationGracePeriod().Priority(100).Obj(),
+				st.MakePod().Name("high-3").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Container("image").PodGroupName("pg-gang").ZeroTerminationGracePeriod().Priority(100).Obj(),
+			},
+			expectedScheduled:              []string{},
+			expectedPreempted:              []string{},
+			expectedUnschedulable:          []string{"high-1", "high-2", "high-3"},
+			expectedPodsPreemptedByWAP:     0,
+			enablePodGroupPreemptionPolicy: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -4230,4 +4428,252 @@ func deleteCompositePodGroups(ctx context.Context, cs clientset.Interface, ns st
 		}
 	}
 	return nil
+}
+
+func TestCompositePodGroupPreemption_NominatedNodeNameRespected(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.GenericWorkload:                 true,
+		features.CompositePodGroup:               true,
+		features.TopologyAwareWorkloadScheduling: true,
+	})
+
+	mockScorePlugin := "mockScorePlugin"
+	registry := make(frameworkruntime.Registry)
+	err := registry.Register(mockScorePlugin, newPresetScorePlugin(map[string]int64{"node1": 100, "node2": 0, "node3": 0}))
+	if err != nil {
+		t.Fatalf("Failed to register custom score plugin: %v", err)
+	}
+
+	cfg := configtesting.V1ToInternalWithDefaults(t, configv1.KubeSchedulerConfiguration{
+		Profiles: []configv1.KubeSchedulerProfile{{
+			SchedulerName: new(v1.DefaultSchedulerName),
+			Plugins: &configv1.Plugins{
+				Score: configv1.PluginSet{
+					Enabled: []configv1.Plugin{
+						{Name: mockScorePlugin},
+					},
+				},
+			},
+		}},
+	})
+
+	testCtx := testutils.InitTestSchedulerWithNS(t, "cpg-preemption-nnn",
+		scheduler.WithProfiles(cfg.Profiles...),
+		scheduler.WithFrameworkOutOfTreeRegistry(registry),
+		scheduler.WithPodMaxBackoffSeconds(1),
+		scheduler.WithPodInitialBackoffSeconds(0),
+	)
+	cs, ns := testCtx.ClientSet, testCtx.NS.Name
+
+	// 1. Create 3 nodes
+	nodes := []*v1.Node{
+		st.MakeNode().Name("node1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+		st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+		st.MakeNode().Name("node3").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1", v1.ResourceMemory: "4Gi", v1.ResourcePods: "32"}).Obj(),
+	}
+	for _, node := range nodes {
+		if _, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed to create node %s: %v", node.Name, err)
+		}
+	}
+
+	// 2. Create CompositePodGroup and Child PodGroup with minCount=2
+	cpg := st.MakeCompositePodGroup().Name("cpg1").Namespace(ns).Priority(50).BasicPolicy().WorkloadRef("wl1", "t1").Obj()
+	if _, err := cs.SchedulingV1alpha3().CompositePodGroups(ns).Create(testCtx.Ctx, cpg, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create composite pod group cpg1: %v", err)
+	}
+
+	pg := st.MakePodGroup().Name("pg1").Namespace(ns).Priority(50).MinCount(2).ParentCompositePodGroup("cpg1").WorkloadRef("t1", "wl1").Obj()
+	if _, err := cs.SchedulingV1beta1().PodGroups(ns).Create(testCtx.Ctx, pg, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create pod group pg1: %v", err)
+	}
+
+	// 3. Create initial pods: pod1 on node1 (high priority), pod2 on node2 & pod3 on node3 (low priority with default grace period)
+	initialPods := []*v1.Pod{
+		st.MakePod().Name("pod1").Namespace(ns).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").Priority(100).ZeroTerminationGracePeriod().Node("node1").Obj(),
+		st.MakePod().Name("pod2").Namespace(ns).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").Priority(10).Node("node2").Obj(),
+		st.MakePod().Name("pod3").Namespace(ns).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").Priority(10).Node("node3").Obj(),
+	}
+	for _, pod := range initialPods {
+		if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, pod, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed to create pod %s: %v", pod.Name, err)
+		}
+	}
+
+	// Wait for initial pods to be scheduled
+	for _, pod := range initialPods {
+		if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, testutils.PodScheduled(cs, ns, pod.Name)); err != nil {
+			t.Fatalf("Failed to wait for initial pod %s to schedule: %v", pod.Name, err)
+		}
+	}
+
+	// 4. Create preemptor pods belonging to pg1
+	preemptorPods := []*v1.Pod{
+		st.MakePod().Name("preemptor-1").Namespace(ns).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").Priority(50).Obj(),
+		st.MakePod().Name("preemptor-2").Namespace(ns).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").Priority(50).Obj(),
+	}
+	for _, pod := range preemptorPods {
+		if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, pod, metav1.CreateOptions{}); err != nil {
+			t.Fatalf("Failed to create preemptor pod %s: %v", pod.Name, err)
+		}
+	}
+
+	// 5. Wait for preemption to occur and verify that NominatedNodeName is set on both preemptor pods
+	initialNNNs := make(map[string]string)
+	for _, pod := range preemptorPods {
+		podName := pod.Name
+		err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+			p, err := cs.CoreV1().Pods(ns).Get(ctx, podName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if p.Status.NominatedNodeName != "" {
+				initialNNNs[podName] = p.Status.NominatedNodeName
+				return true, nil
+			}
+			return false, nil
+		})
+		if err != nil {
+			t.Fatalf("Timed out waiting for NominatedNodeName on %s: %v", podName, err)
+		}
+	}
+
+	for podName, nodeName := range initialNNNs {
+		if nodeName == "node1" {
+			t.Errorf("Expected preemptor pod %s NNN to be node2 or node3, got %s", podName, nodeName)
+		}
+	}
+
+	// 6. Remove pod1 from node1
+	if err := cs.CoreV1().Pods(ns).Delete(testCtx.Ctx, "pod1", metav1.DeleteOptions{GracePeriodSeconds: new(int64(0))}); err != nil {
+		t.Fatalf("Failed to delete pod1: %v", err)
+	}
+
+	// Wait for pod1 to be completely removed from API server
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+		_, err := cs.CoreV1().Pods(ns).Get(ctx, "pod1", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Timed out waiting for pod1 to be deleted: %v", err)
+	}
+
+	// 7. Verify that nominated node names did not change to node1 despite node1 having free space and higher score from preferNode1ScorePlugin
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 3*time.Second, false, func(ctx context.Context) (bool, error) {
+		_, err := cs.CoreV1().Pods(ns).Get(ctx, "pod2", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			t.Fatalf("pod2 got removed")
+		}
+		_, err = cs.CoreV1().Pods(ns).Get(ctx, "pod3", metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			t.Fatalf("pod3 got removed")
+		}
+
+		for _, pod := range preemptorPods {
+			events, err := cs.CoreV1().Events(ns).List(ctx, metav1.ListOptions{
+				FieldSelector: "involvedObject.name=" + pod.Name,
+			})
+			if err != nil {
+				return false, err
+			}
+			for _, event := range events.Items {
+				t.Logf("Event: %v", event.Message)
+			}
+
+			p, err := cs.CoreV1().Pods(ns).Get(ctx, pod.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if p.Spec.NodeName == "node1" {
+				t.Errorf("Pod %s was incorrectly scheduled to node1", pod.Name)
+				return false, nil
+			}
+			if p.Status.NominatedNodeName != initialNNNs[pod.Name] {
+				t.Errorf("Pod %s NominatedNodeName changed from %s to %s. NodeName = %s", pod.Name, initialNNNs[pod.Name], p.Status.NominatedNodeName, p.Spec.NodeName)
+				return false, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) && !wait.Interrupted(err) {
+		t.Fatalf("Unexpected error while checking NNN persistence: %v", err)
+	}
+}
+
+func TestCompositePodGroupPreemptionStatus(t *testing.T) {
+	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+		features.GenericWorkload:                 true,
+		features.CompositePodGroup:               true,
+		features.TopologyAwareWorkloadScheduling: true,
+	})
+	testCtx := testutils.InitTestSchedulerWithNS(t, "cpg-preemption-status")
+
+	cs := testCtx.ClientSet
+	ns := testCtx.NS.Name
+
+	// Create a node.
+	node := st.MakeNode().Name("node-1").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj()
+	if _, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	// Create a low-priority pod low-1 taking whole node
+	lowPod := st.MakePod().Name("low-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").Priority(10).TerminationGracePeriodSeconds(30).Obj()
+	if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, lowPod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create low-priority pod: %v", err)
+	}
+	// Wait for low-priority pod to be scheduled
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false,
+		testutils.PodScheduled(cs, ns, lowPod.Name)); err != nil {
+		t.Fatalf("Failed to wait for low-priority pod to be scheduled: %v", err)
+	}
+	// Create a CompositePodGroup and child PodGroup (priority=100)
+	cpg := st.MakeCompositePodGroup().Name("cpg1").Namespace(ns).Priority(100).BasicPolicy().WorkloadRef("wl1", "t1").Obj()
+	if _, err := cs.SchedulingV1alpha3().CompositePodGroups(ns).Create(testCtx.Ctx, cpg, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create CompositePodGroup: %v", err)
+	}
+	pg := st.MakePodGroup().Name("pg1").Namespace(ns).MinCount(1).Priority(100).ParentCompositePodGroup("cpg1").WorkloadRef("t1", "wl1").Obj()
+	if _, err := cs.SchedulingV1beta1().PodGroups(ns).Create(testCtx.Ctx, pg, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create PodGroup: %v", err)
+	}
+	highPod := st.MakePod().Name("high-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Container("image").PodGroupName("pg1").Priority(100).Obj()
+	if _, err := cs.CoreV1().Pods(ns).Create(testCtx.Ctx, highPod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create high-priority pod: %v", err)
+	}
+	// Poll until the low-priority pod gets DeletionTimestamp set (which indicates preemption is triggered)
+	err := wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 10*time.Second, false, func(ctx context.Context) (bool, error) {
+		pod, err := cs.CoreV1().Pods(ns).Get(ctx, lowPod.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return pod.DeletionTimestamp != nil, nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to wait for low-priority pod to get DeletionTimestamp set: %v", err)
+	}
+	// Verify the child PodGroup condition.
+	// We want PodGroupInitiallyScheduled status to be False, Reason to be Unschedulable, and Message to contain
+	// both "minCount (1) cannot be satisfied" and "pod group preemption: found a placement for podgroup, preempting 1 victims"
+	var cond *metav1.Condition
+	err = wait.PollUntilContextTimeout(testCtx.Ctx, 100*time.Millisecond, 5*time.Second, false, func(ctx context.Context) (bool, error) {
+		currentPG, err := cs.SchedulingV1beta1().PodGroups(ns).Get(ctx, pg.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		cond = apimeta.FindStatusCondition(currentPG.Status.Conditions, schedulingv1beta1.PodGroupInitiallyScheduled)
+		if cond != nil &&
+			cond.Status == metav1.ConditionFalse &&
+			cond.Reason == schedulingv1beta1.PodGroupReasonUnschedulable &&
+			strings.Contains(cond.Message, "minCount (1) cannot be satisfied") &&
+			strings.Contains(cond.Message, "pod group preemption: found a placement for podgroup, preempting 1 victims") {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Logf("Failed to verify PodGroup condition: %v", err)
+		t.Fatalf("Last observed podGroup condition: Status=%s, Reason=%s, Message=%q", cond.Status, cond.Reason, cond.Message)
+	}
 }

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -966,6 +966,128 @@ func TestPreemption(t *testing.T) {
 			// Only index 0 on node1 is evicted; index 1 on node2 is NOT evicted.
 			preemptedPodIndexes: map[int]struct{}{0: {}},
 		},
+		{
+			// When a standalone pod and a CPG member pod have equal priority on the same candidate node,
+			// preemption chooses the standalone pod (Victim Rank 1) over the CPG member pod (Victim Rank 3)
+			// to minimize workload disruption.
+			name:                     "CPG victim tie-breaking with standalone pod",
+			initTokens:               maxTokens,
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("cpg-victim").Priority(asyncframework.LowPriority).MinGroupCount(1).
+					DisruptionModeAll().WorkloadRef("wl1", "t1").Obj(),
+			},
+			podGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg-victim").Priority(asyncframework.LowPriority).MinCount(1).
+					DisruptionModeAll().ParentCompositePodGroup("cpg-victim").WorkloadRef("t1", "wl1").Obj(),
+			},
+			existingPods: []*v1.Pod{
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "standalone-victim",
+					Priority:     &asyncframework.LowPriority,
+					NodeSelector: map[string]string{"node": "node1"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+				}),
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "cpg-victim-1",
+					Priority:     &asyncframework.LowPriority,
+					NodeSelector: map[string]string{"node": "node1"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-victim",
+				}),
+			},
+			pod: initPausePod(&testutils.PausePodConfig{
+				Name:         "preemptor-pod",
+				Priority:     &asyncframework.HighPriority,
+				NodeSelector: map[string]string{"node": "node1"},
+				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+				}},
+			}),
+			// Standalone pod is chosen for preemption; CPG member remains untouched.
+			preemptedPodIndexes: map[int]struct{}{0: {}},
+		},
+		{
+			// In a multi-branch CPG hierarchy with mixed disruption modes, evicting a member of a branch
+			// with DisruptionModeAll triggers eviction of all pods in that branch across nodes, while
+			// sibling branches under a DisruptionModeSingle root remain intact.
+			name:                     "multi-branch CPG hierarchy victim with mixed disruption modes",
+			initTokens:               maxTokens,
+			genericWorkloadEnabled:   true,
+			compositePodGroupEnabled: true,
+			extraNodes: []*v1.Node{
+				st.MakeNode().Name("node2").Capacity(map[v1.ResourceName]string{
+					v1.ResourcePods:   "32",
+					v1.ResourceCPU:    "500m",
+					v1.ResourceMemory: "500",
+				}).Label("node", "node2").Obj(),
+			},
+			compositePodGroups: []*schedulingv1alpha3.CompositePodGroup{
+				st.MakeCompositePodGroup().Name("cpg-root").Priority(asyncframework.LowPriority).BasicPolicy().
+					DisruptionModeSingle().WorkloadRef("wl1", "t1").Obj(),
+				st.MakeCompositePodGroup().Name("cpg-branch-a").Priority(asyncframework.LowPriority).MinGroupCount(1).
+					DisruptionModeAll().ParentCompositePodGroup("cpg-root").WorkloadRef("wl1", "t1").Obj(),
+				st.MakeCompositePodGroup().Name("cpg-branch-b").Priority(asyncframework.LowPriority).BasicPolicy().
+					DisruptionModeSingle().ParentCompositePodGroup("cpg-root").WorkloadRef("wl1", "t1").Obj(),
+			},
+			podGroups: []*schedulingv1beta1.PodGroup{
+				st.MakePodGroup().Name("pg-branch-a").Priority(asyncframework.LowPriority).MinCount(2).
+					DisruptionModeAll().ParentCompositePodGroup("cpg-branch-a").WorkloadRef("t1", "wl1").Obj(),
+				st.MakePodGroup().Name("pg-branch-b").Priority(asyncframework.LowPriority).BasicPolicy().
+					DisruptionModeSingle().ParentCompositePodGroup("cpg-branch-b").WorkloadRef("t1", "wl1").Obj(),
+			},
+			existingPods: []*v1.Pod{
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "branch-a-node1",
+					Priority:     &asyncframework.LowPriority,
+					NodeSelector: map[string]string{"node": "node1"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-branch-a",
+				}),
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "branch-a-node2",
+					Priority:     &asyncframework.LowPriority,
+					NodeSelector: map[string]string{"node": "node2"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-branch-a",
+				}),
+				initPausePod(&testutils.PausePodConfig{
+					Name:         "branch-b-node2",
+					Priority:     &asyncframework.LowPriority,
+					NodeSelector: map[string]string{"node": "node2"},
+					Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+						v1.ResourceCPU:    *resource.NewMilliQuantity(250, resource.DecimalSI),
+						v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+					}},
+					PodGroupName: "pg-branch-b",
+				}),
+			},
+			pod: initPausePod(&testutils.PausePodConfig{
+				Name:         "preemptor-pod",
+				Priority:     &asyncframework.HighPriority,
+				NodeSelector: map[string]string{"node": "node1"},
+				Resources: &v1.ResourceRequirements{Requests: v1.ResourceList{
+					v1.ResourceCPU:    *resource.NewMilliQuantity(300, resource.DecimalSI),
+					v1.ResourceMemory: *resource.NewQuantity(100, resource.DecimalSI),
+				}},
+			}),
+			// Branch A members on node1 and node2 are evicted together; Branch B on node2 is NOT evicted.
+			preemptedPodIndexes: map[int]struct{}{0: {}, 1: {}},
+		},
 	}
 
 	// Create a node with some resources and a label.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This PR extends the integration tests suite for the CompositePodGroup API with additional new tests and test cases for the already existing tests.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

Generative AI was used in the PR preparation. Changes were carefully reviewed before pushing.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
[KEP]: https://github.com/kubernetes/enhancements/issues/6012
```
