### PR TITLE
Do not inherit probe state from a replaced container

### DIFF
--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -58,6 +58,7 @@ import (
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	"k8s.io/kubernetes/pkg/kubelet/network/dns"
+	"k8s.io/kubernetes/pkg/kubelet/prober"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/kubelet/secret"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -5830,6 +5831,149 @@ func Test_generateAPIPodStatus(t *testing.T) {
 			if !apiequality.Semantic.DeepEqual(*expected, actual) {
 				t.Fatalf("Unexpected status: %s", cmp.Diff(*expected, actual))
 			}
+		})
+	}
+}
+
+// Test_generateAPIPodStatusOnKubeletRestart verifies that a new container does not inherit
+// the readiness the API server still reports for the container it replaced. Readiness is
+// preserved across a kubelet restart only when the container the kubelet last observed from
+// the API server is the one the runtime reports.
+//
+// An e2e test could restart the kubelet, but it could not reliably create the stale API
+// server status this depends on. That status appears only when the container is replaced
+// while the kubelet cannot update the API server. An e2e test would have to race the
+// runtime or write the pod status behind the kubelet's back. This test instead builds the
+// same situation from an empty status manager cache and a CRI status whose container
+// differs from the one the pod status still reports.
+//
+// See https://github.com/kubernetes/kubernetes/issues/141473
+func Test_generateAPIPodStatusOnKubeletRestart(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ChangeContainerStatusOnKubeletRestart, false)
+
+	const containerName = "containerA"
+	oldContainerID := kubecontainer.ContainerID{Type: "test", ID: "old_container_id"}
+	newContainerID := kubecontainer.ContainerID{Type: "test", ID: "new_container_id"}
+
+	tests := []struct {
+		name string
+		// apiContainerID is the container ID in the pod status the kubelet last
+		// observed from the API server, which may be outdated.
+		apiContainerID               kubecontainer.ContainerID
+		firstSyncAfterKubeletRestart bool
+		expectedReady                bool
+	}{
+		{
+			name:                         "the same container survived the kubelet restart, first sync",
+			apiContainerID:               newContainerID,
+			firstSyncAfterKubeletRestart: true,
+			expectedReady:                true,
+		},
+		{
+			name:           "the same container survived the kubelet restart",
+			apiContainerID: newContainerID,
+			expectedReady:  true,
+		},
+		{
+			name:                         "a new container was created while the API server was unreachable, first sync",
+			apiContainerID:               oldContainerID,
+			firstSyncAfterKubeletRestart: true,
+			expectedReady:                false,
+		},
+		{
+			name:           "a new container was created while the API server was unreachable",
+			apiContainerID: oldContainerID,
+			expectedReady:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, tCtx := ktesting.NewTestContext(t)
+
+			testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+			defer testKubelet.Cleanup()
+			kl := testKubelet.kubelet
+
+			// newTestKubelet installs a fake probe manager.
+			// Use the real one so that the readiness preservation logic runs.
+			kl.probeManager = prober.NewManager(
+				kl.statusManager,
+				kl.livenessManager,
+				kl.readinessManager,
+				kl.startupManager,
+				kl.runner,
+				&record.FakeRecorder{},
+			)
+
+			// The pod as the kubelet last observed it from the API server. The status
+			// manager cache is empty after a kubelet restart, so generateAPIPodStatus
+			// falls back to this as the previous status.
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "12345678",
+					Name:      "probe-state-preservation",
+					Namespace: "foo",
+				},
+				Spec: v1.PodSpec{
+					NodeName:      "machine",
+					RestartPolicy: v1.RestartPolicyAlways,
+					Containers: []v1.Container{{
+						Name: containerName,
+						ReadinessProbe: &v1.Probe{
+							ProbeHandler:        v1.ProbeHandler{Exec: &v1.ExecAction{}},
+							InitialDelaySeconds: 3600,
+							PeriodSeconds:       1,
+						},
+					}},
+				},
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					Conditions: []v1.PodCondition{{
+						Type:   v1.PodReady,
+						Status: v1.ConditionTrue,
+					}},
+					ContainerStatuses: []v1.ContainerStatus{{
+						Name:        containerName,
+						ContainerID: tc.apiContainerID.String(),
+						State:       v1.ContainerState{Running: &v1.ContainerStateRunning{}},
+						Ready:       true,
+					}},
+				},
+			}
+
+			// On the first sync after a kubelet restart there is no readiness worker yet,
+			// because SyncPod calls generateAPIPodStatus before probeManager.AddPod.
+			if !tc.firstSyncAfterKubeletRestart {
+				kl.probeManager.AddPod(tCtx, pod)
+				t.Cleanup(func() { kl.probeManager.RemovePod(pod) })
+			}
+
+			// The runtime reports a container that started long before the kubelet, so
+			// its start time alone makes it look like a container that survived the
+			// restart.
+			criStatus := &kubecontainer.PodStatus{
+				ID:        pod.UID,
+				Name:      pod.Name,
+				Namespace: pod.Namespace,
+				SandboxStatuses: []*runtimeapi.PodSandboxStatus{{
+					Metadata: &runtimeapi.PodSandboxMetadata{Attempt: uint32(0)},
+					State:    runtimeapi.PodSandboxState_SANDBOX_READY,
+				}},
+				ContainerStatuses: []*kubecontainer.Status{{
+					Name:      containerName,
+					ID:        newContainerID,
+					State:     kubecontainer.ContainerStateRunning,
+					StartedAt: time.Now().Add(-time.Hour),
+				}},
+			}
+
+			actual := kl.generateAPIPodStatus(tCtx, pod, criStatus, false /* podIsTerminal */)
+
+			require.Len(t, actual.ContainerStatuses, 1)
+			cStatus := actual.ContainerStatuses[0]
+			require.Equal(t, newContainerID.String(), cStatus.ContainerID, "the generated status should report the container the runtime runs")
+			assert.Equal(t, tc.expectedReady, cStatus.Ready, "unexpected readiness for container %q", containerName)
 		})
 	}
 }

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -310,7 +310,16 @@ func (m *manager) isContainerStarted(logger klog.Logger, pod *v1.Pod, containerS
 // setReadyStateOnKubeletRestart sets the ready state of a container to false if it was started
 // before kubelet restarted and has a readiness probe, but the pod is not ready yet.
 // This is to avoid flapping ready status of containers that were ready before kubelet restarted.
-func (m *manager) setReadyStateOnKubeletRestart(logger klog.Logger, ready *bool, pod *v1.Pod, containerStatus *v1.ContainerStatus, containerSpec *v1.Container) {
+func (m *manager) setReadyStateOnKubeletRestart(logger klog.Logger, ready *bool, pod *v1.Pod, apiContainerStatuses []v1.ContainerStatus, containerStatus *v1.ContainerStatus, containerSpec *v1.Container) {
+	if !canInheritProbeState(apiContainerStatuses, containerStatus.Name, containerStatus.ContainerID) {
+		// The caller defaults to ready while no readiness worker is registered, which is
+		// the case on the first sync after a kubelet restart, so clear it explicitly.
+		if containerSpec.ReadinessProbe != nil {
+			*ready = false
+		}
+		return
+	}
+
 	var containerStartTime time.Time
 	if containerStatus.State.Running != nil {
 		containerStartTime = containerStatus.State.Running.StartedAt.Time
@@ -379,7 +388,7 @@ func (m *manager) UpdatePodStatus(ctx context.Context, pod *v1.Pod, podStatus *v
 					}
 				}
 				if containerSpec != nil {
-					m.setReadyStateOnKubeletRestart(logger, &ready, pod, &podStatus.ContainerStatuses[i], containerSpec)
+					m.setReadyStateOnKubeletRestart(logger, &ready, pod, pod.Status.ContainerStatuses, &podStatus.ContainerStatuses[i], containerSpec)
 				}
 			}
 		}
@@ -424,7 +433,7 @@ func (m *manager) UpdatePodStatus(ctx context.Context, pod *v1.Pod, podStatus *v
 				}
 			}
 			if !utilfeature.DefaultFeatureGate.Enabled(features.ChangeContainerStatusOnKubeletRestart) {
-				m.setReadyStateOnKubeletRestart(logger, &ready, pod, &podStatus.InitContainerStatuses[i], &initContainer)
+				m.setReadyStateOnKubeletRestart(logger, &ready, pod, pod.Status.InitContainerStatuses, &podStatus.InitContainerStatuses[i], &initContainer)
 			}
 		}
 		podStatus.InitContainerStatuses[i].Ready = ready
@@ -459,4 +468,15 @@ func (m *manager) workerCount() int {
 // status changes for containers that were previously ready.
 func kubeletRestartGracePeriod(start time.Time) time.Time {
 	return start.Add(-time.Second * 10)
+}
+
+// canInheritProbeState checks whether the container the API server last knew about with the given
+// container name is the same container the kubelet is currently probing.
+// A replacement container must not inherit the previous container's probe state after kubelet restarts.
+func canInheritProbeState(apiContainerStatuses []v1.ContainerStatus, name, runtimeID string) bool {
+	apiContainerStatus, ok := podutil.GetContainerStatus(apiContainerStatuses, name)
+	if !ok || apiContainerStatus.ContainerID == "" || runtimeID == "" {
+		return true
+	}
+	return apiContainerStatus.ContainerID == runtimeID
 }

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -29,8 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog/v2"
+	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 	"k8s.io/kubernetes/pkg/probe"
@@ -627,6 +630,210 @@ func TestUpdatePodStatusWithInitContainers(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestUpdatePodStatusOnKubeletRestart(t *testing.T) {
+	const (
+		containerName  = "test_container"
+		oldContainerID = "test://old-container-id"
+		newContainerID = "test://new_container_id"
+	)
+
+	tests := []struct {
+		name string
+		// featureEnabled toggles ChangeContainerStatusOnKubeletRestart feature gate.
+		// When enabled, readiness is never preserved across a kubelet restart.
+		featureEnabled bool
+		// apiContainerID is the container ID in the pod status the kubelet last
+		// observed from the API server, which may be outdated.
+		apiContainerID               string
+		firstSyncAfterKubeletRestart bool
+		expectedReady                bool
+	}{
+		{
+			name:           "feature is disabled, the container survived the kubelet restart",
+			featureEnabled: false,
+			apiContainerID: newContainerID,
+			expectedReady:  true,
+		},
+		{
+			name:           "feature is disabled, the container was replaced while the API server was unreachable",
+			featureEnabled: false,
+			apiContainerID: oldContainerID,
+			expectedReady:  false,
+		},
+		{
+			name:                         "feature is disabled, the container survived the kubelet restart, first sync",
+			featureEnabled:               false,
+			apiContainerID:               newContainerID,
+			firstSyncAfterKubeletRestart: true,
+			expectedReady:                true,
+		},
+		{
+			name:                         "feature is disabled, the container was replaced while the API server was unreachable, first sync",
+			featureEnabled:               false,
+			apiContainerID:               oldContainerID,
+			firstSyncAfterKubeletRestart: true,
+			expectedReady:                false,
+		},
+		{
+			name:           "feature is enabled, the container survived the kubelet restart",
+			featureEnabled: true,
+			apiContainerID: newContainerID,
+			expectedReady:  false,
+		},
+		{
+			name:           "feature is enabled, the container was replaced while the API server was unreachable",
+			featureEnabled: true,
+			apiContainerID: oldContainerID,
+			expectedReady:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ChangeContainerStatusOnKubeletRestart, tc.featureEnabled)
+
+			ctx := ktesting.Init(t)
+			m := newTestManager()
+			// no cleanup: using fake workers.
+
+			// On the first sync after a kubelet restart there is no readiness worker yet,
+			// because the kubelet updates the pod status before it starts probing. The
+			// worker a later sync registers has not produced a result yet.
+			if !tc.firstSyncAfterKubeletRestart {
+				m.workers = map[probeKey]*worker{
+					{testPodUID, containerName, readiness}: {
+						probeType:       readiness,
+						manualTriggerCh: make(chan struct{}, 1),
+					},
+				}
+			}
+
+			// The runtime reports a container that started before the kubelet
+			// restart grace period, so its start time alone makes it look like a
+			// container that survived the restart.
+			startedBeforeKubeletRestart := metav1.Time{Time: kubeletRestartGracePeriod(m.start).Add(-time.Minute)}
+			podStatus := v1.PodStatus{
+				Phase: v1.PodRunning,
+				ContainerStatuses: []v1.ContainerStatus{{
+					Name:        containerName,
+					ContainerID: newContainerID,
+					State: v1.ContainerState{
+						Running: &v1.ContainerStateRunning{StartedAt: startedBeforeKubeletRestart},
+					},
+				}},
+			}
+
+			pod := &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{UID: testPodUID},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{Name: containerName, ReadinessProbe: defaultProbe}},
+				},
+				Status: v1.PodStatus{
+					Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+					ContainerStatuses: []v1.ContainerStatus{{
+						Name:        containerName,
+						ContainerID: tc.apiContainerID,
+						Ready:       true,
+					}},
+				},
+			}
+
+			m.UpdatePodStatus(ctx, pod, &podStatus)
+
+			if got := podStatus.ContainerStatuses[0].Ready; got != tc.expectedReady {
+				t.Errorf("Unexpected readiness for container %v: expected %v but got %v", containerName, tc.expectedReady, got)
+			}
+		})
+	}
+}
+
+func TestUpdatePodStatusOnKubeletRestartWithMultipleContainers(t *testing.T) {
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ChangeContainerStatusOnKubeletRestart, false)
+
+	const (
+		survivedContainer      = "survived_container"
+		survivedContainerID    = "test://survived_container_id"
+		replacedContainer      = "replaced_container"
+		replacedOldContainerID = "test://replaced_container_old_id"
+		replacedNewContainerID = "test://replaced_container_new_id"
+	)
+
+	ctx := ktesting.Init(t)
+	m := newTestManager()
+	// no cleanup: using fake workers.
+
+	// Neither readiness probe has produced a result yet.
+	m.workers = map[probeKey]*worker{
+		{testPodUID, survivedContainer, readiness}: {
+			probeType:       readiness,
+			manualTriggerCh: make(chan struct{}, 1),
+		},
+		{testPodUID, replacedContainer, readiness}: {
+			probeType:       readiness,
+			manualTriggerCh: make(chan struct{}, 1),
+		},
+	}
+
+	startedBeforeKubeletRestart := metav1.Time{Time: kubeletRestartGracePeriod(m.start).Add(-time.Minute)}
+	runningStatus := func(name, id string) v1.ContainerStatus {
+		return v1.ContainerStatus{
+			Name:        name,
+			ContainerID: id,
+			State: v1.ContainerState{
+				Running: &v1.ContainerStateRunning{StartedAt: startedBeforeKubeletRestart},
+			},
+		}
+	}
+
+	podStatus := v1.PodStatus{
+		Phase: v1.PodRunning,
+		ContainerStatuses: []v1.ContainerStatus{
+			runningStatus(survivedContainer, survivedContainerID),
+			runningStatus(replacedContainer, replacedNewContainerID),
+		},
+	}
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{UID: testPodUID},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{Name: survivedContainer, ReadinessProbe: defaultProbe},
+				{Name: replacedContainer, ReadinessProbe: defaultProbe},
+			},
+		},
+		Status: v1.PodStatus{
+			Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+			ContainerStatuses: []v1.ContainerStatus{
+				{Name: survivedContainer, ContainerID: survivedContainerID, Ready: true},
+				{Name: replacedContainer, ContainerID: replacedOldContainerID, Ready: true},
+			},
+		},
+	}
+
+	m.UpdatePodStatus(ctx, pod, &podStatus)
+
+	if !podStatus.ContainerStatuses[0].Ready {
+		t.Errorf("Expected container %v to keep its readiness across the kubelet restart", survivedContainer)
+	}
+	if podStatus.ContainerStatuses[1].Ready {
+		t.Errorf("Expected container %v not to inherit the replaced container's readiness", replacedContainer)
+	}
+
+	// Marking the new container NotReady flips the pod's Ready condition to False.
+	// setReadyStateOnKubeletRestart backs off whenever PodReady is not True, so on
+	// the next sync it also drops the container that did survive the restart,
+	// because its own readiness probe still has not produced a result.
+	pod.Status.Conditions[0].Status = v1.ConditionFalse
+
+	m.UpdatePodStatus(ctx, pod, &podStatus)
+
+	for _, c := range podStatus.ContainerStatuses {
+		if c.Ready {
+			t.Errorf("Expected container %v to be NotReady once the pod is no longer Ready", c.Name)
+		}
 	}
 }
 

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -1035,3 +1035,63 @@ func testProbeWorkersSurviveSyncContextCancellation(tCtx ktesting.TContext) {
 		}
 	}
 }
+
+func TestCanInheritProbeState(t *testing.T) {
+	const (
+		containerName = "test-container"
+		oldID         = "test://old_container_id"
+		newID         = "test://new_container_id"
+	)
+
+	tests := []struct {
+		name                 string
+		apiContainerStatuses []v1.ContainerStatus
+		runtimeID            string
+		expected             bool
+	}{
+		{
+			name:                 "no status from the API server is available",
+			apiContainerStatuses: nil,
+			runtimeID:            newID,
+			expected:             true,
+		},
+		{
+			name:                 "the API server knows the same container",
+			apiContainerStatuses: []v1.ContainerStatus{{Name: containerName, ContainerID: oldID}},
+			runtimeID:            oldID,
+			expected:             true,
+		},
+		{
+			name:                 "the container was replaced",
+			apiContainerStatuses: []v1.ContainerStatus{{Name: containerName, ContainerID: oldID}},
+			runtimeID:            newID,
+			expected:             false,
+		},
+		{
+			name:                 "the container is not in the API server status",
+			apiContainerStatuses: []v1.ContainerStatus{{Name: "other-container", ContainerID: oldID}},
+			runtimeID:            newID,
+			expected:             true,
+		},
+		{
+			name:                 "the API server status has no container ID",
+			apiContainerStatuses: []v1.ContainerStatus{{Name: containerName}},
+			runtimeID:            newID,
+			expected:             true,
+		},
+		{
+			name:                 "the runtime has no container ID",
+			apiContainerStatuses: []v1.ContainerStatus{{Name: containerName, ContainerID: oldID}},
+			runtimeID:            "",
+			expected:             true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canInheritProbeState(tc.apiContainerStatuses, containerName, tc.runtimeID); got != tc.expected {
+				t.Errorf("canInheritProbeState() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -255,10 +255,21 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 		w.containerID = kubecontainer.ParseContainerID(logger, c.ContainerID)
 
 		if !utilfeature.DefaultFeatureGate.Enabled(features.ChangeContainerStatusOnKubeletRestart) {
+			// The container start time alone cannot tell a container that survived the
+			// kubelet restart apart from a new container the runtime created while the
+			// kubelet could not reach the API server, so compare the container ID the
+			// kubelet last observed from the API server with the one the runtime reports.
+			// See https://github.com/kubernetes/kubernetes/issues/141473
+			apiContainerStatuses := w.pod.Status.ContainerStatuses
+			if w.isInitContainer() {
+				apiContainerStatuses = w.pod.Status.InitContainerStatuses
+			}
+			canInherit := canInheritProbeState(apiContainerStatuses, w.container.Name, c.ContainerID)
+
 			// On kubelet restart, we don't want to immediately set the probe result to Failure,
 			// as this could cause a container that was Ready to become NotReady.
 			isRestart := false
-			if c.State.Running != nil {
+			if canInherit && c.State.Running != nil {
 				containerStartTime := c.State.Running.StartedAt.Time
 				if !containerStartTime.IsZero() && containerStartTime.Before(kubeletRestartGracePeriod(w.probeManager.start)) {
 					isRestart = true

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -276,18 +276,20 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 				}
 			}
 
-			// For restartable init containers (sidecars) with a startup probe, seed the
-			// startup result with Success if the container had already started before the
-			// kubelet restarted. This ensures startupManager.Get() returns a valid result,
-			// allowing computeInitContainerActions to detect pod initialization.
-			// See https://github.com/kubernetes/kubernetes/issues/136910
-			if isRestartableInitContainer && w.probeType == startup {
-				if c.Started != nil && *c.Started {
+			// Started can be true before the container passed its own startup probe, so trust
+			// it only when isRestart says the same container survived. A wrong Success cannot
+			// be undone by a later overwrite, because every stored result is published and
+			// consumers act on the first one they see.
+			if isRestart {
+				// For restartable init containers (sidecars) with a startup probe, seed the
+				// startup result with Success if the container had already started before the
+				// kubelet restarted. This ensures startupManager.Get() returns a valid result,
+				// allowing computeInitContainerActions to detect pod initialization.
+				// See https://github.com/kubernetes/kubernetes/issues/136910
+				if isRestartableInitContainer && w.probeType == startup && c.Started != nil && *c.Started {
 					w.resultsManager.Set(w.containerID, results.Success, w.pod)
 				}
-			}
-
-			if !isRestart {
+			} else {
 				w.resultsManager.Set(w.containerID, w.initialValue, w.pod)
 			}
 		} else {

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -858,6 +858,154 @@ func TestDoProbe_TerminatedContainerWithRestartPolicyNever(t *testing.T) {
 	expectResult(t, w, results.Failure, "regular container with pod restart policy Never")
 }
 
+func TestDoProbe_NewContainerOnKubeletRestart(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+
+	const (
+		oldContainerID = "test://old_container_id"
+		newContainerID = "test://new_container_id"
+	)
+
+	tests := []struct {
+		name string
+		// featureEnabled toggles ChangeContainerStatusOnKubeletRestart feature gate.
+		// When enabled, the result is always seeded with the probe's initial value.
+		featureEnabled bool
+		// apiContainerID is the container ID in the pod status the kubelet last
+		// observed from the API server, which may be outdated.
+		apiContainerID string
+		isSidecar      bool
+		probeType      probeType
+		expectSet      bool
+		expectedResult results.Result // only checked if expectSet is true
+	}{
+		{
+			name:           "feature disabled, readiness, the same container survived the kubelet restart",
+			featureEnabled: false,
+			apiContainerID: newContainerID,
+			probeType:      readiness,
+			expectSet:      false,
+		},
+		{
+			name:           "feature disabled, readiness, a new container was created while the API server was unreachable",
+			featureEnabled: false,
+			apiContainerID: oldContainerID,
+			probeType:      readiness,
+			expectSet:      true,
+			expectedResult: results.Failure,
+		},
+		{
+			name:           "feature disabled, readiness, the kubelet never observed a container ID",
+			featureEnabled: false,
+			apiContainerID: "",
+			probeType:      readiness,
+			expectSet:      false,
+		},
+		{
+			name:           "feature disabled, readiness, the same sidecar survived the kubelet restart",
+			featureEnabled: false,
+			apiContainerID: newContainerID,
+			isSidecar:      true,
+			probeType:      readiness,
+			expectSet:      false,
+		},
+		{
+			name:           "feature disabled, readiness, a new sidecar was created while the API server was unreachable",
+			featureEnabled: false,
+			apiContainerID: oldContainerID,
+			isSidecar:      true,
+			probeType:      readiness,
+			expectSet:      true,
+			expectedResult: results.Failure,
+		},
+		{
+			name:           "feature disabled, startup, a new container was created while the API server was unreachable",
+			featureEnabled: false,
+			apiContainerID: oldContainerID,
+			probeType:      startup,
+			expectSet:      true,
+			expectedResult: results.Unknown,
+		},
+		{
+			// Regression test for https://github.com/kubernetes/kubernetes/issues/136910:
+			// a sidecar that survived the restart keeps its startup result.
+			name:           "feature disabled, startup, the same sidecar survived the kubelet restart",
+			featureEnabled: false,
+			apiContainerID: newContainerID,
+			isSidecar:      true,
+			probeType:      startup,
+			expectSet:      true,
+			expectedResult: results.Success,
+		},
+		{
+			name:           "feature disabled, startup, a new sidecar was created while the API server was unreachable",
+			featureEnabled: false,
+			apiContainerID: oldContainerID,
+			isSidecar:      true,
+			probeType:      startup,
+			expectSet:      true,
+			expectedResult: results.Unknown,
+		},
+		{
+			name:           "feature is enabled, readiness, the same container survived the kubelet restart",
+			featureEnabled: true,
+			apiContainerID: newContainerID,
+			probeType:      readiness,
+			expectSet:      true,
+			expectedResult: results.Failure,
+		},
+		{
+			name:           "feature is enabled, readiness, a new container was created while the API server was unreachable",
+			featureEnabled: true,
+			apiContainerID: oldContainerID,
+			probeType:      readiness,
+			expectSet:      true,
+			expectedResult: results.Failure,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ChangeContainerStatusOnKubeletRestart, tc.featureEnabled)
+
+			m := newTestManager()
+
+			// The runtime reports a container that started before the kubelet restart
+			// grace period, so its start time alone makes it look like a container
+			// that survived the restart.
+			podStatus := getTestRunningStatus()
+			podStatus.ContainerStatuses[0].ContainerID = newContainerID
+			podStatus.ContainerStatuses[0].State.Running.StartedAt = metav1.Time{Time: kubeletRestartGracePeriod(m.start).Add(-time.Minute)}
+
+			// The pod status the kubelet last observed from the API server.
+			apiContainerStatus := v1.ContainerStatus{Name: testContainerName, ContainerID: tc.apiContainerID}
+
+			var w *worker
+			if tc.isSidecar {
+				w = newTestWorkerWithRestartableInitContainer(m, tc.probeType)
+				w.spec = &v1.Probe{InitialDelaySeconds: 1000}
+				podStatus.InitContainerStatuses = []v1.ContainerStatus{podStatus.ContainerStatuses[0]}
+				podStatus.ContainerStatuses = nil
+				w.pod.Status.InitContainerStatuses = []v1.ContainerStatus{apiContainerStatus}
+			} else {
+				w = newTestWorker(m, tc.probeType, v1.Probe{InitialDelaySeconds: 1000})
+				w.pod.Status.ContainerStatuses = []v1.ContainerStatus{apiContainerStatus}
+			}
+			m.statusManager.SetPodStatus(logger, w.pod, podStatus)
+
+			w.doProbe(ctx)
+
+			result, ok := resultsManager(m, tc.probeType).Get(kubecontainer.ParseContainerID(logger, newContainerID))
+			if ok != tc.expectSet {
+				t.Errorf("Expected result to be set: %v, but got: %v", tc.expectSet, ok)
+			}
+			if tc.expectSet && result != tc.expectedResult {
+				t.Errorf("Expected result %v, but got: %v", tc.expectedResult, result)
+			}
+		})
+	}
+}
+
 func TestLivenessProbeDisabledByStarted(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	m := newTestManager()

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -18,6 +18,7 @@ package prober
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -876,30 +877,27 @@ func TestDoProbe_NewContainerOnKubeletRestart(t *testing.T) {
 		apiContainerID string
 		isSidecar      bool
 		probeType      probeType
-		expectSet      bool
-		expectedResult results.Result // only checked if expectSet is true
+		// expectedUpdates is the sequence of results the worker is expected to publish.
+		expectedUpdates []results.Result
 	}{
 		{
 			name:           "feature disabled, readiness, the same container survived the kubelet restart",
 			featureEnabled: false,
 			apiContainerID: newContainerID,
 			probeType:      readiness,
-			expectSet:      false,
 		},
 		{
-			name:           "feature disabled, readiness, a new container was created while the API server was unreachable",
-			featureEnabled: false,
-			apiContainerID: oldContainerID,
-			probeType:      readiness,
-			expectSet:      true,
-			expectedResult: results.Failure,
+			name:            "feature disabled, readiness, a new container was created while the API server was unreachable",
+			featureEnabled:  false,
+			apiContainerID:  oldContainerID,
+			probeType:       readiness,
+			expectedUpdates: []results.Result{results.Failure},
 		},
 		{
 			name:           "feature disabled, readiness, the kubelet never observed a container ID",
 			featureEnabled: false,
 			apiContainerID: "",
 			probeType:      readiness,
-			expectSet:      false,
 		},
 		{
 			name:           "feature disabled, readiness, the same sidecar survived the kubelet restart",
@@ -907,60 +905,53 @@ func TestDoProbe_NewContainerOnKubeletRestart(t *testing.T) {
 			apiContainerID: newContainerID,
 			isSidecar:      true,
 			probeType:      readiness,
-			expectSet:      false,
 		},
 		{
-			name:           "feature disabled, readiness, a new sidecar was created while the API server was unreachable",
-			featureEnabled: false,
-			apiContainerID: oldContainerID,
-			isSidecar:      true,
-			probeType:      readiness,
-			expectSet:      true,
-			expectedResult: results.Failure,
+			name:            "feature disabled, readiness, a new sidecar was created while the API server was unreachable",
+			featureEnabled:  false,
+			apiContainerID:  oldContainerID,
+			isSidecar:       true,
+			probeType:       readiness,
+			expectedUpdates: []results.Result{results.Failure},
 		},
 		{
-			name:           "feature disabled, startup, a new container was created while the API server was unreachable",
-			featureEnabled: false,
-			apiContainerID: oldContainerID,
-			probeType:      startup,
-			expectSet:      true,
-			expectedResult: results.Unknown,
+			name:            "feature disabled, startup, a new container was created while the API server was unreachable",
+			featureEnabled:  false,
+			apiContainerID:  oldContainerID,
+			probeType:       startup,
+			expectedUpdates: []results.Result{results.Unknown},
 		},
 		{
 			// Regression test for https://github.com/kubernetes/kubernetes/issues/136910:
 			// a sidecar that survived the restart keeps its startup result.
-			name:           "feature disabled, startup, the same sidecar survived the kubelet restart",
-			featureEnabled: false,
-			apiContainerID: newContainerID,
-			isSidecar:      true,
-			probeType:      startup,
-			expectSet:      true,
-			expectedResult: results.Success,
+			name:            "feature disabled, startup, the same sidecar survived the kubelet restart",
+			featureEnabled:  false,
+			apiContainerID:  newContainerID,
+			isSidecar:       true,
+			probeType:       startup,
+			expectedUpdates: []results.Result{results.Success},
 		},
 		{
-			name:           "feature disabled, startup, a new sidecar was created while the API server was unreachable",
-			featureEnabled: false,
-			apiContainerID: oldContainerID,
-			isSidecar:      true,
-			probeType:      startup,
-			expectSet:      true,
-			expectedResult: results.Unknown,
+			name:            "feature disabled, startup, a new sidecar was created while the API server was unreachable",
+			featureEnabled:  false,
+			apiContainerID:  oldContainerID,
+			isSidecar:       true,
+			probeType:       startup,
+			expectedUpdates: []results.Result{results.Unknown},
 		},
 		{
-			name:           "feature is enabled, readiness, the same container survived the kubelet restart",
-			featureEnabled: true,
-			apiContainerID: newContainerID,
-			probeType:      readiness,
-			expectSet:      true,
-			expectedResult: results.Failure,
+			name:            "feature is enabled, readiness, the same container survived the kubelet restart",
+			featureEnabled:  true,
+			apiContainerID:  newContainerID,
+			probeType:       readiness,
+			expectedUpdates: []results.Result{results.Failure},
 		},
 		{
-			name:           "feature is enabled, readiness, a new container was created while the API server was unreachable",
-			featureEnabled: true,
-			apiContainerID: oldContainerID,
-			probeType:      readiness,
-			expectSet:      true,
-			expectedResult: results.Failure,
+			name:            "feature is enabled, readiness, a new container was created while the API server was unreachable",
+			featureEnabled:  true,
+			apiContainerID:  oldContainerID,
+			probeType:       readiness,
+			expectedUpdates: []results.Result{results.Failure},
 		},
 	}
 
@@ -995,12 +986,17 @@ func TestDoProbe_NewContainerOnKubeletRestart(t *testing.T) {
 
 			w.doProbe(ctx)
 
-			result, ok := resultsManager(m, tc.probeType).Get(kubecontainer.ParseContainerID(logger, newContainerID))
-			if ok != tc.expectSet {
-				t.Errorf("Expected result to be set: %v, but got: %v", tc.expectSet, ok)
+			var updates []results.Result
+			for drained := false; !drained; {
+				select {
+				case update := <-resultsManager(m, tc.probeType).Updates():
+					updates = append(updates, update.Result)
+				default:
+					drained = true
+				}
 			}
-			if tc.expectSet && result != tc.expectedResult {
-				t.Errorf("Expected result %v, but got: %v", tc.expectedResult, result)
+			if !slices.Equal(updates, tc.expectedUpdates) {
+				t.Errorf("Expected updates %v, but got: %v", tc.expectedUpdates, updates)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

The kubelet decides that a container survived a kubelet restart by comparing the container start time against the restart grace period. That check cannot tell such a container apart from a replacement the runtime created while the kubelet could not reach the API server, so a replacement container inherited the previous container's Ready state and was reported Ready until its own readiness probe first ran, delayed by `initialDelaySeconds`.

Add regression tests covering the readiness path in both the prober worker and manager. These tests fail until the container ID check is added.

#### Which issue(s) this PR is related to:

Fixes #141473

#### Special notes for your reviewer:

I tried adding an e2e test, but it did not work out. The bug needs the pod status on the API server to still name the old container while the runtime already runs the replacement, which means cutting the kubelet off from the API server, and that is not something an e2e test can do reliably. Patching the pod status to look stale would work, but it is a hack that does not match how the state actually arises.

I added unit tests instead. They cover the readiness preservation path taken on a kubelet restart and check that readiness is inherited only when the container the API server last reported is still the one the runtime reports.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed an issue where a container that was recreated while the kubelet could not reach the API server was reported Ready after a kubelet restart, before its own readiness probe had run.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

YES. This PR was created with the help of an Claude, which assisted with things like reviewing and translating into English.
