### PR TITLE
e2e: dump the pod when WaitTimeoutForPodReadyInNamespace stops early

### DIFF
--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -638,7 +638,7 @@ func WaitTimeoutForPodReadyInNamespace(ctx context.Context, c clientset.Interfac
 	return WaitForPodCondition(ctx, c, namespace, podName, "running and ready", timeout, func(pod *v1.Pod) (bool, error) {
 		switch pod.Status.Phase {
 		case v1.PodFailed, v1.PodSucceeded:
-			return false, gomega.StopTrying(fmt.Sprintf("The phase of Pod %s is %s which is unexpected.", pod.Name, pod.Status.Phase))
+			return false, gomega.StopTrying(fmt.Sprintf("Expected pod to reach phase %q and be ready, got final phase %q instead:\n%s", v1.PodRunning, pod.Status.Phase, format.Object(pod, 1)))
 		case v1.PodRunning:
 			return podutils.IsPodReady(pod), nil
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig testing

#### What this PR does / why we need it:

`WaitTimeoutForPodReadyInNamespace` bails out when a pod hits Failed or Succeeded, but the error was only the phase. The other wait helpers in the same file already dump the pod with `format.Object`, which is the useful bit when an e2e flakes.

Same dump here.

#### Which issue(s) this PR is related to:

Supersedes #136745

/cc @pohly

```release-note
NONE
```

This PR was written in part with the assistance of generative AI.