### PR TITLE
kubelet: indicate failure threshold status in probe container events

### DIFF
--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -95,8 +95,9 @@ const (
 
 // Probe event reason list
 const (
-	ContainerUnhealthy    = "Unhealthy"
-	ContainerProbeWarning = "ProbeWarning"
+	ContainerUnhealthy           = "Unhealthy"
+	ContainerProbeWarning        = "ProbeWarning"
+	ContainerProbeFailureIgnored = "ProbeFailureIgnored"
 )
 
 // Pod worker event reason list

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -81,7 +81,7 @@ func (pb *prober) recordContainerEvent(ctx context.Context, pod *v1.Pod, contain
 }
 
 // probe probes the container.
-func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, error) {
+func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, status v1.PodStatus, container v1.Container, containerID kubecontainer.ContainerID) (results.Result, string, error) {
 	var probeSpec *v1.Probe
 	switch probeType {
 	case readiness:
@@ -91,13 +91,13 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 	case startup:
 		probeSpec = container.StartupProbe
 	default:
-		return results.Failure, fmt.Errorf("unknown probe type: %q", probeType)
+		return results.Failure, "", fmt.Errorf("unknown probe type: %q", probeType)
 	}
 
 	logger := klog.FromContext(ctx)
 	if probeSpec == nil {
 		logger.Info("Probe is nil", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		return results.Success, nil
+		return results.Success, "", nil
 	}
 
 	result, output, err := pb.runProbeWithRetries(ctx, probeType, probeSpec, pod, status, container, containerID, maxProbeRetries)
@@ -105,32 +105,30 @@ func (pb *prober) probe(ctx context.Context, probeType probeType, pod *v1.Pod, s
 	if err != nil {
 		// Handle probe error
 		logger.V(1).Info("Probe errored", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "err", err)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored and resulted in %s state: %s", probeType, result, err)
-		return results.Failure, err
+		return results.Failure, output, err
 	}
 
 	switch result {
 	case probe.Success:
 		logger.V(3).Info("Probe succeeded", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name)
-		return results.Success, nil
+		return results.Success, output, nil
 
 	case probe.Warning:
 		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerProbeWarning, "%s probe warning: %s", probeType, output)
 		logger.V(3).Info("Probe succeeded with a warning", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "output", output)
-		return results.Success, nil
+		return results.Success, output, nil
 
 	case probe.Failure:
 		logger.V(1).Info("Probe failed", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result, "output", output)
-		pb.recordContainerEvent(ctx, pod, &container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
-		return results.Failure, nil
+		return results.Failure, output, nil
 
 	case probe.Unknown:
 		logger.V(1).Info("Probe unknown without error", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result)
-		return results.Failure, nil
+		return results.Failure, output, nil
 
 	default:
 		logger.V(1).Info("Unsupported probe result", "probeType", probeType, "pod", klog.KObj(pod), "podUID", pod.UID, "containerName", container.Name, "probeResult", result)
-		return results.Failure, nil
+		return results.Failure, output, nil
 	}
 }
 

--- a/pkg/kubelet/prober/prober_test.go
+++ b/pkg/kubelet/prober/prober_test.go
@@ -255,7 +255,7 @@ func TestProbe(t *testing.T) {
 				prober.exec = fakeExecProber{test.execResult, nil}
 			}
 
-			result, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+			result, _, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 
 			if test.expectError {
 				require.Error(t, err, "[%s] Expected probe error but no error was returned.", testID)
@@ -268,7 +268,7 @@ func TestProbe(t *testing.T) {
 			if len(test.expectCommand) > 0 {
 				prober.exec = execprobe.New()
 				prober.runner = &containertest.FakeContainerCommandRunner{}
-				_, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
+				_, _, err := prober.probe(ctx, pType, &v1.Pod{}, v1.PodStatus{}, testContainer, containerID)
 				require.NoError(t, err, "[%s] Didn't expect probe error ", testID)
 
 				if !reflect.DeepEqual(test.expectCommand, prober.runner.(*containertest.FakeContainerCommandRunner).Cmd) {

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -29,6 +29,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/prober/results"
 )
 
@@ -346,8 +347,9 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	}
 
 	// Note, exec probe does NOT have access to pod environment variables or downward API
-	result, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
+	result, output, err := w.probeManager.prober.probe(ctx, w.probeType, w.pod, status, w.container, w.containerID)
 	if err != nil {
+		w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored and resulted in %s state: %s", w.probeType, result, err)
 		// Prober error, throw away the result.
 		return true
 	}
@@ -368,6 +370,13 @@ func (w *worker) doProbe(ctx context.Context) (keepGoing bool) {
 	} else {
 		w.lastResult = result
 		w.resultRun = 1
+	}
+
+	// Record events for probe failures, but with different messages depending on whether the failure threshold has been reached.
+	if (result == results.Failure && w.resultRun < int(w.spec.FailureThreshold)) {
+		w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container, v1.EventTypeWarning, events.ContainerProbeFailureIgnored, "%s probe failed - ignored (%d/%d): %s", w.probeType, w.resultRun, w.spec.FailureThreshold, output)
+	} else if (result == results.Failure) {
+		w.probeManager.prober.recordContainerEvent(ctx, w.pod, &w.container, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed - threshold reached (%d/%d): %s", w.probeType, w.resultRun, w.spec.FailureThreshold, output)
 	}
 
 	if (result == results.Failure && w.resultRun < int(w.spec.FailureThreshold)) ||

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -26,7 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
@@ -1109,5 +1111,87 @@ func TestChangeContainerStatusOnKubeletRestart(t *testing.T) {
 				t.Errorf("Expected result %v, but got: %v", tc.expectedResult, result)
 			}
 		})
+	}
+}
+
+func TestProbeEventsWithThreshold(t *testing.T) {
+	_ = v1.AddToScheme(legacyscheme.Scheme)
+	logger, ctx := ktesting.NewTestContext(t)
+	m := newTestManager()
+	fakeRecorder := record.NewFakeRecorder(10)
+	m.prober.recorder = fakeRecorder
+
+	w := newTestWorker(m, liveness, v1.Probe{SuccessThreshold: 1, FailureThreshold: 3})
+	m.statusManager.SetPodStatus(logger, w.pod, getTestRunningStatus())
+
+	// 1. Test Probe Success: no event recorded
+	m.prober.exec = fakeExecProber{probe.Success, nil}
+	w.doProbe(ctx)
+	if len(fakeRecorder.Events) != 0 {
+		t.Errorf("Expected 0 events on probe success, got %d", len(fakeRecorder.Events))
+	}
+
+	// 2. Test Probe Warning: event recorded with ContainerProbeWarning
+	m.prober.exec = fakeExecProber{probe.Warning, nil}
+	w.doProbe(ctx)
+	select {
+	case event := <-fakeRecorder.Events:
+		expected := "Warning ProbeWarning Liveness probe warning: "
+		if event != expected {
+			t.Errorf("Expected warning event %q, got %q", expected, event)
+		}
+	default:
+		t.Errorf("Expected event for probe warning")
+	}
+
+	// 3. Test Probe Failure - 1st failure (ignored, 1/3)
+	m.prober.exec = fakeExecProber{probe.Failure, nil}
+	w.doProbe(ctx)
+	select {
+	case event := <-fakeRecorder.Events:
+		expected := "Warning ProbeFailureIgnored Liveness probe failed - ignored (1/3): "
+		if event != expected {
+			t.Errorf("Expected failure event %q, got %q", expected, event)
+		}
+	default:
+		t.Errorf("Expected event for 1st probe failure")
+	}
+
+	// 4. Test Probe Failure - 2nd failure (ignored, 2/3)
+	w.doProbe(ctx)
+	select {
+	case event := <-fakeRecorder.Events:
+		expected := "Warning ProbeFailureIgnored Liveness probe failed - ignored (2/3): "
+		if event != expected {
+			t.Errorf("Expected failure event %q, got %q", expected, event)
+		}
+	default:
+		t.Errorf("Expected event for 2nd probe failure")
+	}
+
+	// 5. Test Probe Failure - 3rd failure (threshold reached, 3/3)
+	w.doProbe(ctx)
+	select {
+	case event := <-fakeRecorder.Events:
+		expected := "Warning Unhealthy Liveness probe failed - threshold reached (3/3): "
+		if event != expected {
+			t.Errorf("Expected failure event %q, got %q", expected, event)
+		}
+	default:
+		t.Errorf("Expected event for 3rd probe failure")
+	}
+
+	// 6. Test Probe Error: event recorded for error state
+	w.onHold = false
+	m.prober.exec = fakeExecProber{probe.Unknown, fmt.Errorf("exec error")}
+	w.doProbe(ctx)
+	select {
+	case event := <-fakeRecorder.Events:
+		expected := "Warning Unhealthy Liveness probe errored and resulted in Failure state: exec error"
+		if event != expected {
+			t.Errorf("Expected error event %q, got %q", expected, event)
+		}
+	default:
+		t.Errorf("Expected event for probe error")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
When a probe fails in Kubernetes, a container event was previously emitted without indicating whether the `FailureThreshold` had been reached. Users and monitoring systems had no direct way of knowing whether a probe failure caused a control plane state change (such as container restart or readiness false) or was silently ignored due to being below the threshold.
This PR addresses this by:
1. Exposing the probe output string from `probe()` in `prober.go` to `worker.go`.
2. Emitting a dedicated `ProbeFailureIgnored` warning event (`events.ContainerProbeFailureIgnored`) when a probe failure occurs below `FailureThreshold`.
3. Emitting the existing `Unhealthy` warning event (`events.ContainerUnhealthy`) when `FailureThreshold` is reached.

#### Which issue(s) this PR is related to:
Fixes #115823

#### Special notes for your reviewer:
- Probe failure events are emitted from `worker.go` where `resultRun` and `FailureThreshold` tracking state reside.
- A new event reason `ContainerProbeFailureIgnored` (`ProbeFailureIgnored`) is introduced for below-threshold failures. This preserves existing alerting behavior for monitoring systems filtering on `reason: Unhealthy`.
- Unit tests (`TestProbeEventsWithThreshold`) have been added in `worker_test.go` covering success, warning, ignored failure, threshold-reached failure, and probe error cases.

#### Does this PR introduce a user-facing change?
```release-note
Probe failure events now indicate failure threshold status and count. Probe failures below FailureThreshold emit event reason `ProbeFailureIgnored` (e.g., `Liveness probe failed - ignored (1/3)`), while failures reaching FailureThreshold emit event reason `Unhealthy` (e.g., `Liveness probe failed - threshold reached (3/3)`).
```

Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```docs
```