### PR TITLE
Experiment: print GOMAXPROCS and cgroup from ginkgo to debug the ci-kind-dra-1-34 timeout

### DIFF
--- a/vendor/github.com/onsi/ginkgo/v2/ginkgo/main.go
+++ b/vendor/github.com/onsi/ginkgo/v2/ginkgo/main.go
@@ -3,6 +3,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
+	"runtime/debug"
+	"strings"
+
 	"github.com/onsi/ginkgo/v2/ginkgo/build"
 	"github.com/onsi/ginkgo/v2/ginkgo/command"
 	"github.com/onsi/ginkgo/v2/ginkgo/generators"
@@ -30,6 +34,41 @@ func GenerateCommands() []command.Command {
 }
 
 func main() {
+	// Temporary diagnostic for kubernetes/test-infra#37727 and kubernetes/kubernetes#141435:
+	// print the CPU the Go runtime sees, plus cpu.max at each cgroup level, so a
+	// real presubmit run shows whether the runner init leaf hides the pod quota.
+	fmt.Fprintf(os.Stderr, "DRA-CPU-DIAG: GOMAXPROCS=%d NumCPU=%d GOMAXPROCS_env=%q\n",
+		runtime.GOMAXPROCS(0), runtime.NumCPU(), os.Getenv("GOMAXPROCS"))
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range bi.Settings {
+			if s.Key == "DefaultGODEBUG" {
+				fmt.Fprintf(os.Stderr, "DRA-CPU-DIAG: DefaultGODEBUG=%s\n", s.Value)
+			}
+		}
+	}
+	if raw, err := os.ReadFile("/proc/self/cgroup"); err == nil {
+		path := strings.TrimSpace(string(raw))
+		if i := strings.Index(path, "::"); i >= 0 {
+			path = path[i+2:]
+		}
+		for p := path; ; {
+			max, _ := os.ReadFile("/sys/fs/cgroup" + p + "/cpu.max")
+			fmt.Fprintf(os.Stderr, "DRA-CPU-DIAG: %s cpu.max=[%s]\n", p, strings.TrimSpace(string(max)))
+			if p == "/" || p == "" {
+				break
+			}
+			if i := strings.LastIndex(p, "/"); i > 0 {
+				p = p[:i]
+			} else {
+				p = "/"
+			}
+		}
+	}
+
+	// Experiment for kubernetes/test-infra#37727: print the diagnostic and exit so the
+	// presubmit finishes fast without running the whole suite. Delete to restore ginkgo.
+	os.Exit(0)
+
 	program = command.Program{
 		Name:           "ginkgo",
 		Heading:        fmt.Sprintf("Ginkgo Version %s", types.VERSION),


### PR DESCRIPTION
**What this is**

A throwaway draft to gather data for kubernetes/test-infra#37727 and #141435. It is not for merge.

I add a small print to `vendor/github.com/onsi/ginkgo/v2/ginkgo/main.go`. When a presubmit build ginkgo and run it, the ginkgo CLI print the GOMAXPROCS it get, the baked GODEBUG, and the cpu.max at each cgroup level. Then it exit, so the suite do not run and the job finish fast.

**Why**

`ci-kind-dra-1-34` time out (#141435). I think the runner init leaf have no cpu.max, so Go size GOMAXPROCS to the whole node instead of the 2 CPU pod quota, and everything oversubscribe. pohly ask in kubernetes/test-infra#37728 to gather this from a real presubmit instead of hacking the actual jobs, so this is that.

**How to read it**

`/test pull-kubernetes-kind-dra`, then look for `DRA-CPU-DIAG:` in the build log. If GOMAXPROCS is the node count (not 2) and the `init` leaf cpu.max is `max`, that confirm the oversubscribe.

**Note**

It modify a vendored file on purpose, so `verify-vendor` will fail. That is expected. I will close this after i get the numbers.

/hold
