### PR TITLE
restclient: register resolverLatency metric with legacyregistry

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -246,6 +246,7 @@ func init() {
 		TransportCacheGCCalls:        &transportCacheGCCallsAdapter{m: transportCacheGCCalls},
 		RegisterFn: func() {
 			legacyregistry.MustRegister(requestLatency)
+			legacyregistry.MustRegister(resolverLatency)
 			legacyregistry.MustRegister(requestSize)
 			legacyregistry.MustRegister(responseSize)
 			legacyregistry.MustRegister(rateLimiterLatency)

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"k8s.io/client-go/tools/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -82,6 +83,32 @@ func TestClientGOMetrics(t *testing.T) {
 						# HELP rest_client_exec_plugin_call_total [ALPHA] Number of calls to an exec plugin, partitioned by the type of event encountered (no_error, plugin_execution_error, plugin_not_found_error, client_internal_error) and an optional exit code. The exit code will be set to 0 if and only if the plugin call was successful.
         				# TYPE rest_client_exec_plugin_call_total counter
         				rest_client_exec_plugin_call_total{call_status="no_error",code="0"} 1
+				`,
+		},
+		{
+			description: "DNS resolver latency in seconds",
+			name:        "rest_client_dns_resolution_duration_seconds",
+			metric:      resolverLatency,
+			update: func() {
+				metrics.ResolverLatency.Observe(context.TODO(), "www.foo.com", time.Second)
+			},
+			want: `
+			            # HELP rest_client_dns_resolution_duration_seconds [ALPHA] DNS resolver latency in seconds. Broken down by host.
+			            # TYPE rest_client_dns_resolution_duration_seconds histogram
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="0.005"} 0
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="0.025"} 0
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="0.1"} 0
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="0.25"} 0
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="0.5"} 0
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="1"} 1
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="2"} 1
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="4"} 1
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="8"} 1
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="15"} 1
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="30"} 1
+			            rest_client_dns_resolution_duration_seconds_bucket{host="www.foo.com",le="+Inf"} 1
+			            rest_client_dns_resolution_duration_seconds_sum{host="www.foo.com"} 1
+			            rest_client_dns_resolution_duration_seconds_count{host="www.foo.com"} 1
 				`,
 		},
 		{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `rest_client_dns_resolution_duration_seconds` metric was wired into client-go through the ResolverLatency adapter but never passed to `legacyregistry.MustRegister`, so the underlying HistogramVec was never created and every observation was silently dropped by the IsCreated no-op short circuit. 

The metric is declared in the instrumentation documentation list, yet no component ever exposed it on `/metrics`.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix: silently dropped DNS resolution latency metric in restclient
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
