### PR TITLE
fix: reject Watch when deletion happened in the List→Watch window

### DIFF
--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -318,6 +318,12 @@ type tracker struct {
 	// also tracked by GroupVersionResource instead of GroupVersion, so the
 	// same is done here to match how List is implemented.
 	resourceVersions map[schema.GroupVersionResource]int64
+	// deletedResourceVersions tracks the highest resource version of any
+	// deleted object per GVR, so that a Watch requested with a resource
+	// version older than a deletion can detect that it can no longer serve
+	// the complete stream (the deletion event has already been lost) and
+	// reject, causing the reflector to relist and converge.
+	deletedResourceVersions map[schema.GroupVersionResource]int64
 }
 
 // versionedObject stores an object together with the resource version that was
@@ -341,7 +347,8 @@ func NewObjectTracker(scheme ObjectScheme, decoder runtime.Decoder) ObjectTracke
 		decoder:          decoder,
 		objects:          make(map[schema.GroupVersionResource]map[types.NamespacedName]versionedObject),
 		watchers:         make(map[schema.GroupVersionResource]map[string][]*watch.RaceFreeFakeWatcher),
-		resourceVersions: make(map[schema.GroupVersionResource]int64),
+		resourceVersions:         make(map[schema.GroupVersionResource]int64),
+		deletedResourceVersions: make(map[schema.GroupVersionResource]int64),
 	}
 }
 
@@ -440,6 +447,18 @@ func (t *tracker) Watch(gvr schema.GroupVersionResource, ns string, opts ...meta
 	// Deliver all objects that match the list options, for example
 	// between the initial List and the following Watch.
 	if addExisting {
+		// A deletion in that same window can no longer be delivered: the
+		// deleted object is gone from t.objects and no tombstone is kept.
+		// Reject the watch like the real API server would for an expired
+		// resource version, so that the reflector relists and converges on
+		// the tracker's contents instead of holding onto a phantom object
+		// forever.
+		if addFromRV > 0 {
+			if deletedRV, ok := t.deletedResourceVersions[gvr]; ok && addFromRV < deletedRV {
+				return nil, apierrors.NewResourceExpired(fmt.Sprintf("too old resource version: %d; a deletion happened at resource version %d, which can no longer be delivered", addFromRV, deletedRV))
+			}
+		}
+
 		objs := t.objects[gvr]
 		matchingObjs, err := filterByNamespace(objs, ns)
 		if err != nil {
@@ -727,6 +746,21 @@ func (t *tracker) Delete(gvr schema.GroupVersionResource, ns, name string, opts 
 	}
 
 	delete(objs, namespacedName)
+
+	// Bump the resource version for the deletion, like any other change.
+	// This ensures that a Watch started with a resource version from a
+	// List that still included the deleted object can detect that it can
+	// no longer serve the deletion event and reject the watch.
+	resourceVersion, ok := t.resourceVersions[gvr]
+	if !ok {
+		resourceVersion = 1
+	}
+	resourceVersion++
+	t.resourceVersions[gvr] = resourceVersion
+	if resourceVersion > t.deletedResourceVersions[gvr] {
+		t.deletedResourceVersions[gvr] = resourceVersion
+	}
+
 	for _, w := range t.getWatches(gvr, ns) {
 		w.Delete(obj.DeepCopyObject())
 	}

--- a/staging/src/k8s.io/client-go/testing/internal/delete_gap_test.go
+++ b/staging/src/k8s.io/client-go/testing/internal/delete_gap_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
+	_ "k8s.io/klog/v2/ktesting/init" // for -testing.v
+)
+
+// TestListAndWatchDelete mirrors TestListAndWatch for deletions: the object
+// is deleted after the cache sync and before the Watch call in the
+// reflector's ListAndWatch is allowed to continue.
+//
+// Unlike a lost create (covered by TestListAndWatch), a lost delete is
+// irrecoverable: the informer's store would keep a phantom object forever
+// because no relist happens and no DeleteFunc ever fires. The fake client
+// must converge on the tracker's contents regardless of the timing of
+// Watch, for deletions as it now does for creations — either the deletion
+// is delivered, or the watch is rejected so that the reflector relists.
+//
+// This runs in a synctest bubble, therefore time is virtual.
+func TestListAndWatchDelete(t *testing.T) { synctest.Test(t, testListAndWatchDelete) }
+func testListAndWatchDelete(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cm1",
+			Namespace: "default",
+		},
+	}
+	client := fake.NewClientset(cm)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	deleteDone := make(chan struct{})
+
+	f := informers.NewSharedInformerFactory(client, 0)
+	configMapInformer := f.InformerFor(&v1.ConfigMap{}, func(client kubernetes.Interface, defaultEventHandlerResyncPeriod time.Duration) cache.SharedIndexInformer {
+
+		return cache.NewSharedIndexInformer(cache.ToListWatcherWithWatchListSemantics(&cache.ListWatch{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				objs, err := client.CoreV1().ConfigMaps("").List(context.Background(), options)
+				logger.Info("Listed", "configMaps", objs, "err", err)
+				return objs, err
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				logger.Info("Delaying Watch...")
+				<-deleteDone
+				logger.Info("Continuing Watch...")
+				return client.CoreV1().ConfigMaps("").Watch(context.Background(), options)
+			},
+		}, client), &v1.ConfigMap{}, defaultEventHandlerResyncPeriod, nil)
+	})
+
+	var adds, updates, deletes int
+	if _, err := configMapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(_ any) { adds++ },
+		UpdateFunc: func(_, _ any) { updates++ },
+		DeleteFunc: func(_ any) { deletes++ },
+	}); err != nil {
+		t.Fatalf("Unexpected error adding event handler: %v", err)
+	}
+
+	store := configMapInformer.GetStore()
+	f.Start(stopCh)
+	f.WaitForCacheSync(stopCh)
+	logger.Info("Caches synced")
+
+	if err := client.CoreV1().ConfigMaps("default").Delete(ctx, "cm1", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Unexpected error deleting ConfigMap: %v", err)
+	}
+	logger.Info("Deleted the ConfigMap")
+	close(deleteDone)
+
+	// Wait for the watch setup, its rejection and the re-list triggered by
+	// the expired resource version, then event processing.
+	synctest.Wait()
+
+	if objs := store.List(); len(objs) != 0 {
+		t.Errorf("Unexpected item(s) in informer cache, want 0, got %d = %v", len(objs), objs)
+	}
+	if adds != 1 || updates != 0 || deletes != 1 {
+		t.Errorf("Expected the object to be added and deleted, got adds/updates/deletes %d/%d/%d", adds, updates, deletes)
+	}
+}


### PR DESCRIPTION
A deletion between the reflector's List and its Watch was lost: the tracker
deleted the object and sent the Delete event to watchers that existed at that
moment, but a watcher registered later (via Watch) never learned about it.
Unlike a lost create (fixed by #135959, #136143), a lost delete is
irrecoverable — the informer's store keeps a phantom object forever, no
DeleteFunc ever fires, and no relist happens, so every later read from that
informer's lister returns a phantom object for the lifetime of the test.

**Fix**: bump the resource version on deletion and track the highest deleted RV
per GVR. When Watch is called with a specific resource version (from a prior
List) and a deletion happened at a higher RV, return ResourceExpired so the
reflector relists and converges on the tracker's true contents.

This mirrors how the real API server handles an expired resource version:
the reflector's ListAndWatch retries with a fresh List → Watch cycle.

**Changes**:
1. `staging/src/k8s.io/client-go/testing/fixture.go`:
   - Add `deletedResourceVersions` map to the tracker struct
   - Bump `resourceVersions` on delete (like any other change)
   - Record the bumped RV in `deletedResourceVersions`
   - In `Watch`, reject with `ResourceExpired` when the requested RV is older than a deletion

2. `staging/src/k8s.io/client-go/testing/internal/delete_gap_test.go`:
   - New test `TestListAndWatchDelete` that reproduces the gap and verifies the fix

Fixes #141528

Signed-off-by: waterWang <672684719@qq.com>