### PR TITLE
cri-streaming: replace fake clock with synctest

### DIFF
--- a/staging/src/k8s.io/cri-streaming/pkg/streaming/request_cache.go
+++ b/staging/src/k8s.io/cri-streaming/pkg/streaming/request_cache.go
@@ -24,8 +24,6 @@ import (
 	"math"
 	"sync"
 	"time"
-
-	"k8s.io/utils/clock"
 )
 
 var (
@@ -41,9 +39,6 @@ var (
 // random token for their retrieval. The requestCache is used for building streaming URLs without
 // the need to encode every request parameter in the URL.
 type requestCache struct {
-	// clock is used to obtain the current time
-	clock clock.Clock
-
 	// tokens maps the generate token to the request for fast retrieval.
 	tokens map[string]*list.Element
 	// ll maintains an age-ordered request list for faster garbage collection of expired requests.
@@ -63,7 +58,6 @@ type cacheEntry struct {
 
 func newRequestCache() *requestCache {
 	return &requestCache{
-		clock:  clock.RealClock{},
 		ll:     list.New(),
 		tokens: make(map[string]*list.Element),
 	}
@@ -84,7 +78,11 @@ func (c *requestCache) Insert(req request) (token string, err error) {
 	if err != nil {
 		return "", err
 	}
-	ele := c.ll.PushFront(&cacheEntry{token, req, c.clock.Now().Add(cacheTTL)})
+	ele := c.ll.PushFront(&cacheEntry{
+		token:      token,
+		req:        req,
+		expireTime: time.Now().Add(cacheTTL),
+	})
 
 	c.tokens[token] = ele
 	return token, nil
@@ -102,7 +100,7 @@ func (c *requestCache) Consume(token string) (req request, found bool) {
 	delete(c.tokens, token)
 
 	entry := ele.Value.(*cacheEntry)
-	if c.clock.Now().After(entry.expireTime) {
+	if time.Now().After(entry.expireTime) {
 		// Entry already expired.
 		return nil, false
 	}
@@ -131,7 +129,7 @@ func (c *requestCache) uniqueToken() (string, error) {
 
 // Must be write-locked prior to calling.
 func (c *requestCache) gc() {
-	now := c.clock.Now()
+	now := time.Now()
 	for c.ll.Len() > 0 {
 		oldest := c.ll.Back()
 		entry := oldest.Value.(*cacheEntry)

--- a/staging/src/k8s.io/cri-streaming/pkg/streaming/request_cache_test.go
+++ b/staging/src/k8s.io/cri-streaming/pkg/streaming/request_cache_test.go
@@ -21,16 +21,15 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	testingclock "k8s.io/utils/clock/testing"
 )
 
 func TestInsert(t *testing.T) {
-	c, _ := newTestCache()
+	c := newRequestCache()
 
 	// Insert normal
 	oldestTok, err := c.Insert(nextRequest())
@@ -80,131 +79,128 @@ func TestInsert(t *testing.T) {
 }
 
 func TestConsume(t *testing.T) {
-	c, clock := newTestCache()
+	synctest.Test(t, func(t *testing.T) {
+		c := newRequestCache()
 
-	{ // Insert & consume.
-		req := nextRequest()
-		tok, err := c.Insert(req)
-		require.NoError(t, err)
-		assertCacheSize(t, c, 1)
+		{ // Insert & consume.
+			req := nextRequest()
+			tok, err := c.Insert(req)
+			require.NoError(t, err)
+			assertCacheSize(t, c, 1)
 
-		cachedReq, ok := c.Consume(tok)
-		assert.True(t, ok)
-		assert.Equal(t, req, cachedReq)
-		assertCacheSize(t, c, 0)
-	}
+			cachedReq, ok := c.Consume(tok)
+			assert.True(t, ok)
+			assert.Equal(t, req, cachedReq)
+			assertCacheSize(t, c, 0)
+		}
 
-	{ // Insert & consume out of order
-		req1 := nextRequest()
-		tok1, err := c.Insert(req1)
-		require.NoError(t, err)
-		assertCacheSize(t, c, 1)
+		{ // Insert & consume out of order
+			req1 := nextRequest()
+			tok1, err := c.Insert(req1)
+			require.NoError(t, err)
+			assertCacheSize(t, c, 1)
 
-		req2 := nextRequest()
-		tok2, err := c.Insert(req2)
-		require.NoError(t, err)
-		assertCacheSize(t, c, 2)
+			req2 := nextRequest()
+			tok2, err := c.Insert(req2)
+			require.NoError(t, err)
+			assertCacheSize(t, c, 2)
 
-		cachedReq2, ok := c.Consume(tok2)
-		assert.True(t, ok)
-		assert.Equal(t, req2, cachedReq2)
-		assertCacheSize(t, c, 1)
+			cachedReq2, ok := c.Consume(tok2)
+			assert.True(t, ok)
+			assert.Equal(t, req2, cachedReq2)
+			assertCacheSize(t, c, 1)
 
-		cachedReq1, ok := c.Consume(tok1)
-		assert.True(t, ok)
-		assert.Equal(t, req1, cachedReq1)
-		assertCacheSize(t, c, 0)
-	}
+			cachedReq1, ok := c.Consume(tok1)
+			assert.True(t, ok)
+			assert.Equal(t, req1, cachedReq1)
+			assertCacheSize(t, c, 0)
+		}
 
-	{ // Consume a second time
-		req := nextRequest()
-		tok, err := c.Insert(req)
-		require.NoError(t, err)
-		assertCacheSize(t, c, 1)
+		{ // Consume a second time
+			req := nextRequest()
+			tok, err := c.Insert(req)
+			require.NoError(t, err)
+			assertCacheSize(t, c, 1)
 
-		cachedReq, ok := c.Consume(tok)
-		assert.True(t, ok)
-		assert.Equal(t, req, cachedReq)
-		assertCacheSize(t, c, 0)
+			cachedReq, ok := c.Consume(tok)
+			assert.True(t, ok)
+			assert.Equal(t, req, cachedReq)
+			assertCacheSize(t, c, 0)
 
-		_, ok = c.Consume(tok)
-		assert.False(t, ok)
-		assertCacheSize(t, c, 0)
-	}
+			_, ok = c.Consume(tok)
+			assert.False(t, ok)
+			assertCacheSize(t, c, 0)
+		}
 
-	{ // Consume without insert
-		_, ok := c.Consume("fooBAR")
-		assert.False(t, ok)
-		assertCacheSize(t, c, 0)
-	}
+		{ // Consume without insert
+			_, ok := c.Consume("fooBAR")
+			assert.False(t, ok)
+			assertCacheSize(t, c, 0)
+		}
 
-	{ // Consume expired
-		tok, err := c.Insert(nextRequest())
-		require.NoError(t, err)
-		assertCacheSize(t, c, 1)
+		{ // Consume expired
+			tok, err := c.Insert(nextRequest())
+			require.NoError(t, err)
+			assertCacheSize(t, c, 1)
 
-		clock.Step(2 * cacheTTL)
+			time.Sleep(2 * cacheTTL)
 
-		_, ok := c.Consume(tok)
-		assert.False(t, ok)
-		assertCacheSize(t, c, 0)
-	}
+			_, ok := c.Consume(tok)
+			assert.False(t, ok)
+			assertCacheSize(t, c, 0)
+		}
+	})
 }
 
 func TestGC(t *testing.T) {
-	c, clock := newTestCache()
+	synctest.Test(t, func(t *testing.T) {
+		c := newRequestCache()
 
-	// When empty
-	c.gc()
-	assertCacheSize(t, c, 0)
+		// When empty
+		c.gc()
+		assertCacheSize(t, c, 0)
 
-	tok1, err := c.Insert(nextRequest())
-	require.NoError(t, err)
-	assertCacheSize(t, c, 1)
-	clock.Step(10 * time.Second)
-	tok2, err := c.Insert(nextRequest())
-	require.NoError(t, err)
-	assertCacheSize(t, c, 2)
-
-	// expired: tok1, tok2
-	// non-expired: tok3, tok4
-	clock.Step(2 * cacheTTL)
-	tok3, err := c.Insert(nextRequest())
-	require.NoError(t, err)
-	assertCacheSize(t, c, 1)
-	clock.Step(10 * time.Second)
-	tok4, err := c.Insert(nextRequest())
-	require.NoError(t, err)
-	assertCacheSize(t, c, 2)
-
-	_, ok := c.Consume(tok1)
-	assert.False(t, ok)
-	_, ok = c.Consume(tok2)
-	assert.False(t, ok)
-	_, ok = c.Consume(tok3)
-	assert.True(t, ok)
-	_, ok = c.Consume(tok4)
-	assert.True(t, ok)
-
-	// When full, nothing is expired.
-	for i := 0; i < maxInFlight; i++ {
-		_, err := c.Insert(nextRequest())
+		tok1, err := c.Insert(nextRequest())
 		require.NoError(t, err)
-	}
-	assertCacheSize(t, c, maxInFlight)
+		assertCacheSize(t, c, 1)
+		time.Sleep(10 * time.Second)
+		tok2, err := c.Insert(nextRequest())
+		require.NoError(t, err)
+		assertCacheSize(t, c, 2)
 
-	// When everything is expired
-	clock.Step(2 * cacheTTL)
-	_, err = c.Insert(nextRequest())
-	require.NoError(t, err)
-	assertCacheSize(t, c, 1)
-}
+		// expired: tok1, tok2
+		// non-expired: tok3, tok4
+		time.Sleep(2 * cacheTTL)
+		tok3, err := c.Insert(nextRequest())
+		require.NoError(t, err)
+		assertCacheSize(t, c, 1)
+		time.Sleep(10 * time.Second)
+		tok4, err := c.Insert(nextRequest())
+		require.NoError(t, err)
+		assertCacheSize(t, c, 2)
 
-func newTestCache() (*requestCache, *testingclock.FakeClock) {
-	c := newRequestCache()
-	fakeClock := testingclock.NewFakeClock(time.Now())
-	c.clock = fakeClock
-	return c, fakeClock
+		_, ok := c.Consume(tok1)
+		assert.False(t, ok)
+		_, ok = c.Consume(tok2)
+		assert.False(t, ok)
+		_, ok = c.Consume(tok3)
+		assert.True(t, ok)
+		_, ok = c.Consume(tok4)
+		assert.True(t, ok)
+
+		// When full, nothing is expired.
+		for range maxInFlight {
+			_, err := c.Insert(nextRequest())
+			require.NoError(t, err)
+		}
+		assertCacheSize(t, c, maxInFlight)
+
+		// When everything is expired
+		time.Sleep(2 * cacheTTL)
+		_, err = c.Insert(nextRequest())
+		require.NoError(t, err)
+		assertCacheSize(t, c, 1)
+	})
 }
 
 func assertCacheSize(t *testing.T, cache *requestCache, expectedSize int) {


### PR DESCRIPTION
- relates to https://github.com/containerd/containerd/pull/13997


The request cache uses k8s.io/utils/clock solely to allow tests to control the passage of time. Production code otherwise only needs the current time when creating and expiring cache entries.

Use time.Now directly in the request cache and run the time-dependent tests in a testing/synctest bubble. This allows the tests to advance fake time using time.Sleep without waiting in real time.

This removes the clock abstraction from the production code and drops the remaining use of k8s.io/utils/clock in the request cache.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
