### PR TITLE
kubelet: pass probe logger into exec command

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -212,7 +212,11 @@ func (pb *prober) runProbe(ctx context.Context, probeType probeType, p *v1.Probe
 type execInContainer struct {
 	// run executes a command in a container. Combined stdout and stderr output is always returned. An
 	// error is returned if one occurred.
-	run       func() ([]byte, error)
+	run func() ([]byte, error)
+	// logger is captured from the probe context at construction time because
+	// the exec.Cmd interface does not allow passing a context into Start, so
+	// storing it here is the only way to keep logging contextual.
+	logger    klog.Logger
 	writer    io.Writer
 	pod       *v1.Pod
 	container v1.Container
@@ -221,6 +225,7 @@ type execInContainer struct {
 func (pb *prober) newExecInContainer(ctx context.Context, pod *v1.Pod, container v1.Container, containerID kubecontainer.ContainerID, cmd []string, timeout time.Duration) exec.Cmd {
 	return &execInContainer{
 		run:       func() ([]byte, error) { return pb.runner.RunInContainer(ctx, containerID, cmd, timeout) },
+		logger:    klog.FromContext(ctx),
 		pod:       pod,
 		container: container,
 	}
@@ -267,9 +272,7 @@ func (eic *execInContainer) Start() error {
 	if eic.writer != nil {
 		// only record the write error, do not cover the command run error
 		if p, err := eic.writer.Write(data); err != nil {
-			// Use klog.TODO() because we currently do not have a proper context/logger to pass in.
-			// Replace this with an appropriate context/logger when refactoring this function to accept a context parameter.
-			klog.TODO().Error(err, "Unable to write all bytes from execInContainer", "expectedBytes", len(data), "actualBytes", p, "pod", klog.KObj(eic.pod), "containerName", eic.container.Name)
+			eic.logger.Error(err, "Unable to write all bytes from execInContainer", "expectedBytes", len(data), "actualBytes", p, "pod", klog.KObj(eic.pod), "containerName", eic.container.Name)
 		}
 	}
 	return err


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Capture the probe logger when creating the short-lived exec command object and reuse it in `Start()` instead of logging with `klog.TODO()`. `exec.Cmd` does not allow passing a context into `Start`, so the logger is bound when the command is created from the probe context.

#### Which issue(s) this PR fixes:

Part of #130069

#### Special notes for your reviewer:

Focused build and vet passed.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```