### PR TITLE
WIP apiserver: de-flake TestTimeTravelHealthcheck

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory_test.go
@@ -375,25 +375,28 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 
 	ready := make(chan struct{})
 	signal := make(chan struct{})
+	// firstProbeStarted is closed once the first probe has entered the mocked
+	// client, which happens only after it has consumed the rate limiter token.
+	firstProbeStarted := make(chan struct{})
+	// releaseFirstProbe keeps the first probe in flight until the test releases
+	// it, so the second probe is guaranteed to run before the first one returns.
+	releaseFirstProbe := make(chan struct{})
 
 	var counter uint64
 	newETCD3Client = func(c storagebackend.TransportConfig) (*kubernetes.Client, error) {
 		defer close(ready)
 		dummyKV := mockKV{
 			get: func(ctx context.Context) (*clientv3.GetResponse, error) {
-				atomic.AddUint64(&counter, 1)
-				val := atomic.LoadUint64(&counter)
-				// the first request wait for a custom timeout to trigger an error.
-				// We don't use the context timeout because we want to check that
-				// the cached answer is not overridden, and since the rate limit is
-				// based on cfg.HealthcheckTimeout / 2, the timeout will race with
-				// the race limiter to server the new request from the cache or allow
-				// it to go through
+				val := atomic.AddUint64(&counter, 1)
+				// The first probe blocks until the test releases it and then
+				// returns an error. Its timestamp is captured before it blocks,
+				// so this late error must not overwrite a newer cached success.
 				if val == 1 {
+					close(firstProbeStarted)
 					select {
 					case <-ctx.Done():
 						return nil, ctx.Err()
-					case <-time.After((2 * cfg.HealthcheckTimeout) / 3):
+					case <-releaseFirstProbe:
 						return nil, fmt.Errorf("etcd down")
 					}
 				}
@@ -413,16 +416,20 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	}
 	// Wait for healthcheck to establish connection
 	<-ready
-	// run a first request that fails after 2 seconds
+	// run a first request that stays in flight until released
 	go func() {
 		err := healthcheck()
-		if !strings.Contains(err.Error(), "etcd down") {
+		if err == nil || !strings.Contains(err.Error(), "etcd down") {
 			t.Errorf("healthcheck() mismatch want %v got %v", fmt.Errorf("etcd down"), err)
 		}
 		close(signal)
 	}()
 
-	// wait until the rate limit allows new connections
+	// Only start timing the rate limiter once the first probe has consumed its
+	// token. Because time.Sleep never wakes early, sleeping the limiter interval
+	// (HealthcheckTimeout/2) then guarantees the next probe is admitted, without
+	// racing the limiter refill as the previous timer-based version did.
+	<-firstProbeStarted
 	time.Sleep(cfg.HealthcheckTimeout / 2)
 
 	select {
@@ -440,6 +447,10 @@ func TestTimeTravelHealthcheck(t *testing.T) {
 	if c != 2 {
 		t.Errorf("healthcheck() called etcd %d times, expected only two calls", c)
 	}
+
+	// Release the first probe; its error is stamped with an older timestamp and
+	// must not override the cached success from the second probe.
+	close(releaseFirstProbe)
 
 	// cached request should be success and not be overridden by the late error
 	<-signal


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

This PR addresses flakes in TestTimeTravelHealthcheck due to the test sleeping exactly one rate-limiter interval (HealthcheckTimeout/2) without waiting for the first probe to start (which consumes the limiter token), so the second healthcheck's outcome was nondeterministic: when it ran before the limiter had refilled its token, it returned the initial cached placeholder instead of issuing a real etcd call, leaving the counter at 1 — whereas we expect the refilled limiter to admit a real etcd call that returns success and increments the counter to 2.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
