### PR TITLE
APF: fix exempt priority level target seats metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/apf_controller.go
@@ -478,7 +478,11 @@ func (cfgCtlr *configController) updateBorrowingLocked(setCompleters bool, plSta
 		}
 		relChange := relDiff(float64(currentCL), float64(plState.currentCL))
 		plState.currentCL = currentCL
-		metrics.NotePriorityLevelConcurrencyAdjustment(plState.pl.Name, float64(plState.seatDemandStats.highWatermark), plState.seatDemandStats.avg, plState.seatDemandStats.stdDev, plState.seatDemandStats.smoothed, float64(items[idx].target), currentCL)
+		seatDemandTarget := float64(currentCL)
+		if isNonExempt {
+			seatDemandTarget = items[idx].target
+		}
+		metrics.NotePriorityLevelConcurrencyAdjustment(plState.pl.Name, float64(plState.seatDemandStats.highWatermark), plState.seatDemandStats.avg, plState.seatDemandStats.stdDev, plState.seatDemandStats.smoothed, seatDemandTarget, currentCL)
 		logLevel := klog.Level(4)
 		if relChange >= 0.05 {
 			logLevel = 2

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/exempt_borrowing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/exempt_borrowing_test.go
@@ -26,11 +26,15 @@ import (
 	"k8s.io/apiserver/pkg/util/flowcontrol/metrics"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/component-base/metrics/legacyregistry"
 
 	flowcontrol "k8s.io/api/flowcontrol/v1"
 )
 
 func TestUpdateBorrowing(t *testing.T) {
+	metrics.Register()
+	metrics.Reset()
+
 	startTime := time.Now()
 	clk, _ := testeventclock.NewFake(startTime, 0, nil)
 	plcExempt := fcboot.MandatoryPriorityLevelConfigurationExempt
@@ -160,5 +164,30 @@ func TestUpdateBorrowing(t *testing.T) {
 	} else {
 		t.Logf("Scenario 3: expected and got %d for lo", expected)
 	}
+	if expected, actual := float64(stateExempt.currentCL), priorityLevelTargetSeats(t, plcExempt.Name); expected != actual {
+		t.Errorf("Scenario 3: expected target seats %v, got %v for exempt", expected, actual)
+	}
+}
 
+func priorityLevelTargetSeats(t *testing.T, priorityLevel string) float64 {
+	t.Helper()
+
+	metricFamilies, err := legacyregistry.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+	for _, family := range metricFamilies {
+		if family.GetName() != "apiserver_flowcontrol_target_seats" {
+			continue
+		}
+		for _, metric := range family.Metric {
+			for _, label := range metric.Label {
+				if label.GetName() == "priority_level" && label.GetValue() == priorityLevel {
+					return metric.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+	t.Fatalf("Target seats metric not found for priority level %q", priorityLevel)
+	return 0
 }


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

Fixes the APF `target_seats` metric for exempt priority levels.

Exempt priority levels are not included in the non-exempt allocation `items` slice, but the metric update path still read `items[idx].target`. For exempt priority levels, `idx` comes from a missing map entry and defaults to `0`, so `target_seats{priority_level="exempt"}` could incorrectly report the target from the first non-exempt priority level.

This PR records the exempt priority level target from its own computed current concurrency limit instead.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
Fixed the APF `apiserver_flowcontrol_target_seats` metric for exempt priority levels.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```