### PR TITLE
Reduce useless duplicate reading of certificate data #141445

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -112,6 +112,9 @@ type ConfigFlags struct {
 	clientConfig     clientcmd.ClientConfig
 	clientConfigLock sync.Mutex
 
+	restConfig     *rest.Config
+	restConfigLock sync.Mutex
+
 	restMapper     meta.RESTMapper
 	restMapperLock sync.Mutex
 
@@ -139,7 +142,7 @@ type ConfigFlags struct {
 // Expects the AddFlags method to have been called. If WrapConfigFn
 // is non-nil this function can transform config before return.
 func (f *ConfigFlags) ToRESTConfig() (*rest.Config, error) {
-	c, err := f.ToRawKubeConfigLoader().ClientConfig()
+	c, err := f.toRESTConfig()
 	if err != nil {
 		return nil, err
 	}
@@ -147,6 +150,36 @@ func (f *ConfigFlags) ToRESTConfig() (*rest.Config, error) {
 		return f.WrapConfigFn(c), nil
 	}
 	return c, nil
+}
+
+// toRESTConfig resolves the raw kubeconfig into a *rest.Config. When persistent config
+// is in use the resolved config is memoized, matching what this struct already does for
+// the client config, the rest mapper and the discovery client.
+//
+// Resolving is not free: clientcmd validates the config every time, which stats and
+// opens the certificate-authority, client-certificate and client-key files when those
+// are given as paths. A command that builds a REST client for each of N group-versions
+// calls ToRESTConfig N times and pays that cost N times over.
+//
+// Callers mutate the returned config -- ContentConfig, GroupVersion, APIPath -- so each
+// one gets its own copy.
+func (f *ConfigFlags) toRESTConfig() (*rest.Config, error) {
+	if !f.usePersistentConfig {
+		return f.ToRawKubeConfigLoader().ClientConfig()
+	}
+
+	f.restConfigLock.Lock()
+	defer f.restConfigLock.Unlock()
+
+	if f.restConfig == nil {
+		c, err := f.ToRawKubeConfigLoader().ClientConfig()
+		if err != nil {
+			return nil, err
+		}
+		f.restConfig = c
+	}
+
+	return rest.CopyConfig(f.restConfig), nil
 }
 
 // ToRawKubeConfigLoader binds config flag values to config overrides

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+)
+
+const testKubeConfig = `apiVersion: v1
+kind: Config
+clusters:
+- name: test
+  cluster:
+    server: https://localhost:6443
+    insecure-skip-tls-verify: true
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+current-context: test
+users:
+- name: test
+  user:
+    token: sometoken
+`
+
+func writeKubeConfig(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, []byte(testKubeConfig), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestToRESTConfigResolvesOnceWithPersistentConfig(t *testing.T) {
+	f := NewConfigFlags(true)
+	f.KubeConfig = ptr.To(writeKubeConfig(t))
+
+	first, err := f.ToRESTConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := f.ToRESTConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if first == second {
+		t.Fatal("expected each caller to get its own copy, got the same pointer")
+	}
+	if f.restConfig == nil {
+		t.Fatal("expected the resolved config to be memoized")
+	}
+	if first == f.restConfig || second == f.restConfig {
+		t.Fatal("expected callers to get copies, not the memoized config itself")
+	}
+	if first.Host != second.Host || first.BearerToken != second.BearerToken {
+		t.Errorf("expected identical configs, got %q/%q", first.Host, second.Host)
+	}
+}
+
+func TestToRESTConfigCopiesAreIndependent(t *testing.T) {
+	f := NewConfigFlags(true)
+	f.KubeConfig = ptr.To(writeKubeConfig(t))
+
+	first, err := f.ToRESTConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Callers routinely mutate these; the mutation must not leak into later callers.
+	first.APIPath = "/apis"
+	first.ContentConfig.GroupVersion = nil
+	first.UserAgent = "mutated"
+
+	second, err := f.ToRESTConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.APIPath == "/apis" || second.UserAgent == "mutated" {
+		t.Errorf("mutation of one config leaked into the next: APIPath=%q UserAgent=%q", second.APIPath, second.UserAgent)
+	}
+}
+
+func TestToRESTConfigDoesNotMemoizeWithoutPersistentConfig(t *testing.T) {
+	f := NewConfigFlags(false)
+	f.KubeConfig = ptr.To(writeKubeConfig(t))
+
+	if _, err := f.ToRESTConfig(); err != nil {
+		t.Fatal(err)
+	}
+	if f.restConfig != nil {
+		t.Error("expected no memoization when usePersistentConfig is false")
+	}
+}
+
+func TestToRESTConfigAppliesWrapConfigFnPerCall(t *testing.T) {
+	f := NewConfigFlags(true)
+	f.KubeConfig = ptr.To(writeKubeConfig(t))
+
+	calls := 0
+	f.WrapConfigFn = func(c *rest.Config) *rest.Config {
+		calls++
+		c.UserAgent = "wrapped"
+		return c
+	}
+
+	for i := 0; i < 3; i++ {
+		c, err := f.ToRESTConfig()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if c.UserAgent != "wrapped" {
+			t.Errorf("call %d: expected WrapConfigFn to be applied, got UserAgent=%q", i, c.UserAgent)
+		}
+	}
+	if calls != 3 {
+		t.Errorf("expected WrapConfigFn to run on every call, ran %d times", calls)
+	}
+	if f.restConfig.UserAgent == "wrapped" {
+		t.Error("expected WrapConfigFn to mutate the copy, not the memoized config")
+	}
+}
+
+func TestToRESTConfigPropagatesError(t *testing.T) {
+	f := NewConfigFlags(true)
+	f.KubeConfig = ptr.To(filepath.Join(t.TempDir(), "does-not-exist"))
+
+	if _, err := f.ToRESTConfig(); err == nil {
+		t.Fatal("expected an error for a missing kubeconfig")
+	}
+	if f.restConfig != nil {
+		t.Error("expected nothing to be memoized after a failed resolve")
+	}
+	// A second call must still report the error rather than a memoized nil.
+	if _, err := f.ToRESTConfig(); err == nil {
+		t.Fatal("expected an error on the second call too")
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -42,9 +42,13 @@ var (
 	ClusterDefaults = clientcmdapi.Cluster{Server: getDefaultServer()}
 	// DefaultClientConfig represents the legacy behavior of this package for defaulting
 	// DEPRECATED will be replace
-	DefaultClientConfig = DirectClientConfig{*clientcmdapi.NewConfig(), "", &ConfigOverrides{
-		ClusterDefaults: ClusterDefaults,
-	}, nil, NewDefaultClientConfigLoadingRules(), promptedCredentials{}}
+	DefaultClientConfig = DirectClientConfig{
+		config: *clientcmdapi.NewConfig(),
+		overrides: &ConfigOverrides{
+			ClusterDefaults: ClusterDefaults,
+		},
+		configAccess: NewDefaultClientConfigLoadingRules(),
+	}
 )
 
 // getDefaultServer returns a default setting for DefaultClientConfig
@@ -93,21 +97,42 @@ type DirectClientConfig struct {
 	configAccess   ConfigAccess
 	// promptedCredentials store the credentials input by the user
 	promptedCredentials promptedCredentials
+	// confirmedUsable and confirmUsableErr memoize ConfirmUsable. Like the rest of
+	// this struct they are not guarded by a lock; DirectClientConfig has never been
+	// safe for concurrent use.
+	confirmedUsable  bool
+	confirmUsableErr error
 }
 
 // NewDefaultClientConfig creates a DirectClientConfig using the config.CurrentContext as the context name
 func NewDefaultClientConfig(config clientcmdapi.Config, overrides *ConfigOverrides) OverridingClientConfig {
-	return &DirectClientConfig{config, config.CurrentContext, overrides, nil, NewDefaultClientConfigLoadingRules(), promptedCredentials{}}
+	return &DirectClientConfig{
+		config:       config,
+		contextName:  config.CurrentContext,
+		overrides:    overrides,
+		configAccess: NewDefaultClientConfigLoadingRules(),
+	}
 }
 
 // NewNonInteractiveClientConfig creates a DirectClientConfig using the passed context name and does not have a fallback reader for auth information
 func NewNonInteractiveClientConfig(config clientcmdapi.Config, contextName string, overrides *ConfigOverrides, configAccess ConfigAccess) OverridingClientConfig {
-	return &DirectClientConfig{config, contextName, overrides, nil, configAccess, promptedCredentials{}}
+	return &DirectClientConfig{
+		config:       config,
+		contextName:  contextName,
+		overrides:    overrides,
+		configAccess: configAccess,
+	}
 }
 
 // NewInteractiveClientConfig creates a DirectClientConfig using the passed context name and a reader in case auth information is not provided via files or flags
 func NewInteractiveClientConfig(config clientcmdapi.Config, contextName string, overrides *ConfigOverrides, fallbackReader io.Reader, configAccess ConfigAccess) OverridingClientConfig {
-	return &DirectClientConfig{config, contextName, overrides, fallbackReader, configAccess, promptedCredentials{}}
+	return &DirectClientConfig{
+		config:         config,
+		contextName:    contextName,
+		overrides:      overrides,
+		fallbackReader: fallbackReader,
+		configAccess:   configAccess,
+	}
 }
 
 // NewClientConfigFromBytes takes your kubeconfig and gives you back a ClientConfig
@@ -117,7 +142,7 @@ func NewClientConfigFromBytes(configBytes []byte) (OverridingClientConfig, error
 		return nil, err
 	}
 
-	return &DirectClientConfig{*config, "", &ConfigOverrides{}, nil, nil, promptedCredentials{}}, nil
+	return &DirectClientConfig{config: *config, overrides: &ConfigOverrides{}}, nil
 }
 
 // RESTConfigFromKubeConfig is a convenience method to give back a restconfig from your kubeconfig bytes.
@@ -428,7 +453,21 @@ func (config *DirectClientConfig) ConfigAccess() ConfigAccess {
 
 // ConfirmUsable looks a particular context and determines if that particular part of the config is useable.  There might still be errors in the config,
 // but no errors in the sections requested or referenced.  It does not return early so that it can find as many errors as possible.
+//
+// The result is memoized. Validation is a pure function of the config and the overrides,
+// which are both fixed when the DirectClientConfig is built; the only thing it observes
+// beyond them is whether the referenced certificate, key and token files can be opened.
+// Both ClientConfig and Namespace call this, so re-validating means probing those files
+// once per call for no new information.
 func (config *DirectClientConfig) ConfirmUsable() error {
+	if !config.confirmedUsable {
+		config.confirmUsableErr = config.confirmUsable()
+		config.confirmedUsable = true
+	}
+	return config.confirmUsableErr
+}
+
+func (config *DirectClientConfig) confirmUsable() error {
 	validationErrors := make([]error, 0)
 
 	var contextName string

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -18,6 +18,7 @@ package clientcmd
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -1383,5 +1384,68 @@ func TestClientCertOverrideData(t *testing.T) {
 
 			tc.validate(t, authInfo)
 		})
+	}
+}
+
+func TestConfirmUsableProbesCredentialFilesOnce(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "client.crt")
+	keyFile := filepath.Join(dir, "client.key")
+	caFile := filepath.Join(dir, "ca.crt")
+	for _, f := range []string{certFile, keyFile, caFile} {
+		if err := os.WriteFile(f, []byte("ignored"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := clientcmdapi.NewConfig()
+	cfg.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server:               "https://localhost:8443",
+		CertificateAuthority: caFile,
+	}
+	cfg.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		ClientCertificate: certFile,
+		ClientKey:         keyFile,
+	}
+	cfg.Contexts["clean"] = &clientcmdapi.Context{Cluster: "clean", AuthInfo: "clean"}
+	cfg.CurrentContext = "clean"
+
+	config := NewNonInteractiveClientConfig(*cfg, "clean", &ConfigOverrides{}, nil).(*DirectClientConfig)
+
+	if err := config.ConfirmUsable(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Removing the files must not change the answer: the second call is memoized, and
+	// both ClientConfig and Namespace reach ConfirmUsable on the same object.
+	for _, f := range []string{certFile, keyFile, caFile} {
+		if err := os.Remove(f); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := config.ConfirmUsable(); err != nil {
+		t.Errorf("expected the memoized result, got: %v", err)
+	}
+	if _, _, err := config.Namespace(); err != nil {
+		t.Errorf("expected Namespace to reuse the memoized result, got: %v", err)
+	}
+}
+
+func TestConfirmUsableMemoizesErrors(t *testing.T) {
+	cfg := clientcmdapi.NewConfig()
+	cfg.CurrentContext = "missing"
+
+	config := NewNonInteractiveClientConfig(*cfg, "missing", &ConfigOverrides{}, nil).(*DirectClientConfig)
+
+	first := config.ConfirmUsable()
+	if first == nil {
+		t.Fatal("expected an error for a config with a missing context")
+	}
+	second := config.ConfirmUsable()
+	if second == nil {
+		t.Fatal("expected the memoized error on the second call")
+	}
+	if first.Error() != second.Error() {
+		t.Errorf("expected the same error, got %q and %q", first, second)
 	}
 }

--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -251,8 +251,10 @@ func (v *trackedTransport) WrappedRoundTripper() http.RoundTripper {
 
 // tlsConfigKey returns a unique key for tls.Config objects returned from TLSConfigFor
 func tlsConfigKey(c *Config) (tlsCacheKey, bool, error) {
-	// Make sure ca/key/cert content is loaded
-	if err := loadTLSFiles(c); err != nil {
+	// Make sure the reload flags are set and that the ca/key/cert content the key is
+	// built from is loaded. Content the key refers to by path is left for TLSConfigFor
+	// to load on a cache miss.
+	if err := loadTLSFilesForKey(c); err != nil {
 		return tlsCacheKey{}, false, err
 	}
 

--- a/staging/src/k8s.io/client-go/transport/cache_test.go
+++ b/staging/src/k8s.io/client-go/transport/cache_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"sync"
@@ -996,4 +997,121 @@ func installFakeMetrics(t *testing.T) (*recordingCreateCalls, *recordingCacheGCC
 		metrics.TransportCacheEntries = origEntries
 	})
 	return createCalls, gcCalls, rotationGCCalls, cacheEntries
+}
+
+// TestTLSConfigKeyDoesNotReadPathKeyedFiles asserts that building the transport cache
+// key does not read credential files whose path, rather than content, is what the key
+// is built from. A client that constructs one REST client per group-version calls
+// tlsConfigKey once per client, so reading here costs one open per file per client even
+// when every call after the first is a cache hit.
+func TestTLSConfigKeyDoesNotReadPathKeyedFiles(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientgofeaturegate.ClientsAllowCARotation, true)
+
+	dir := t.TempDir()
+	caFile := filepath.Join(dir, "ca.crt")
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	for f, data := range map[string]string{caFile: rootCACert, certFile: certData, keyFile: keyData} {
+		if err := os.WriteFile(f, []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	newConfig := func() *Config {
+		return &Config{TLS: TLSConfig{CAFile: caFile, CertFile: certFile, KeyFile: keyFile}}
+	}
+
+	config := newConfig()
+	key, canCache, err := tlsConfigKey(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !canCache {
+		t.Fatal("expected a cacheable config")
+	}
+	if !config.TLS.ReloadCAFiles || !config.TLS.ReloadTLSFiles {
+		t.Fatalf("expected both reload flags to be set, got ReloadCAFiles=%v ReloadTLSFiles=%v",
+			config.TLS.ReloadCAFiles, config.TLS.ReloadTLSFiles)
+	}
+	if len(config.TLS.CAData) != 0 || len(config.TLS.CertData) != 0 || len(config.TLS.KeyData) != 0 {
+		t.Error("expected no credential data to be loaded while building the cache key")
+	}
+
+	// Removing the files must not change the key, which proves they were never read.
+	for _, f := range []string{caFile, certFile, keyFile} {
+		if err := os.Remove(f); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	key2, canCache2, err := tlsConfigKey(newConfig())
+	if err != nil {
+		t.Fatalf("unexpected error after removing the credential files: %v", err)
+	}
+	if !canCache2 {
+		t.Fatal("expected a cacheable config")
+	}
+	if key != key2 {
+		t.Errorf("expected identical cache keys, got:\n\t%s\n\t%s", key, key2)
+	}
+}
+
+// TestTLSConfigForLoadsPathKeyedFiles asserts that TLSConfigFor still loads the
+// credential data that tlsConfigKey now skips, so a cache miss is unaffected.
+func TestTLSConfigForLoadsPathKeyedFiles(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientgofeaturegate.ClientsAllowCARotation, true)
+
+	dir := t.TempDir()
+	caFile := filepath.Join(dir, "ca.crt")
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	for f, data := range map[string]string{caFile: rootCACert, certFile: certData, keyFile: keyData} {
+		if err := os.WriteFile(f, []byte(data), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	config := &Config{TLS: TLSConfig{CAFile: caFile, CertFile: certFile, KeyFile: keyFile}}
+	if _, _, err := tlsConfigKey(config); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tlsConfig, err := TLSConfigFor(config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tlsConfig == nil {
+		t.Fatal("expected a tls.Config")
+	}
+	if tlsConfig.RootCAs == nil {
+		t.Error("expected RootCAs to be populated from the CA file")
+	}
+	if string(config.TLS.CAData) != rootCACert {
+		t.Error("expected TLSConfigFor to load CAData")
+	}
+	if string(config.TLS.CertData) != certData || string(config.TLS.KeyData) != keyData {
+		t.Error("expected TLSConfigFor to load CertData/KeyData")
+	}
+}
+
+// TestTLSConfigKeyStillReadsContentKeyedFiles asserts the complement: when the key is
+// built from content rather than path, tlsConfigKey must keep reading the files, so two
+// configs naming different files with identical content still share a transport.
+func TestTLSConfigKeyStillReadsContentKeyedFiles(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientgofeaturegate.ClientsAllowCARotation, false)
+
+	caFile1 := writeCAFile(t, []byte(testCACert1))
+	caFile2 := writeCAFile(t, []byte(testCACert1))
+
+	key1, canCache1, err := tlsConfigKey(&Config{TLS: TLSConfig{CAFile: caFile1}})
+	if err != nil || !canCache1 {
+		t.Fatalf("unexpected: err=%v, canCache=%v", err, canCache1)
+	}
+	key2, canCache2, err := tlsConfigKey(&Config{TLS: TLSConfig{CAFile: caFile2}})
+	if err != nil || !canCache2 {
+		t.Fatalf("unexpected: err=%v, canCache=%v", err, canCache2)
+	}
+	if key1 != key2 {
+		t.Errorf("expected identical cache keys for identical CA content, got:\n\t%s\n\t%s", key1, key2)
+	}
 }

--- a/staging/src/k8s.io/client-go/transport/transport.go
+++ b/staging/src/k8s.io/client-go/transport/transport.go
@@ -146,7 +146,9 @@ func TLSConfigFor(c *Config) (*tls.Config, error) {
 
 	var dynamicCertLoader func() (*tls.Certificate, error)
 	if c.TLS.ReloadTLSFiles {
-		dynamicCertLoader = cachingCertificateLoader(c.TLS.CertFile, c.TLS.KeyFile)
+		// loadTLSFiles above has already read the cert and the key, so seed the loader
+		// with what it read rather than making it open both files a second time.
+		dynamicCertLoader = cachingCertificateLoader(c.TLS.CertFile, c.TLS.KeyFile, c.TLS.CertData, c.TLS.KeyData)
 	}
 
 	if c.HasCertAuth() || c.HasCertCallback() {
@@ -436,10 +438,26 @@ func newCertificateCacheEntry(certFile, keyFile string) certificateCacheEntry {
 	return certificateCacheEntry{cert: &cert, err: err, birth: time.Now()}
 }
 
+// newCertificateCacheEntryFromData builds an entry from cert and key contents that have
+// already been read off disk, so that seeding the cache costs no further opens.
+func newCertificateCacheEntryFromData(certData, keyData []byte) certificateCacheEntry {
+	cert, err := tls.X509KeyPair(certData, keyData)
+	return certificateCacheEntry{cert: &cert, err: err, birth: time.Now()}
+}
+
 // cachingCertificateLoader ensures that we don't hammer the filesystem when opening many connections
-// the underlying cert files are read at most once every second
-func cachingCertificateLoader(certFile, keyFile string) func() (*tls.Certificate, error) {
-	current := newCertificateCacheEntry(certFile, keyFile)
+// the underlying cert files are read at most once every second.
+//
+// certData and keyData are the contents of certFile and keyFile as the caller has already
+// read them; they seed the cache so that the first entry costs no additional reads. Pass
+// nil for either to have the initial entry read from disk like every later one.
+func cachingCertificateLoader(certFile, keyFile string, certData, keyData []byte) func() (*tls.Certificate, error) {
+	var current certificateCacheEntry
+	if len(certData) > 0 && len(keyData) > 0 {
+		current = newCertificateCacheEntryFromData(certData, keyData)
+	} else {
+		current = newCertificateCacheEntry(certFile, keyFile)
+	}
 	var currentMtx sync.RWMutex
 
 	return func() (*tls.Certificate, error) {

--- a/staging/src/k8s.io/client-go/transport/transport.go
+++ b/staging/src/k8s.io/client-go/transport/transport.go
@@ -210,10 +210,10 @@ func TLSConfigFor(c *Config) (*tls.Config, error) {
 	return tlsConfig, nil
 }
 
-// loadTLSFiles copies the data from the CertFile, KeyFile, and CAFile fields into the CertData,
-// KeyData, and CAFile fields, or returns an error. If no error is returned, all three fields are
-// either populated or were empty to start.
-func loadTLSFiles(c *Config) error {
+// setReloadFiles decides whether the CA and the client cert/key are to be reloaded
+// from disk rather than pinned to the contents read once, based purely on which of the
+// file and data fields are populated. It reads no files.
+func setReloadFiles(c *Config) error {
 	// Check that we are purely loading CA from file
 	if clientgofeaturegate.FeatureGates().Enabled(clientgofeaturegate.ClientsAllowCARotation) {
 		if len(c.TLS.CAFile) > 0 && len(c.TLS.CAData) == 0 {
@@ -226,6 +226,17 @@ func loadTLSFiles(c *Config) error {
 	// Check that we are purely loading certs and keys from files
 	if len(c.TLS.CertFile) > 0 && len(c.TLS.CertData) == 0 && len(c.TLS.KeyFile) > 0 && len(c.TLS.KeyData) == 0 {
 		c.TLS.ReloadTLSFiles = true
+	}
+
+	return nil
+}
+
+// loadTLSFiles copies the data from the CertFile, KeyFile, and CAFile fields into the CertData,
+// KeyData, and CAFile fields, or returns an error. If no error is returned, all three fields are
+// either populated or were empty to start.
+func loadTLSFiles(c *Config) error {
+	if err := setReloadFiles(c); err != nil {
+		return err
 	}
 
 	var err error
@@ -241,6 +252,41 @@ func loadTLSFiles(c *Config) error {
 
 	c.TLS.KeyData, err = dataFromSliceOrFile(c.TLS.KeyData, c.TLS.KeyFile)
 	return err
+}
+
+// loadTLSFilesForKey sets the reload flags and loads only the credential data that
+// actually participates in the transport cache key. Credentials that the key
+// represents by path -- the CA when ReloadCAFiles is set, the client cert and key when
+// ReloadTLSFiles is set -- are deliberately not read here: their contents do not affect
+// the key, and TLSConfigFor loads them via loadTLSFiles on a cache miss. This keeps a
+// cache hit from re-reading every credential file, which is what a client that builds
+// one REST client per group-version ends up doing.
+func loadTLSFilesForKey(c *Config) error {
+	if err := setReloadFiles(c); err != nil {
+		return err
+	}
+
+	var err error
+	if !c.TLS.ReloadCAFiles {
+		c.TLS.CAData, err = dataFromSliceOrFile(c.TLS.CAData, c.TLS.CAFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	if !c.TLS.ReloadTLSFiles {
+		c.TLS.CertData, err = dataFromSliceOrFile(c.TLS.CertData, c.TLS.CertFile)
+		if err != nil {
+			return err
+		}
+
+		c.TLS.KeyData, err = dataFromSliceOrFile(c.TLS.KeyData, c.TLS.KeyFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // dataFromSliceOrFile returns data from the slice (if non-empty), or from the file,

--- a/staging/src/k8s.io/client-go/transport/transport_test.go
+++ b/staging/src/k8s.io/client-go/transport/transport_test.go
@@ -24,6 +24,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	clientgofeaturegate "k8s.io/client-go/features"
@@ -619,5 +622,78 @@ func TestRootCertPoolEmptyData(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestCachingCertificateLoaderSeededFromData asserts that the seeded loader returns the
+// same certificate as one that reads from disk, and that seeding costs no file access.
+func TestCachingCertificateLoaderSeededFromData(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	if err := os.WriteFile(certFile, []byte(certData), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte(keyData), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	fromDisk, err := cachingCertificateLoader(certFile, keyFile, nil, nil)()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Remove the files first: a seeded loader must not need them for its first entry.
+	for _, f := range []string{certFile, keyFile} {
+		if err := os.Remove(f); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	seeded, err := cachingCertificateLoader(certFile, keyFile, []byte(certData), []byte(keyData))()
+	if err != nil {
+		t.Fatalf("unexpected error from the seeded loader: %v", err)
+	}
+
+	if !reflect.DeepEqual(fromDisk.Certificate, seeded.Certificate) {
+		t.Error("expected the seeded loader to produce the same certificate as reading from disk")
+	}
+}
+
+// TestTLSConfigForDoesNotRereadCertAndKey asserts that TLSConfigFor produces a working
+// client certificate without opening the cert and key files a second time, by removing
+// them between loading the config and asking for the certificate.
+func TestTLSConfigForDoesNotRereadCertAndKey(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+	if err := os.WriteFile(certFile, []byte(certData), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte(keyData), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Config{TLS: TLSConfig{CertFile: certFile, KeyFile: keyFile}}
+	tlsConfig, err := TLSConfigFor(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !c.TLS.ReloadTLSFiles {
+		t.Fatal("expected ReloadTLSFiles to be set for file-based credentials")
+	}
+
+	for _, f := range []string{certFile, keyFile} {
+		if err := os.Remove(f); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cert, err := tlsConfig.GetClientCertificate(&tls.CertificateRequestInfo{})
+	if err != nil {
+		t.Fatalf("expected the seeded certificate, got: %v", err)
+	}
+	if len(cert.Certificate) == 0 {
+		t.Error("expected a non-empty client certificate")
 	}
 }


### PR DESCRIPTION
This PR reduces unnecessary duplicate reads of certificate, key, and CA files during kubectl operations such as command completion.

The issue is caused by multiple layers independently accessing the same credential files for configuration validation, TLS cache-key generation, and certificate loading.

This change reuses data that has already been resolved or loaded, reducing unnecessary filesystem I/O.

Changes
Avoid reading credential files again when generating the TLS transport cache key.
Memoize DirectClientConfig.ConfirmUsable() to avoid repeated credential and CA readability checks.
Seed the caching certificate loader with certificate and key data already available in the REST configuration.
Resolve and reuse the REST config when persistent configuration is enabled.
Testing

Built the affected packages successfully:

go build ./staging/src/k8s.io/client-go/... ./staging/src/k8s.io/cli-runtime/...

Ran the targeted tests:

go test ./staging/src/k8s.io/client-go/transport/... \
  ./staging/src/k8s.io/client-go/tools/clientcmd/... \
  ./staging/src/k8s.io/cli-runtime/pkg/genericclioptions/...

All targeted tests passed:

ok      k8s.io/client-go/transport
ok      k8s.io/client-go/transport/websocket
ok      k8s.io/client-go/tools/clientcmd
ok      k8s.io/client-go/tools/clientcmd/api
ok      k8s.io/client-go/tools/clientcmd/api/v1
ok      k8s.io/cli-runtime/pkg/genericclioptions
Issue

Fixes kubernetes/kubectl#1880

Motivation

When certificate and key files are configured by path, kubectl __complete -n '' can repeatedly open and read the same files.

This is particularly noticeable on systems with expensive filesystem access, such as environments with on-access antivirus scanning.

The changes in this PR eliminate redundant reads while preserving the existing client configuration and TLS behavior.

Checklist

Code builds successfully.

Targeted unit tests pass.

Changes are limited to the affected client configuration, transport, and CLI runtime paths.

The changes address the root cause described in kubernetes/kubectl#1880.