### PR TITLE
kubectl explain: do not write output when rendering fails

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/explain.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v2
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -88,12 +89,15 @@ func printModelDescriptionWithGenerator(
 		return fmt.Errorf("failed to parse openapi schema for %s: %w", resourcePath, err)
 	}
 
-	err = generator.Render(outputFormat, parsedV3Schema, gvr, fieldsPath, recursive, maxDepth, w)
-
-	explainErr := explainError("")
-	if errors.As(err, &explainErr) {
+	var buf bytes.Buffer
+	err = generator.Render(outputFormat, parsedV3Schema, gvr, fieldsPath, recursive, maxDepth, &buf)
+	if explainErr, ok := errors.AsType[explainError](err); ok {
 		return explainErr
 	}
+	if err != nil {
+		return err
+	}
 
+	_, err = io.Copy(w, &buf)
 	return err
 }

--- a/staging/src/k8s.io/kubectl/pkg/explain/v2/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/v2/explain_test.go
@@ -79,6 +79,21 @@ func TestExplainErrors(t *testing.T) {
 	require.ErrorContains(t, err, "unrecognized format: unknown-format")
 }
 
+// TestExplainInvalidFieldPathWritesNoOutput verifies that when explain fails on
+// an invalid field path, nothing (not even the KIND/VERSION header) is written
+// to the output writer. A failing command must not emit partial output to
+// stdout, which would otherwise pollute pipes and redirects.
+func TestExplainInvalidFieldPathWritesNoOutput(t *testing.T) {
+	var buf bytes.Buffer
+
+	podsGVR := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}
+	client := openapitest.NewEmbeddedFileClient()
+
+	err := PrintModelDescription([]string{"spec", "nonexistentfield"}, &buf, client, podsGVR, false, 0, "plaintext")
+	require.ErrorContains(t, err, `field "nonexistentfield" does not exist`)
+	require.Empty(t, buf.String(), "no output should be written to w when explain fails")
+}
+
 // Shows that the correct GVR is fetched from the open api client when
 // given to explain
 func TestExplainOpenAPIClient(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`kubectl explain` writes its template straight to the output writer, so the `KIND`/`VERSION` header goes out before the field path is walked. With an invalid field path (for example `kubectl explain pods.spec.nonexistentfield`), the command prints the header to stdout and then exits non-zero with the field error on stderr:

```console
$ kubectl explain pods.spec.nonexistentfield 2>/dev/null; echo "exit=$?"
KIND:       Pod
VERSION:    v1

exit=1
```

A command that fails shouldn't write to stdout. Scripts treat stdout as the result, so the leftover header ends up in redirects, pipes, and `$(...)` as if the command had worked (a redirect saves it to a file, a pipeline masks the failure exit code, `$(...)` captures non-empty output on a failed lookup).

This renders the schema into a buffer first and only copies it to the output writer once the render succeeds, so a failed `explain` writes nothing to stdout. The error and exit code are unchanged, and normal `explain` output is the same as before.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes kubernetes/kubectl#1872

#### Special notes for your reviewer:
- Reproduces on master (`v1.38.0-alpha.0`) as well as released `v1.36.1`.
- Added `TestExplainInvalidFieldPathWritesNoOutput` in `pkg/explain/v2/explain_test.go`. It fails without the fix (the writer still contains the `KIND`/`VERSION` header) and passes with it.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl explain no longer prints the KIND/VERSION header to stdout when the command fails because of an invalid field path; the error is still written to stderr and the exit code is unchanged.
```

