### PR TITLE
cri-streaming: define exit error contract

### DIFF
--- a/staging/src/k8s.io/cri-streaming/go.mod
+++ b/staging/src/k8s.io/cri-streaming/go.mod
@@ -15,7 +15,6 @@ require (
 	k8s.io/cri-api v0.0.0
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/streaming v0.0.0
-	k8s.io/utils v0.0.0-20260626114624-be93311217bd
 )
 
 require (
@@ -30,6 +29,7 @@ require (
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/protobuf v1.36.12 // indirect
+	k8s.io/utils v0.0.0-20260626114624-be93311217bd // indirect
 )
 
 replace (

--- a/staging/src/k8s.io/cri-streaming/pkg/streaming/remotecommand/exec.go
+++ b/staging/src/k8s.io/cri-streaming/pkg/streaming/remotecommand/exec.go
@@ -18,20 +18,59 @@ package remotecommand
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"time"
 
 	"k8s.io/streaming/pkg/runtime"
-	utilexec "k8s.io/utils/exec"
 )
+
+// ExitError is returned by [Executor.ExecInContainer] when the command
+// terminates with a non-zero exit code.
+//
+// ExitCode returns the command's exit code, or -1 if no exit code is
+// available, for example if the process was terminated by a signal.
+//
+// [*os/exec.ExitError] satisfies this interface.
+type ExitError interface {
+	error
+	ExitCode() int
+}
 
 // Executor knows how to execute a command in a container in a pod.
 type Executor interface {
 	// ExecInContainer executes a command in a container in the pod, copying data
 	// between in/out/err and the container's stdin/stdout/stderr.
+	//
+	// If the command terminates with a non-zero exit code,
+	// ExecInContainer should return an [ExitError].
 	ExecInContainer(ctx context.Context, name string, uid string, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan TerminalSize, timeout time.Duration) error
+}
+
+// legacyExitError matches [k8s.io/utils/exec.ExitError] for backward compatibility.
+type legacyExitError interface {
+	error
+	Exited() bool
+	ExitStatus() int
+}
+
+func exitCode(err error) (int, bool) {
+	if exitErr, ok := errors.AsType[ExitError](err); ok {
+		// ExitCode returns -1 if the process has not exited or was terminated
+		// by a signal, so only accept non-negative exit codes.
+		if code := exitErr.ExitCode(); code >= 0 {
+			return code, true
+		}
+	}
+
+	if exitErrLegacy, ok := errors.AsType[legacyExitError](err); ok && exitErrLegacy.Exited() {
+		return exitErrLegacy.ExitStatus(), true
+	}
+
+	return 0, false
 }
 
 // ServeExec handles requests to execute a command in a container. After
@@ -47,28 +86,27 @@ func ServeExec(w http.ResponseWriter, req *http.Request, executor Executor, podN
 
 	err := executor.ExecInContainer(req.Context(), podName, uid, container, cmd, ctx.stdinStream, ctx.stdoutStream, ctx.stderrStream, ctx.tty, ctx.resizeChan, 0)
 	if err != nil {
-		if exitErr, ok := err.(utilexec.ExitError); ok && exitErr.Exited() {
-			rc := exitErr.ExitStatus()
-			ctx.writeStatus(&streamStatusError{ErrStatus: streamStatus{
+		if rc, ok := exitCode(err); ok {
+			_ = ctx.writeStatus(&streamStatusError{ErrStatus: streamStatus{
 				Status: statusFailure,
 				Reason: NonZeroExitCodeReason,
 				Details: &streamStatusDetails{
 					Causes: []streamStatusCause{
 						{
 							Type:    ExitCodeCauseType,
-							Message: fmt.Sprintf("%d", rc),
+							Message: strconv.Itoa(rc),
 						},
 					},
 				},
-				Message: fmt.Sprintf("command terminated with non-zero exit code: %v", exitErr),
+				Message: fmt.Sprintf("command terminated with non-zero exit code: %v", err),
 			}})
 		} else {
 			err = fmt.Errorf("error executing command in container: %v", err)
 			runtime.HandleError(err)
-			ctx.writeStatus(newInternalError(err))
+			_ = ctx.writeStatus(newInternalError(err))
 		}
 	} else {
-		ctx.writeStatus(&streamStatusError{ErrStatus: streamStatus{
+		_ = ctx.writeStatus(&streamStatusError{ErrStatus: streamStatus{
 			Status: statusSuccess,
 		}})
 	}

--- a/staging/src/k8s.io/cri-streaming/pkg/streaming/remotecommand/exec_test.go
+++ b/staging/src/k8s.io/cri-streaming/pkg/streaming/remotecommand/exec_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Verify that [exec.ExitError] can be returned directly by Executor implementations.
+var _ ExitError = (*exec.ExitError)(nil)
+
+type testExitError struct {
+	error
+	code int
+}
+
+func (e testExitError) ExitCode() int { return e.code }
+
+type testLegacyExitError struct {
+	error
+	code   int
+	exited bool
+}
+
+func (e testLegacyExitError) Exited() bool    { return e.exited }
+func (e testLegacyExitError) ExitStatus() int { return e.code }
+
+type testBothExitError struct {
+	error
+	exitCode   int
+	exitStatus int
+	exited     bool
+}
+
+func (e testBothExitError) ExitCode() int   { return e.exitCode }
+func (e testBothExitError) Exited() bool    { return e.exited }
+func (e testBothExitError) ExitStatus() int { return e.exitStatus }
+
+func TestExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+		ok   bool
+	}{
+		{
+			name: "exit error",
+			err:  testExitError{code: 42},
+			want: 42,
+			ok:   true,
+		},
+		{
+			name: "wrapped exit error",
+			err:  fmt.Errorf("wrapped: %w", testExitError{code: 42}),
+			want: 42,
+			ok:   true,
+		},
+		{
+			name: "legacy exit error",
+			err:  testLegacyExitError{code: 42, exited: true},
+			want: 42,
+			ok:   true,
+		},
+		{
+			name: "legacy not exited",
+			err:  testLegacyExitError{code: 42},
+		},
+		{
+			// Use a zero-value ProcessState to avoid spawning a process just to obtain an
+			// *exec.ExitError. Its exit code is not meaningful for this test.
+			name: "stdlib ExitError",
+			err:  &exec.ExitError{ProcessState: &os.ProcessState{}},
+			want: 0,
+			ok:   true,
+		},
+		{
+			// Verify that wrapped stdlib ExitErrors are detected without executing a command.
+			name: "wrapped stdlib ExitError",
+			err:  fmt.Errorf("wrapped: %w", &exec.ExitError{ProcessState: &os.ProcessState{}}),
+			want: 0,
+			ok:   true,
+		},
+		{
+			name: "regular error",
+			err:  errors.New("boom"),
+		},
+		{
+			name: "nil",
+		},
+		{
+			name: "prefer ExitError",
+			err:  testBothExitError{exitCode: 42, exitStatus: 13},
+			want: 42,
+			ok:   true,
+		},
+		{
+			name: "negative exit code",
+			err:  testExitError{code: -1},
+		},
+		{
+			name: "negative exit code falls back to legacy",
+			err: testBothExitError{
+				exitCode:   -1,
+				exitStatus: 42,
+				exited:     true,
+			},
+			want: 42,
+			ok:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := exitCode(tc.err)
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, tc.ok, ok)
+		})
+	}
+}

--- a/staging/src/k8s.io/cri-streaming/pkg/streaming/server.go
+++ b/staging/src/k8s.io/cri-streaming/pkg/streaming/server.go
@@ -59,6 +59,11 @@ type Server interface {
 
 // Runtime is the interface to execute the commands and provide the streams.
 type Runtime interface {
+	// Exec executes a command in a container.
+	//
+	// If the command terminates with a non-zero exit code, Exec should return
+	// a [remotecommandserver.ExitError]. In particular, [*os/exec.ExitError]
+	// satisfies this contract.
 	Exec(ctx context.Context, containerID string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize) error
 	Attach(ctx context.Context, containerID string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize) error
 	PortForward(ctx context.Context, podSandboxID string, port int32, stream io.ReadWriteCloser) error
@@ -363,9 +368,11 @@ type criAdapter struct {
 	Runtime
 }
 
-var _ remotecommandserver.Executor = &criAdapter{}
-var _ remotecommandserver.Attacher = &criAdapter{}
-var _ portforward.PortForwarder = &criAdapter{}
+var (
+	_ remotecommandserver.Executor = &criAdapter{}
+	_ remotecommandserver.Attacher = &criAdapter{}
+	_ portforward.PortForwarder    = &criAdapter{}
+)
 
 func (a *criAdapter) ExecInContainer(ctx context.Context, podName string, podUID string, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommandserver.TerminalSize, timeout time.Duration) error {
 	return a.Runtime.Exec(ctx, container, cmd, in, out, err, tty, resize)


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/14003

ServeExec currently depends on k8s.io/utils/exec.ExitError to distinguish a command terminating with a non-zero exit status from an error executing the command. This makes the k8s.io/utils interface an implicit part of the Executor contract, even though it is defined outside cri-streaming.

Define the exit-error contract alongside Executor instead. Use ExitCode, matching os.ProcessState and allowing *os/exec.ExitError to satisfy the interface directly without requiring an adapter or a dependency on k8s.io/utils/exec. This allows users of cri-streaming to implement the contract using standard library errors while retaining compatibility with existing implementations.

Continue accepting the legacy Exited/ExitStatus interface for backwards compatibility, and use errors.AsType so wrapped exit errors are handled as well.

Document the same contract on Runtime.Exec, whose errors are forwarded unchanged by criAdapter to Executor.ExecInContainer.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
