### PR TITLE
scheduler: replace test/utils/image dependency with local const

### DIFF
--- a/pkg/scheduler/.import-restrictions
+++ b/pkg/scheduler/.import-restrictions
@@ -14,8 +14,6 @@ rules:
     allowedPrefixes: [ "" ]
   - selectorRegexp: ^k8s[.]io/kubernetes/pkg/features$
     allowedPrefixes: [ "" ]
-  - selectorRegexp: ^k8s[.]io/kubernetes/test/utils/image$
-    allowedPrefixes: [ "" ]
   - selectorRegexp: ^k8s[.]io/kubernetes/test/utils/ktesting($|/)
     allowedPrefixes: [ "" ]
 

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -32,11 +32,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 	"k8s.io/utils/ptr"
 )
 
 var zero int64
+
+// pauseImage is a placeholder image name for pod fixtures.
+// It is suitable for tests that need a valid non-empty image name, but never actually pull that image.
+const pauseImage = "pause"
 
 // NodeSelectorWrapper wraps a NodeSelector inside.
 type NodeSelectorWrapper struct{ v1.NodeSelector }
@@ -514,14 +517,14 @@ func (p *PodWrapper) Toleration(key string) *PodWrapper {
 // HostPort creates a container with a hostPort valued `hostPort`,
 // and injects into the inner pod.
 func (p *PodWrapper) HostPort(port int32) *PodWrapper {
-	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name("container").Image("pause").HostPort(port).Obj())
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name("container").Image(pauseImage).HostPort(port).Obj())
 	return p
 }
 
 // ContainerPort creates a container with ports valued `ports`,
 // and injects into the inner pod.
 func (p *PodWrapper) ContainerPort(ports []v1.ContainerPort) *PodWrapper {
-	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name("container").Image("pause").ContainerPort(ports).Obj())
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name("container").Image(pauseImage).ContainerPort(ports).Obj())
 	return p
 }
 
@@ -530,7 +533,7 @@ func (p *PodWrapper) ContainerPort(ports []v1.ContainerPort) *PodWrapper {
 func (p *PodWrapper) InitContainerPort(sidecar bool, ports []v1.ContainerPort) *PodWrapper {
 	c := MakeContainer().
 		Name("init-container").
-		Image("pause").
+		Image(pauseImage).
 		ContainerPort(ports)
 	if sidecar {
 		c.RestartPolicy(v1.ContainerRestartPolicyAlways)
@@ -791,7 +794,7 @@ func (p *PodWrapper) Res(resMap map[v1.ResourceName]string) *PodWrapper {
 	}
 
 	name := fmt.Sprintf("con%d", len(p.Spec.Containers))
-	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image(imageutils.GetPauseImageName()).Resources(resMap).Obj())
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image(pauseImage).Resources(resMap).Obj())
 	return p
 }
 
@@ -818,7 +821,7 @@ func (p *PodWrapper) Req(reqMap map[v1.ResourceName]string) *PodWrapper {
 	}
 
 	name := fmt.Sprintf("con%d", len(p.Spec.Containers))
-	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image(imageutils.GetPauseImageName()).ResourceRequests(reqMap).Obj())
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image(pauseImage).ResourceRequests(reqMap).Obj())
 	return p
 }
 
@@ -829,7 +832,7 @@ func (p *PodWrapper) Lim(limMap map[v1.ResourceName]string) *PodWrapper {
 	}
 
 	name := fmt.Sprintf("con%d", len(p.Spec.Containers))
-	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image(imageutils.GetPauseImageName()).ResourceLimits(limMap).Obj())
+	p.Spec.Containers = append(p.Spec.Containers, MakeContainer().Name(name).Image(pauseImage).ResourceLimits(limMap).Obj())
 	return p
 }
 
@@ -840,7 +843,7 @@ func (p *PodWrapper) InitReq(resMap map[v1.ResourceName]string) *PodWrapper {
 	}
 
 	name := fmt.Sprintf("init-con%d", len(p.Spec.InitContainers))
-	p.Spec.InitContainers = append(p.Spec.InitContainers, MakeContainer().Name(name).Image(imageutils.GetPauseImageName()).Resources(resMap).Obj())
+	p.Spec.InitContainers = append(p.Spec.InitContainers, MakeContainer().Name(name).Image(pauseImage).Resources(resMap).Obj())
 	return p
 }
 
@@ -851,7 +854,7 @@ func (p *PodWrapper) SidecarReq(resMap map[v1.ResourceName]string) *PodWrapper {
 	}
 
 	name := fmt.Sprintf("sidecar-con%d", len(p.Spec.InitContainers))
-	p.Spec.InitContainers = append(p.Spec.InitContainers, MakeContainer().Name(name).Image(imageutils.GetPauseImageName()).RestartPolicy(v1.ContainerRestartPolicyAlways).Resources(resMap).Obj())
+	p.Spec.InitContainers = append(p.Spec.InitContainers, MakeContainer().Name(name).Image(pauseImage).RestartPolicy(v1.ContainerRestartPolicyAlways).Resources(resMap).Obj())
 	return p
 }
 


### PR DESCRIPTION
pkg/scheduler/testing only uses k8s.io/kubernetes/test/utils/image for imageutils.GetPauseImageName(), and exclusively in fixtures where the image is never run.

Replace with a pauseImage const, also aligning the three existing call sites already supplied with hardcoded "pause".

Part of removal of k/k imports in pkg/scheduler to support move to staging.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the `k8s.io/kubernetes/test/utils/image` dependency in `pkg/scheduler`. The only usage was `imageutils.GetPauseImageName()` in `pkg/scheduler/testing/wrappers.go`, for a single placeholder image name. This replaces it with a local `pauseImage` const, which is safe as these fixtures are never run, so the image is never pulled.

This also aligns the three existing call sites in the same file that already hardcode `"pause"`.

Part of #141411 which requires there be no `k8s.io/kubernetes` dependencies from `pkg/scheduler`.

#### Which issue(s) this PR is related to:

Fixes #141495.

#### Special notes for your reviewer:

Depends on #141415. Once merged, will rebase and add removal of the `test/utils/image` entry from `pkg/scheduler/.import-restrictions`. Holding until then. 
/hold

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```