### PR TITLE
docs(dra): document force-deleted pods as exclusivity edge case

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -130,6 +130,13 @@ type DRAPlugin interface {
 	// that, but if something went wrong, then the DRA driver is the last
 	// line of defense against using the same device for two different
 	// unrelated workloads.
+	
+	// Note: When a Pod using a Dynamic Resource Allocation ResourceClaim is force-deleted (such as via 
+	// kubectl delete pod --force --grace-period=0) or affected by node loss, the control-plane record 
+	// can be removed immediately while node-level teardown runs asynchronously. This can lead to a 
+	// race condition where a replacement pod's claim is prepared before the previous container has 
+	// fully stopped. Kubernetes cannot guarantee exclusive device handoff in this scenario, so the 
+	// DRA driver must enforce idempotence and device exclusivity to prevent concurrent preparation.
 	//
 	// If an error is returned, the result is ignored. Otherwise the result
 	// must have exactly one entry for each claim, identified by the UID of

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -130,8 +130,8 @@ type DRAPlugin interface {
 	// that, but if something went wrong, then the DRA driver is the last
 	// line of defense against using the same device for two different
 	// unrelated workloads. Real-world scenarios in which this can occur:
-	// - Pod force-deletion (such as via kubectl delete pod --force --grace-period=0)
-	// - Node loss
+	//   - Pod force-deletion (such as via kubectl delete pod --force --grace-period=0)
+	//   - Node loss
 	// In these cases, the control-plane record can be removed immediately while
 	// node-level teardown runs asynchronously. This can lead to a race condition
 	// where a replacement pod's claim is prepared before the previous container

--- a/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/kubeletplugin/draplugin.go
@@ -129,14 +129,15 @@ type DRAPlugin interface {
 	// for some other ResourceClaim. Kubernetes tries very hard to ensure
 	// that, but if something went wrong, then the DRA driver is the last
 	// line of defense against using the same device for two different
-	// unrelated workloads.
-	
-	// Note: When a Pod using a Dynamic Resource Allocation ResourceClaim is force-deleted (such as via 
-	// kubectl delete pod --force --grace-period=0) or affected by node loss, the control-plane record 
-	// can be removed immediately while node-level teardown runs asynchronously. This can lead to a 
-	// race condition where a replacement pod's claim is prepared before the previous container has 
-	// fully stopped. Kubernetes cannot guarantee exclusive device handoff in this scenario, so the 
-	// DRA driver must enforce idempotence and device exclusivity to prevent concurrent preparation.
+	// unrelated workloads. Real-world scenarios in which this can occur:
+	// - Pod force-deletion (such as via kubectl delete pod --force --grace-period=0)
+	// - Node loss
+	// In these cases, the control-plane record can be removed immediately while
+	// node-level teardown runs asynchronously. This can lead to a race condition
+	// where a replacement pod's claim is prepared before the previous container
+	// has fully stopped. Because Kubernetes cannot guarantee exclusive device
+	// handoff in this scenario, the DRA driver must enforce idempotence and device
+	// exclusivity to prevent concurrent preparation.
 	//
 	// If an error is returned, the result is ignored. Otherwise the result
 	// must have exactly one entry for each claim, identified by the UID of


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR documents a race condition caused by pod force-deletion (`--force --grace-period=0`) or node loss, where control-plane state clears before node teardown completes. Clarifies that the DRA driver acts as the final line of defense to enforce device exclusivity.
#### Which issue(s) this PR is related to:
#141471
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
