### PR TITLE
kubelet: update ASW when CSIDriver attachment requirement changes

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -192,6 +192,9 @@ type ActualStateOfWorld interface {
 
 	// UpdateReconstructedVolumeAttachability updates volume attachability from the API server.
 	UpdateReconstructedVolumeAttachability(volumeName v1.UniqueVolumeName, volumeAttachable bool)
+
+	// MarkVolumeAttachability updates attachability for an existing volume.
+	MarkVolumeAttachability(volumeName v1.UniqueVolumeName, attachable bool)
 }
 
 // MountedVolume represents a volume that has successfully been mounted to a pod.
@@ -605,6 +608,23 @@ func (asw *actualStateOfWorld) UpdateReconstructedVolumeAttachability(volumeName
 	if volumeObj.pluginIsAttachable != volumeAttachabilityUncertain {
 		// Reconciler must have updated volume state, i.e. when a pod uses the volume and
 		// succeeded mounting the volume. Such update has fixed the device path.
+		return
+	}
+
+	if attachable {
+		volumeObj.pluginIsAttachable = volumeAttachabilityTrue
+	} else {
+		volumeObj.pluginIsAttachable = volumeAttachabilityFalse
+	}
+	asw.attachedVolumes[volumeName] = volumeObj
+}
+
+func (asw *actualStateOfWorld) MarkVolumeAttachability(volumeName v1.UniqueVolumeName, attachable bool) {
+	asw.Lock()
+	defer asw.Unlock()
+
+	volumeObj, volumeExists := asw.attachedVolumes[volumeName]
+	if !volumeExists {
 		return
 	}
 

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
@@ -701,6 +701,49 @@ func Test_MarkVolumeAsDetached_Negative_PodInVolume(t *testing.T) {
 	verifyPodExistsInVolumeAsw(t, podName, generatedVolumeName, "fake/device/path" /* expectedDevicePath */, asw)
 }
 
+// Calls MarkVolumeAsAttached() once to add volume
+// Calls MarkVolumeAttachability() to set the volume as non-attachable
+// Verifies volume still exists in ASW via GetAttachedVolume()
+// Verifies PluginIsAttachable is updated to false
+func TestMarkVolumeAttachability(t *testing.T) {
+	volumePluginMgr, plugin := volumetesting.GetTestKubeletVolumePluginMgr(t)
+	asw := NewActualStateOfWorld("mynode", volumePluginMgr)
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: "pod1uid"},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{{
+				Name: "volume-name",
+				VolumeSource: v1.VolumeSource{
+					GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{
+						PDName: "fake-device1",
+					},
+				},
+			}},
+		},
+	}
+	volumeSpec := &volume.Spec{Volume: &pod.Spec.Volumes[0]}
+	volumeName, err := util.GetUniqueVolumeNameFromSpec(plugin, volumeSpec)
+	if err != nil {
+		t.Fatalf("GetUniqueVolumeNameFromSpec failed: %v", err)
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+	if err := asw.MarkVolumeAsAttached(logger, volumeName, volumeSpec, "", "fake/device/path"); err != nil {
+		t.Fatalf("MarkVolumeAsAttached failed: %v", err)
+	}
+
+	asw.MarkVolumeAttachability(volumeName, false)
+
+	attachedVolume, found := asw.GetAttachedVolume(volumeName)
+	if !found {
+		t.Fatalf("Expected volume %q to remain in ASW", volumeName)
+	}
+	if attachedVolume.PluginIsAttachable {
+		t.Fatalf("Expected volume %q to be non-attachable", volumeName)
+	}
+}
+
 func getTestPod(podName, podUID, outerVolumeName, pdName string) *v1.Pod {
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -212,6 +212,7 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods(logger klog.L
 					// It is not possible right now for a CSI plugin to be both attachable and non-deviceMountable
 					// So the uniqueVolumeName should remain the same after the attachability change
 					dswp.desiredStateOfWorld.MarkVolumeAttachability(volumeToMount.VolumeName, false)
+					dswp.actualStateOfWorld.MarkVolumeAttachability(volumeToMount.VolumeName, false)
 					logger.Info("Volume changes from attachable to non-attachable", "volumeName", volumeToMount.VolumeName)
 					continue
 				}

--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator_test.go
@@ -572,6 +572,25 @@ func TestFindAndRemoveNonattachableVolumes(t *testing.T) {
 
 	expectedVolumeName := v1.UniqueVolumeName(generatedVolumeName)
 
+	volumesToMount := fakesDSW.GetVolumesToMount()
+	if len(volumesToMount) != 1 {
+		t.Fatalf("Expected one volume in DSW, got %d", len(volumesToMount))
+	}
+
+	err := dswp.actualStateOfWorld.MarkVolumeAsAttached(
+		logger, expectedVolumeName, volumesToMount[0].VolumeSpec, "", "")
+	if err != nil {
+		t.Fatalf("Failed to add volume to ASW: %v", err)
+	}
+
+	attachedVolume, found := dswp.actualStateOfWorld.GetAttachedVolume(expectedVolumeName)
+	if !found {
+		t.Fatalf("Expected volume %q in ASW", expectedVolumeName)
+	}
+	if !attachedVolume.PluginIsAttachable {
+		t.Fatalf("Expected volume %q to be attachable in ASW", expectedVolumeName)
+	}
+
 	volumeExists := fakesDSW.VolumeExists(expectedVolumeName, "" /* SELinuxContext */)
 	if !volumeExists {
 		t.Fatalf(
@@ -589,7 +608,7 @@ func TestFindAndRemoveNonattachableVolumes(t *testing.T) {
 
 	dswp.findAndRemoveDeletedPods(logger)
 	// After the volume plugin changes to nonattachable, the corresponding volume attachable field should change.
-	volumesToMount := fakesDSW.GetVolumesToMount()
+	volumesToMount = fakesDSW.GetVolumesToMount()
 	for _, volume := range volumesToMount {
 		if volume.VolumeName == expectedVolumeName {
 			if volume.PluginIsAttachable {
@@ -598,6 +617,13 @@ func TestFindAndRemoveNonattachableVolumes(t *testing.T) {
 					expectedVolumeName)
 			}
 		}
+	}
+	attachedVolume, found = dswp.actualStateOfWorld.GetAttachedVolume(expectedVolumeName)
+	if !found {
+		t.Fatalf("Expected volume %q to remain in ASW", expectedVolumeName)
+	}
+	if attachedVolume.PluginIsAttachable {
+		t.Fatalf("Expected volume %q to become non-attachable in ASW", expectedVolumeName)
 	}
 }
 

--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -274,6 +274,21 @@ func WaitForVolumeAttachmentCreated(ctx context.Context, attachmentName string, 
 	return nil
 }
 
+// WaitForVolumeAttached waits for the VolumeAttachment with the passed in attachmentName to become attached.
+func WaitForVolumeAttached(ctx context.Context, attachmentName string, cs clientset.Interface, timeout time.Duration) error {
+	waitErr := wait.PollUntilContextTimeout(ctx, framework.Poll, timeout, true, func(ctx context.Context) (bool, error) {
+		va, err := cs.StorageV1().VolumeAttachments().Get(ctx, attachmentName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return va.Status.Attached, nil
+	})
+	if waitErr != nil {
+		return fmt.Errorf("error waiting for volume attachment %v to become attached: %w", attachmentName, waitErr)
+	}
+	return nil
+}
+
 // WaitForVolumeAttachmentTerminated waits for the VolumeAttachment with the passed in attachmentName to be terminated.
 func WaitForVolumeAttachmentTerminated(ctx context.Context, attachmentName string, cs clientset.Interface, timeout time.Duration) error {
 	waitErr := wait.PollUntilContextTimeout(ctx, 10*time.Second, timeout, true, func(ctx context.Context) (bool, error) {

--- a/test/e2e/storage/csimock/csi_attach_volume.go
+++ b/test/e2e/storage/csimock/csi_attach_volume.go
@@ -132,6 +132,14 @@ var _ = utils.SIGDescribe("CSI Mock volume attach", func() {
 			ginkgo.By("Checking if VolumeAttachment was created for the pod")
 			err = e2evolume.WaitForVolumeAttachmentCreated(ctx, attachmentName, m.cs, interval, csiVolumeAttachmentTimeout)
 			framework.ExpectNoError(err, "Failed to wait for VolumeAttachment %s to be created: %v", attachmentName, err)
+			ginkgo.By("Wait for VolumeAttachment to become attached")
+			err = e2evolume.WaitForVolumeAttached(ctx, attachmentName, m.cs, csiVolumeAttachmentTimeout)
+			framework.ExpectNoError(err, "VolumeAttachment %q did not become attached: %v", attachmentName, err)
+
+			ginkgo.By("Wait for pod volume mount to complete")
+			err = e2epod.WaitForPodNameRunningInNamespace(ctx, m.cs, pod.Name, pod.Namespace)
+			framework.ExpectNoError(err, "Pod did not start with AttachRequired=true: %v", err)
+
 			ginkgo.By("Delete CSIDriver object")
 			err = m.cs.StorageV1().CSIDrivers().Delete(ctx, driverName, metav1.DeleteOptions{})
 			framework.ExpectNoError(err, "Failed to delete CSIDriver: %v", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a CSIDriver changes `spec.attachRequired` from `true` to `false`, the kubelet updates the volume's desired-state attachability but leaves an already-created actual-state entry marked attachable.

The kubelet then continues reporting the volume in `Node.Status.VolumesInUse`. The attach/detach controller retains the old VolumeAttachment, even though controller attachment is no longer required.

Update the actual-state volume attachability together with desired state when the kubelet detects this transition. The mounted volume remains in actual state; only its controller-attachment requirement changes.

#### Which issue(s) this PR is related to:

Fixes #141521
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
The e2e test now waits for the original VolumeAttachment to attach and for the pod to become Running before changing `AttachRequired`. This removes the race and ensures the transition is tested after kubelet actual state has been initialized.

Manually verified with a kubelet built from this change.
