### PR TITLE
code-generator: fix informer-gen interface comment to match Typed return type

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/interface.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/cr/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// Examples returns a ExampleInformer.
+	// Examples returns a TypedExampleInformer.
 	Examples() TypedExampleInformer
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/interface.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// CustomResourceDefinitions returns a CustomResourceDefinitionInformer.
+	// CustomResourceDefinitions returns a TypedCustomResourceDefinitionInformer.
 	CustomResourceDefinitions() TypedCustomResourceDefinitionInformer
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/interface.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// CustomResourceDefinitions returns a CustomResourceDefinitionInformer.
+	// CustomResourceDefinitions returns a TypedCustomResourceDefinitionInformer.
 	CustomResourceDefinitions() TypedCustomResourceDefinitionInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/interface.go
@@ -24,17 +24,17 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// MutatingAdmissionPolicies returns a MutatingAdmissionPolicyInformer.
+	// MutatingAdmissionPolicies returns a TypedMutatingAdmissionPolicyInformer.
 	MutatingAdmissionPolicies() TypedMutatingAdmissionPolicyInformer
-	// MutatingAdmissionPolicyBindings returns a MutatingAdmissionPolicyBindingInformer.
+	// MutatingAdmissionPolicyBindings returns a TypedMutatingAdmissionPolicyBindingInformer.
 	MutatingAdmissionPolicyBindings() TypedMutatingAdmissionPolicyBindingInformer
-	// MutatingWebhookConfigurations returns a MutatingWebhookConfigurationInformer.
+	// MutatingWebhookConfigurations returns a TypedMutatingWebhookConfigurationInformer.
 	MutatingWebhookConfigurations() TypedMutatingWebhookConfigurationInformer
-	// ValidatingAdmissionPolicies returns a ValidatingAdmissionPolicyInformer.
+	// ValidatingAdmissionPolicies returns a TypedValidatingAdmissionPolicyInformer.
 	ValidatingAdmissionPolicies() TypedValidatingAdmissionPolicyInformer
-	// ValidatingAdmissionPolicyBindings returns a ValidatingAdmissionPolicyBindingInformer.
+	// ValidatingAdmissionPolicyBindings returns a TypedValidatingAdmissionPolicyBindingInformer.
 	ValidatingAdmissionPolicyBindings() TypedValidatingAdmissionPolicyBindingInformer
-	// ValidatingWebhookConfigurations returns a ValidatingWebhookConfigurationInformer.
+	// ValidatingWebhookConfigurations returns a TypedValidatingWebhookConfigurationInformer.
 	ValidatingWebhookConfigurations() TypedValidatingWebhookConfigurationInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/interface.go
@@ -24,13 +24,13 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// MutatingAdmissionPolicies returns a MutatingAdmissionPolicyInformer.
+	// MutatingAdmissionPolicies returns a TypedMutatingAdmissionPolicyInformer.
 	MutatingAdmissionPolicies() TypedMutatingAdmissionPolicyInformer
-	// MutatingAdmissionPolicyBindings returns a MutatingAdmissionPolicyBindingInformer.
+	// MutatingAdmissionPolicyBindings returns a TypedMutatingAdmissionPolicyBindingInformer.
 	MutatingAdmissionPolicyBindings() TypedMutatingAdmissionPolicyBindingInformer
-	// ValidatingAdmissionPolicies returns a ValidatingAdmissionPolicyInformer.
+	// ValidatingAdmissionPolicies returns a TypedValidatingAdmissionPolicyInformer.
 	ValidatingAdmissionPolicies() TypedValidatingAdmissionPolicyInformer
-	// ValidatingAdmissionPolicyBindings returns a ValidatingAdmissionPolicyBindingInformer.
+	// ValidatingAdmissionPolicyBindings returns a TypedValidatingAdmissionPolicyBindingInformer.
 	ValidatingAdmissionPolicyBindings() TypedValidatingAdmissionPolicyBindingInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/interface.go
@@ -24,17 +24,17 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// MutatingAdmissionPolicies returns a MutatingAdmissionPolicyInformer.
+	// MutatingAdmissionPolicies returns a TypedMutatingAdmissionPolicyInformer.
 	MutatingAdmissionPolicies() TypedMutatingAdmissionPolicyInformer
-	// MutatingAdmissionPolicyBindings returns a MutatingAdmissionPolicyBindingInformer.
+	// MutatingAdmissionPolicyBindings returns a TypedMutatingAdmissionPolicyBindingInformer.
 	MutatingAdmissionPolicyBindings() TypedMutatingAdmissionPolicyBindingInformer
-	// MutatingWebhookConfigurations returns a MutatingWebhookConfigurationInformer.
+	// MutatingWebhookConfigurations returns a TypedMutatingWebhookConfigurationInformer.
 	MutatingWebhookConfigurations() TypedMutatingWebhookConfigurationInformer
-	// ValidatingAdmissionPolicies returns a ValidatingAdmissionPolicyInformer.
+	// ValidatingAdmissionPolicies returns a TypedValidatingAdmissionPolicyInformer.
 	ValidatingAdmissionPolicies() TypedValidatingAdmissionPolicyInformer
-	// ValidatingAdmissionPolicyBindings returns a ValidatingAdmissionPolicyBindingInformer.
+	// ValidatingAdmissionPolicyBindings returns a TypedValidatingAdmissionPolicyBindingInformer.
 	ValidatingAdmissionPolicyBindings() TypedValidatingAdmissionPolicyBindingInformer
-	// ValidatingWebhookConfigurations returns a ValidatingWebhookConfigurationInformer.
+	// ValidatingWebhookConfigurations returns a TypedValidatingWebhookConfigurationInformer.
 	ValidatingWebhookConfigurations() TypedValidatingWebhookConfigurationInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/apiserverinternal/v1alpha1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// StorageVersions returns a StorageVersionInformer.
+	// StorageVersions returns a TypedStorageVersionInformer.
 	StorageVersions() TypedStorageVersionInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/apps/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1/interface.go
@@ -24,15 +24,15 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ControllerRevisions returns a ControllerRevisionInformer.
+	// ControllerRevisions returns a TypedControllerRevisionInformer.
 	ControllerRevisions() TypedControllerRevisionInformer
-	// DaemonSets returns a DaemonSetInformer.
+	// DaemonSets returns a TypedDaemonSetInformer.
 	DaemonSets() TypedDaemonSetInformer
-	// Deployments returns a DeploymentInformer.
+	// Deployments returns a TypedDeploymentInformer.
 	Deployments() TypedDeploymentInformer
-	// ReplicaSets returns a ReplicaSetInformer.
+	// ReplicaSets returns a TypedReplicaSetInformer.
 	ReplicaSets() TypedReplicaSetInformer
-	// StatefulSets returns a StatefulSetInformer.
+	// StatefulSets returns a TypedStatefulSetInformer.
 	StatefulSets() TypedStatefulSetInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/interface.go
@@ -24,11 +24,11 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ControllerRevisions returns a ControllerRevisionInformer.
+	// ControllerRevisions returns a TypedControllerRevisionInformer.
 	ControllerRevisions() TypedControllerRevisionInformer
-	// Deployments returns a DeploymentInformer.
+	// Deployments returns a TypedDeploymentInformer.
 	Deployments() TypedDeploymentInformer
-	// StatefulSets returns a StatefulSetInformer.
+	// StatefulSets returns a TypedStatefulSetInformer.
 	StatefulSets() TypedStatefulSetInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/interface.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/interface.go
@@ -24,15 +24,15 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ControllerRevisions returns a ControllerRevisionInformer.
+	// ControllerRevisions returns a TypedControllerRevisionInformer.
 	ControllerRevisions() TypedControllerRevisionInformer
-	// DaemonSets returns a DaemonSetInformer.
+	// DaemonSets returns a TypedDaemonSetInformer.
 	DaemonSets() TypedDaemonSetInformer
-	// Deployments returns a DeploymentInformer.
+	// Deployments returns a TypedDeploymentInformer.
 	Deployments() TypedDeploymentInformer
-	// ReplicaSets returns a ReplicaSetInformer.
+	// ReplicaSets returns a TypedReplicaSetInformer.
 	ReplicaSets() TypedReplicaSetInformer
-	// StatefulSets returns a StatefulSetInformer.
+	// StatefulSets returns a TypedStatefulSetInformer.
 	StatefulSets() TypedStatefulSetInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// HorizontalPodAutoscalers returns a HorizontalPodAutoscalerInformer.
+	// HorizontalPodAutoscalers returns a TypedHorizontalPodAutoscalerInformer.
 	HorizontalPodAutoscalers() TypedHorizontalPodAutoscalerInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2/interface.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// HorizontalPodAutoscalers returns a HorizontalPodAutoscalerInformer.
+	// HorizontalPodAutoscalers returns a TypedHorizontalPodAutoscalerInformer.
 	HorizontalPodAutoscalers() TypedHorizontalPodAutoscalerInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/batch/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// CronJobs returns a CronJobInformer.
+	// CronJobs returns a TypedCronJobInformer.
 	CronJobs() TypedCronJobInformer
-	// Jobs returns a JobInformer.
+	// Jobs returns a TypedJobInformer.
 	Jobs() TypedJobInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/batch/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1beta1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// CronJobs returns a CronJobInformer.
+	// CronJobs returns a TypedCronJobInformer.
 	CronJobs() TypedCronJobInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/certificates/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1/interface.go
@@ -24,11 +24,11 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// CertificateSigningRequests returns a CertificateSigningRequestInformer.
+	// CertificateSigningRequests returns a TypedCertificateSigningRequestInformer.
 	CertificateSigningRequests() TypedCertificateSigningRequestInformer
-	// ClusterTrustBundles returns a ClusterTrustBundleInformer.
+	// ClusterTrustBundles returns a TypedClusterTrustBundleInformer.
 	ClusterTrustBundles() TypedClusterTrustBundleInformer
-	// PodCertificateRequests returns a PodCertificateRequestInformer.
+	// PodCertificateRequests returns a TypedPodCertificateRequestInformer.
 	PodCertificateRequests() TypedPodCertificateRequestInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/certificates/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1alpha1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ClusterTrustBundles returns a ClusterTrustBundleInformer.
+	// ClusterTrustBundles returns a TypedClusterTrustBundleInformer.
 	ClusterTrustBundles() TypedClusterTrustBundleInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/certificates/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1beta1/interface.go
@@ -24,11 +24,11 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// CertificateSigningRequests returns a CertificateSigningRequestInformer.
+	// CertificateSigningRequests returns a TypedCertificateSigningRequestInformer.
 	CertificateSigningRequests() TypedCertificateSigningRequestInformer
-	// ClusterTrustBundles returns a ClusterTrustBundleInformer.
+	// ClusterTrustBundles returns a TypedClusterTrustBundleInformer.
 	ClusterTrustBundles() TypedClusterTrustBundleInformer
-	// PodCertificateRequests returns a PodCertificateRequestInformer.
+	// PodCertificateRequests returns a TypedPodCertificateRequestInformer.
 	PodCertificateRequests() TypedPodCertificateRequestInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/coordination/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// Leases returns a LeaseInformer.
+	// Leases returns a TypedLeaseInformer.
 	Leases() TypedLeaseInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/coordination/v1alpha2/interface.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1alpha2/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// LeaseCandidates returns a LeaseCandidateInformer.
+	// LeaseCandidates returns a TypedLeaseCandidateInformer.
 	LeaseCandidates() TypedLeaseCandidateInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/coordination/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/coordination/v1beta1/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// Leases returns a LeaseInformer.
+	// Leases returns a TypedLeaseInformer.
 	Leases() TypedLeaseInformer
-	// LeaseCandidates returns a LeaseCandidateInformer.
+	// LeaseCandidates returns a TypedLeaseCandidateInformer.
 	LeaseCandidates() TypedLeaseCandidateInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/core/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/interface.go
@@ -24,37 +24,37 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ComponentStatuses returns a ComponentStatusInformer.
+	// ComponentStatuses returns a TypedComponentStatusInformer.
 	ComponentStatuses() TypedComponentStatusInformer
-	// ConfigMaps returns a ConfigMapInformer.
+	// ConfigMaps returns a TypedConfigMapInformer.
 	ConfigMaps() TypedConfigMapInformer
-	// Endpoints returns a EndpointsInformer.
+	// Endpoints returns a TypedEndpointsInformer.
 	Endpoints() TypedEndpointsInformer
-	// Events returns a EventInformer.
+	// Events returns a TypedEventInformer.
 	Events() TypedEventInformer
-	// LimitRanges returns a LimitRangeInformer.
+	// LimitRanges returns a TypedLimitRangeInformer.
 	LimitRanges() TypedLimitRangeInformer
-	// Namespaces returns a NamespaceInformer.
+	// Namespaces returns a TypedNamespaceInformer.
 	Namespaces() TypedNamespaceInformer
-	// Nodes returns a NodeInformer.
+	// Nodes returns a TypedNodeInformer.
 	Nodes() TypedNodeInformer
-	// PersistentVolumes returns a PersistentVolumeInformer.
+	// PersistentVolumes returns a TypedPersistentVolumeInformer.
 	PersistentVolumes() TypedPersistentVolumeInformer
-	// PersistentVolumeClaims returns a PersistentVolumeClaimInformer.
+	// PersistentVolumeClaims returns a TypedPersistentVolumeClaimInformer.
 	PersistentVolumeClaims() TypedPersistentVolumeClaimInformer
-	// Pods returns a PodInformer.
+	// Pods returns a TypedPodInformer.
 	Pods() TypedPodInformer
-	// PodTemplates returns a PodTemplateInformer.
+	// PodTemplates returns a TypedPodTemplateInformer.
 	PodTemplates() TypedPodTemplateInformer
-	// ReplicationControllers returns a ReplicationControllerInformer.
+	// ReplicationControllers returns a TypedReplicationControllerInformer.
 	ReplicationControllers() TypedReplicationControllerInformer
-	// ResourceQuotas returns a ResourceQuotaInformer.
+	// ResourceQuotas returns a TypedResourceQuotaInformer.
 	ResourceQuotas() TypedResourceQuotaInformer
-	// Secrets returns a SecretInformer.
+	// Secrets returns a TypedSecretInformer.
 	Secrets() TypedSecretInformer
-	// Services returns a ServiceInformer.
+	// Services returns a TypedServiceInformer.
 	Services() TypedServiceInformer
-	// ServiceAccounts returns a ServiceAccountInformer.
+	// ServiceAccounts returns a TypedServiceAccountInformer.
 	ServiceAccounts() TypedServiceAccountInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/discovery/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/discovery/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// EndpointSlices returns a EndpointSliceInformer.
+	// EndpointSlices returns a TypedEndpointSliceInformer.
 	EndpointSlices() TypedEndpointSliceInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/discovery/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/discovery/v1beta1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// EndpointSlices returns a EndpointSliceInformer.
+	// EndpointSlices returns a TypedEndpointSliceInformer.
 	EndpointSlices() TypedEndpointSliceInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/events/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// Events returns a EventInformer.
+	// Events returns a TypedEventInformer.
 	Events() TypedEventInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/events/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/events/v1beta1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// Events returns a EventInformer.
+	// Events returns a TypedEventInformer.
 	Events() TypedEventInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/interface.go
@@ -24,15 +24,15 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// DaemonSets returns a DaemonSetInformer.
+	// DaemonSets returns a TypedDaemonSetInformer.
 	DaemonSets() TypedDaemonSetInformer
-	// Deployments returns a DeploymentInformer.
+	// Deployments returns a TypedDeploymentInformer.
 	Deployments() TypedDeploymentInformer
-	// Ingresses returns a IngressInformer.
+	// Ingresses returns a TypedIngressInformer.
 	Ingresses() TypedIngressInformer
-	// NetworkPolicies returns a NetworkPolicyInformer.
+	// NetworkPolicies returns a TypedNetworkPolicyInformer.
 	NetworkPolicies() TypedNetworkPolicyInformer
-	// ReplicaSets returns a ReplicaSetInformer.
+	// ReplicaSets returns a TypedReplicaSetInformer.
 	ReplicaSets() TypedReplicaSetInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// FlowSchemas returns a FlowSchemaInformer.
+	// FlowSchemas returns a TypedFlowSchemaInformer.
 	FlowSchemas() TypedFlowSchemaInformer
-	// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
+	// PriorityLevelConfigurations returns a TypedPriorityLevelConfigurationInformer.
 	PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta1/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// FlowSchemas returns a FlowSchemaInformer.
+	// FlowSchemas returns a TypedFlowSchemaInformer.
 	FlowSchemas() TypedFlowSchemaInformer
-	// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
+	// PriorityLevelConfigurations returns a TypedPriorityLevelConfigurationInformer.
 	PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/interface.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta2/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// FlowSchemas returns a FlowSchemaInformer.
+	// FlowSchemas returns a TypedFlowSchemaInformer.
 	FlowSchemas() TypedFlowSchemaInformer
-	// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
+	// PriorityLevelConfigurations returns a TypedPriorityLevelConfigurationInformer.
 	PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/interface.go
+++ b/staging/src/k8s.io/client-go/informers/flowcontrol/v1beta3/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// FlowSchemas returns a FlowSchemaInformer.
+	// FlowSchemas returns a TypedFlowSchemaInformer.
 	FlowSchemas() TypedFlowSchemaInformer
-	// PriorityLevelConfigurations returns a PriorityLevelConfigurationInformer.
+	// PriorityLevelConfigurations returns a TypedPriorityLevelConfigurationInformer.
 	PriorityLevelConfigurations() TypedPriorityLevelConfigurationInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/lifecycle/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/lifecycle/v1alpha1/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// Evictions returns a EvictionInformer.
+	// Evictions returns a TypedEvictionInformer.
 	Evictions() TypedEvictionInformer
-	// EvictionRequests returns a EvictionRequestInformer.
+	// EvictionRequests returns a TypedEvictionRequestInformer.
 	EvictionRequests() TypedEvictionRequestInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/networking/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/interface.go
@@ -24,15 +24,15 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// IPAddresses returns a IPAddressInformer.
+	// IPAddresses returns a TypedIPAddressInformer.
 	IPAddresses() TypedIPAddressInformer
-	// Ingresses returns a IngressInformer.
+	// Ingresses returns a TypedIngressInformer.
 	Ingresses() TypedIngressInformer
-	// IngressClasses returns a IngressClassInformer.
+	// IngressClasses returns a TypedIngressClassInformer.
 	IngressClasses() TypedIngressClassInformer
-	// NetworkPolicies returns a NetworkPolicyInformer.
+	// NetworkPolicies returns a TypedNetworkPolicyInformer.
 	NetworkPolicies() TypedNetworkPolicyInformer
-	// ServiceCIDRs returns a ServiceCIDRInformer.
+	// ServiceCIDRs returns a TypedServiceCIDRInformer.
 	ServiceCIDRs() TypedServiceCIDRInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/interface.go
@@ -24,13 +24,13 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// IPAddresses returns a IPAddressInformer.
+	// IPAddresses returns a TypedIPAddressInformer.
 	IPAddresses() TypedIPAddressInformer
-	// Ingresses returns a IngressInformer.
+	// Ingresses returns a TypedIngressInformer.
 	Ingresses() TypedIngressInformer
-	// IngressClasses returns a IngressClassInformer.
+	// IngressClasses returns a TypedIngressClassInformer.
 	IngressClasses() TypedIngressClassInformer
-	// ServiceCIDRs returns a ServiceCIDRInformer.
+	// ServiceCIDRs returns a TypedServiceCIDRInformer.
 	ServiceCIDRs() TypedServiceCIDRInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/node/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// RuntimeClasses returns a RuntimeClassInformer.
+	// RuntimeClasses returns a TypedRuntimeClassInformer.
 	RuntimeClasses() TypedRuntimeClassInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/node/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1alpha1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// RuntimeClasses returns a RuntimeClassInformer.
+	// RuntimeClasses returns a TypedRuntimeClassInformer.
 	RuntimeClasses() TypedRuntimeClassInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/node/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1beta1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// RuntimeClasses returns a RuntimeClassInformer.
+	// RuntimeClasses returns a TypedRuntimeClassInformer.
 	RuntimeClasses() TypedRuntimeClassInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/policy/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// PodDisruptionBudgets returns a PodDisruptionBudgetInformer.
+	// PodDisruptionBudgets returns a TypedPodDisruptionBudgetInformer.
 	PodDisruptionBudgets() TypedPodDisruptionBudgetInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/policy/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1beta1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// PodDisruptionBudgets returns a PodDisruptionBudgetInformer.
+	// PodDisruptionBudgets returns a TypedPodDisruptionBudgetInformer.
 	PodDisruptionBudgets() TypedPodDisruptionBudgetInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/interface.go
@@ -24,13 +24,13 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ClusterRoles returns a ClusterRoleInformer.
+	// ClusterRoles returns a TypedClusterRoleInformer.
 	ClusterRoles() TypedClusterRoleInformer
-	// ClusterRoleBindings returns a ClusterRoleBindingInformer.
+	// ClusterRoleBindings returns a TypedClusterRoleBindingInformer.
 	ClusterRoleBindings() TypedClusterRoleBindingInformer
-	// Roles returns a RoleInformer.
+	// Roles returns a TypedRoleInformer.
 	Roles() TypedRoleInformer
-	// RoleBindings returns a RoleBindingInformer.
+	// RoleBindings returns a TypedRoleBindingInformer.
 	RoleBindings() TypedRoleBindingInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/interface.go
@@ -24,13 +24,13 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ClusterRoles returns a ClusterRoleInformer.
+	// ClusterRoles returns a TypedClusterRoleInformer.
 	ClusterRoles() TypedClusterRoleInformer
-	// ClusterRoleBindings returns a ClusterRoleBindingInformer.
+	// ClusterRoleBindings returns a TypedClusterRoleBindingInformer.
 	ClusterRoleBindings() TypedClusterRoleBindingInformer
-	// Roles returns a RoleInformer.
+	// Roles returns a TypedRoleInformer.
 	Roles() TypedRoleInformer
-	// RoleBindings returns a RoleBindingInformer.
+	// RoleBindings returns a TypedRoleBindingInformer.
 	RoleBindings() TypedRoleBindingInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/interface.go
@@ -24,13 +24,13 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ClusterRoles returns a ClusterRoleInformer.
+	// ClusterRoles returns a TypedClusterRoleInformer.
 	ClusterRoles() TypedClusterRoleInformer
-	// ClusterRoleBindings returns a ClusterRoleBindingInformer.
+	// ClusterRoleBindings returns a TypedClusterRoleBindingInformer.
 	ClusterRoleBindings() TypedClusterRoleBindingInformer
-	// Roles returns a RoleInformer.
+	// Roles returns a TypedRoleInformer.
 	Roles() TypedRoleInformer
-	// RoleBindings returns a RoleBindingInformer.
+	// RoleBindings returns a TypedRoleBindingInformer.
 	RoleBindings() TypedRoleBindingInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/resource/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1/interface.go
@@ -24,15 +24,15 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// DeviceClasses returns a DeviceClassInformer.
+	// DeviceClasses returns a TypedDeviceClassInformer.
 	DeviceClasses() TypedDeviceClassInformer
-	// DeviceTaintRules returns a DeviceTaintRuleInformer.
+	// DeviceTaintRules returns a TypedDeviceTaintRuleInformer.
 	DeviceTaintRules() TypedDeviceTaintRuleInformer
-	// ResourceClaims returns a ResourceClaimInformer.
+	// ResourceClaims returns a TypedResourceClaimInformer.
 	ResourceClaims() TypedResourceClaimInformer
-	// ResourceClaimTemplates returns a ResourceClaimTemplateInformer.
+	// ResourceClaimTemplates returns a TypedResourceClaimTemplateInformer.
 	ResourceClaimTemplates() TypedResourceClaimTemplateInformer
-	// ResourceSlices returns a ResourceSliceInformer.
+	// ResourceSlices returns a TypedResourceSliceInformer.
 	ResourceSlices() TypedResourceSliceInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/resource/v1alpha3/interface.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1alpha3/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// DeviceTaintRules returns a DeviceTaintRuleInformer.
+	// DeviceTaintRules returns a TypedDeviceTaintRuleInformer.
 	DeviceTaintRules() TypedDeviceTaintRuleInformer
-	// ResourcePoolStatusRequests returns a ResourcePoolStatusRequestInformer.
+	// ResourcePoolStatusRequests returns a TypedResourcePoolStatusRequestInformer.
 	ResourcePoolStatusRequests() TypedResourcePoolStatusRequestInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/interface.go
@@ -24,13 +24,13 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// DeviceClasses returns a DeviceClassInformer.
+	// DeviceClasses returns a TypedDeviceClassInformer.
 	DeviceClasses() TypedDeviceClassInformer
-	// ResourceClaims returns a ResourceClaimInformer.
+	// ResourceClaims returns a TypedResourceClaimInformer.
 	ResourceClaims() TypedResourceClaimInformer
-	// ResourceClaimTemplates returns a ResourceClaimTemplateInformer.
+	// ResourceClaimTemplates returns a TypedResourceClaimTemplateInformer.
 	ResourceClaimTemplates() TypedResourceClaimTemplateInformer
-	// ResourceSlices returns a ResourceSliceInformer.
+	// ResourceSlices returns a TypedResourceSliceInformer.
 	ResourceSlices() TypedResourceSliceInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/interface.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/interface.go
@@ -24,15 +24,15 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// DeviceClasses returns a DeviceClassInformer.
+	// DeviceClasses returns a TypedDeviceClassInformer.
 	DeviceClasses() TypedDeviceClassInformer
-	// DeviceTaintRules returns a DeviceTaintRuleInformer.
+	// DeviceTaintRules returns a TypedDeviceTaintRuleInformer.
 	DeviceTaintRules() TypedDeviceTaintRuleInformer
-	// ResourceClaims returns a ResourceClaimInformer.
+	// ResourceClaims returns a TypedResourceClaimInformer.
 	ResourceClaims() TypedResourceClaimInformer
-	// ResourceClaimTemplates returns a ResourceClaimTemplateInformer.
+	// ResourceClaimTemplates returns a TypedResourceClaimTemplateInformer.
 	ResourceClaimTemplates() TypedResourceClaimTemplateInformer
-	// ResourceSlices returns a ResourceSliceInformer.
+	// ResourceSlices returns a TypedResourceSliceInformer.
 	ResourceSlices() TypedResourceSliceInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// PriorityClasses returns a PriorityClassInformer.
+	// PriorityClasses returns a TypedPriorityClassInformer.
 	PriorityClasses() TypedPriorityClassInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1alpha3/interface.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1alpha3/interface.go
@@ -24,11 +24,11 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// CompositePodGroups returns a CompositePodGroupInformer.
+	// CompositePodGroups returns a TypedCompositePodGroupInformer.
 	CompositePodGroups() TypedCompositePodGroupInformer
-	// PodGroups returns a PodGroupInformer.
+	// PodGroups returns a TypedPodGroupInformer.
 	PodGroups() TypedPodGroupInformer
-	// Workloads returns a WorkloadInformer.
+	// Workloads returns a TypedWorkloadInformer.
 	Workloads() TypedWorkloadInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/interface.go
@@ -24,11 +24,11 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// PodGroups returns a PodGroupInformer.
+	// PodGroups returns a TypedPodGroupInformer.
 	PodGroups() TypedPodGroupInformer
-	// PriorityClasses returns a PriorityClassInformer.
+	// PriorityClasses returns a TypedPriorityClassInformer.
 	PriorityClasses() TypedPriorityClassInformer
-	// Workloads returns a WorkloadInformer.
+	// Workloads returns a TypedWorkloadInformer.
 	Workloads() TypedWorkloadInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/storage/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/interface.go
@@ -24,17 +24,17 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// CSIDrivers returns a CSIDriverInformer.
+	// CSIDrivers returns a TypedCSIDriverInformer.
 	CSIDrivers() TypedCSIDriverInformer
-	// CSINodes returns a CSINodeInformer.
+	// CSINodes returns a TypedCSINodeInformer.
 	CSINodes() TypedCSINodeInformer
-	// CSIStorageCapacities returns a CSIStorageCapacityInformer.
+	// CSIStorageCapacities returns a TypedCSIStorageCapacityInformer.
 	CSIStorageCapacities() TypedCSIStorageCapacityInformer
-	// StorageClasses returns a StorageClassInformer.
+	// StorageClasses returns a TypedStorageClassInformer.
 	StorageClasses() TypedStorageClassInformer
-	// VolumeAttachments returns a VolumeAttachmentInformer.
+	// VolumeAttachments returns a TypedVolumeAttachmentInformer.
 	VolumeAttachments() TypedVolumeAttachmentInformer
-	// VolumeAttributesClasses returns a VolumeAttributesClassInformer.
+	// VolumeAttributesClasses returns a TypedVolumeAttributesClassInformer.
 	VolumeAttributesClasses() TypedVolumeAttributesClassInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/interface.go
@@ -24,11 +24,11 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// CSIStorageCapacities returns a CSIStorageCapacityInformer.
+	// CSIStorageCapacities returns a TypedCSIStorageCapacityInformer.
 	CSIStorageCapacities() TypedCSIStorageCapacityInformer
-	// VolumeAttachments returns a VolumeAttachmentInformer.
+	// VolumeAttachments returns a TypedVolumeAttachmentInformer.
 	VolumeAttachments() TypedVolumeAttachmentInformer
-	// VolumeAttributesClasses returns a VolumeAttributesClassInformer.
+	// VolumeAttributesClasses returns a TypedVolumeAttributesClassInformer.
 	VolumeAttributesClasses() TypedVolumeAttributesClassInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/interface.go
@@ -24,17 +24,17 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// CSIDrivers returns a CSIDriverInformer.
+	// CSIDrivers returns a TypedCSIDriverInformer.
 	CSIDrivers() TypedCSIDriverInformer
-	// CSINodes returns a CSINodeInformer.
+	// CSINodes returns a TypedCSINodeInformer.
 	CSINodes() TypedCSINodeInformer
-	// CSIStorageCapacities returns a CSIStorageCapacityInformer.
+	// CSIStorageCapacities returns a TypedCSIStorageCapacityInformer.
 	CSIStorageCapacities() TypedCSIStorageCapacityInformer
-	// StorageClasses returns a StorageClassInformer.
+	// StorageClasses returns a TypedStorageClassInformer.
 	StorageClasses() TypedStorageClassInformer
-	// VolumeAttachments returns a VolumeAttachmentInformer.
+	// VolumeAttachments returns a TypedVolumeAttachmentInformer.
 	VolumeAttachments() TypedVolumeAttachmentInformer
-	// VolumeAttributesClasses returns a VolumeAttributesClassInformer.
+	// VolumeAttributesClasses returns a TypedVolumeAttributesClassInformer.
 	VolumeAttributesClasses() TypedVolumeAttributesClassInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/storagemigration/v1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storagemigration/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// StorageVersionMigrations returns a StorageVersionMigrationInformer.
+	// StorageVersionMigrations returns a TypedStorageVersionMigrationInformer.
 	StorageVersionMigrations() TypedStorageVersionMigrationInformer
 }
 

--- a/staging/src/k8s.io/client-go/informers/storagemigration/v1beta1/interface.go
+++ b/staging/src/k8s.io/client-go/informers/storagemigration/v1beta1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// StorageVersionMigrations returns a StorageVersionMigrationInformer.
+	// StorageVersionMigrations returns a TypedStorageVersionMigrationInformer.
 	StorageVersionMigrations() TypedStorageVersionMigrationInformer
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/versioninterface.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/versioninterface.go
@@ -84,7 +84,7 @@ var versionTemplate = `
 // Interface provides access to all the informers in this group version.
 type Interface interface {
 	$range .types -$
-		// $.|publicPlural$ returns a $.|public$Informer.
+		// $.|publicPlural$ returns a Typed$.|public$Informer.
 		$.|publicPlural$() Typed$.|public$Informer
 	$end$
 }

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/example/v1/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ClusterTestTypes returns a ClusterTestTypeInformer.
+	// ClusterTestTypes returns a TypedClusterTestTypeInformer.
 	ClusterTestTypes() TypedClusterTestTypeInformer
-	// TestTypes returns a TestTypeInformer.
+	// TestTypes returns a TypedTestTypeInformer.
 	TestTypes() TypedTestTypeInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/example/v1/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ClusterTestTypes returns a ClusterTestTypeInformer.
+	// ClusterTestTypes returns a TypedClusterTestTypeInformer.
 	ClusterTestTypes() TypedClusterTestTypeInformer
-	// TestTypes returns a TestTypeInformer.
+	// TestTypes returns a TypedTestTypeInformer.
 	TestTypes() TypedTestTypeInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/core/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/core/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// TestTypes returns a TestTypeInformer.
+	// TestTypes returns a TypedTestTypeInformer.
 	TestTypes() TypedTestTypeInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// TestTypes returns a TestTypeInformer.
+	// TestTypes returns a TypedTestTypeInformer.
 	TestTypes() TypedTestTypeInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example2/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// TestTypes returns a TestTypeInformer.
+	// TestTypes returns a TypedTestTypeInformer.
 	TestTypes() TypedTestTypeInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/example3.io/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// TestTypes returns a TestTypeInformer.
+	// TestTypes returns a TypedTestTypeInformer.
 	TestTypes() TypedTestTypeInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/conflicting/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/conflicting/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// TestTypes returns a TestTypeInformer.
+	// TestTypes returns a TypedTestTypeInformer.
 	TestTypes() TypedTestTypeInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example/v1/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ClusterTestTypes returns a ClusterTestTypeInformer.
+	// ClusterTestTypes returns a TypedClusterTestTypeInformer.
 	ClusterTestTypes() TypedClusterTestTypeInformer
-	// TestTypes returns a TestTypeInformer.
+	// TestTypes returns a TypedTestTypeInformer.
 	TestTypes() TypedTestTypeInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/example2/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// TestTypes returns a TestTypeInformer.
+	// TestTypes returns a TypedTestTypeInformer.
 	TestTypes() TypedTestTypeInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/extensions/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/extensions/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// TestTypes returns a TestTypeInformer.
+	// TestTypes returns a TypedTestTypeInformer.
 	TestTypes() TypedTestTypeInformer
 }
 

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/interface.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/api/v1/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ClusterTestTypes returns a ClusterTestTypeInformer.
+	// ClusterTestTypes returns a TypedClusterTestTypeInformer.
 	ClusterTestTypes() TypedClusterTestTypeInformer
-	// TestTypes returns a TestTypeInformer.
+	// TestTypes returns a TypedTestTypeInformer.
 	TestTypes() TypedTestTypeInformer
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/interface.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// APIServices returns a APIServiceInformer.
+	// APIServices returns a TypedAPIServiceInformer.
 	APIServices() TypedAPIServiceInformer
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/interface.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration/v1beta1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// APIServices returns a APIServiceInformer.
+	// APIServices returns a TypedAPIServiceInformer.
 	APIServices() TypedAPIServiceInformer
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/interface.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1alpha1/interface.go
@@ -24,9 +24,9 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// Fischers returns a FischerInformer.
+	// Fischers returns a TypedFischerInformer.
 	Fischers() TypedFischerInformer
-	// Flunders returns a FlunderInformer.
+	// Flunders returns a TypedFlunderInformer.
 	Flunders() TypedFlunderInformer
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/interface.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/wardle/v1beta1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// Flunders returns a FlunderInformer.
+	// Flunders returns a TypedFlunderInformer.
 	Flunders() TypedFlunderInformer
 }
 

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/interface.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/samplecontroller/v1alpha1/interface.go
@@ -24,7 +24,7 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// Foos returns a FooInformer.
+	// Foos returns a TypedFooInformer.
 	Foos() TypedFooInformer
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR injects `Typed` semantics to Typed interface comments in `staging/src/k8s.io/code-generator/cmd/informer-gen/generators/versioninterface.go`. Also regenerated.

I noticed this while bringing in 1.37 bits, including regeneration, to cluster-autoscaler:

- https://github.com/kubernetes/autoscaler/pull/10144#discussion_r3787848136

`informer-gen`'s `versionTemplate` documents each group-version accessor as returning an untyped `<Name>Informer`, while the signature directly below it returns `Typed<Name>Informer`:

```go
// ControllerRevisions returns a ControllerRevisionInformer.
ControllerRevisions() TypedControllerRevisionInformer
```

The adjacent versionFuncTemplate does the correct thing, so the two templates in the same file disagree.

#139821 changed both templates' signatures to Typed*Informer and updated the func template's comment, but left the
interface template's comment untouched.

/sig api-machinery
/cc @liggitt @pohly

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
