### PR TITLE
apiserver: trim unused Pod spec fields from the shared informer cache

### DIFF
--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -166,6 +167,9 @@ func BuildGenericConfig(
 		if accessor, err := meta.Accessor(obj); err == nil && accessor.GetManagedFields() != nil {
 			accessor.SetManagedFields(nil)
 		}
+		if pod, ok := obj.(*corev1.Pod); ok {
+			trimPodSpec(pod)
+		}
 		return obj, nil
 	}
 	versionedInformers = clientgoinformers.NewSharedInformerFactoryWithOptions(
@@ -250,6 +254,41 @@ func BuildGenericConfig(
 	genericConfig.AggregatedDiscoveryGroupManager = aggregated.NewResourceManager("apis")
 
 	return
+}
+
+// trimPodSpec clears Pod spec fields on objects in the self-requested
+// informers that are not read by any of the in-process consumers of this
+// shared cache (NodeRestriction and ResourceQuota admission, the node
+// authorizer, and PodSecurity admission), to reduce the informer's memory
+// footprint. See https://github.com/kubernetes/kubernetes/issues/125469.
+//
+// Only fields verified unread by all of those consumers are cleared here;
+// fields any of them touch (e.g. ServiceAccountName, Volumes, container
+// resources) are left alone.
+//
+// If you add a Pod field read to one of those four consumers, check whether
+// it's cleared here first — nothing else will catch the conflict.
+func trimPodSpec(pod *corev1.Pod) {
+	pod.Spec.RestartPolicy = ""
+	pod.Spec.TerminationGracePeriodSeconds = nil
+	pod.Spec.DNSPolicy = ""
+	pod.Spec.NodeSelector = nil
+	pod.Spec.DeprecatedServiceAccount = ""
+	pod.Spec.AutomountServiceAccountToken = nil
+	pod.Spec.ShareProcessNamespace = nil
+	pod.Spec.Hostname = ""
+	pod.Spec.Subdomain = ""
+	pod.Spec.SchedulerName = ""
+	pod.Spec.Tolerations = nil
+	pod.Spec.HostAliases = nil
+	pod.Spec.Priority = nil
+	pod.Spec.DNSConfig = nil
+	pod.Spec.ReadinessGates = nil
+	pod.Spec.EnableServiceLinks = nil
+	pod.Spec.PreemptionPolicy = nil
+	pod.Spec.TopologySpreadConstraints = nil
+	pod.Spec.SetHostnameAsFQDN = nil
+	pod.Spec.SchedulingGates = nil
 }
 
 // BuildAuthorizer constructs the authorizer. If authorization is not set in s, it returns nil, nil, false, nil

--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -256,18 +256,11 @@ func BuildGenericConfig(
 	return
 }
 
-// trimPodSpec clears Pod spec fields on objects in the self-requested
-// informers that are not read by any of the in-process consumers of this
-// shared cache (NodeRestriction and ResourceQuota admission, the node
-// authorizer, and PodSecurity admission), to reduce the informer's memory
-// footprint. See https://github.com/kubernetes/kubernetes/issues/125469.
+// trimPodSpec clears Pod spec fields unused by admission/authorization code
+// reading off this shared cache, to shrink its memory footprint. See
+// https://github.com/kubernetes/kubernetes/issues/125469.
 //
-// Only fields verified unread by all of those consumers are cleared here;
-// fields any of them touch (e.g. ServiceAccountName, Volumes, container
-// resources) are left alone.
-//
-// If you add a Pod field read to one of those four consumers, check whether
-// it's cleared here first — nothing else will catch the conflict.
+// Before reading a new Pod field from this cache, check it isn't cleared here.
 func trimPodSpec(pod *corev1.Pod) {
 	pod.Spec.RestartPolicy = ""
 	pod.Spec.TerminationGracePeriodSeconds = nil

--- a/pkg/controlplane/apiserver/config_test.go
+++ b/pkg/controlplane/apiserver/config_test.go
@@ -21,7 +21,12 @@ import (
 	"net"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
+	corev1 "k8s.io/api/core/v1"
 	extensionsapiserver "k8s.io/apiextensions-apiserver/pkg/apiserver"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
@@ -30,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/controlplane/apiserver/options"
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
 	netutils "k8s.io/utils/net"
+	"k8s.io/utils/ptr"
 )
 
 func TestBuildGenericConfig(t *testing.T) {
@@ -74,5 +80,89 @@ func TestBuildGenericConfig(t *testing.T) {
 	}
 	if restOptions.StorageConfig.StorageObjectCountTracker != genericConfig.StorageObjectCountTracker {
 		t.Errorf("There are different StorageObjectCountTracker in restOptions and serverConfig")
+	}
+}
+
+// fullPodSpecForTrimTest returns a Pod with every field trimPodSpec targets,
+// and every field NodeRestriction/ResourceQuota/the node authorizer/PodSecurity
+// actually read (see pkg/controlplane/apiserver/config.go), populated with a
+// non-zero value.
+func fullPodSpecForTrimTest() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-pod",
+			Namespace:   "test-ns",
+			Annotations: map[string]string{"example.com/foo": "bar"},
+		},
+		Spec: corev1.PodSpec{
+			// Fields trimPodSpec must clear.
+			RestartPolicy:                 corev1.RestartPolicyAlways,
+			TerminationGracePeriodSeconds: ptr.To(int64(30)),
+			DNSPolicy:                     corev1.DNSClusterFirst,
+			NodeSelector:                  map[string]string{"kubernetes.io/os": "linux"},
+			DeprecatedServiceAccount:      "legacy-sa",
+			AutomountServiceAccountToken:  ptr.To(true),
+			ShareProcessNamespace:         ptr.To(true),
+			Hostname:                      "my-host",
+			Subdomain:                     "my-subdomain",
+			SchedulerName:                 "default-scheduler",
+			Tolerations:                   []corev1.Toleration{{Key: "k", Operator: corev1.TolerationOpExists}},
+			HostAliases:                   []corev1.HostAlias{{IP: "10.0.0.1", Hostnames: []string{"foo"}}},
+			Priority:                      ptr.To(int32(10)),
+			DNSConfig:                     &corev1.PodDNSConfig{Nameservers: []string{"8.8.8.8"}},
+			ReadinessGates:                []corev1.PodReadinessGate{{ConditionType: "my-condition"}},
+			EnableServiceLinks:            ptr.To(true),
+			PreemptionPolicy:              ptr.To(corev1.PreemptLowerPriority),
+			TopologySpreadConstraints:     []corev1.TopologySpreadConstraint{{MaxSkew: 1, TopologyKey: "kubernetes.io/hostname"}},
+			SetHostnameAsFQDN:             ptr.To(true),
+			SchedulingGates:               []corev1.PodSchedulingGate{{Name: "my-gate"}},
+
+			// Fields at least one consumer reads; trimPodSpec must leave these alone.
+			NodeName:           "node-1",
+			ServiceAccountName: "my-sa",
+			Volumes: []corev1.Volume{
+				{Name: "v", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: "s"}}},
+			},
+			ResourceClaims: []corev1.PodResourceClaim{{Name: "c"}},
+			Containers: []corev1.Container{
+				{
+					Name: "c",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestTrimPodSpec(t *testing.T) {
+	pod := fullPodSpecForTrimTest()
+	trimPodSpec(pod)
+
+	want := fullPodSpecForTrimTest()
+	want.Spec.RestartPolicy = ""
+	want.Spec.TerminationGracePeriodSeconds = nil
+	want.Spec.DNSPolicy = ""
+	want.Spec.NodeSelector = nil
+	want.Spec.DeprecatedServiceAccount = ""
+	want.Spec.AutomountServiceAccountToken = nil
+	want.Spec.ShareProcessNamespace = nil
+	want.Spec.Hostname = ""
+	want.Spec.Subdomain = ""
+	want.Spec.SchedulerName = ""
+	want.Spec.Tolerations = nil
+	want.Spec.HostAliases = nil
+	want.Spec.Priority = nil
+	want.Spec.DNSConfig = nil
+	want.Spec.ReadinessGates = nil
+	want.Spec.EnableServiceLinks = nil
+	want.Spec.PreemptionPolicy = nil
+	want.Spec.TopologySpreadConstraints = nil
+	want.Spec.SetHostnameAsFQDN = nil
+	want.Spec.SchedulingGates = nil
+
+	if diff := cmp.Diff(want, pod); diff != "" {
+		t.Errorf("trimPodSpec() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/controlplane/apiserver/config_test.go
+++ b/pkg/controlplane/apiserver/config_test.go
@@ -83,10 +83,8 @@ func TestBuildGenericConfig(t *testing.T) {
 	}
 }
 
-// fullPodSpecForTrimTest returns a Pod with every field trimPodSpec targets,
-// and every field NodeRestriction/ResourceQuota/the node authorizer/PodSecurity
-// actually read (see pkg/controlplane/apiserver/config.go), populated with a
-// non-zero value.
+// fullPodSpecForTrimTest returns a Pod with every field relevant to
+// trimPodSpec set to a non-zero value.
 func fullPodSpecForTrimTest() *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Extends the existing `ManagedFields` trim on the shared Pod informer (`pkg/controlplane/apiserver/config.go`) to also clear ~20 `Spec` fields (scheduling/DNS/hostname-related, full list in the diff) that none of its four consumers — NodeRestriction, ResourceQuota, the node authorizer, PodSecurity — read.

Measured on kind: ~9% smaller per pod normally, ~15% with common scheduling fields set (tolerations, node selector, etc). Same shape as the existing `ManagedFields` trim.

**Tradeoff:** no compiler check ties this list to what the four consumers read. If one starts reading a cleared field later, it breaks silently. `TestTrimPodSpec` pins today's contract, nothing more.

Part of #125469.

#### Special notes for your reviewer:
Used AI assistance (Claude Code) for the field audit and implementation; reviewed and tested myself.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```