### PR TITLE
scheduler: replace pkg/controller dependency with a literal resync period

### DIFF
--- a/pkg/scheduler/.import-restrictions
+++ b/pkg/scheduler/.import-restrictions
@@ -8,8 +8,6 @@ rules:
     allowedPrefixes: [ "" ]
   - selectorRegexp: ^k8s[.]io/kubernetes/pkg/apis/scheduling$
     allowedPrefixes: [ "" ]
-  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/controller$
-    allowedPrefixes: [ "" ]
   - selectorRegexp: ^k8s[.]io/kubernetes/pkg/controller/volume/persistentvolume/testing$
     allowedPrefixes: [ "" ]
   - selectorRegexp: ^k8s[.]io/kubernetes/pkg/features$

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	_ "k8s.io/klog/v2/ktesting/init"
-	"k8s.io/kubernetes/pkg/controller"
 	pvtesting "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/testing"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 )
@@ -159,7 +158,7 @@ func newTestBinder(t *testing.T, ctx context.Context) *testEnv {
 		}
 		return true, watch, nil
 	})
-	informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
 
 	podInformer := informerFactory.Core().V1().Pods()
 	nodeInformer := informerFactory.Core().V1().Nodes()


### PR DESCRIPTION
binder_test.go used k8s.io/kubernetes/pkg/controller only for NoResyncPeriodFunc, which returns 0. Pass 0 directly, as the rest of pkg/scheduler already does when constructing informer factories.

Part of removal of k/k imports in pkg/scheduler to support move to staging.

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the `k8s.io/kubernetes/pkg/controller` dependency in `pkg/scheduler`. The only usage was `controller.NoResyncPeriodFunc()` in `binder_test.go`, which returns `0`. This passes `0` directly, as the rest of `pkg/scheduler` already does when constructing informer factories.

`NoResyncPeriodFunc()` exists to satisfy the `ResyncPeriodFunc` type where it is passed as a value. This functionality is not needed here.

Part of #141411 which requires there be no `k8s.io/kubernetes` dependencies from `pkg/scheduler`.

#### Which issue(s) this PR is related to:

Fixes #141497.

#### Special notes for your reviewer:

Depends on #141415. Once merged, will rebase and add removal of the `k8s.io/kubernetes/pkg/controller` entry from `pkg/scheduler/.import-restrictions`. Holding until then.

/hold

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```