### PR TITLE
kubelet: refactor command runner and CRI metrics instrumentation

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/util/flowcontrol"
+	internalapi "k8s.io/cri-api/pkg/apis"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/credentialprovider"
@@ -833,3 +834,22 @@ const (
 	// log output that the termination message can contain.
 	MaxContainerTerminationMessageLogLines = 80
 )
+
+type commandRunner struct {
+	runtimeService internalapi.RuntimeService
+}
+
+var _ CommandRunner = &commandRunner{}
+
+// NewCommandRunner creates a new CommandRunner that uses the CRI RuntimeService.
+func NewCommandRunner(runtimeService internalapi.RuntimeService) CommandRunner {
+	return &commandRunner{runtimeService: runtimeService}
+}
+
+func (r *commandRunner) RunInContainer(ctx context.Context, id ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
+	stdout, stderr, err := r.runtimeService.ExecSync(ctx, id.ID, cmd, timeout)
+	// NOTE(tallclair): This does not correctly interleave stdout & stderr, but should be sufficient
+	// for logging purposes. A combined output option will need to be added to the ExecSyncRequest
+	// if more precise output ordering is ever required.
+	return append(stdout, stderr...), err
+}

--- a/pkg/kubelet/container/runtime_test.go
+++ b/pkg/kubelet/container/runtime_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	critesting "k8s.io/cri-api/pkg/apis/testing"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
@@ -785,4 +786,19 @@ func TestSortContainerStatusesByCreationTime(t *testing.T) {
 	// Test Less
 	assert.True(t, statuses.Less(1, 0), "Less(1, 0) should be true")
 	assert.False(t, statuses.Less(0, 1), "Less(0, 1) should be false")
+}
+
+func TestNewCommandRunner(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	fakeRuntime := critesting.NewFakeRuntimeService()
+	runner := NewCommandRunner(fakeRuntime)
+
+	output, err := runner.RunInContainer(tCtx, ContainerID{ID: "test-container-id"}, []string{"echo", "hello"}, time.Second)
+	require.NoError(t, err)
+	assert.Empty(t, output)
+	assert.Contains(t, fakeRuntime.Called, "ExecSync")
+
+	fakeRuntime.InjectError("ExecSync", assert.AnError)
+	_, err = runner.RunInContainer(tCtx, ContainerID{ID: "test-container-id"}, []string{"echo", "hello"}, time.Second)
+	assert.ErrorIs(t, err, assert.AnError)
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -109,6 +109,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/logs"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/metrics/collectors"
+	"k8s.io/kubernetes/pkg/kubelet/metrics/cri"
 	"k8s.io/kubernetes/pkg/kubelet/network/dns"
 	"k8s.io/kubernetes/pkg/kubelet/nodeshutdown"
 	oomwatcher "k8s.io/kubernetes/pkg/kubelet/oom"
@@ -419,6 +420,7 @@ func PreInitRuntimeService(ctx context.Context, kubeCfg *kubeletconfiginternal.K
 		Build(ctx); err != nil {
 		return err
 	}
+	kubeDeps.RemoteRuntimeService = cri.NewInstrumentedRuntimeService(kubeDeps.RemoteRuntimeService)
 	if kubeDeps.RemoteImageService, err = remote.NewRemoteImageServiceBuilder().
 		WithEndpoint(remoteImageEndpoint).
 		WithConnectionTimeout(kubeCfg.RuntimeRequestTimeout.Duration).
@@ -427,6 +429,7 @@ func PreInitRuntimeService(ctx context.Context, kubeCfg *kubeletconfiginternal.K
 		Build(ctx); err != nil {
 		return err
 	}
+	kubeDeps.RemoteImageService = cri.NewInstrumentedImageManagerService(kubeDeps.RemoteImageService)
 
 	kubeDeps.useLegacyCadvisorStats = cadvisor.UsingLegacyCadvisorStats(kubeCfg.ContainerRuntimeEndpoint)
 
@@ -847,7 +850,7 @@ func NewMainKubelet(ctx context.Context,
 	}
 	klet.containerRuntime = runtime
 	klet.streamingRuntime = runtime
-	klet.runner = runtime
+	klet.runner = kubecontainer.NewCommandRunner(kubeDeps.RemoteRuntimeService)
 	resizeAdmitHandler := allocation.NewPodResizesAdmitHandler(klet.containerManager, runtime, klet.allocationManager)
 
 	runtimeCache, err := kubecontainer.NewRuntimeCache(klet.containerRuntime, runtimeCacheRefreshPeriod)

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -144,7 +144,7 @@ func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.R
 	)
 	kubeRuntimeManager.runner = lifecycle.NewHandlerRunner(
 		&fakeHTTP{},
-		kubeRuntimeManager,
+		kubecontainer.NewCommandRunner(runtimeService),
 		kubeRuntimeManager,
 		recorder)
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -1351,15 +1351,6 @@ func (m *kubeGenericRuntimeManager) GetAttach(ctx context.Context, id kubecontai
 	return url.Parse(resp.Url)
 }
 
-// RunInContainer synchronously executes the command in the container, and returns the output.
-func (m *kubeGenericRuntimeManager) RunInContainer(ctx context.Context, id kubecontainer.ContainerID, cmd []string, timeout time.Duration) ([]byte, error) {
-	stdout, stderr, err := m.runtimeService.ExecSync(ctx, id.ID, cmd, timeout)
-	// NOTE(tallclair): This does not correctly interleave stdout & stderr, but should be sufficient
-	// for logging purposes. A combined output option will need to be added to the ExecSyncRequest
-	// if more precise output ordering is ever required.
-	return append(stdout, stderr...), err
-}
-
 // removeContainer removes the container and optionally the container logs.
 // Notice that we remove the container logs first, so that container will not be removed if
 // container logs are failed to be removed, and kubelet will retry this later. This guarantees

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -208,11 +208,10 @@ type kubeGenericRuntimeManager struct {
 	podInitContainerTimeRecorder PodInitContainerTimeRecorder
 }
 
-// KubeGenericRuntime is a interface contains interfaces for container runtime and command.
+// KubeGenericRuntime is a interface contains interfaces for container runtime and streaming runtime.
 type KubeGenericRuntime interface {
 	kubecontainer.Runtime
 	kubecontainer.StreamingRuntime
-	kubecontainer.CommandRunner
 }
 
 // NewKubeGenericRuntimeManager creates a new kubeGenericRuntimeManager
@@ -261,8 +260,6 @@ func NewKubeGenericRuntimeManager(
 ) (KubeGenericRuntime, []images.PostImageGCHook, error) {
 	logger := klog.FromContext(ctx)
 
-	runtimeService = newInstrumentedRuntimeService(runtimeService)
-	imageService = newInstrumentedImageManagerService(imageService)
 	tracer := tracerProvider.Tracer(instrumentationScope)
 	kubeRuntimeManager := &kubeGenericRuntimeManager{
 		recorder:                     recorder,
@@ -368,7 +365,7 @@ func NewKubeGenericRuntimeManager(
 		imagePullQPS,
 		imagePullBurst,
 		podPullingTimeRecorder)
-	kubeRuntimeManager.runner = lifecycle.NewHandlerRunner(insecureContainerLifecycleHTTPClient, kubeRuntimeManager, kubeRuntimeManager, recorder)
+	kubeRuntimeManager.runner = lifecycle.NewHandlerRunner(insecureContainerLifecycleHTTPClient, kubecontainer.NewCommandRunner(runtimeService), kubeRuntimeManager, recorder)
 	kubeRuntimeManager.containerGC = newContainerGC(runtimeService, podStateProvider, kubeRuntimeManager, tracer)
 	kubeRuntimeManager.podStateProvider = podStateProvider
 

--- a/pkg/kubelet/metrics/cri/instrumented_services.go
+++ b/pkg/kubelet/metrics/cri/instrumented_services.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kuberuntime
+package cri
 
 import (
 	"context"
@@ -31,8 +31,8 @@ type instrumentedRuntimeService struct {
 	service internalapi.RuntimeService
 }
 
-// Creates an instrumented RuntimeInterface from an existing RuntimeService.
-func newInstrumentedRuntimeService(service internalapi.RuntimeService) internalapi.RuntimeService {
+// NewInstrumentedRuntimeService creates an instrumented RuntimeService from an existing RuntimeService.
+func NewInstrumentedRuntimeService(service internalapi.RuntimeService) internalapi.RuntimeService {
 	return &instrumentedRuntimeService{service: service}
 }
 
@@ -42,8 +42,8 @@ type instrumentedImageManagerService struct {
 	service internalapi.ImageManagerService
 }
 
-// Creates an instrumented ImageManagerService from an existing ImageManagerService.
-func newInstrumentedImageManagerService(service internalapi.ImageManagerService) internalapi.ImageManagerService {
+// NewInstrumentedImageManagerService creates an instrumented ImageManagerService from an existing ImageManagerService.
+func NewInstrumentedImageManagerService(service internalapi.ImageManagerService) internalapi.ImageManagerService {
 	return &instrumentedImageManagerService{service: service}
 }
 
@@ -332,7 +332,7 @@ func (in instrumentedImageManagerService) ImageFsInfo(ctx context.Context) (*run
 
 	fsInfo, err := in.service.ImageFsInfo(ctx)
 	recordError(operation, err)
-	return fsInfo, nil
+	return fsInfo, err
 }
 
 func (in instrumentedImageManagerService) Close(ctx context.Context) error {

--- a/pkg/kubelet/metrics/cri/instrumented_services_test.go
+++ b/pkg/kubelet/metrics/cri/instrumented_services_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kuberuntime
+package cri
 
 import (
 	"net"
@@ -23,9 +23,11 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	compbasemetrics "k8s.io/component-base/metrics"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	critesting "k8s.io/cri-api/pkg/apis/testing"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/test/utils/ktesting"
 )
@@ -72,24 +74,24 @@ func TestRecordOperation(t *testing.T) {
 
 func TestInstrumentedVersion(t *testing.T) {
 	tCtx := ktesting.Init(t)
-	fakeRuntime, _, _, _ := createTestRuntimeManager(tCtx)
-	irs := newInstrumentedRuntimeService(fakeRuntime)
+	fakeRuntime := critesting.NewFakeRuntimeService()
+	irs := NewInstrumentedRuntimeService(fakeRuntime)
 	vr, err := irs.Version(tCtx, "1")
 	assert.NoError(t, err)
-	assert.Equal(t, kubeRuntimeAPIVersion, vr.Version)
+	assert.Equal(t, critesting.FakeVersion, vr.Version)
 }
 
 func TestStatus(t *testing.T) {
 	tCtx := ktesting.Init(t)
-	fakeRuntime, _, _, _ := createTestRuntimeManager(tCtx)
+	fakeRuntime := critesting.NewFakeRuntimeService()
 	fakeRuntime.FakeStatus = &runtimeapi.RuntimeStatus{
 		Conditions: []*runtimeapi.RuntimeCondition{
 			{Type: runtimeapi.RuntimeReady, Status: false},
 			{Type: runtimeapi.NetworkReady, Status: true},
 		},
 	}
-	irs := newInstrumentedRuntimeService(fakeRuntime)
-	actural, err := irs.Status(tCtx, false)
+	irs := NewInstrumentedRuntimeService(fakeRuntime)
+	actual, err := irs.Status(tCtx, false)
 	assert.NoError(t, err)
 	expected := &runtimeapi.RuntimeStatus{
 		Conditions: []*runtimeapi.RuntimeCondition{
@@ -97,5 +99,26 @@ func TestStatus(t *testing.T) {
 			{Type: runtimeapi.NetworkReady, Status: true},
 		},
 	}
-	assert.Equal(t, expected, actural.Status)
+	assert.Equal(t, expected, actual.Status)
+}
+
+func TestInstrumentedImageService(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	fakeImageService := critesting.NewFakeImageService()
+	fakeImageService.SetFakeImages([]string{"nginx:latest"})
+	fakeImageService.FakeFilesystemUsage = []*runtimeapi.FilesystemUsage{
+		{
+			FsId: &runtimeapi.FilesystemIdentifier{Mountpoint: "/var/lib/containerd"},
+		},
+	}
+
+	iis := NewInstrumentedImageManagerService(fakeImageService)
+
+	images, err := iis.ListImages(tCtx, nil)
+	require.NoError(t, err)
+	assert.Len(t, images, 1)
+
+	fsInfo, err := iis.ImageFsInfo(tCtx)
+	require.NoError(t, err)
+	assert.Len(t, fsInfo.ImageFilesystems, 1)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR takes over #140767.

Several packages depend on `kuberuntime_manager` to provide the `CommandRunner` interface, but this is actually a simple wrapper around the CRI runtime service (`ExecSync`).
This PR:
1. Decouples `CommandRunner` from `kuberuntime`: Moves the wrapper into `kubecontainer.NewCommandRunner` in `pkg/kubelet/container`, simplifying dependency cycles.
2. Instruments CRI services at initialization: Moves `instrumented_services` out of `pkg/kubelet/kuberuntime` to a dedicated `pkg/kubelet/metrics/cri` package, and initializes them in `PreInitRuntimeService` so all kubelet components calling the runtime and image services are uniformly instrumented.

#### Which issue(s) this PR is related to:
N/A
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig node