### PR TITLE
apiextensions-apiserver: use etcdOptionsCopy in NewCRDRESTOptionsGetter

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
@@ -156,7 +156,7 @@ func NewCRDRESTOptionsGetter(etcdOptions genericoptions.EtcdOptions, resourceTra
 	etcdOptionsCopy.StorageConfig.StorageObjectCountTracker = tracker
 	etcdOptionsCopy.WatchCacheSizes = nil // this control is not provided for custom resources
 
-	return etcdOptions.CreateRESTOptionsGetter(&genericoptions.SimpleStorageFactory{StorageConfig: etcdOptionsCopy.StorageConfig}, resourceTransformers)
+	return etcdOptionsCopy.CreateRESTOptionsGetter(&genericoptions.SimpleStorageFactory{StorageConfig: etcdOptionsCopy.StorageConfig}, resourceTransformers)
 }
 
 type serviceResolver struct {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"testing"
+
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
+)
+
+func TestNewCRDRESTOptionsGetter(t *testing.T) {
+	etcdOptions := genericoptions.NewEtcdOptions(&storagebackend.Config{})
+	etcdOptions.WatchCacheSizes = []string{"foos.example.com#0", "bars.example.com#100"}
+
+	getter := NewCRDRESTOptionsGetter(*etcdOptions, nil, nil)
+	factory, ok := getter.(*genericoptions.StorageFactoryRestOptionsFactory)
+	if !ok {
+		t.Fatalf("expected *genericoptions.StorageFactoryRestOptionsFactory, got %T", getter)
+	}
+
+	if factory.Options.WatchCacheSizes != nil {
+		t.Errorf("expected WatchCacheSizes to be nil for custom resources, got %v", factory.Options.WatchCacheSizes)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

In `staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go`, `NewCRDRESTOptionsGetter` prepares `etcdOptionsCopy` with custom resource specific storage configurations and explicitly clears `etcdOptionsCopy.WatchCacheSizes = nil // this control is not provided for custom resources`.

However, the final return statement previously invoked `etcdOptions.CreateRESTOptionsGetter(...)` on the original `etcdOptions` instead of `etcdOptionsCopy`. Because `CreateRESTOptionsGetter` copies the receiver's options into `StorageFactoryRestOptionsFactory.Options`, the original `WatchCacheSizes` remained present and line 157 was ineffective dead code.

This PR updates `NewCRDRESTOptionsGetter` to call `etcdOptionsCopy.CreateRESTOptionsGetter(...)`, ensuring `WatchCacheSizes = nil` is actually set in the resulting REST options getter for custom resources.

#### Which issue(s) this PR fixes:

Fixes #141217

#### Special notes for your reviewer:

- Includes a unit test in `staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options_test.go` verifying that `NewCRDRESTOptionsGetter` returns a REST options factory with `WatchCacheSizes == nil`.

#### Does this PR introduce a user-facing change?

```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None
