### PR TITLE
kubelet: reconstruct memory request from cgroup v2 parameters

### DIFF
--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -481,7 +482,21 @@ func readCgroupMemoryConfig(cgroupPath string, memLimitFile string) (*ResourceCo
 		return nil, fmt.Errorf("failed to read %s for cgroup %v: %v", memLimitFile, cgroupPath, err)
 	}
 	mLim := int64(memLimit)
-	//TODO(vinaykul,InPlacePodVerticalScaling): Add memory request support
-	return &ResourceConfig{Memory: &mLim}, nil
 
+	rc := &ResourceConfig{Memory: &mLim}
+
+	if libcontainercgroups.IsCgroup2UnifiedMode() {
+		// Read memory.min, memory.low, and memory.high for cgroups v2
+		for _, param := range []string{Cgroup2MemoryMin, Cgroup2MemoryLow, Cgroup2MemoryHigh} {
+			val, err := fscommon.GetCgroupParamUint(cgroupPath, param)
+			if err == nil && val > 0 {
+				if rc.Unified == nil {
+					rc.Unified = make(map[string]string)
+				}
+				rc.Unified[param] = strconv.FormatUint(val, 10)
+			}
+		}
+	}
+
+	return rc, nil
 }

--- a/pkg/kubelet/cm/cgroup_manager_linux_test.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux_test.go
@@ -19,9 +19,13 @@ limitations under the License.
 package cm
 
 import (
+	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	libcontainercgroups "github.com/opencontainers/cgroups"
 )
 
 // TestNewCgroupName tests confirms that #68416 is fixed
@@ -204,6 +208,62 @@ func TestCpuWeightToCPUShares(t *testing.T) {
 		if actual := cpuWeightToCPUShares(testCase.cpuWeight); actual != testCase.expectedCpuShares {
 			t.Errorf("cpuWeight: %v, expectedCpuShares: %v, actualCpuShares: %v",
 				testCase.cpuWeight, testCase.expectedCpuShares, actual)
+		}
+	}
+}
+
+func TestReadCgroupMemoryConfig(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "cgroup_memory_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	limitFile := "memory.max"
+	limitVal := "2097152"
+	if err := os.WriteFile(filepath.Join(tempDir, limitFile), []byte(limitVal), 0644); err != nil {
+		t.Fatalf("failed to write limit file: %v", err)
+	}
+
+	minVal := "102400"
+	lowVal := "204800"
+	highVal := "409600"
+	if err := os.WriteFile(filepath.Join(tempDir, "memory.min"), []byte(minVal), 0644); err != nil {
+		t.Fatalf("failed to write memory.min: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "memory.low"), []byte(lowVal), 0644); err != nil {
+		t.Fatalf("failed to write memory.low: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "memory.high"), []byte(highVal), 0644); err != nil {
+		t.Fatalf("failed to write memory.high: %v", err)
+	}
+
+	rc, err := readCgroupMemoryConfig(tempDir, limitFile)
+	if err != nil {
+		t.Fatalf("failed to read cgroup memory config: %v", err)
+	}
+
+	if rc.Memory == nil || *rc.Memory != 2097152 {
+		t.Errorf("expected Memory limit to be 2097152, got %v", rc.Memory)
+	}
+
+	if libcontainercgroups.IsCgroup2UnifiedMode() {
+		if rc.Unified == nil {
+			t.Errorf("expected Unified map to be populated in cgroup v2 mode")
+		} else {
+			if val, ok := rc.Unified["memory.min"]; !ok || val != minVal {
+				t.Errorf("expected memory.min to be %s, got %s", minVal, val)
+			}
+			if val, ok := rc.Unified["memory.low"]; !ok || val != lowVal {
+				t.Errorf("expected memory.low to be %s, got %s", lowVal, val)
+			}
+			if val, ok := rc.Unified["memory.high"]; !ok || val != highVal {
+				t.Errorf("expected memory.high to be %s, got %s", highVal, val)
+			}
+		}
+	} else {
+		if rc.Unified != nil {
+			t.Errorf("expected Unified map to be nil in cgroup v1 mode")
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
This PR resolves an issue in the Kubelet where memory requests (configured via cgroups v2 `memory.min` / `memory.low` / `memory.high` when `MemoryQoS` is enabled) are completely omitted when reading cgroup configuration. 

#### Root Cause:
In `pkg/kubelet/cm/cgroup_manager_linux.go`, `readCgroupMemoryConfig` is used to retrieve memory configuration of a cgroup from cgroupfs. However, it only read the memory limit parameter (e.g. `memory.max`), completely ignoring memory request parameters. Because of this, Kubelet's state reconstruction on startup/reconciliation and vertical scaling validations (in `validatePodResizeAction`) received a `ResourceConfig` structure with no unified memory request settings, leading to discrepancies, validation issues, or incorrect QoS settings after restarts.

#### Solution:
- Updated `readCgroupMemoryConfig` to check if unified cgroup v2 mode is enabled.
- If cgroup v2 unified mode is active, read the configured memory requests/limits (`memory.min`, `memory.low`, `memory.high`) from cgroupfs.
- If these parameters exist and are set (> 0), populate them into the `Unified` settings of the returned `ResourceConfig`.
- Added unit tests in `cgroup_manager_linux_test.go` to verify this parser behavior.

#### Which issue(s) this PR fixes:
Fixes #141481

#### Special notes for your reviewer:
None.

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
