### PR TITLE
admissionregistration: mark ParamRef.parameterNotFoundAction as required in OpenAPI schema

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -564,6 +564,9 @@
           "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset."
         }
       },
+      "required": [
+        "parameterNotFoundAction"
+      ],
       "type": "object",
       "x-kubernetes-map-type": "atomic"
     },
@@ -1885,6 +1888,9 @@
           "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset."
         }
       },
+      "required": [
+        "parameterNotFoundAction"
+      ],
       "type": "object",
       "x-kubernetes-map-type": "atomic"
     },

--- a/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
+++ b/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1_openapi.json
@@ -662,6 +662,9 @@
             "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset."
           }
         },
+        "required": [
+          "parameterNotFoundAction"
+        ],
         "type": "object",
         "x-kubernetes-map-type": "atomic"
       },

--- a/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1beta1_openapi.json
+++ b/api/openapi-spec/v3/apis__admissionregistration.k8s.io__v1beta1_openapi.json
@@ -447,6 +447,9 @@
             "description": "selector can be used to match multiple param objects based on their labels. Supply selector: {} to match all resources of the ParamKind.\n\nIf multiple params are found, they are all evaluated with the policy expressions and the results are ANDed together.\n\nOne of `name` or `selector` must be set, but `name` and `selector` are mutually exclusive properties. If one is set, the other must be unset."
           }
         },
+        "required": [
+          "parameterNotFoundAction"
+        ],
         "type": "object",
         "x-kubernetes-map-type": "atomic"
       },

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2636,6 +2636,7 @@ func schema_k8sio_api_admissionregistration_v1_ParamRef(ref common.ReferenceCall
 						},
 					},
 				},
+				Required: []string{"parameterNotFoundAction"},
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{
@@ -5959,6 +5960,7 @@ func schema_k8sio_api_admissionregistration_v1beta1_ParamRef(ref common.Referenc
 						},
 					},
 				},
+				Required: []string{"parameterNotFoundAction"},
 			},
 			VendorExtensible: spec.VendorExtensible{
 				Extensions: spec.Extensions{

--- a/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
@@ -776,6 +776,7 @@ message ParamRef {
   // Allowed values are `Allow` or `Deny`
   //
   // Required
+  // +required
   optional string parameterNotFoundAction = 4;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types.go
@@ -598,7 +598,7 @@ type ParamRef struct {
 	// Allowed values are `Allow` or `Deny`
 	//
 	// Required
-	ParameterNotFoundAction *ParameterNotFoundActionType `json:"parameterNotFoundAction,omitempty" protobuf:"bytes,4,rep,name=parameterNotFoundAction"`
+	ParameterNotFoundAction *ParameterNotFoundActionType `json:"parameterNotFoundAction" protobuf:"bytes,4,rep,name=parameterNotFoundAction"`
 }
 
 // MatchResources decides whether to run the admission control policy on an object based

--- a/staging/src/k8s.io/api/admissionregistration/v1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types.go
@@ -598,7 +598,8 @@ type ParamRef struct {
 	// Allowed values are `Allow` or `Deny`
 	//
 	// Required
-	ParameterNotFoundAction *ParameterNotFoundActionType `json:"parameterNotFoundAction" protobuf:"bytes,4,rep,name=parameterNotFoundAction"`
+	// +required
+	ParameterNotFoundAction *ParameterNotFoundActionType `json:"parameterNotFoundAction,omitempty" protobuf:"bytes,4,rep,name=parameterNotFoundAction"`
 }
 
 // MatchResources decides whether to run the admission control policy on an object based

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
@@ -781,6 +781,7 @@ message ParamRef {
   // Allowed values are `Allow` or `Deny`
   //
   // Required
+  // +required
   optional string parameterNotFoundAction = 4;
 }
 

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
@@ -551,7 +551,7 @@ type ParamRef struct {
 	// Allowed values are `Allow` or `Deny`
 	//
 	// Required
-	ParameterNotFoundAction *ParameterNotFoundActionType `json:"parameterNotFoundAction,omitempty" protobuf:"bytes,4,rep,name=parameterNotFoundAction"`
+	ParameterNotFoundAction *ParameterNotFoundActionType `json:"parameterNotFoundAction" protobuf:"bytes,4,rep,name=parameterNotFoundAction"`
 }
 
 // MatchResources decides whether to run the admission control policy on an object based

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
@@ -551,7 +551,8 @@ type ParamRef struct {
 	// Allowed values are `Allow` or `Deny`
 	//
 	// Required
-	ParameterNotFoundAction *ParameterNotFoundActionType `json:"parameterNotFoundAction" protobuf:"bytes,4,rep,name=parameterNotFoundAction"`
+	// +required
+	ParameterNotFoundAction *ParameterNotFoundActionType `json:"parameterNotFoundAction,omitempty" protobuf:"bytes,4,rep,name=parameterNotFoundAction"`
 }
 
 // MatchResources decides whether to run the admission control policy on an object based


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

`ParamRef.parameterNotFoundAction` (used by both `ValidatingAdmissionPolicyBinding` and `MutatingAdmissionPolicyBinding`) has always been rejected by apiserver validation when omitted (`spec.paramRef.parameterNotFoundAction: Required value`, see `validateParamRef`), but the field is declared as a pointer with `omitempty` and no `+required` marker, so the generated OpenAPI schema treats it as optional.

As a result, client-side schema validators (kubeconform, IDE integrations, CI manifest checks) cannot flag the missing field, and the error only surfaces at apply time. This was reported in #130822, which was closed by documenting the field rather than fixing the schema.

This PR adds the `// +required` marker in `v1` and `v1beta1`, which kube-openapi honors over `omitempty`, making the published OpenAPI schema declare the field as required, matching the server-side validation that has always existed.

Why this is safe for existing users:
- No serialization change: the Go type and JSON tags are untouched; only the generated schema gains a `required` entry.
- No acceptance-behavior change: objects omitting the field were already rejected by apiserver validation, so no stored object or working client lacks it.
- `v1alpha1` is intentionally untouched: it defaults the field to `Deny`, so it is genuinely optional there.

#### Which issue(s) this PR is related to:

Ref #130822

#### Special notes for your reviewer:

Mechanical change: `// +required` marker in the two versioned types files plus regenerated `zz_generated.openapi.go` and `api/openapi-spec`.

#### Does this PR introduce a user-facing change?

```release-note
The OpenAPI schema for ValidatingAdmissionPolicyBinding and MutatingAdmissionPolicyBinding now correctly marks `spec.paramRef.parameterNotFoundAction` as required, matching long-standing apiserver validation. Client-side validators (e.g. kubeconform) can now catch the missing field before apply.
```
