### PR TITLE
[release-1.36] test(utils): bump agnhost image tag to 2.66.1

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -83,7 +83,7 @@ dependencies:
 
   # agnhost - E2E test image
   - name: "agnhost"
-    version: 2.63.0
+    version: 2.66.1
     refPaths:
     - path: test/utils/image/manifest.go
       match: configs\[Agnhost\] = Config{list\.PromoterE2eRegistry, "agnhost", "\d+\.\d+\.\d+"}

--- a/hack/testdata/pod-with-large-name.yaml
+++ b/hack/testdata/pod-with-large-name.yaml
@@ -8,5 +8,5 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
     command: ["/agnhost", "serve-hostname"]

--- a/test/e2e/dra/test-driver/deploy/example/pod-external-toleration.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-external-toleration.yaml
@@ -28,13 +28,13 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
   resourceClaims:
   - name: resource

--- a/test/e2e/dra/test-driver/deploy/example/pod-external.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-external.yaml
@@ -24,13 +24,13 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
   resourceClaims:
   - name: resource

--- a/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
+++ b/test/e2e/dra/test-driver/deploy/example/pod-inline.yaml
@@ -29,13 +29,13 @@ spec:
   restartPolicy: Never
   containers:
   - name: with-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
     resources:
       claims:
       - name: resource
   - name: without-resource
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
     command: ["sh", "-c", "set && mount && ls -la /dev/ && /agnhost pause"]
   terminationGracePeriodSeconds: 0 # Shut down immediately.
   resourceClaims:

--- a/test/e2e/testing-manifests/kubectl/agnhost-primary-pod.yaml
+++ b/test/e2e/testing-manifests/kubectl/agnhost-primary-pod.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
     - name: primary
-      image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+      image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
       env:
         - name: PRIMARY
           value: "true"
@@ -21,7 +21,7 @@ spec:
         - mountPath: /agnhost-primary-data
           name: data
     - name: sentinel
-      image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+      image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
       env:
         - name: SENTINEL
           value: "true"

--- a/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
+++ b/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: netexec
-        image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+        image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
         command: ["/agnhost", "netexec"]
         ports:
         - containerPort: 8080

--- a/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
+++ b/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
@@ -42,7 +42,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+    image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
     command: ["/agnhost", "serve-hostname"]
     resources:
       limits:

--- a/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
@@ -30,7 +30,7 @@ items:
   spec:
     containers:
     - name: kubernetes-serve-hostname
-      image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+      image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
       command: ["/agnhost", "serve-hostname"]
       resources:
         limits:

--- a/test/images/kitten/BASEIMAGE
+++ b/test/images/kitten/BASEIMAGE
@@ -1,7 +1,7 @@
-linux/amd64=REGISTRY/agnhost:2.63.0-linux-amd64
-linux/arm64=REGISTRY/agnhost:2.63.0-linux-arm64
-linux/ppc64le=REGISTRY/agnhost:2.63.0-linux-ppc64le
-linux/s390x=REGISTRY/agnhost:2.63.0-linux-s390x
-windows/amd64/1809=REGISTRY/agnhost:2.63.0-windows-amd64-1809
-windows/amd64/ltsc2022=REGISTRY/agnhost:2.63.0-windows-amd64-ltsc2022
-windows/amd64/ltsc2025=REGISTRY/agnhost:2.63.0-windows-amd64-ltsc2025
+linux/amd64=REGISTRY/agnhost:2.66.1-linux-amd64
+linux/arm64=REGISTRY/agnhost:2.66.1-linux-arm64
+linux/ppc64le=REGISTRY/agnhost:2.66.1-linux-ppc64le
+linux/s390x=REGISTRY/agnhost:2.66.1-linux-s390x
+windows/amd64/1809=REGISTRY/agnhost:2.66.1-windows-amd64-1809
+windows/amd64/ltsc2022=REGISTRY/agnhost:2.66.1-windows-amd64-ltsc2022
+windows/amd64/ltsc2025=REGISTRY/agnhost:2.66.1-windows-amd64-ltsc2025

--- a/test/images/nautilus/BASEIMAGE
+++ b/test/images/nautilus/BASEIMAGE
@@ -1,7 +1,7 @@
-linux/amd64=REGISTRY/agnhost:2.63.0-linux-amd64
-linux/arm64=REGISTRY/agnhost:2.63.0-linux-arm64
-linux/ppc64le=REGISTRY/agnhost:2.63.0-linux-ppc64le
-linux/s390x=REGISTRY/agnhost:2.63.0-linux-s390x
-windows/amd64/1809=REGISTRY/agnhost:2.63.0-windows-amd64-1809
-windows/amd64/ltsc2022=REGISTRY/agnhost:2.63.0-windows-amd64-ltsc2022
-windows/amd64/ltsc2025=REGISTRY/agnhost:2.63.0-windows-amd64-ltsc2025
+linux/amd64=REGISTRY/agnhost:2.66.1-linux-amd64
+linux/arm64=REGISTRY/agnhost:2.66.1-linux-arm64
+linux/ppc64le=REGISTRY/agnhost:2.66.1-linux-ppc64le
+linux/s390x=REGISTRY/agnhost:2.66.1-linux-s390x
+windows/amd64/1809=REGISTRY/agnhost:2.66.1-windows-amd64-1809
+windows/amd64/ltsc2022=REGISTRY/agnhost:2.66.1-windows-amd64-ltsc2022
+windows/amd64/ltsc2025=REGISTRY/agnhost:2.66.1-windows-amd64-ltsc2025

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -209,7 +209,7 @@ const (
 func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
 	configs := map[ImageID]Config{}
 	configs[AgnhostPrev] = Config{list.PromoterE2eRegistry, "agnhost", "2.55"}
-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.63.0"}
+	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.66.1"}
 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Bumps the `Agnhost` image tag to `2.66.1` in `test/utils/image/manifest.go` on the `release-1.36` branch to consume the updated pre-built e2e test image.

This replaces the approach from #141431 (no backporting build changes to release branches).

Thanks @liggitt and @BenTheElder for the guidance!

#### Which issue(s) this PR fixes:
Refers to #141396

#### Special notes for your reviewer:
Supersedes and replaces #141431.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
