### PR TITLE
apiextensions: report why the test server's healthz wait failed

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
@@ -216,23 +216,32 @@ func StartTestServer(t Logger, _ *TestServerInstanceOptions, customFlags []strin
 	if err != nil {
 		return result, fmt.Errorf("failed to create a client: %v", err)
 	}
-	err = wait.Poll(100*time.Millisecond, time.Minute, func() (bool, error) {
+	// Keep the outcome of the last probe around: on timeout it is the only
+	// clue about what the server was still waiting for, and /healthz names
+	// the checks that did not pass in its body.
+	var lastStatus int
+	var lastBody []byte
+	var lastErr error
+	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, time.Minute, false, func(ctx context.Context) (bool, error) {
 		select {
 		case err := <-errCh:
 			return false, err
 		default:
 		}
 
-		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO())
+		res := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(ctx)
 		status := 0
-		result.StatusCode(&status)
-		if status == 200 {
-			return true, nil
+		res.StatusCode(&status)
+		body, rerr := res.Raw()
+		// The probe that runs into the poll deadline is aborted mid-flight and
+		// carries no useful outcome; keep the last one that actually completed.
+		if ctx.Err() == nil {
+			lastStatus, lastBody, lastErr = status, body, rerr
 		}
-		return false, nil
+		return status == 200, nil
 	})
 	if err != nil {
-		return result, fmt.Errorf("failed to wait for /healthz to return ok: %v", err)
+		return result, fmt.Errorf("failed to wait for /healthz to return ok: %w (last status %d, last error %v, last body %.512q)", err, lastStatus, lastErr, lastBody)
 	}
 
 	// from here the caller must call tearDown

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
@@ -241,7 +241,12 @@ func StartTestServer(t Logger, _ *TestServerInstanceOptions, customFlags []strin
 		return status == 200, nil
 	})
 	if err != nil {
-		return result, fmt.Errorf("failed to wait for /healthz to return ok: %w (last status %d, last error %v, last body %.512q)", err, lastStatus, lastErr, lastBody)
+		// A probe that got a response leaves lastErr nil, which is the common
+		// case here, so only mention the error when there is one to report.
+		if lastErr != nil {
+			return result, fmt.Errorf("failed to wait for /healthz to return ok: %w (last status %d, last body %.512q, last error %w)", err, lastStatus, lastBody, lastErr)
+		}
+		return result, fmt.Errorf("failed to wait for /healthz to return ok: %w (last status %d, last body %.512q)", err, lastStatus, lastBody)
 	}
 
 	// from here the caller must call tearDown


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:

When the embedded apiextensions-apiserver doesn't come up, `StartTestServer` gives you
this and nothing else:

    failed to wait for /healthz to return ok: timed out waiting for the condition

The status code, the response body and the request error all get thrown away. /healthz
lists the checks that haven't passed yet in its body, so the one thing that would tell
you what the server was stuck on is exactly the thing that gets dropped.

It now keeps the last probe that actually finished and prints it alongside the timeout.
Real output from a run where I pointed the probe at a bad path on purpose:

    failed to wait for /healthz to return ok: context deadline exceeded (last status 404,
    last error the server could not find the requested resource, last body "{\n  \"paths\":
    [\n    \"/apis\",\n ... \"/healthz/poststarthook/crd-informer-synced\", ...")

The probe that runs into the poll deadline gets aborted halfway and has nothing useful in
it, so it's skipped in favour of the previous one. My first version didn't do that and
printed `last status 0, last body ""` every time, which is how the guard ended up there.

While I was in here I swapped `wait.Poll` for `PollUntilContextTimeout`. `wait.Poll` is
deprecated ("This method does not return errors from context, use PollUntilContextTimeout"
in wait/poll.go) and it ignored the server context, so a teardown racing startup still
burned the full minute. `immediate` is false to keep the old sleep-first behaviour. The
`context.TODO()` on the probe goes away with it.

To be clear about what this is: it does not fix #141178. The conversion tests will keep
flaking. It just means the next failure says something. The triage on that issue had to
work backwards from four different symptoms that all look identical in the log, because
they all end at the same line.

The same wait.Poll pattern is in the kube-apiserver, kube-scheduler, kube-controller-manager
and cloud-provider test servers. I left those alone so this stays in one SIG. Happy to do
them separately if that's wanted.

#### Which issue(s) this PR is related to:

Related to #141178

#### Special notes for your reviewer:

No test change. This is the error path of a test helper, and every apiextensions
integration test goes through it - ./test/integration/conversion/ passes unchanged. To see
the new message I temporarily pointed the probe at /healthz-nope and ran
`go test ./test/integration/ -run TestMultipleRegistration`, which is where the output
above came from, then put it back.

I used AI assistance while working on this.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig api-machinery
/assign @jpbetz
/cc @jefftree
