### PR TITLE
Stop preStop sleep hook when the container exits

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -19,6 +19,7 @@ package container
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"strings"
@@ -41,6 +42,9 @@ import (
 	"k8s.io/kubernetes/third_party/forked/golang/expansion"
 	utilsnet "k8s.io/utils/net"
 )
+
+// ErrContainerExited indicates that a lifecycle handler's container exited while the handler was running.
+var ErrContainerExited = errors.New("container exited")
 
 // HandlerRunner runs a lifecycle handler for a container.
 type HandlerRunner interface {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -894,7 +894,7 @@ func NewMainKubelet(ctx context.Context,
 		RelistPeriod:    genericPlegRelistPeriod,
 		RelistThreshold: genericPlegRelistThreshold,
 	}
-	klet.pleg = pleg.NewGenericPLEG(klet.containerRuntime, eventChannel, genericRelistDuration, podCache, clock.RealClock{})
+	klet.pleg = pleg.NewGenericPLEG(klet.containerRuntime, eventChannel, genericRelistDuration, podCache, clock.RealClock{}, runtime.NotifyContainerDied)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.EventedPLEG) {
 		// EventedPLEG only watches the CRI event stream and requests relists.

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -388,7 +388,7 @@ func newTestKubeletWithImageList(
 	kubelet.resyncInterval = 10 * time.Second
 	kubelet.workQueue = queue.NewBasicWorkQueue(fakeClock)
 	// Relist period does not affect the tests.
-	kubelet.pleg = pleg.NewGenericPLEG(fakeRuntime, make(chan *pleg.PodLifecycleEvent, 100), &pleg.RelistDuration{RelistPeriod: time.Hour, RelistThreshold: genericPlegRelistThreshold}, podCache, clock.RealClock{})
+	kubelet.pleg = pleg.NewGenericPLEG(fakeRuntime, make(chan *pleg.PodLifecycleEvent, 100), &pleg.RelistDuration{RelistPeriod: time.Hour, RelistThreshold: genericPlegRelistThreshold}, podCache, clock.RealClock{}, nil)
 	kubelet.clock = fakeClock
 
 	nodeRef := &v1.ObjectReference{

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -117,6 +117,7 @@ func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.R
 		podLogsDirectory:   fakePodLogsDirectory,
 		actuatedState:      state.NewStateMemory(logger, nil),
 	}
+	kubeRuntimeManager.containerExitCancels = make(map[string]context.CancelFunc)
 
 	// Initialize swap controller availability check (always false for tests)
 	kubeRuntimeManager.getSwapControllerAvailable = func() bool { return false }

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -117,7 +117,7 @@ func newFakeKubeRuntimeManager(ctx context.Context, runtimeService internalapi.R
 		podLogsDirectory:   fakePodLogsDirectory,
 		actuatedState:      state.NewStateMemory(logger, nil),
 	}
-	kubeRuntimeManager.containerExitCancels = make(map[string]context.CancelFunc)
+	kubeRuntimeManager.containerExitCancels = make(map[string]context.CancelCauseFunc)
 
 	// Initialize swap controller availability check (always false for tests)
 	kubeRuntimeManager.getSwapControllerAvailable = func() bool { return false }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -780,17 +780,55 @@ func (m *kubeGenericRuntimeManager) toKubeContainerStatus(ctx context.Context, p
 	return cStatus
 }
 
+func (m *kubeGenericRuntimeManager) registerContainerExitCancel(containerID string, cancel context.CancelFunc) func() {
+	m.containerExitCancelsLock.Lock()
+	m.containerExitCancels[containerID] = cancel
+	m.containerExitCancelsLock.Unlock()
+
+	return func() {
+		m.containerExitCancelsLock.Lock()
+		defer m.containerExitCancelsLock.Unlock()
+		delete(m.containerExitCancels, containerID)
+	}
+}
+
+// NotifyContainerDied cancels a sleep lifecycle hook running for the container.
+func (m *kubeGenericRuntimeManager) NotifyContainerDied(containerID string) {
+	m.containerExitCancelsLock.Lock()
+	cancel := m.containerExitCancels[containerID]
+	delete(m.containerExitCancels, containerID)
+	m.containerExitCancelsLock.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
 // executePreStopHook runs the pre-stop lifecycle hooks if applicable and returns the duration it takes.
 func (m *kubeGenericRuntimeManager) executePreStopHook(ctx context.Context, pod *v1.Pod, containerID kubecontainer.ContainerID, containerSpec *v1.Container, gracePeriod int64) int64 {
 	logger := klog.FromContext(ctx)
+	hookCtx := ctx
+	if containerSpec.Lifecycle.PreStop.Sleep != nil {
+		var cancelHook context.CancelFunc
+		hookCtx, cancelHook = context.WithCancel(ctx)
+		defer cancelHook()
+		unregister := m.registerContainerExitCancel(containerID.ID, cancelHook)
+		defer unregister()
+
+		status, err := m.runtimeService.ContainerStatus(ctx, containerID.ID, false)
+		if crierror.IsNotFound(err) || err == nil && status.GetStatus().GetState() == runtimeapi.ContainerState_CONTAINER_EXITED {
+			logger.V(3).Info("Skipping preStop sleep hook because container already exited", "pod", klog.KObj(pod), "podUID", pod.UID,
+				"containerName", containerSpec.Name, "containerID", containerID.String())
+			return 0
+		}
+	}
 	logger.V(3).Info("Running preStop hook", "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", containerSpec.Name, "containerID", containerID.String())
 
 	start := metav1.Now()
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		defer utilruntime.HandleCrashWithContext(ctx)
-		if _, err := m.runner.Run(ctx, containerID, pod, containerSpec, containerSpec.Lifecycle.PreStop); err != nil {
+		defer utilruntime.HandleCrashWithContext(hookCtx)
+		if _, err := m.runner.Run(hookCtx, containerID, pod, containerSpec, containerSpec.Lifecycle.PreStop); err != nil {
 			logger.Error(err, "PreStop hook failed", "pod", klog.KObj(pod), "podUID", pod.UID,
 				"containerName", containerSpec.Name, "containerID", containerID.String())
 			// do not record the message in the event so that secrets won't leak from the server.

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -780,7 +780,7 @@ func (m *kubeGenericRuntimeManager) toKubeContainerStatus(ctx context.Context, p
 	return cStatus
 }
 
-func (m *kubeGenericRuntimeManager) registerContainerExitCancel(containerID string, cancel context.CancelFunc) func() {
+func (m *kubeGenericRuntimeManager) registerContainerExitCancel(containerID string, cancel context.CancelCauseFunc) func() {
 	m.containerExitCancelsLock.Lock()
 	m.containerExitCancels[containerID] = cancel
 	m.containerExitCancelsLock.Unlock()
@@ -799,7 +799,7 @@ func (m *kubeGenericRuntimeManager) NotifyContainerDied(containerID string) {
 	delete(m.containerExitCancels, containerID)
 	m.containerExitCancelsLock.Unlock()
 	if cancel != nil {
-		cancel()
+		cancel(kubecontainer.ErrContainerExited)
 	}
 }
 
@@ -808,9 +808,9 @@ func (m *kubeGenericRuntimeManager) executePreStopHook(ctx context.Context, pod 
 	logger := klog.FromContext(ctx)
 	hookCtx := ctx
 	if containerSpec.Lifecycle.PreStop.Sleep != nil {
-		var cancelHook context.CancelFunc
-		hookCtx, cancelHook = context.WithCancel(ctx)
-		defer cancelHook()
+		var cancelHook context.CancelCauseFunc
+		hookCtx, cancelHook = context.WithCancelCause(ctx)
+		defer cancelHook(nil)
 		unregister := m.registerContainerExitCancel(containerID.ID, cancelHook)
 		defer unregister()
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -226,7 +227,8 @@ func TestExecutePreStopSleepHook(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
-			fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
+			recorder := record.NewFakeRecorder(1)
+			fakeRuntime, _, m, err := createTestRuntimeManager(tCtx, withRecorder(recorder))
 			require.NoError(t, err)
 
 			pod := makeTestPod("pod", "namespace", "pod-uid", []v1.Container{{
@@ -264,6 +266,11 @@ func TestExecutePreStopSleepHook(t *testing.T) {
 				assert.Zero(t, elapsed)
 			case <-time.After(5 * time.Second):
 				t.Fatal("preStop sleep hook did not return after the container exited")
+			}
+			select {
+			case event := <-recorder.Events:
+				t.Fatalf("unexpected event after clean container exit: %s", event)
+			default:
 			}
 		})
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -206,6 +206,69 @@ func TestKillContainer(t *testing.T) {
 	}
 }
 
+func TestExecutePreStopSleepHook(t *testing.T) {
+	tests := []struct {
+		name                string
+		initialState        runtimeapi.ContainerState
+		notifyContainerDied bool
+	}{
+		{
+			name:                "cancel running hook when container exits",
+			initialState:        runtimeapi.ContainerState_CONTAINER_RUNNING,
+			notifyContainerDied: true,
+		},
+		{
+			name:         "skip hook when container already exited",
+			initialState: runtimeapi.ContainerState_CONTAINER_EXITED,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
+			require.NoError(t, err)
+
+			pod := makeTestPod("pod", "namespace", "pod-uid", []v1.Container{{
+				Name:  "container",
+				Image: "image",
+				Lifecycle: &v1.Lifecycle{
+					PreStop: &v1.LifecycleHandler{
+						Sleep: &v1.SleepAction{Seconds: 30},
+					},
+				},
+			}})
+			_, fakeContainers := makeAndSetFakePod(tCtx, m, fakeRuntime, pod)
+			require.Len(t, fakeContainers, 1)
+			fakeContainers[0].State = test.initialState
+			containerID := kubecontainer.ContainerID{Type: m.runtimeName, ID: fakeContainers[0].Id}
+
+			done := make(chan int64, 1)
+			go func() {
+				done <- m.executePreStopHook(tCtx, pod, containerID, &pod.Spec.Containers[0], 40)
+			}()
+			t.Cleanup(func() { m.NotifyContainerDied(containerID.ID) })
+
+			if test.notifyContainerDied {
+				require.Eventually(t, func() bool {
+					m.containerExitCancelsLock.Lock()
+					defer m.containerExitCancelsLock.Unlock()
+					_, ok := m.containerExitCancels[containerID.ID]
+					return ok
+				}, 5*time.Second, 10*time.Millisecond)
+				m.NotifyContainerDied(containerID.ID)
+			}
+
+			select {
+			case elapsed := <-done:
+				assert.Zero(t, elapsed)
+			case <-time.After(5 * time.Second):
+				t.Fatal("preStop sleep hook did not return after the container exited")
+			}
+		})
+	}
+}
+
 // TestToKubeContainerStatus tests the converting the CRI container status to
 // the internal type (i.e., toKubeContainerStatus()) for containers in
 // different states.

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
@@ -125,6 +126,10 @@ type kubeGenericRuntimeManager struct {
 	// Runner of lifecycle events.
 	runner kubecontainer.HandlerRunner
 
+	// Cancels sleep lifecycle hooks when their containers exit.
+	containerExitCancelsLock sync.Mutex
+	containerExitCancels     map[string]context.CancelFunc
+
 	// RuntimeHelper that wraps kubelet to generate runtime container options.
 	runtimeHelper kubecontainer.RuntimeHelper
 
@@ -212,6 +217,7 @@ type kubeGenericRuntimeManager struct {
 type KubeGenericRuntime interface {
 	kubecontainer.Runtime
 	kubecontainer.StreamingRuntime
+	NotifyContainerDied(containerID string)
 }
 
 // NewKubeGenericRuntimeManager creates a new kubeGenericRuntimeManager
@@ -288,6 +294,7 @@ func NewKubeGenericRuntimeManager(
 		memoryReservationPolicy:      memoryReservationPolicy,
 		podLogsDirectory:             podLogsDirectory,
 		podInitContainerTimeRecorder: podInitContainerTimeRecorder,
+		containerExitCancels:         make(map[string]context.CancelFunc),
 	}
 
 	// Initialize swap controller availability check with lazy evaluation

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -128,7 +128,7 @@ type kubeGenericRuntimeManager struct {
 
 	// Cancels sleep lifecycle hooks when their containers exit.
 	containerExitCancelsLock sync.Mutex
-	containerExitCancels     map[string]context.CancelFunc
+	containerExitCancels     map[string]context.CancelCauseFunc
 
 	// RuntimeHelper that wraps kubelet to generate runtime container options.
 	runtimeHelper kubecontainer.RuntimeHelper
@@ -294,7 +294,7 @@ func NewKubeGenericRuntimeManager(
 		memoryReservationPolicy:      memoryReservationPolicy,
 		podLogsDirectory:             podLogsDirectory,
 		podInitContainerTimeRecorder: podInitContainerTimeRecorder,
-		containerExitCancels:         make(map[string]context.CancelFunc),
+		containerExitCancels:         make(map[string]context.CancelCauseFunc),
 	}
 
 	// Initialize swap controller availability check with lazy evaluation

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -112,6 +112,9 @@ func (hr *handlerRunner) runSleepHandler(ctx context.Context, seconds int64) err
 	c := time.After(time.Duration(seconds) * time.Second)
 	select {
 	case <-ctx.Done():
+		if errors.Is(context.Cause(ctx), kubecontainer.ErrContainerExited) {
+			return nil
+		}
 		// unexpected termination
 		metrics.LifecycleHandlerSleepTerminated.Inc()
 		return fmt.Errorf("container terminated before sleep hook finished")

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -811,6 +811,7 @@ func TestRunSleepHandler(t *testing.T) {
 		name                          string
 		sleepSeconds                  int64
 		terminationGracePeriodSeconds int64
+		cancelCause                   error
 		expectErr                     bool
 		expectedErr                   string
 	}{
@@ -826,14 +827,25 @@ func TestRunSleepHandler(t *testing.T) {
 			expectErr:                     true,
 			expectedErr:                   "container terminated before sleep hook finished",
 		},
+		{
+			name:                          "container exited before sleep finished",
+			sleepSeconds:                  30,
+			terminationGracePeriodSeconds: 30,
+			cancelCause:                   kubecontainer.ErrContainerExited,
+		},
 	}
 
 	for _, tt := range tests {
 		tCtx.SyncTest(tt.name, func(tCtx ktesting.TContext) {
 			t := tCtx.TB()
 			pod.Spec.Containers[0].Lifecycle.PreStop.Sleep = &v1.SleepAction{Seconds: tt.sleepSeconds}
-			ctx, cancel := context.WithTimeout(tCtx, time.Duration(tt.terminationGracePeriodSeconds)*time.Second)
-			defer cancel()
+			timeoutCtx, cancelTimeout := context.WithTimeout(tCtx, time.Duration(tt.terminationGracePeriodSeconds)*time.Second)
+			defer cancelTimeout()
+			ctx, cancel := context.WithCancelCause(timeoutCtx)
+			defer cancel(nil)
+			if tt.cancelCause != nil {
+				cancel(tt.cancelCause)
+			}
 
 			_, err := handlerRunner.Run(ctx, containerID, &pod, &container, container.Lifecycle.PreStop)
 

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -54,6 +54,8 @@ type GenericPLEG struct {
 	runtime kubecontainer.Runtime
 	// The channel from which the subscriber listens events.
 	eventChannel chan *PodLifecycleEvent
+	// Called after a container exit is confirmed in the runtime cache.
+	containerDiedHandler func(string)
 	// The internal cache for pod/container information.
 	// Guarded by relistLock.
 	podRecords podRecords
@@ -132,18 +134,19 @@ type podRecords map[types.UID]*podRecord
 // NewGenericPLEG instantiates a new GenericPLEG object and return it.
 func NewGenericPLEG(runtime kubecontainer.Runtime, eventChannel chan *PodLifecycleEvent,
 	relistDuration *RelistDuration, cache kubecontainer.Cache,
-	clock clock.Clock) PodLifecycleEventGenerator {
+	clock clock.Clock, containerDiedHandler func(string)) PodLifecycleEventGenerator {
 	if cache == nil {
 		panic("cache cannot be nil")
 	}
 	return &GenericPLEG{
-		relistDuration: relistDuration,
-		runtime:        runtime,
-		eventChannel:   eventChannel,
-		podRecords:     make(podRecords),
-		cache:          cache,
-		clock:          clock,
-		relistRequests: make(chan relistRequest, 200),
+		relistDuration:       relistDuration,
+		runtime:              runtime,
+		eventChannel:         eventChannel,
+		podRecords:           make(podRecords),
+		cache:                cache,
+		clock:                clock,
+		relistRequests:       make(chan relistRequest, 200),
+		containerDiedHandler: containerDiedHandler,
 	}
 }
 
@@ -402,6 +405,9 @@ func (g *GenericPLEG) reconcilePodRecord(ctx context.Context, pid types.UID) {
 				}
 			}
 			if containerID, ok := events[i].Data.(string); ok {
+				if g.containerDiedHandler != nil {
+					g.containerDiedHandler(containerID)
+				}
 				if exitCode, ok := containerExitCode[containerID]; ok && pod != nil {
 					logger.V(2).Info("Generic (PLEG): container finished", "podID", pod.ID, "containerID", containerID, "exitCode", exitCode)
 				}

--- a/pkg/kubelet/pleg/generic_test.go
+++ b/pkg/kubelet/pleg/generic_test.go
@@ -73,6 +73,7 @@ func newTestGenericPLEGWithChannelSize(eventChannelCap int) *TestGenericPLEG {
 		&RelistDuration{RelistPeriod: time.Hour, RelistThreshold: 3 * time.Minute},
 		fakeCache,
 		clock,
+		nil,
 	).(*GenericPLEG)
 	return &TestGenericPLEG{pleg: pleg, runtime: fakeRuntime, clock: clock}
 }
@@ -332,6 +333,7 @@ func newTestGenericPLEGWithRuntimeMock(runtimeMock kubecontainer.Runtime) *Gener
 		&RelistDuration{RelistPeriod: time.Hour, RelistThreshold: 2 * time.Hour},
 		kubecontainer.NewCache(),
 		clock.RealClock{},
+		nil,
 	).(*GenericPLEG)
 	return pleg
 }
@@ -644,6 +646,7 @@ func TestUpdateCacheUsesPodTimestampWhenEventedPLEGIsEnabled(t *testing.T) {
 		&RelistDuration{RelistPeriod: time.Hour, RelistThreshold: 3 * time.Minute},
 		cache,
 		testingclock.NewFakeClock(time.Time{}),
+		nil,
 	).(*GenericPLEG)
 
 	cache.Set(podID, &kubecontainer.PodStatus{ID: podID}, nil, cachedTimestamp)
@@ -886,6 +889,7 @@ func TestWorkerLoop(t *testing.T) {
 			&RelistDuration{RelistPeriod: 2 * time.Second},
 			cache,
 			clock.RealClock{},
+			nil,
 		).(*GenericPLEG)
 
 		pod1 := &kubecontainer.Pod{ID: "pod1", Name: "pod1", Containers: []*kubecontainer.Container{{ID: kubecontainer.ContainerID{Type: "test", ID: "c1"}, State: kubecontainer.ContainerStateRunning}}}

--- a/test/e2e/common/node/lifecycle_hook.go
+++ b/test/e2e/common/node/lifecycle_hook.go
@@ -734,6 +734,42 @@ var _ = SIGDescribe("Lifecycle Sleep Hook", framework.WithNodeConformance(), fun
 				framework.Failf("unexpected delay duration before killing the pod, cost = %v", cost)
 			}
 		})
+
+	})
+})
+
+// TODO: Move this test into the NodeConformance suite above after it is proven stable across supported runtimes.
+var _ = SIGDescribe("Lifecycle Sleep Hook when container exits", func() {
+	f := framework.NewDefaultFramework("pod-lifecycle-sleep-action-container-exit")
+	f.NamespacePodSecurityLevel = admissionapi.LevelBaseline
+
+	ginkgo.It("stops sleep action during pod termination", func(ctx context.Context) {
+		const (
+			containerLifetime = 10
+			sleepSeconds      = 30
+			gracePeriod       = 40
+			deletionTimeout   = 20 * time.Second
+		)
+		lifecycle := &v1.Lifecycle{
+			PreStop: &v1.LifecycleHandler{
+				Sleep: &v1.SleepAction{Seconds: sleepSeconds},
+			},
+		}
+		name := "pod-with-prestop-sleep-hook"
+		podWithHook := getPodWithHook(name, imageutils.GetE2EImage(imageutils.BusyBox), lifecycle)
+		podWithHook.Spec.Containers[0].Command = []string{"/bin/sleep", fmt.Sprintf("%d", containerLifetime)}
+		podWithHook.Spec.RestartPolicy = v1.RestartPolicyNever
+		podWithHook.Spec.TerminationGracePeriodSeconds = ptr.To[int64](gracePeriod)
+
+		ginkgo.By("create a pod whose container exits before the sleep action finishes")
+		podClient := e2epod.NewPodClient(f)
+		podClient.CreateSync(ctx, podWithHook)
+		ginkgo.By("delete the pod while its container is still running")
+		framework.ExpectNoError(podClient.Delete(ctx, name, metav1.DeleteOptions{}))
+		framework.ExpectNoError(
+			e2epod.WaitForPodNotFoundInNamespace(ctx, f.ClientSet, name, f.Namespace.Name, deletionTimeout),
+			"pod should finish terminating when its container exits",
+		)
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When a container exits while its native Sleep preStop hook is running, kubelet still waits for the full configured sleep duration. This PR uses the container-death notification from PLEG to cancel the running sleep hook immediately, avoiding unnecessary delays in pod termination.
#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #134338
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
