### PR TITLE
metrics: graduate volume_operation_total_errors to BETA

### DIFF
--- a/hack/tools/instrumentation/documentation/documentation-list.yaml
+++ b/hack/tools/instrumentation/documentation/documentation-list.yaml
@@ -7312,16 +7312,6 @@
   componentEndpoints:
   - component: kubelet
     endpoint: /metrics
-- name: volume_operation_errors_total
-  help: Total volume operation errors
-  type: Counter
-  stabilityLevel: ALPHA
-  labels:
-  - operation_name
-  - plugin_name
-  componentEndpoints:
-  - component: kube-controller-manager
-    endpoint: /metrics
 - name: volume_operation_total_errors
   help: Total volume operation errors
   type: Counter
@@ -8264,6 +8254,16 @@
   - 600
   componentEndpoints:
   - component: kubelet
+    endpoint: /metrics
+- name: volume_operation_errors_total
+  help: Total volume operation errors
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - operation_name
+  - plugin_name
+  componentEndpoints:
+  - component: kube-controller-manager
     endpoint: /metrics
 - name: volume_operation_total_seconds
   help: Storage operation end to end duration in seconds

--- a/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
+++ b/hack/tools/instrumentation/testdata/stable-metrics-list.yaml
@@ -669,6 +669,13 @@
   - 120
   - 300
   - 600
+- name: volume_operation_errors_total
+  help: Total volume operation errors
+  type: Counter
+  stabilityLevel: BETA
+  labels:
+  - operation_name
+  - plugin_name
 - name: volume_operation_total_seconds
   help: Storage operation end to end duration in seconds
   type: Histogram

--- a/pkg/controller/volume/persistentvolume/metrics/metrics.go
+++ b/pkg/controller/volume/persistentvolume/metrics/metrics.go
@@ -147,7 +147,7 @@ var (
 		&metrics.CounterOpts{
 			Name:           "volume_operation_errors_total",
 			Help:           "Total volume operation errors",
-			StabilityLevel: metrics.ALPHA,
+			StabilityLevel: metrics.BETA,
 		},
 		[]string{"plugin_name", "operation_name"})
 

--- a/pkg/controller/volume/persistentvolume/metrics/metrics.go
+++ b/pkg/controller/volume/persistentvolume/metrics/metrics.go
@@ -286,7 +286,7 @@ func RecordRetroactiveStorageClassMetric(success bool) {
 }
 
 // RecordVolumeOperationErrorMetric records error count into metric
-// volume_operation_total_errors for provisioning/deletion operations
+// volume_operation_errors_total for provisioning/deletion operations
 func RecordVolumeOperationErrorMetric(pluginName, opName string) {
 	if pluginName == "" {
 		pluginName = "N/A"

--- a/pkg/controller/volume/persistentvolume/metrics/metrics_test.go
+++ b/pkg/controller/volume/persistentvolume/metrics/metrics_test.go
@@ -32,7 +32,7 @@ func TestVolumeOperationError(t *testing.T) {
 
 	RecordVolumeOperationErrorMetric("kubernetes.io/fake-plugin", "deletion")
 
-	want := `# HELP volume_operation_errors_total [ALPHA] Total volume operation errors
+	want := `# HELP volume_operation_errors_total [BETA] Total volume operation errors
 # TYPE volume_operation_errors_total counter
 volume_operation_errors_total{operation_name="deletion",plugin_name="kubernetes.io/fake-plugin"} 1
 `


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Promotes the `volume_operation_errors_total` metric (in pkg/controller/volume/persistentvolume/metrics/metrics.go) from Alpha to Beta stability, completing the remaining item from #136310 

#### Which issue(s) this PR is related to:

Fixes #136310

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
kube-controller-manager: promoted metric 'volume_operation_errors_total' from ALPHA to BETA stability.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
