### PR TITLE
kubelet: Add tests for PID limit loadavg parsing

### DIFF
--- a/pkg/kubelet/stats/pidlimit/pidlimit.go
+++ b/pkg/kubelet/stats/pidlimit/pidlimit.go
@@ -17,6 +17,10 @@ limitations under the License.
 package pidlimit
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
+
 	"k8s.io/api/core/v1"
 )
 
@@ -24,3 +28,15 @@ const (
 	// PIDs is the (internal) name for this resource
 	PIDs v1.ResourceName = "pid"
 )
+
+func parseRunningTaskCount(loadavg string) (int64, error) {
+	fields := strings.Fields(loadavg)
+	if len(fields) < 5 {
+		return 0, fmt.Errorf("not enough fields in /proc/loadavg")
+	}
+	subfields := strings.Split(fields[3], "/")
+	if len(subfields) != 2 {
+		return 0, fmt.Errorf("error parsing fourth field of /proc/loadavg")
+	}
+	return strconv.ParseInt(subfields[1], 10, 64)
+}

--- a/pkg/kubelet/stats/pidlimit/pidlimit_linux.go
+++ b/pkg/kubelet/stats/pidlimit/pidlimit_linux.go
@@ -19,10 +19,8 @@ limitations under the License.
 package pidlimit
 
 import (
-	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -74,13 +72,5 @@ func runningTaskCount() (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	fields := strings.Fields(string(bytes))
-	if len(fields) < 5 {
-		return 0, fmt.Errorf("not enough fields in /proc/loadavg")
-	}
-	subfields := strings.Split(fields[3], "/")
-	if len(subfields) != 2 {
-		return 0, fmt.Errorf("error parsing fourth field of /proc/loadavg")
-	}
-	return strconv.ParseInt(subfields[1], 10, 64)
+	return parseRunningTaskCount(string(bytes))
 }

--- a/pkg/kubelet/stats/pidlimit/pidlimit_test.go
+++ b/pkg/kubelet/stats/pidlimit/pidlimit_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pidlimit
+
+import "testing"
+
+func TestParseRunningTaskCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		loadavg string
+		want    int64
+		wantErr bool
+	}{
+		{
+			name:    "valid",
+			loadavg: "1.36 3.49 4.53 2/3518 3715089\n",
+			want:    3518,
+		},
+		{
+			name:    "valid with extra whitespace",
+			loadavg: "  1.36\t3.49 4.53 2/42 3715089  \n",
+			want:    42,
+		},
+		{
+			name:    "not enough fields",
+			loadavg: "1.36 3.49 4.53 2/3518",
+			wantErr: true,
+		},
+		{
+			name:    "missing task separator",
+			loadavg: "1.36 3.49 4.53 3518 3715089",
+			wantErr: true,
+		},
+		{
+			name:    "too many task separators",
+			loadavg: "1.36 3.49 4.53 2/3518/7 3715089",
+			wantErr: true,
+		},
+		{
+			name:    "invalid task count",
+			loadavg: "1.36 3.49 4.53 2/not-a-number 3715089",
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseRunningTaskCount(test.loadavg)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("parseRunningTaskCount() error = %v, wantErr %t", err, test.wantErr)
+			}
+			if got != test.want {
+				t.Errorf("parseRunningTaskCount() = %d, want %d", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Extracts parsing of the running task count from `/proc/loadavg` and adds table-driven unit coverage for valid input, whitespace, malformed field counts, malformed separators, and non-numeric task counts.

#### Which issue(s) this PR is related to:

Related to #109717

#### Special notes for your reviewer:

This preserves the existing runtime behavior. The parser is moved into a helper so it can be tested on all supported development platforms.

Tests:

`go test -cover ./pkg/kubelet/stats/pidlimit`

The Linux test binary also cross-compiles successfully with `GOOS=linux go test -c ./pkg/kubelet/stats/pidlimit`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
