### PR TITLE
core: migrate PVC volumeName to declarative validation

### DIFF
--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -340,6 +340,37 @@ func Validate_Endpoints(
 	return errs
 }
 
+// Validate_EphemeralVolumeSource validates an instance of EphemeralVolumeSource according
+// to declarative validation rules in the API schema.
+func Validate_EphemeralVolumeSource(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *corev1.EphemeralVolumeSource) (errs field.ErrorList) {
+
+	{ // field corev1.EphemeralVolumeSource.VolumeClaimTemplate
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *corev1.PersistentVolumeClaimTemplate,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_PersistentVolumeClaimTemplate(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *corev1.EphemeralVolumeSource) *corev1.PersistentVolumeClaimTemplate {
+				return oldObj.VolumeClaimTemplate
+			})
+		errs = append(errs, fn(fldPath.Child("volumeClaimTemplate"), obj.VolumeClaimTemplate, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
 // Validate_Event validates an instance of Event according
 // to declarative validation rules in the API schema.
 func Validate_Event(
@@ -1111,7 +1142,27 @@ func Validate_PersistentVolumeClaim(
 		errs = append(errs, fn(fldPath.Child("metadata"), &obj.ObjectMeta, oldVal, oldObj != nil)...)
 	}
 
-	// field corev1.PersistentVolumeClaim.Spec has no validation
+	{ // field corev1.PersistentVolumeClaim.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *corev1.PersistentVolumeClaimSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_PersistentVolumeClaimSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *corev1.PersistentVolumeClaim) *corev1.PersistentVolumeClaimSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
+	}
 
 	{ // field corev1.PersistentVolumeClaim.Status
 		fn := func(
@@ -1135,6 +1186,56 @@ func Validate_PersistentVolumeClaim(
 		errs = append(errs, fn(fldPath.Child("status"), &obj.Status, oldVal, oldObj != nil)...)
 	}
 
+	return errs
+}
+
+// Validate_PersistentVolumeClaimSpec validates an instance of PersistentVolumeClaimSpec according
+// to declarative validation rules in the API schema.
+func Validate_PersistentVolumeClaimSpec(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *corev1.PersistentVolumeClaimSpec) (errs field.ErrorList) {
+
+	// field corev1.PersistentVolumeClaimSpec.AccessModes has no validation
+	// field corev1.PersistentVolumeClaimSpec.Selector has no validation
+	// field corev1.PersistentVolumeClaimSpec.Resources has no validation
+
+	{ // field corev1.PersistentVolumeClaimSpec.VolumeName
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoUnset, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *corev1.PersistentVolumeClaimSpec) *string {
+				return &oldObj.VolumeName
+			})
+		errs = append(errs, fn(fldPath.Child("volumeName"), &obj.VolumeName, oldVal, oldObj != nil)...)
+	}
+
+	// field corev1.PersistentVolumeClaimSpec.StorageClassName has no validation
+	// field corev1.PersistentVolumeClaimSpec.VolumeMode has no validation
+	// field corev1.PersistentVolumeClaimSpec.DataSource has no validation
+	// field corev1.PersistentVolumeClaimSpec.DataSourceRef has no validation
+	// field corev1.PersistentVolumeClaimSpec.VolumeAttributesClassName has no validation
 	return errs
 }
 
@@ -1181,6 +1282,39 @@ func Validate_PersistentVolumeClaimStatus(
 				return oldObj.HealthStatus
 			})
 		errs = append(errs, fn(fldPath.Child("healthStatus"), obj.HealthStatus, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
+// Validate_PersistentVolumeClaimTemplate validates an instance of PersistentVolumeClaimTemplate according
+// to declarative validation rules in the API schema.
+func Validate_PersistentVolumeClaimTemplate(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *corev1.PersistentVolumeClaimTemplate) (errs field.ErrorList) {
+
+	// field corev1.PersistentVolumeClaimTemplate.ObjectMeta has no validation
+
+	{ // field corev1.PersistentVolumeClaimTemplate.Spec
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *corev1.PersistentVolumeClaimSpec,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_PersistentVolumeClaimSpec(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *corev1.PersistentVolumeClaimTemplate) *corev1.PersistentVolumeClaimSpec {
+				return &oldObj.Spec
+			})
+		errs = append(errs, fn(fldPath.Child("spec"), &obj.Spec, oldVal, oldObj != nil)...)
 	}
 
 	return errs
@@ -1285,7 +1419,30 @@ func Validate_PodSpec(
 		errs = append(errs, e...)
 	}
 
-	// field corev1.PodSpec.Volumes has no validation
+	{ // field corev1.PodSpec.Volumes
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj []corev1.Volume,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// iterate the list and call the type's validation function
+			if e := validate.EachValSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Volume); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *corev1.PodSpec) []corev1.Volume {
+				return oldObj.Volumes
+			})
+		errs = append(errs, fn(fldPath.Child("volumes"), obj.Volumes, oldVal, oldObj != nil)...)
+	}
+
 	// field corev1.PodSpec.InitContainers has no validation
 	// field corev1.PodSpec.Containers has no validation
 	// field corev1.PodSpec.EphemeralContainers has no validation
@@ -2077,6 +2234,39 @@ func Validate_Toleration(
 	return errs
 }
 
+// Validate_Volume validates an instance of Volume according
+// to declarative validation rules in the API schema.
+func Validate_Volume(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *corev1.Volume) (errs field.ErrorList) {
+
+	// field corev1.Volume.Name has no validation
+
+	{ // field corev1.Volume.VolumeSource
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *corev1.VolumeSource,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_VolumeSource(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *corev1.Volume) *corev1.VolumeSource {
+				return &oldObj.VolumeSource
+			})
+		errs = append(errs, fn(safe.Value(fldPath, func() *field.Path { return fldPath.Child("corev1.VolumeSource") }), &obj.VolumeSource, oldVal, oldObj != nil)...)
+	}
+
+	return errs
+}
+
 // Validate_VolumeHealthCondition validates an instance of VolumeHealthCondition according
 // to declarative validation rules in the API schema.
 func Validate_VolumeHealthCondition(
@@ -2248,5 +2438,66 @@ func Validate_VolumeHealthStatusType(
 		errs = append(errs, e...)
 	}
 
+	return errs
+}
+
+// Validate_VolumeSource validates an instance of VolumeSource according
+// to declarative validation rules in the API schema.
+func Validate_VolumeSource(
+	ctx context.Context, op operation.Operation, fldPath *field.Path,
+	obj, oldObj *corev1.VolumeSource) (errs field.ErrorList) {
+
+	// field corev1.VolumeSource.HostPath has no validation
+	// field corev1.VolumeSource.EmptyDir has no validation
+	// field corev1.VolumeSource.GCEPersistentDisk has no validation
+	// field corev1.VolumeSource.AWSElasticBlockStore has no validation
+	// field corev1.VolumeSource.GitRepo has no validation
+	// field corev1.VolumeSource.Secret has no validation
+	// field corev1.VolumeSource.NFS has no validation
+	// field corev1.VolumeSource.ISCSI has no validation
+	// field corev1.VolumeSource.Glusterfs has no validation
+	// field corev1.VolumeSource.PersistentVolumeClaim has no validation
+	// field corev1.VolumeSource.RBD has no validation
+	// field corev1.VolumeSource.FlexVolume has no validation
+	// field corev1.VolumeSource.Cinder has no validation
+	// field corev1.VolumeSource.CephFS has no validation
+	// field corev1.VolumeSource.Flocker has no validation
+	// field corev1.VolumeSource.DownwardAPI has no validation
+	// field corev1.VolumeSource.FC has no validation
+	// field corev1.VolumeSource.AzureFile has no validation
+	// field corev1.VolumeSource.ConfigMap has no validation
+	// field corev1.VolumeSource.VsphereVolume has no validation
+	// field corev1.VolumeSource.Quobyte has no validation
+	// field corev1.VolumeSource.AzureDisk has no validation
+	// field corev1.VolumeSource.PhotonPersistentDisk has no validation
+	// field corev1.VolumeSource.Projected has no validation
+	// field corev1.VolumeSource.PortworxVolume has no validation
+	// field corev1.VolumeSource.ScaleIO has no validation
+	// field corev1.VolumeSource.StorageOS has no validation
+	// field corev1.VolumeSource.CSI has no validation
+
+	{ // field corev1.VolumeSource.Ephemeral
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *corev1.EphemeralVolumeSource,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if equality.Semantic.DeepEqual(obj, oldObj) {
+					return nil
+				}
+			}
+			// call the type's validation function
+			errs = append(errs, Validate_EphemeralVolumeSource(ctx, op, fldPath, obj, oldObj)...)
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *corev1.VolumeSource) *corev1.EphemeralVolumeSource {
+				return oldObj.Ephemeral
+			})
+		errs = append(errs, fn(fldPath.Child("ephemeral"), obj.Ephemeral, oldVal, oldObj != nil)...)
+	}
+
+	// field corev1.VolumeSource.Image has no validation
 	return errs
 }

--- a/pkg/apis/core/v1/zz_generated.validations.go
+++ b/pkg/apis/core/v1/zz_generated.validations.go
@@ -353,9 +353,18 @@ func Validate_EphemeralVolumeSource(
 			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update {
-				if equality.Semantic.DeepEqual(obj, oldObj) {
+				if validate.SemanticDeepEqual(obj, oldObj) {
 					return nil
 				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_PersistentVolumeClaimTemplate(ctx, op, fldPath, obj, oldObj)...)
@@ -1149,7 +1158,7 @@ func Validate_PersistentVolumeClaim(
 			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update {
-				if equality.Semantic.DeepEqual(obj, oldObj) {
+				if validate.SemanticDeepEqual(obj, oldObj) {
 					return nil
 				}
 			}
@@ -1215,7 +1224,8 @@ func Validate_PersistentVolumeClaimSpec(
 			if e := validate.OptionalValue(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
-			if e := validate.UpdateValueByCompare(ctx, op, fldPath, obj, oldObj, validate.NoUnset, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.UpdateValue(ctx, op, fldPath, obj, oldObj,
+				func(a string, b string) bool { return a == b }, validate.NoUnset, validate.NoModify).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -1302,7 +1312,7 @@ func Validate_PersistentVolumeClaimTemplate(
 			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update {
-				if equality.Semantic.DeepEqual(obj, oldObj) {
+				if validate.SemanticDeepEqual(obj, oldObj) {
 					return nil
 				}
 			}
@@ -1426,9 +1436,17 @@ func Validate_PodSpec(
 			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update {
-				if equality.Semantic.DeepEqual(obj, oldObj) {
+				if validate.SemanticDeepEqual(obj, oldObj) {
 					return nil
 				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// iterate the list and call the type's validation function
 			if e := validate.EachValSliceVal(ctx, op, fldPath, obj, oldObj, nil, nil, Validate_Volume); len(e) != 0 {
@@ -2249,7 +2267,7 @@ func Validate_Volume(
 			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update {
-				if equality.Semantic.DeepEqual(obj, oldObj) {
+				if validate.SemanticDeepEqual(obj, oldObj) {
 					return nil
 				}
 			}
@@ -2483,9 +2501,17 @@ func Validate_VolumeSource(
 			oldValueCorrelated bool) (errs field.ErrorList) {
 			// don't revalidate unchanged data
 			if oldValueCorrelated && op.Type == operation.Update {
-				if equality.Semantic.DeepEqual(obj, oldObj) {
+				if validate.SemanticDeepEqual(obj, oldObj) {
 					return nil
 				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
 			}
 			// call the type's validation function
 			errs = append(errs, Validate_EphemeralVolumeSource(ctx, op, fldPath, obj, oldObj)...)

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2571,10 +2571,17 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
 
 	// PVController needs to update PVC.Spec w/ VolumeName.
 	// Claims are immutable in order to enforce quota, range limits, etc. without gaming the system.
-	if len(oldPvc.Spec.VolumeName) == 0 {
-		// volumeName changes are allowed once.
-		oldPvcClone.Spec.VolumeName = newPvcClone.Spec.VolumeName // +k8s:verify-mutation:reason=clone
+	// A volumeName may be set once, but cannot be modified or cleared after it is set.
+	if len(oldPvc.Spec.VolumeName) > 0 {
+		if len(newPvc.Spec.VolumeName) == 0 {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "volumeName"), nil, "field cannot be cleared once set").WithOrigin("update").MarkCoveredByDeclarative().MarkAlpha())
+		} else if newPvc.Spec.VolumeName != oldPvc.Spec.VolumeName {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "volumeName"), nil, "field cannot be modified once set").WithOrigin("update").MarkCoveredByDeclarative().MarkAlpha())
+		}
 	}
+	// Exclude VolumeName from the generic spec comparison because its set-once
+	// transition is handled by the field-specific check above.
+	oldPvcClone.Spec.VolumeName = newPvcClone.Spec.VolumeName // +k8s:verify-mutation:reason=clone
 
 	if validateStorageClassUpgradeFromAnnotation(oldPvcClone.Annotations, newPvcClone.Annotations,
 		oldPvcClone.Spec.StorageClassName, newPvcClone.Spec.StorageClassName) {

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -2407,6 +2407,10 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 		},
 		VolumeName: "volume",
 	})
+	invalidUpdateClaimVolumeName := validUpdateClaim.DeepCopy()
+	invalidUpdateClaimVolumeName.Spec.VolumeName = "other-volume"
+	invalidUpdateClaimVolumeNameCleared := validUpdateClaim.DeepCopy()
+	invalidUpdateClaimVolumeNameCleared.Spec.VolumeName = ""
 	invalidUpdateClaimResources := testVolumeClaim("foo", "ns", core.PersistentVolumeClaimSpec{
 		AccessModes: []core.PersistentVolumeAccessMode{
 			core.ReadWriteOnce,
@@ -2826,6 +2830,7 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 		isExpectedFailure           bool
 		oldClaim                    *core.PersistentVolumeClaim
 		newClaim                    *core.PersistentVolumeClaim
+		expectedVolumeNameError     string
 		enableRecoverFromExpansion  bool
 		enableVolumeAttributesClass bool
 	}{
@@ -2838,6 +2843,18 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 			isExpectedFailure: false,
 			oldClaim:          validUpdateClaim,
 			newClaim:          validUpdateClaim,
+		},
+		"invalid-update-volumeName": {
+			isExpectedFailure:       true,
+			oldClaim:                validUpdateClaim,
+			newClaim:                invalidUpdateClaimVolumeName,
+			expectedVolumeNameError: "field cannot be modified once set",
+		},
+		"invalid-clear-volumeName": {
+			isExpectedFailure:       true,
+			oldClaim:                validUpdateClaim,
+			newClaim:                invalidUpdateClaimVolumeNameCleared,
+			expectedVolumeNameError: "field cannot be cleared once set",
 		},
 		"invalid-update-change-resources-on-bound-claim": {
 			isExpectedFailure: true,
@@ -3141,6 +3158,24 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 			}
 			if len(errs) > 0 && !scenario.isExpectedFailure {
 				t.Errorf("Unexpected failure for scenario: %s - %+v", name, errs)
+			}
+			if scenario.expectedVolumeNameError != "" {
+				var volumeNameError *field.Error
+				for _, err := range errs {
+					if err.Field == "spec.volumeName" {
+						volumeNameError = err
+						break
+					}
+				}
+				if volumeNameError == nil {
+					t.Fatalf("Expected an error for spec.volumeName, got: %v", errs)
+				}
+				if !volumeNameError.CoveredByDeclarative {
+					t.Errorf("Expected spec.volumeName error to be covered by declarative validation: %v", volumeNameError)
+				}
+				if volumeNameError.Detail != scenario.expectedVolumeNameError {
+					t.Errorf("Expected spec.volumeName error detail %q, got %q", scenario.expectedVolumeNameError, volumeNameError.Detail)
+				}
 			}
 		})
 	}

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -1766,6 +1766,7 @@ message EphemeralVolumeSource {
   //
   // Required, must not be nil.
   // +required
+  // +k8s:alpha(since: "1.37")=+k8s:required
   optional PersistentVolumeClaimTemplate volumeClaimTemplate = 1;
 }
 
@@ -3487,6 +3488,9 @@ message PersistentVolumeClaimSpec {
 
   // volumeName is the binding reference to the PersistentVolume backing this claim.
   // +optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:update=NoModify
+  // +k8s:alpha(since: "1.37")=+k8s:update=NoUnset
   optional string volumeName = 3;
 
   // storageClassName is the name of the StorageClass required by the claim.
@@ -4687,6 +4691,7 @@ message PodSpec {
   // List of volumes that can be mounted by containers belonging to the pod.
   // More info: https://kubernetes.io/docs/concepts/storage/volumes
   // +optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
   // +patchMergeKey=name
   // +patchStrategy=merge,retainKeys
   // +listType=map
@@ -7702,6 +7707,7 @@ message VolumeSource {
   // persistent volumes at the same time.
   //
   // +optional
+  // +k8s:alpha(since: "1.37")=+k8s:optional
   optional EphemeralVolumeSource ephemeral = 29;
 
   // image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -204,6 +204,7 @@ type VolumeSource struct {
 	// persistent volumes at the same time.
 	//
 	// +optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
 	Ephemeral *EphemeralVolumeSource `json:"ephemeral,omitempty" protobuf:"bytes,29,opt,name=ephemeral"`
 	// image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
 	// The volume is resolved at pod startup depending on which PullPolicy value is provided:
@@ -2550,6 +2551,7 @@ type EphemeralVolumeSource struct {
 	//
 	// Required, must not be nil.
 	// +required
+	// +k8s:alpha(since: "1.37")=+k8s:required
 	VolumeClaimTemplate *PersistentVolumeClaimTemplate `json:"volumeClaimTemplate,omitempty" protobuf:"bytes,1,opt,name=volumeClaimTemplate"`
 
 	// ReadOnly is tombstoned to show why 2 is a reserved protobuf tag.
@@ -4438,6 +4440,7 @@ type PodSpec struct {
 	// List of volumes that can be mounted by containers belonging to the pod.
 	// More info: https://kubernetes.io/docs/concepts/storage/volumes
 	// +optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge,retainKeys
 	// +listType=map

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -573,6 +573,9 @@ type PersistentVolumeClaimSpec struct {
 	Resources VolumeResourceRequirements `json:"resources,omitempty" protobuf:"bytes,2,opt,name=resources"`
 	// volumeName is the binding reference to the PersistentVolume backing this claim.
 	// +optional
+	// +k8s:alpha(since: "1.37")=+k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:update=NoModify
+	// +k8s:alpha(since: "1.37")=+k8s:update=NoUnset
 	VolumeName string `json:"volumeName,omitempty" protobuf:"bytes,3,opt,name=volumeName"`
 	// storageClassName is the name of the StorageClass required by the claim.
 	// More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1

--- a/test/declarative_validation/core/persistentvolumeclaim/declarative_validation_test.go
+++ b/test/declarative_validation/core/persistentvolumeclaim/declarative_validation_test.go
@@ -73,6 +73,35 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 
 	updateObj := mkValidPersistentVolumeClaim()
 	meta.RunObjectMetaUpdateTestCases(t, ctx, &updateObj, registry.Strategy, meta.WithStringentFinalizerValidation())
+
+	tests := map[string]struct {
+		newVolumeName string
+		expectedErr   field.ErrorList
+	}{
+		"volumeName cannot be modified once set": {
+			newVolumeName: "other-volume",
+			expectedErr: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "volumeName"), nil, "field cannot be modified once set").WithOrigin("update").MarkAlpha(),
+			},
+		},
+		"volumeName cannot be cleared once set": {
+			newVolumeName: "",
+			expectedErr: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "volumeName"), nil, "field cannot be cleared once set").WithOrigin("update").MarkAlpha(),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldObj := mkValidPersistentVolumeClaim()
+			oldObj.ResourceVersion = "1"
+			oldObj.Spec.VolumeName = "volume"
+			updateObj := oldObj.DeepCopy()
+			updateObj.Spec.VolumeName = tc.newVolumeName
+			apitesting.VerifyUpdateValidationEquivalence(t, ctx, updateObj, &oldObj, registry.Strategy, tc.expectedErr)
+		})
+	}
 }
 
 func TestDeclarativeValidateStatusUpdate(t *testing.T) {

--- a/test/declarative_validation/core/persistentvolumeclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/core/persistentvolumeclaim/zz_generated.validations.v1_test.go
@@ -61,6 +61,9 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.volumeName": {
+				{ErrorType: "FieldValueInvalid", Origin: "update"},
+			},
 			"status.healthStatus.healthConditions": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
 			},

--- a/test/declarative_validation/coverage-allowlist.yaml
+++ b/test/declarative_validation/coverage-allowlist.yaml
@@ -22,3 +22,24 @@
   errorType: '*'
   origin: '*'
   reason: Not served by kube-apiserver.
+
+- apiVersion: v1
+  kind: Pod
+  path: spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: v1
+  kind: PodTemplate
+  path: template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: v1
+  kind: ReplicationController
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.

--- a/test/declarative_validation/coverage-allowlist.yaml
+++ b/test/declarative_validation/coverage-allowlist.yaml
@@ -25,9 +25,23 @@
 
 - apiVersion: v1
   kind: Pod
+  path: spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: v1
+  kind: Pod
   path: spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
   errorType: FieldValueInvalid
   origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: v1
+  kind: PodTemplate
+  path: template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
   reason: Nested in a Pod volume list without update correlation.
 
 - apiVersion: v1
@@ -39,6 +53,195 @@
 
 - apiVersion: v1
   kind: ReplicationController
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: v1
+  kind: ReplicationController
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1
+  kind: DaemonSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1
+  kind: DaemonSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta2
+  kind: DaemonSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta2
+  kind: DaemonSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1
+  kind: Deployment
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1
+  kind: Deployment
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta2
+  kind: Deployment
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta2
+  kind: Deployment
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1
+  kind: ReplicaSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1
+  kind: ReplicaSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta2
+  kind: ReplicaSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta2
+  kind: ReplicaSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1
+  kind: StatefulSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1
+  kind: StatefulSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta1
+  kind: StatefulSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta1
+  kind: StatefulSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta2
+  kind: StatefulSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: apps/v1beta2
+  kind: StatefulSet
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: batch/v1
+  kind: CronJob
+  path: spec.jobTemplate.spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: batch/v1
+  kind: CronJob
+  path: spec.jobTemplate.spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  path: spec.jobTemplate.spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  path: spec.jobTemplate.spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
+  errorType: FieldValueInvalid
+  origin: update
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: batch/v1
+  kind: Job
+  path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate
+  errorType: FieldValueRequired
+  origin: '*'
+  reason: Nested in a Pod volume list without update correlation.
+
+- apiVersion: batch/v1
+  kind: Job
   path: spec.template.spec.volumes[*].ephemeral.volumeClaimTemplate.spec.volumeName
   errorType: FieldValueInvalid
   origin: update


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Migrates PersistentVolumeClaimSpec.VolumeName to declarative validation.

- Preserves the existing empty-to-set transition used by the PV controller.
- Rejects modifying or clearing volumeName after it has been set.
- Adds the generated validation code and declarative-validation coverage.
- Keeps handwritten and declarative validation behavior equivalent.

#### Which issue(s) is this PR related to:
Related to #136785

#### Special notes for your reviewer:
VolumeName uses NoModify and NoUnset to model the existing set-once behavior. Nested rules propagated through ephemeral volume claim templates are covered by the validation coverage allowlist because the surrounding volume lists do not provide update correlation.

#### Does this PR introduce a user-facing change?
No. This makes declarative validation equivalent to the existing handwritten validation.

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
None

```release-note
NONE
```

```docs
NONE
```