### PR TITLE
storage/testing: reset injected decode failures

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -203,7 +203,8 @@ func TestDeleteWithConflictAndMissingExpectedTransformOrDecodeError(t *testing.T
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.AllowUnsafeMalformedObjectDeletion, true)
 
 	transformer := &testTransformer{Transformer: identity.NewEncryptCheckTransformer()}
-	ctx, s, _ := testSetup(t, withTransformer(transformer))
+	ctx, s, terminate := testSetup(t, withTransformer(transformer))
+	t.Cleanup(terminate)
 
 	storagetesting.RunTestDeleteWithConflictAndMissingExpectedTransformOrDecodeError(ctx, t, s, transformer.setFailing)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -2321,6 +2321,9 @@ func RunTestDeleteWithConflictAndMissingExpectedTransformOrDecodeError(ctx conte
 
 	// Initially, TransformFromStorage or Decode should fail.
 	setFailing(true)
+	// Watch goroutines can outlive the test; a store left failing panics them once
+	// decode errors become fatal again.
+	defer setFailing(false)
 
 	err := store.Delete(ctx, key, &example.Pod{}, nil, injectUpdate, nil,
 		storage.DeleteOptions{ExpectTransformOrDecodeError: true})
@@ -2340,6 +2343,10 @@ func RunTestDeleteExpectedTransformOrDecodeError(ctx context.Context, t testing.
 	}
 
 	setFailing(true)
+	// Watch goroutines can outlive the test; a store left failing panics them once
+	// decode errors become fatal again.
+	defer setFailing(false)
+
 	err := store.Delete(ctx, key, &example.Pod{}, nil, storage.ValidateAllObjectFunc, nil,
 		storage.DeleteOptions{ExpectTransformOrDecodeError: true})
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

The shared delete tests inject a transform/decode failure into the store and leave it set. `RunTestDeleteExpectedTransformOrDecodeError` never clears it on any path, and `RunTestDeleteWithConflictAndMissingExpectedTransformOrDecodeError` clears it only from inside the delete validator, so it survives whenever that validator is not reached. This adds a `defer setFailing(false)` to both, matching how the other fault-injecting helpers in `pkg/storage/testing` undo themselves (`defer revertTransformer()` in `watcher_tests.go` and elsewhere in `store_tests.go`).

That matters because nothing drains the etcd3 watch when a test tears down:

- `CacheDelegator.Stop` waits only for the consistency checker, `Cacher.Stop` only for the reflector driver.
- `watchChan.Stop` is a bare `cancel()`, and `EtcdTestServer.Terminate` is a no-op.
- `watchChan.run` does join its decode goroutines via `resultChanWG.Wait()`, but `run` is started bare and nobody waits for *it*.
- After the cancel, the `select` in `scheduleEventProcessing` can still take a buffered event and start a decode, and `decodeObj` takes no context.

So a decode can run against a still-failing store after the test that poisoned it has finished. In `pull-kubernetes-unit`, `hack/make-rules/test.sh` sets `KUBE_PANIC_WATCH_DECODE_ERROR=true`, and `TestDeleteWithConflictAndExpectedDecodeError` suppresses the resulting panic with `TestOnlySetFatalOnDecodeError(t, false)` — whose `t.Cleanup` restores the flag last. A late decode therefore panics the whole test binary.

`ConcurrentWatchObjectDecode` defaulting to true in 1.37 is what widened the window, by moving the decode onto a per-event goroutine.

#### Which issue(s) this PR is related to:

#141494

That issue names the wrong test. The panic happens on a background goroutine, so Go attributes it to whichever test is running at the time — the next one in file order, `TestDeleteWithSuggestionAndMissingExpectedTransformOrDecodeError`. The test that actually leaves the store failing is its predecessor, `TestDeleteWithConflictAndExpectedDecodeError`. Worth keeping the issue open until the panic stops showing up in CI.

#### Special notes for your reviewer:

The panic is rare — the issue reports a single occurrence, and I could not hit it in 40 runs of the two tests. Rather than guess, I forced the window with a temporary `time.Sleep(2 * time.Second)` at the top of the per-event goroutine in `scheduleEventProcessing`, then ran the two tests in file order.

Before, on master, it panics on the first iteration with the issue's stack (line numbers shifted by one by the probe):

```
--- PASS: TestDeleteWithConflictAndExpectedDecodeError (2.53s)
=== RUN   TestDeleteWithSuggestionAndMissingExpectedTransformOrDecodeError
panic: synthetic error

goroutine 341 [running]:
k8s.io/apiserver/pkg/storage/etcd3.decodeObj(...)
	staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:886 +0x1f5
k8s.io/apiserver/pkg/storage/etcd3.(*watchChan).prepareObjs(...)
	staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:832 +0xe5
k8s.io/apiserver/pkg/storage/etcd3.(*watchChan).transform(...)
	staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:663 +0x32
k8s.io/apiserver/pkg/storage/etcd3.(*concurrentOrderedEventProcessing).scheduleEventProcessing.func1(...)
	staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go:613 +0xa5
created by ...scheduleEventProcessing in goroutine 300
FAIL	k8s.io/apiserver/pkg/storage/cacher	4.559s
```

With this change and the same probe still in place, `-count=6` over both tests is 12/12 clean:

```
ok  	k8s.io/apiserver/pkg/storage/cacher	30.098s
```

The probe is not part of this PR — `watcher.go` is unchanged here. Without the fix the poisoned store is also visible as `watcher.go:665] failed to prepare current and previous objects: synthetic error` logged during the *following* test.

With the probe removed:

- `./pkg/storage/cacher/... ./pkg/storage/etcd3/... -count=1` — all packages ok
- the four fault-injection tests across both packages, `-count=10` — ok

No `_test.go` delta because the changed file is itself the shared test suite. A committed regression test would need a sleep injected into the production watch path to be deterministic, which does not seem worth carrying.

Three related things I noticed and deliberately kept out of this PR, happy to follow up on any of them:

- `cacher_test.go:206` discards its teardown (`ctx, s, _ := testSetup(...)`), leaking a cacher and an etcd server.
- `etcd3/store_test.go:220` injects a decode fault without `TestOnlySetFatalOnDecodeError`, unlike its cacher twin.
- The comment in `decodeObj` still refers to a `defer` that was removed in b3f9272d57a.

I used Claude Code while investigating the root cause and preparing this change. I have reviewed it and can explain every line.

```release-note
NONE
```
