### PR TITLE
Verify each resource creates a single storage instance in integration tests

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -45,6 +45,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	genericfeatures "k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/server/flagz"
 	serveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -97,6 +98,10 @@ type TestServerInstanceOptions struct {
 	EnableCertAuth bool
 	// Wrap the storage version interface of the created server's generic server.
 	StorageVersionWrapFunc func(storageversion.Manager) storageversion.Manager
+	// Wrap the RESTOptionsGetter for the kube-apiserver's own resources, before
+	// any storage is constructed. Does not cover apiextensions (CRDs) or the
+	// aggregator, which build their storage from their own getters.
+	RESTOptionsGetterWrapFunc func(generic.RESTOptionsGetter) generic.RESTOptionsGetter
 	// CA file used for requestheader authn during communication between:
 	// 1. kube-apiserver and peer when the local apiserver is not able to serve the request due
 	// to version skew
@@ -436,6 +441,10 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	config, err := app.NewConfig(completedOptions)
 	if err != nil {
 		return result, err
+	}
+	if instanceOptions.RESTOptionsGetterWrapFunc != nil {
+		config.KubeAPIs.ControlPlane.Generic.RESTOptionsGetter =
+			instanceOptions.RESTOptionsGetterWrapFunc(config.KubeAPIs.ControlPlane.Generic.RESTOptionsGetter)
 	}
 	completed, err := config.Complete()
 	if err != nil {

--- a/test/integration/controlplane/storage_instance_test.go
+++ b/test/integration/controlplane/storage_instance_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"maps"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
+	"k8s.io/apiserver/pkg/storage/storagebackend/factory"
+	"k8s.io/client-go/tools/cache"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+type countingRESTOptionsGetter struct {
+	delegate generic.RESTOptionsGetter
+
+	lock   sync.Mutex
+	counts map[schema.GroupResource]int
+}
+
+func (c *countingRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource, example runtime.Object) (generic.RESTOptions, error) {
+	opts, err := c.delegate.GetRESTOptions(resource, example)
+	if err != nil {
+		return opts, err
+	}
+
+	decorator := opts.Decorator
+	opts.Decorator = func(
+		config *storagebackend.ConfigForResource,
+		resourcePrefix string,
+		cacheKeyFunc func(obj runtime.Object) (string, error),
+		newFunc func() runtime.Object,
+		newListFunc func() runtime.Object,
+		getAttrsFunc storage.AttrFunc,
+		trigger storage.IndexerFuncs,
+		indexers *cache.Indexers) (storage.Interface, factory.DestroyFunc, error) {
+		c.lock.Lock()
+		c.counts[resource]++
+		c.lock.Unlock()
+		return decorator(config, resourcePrefix, cacheKeyFunc, newFunc, newListFunc, getAttrsFunc, trigger, indexers)
+	}
+	return opts, nil
+}
+
+func (c *countingRESTOptionsGetter) snapshot() map[schema.GroupResource]int {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return maps.Clone(c.counts)
+}
+
+// knownDuplicateStorageInstances allowlists resources that are known to build
+// more than one storage instance today, so this test does not block unrelated
+// changes. Entries should only ever be removed, never added.
+// Kube-apiserver built-in resource only.
+// See https://github.com/kubernetes/kubernetes/issues/133877.
+var knownDuplicateStorageInstances = map[schema.GroupResource]int{
+	{Group: "", Resource: "events"}:          2,
+	{Group: "", Resource: "serviceaccounts"}: 2,
+}
+
+func TestSingleStorageInstancePerResource(t *testing.T) {
+	counter := &countingRESTOptionsGetter{counts: map[schema.GroupResource]int{}}
+
+	instanceOptions := kubeapiservertesting.NewDefaultTestServerOptions()
+	instanceOptions.RESTOptionsGetterWrapFunc = func(delegate generic.RESTOptionsGetter) generic.RESTOptionsGetter {
+		counter.delegate = delegate
+		return counter
+	}
+
+	server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	counts := counter.snapshot()
+	if len(counts) == 0 {
+		t.Fatalf("no store was observed; the counting RESTOptionsGetter is no longer wired into storage construction")
+	}
+	resources := slices.SortedFunc(maps.Keys(counts), func(a, b schema.GroupResource) int {
+		return strings.Compare(a.String(), b.String())
+	})
+
+	for _, gr := range resources {
+		want := 1
+		known, isKnown := knownDuplicateStorageInstances[gr]
+		if isKnown {
+			want = known
+		}
+		got := counts[gr]
+		switch {
+		case got == want:
+		case isKnown:
+			t.Errorf("%s: built %d storage instances, expected the known-broken count of %d; update knownDuplicateStorageInstances", gr, got, want)
+		default:
+			t.Errorf("%s: built %d storage instances, expected exactly 1; a resource must not initialize its storage more than once (see https://github.com/kubernetes/kubernetes/issues/133877)", gr, got)
+		}
+	}
+
+	allowlisted := slices.SortedFunc(maps.Keys(knownDuplicateStorageInstances), func(a, b schema.GroupResource) int {
+		return strings.Compare(a.String(), b.String())
+	})
+	for _, gr := range allowlisted {
+		if _, ok := counts[gr]; !ok {
+			t.Errorf("%s: listed in knownDuplicateStorageInstances but no storage was built; remove the stale entry", gr)
+		}
+	}
+
+}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
#### What this PR does / why we need it:
Add an intergration test that counts how many each built-in kube-apiserver resource constructs a storage instcance, by wraping the RESTOptionGetter used during storage construction. This catches regressions where a resource's REST storage is initilalized more than once. Two resources (events,serviceaccount) are currently known to build storage twice and are allowlisted; the allowlist should only shirnk over time, never grow.

Also adds a RESTOptionWrapFunc hook to the kube-apiserver test harness(cmd/kube-apiserver/app/testing/testserver.go) so tests can observe/wrap storage construction. This does not cover apiextentions(CRDs) or the aggregator, which build storage from their own getters.
#### Which issue(s) this PR is related to:
#133877

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```