### PR TITLE
endpoints: fix empty involvedObject.namespace on failure events

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -458,8 +458,9 @@ func (e *Controller) syncService(ctx context.Context, key string) error {
 		}
 		currentEndpoints = &v1.Endpoints{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:   service.Name,
-				Labels: service.Labels,
+				Name:      service.Name,
+				Namespace: service.Namespace,
+				Labels:    service.Labels,
 			},
 		}
 	} else if e.staleEndpointsTracker.IsStale(currentEndpoints) {

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,6 +41,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clientscheme "k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	utiltesting "k8s.io/client-go/util/testing"
 	endptspkg "k8s.io/kubernetes/pkg/api/v1/endpoints"
@@ -1105,6 +1107,7 @@ func TestSyncEndpointsItems(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: "",
 			Name:            "foo",
+			Namespace:       ns,
 			Labels: map[string]string{
 				LabelManagedBy:       ControllerName,
 				v1.IsHeadlessService: "",
@@ -1162,6 +1165,7 @@ func TestSyncEndpointsItemsWithLabels(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: "",
 			Name:            "foo",
+			Namespace:       ns,
 			Labels:          serviceLabels,
 		},
 		Subsets: endptspkg.SortSubsets(expectedSubsets),
@@ -1501,7 +1505,8 @@ func TestSyncEndpointsHeadlessWithoutPort(t *testing.T) {
 	endpointsHandler.ValidateRequestCount(t, 1)
 	data := runtime.EncodeOrDie(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), &v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "foo",
+			Name:      "foo",
+			Namespace: ns,
 			Labels: map[string]string{
 				LabelManagedBy:       ControllerName,
 				v1.IsHeadlessService: "",
@@ -3302,5 +3307,49 @@ func TestPodToEndpointAddressForServiceEmptyIPFamilies(t *testing.T) {
 				t.Errorf("got IP %q (IPv6=%v), want family %v", addr.IP, isV6, tc.wantFamily)
 			}
 		})
+	}
+}
+
+// TestSyncServiceFailedCreateEndpointsEventHasNamespace verifies that when
+// syncService fails to create a brand new Endpoints object, the resulting
+// FailedToCreateEndpoint event carries the service's namespace on
+// involvedObject, not just in the message text.
+func TestSyncServiceFailedCreateEndpointsEventHasNamespace(t *testing.T) {
+	ns := "target-ns"
+	tCtx := ktesting.Init(t)
+	client, controller := newFakeController(tCtx, 0*time.Second)
+
+	controller.serviceStore.Add(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
+		Spec: v1.ServiceSpec{
+			Selector: map[string]string{"foo": "bar"},
+			Ports:    []v1.ServicePort{{Port: 80}},
+		},
+	})
+
+	client.PrependReactor("create", "endpoints", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "endpoints"}, "foo")
+	})
+
+	gotEvents := make(chan *v1.Event, 1)
+	watcher := controller.eventBroadcaster.StartEventWatcher(func(e *v1.Event) {
+		if e.Reason == "FailedToCreateEndpoint" {
+			gotEvents <- e
+		}
+	})
+	defer watcher.Stop()
+
+	if err := controller.syncService(tCtx, ns+"/foo"); err == nil {
+		t.Fatal("expected syncService to return the AlreadyExists error")
+	}
+
+	var gotEvent *v1.Event
+	select {
+	case gotEvent = <-gotEvents:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for a FailedToCreateEndpoint event to be recorded")
+	}
+	if gotEvent.InvolvedObject.Namespace != ns {
+		t.Errorf("event involvedObject.namespace = %q, want %q", gotEvent.InvolvedObject.Namespace, ns)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

`syncService`'s placeholder Endpoints object (built when the lister returns
NotFound) never sets `Namespace`:

```go
currentEndpoints = &v1.Endpoints{
    ObjectMeta: metav1.ObjectMeta{
        Name:   service.Name,
        Labels: service.Labels,
    },
}
```

If the following Create fails, the FailedToCreateEndpoint/
FailedToUpdateEndpoint event is recorded against that object, so
involvedObject.namespace is empty. Worse, client-go's makeEvent defaults
an empty ref namespace to default:

```go
namespace := ref.Namespace
if namespace == "" {
    namespace = metav1.NamespaceDefault
}
return &v1.Event{
    ObjectMeta: metav1.ObjectMeta{Namespace: namespace},
    InvolvedObject: *ref,
    ...
}
```

so the Event itself gets misfiled into the default namespace instead of
the service's. kubectl get events -n <service-ns> never shows it.

Fix: set Namespace: service.Namespace on the placeholder.

This PR was written in part with the assistance of generative AI; all changes
were authored and reviewed by me.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Fixes https://github.com/kubernetes/kubernetes/issues/141508

#### Special notes for your reviewer:

- Added TestSyncServiceFailedCreateEndpointsEventHasNamespace, which fails
  without this fix (involvedObject.namespace == "") and passes with it.
- Updated the expected wire-body fixtures in TestSyncEndpointsItems,
  TestSyncEndpointsItemsWithLabels, and TestSyncEndpointsHeadlessWithoutPort
  to include the now-populated Namespace field, matching the corrected
  behavior.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed `FailedToCreateEndpoint`/`FailedToUpdateEndpoint` events from the endpoints controller being misfiled into the `default` namespace instead of the service's namespace.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
