### PR TITLE
discovery: graduate declarative validation to stable

### DIFF
--- a/pkg/apis/discovery/v1/zz_generated.validations.go
+++ b/pkg/apis/discovery/v1/zz_generated.validations.go
@@ -68,7 +68,7 @@ func Validate_AddressType(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *discoveryv1.AddressType) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil).MarkBeta(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -94,11 +94,11 @@ func Validate_Endpoint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -167,11 +167,11 @@ func Validate_EndpointSlice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -202,7 +202,7 @@ func Validate_EndpointSlice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/discovery/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/discovery/v1beta1/zz_generated.validations.go
@@ -68,7 +68,7 @@ func Validate_AddressType(
 	ctx context.Context, op operation.Operation, fldPath *field.Path,
 	obj, oldObj *discoveryv1beta1.AddressType) (errs field.ErrorList) {
 
-	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil).MarkBeta(); len(e) != 0 {
+	if e := validate.Enum(ctx, op, fldPath, obj, oldObj, symbolsForAddressType, nil); len(e) != 0 {
 		errs = append(errs, e...)
 	}
 
@@ -94,11 +94,11 @@ func Validate_Endpoint(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.MaxItems(ctx, op, fldPath, obj, oldObj, 100).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -166,11 +166,11 @@ func Validate_EndpointSlice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
-			if e := validate.Immutable(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -201,7 +201,7 @@ func Validate_EndpointSlice(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -33,11 +33,6 @@ import (
 )
 
 var (
-	supportedAddressTypes = sets.New(
-		discovery.AddressTypeIPv4,
-		discovery.AddressTypeIPv6,
-		discovery.AddressTypeFQDN,
-	)
 	supportedPortProtocols = sets.New(
 		corev1.ProtocolTCP,
 		corev1.ProtocolUDP,
@@ -59,7 +54,6 @@ var ValidateEndpointSliceName = apimachineryvalidation.NameIsDNSSubdomain
 // ValidateEndpointSlice validates an EndpointSlice.
 func ValidateEndpointSlice(endpointSlice, oldEndpointSlice *discovery.EndpointSlice) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMeta(&endpointSlice.ObjectMeta, true, ValidateEndpointSliceName, field.NewPath("metadata"))
-	allErrs = append(allErrs, validateAddressType(endpointSlice.AddressType)...)
 	allErrs = append(allErrs, validatePorts(endpointSlice.Ports, field.NewPath("ports"))...)
 
 	endpointsErrs := validateEndpoints(endpointSlice.Endpoints, endpointSlice.AddressType, field.NewPath("endpoints"))
@@ -84,10 +78,7 @@ func ValidateEndpointSliceCreate(endpointSlice *discovery.EndpointSlice) field.E
 
 // ValidateEndpointSliceUpdate validates an EndpointSlice when it is updated.
 func ValidateEndpointSliceUpdate(newEndpointSlice, oldEndpointSlice *discovery.EndpointSlice) field.ErrorList {
-	allErrs := ValidateEndpointSlice(newEndpointSlice, oldEndpointSlice)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newEndpointSlice.AddressType, oldEndpointSlice.AddressType, field.NewPath("addressType")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
-
-	return allErrs
+	return ValidateEndpointSlice(newEndpointSlice, oldEndpointSlice)
 }
 
 func validateEndpoints(endpoints []discovery.Endpoint, addrType discovery.AddressType, fldPath *field.Path) field.ErrorList {
@@ -102,11 +93,6 @@ func validateEndpoints(endpoints []discovery.Endpoint, addrType discovery.Addres
 		idxPath := fldPath.Index(i)
 		addressPath := idxPath.Child("addresses")
 
-		if len(endpoint.Addresses) == 0 {
-			allErrs = append(allErrs, field.Required(addressPath, "must contain at least 1 address").MarkCoveredByDeclarative())
-		} else if len(endpoint.Addresses) > maxAddresses {
-			allErrs = append(allErrs, field.TooMany(addressPath, len(endpoint.Addresses), maxAddresses).WithOrigin("maxItems").MarkCoveredByDeclarative())
-		}
 		for i, address := range endpoint.Addresses {
 			// This validates known address types, unknown types fall through
 			// and do not get validated.
@@ -197,18 +183,6 @@ func validatePorts(endpointPorts []discovery.EndpointPort, fldPath *field.Path) 
 		if endpointPort.AppProtocol != nil {
 			allErrs = append(allErrs, apivalidation.ValidateQualifiedName(*endpointPort.AppProtocol, idxPath.Child("appProtocol"))...)
 		}
-	}
-
-	return allErrs
-}
-
-func validateAddressType(addressType discovery.AddressType) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if addressType == "" {
-		allErrs = append(allErrs, field.Required(field.NewPath("addressType"), "").MarkCoveredByDeclarative())
-	} else if !supportedAddressTypes.Has(addressType) {
-		allErrs = append(allErrs, field.NotSupported(field.NewPath("addressType"), addressType, sets.List(supportedAddressTypes)).MarkCoveredByDeclarative())
 	}
 
 	return allErrs

--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -39,7 +39,6 @@ var (
 		corev1.ProtocolSCTP,
 	)
 	maxTopologyLabels = 16
-	maxAddresses      = 100
 	maxPorts          = 20000
 	maxEndpoints      = 1000
 	maxZoneHints      = 8

--- a/pkg/apis/discovery/validation/validation_test.go
+++ b/pkg/apis/discovery/validation/validation_test.go
@@ -336,34 +336,6 @@ func TestValidateEndpointSlice(t *testing.T) {
 				Endpoints:   generateEndpoints(maxEndpoints + 1),
 			},
 		},
-		"no-endpoint-addresses": {
-			expectedErrors: 1,
-			endpointSlice: &discovery.EndpointSlice{
-				ObjectMeta:  standardMeta,
-				AddressType: discovery.AddressTypeIPv4,
-				Ports: []discovery.EndpointPort{{
-					Name:     ptr.To("http"),
-					Protocol: ptr.To(corev1.ProtocolTCP),
-				}},
-				Endpoints: []discovery.Endpoint{{
-					Addresses: generateIPAddresses(0),
-				}},
-			},
-		},
-		"too-many-addresses": {
-			expectedErrors: 1,
-			endpointSlice: &discovery.EndpointSlice{
-				ObjectMeta:  standardMeta,
-				AddressType: discovery.AddressTypeIPv4,
-				Ports: []discovery.EndpointPort{{
-					Name:     ptr.To("http"),
-					Protocol: ptr.To(corev1.ProtocolTCP),
-				}},
-				Endpoints: []discovery.Endpoint{{
-					Addresses: generateIPAddresses(maxAddresses + 1),
-				}},
-			},
-		},
 		"bad-topology-key": {
 			expectedErrors: 1,
 			endpointSlice: &discovery.EndpointSlice{
@@ -652,7 +624,7 @@ func TestValidateEndpointSlice(t *testing.T) {
 			},
 		},
 		"empty-everything": {
-			expectedErrors: 3,
+			expectedErrors: 2,
 			endpointSlice:  &discovery.EndpointSlice{},
 		},
 		"zone-key-topology": {
@@ -773,34 +745,6 @@ func TestValidateEndpointSliceCreate(t *testing.T) {
 				}},
 			},
 		},
-		"deprecated-address-type": {
-			expectedErrors: 1,
-			endpointSlice: &discovery.EndpointSlice{
-				ObjectMeta:  standardMeta,
-				AddressType: discovery.AddressType("IP"),
-				Ports: []discovery.EndpointPort{{
-					Name:     ptr.To("http"),
-					Protocol: ptr.To(corev1.ProtocolTCP),
-				}},
-				Endpoints: []discovery.Endpoint{{
-					Addresses: generateIPAddresses(1),
-				}},
-			},
-		},
-		"bad-address-type": {
-			expectedErrors: 1,
-			endpointSlice: &discovery.EndpointSlice{
-				ObjectMeta:  standardMeta,
-				AddressType: discovery.AddressType("other"),
-				Ports: []discovery.EndpointPort{{
-					Name:     ptr.To("http"),
-					Protocol: ptr.To(corev1.ProtocolTCP),
-				}},
-				Endpoints: []discovery.Endpoint{{
-					Addresses: generateIPAddresses(1),
-				}},
-			},
-		},
 	}
 
 	for name, testCase := range testCases {
@@ -872,28 +816,6 @@ func TestValidateEndpointSliceUpdate(t *testing.T) {
 			expectedErrors: 1,
 		},
 
-		"deprecated address type": {
-			expectedErrors: 1,
-			oldEndpointSlice: &discovery.EndpointSlice{
-				ObjectMeta:  standardMeta,
-				AddressType: discovery.AddressType("IP"),
-			},
-			newEndpointSlice: &discovery.EndpointSlice{
-				ObjectMeta:  standardMeta,
-				AddressType: discovery.AddressType("IP"),
-			},
-		},
-		"valid and identical slices with different address types": {
-			oldEndpointSlice: &discovery.EndpointSlice{
-				ObjectMeta:  standardMeta,
-				AddressType: discovery.AddressType("other"),
-			},
-			newEndpointSlice: &discovery.EndpointSlice{
-				ObjectMeta:  standardMeta,
-				AddressType: discovery.AddressTypeIPv4,
-			},
-			expectedErrors: 1,
-		},
 		"invalid slices with valid address types": {
 			oldEndpointSlice: &discovery.EndpointSlice{
 				ObjectMeta:  standardMeta,

--- a/pkg/apis/discovery/validation/validation_test.go
+++ b/pkg/apis/discovery/validation/validation_test.go
@@ -192,20 +192,6 @@ func TestValidateEndpointSlice(t *testing.T) {
 				Ports:       generatePorts(maxPorts),
 			},
 		},
-		"max-addresses": {
-			expectedErrors: 0,
-			endpointSlice: &discovery.EndpointSlice{
-				ObjectMeta:  standardMeta,
-				AddressType: discovery.AddressTypeIPv4,
-				Ports: []discovery.EndpointPort{{
-					Name:     ptr.To("http"),
-					Protocol: ptr.To(corev1.ProtocolTCP),
-				}},
-				Endpoints: []discovery.Endpoint{{
-					Addresses: generateIPAddresses(maxAddresses),
-				}},
-			},
-		},
 		"max-topology-keys": {
 			expectedErrors: 0,
 			endpointSlice: &discovery.EndpointSlice{

--- a/staging/src/k8s.io/api/discovery/v1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1/generated.proto
@@ -39,8 +39,8 @@ message Endpoint {
   // additional addresses beyond the first, and kube-proxy does not look at them.
   // +listType=set
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
-  // +k8s:beta(since: "1.37")=+k8s:maxItems=100
+  // +k8s:required
+  // +k8s:maxItems=100
   repeated string addresses = 1;
 
   // conditions contains information about the current status of the endpoint.
@@ -185,15 +185,15 @@ message EndpointSlice {
   // slices of addressType "IPv4" and "IPv6". No semantics are defined for
   // the "FQDN" type.
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
-  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:required
+  // +k8s:immutable
   optional string addressType = 4;
 
   // endpoints is a list of unique endpoints in this slice. Each slice may
   // include a maximum of 1000 endpoints.
   // +optional
   // +listType=atomic
-  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:optional
   repeated Endpoint endpoints = 2;
 
   // ports specifies the list of network ports exposed by each endpoint in

--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -49,15 +49,15 @@ type EndpointSlice struct {
 	// slices of addressType "IPv4" and "IPv6". No semantics are defined for
 	// the "FQDN" type.
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
-	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:required
+	// +k8s:immutable
 	AddressType AddressType `json:"addressType" protobuf:"bytes,4,rep,name=addressType"`
 
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
 	// +optional
 	// +listType=atomic
-	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:optional
 	Endpoints []Endpoint `json:"endpoints" protobuf:"bytes,2,rep,name=endpoints"`
 
 	// ports specifies the list of network ports exposed by each endpoint in
@@ -73,7 +73,7 @@ type EndpointSlice struct {
 
 // AddressType represents the type of address referred to by an endpoint.
 // +enum
-// +k8s:beta(since: "1.37")=+k8s:enum
+// +k8s:enum
 type AddressType string
 
 const (
@@ -97,8 +97,8 @@ type Endpoint struct {
 	// additional addresses beyond the first, and kube-proxy does not look at them.
 	// +listType=set
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
-	// +k8s:beta(since: "1.37")=+k8s:maxItems=100
+	// +k8s:required
+	// +k8s:maxItems=100
 	Addresses []string `json:"addresses" protobuf:"bytes,1,rep,name=addresses"`
 
 	// conditions contains information about the current status of the endpoint.

--- a/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1beta1/generated.proto
@@ -39,8 +39,8 @@ message Endpoint {
   // use the first element. Refer to: https://issue.k8s.io/106267
   // +listType=set
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
-  // +k8s:beta(since: "1.37")=+k8s:maxItems=100
+  // +k8s:required
+  // +k8s:maxItems=100
   repeated string addresses = 1;
 
   // conditions contains information about the current status of the endpoint.
@@ -171,14 +171,14 @@ message EndpointSlice {
   // * IPv6: Represents an IPv6 Address.
   // * FQDN: Represents a Fully Qualified Domain Name.
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
-  // +k8s:beta(since: "1.37")=+k8s:immutable
+  // +k8s:required
+  // +k8s:immutable
   optional string addressType = 4;
 
   // endpoints is a list of unique endpoints in this slice. Each slice may
   // include a maximum of 1000 endpoints.
   // +listType=atomic
-  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:optional
   repeated Endpoint endpoints = 2;
 
   // ports specifies the list of network ports exposed by each endpoint in

--- a/staging/src/k8s.io/api/discovery/v1beta1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1beta1/types.go
@@ -46,14 +46,14 @@ type EndpointSlice struct {
 	// * IPv6: Represents an IPv6 Address.
 	// * FQDN: Represents a Fully Qualified Domain Name.
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
-	// +k8s:beta(since: "1.37")=+k8s:immutable
+	// +k8s:required
+	// +k8s:immutable
 	AddressType AddressType `json:"addressType" protobuf:"bytes,4,rep,name=addressType"`
 
 	// endpoints is a list of unique endpoints in this slice. Each slice may
 	// include a maximum of 1000 endpoints.
 	// +listType=atomic
-	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:optional
 	Endpoints []Endpoint `json:"endpoints" protobuf:"bytes,2,rep,name=endpoints"`
 
 	// ports specifies the list of network ports exposed by each endpoint in
@@ -68,7 +68,7 @@ type EndpointSlice struct {
 
 // AddressType represents the type of address referred to by an endpoint.
 // +enum
-// +k8s:beta(since: "1.37")=+k8s:enum
+// +k8s:enum
 type AddressType string
 
 const (
@@ -92,8 +92,8 @@ type Endpoint struct {
 	// use the first element. Refer to: https://issue.k8s.io/106267
 	// +listType=set
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
-	// +k8s:beta(since: "1.37")=+k8s:maxItems=100
+	// +k8s:required
+	// +k8s:maxItems=100
 	Addresses []string `json:"addresses" protobuf:"bytes,1,rep,name=addresses"`
 
 	// conditions contains information about the current status of the endpoint.

--- a/test/declarative_validation/discovery/endpointslice/declarative_validation_test.go
+++ b/test/declarative_validation/discovery/endpointslice/declarative_validation_test.go
@@ -62,25 +62,25 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				obj.Endpoints[0].Addresses = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), "").MarkBeta(),
+				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), ""),
 			},
 		},
 		"invalid too many endpoint addresses": {
 			input: mkValidEndpointSlice(tweakAddresses(101)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems").MarkBeta(),
+				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems"),
 			},
 		},
 		"invalid missing addressType": {
 			input: mkValidEndpointSlice(tweakAddressType("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("addressType"), "").MarkBeta(),
+				field.Required(field.NewPath("addressType"), ""),
 			},
 		},
 		"invalid addressType not supported": {
 			input: mkValidEndpointSlice(tweakAddressType("invalid")),
 			expectedErrs: field.ErrorList{
-				field.NotSupported(field.NewPath("addressType"), discovery.AddressType("invalid"), []string{string(discovery.AddressTypeIPv4), string(discovery.AddressTypeIPv6), string(discovery.AddressTypeFQDN)}).MarkBeta(),
+				field.NotSupported(field.NewPath("addressType"), discovery.AddressType("invalid"), []string{string(discovery.AddressTypeIPv4), string(discovery.AddressTypeIPv6), string(discovery.AddressTypeFQDN)}),
 			},
 		},
 	}
@@ -130,21 +130,21 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 				obj.Endpoints[0].Addresses = nil
 			}),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), "").MarkBeta(),
+				field.Required(field.NewPath("endpoints").Index(0).Child("addresses"), ""),
 			},
 		},
 		"invalid update too many addresses": {
 			oldObj:    mkValidEndpointSlice(),
 			updateObj: mkValidEndpointSlice(tweakAddresses(101)),
 			expectedErrs: field.ErrorList{
-				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems").MarkBeta(),
+				field.TooMany(field.NewPath("endpoints").Index(0).Child("addresses"), 101, 100).WithOrigin("maxItems"),
 			},
 		},
 		"invalid update addressType immutable": {
 			oldObj:    mkValidEndpointSlice(),
 			updateObj: mkValidEndpointSlice(tweakAddressType(discovery.AddressTypeIPv6)),
 			expectedErrs: field.ErrorList{
-				field.Invalid(field.NewPath("addressType"), discovery.AddressTypeIPv6, "field is immutable").WithOrigin("immutable").MarkBeta(),
+				field.Invalid(field.NewPath("addressType"), discovery.AddressTypeIPv6, "field is immutable").WithOrigin("immutable"),
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Graduates the `discovery` declarative validation rules from beta to stable and deletes the handwritten validation they replace, per KEP-5073.

The rules have been at beta since 1.37 (`+k8s:beta(since: "1.37")`), which is the whole of their soak — every beta rule in the tree carries that same `since`, so this wave only became eligible when 1.37 shipped.

Twelve markers across `discovery/v1` and `discovery/v1beta1` lose their wrapper, and the five handwritten checks they cover come out of `pkg/apis/discovery/validation/validation.go`:

| rule | handwritten check removed |
|---|---|
| `AddressType` `+k8s:required` | `validateAddressType` — `field.Required` |
| `type AddressType` `+k8s:enum` | `validateAddressType` — `field.NotSupported` |
| `AddressType` `+k8s:immutable` | `ValidateEndpointSliceUpdate` — `ValidateImmutableField` |
| `Endpoint.Addresses` `+k8s:required` | `validateEndpoints` — `field.Required` |
| `Endpoint.Addresses` `+k8s:maxItems=100` | `validateEndpoints` — `field.TooMany` |

`EndpointSlice.Endpoints` `+k8s:optional` is the sixth marker per version; `OptionalSlice` is non-erroring so it has no handwritten counterpart. `validateAddressType` and `supportedAddressTypes` are deleted outright — both become dead.

#### Which issue(s) this PR is related to:

Part of #141532

#### Special notes for your reviewer:

**Dropping the wrapper and deleting the handwritten check are one atomic change.** `FilterCoveredHandwrittenErrors` (`apimachinery/pkg/api/validate/errors.go:50-68`) only suppresses a handwritten error when a matching *beta* declarative error is enforced:

```go
for _, dErr := range enforcedDeclarativeErrs {
    if dErr.IsBeta() && matcher.Matches(fe, dErr) {
```

A standard rule does not suppress its handwritten twin. I checked this rather than assuming it — restoring just the `Addresses` required check on top of the graduated rule gives:

```
E0823 00:43:29.699622 validate.go:188] "Unexpected difference between hand written validation and
declarative validation error results, unmatched error(s) found
{Type=\"Required value\", Field=\"endpoints[0].addresses\", Origin=\"\"}."

--- FAIL: TestDeclarativeValidate/v1/invalid_missing_endpoint_addresses/with_declarative_validation_(Beta_enabled)
    validation.go:396: unmatched error:
    testutil.go:134: Wanted count 0, got 1 for metric apiserver_validation_declarative_validation_mismatch_total
```

That matches the contract stated at `apiserver/pkg/registry/rest/validate.go:382`: "Standard (no prefix): Enforced. HV counterparts are expected to be deleted from source."

**Both versions move in the same commit.** `v1beta1` is not served (`removed=1.25`, no `v1beta1Storage`) but is still registered in the scheme, and `VerifyVersionedValidationEquivalence` compares error counts across every registered version — graduating only `v1` desyncs them.

**Verification.** `go test ./test/declarative_validation/discovery/...` is the load-bearing one: 774 subtests, 0 failures, covering all three gate configurations and both versions. The Beta-disabled configuration is the one that matters here, since it is what proves the graduated rules are enforced without the gate and without the handwritten checks:

```
--- PASS: TestDeclarativeValidate/v1/invalid_missing_addressType/with_declarative_validation_(Beta_disabled)
--- PASS: TestDeclarativeValidate/v1/invalid_addressType_not_supported/with_declarative_validation_(Beta_disabled)
--- PASS: TestDeclarativeValidate/v1/invalid_missing_endpoint_addresses/with_declarative_validation_(Beta_disabled)
--- PASS: TestDeclarativeValidate/v1/invalid_too_many_endpoint_addresses/with_declarative_validation_(Beta_disabled)
--- PASS: TestDeclarativeValidate/v1beta1/... (same four)
```

Each of those asserts `apiserver_validation_declarative_validation_mismatch_total == 0`, which is the KEP's second criterion.

Also run: `hack/verify-codegen.sh` (clean — this is what exercises `validationStability`, validation-gen's own lint rule (`code-generator/cmd/validation-gen/lint_rules.go:81`, wired in at `targets.go:348`), which derives the required stability level from the API version in the package path and so is what confirms the unwrapped tags are legal in a `v1` package), `hack/verify-golangci-lint.sh ./pkg/apis/discovery/... ./staging/src/k8s.io/api/discovery/...` (0 issues), and `go test ./pkg/apis/discovery/...`.

**On the test changes.** `validation_test.go` asserts by error *count*, so the six cases that existed only to exercise the deleted handwritten checks now expect zero errors; I removed them rather than leaving `expectedErrors: 0` cases with misleading names. `empty-everything` goes 3→2, keeping its ObjectMeta coverage. `max-addresses` and `maxAddresses` come out too: that case calls `ValidateEndpointSlice` directly, so with the handwritten `TooMany` check deleted it no longer pins the 100 boundary. `test/declarative_validation/discovery/endpointslice` covers it. The `.MarkBeta()` calls in the declarative fixtures have to go because the third sub-test matches on stability level (`ByValidationStabilityLevel()`).

**On scope.** The alpha→beta wave was tree-wide (#140166, 126 files). I've done one group here because beta→stable also deletes handwritten validation, and a 592-rule version of that seems unreviewable; KEP-5073 says the scope is per-rule and allows incremental cleanup. If you'd rather have this bigger, or start with a different group, say so — the patch shape is the same everywhere and I'm happy to keep going through the rest.

I used Claude Code while investigating the lifecycle mechanics and preparing this change. I have reviewed it and can explain every line.

```release-note
NONE
```


