### PR TITLE
Replace VolumeAttachments that refer to a deleted PersistentVolume

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -782,6 +782,10 @@ func (adc *attachDetachController) VolumeAttachmentLister() storagelistersv1.Vol
 	return adc.volumeAttachmentLister
 }
 
+func (adc *attachDetachController) PersistentVolumeLister() corelisters.PersistentVolumeLister {
+	return adc.pvLister
+}
+
 // VolumeHost implementation
 // This is an unfortunate requirement of the current factoring of volume plugin
 // initializing code. It requires kubelet specific methods used by the mounting

--- a/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
@@ -52,7 +52,8 @@ type DesiredStateOfWorld interface {
 	// specified volume and is scheduled to the specified node.
 	// A unique volumeName is generated from the volumeSpec and returned on
 	// success.
-	// If the pod already exists under the specified volume, this is a no-op.
+	// If the pod already exists under the specified volume, only the recorded
+	// volume spec may change, see [isAttachablePV].
 	// If volumeSpec is not an attachable volume plugin, an error is returned.
 	// If no volume with the name volumeName exists in the list of volumes that
 	// should be attached to the specified node, the volume is implicitly added.
@@ -165,7 +166,7 @@ type volumeToAttach struct {
 
 	// spec is the volume spec containing the specification for this volume.
 	// Used to generate the volume plugin object, and passed to attach/detach
-	// methods.
+	// methods. See [isAttachablePV] for which PersistentVolume this is.
 	spec *volume.Spec
 
 	// scheduledPods is a map containing the set of pods that reference this
@@ -173,6 +174,22 @@ type volumeToAttach struct {
 	// the name of the pod and the value is a pod object containing more
 	// information about the pod.
 	scheduledPods map[types.UniquePodName]pod
+}
+
+// isAttachablePV reports whether the spec's PersistentVolume can still be
+// attached, which is what a volume records the spec of.
+//
+// Several PersistentVolumes can map to one volume, because the PV name does not
+// take part in the unique volume name, so a PV re-created for the same
+// underlying volume reaches AddPod while pods that use the previous one are
+// still scheduled to the node. An attacher refuses a PV that is being deleted,
+// and a deletionTimestamp is never cleared, so such a PV must never displace the
+// recorded spec, however stale that spec is.
+func isAttachablePV(volumeSpec *volume.Spec) bool {
+	// An inline volume spec, including a PersistentVolume synthesized by CSI
+	// migration, is not an API object and cannot be deleted on its own.
+	return volumeSpec.PersistentVolume == nil ||
+		volumeSpec.PersistentVolume.DeletionTimestamp == nil
 }
 
 // The pod represents a pod that references the underlying volume and is
@@ -241,6 +258,10 @@ func (dsw *desiredStateOfWorld) AddPod(
 			spec:                     volumeSpec,
 			scheduledPods:            make(map[types.UniquePodName]pod),
 		}
+		dsw.nodesManaged[nodeName].volumesToAttach[volumeName] = volumeObj
+	} else if isAttachablePV(volumeSpec) {
+		// Follow the PersistentVolume the pods use, from a fresh copy of it.
+		volumeObj.spec = volumeSpec
 		dsw.nodesManaged[nodeName].volumesToAttach[volumeName] = volumeObj
 	}
 	if _, podExists := volumeObj.scheduledPods[podName]; !podExists {

--- a/pkg/controller/volume/attachdetach/cache/desired_state_of_world_test.go
+++ b/pkg/controller/volume/attachdetach/cache/desired_state_of_world_test.go
@@ -20,8 +20,10 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	controllervolumetesting "k8s.io/kubernetes/pkg/controller/volume/attachdetach/testing"
+	"k8s.io/kubernetes/pkg/volume"
 	volumetesting "k8s.io/kubernetes/pkg/volume/testing"
 	"k8s.io/kubernetes/pkg/volume/util/types"
 )
@@ -1076,5 +1078,124 @@ func Test_GetPodsOnNodes(t *testing.T) {
 	}
 	if pods[0].Name != pod1Name {
 		t.Errorf("Expected pod %s/%s, got %s", pod1Name, pod1Name, pods[0].Name)
+	}
+}
+
+// Calls AddPod() for two pods that use different PersistentVolumes of one volume.
+// Verifies which PersistentVolume the volume ends up recording the spec of.
+func Test_AddPod_Positive_SeveralPVsOfOneVolume(t *testing.T) {
+	const (
+		diskName      = "shared-disk"
+		alivePV       = "pv-alive"
+		otherAlivePV  = "pv-alive-other"
+		terminatingPV = "pv-terminating"
+	)
+	// A PersistentVolume name does not take part in the unique volume name, so the
+	// specs below all map to one volume, as PersistentVolumes re-created for the same
+	// underlying volume do.
+	makePVSpec := func(name string, terminating bool) *volume.Spec {
+		pv := &v1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: v1.PersistentVolumeSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{PDName: diskName},
+				},
+			},
+		}
+		if terminating {
+			pv.DeletionTimestamp = new(metav1.Now())
+		}
+		return volume.NewSpecFromPersistentVolume(pv, false)
+	}
+	makeInlineSpec := func() *volume.Spec {
+		return volume.NewSpecFromVolume(&v1.Volume{
+			Name: "inline-volume",
+			VolumeSource: v1.VolumeSource{
+				GCEPersistentDisk: &v1.GCEPersistentDiskVolumeSource{PDName: diskName},
+			},
+		})
+	}
+
+	testCases := []struct {
+		name string
+		// first is added before second, both for the same volume.
+		first, second *volume.Spec
+		// expectRecordedPV is the PersistentVolume the volume is expected to record the
+		// spec of. Empty means the inline volume spec.
+		expectRecordedPV string
+	}{
+		{
+			name:             "terminating PV, keep alive PV",
+			first:            makePVSpec(alivePV, false),
+			second:           makePVSpec(terminatingPV, true),
+			expectRecordedPV: alivePV,
+		},
+		{
+			name:             "alive PV, replace terminating PV",
+			first:            makePVSpec(terminatingPV, true),
+			second:           makePVSpec(alivePV, false),
+			expectRecordedPV: alivePV,
+		},
+		{
+			name:             "alive PV, replace alive PV",
+			first:            makePVSpec(alivePV, false),
+			second:           makePVSpec(otherAlivePV, false),
+			expectRecordedPV: otherAlivePV,
+		},
+		{
+			name:             "terminating PV, keep terminating PV",
+			first:            makePVSpec(terminatingPV, true),
+			second:           makePVSpec("pv-terminating-other", true),
+			expectRecordedPV: terminatingPV,
+		},
+		{
+			name:             "inline spec, replace terminating PV",
+			first:            makePVSpec(terminatingPV, true),
+			second:           makeInlineSpec(),
+			expectRecordedPV: "",
+		},
+		{
+			name:             "terminating PV, keep inline spec",
+			first:            makeInlineSpec(),
+			second:           makePVSpec(terminatingPV, true),
+			expectRecordedPV: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
+			dsw := NewDesiredStateOfWorld(volumePluginMgr)
+			nodeName := k8stypes.NodeName("node-name")
+			dsw.AddNode(nodeName)
+
+			// Act
+			firstVolumeName, err := dsw.AddPod("first-pod", controllervolumetesting.NewPod("first-pod", "first-pod"), tc.first, nodeName)
+			if err != nil {
+				t.Fatalf("AddPod failed. Expected: <no error> Actual: <%v>", err)
+			}
+			secondVolumeName, err := dsw.AddPod("second-pod", controllervolumetesting.NewPod("second-pod", "second-pod"), tc.second, nodeName)
+			if err != nil {
+				t.Fatalf("AddPod failed. Expected: <no error> Actual: <%v>", err)
+			}
+
+			// Assert
+			if firstVolumeName != secondVolumeName {
+				t.Fatalf("Both specs must map to one volume. Expected: <%v> Actual: <%v>", firstVolumeName, secondVolumeName)
+			}
+			volumesToAttach := dsw.GetVolumesToAttach()
+			if len(volumesToAttach) != 1 {
+				t.Fatalf("len(volumesToAttach) Expected: <1> Actual: <%v>", len(volumesToAttach))
+			}
+			recordedPV := ""
+			if pv := volumesToAttach[0].VolumeSpec.PersistentVolume; pv != nil {
+				recordedPV = pv.Name
+			}
+			if recordedPV != tc.expectRecordedPV {
+				t.Errorf("Recorded PV Expected: <%q> Actual: <%q>", tc.expectRecordedPV, recordedPV)
+			}
+		})
 	}
 }

--- a/pkg/controller/volume/attachdetach/util/util_test.go
+++ b/pkg/controller/volume/attachdetach/util/util_test.go
@@ -307,6 +307,7 @@ func setup(nodeName string, t *testing.T) (*volume.VolumePluginMgr, csimigration
 		nodeName,
 		csiDriverLister,
 		volumeAttachmentLister,
+		factory.Core().V1().PersistentVolumes().Lister(),
 	)
 
 	plugMgr.Host = fakeAttachDetachVolumeHost

--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -77,7 +77,7 @@ func (c *csiAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string
 	}
 
 	node := string(nodeName)
-	attachID := getAttachmentName(pvSrc.VolumeHandle, pvSrc.Driver, node)
+	attachID := GetVolumeAttachmentName(pvSrc.VolumeHandle, pvSrc.Driver, node)
 
 	attachment, err := c.plugin.volumeAttachmentLister.Get(attachID)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -134,7 +134,7 @@ func (c *csiAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string
 
 	klog.V(4).Info(log("attacher.Attach finished OK with VolumeAttachment object [%s]", attachID))
 
-	// Don't return attachID as a devicePath. We can reconstruct the attachID using getAttachmentName()
+	// Don't return attachID as a devicePath. We can reconstruct the attachID using GetVolumeAttachmentName()
 	return "", nil
 }
 
@@ -150,7 +150,7 @@ func (c *csiAttacher) WaitForAttach(spec *volume.Spec, _ string, pod *v1.Pod, _ 
 	}
 
 	volumeHandle := source.VolumeHandle
-	attachID := getAttachmentName(source.VolumeHandle, source.Driver, string(c.plugin.host.GetNodeName()))
+	attachID := GetVolumeAttachmentName(source.VolumeHandle, source.Driver, string(c.plugin.host.GetNodeName()))
 
 	attach, err := c.k8s.StorageV1().VolumeAttachments().Get(context.TODO(), attachID, metav1.GetOptions{})
 	if err != nil {
@@ -225,7 +225,7 @@ func (c *csiAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.No
 			}
 		}
 
-		attachID := getAttachmentName(volumeHandle, driverName, string(nodeName))
+		attachID := GetVolumeAttachmentName(volumeHandle, driverName, string(nodeName))
 		var attach *storage.VolumeAttachment
 		if c.plugin.volumeAttachmentLister != nil {
 			attach, err = c.plugin.volumeAttachmentLister.Get(attachID)
@@ -437,7 +437,7 @@ func (c *csiAttacher) Detach(volumeName string, nodeName types.NodeName) error {
 
 	driverName := parts[0]
 	volID = parts[1]
-	attachID = getAttachmentName(volID, driverName, string(nodeName))
+	attachID = GetVolumeAttachmentName(volID, driverName, string(nodeName))
 
 	if err := c.k8s.StorageV1().VolumeAttachments().Delete(context.TODO(), attachID, metav1.DeleteOptions{}); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -589,8 +589,11 @@ func (c *csiAttacher) UnmountDevice(deviceMountPath string) error {
 	return nil
 }
 
-// getAttachmentName returns csi-<sha256(volName,csiDriverName,NodeName)>
-func getAttachmentName(volName, csiDriverName, nodeName string) string {
+// GetVolumeAttachmentName returns csi-<sha256(volName,csiDriverName,NodeName)>, the name of
+// the VolumeAttachment object for one volume handle attached to one node. Note that the
+// PersistentVolume name does not take part in it: several PersistentVolumes of the same
+// volume can share a VolumeAttachment.
+func GetVolumeAttachmentName(volName, csiDriverName, nodeName string) string {
 	result := sha256.Sum256([]byte(fmt.Sprintf("%s%s%s", volName, csiDriverName, nodeName)))
 	return fmt.Sprintf("csi-%x", result)
 }

--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -84,7 +84,77 @@ func (c *csiAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string
 		return "", errors.New(log("failed to get volume attachment from lister: %v", err))
 	}
 
+	// Name of the PV that the VolumeAttachment must refer to. Empty for volumes that
+	// are attached from an inline volume spec, those are not referenced by PV name.
+	var specPVName string
+	if !spec.InlineVolumeSpecForCSIMigration && spec.PersistentVolume != nil {
+		specPVName = spec.PersistentVolume.Name
+	}
+
+	// Empty unless the PV is being deleted or is gone, in which case it describes which
+	// of the two it is.
+	var specPVDeletion string
+	if specPVName != "" {
+		specPVDeletion, err = c.persistentVolumeDeletion(specPVName)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Several PVs can share a volume handle,
+	// so the VolumeAttachment found above may refer to a PV that is already
+	// being deleted and never become attached (external-attacher refuses it).
+	// Since spec.source of a VolumeAttachment is immutable, the only way to
+	// fix it is to delete it.
+	if attachment != nil && attachment.Spec.Source.PersistentVolumeName != nil &&
+		!attachment.Status.Attached && attachment.Status.AttachError != nil {
+		// Safe to delete: !Attached means we have never reported this as attached.
+		// Also check AttachError to try our best not to abort an in-flight attach,
+		// which may succeed eventually.
+		// If it really cannot attach, waitForVolumeAttachmentWithLister will abort
+		// and we return to here fast on retry.
+		referencedPVName := *attachment.Spec.Source.PersistentVolumeName
+		// Ask about the same PV only once, so that this attempt cannot delete the object
+		// because the PV is dying and then create a new one for that same PV as if it were
+		// alive.
+		referencedPVDeletion := specPVDeletion
+		if referencedPVName != specPVName {
+			referencedPVDeletion, err = c.persistentVolumeDeletion(referencedPVName)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		if referencedPVDeletion != "" {
+			// Just continue to wait if a previous detach timed out.
+			if attachment.GetDeletionTimestamp() == nil {
+				if err := c.deleteStaleVolumeAttachment(attachment, referencedPVDeletion); err != nil {
+					return "", err
+				}
+			}
+			attachment = nil
+
+			if specPVDeletion == "" {
+				// The new VolumeAttachment has the same name as the deleted one, wait
+				// until the old object is really gone before creating it again.
+				if err := c.waitForVolumeDetachmentWithLister(spec, pvSrc.VolumeHandle, attachID, c.watchTimeout); err != nil {
+					return "", err
+				}
+			}
+		}
+	}
+
 	if attachment == nil {
+		if specPVDeletion != "" {
+			// Creating the VolumeAttachment would be pointless, external-attacher
+			// refuses to attach a PV that is being deleted or gone. It would also
+			// outlive this attach attempt and, because its name does not depend on the
+			// PV name, block attaching the next PV that uses the same volume handle on
+			// this node until something deletes it. This error surfaces in the pod's
+			// FailedAttachVolume event.
+			return "", errors.New(log("attacher.Attach failed: %s", specPVDeletion))
+		}
+
 		var vaSrc storage.VolumeAttachmentSource
 		if spec.InlineVolumeSpecForCSIMigration {
 			// inline PV scenario - use PV spec to populate VA source.
@@ -136,6 +206,50 @@ func (c *csiAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string
 
 	// Don't return attachID as a devicePath. We can reconstruct the attachID using GetVolumeAttachmentName()
 	return "", nil
+}
+
+// persistentVolumeDeletion returns a message describing why the named PersistentVolume
+// cannot be attached, or an empty string if it can. The wording matches external-attacher,
+// which refuses to attach a PV that is being deleted and cannot attach one that is gone.
+func (c *csiAttacher) persistentVolumeDeletion(pvName string) (string, error) {
+	pv, err := c.plugin.persistentVolumeLister.Get(pvName)
+	if apierrors.IsNotFound(err) {
+		// The specs that reach Attach come from this same cache,
+		// so a PV missing from it is one whose deletion was observed.
+		return fmt.Sprintf("persistentvolume %q not found", pvName), nil
+	}
+	if err != nil {
+		return "", errors.New(log("failed to get PersistentVolume %q from lister: %v", pvName, err))
+	}
+	if pv.GetDeletionTimestamp() != nil {
+		return fmt.Sprintf("PersistentVolume %q is marked for deletion", pvName), nil
+	}
+	return "", nil
+}
+
+// deleteStaleVolumeAttachment deletes a VolumeAttachment that refers to a PersistentVolume
+// that is being deleted or gone, so that it can be created again referring to the PV that
+// is being attached now.
+func (c *csiAttacher) deleteStaleVolumeAttachment(attachment *storage.VolumeAttachment, referencedPVDeletion string) error {
+	klog.V(2).Info(log("attacher.Attach is deleting VolumeAttachment [%s]: %s and the volume was never attached",
+		attachment.Name, referencedPVDeletion))
+
+	// Delete the exact revision we made decision on,
+	// not one that has changed since and is attached by now.
+	opts := metav1.DeleteOptions{
+		Preconditions: &metav1.Preconditions{
+			UID:             &attachment.UID,
+			ResourceVersion: &attachment.ResourceVersion,
+		},
+	}
+
+	err := c.k8s.StorageV1().VolumeAttachments().Delete(context.TODO(), attachment.Name, opts)
+	if err != nil && !apierrors.IsNotFound(err) {
+		// A conflict means the object changed since it was cached. Report the error and
+		// let the next attach attempt look at the current object.
+		return errors.New(log("attacher.Attach failed to delete stale VolumeAttachment [%s]: %v", attachment.Name, err))
+	}
+	return nil
 }
 
 // WaitForAttach waits for the attach operation to complete and returns the device path when it is done.
@@ -452,10 +566,12 @@ func (c *csiAttacher) Detach(volumeName string, nodeName types.NodeName) error {
 
 	// Attach and detach functionality is exclusive to the CSI plugin that runs in the AttachDetachController,
 	// and has access to a VolumeAttachment lister that can be polled for the current status.
-	return c.waitForVolumeDetachmentWithLister(volID, attachID, c.watchTimeout)
+	return c.waitForVolumeDetachmentWithLister(nil, volID, attachID, c.watchTimeout)
 }
 
-func (c *csiAttacher) waitForVolumeDetachmentWithLister(volumeHandle, attachID string, timeout time.Duration) error {
+// waitForVolumeDetachmentWithLister waits until the VolumeAttachment object is gone. spec
+// may be nil, it is only used to name the CSI driver in log messages.
+func (c *csiAttacher) waitForVolumeDetachmentWithLister(spec *volume.Spec, volumeHandle, attachID string, timeout time.Duration) error {
 	klog.V(4).Info(log("probing VolumeAttachment [id=%v]", attachID))
 
 	verifyStatus := func() (bool, error) {
@@ -479,7 +595,7 @@ func (c *csiAttacher) waitForVolumeDetachmentWithLister(volumeHandle, attachID s
 		return successful, nil
 	}
 
-	return c.waitForVolumeAttachDetachStatusWithLister(nil, volumeHandle, attachID, timeout, verifyStatus, "Detach")
+	return c.waitForVolumeAttachDetachStatusWithLister(spec, volumeHandle, attachID, timeout, verifyStatus, "Detach")
 }
 
 func (c *csiAttacher) waitForVolumeAttachDetachStatusWithLister(spec *volume.Spec, volumeHandle, attachID string, timeout time.Duration, verifyStatus func() (bool, error), operation string) error {

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -129,7 +129,7 @@ func TestAttacherAttach(t *testing.T) {
 			nodeName:   "testnode-01",
 			driverName: "testdriver-01",
 			volumeName: "testvol-01",
-			attachID:   getAttachmentName("testvol-01", "testdriver-01", "testnode-01"),
+			attachID:   GetVolumeAttachmentName("testvol-01", "testdriver-01", "testnode-01"),
 			spec:       volume.NewSpecFromPersistentVolume(makeTestPV("pv01", 10, "testdriver-01", "testvol-01"), false),
 		},
 		{
@@ -137,7 +137,7 @@ func TestAttacherAttach(t *testing.T) {
 			nodeName:   "node02",
 			driverName: "driver02",
 			volumeName: "vol02",
-			attachID:   getAttachmentName("vol02", "driver02", "node02"),
+			attachID:   GetVolumeAttachmentName("vol02", "driver02", "node02"),
 			spec:       volume.NewSpecFromPersistentVolume(makeTestPV("pv01", 10, "driver02", "vol02"), false),
 		},
 		{
@@ -145,7 +145,7 @@ func TestAttacherAttach(t *testing.T) {
 			nodeName:     "node02",
 			driverName:   "driver02",
 			volumeName:   "vol01",
-			attachID:     getAttachmentName("vol02", "driver02", "node02"),
+			attachID:     GetVolumeAttachmentName("vol02", "driver02", "node02"),
 			spec:         volume.NewSpecFromPersistentVolume(makeTestPV("pv01", 10, "driver02", "vol01"), false),
 			shouldFail:   true,
 			watchTimeout: testWatchFailTimeout,
@@ -155,7 +155,7 @@ func TestAttacherAttach(t *testing.T) {
 			nodeName:     "node02",
 			driverName:   "driver000",
 			volumeName:   "vol02",
-			attachID:     getAttachmentName("vol02", "driver02", "node02"),
+			attachID:     GetVolumeAttachmentName("vol02", "driver02", "node02"),
 			spec:         volume.NewSpecFromPersistentVolume(makeTestPV("pv01", 10, "driver01", "vol02"), false),
 			shouldFail:   true,
 			watchTimeout: testWatchFailTimeout,
@@ -165,7 +165,7 @@ func TestAttacherAttach(t *testing.T) {
 			nodeName:     "node000",
 			driverName:   "driver000",
 			volumeName:   "vol02",
-			attachID:     getAttachmentName("vol02", "driver02", "node02"),
+			attachID:     GetVolumeAttachmentName("vol02", "driver02", "node02"),
 			spec:         volume.NewSpecFromPersistentVolume(makeTestPV("pv01", 10, "driver02", "vol02"), false),
 			shouldFail:   true,
 			watchTimeout: testWatchFailTimeout,
@@ -175,7 +175,7 @@ func TestAttacherAttach(t *testing.T) {
 			nodeName:            "node02",
 			driverName:          "driver02",
 			volumeName:          "vol02",
-			attachID:            getAttachmentName("vol02", "driver02", "node02"),
+			attachID:            GetVolumeAttachmentName("vol02", "driver02", "node02"),
 			spec:                volume.NewSpecFromPersistentVolume(makeTestPV("pv01", 10, "driver02", "vol02"), false),
 			injectAttacherError: true,
 			shouldFail:          true,
@@ -185,7 +185,7 @@ func TestAttacherAttach(t *testing.T) {
 			nodeName:   "node000",
 			driverName: "driver000",
 			volumeName: "vol02",
-			attachID:   getAttachmentName("vol02", "driver02", "node02"),
+			attachID:   GetVolumeAttachmentName("vol02", "driver02", "node02"),
 			spec:       volume.NewSpecFromVolume(makeTestVol("pv01", "driver02")),
 			shouldFail: true, // csi not enabled
 		},
@@ -194,7 +194,7 @@ func TestAttacherAttach(t *testing.T) {
 			nodeName:   "node000",
 			driverName: "driver000",
 			volumeName: "vol02",
-			attachID:   getAttachmentName("vol02", "driver02", "node02"),
+			attachID:   GetVolumeAttachmentName("vol02", "driver02", "node02"),
 			shouldFail: true, // csi not enabled
 		},
 	}
@@ -259,20 +259,20 @@ func TestAttacherAttachWithInline(t *testing.T) {
 		{
 			name:     "test ok 1 with PV",
 			nodeName: "node01",
-			attachID: getAttachmentName("vol01", "driver01", "node01"),
+			attachID: GetVolumeAttachmentName("vol01", "driver01", "node01"),
 			spec:     volume.NewSpecFromPersistentVolume(makeTestPV("pv01", 10, "driver01", "vol01"), false),
 		},
 		{
 			name:       "test failure, attach with volSrc",
 			nodeName:   "node01",
-			attachID:   getAttachmentName("vol01", "driver01", "node01"),
+			attachID:   GetVolumeAttachmentName("vol01", "driver01", "node01"),
 			spec:       volume.NewSpecFromVolume(makeTestVol("vol01", "driver01")),
 			shouldFail: true,
 		},
 		{
 			name:                "attacher error",
 			nodeName:            "node02",
-			attachID:            getAttachmentName("vol02", "driver02", "node02"),
+			attachID:            GetVolumeAttachmentName("vol02", "driver02", "node02"),
 			spec:                volume.NewSpecFromPersistentVolume(makeTestPV("pv02", 10, "driver02", "vol02"), false),
 			injectAttacherError: true,
 			shouldFail:          true,
@@ -280,7 +280,7 @@ func TestAttacherAttachWithInline(t *testing.T) {
 		{
 			name:       "missing spec",
 			nodeName:   "node02",
-			attachID:   getAttachmentName("vol02", "driver02", "node02"),
+			attachID:   GetVolumeAttachmentName("vol02", "driver02", "node02"),
 			shouldFail: true,
 		},
 	}
@@ -398,7 +398,7 @@ func TestAttacherWithCSIDriver(t *testing.T) {
 			}(spec)
 
 			if test.expectVolumeAttachment {
-				expectedAttachID := getAttachmentName("test-vol", test.driver, "fakeNode")
+				expectedAttachID := GetVolumeAttachmentName("test-vol", test.driver, "fakeNode")
 				status := storage.VolumeAttachmentStatus{
 					Attached: true,
 				}
@@ -498,20 +498,20 @@ func TestAttacherWaitForAttach(t *testing.T) {
 			driver: "attachable",
 			makeAttachment: func() *storage.VolumeAttachment {
 
-				testAttachID := getAttachmentName("test-vol", "attachable", "fakeNode")
+				testAttachID := GetVolumeAttachmentName("test-vol", "attachable", "fakeNode")
 				successfulAttachment := makeTestAttachment(testAttachID, "fakeNode", "test-pv")
 				successfulAttachment.Status.Attached = true
 				return successfulAttachment
 			},
 			spec:             volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, "attachable", "test-vol"), false),
-			expectedAttachID: getAttachmentName("test-vol", "attachable", "fakeNode"),
+			expectedAttachID: GetVolumeAttachmentName("test-vol", "attachable", "fakeNode"),
 			expectError:      false,
 		},
 		{
 			name: "failed attach with vol source",
 			makeAttachment: func() *storage.VolumeAttachment {
 
-				testAttachID := getAttachmentName("test-vol", "attachable", "fakeNode")
+				testAttachID := GetVolumeAttachmentName("test-vol", "attachable", "fakeNode")
 				successfulAttachment := makeTestAttachment(testAttachID, "fakeNode", "volSrc01")
 				successfulAttachment.Status.Attached = true
 				return successfulAttachment
@@ -578,20 +578,20 @@ func TestAttacherWaitForAttachWithInline(t *testing.T) {
 			name: "successful attach with PV",
 			makeAttachment: func() *storage.VolumeAttachment {
 
-				testAttachID := getAttachmentName("test-vol", "attachable", "fakeNode")
+				testAttachID := GetVolumeAttachmentName("test-vol", "attachable", "fakeNode")
 				successfulAttachment := makeTestAttachment(testAttachID, "fakeNode", "test-pv")
 				successfulAttachment.Status.Attached = true
 				return successfulAttachment
 			},
 			spec:             volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, "attachable", "test-vol"), false),
-			expectedAttachID: getAttachmentName("test-vol", "attachable", "fakeNode"),
+			expectedAttachID: GetVolumeAttachmentName("test-vol", "attachable", "fakeNode"),
 			expectError:      false,
 		},
 		{
 			name: "failed attach with volSrc",
 			makeAttachment: func() *storage.VolumeAttachment {
 
-				testAttachID := getAttachmentName("test-vol", "attachable", "fakeNode")
+				testAttachID := GetVolumeAttachmentName("test-vol", "attachable", "fakeNode")
 				successfulAttachment := makeTestAttachment(testAttachID, "fakeNode", "volSrc01")
 				successfulAttachment.Status.Attached = true
 				return successfulAttachment
@@ -703,7 +703,7 @@ func TestAttacherVolumesAreAttached(t *testing.T) {
 			// create and save volume attchments
 			for _, attachedSpec := range tc.attachedSpecs {
 				specs = append(specs, attachedSpec.spec)
-				attachID := getAttachmentName(attachedSpec.volName, testDriver, nodeName)
+				attachID := GetVolumeAttachmentName(attachedSpec.volName, testDriver, nodeName)
 				attachment := makeTestAttachment(attachID, nodeName, attachedSpec.spec.Name())
 				attachment.Status.Attached = attachedSpec.attached
 				_, err := csiAttacher.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, metav1.CreateOptions{})
@@ -773,7 +773,7 @@ func TestAttacherVolumesAreAttachedWithInline(t *testing.T) {
 			// create and save volume attchments
 			for _, attachedSpec := range tc.attachedSpecs {
 				specs = append(specs, attachedSpec.spec)
-				attachID := getAttachmentName(attachedSpec.volName, testDriver, nodeName)
+				attachID := GetVolumeAttachmentName(attachedSpec.volName, testDriver, nodeName)
 				attachment := makeTestAttachment(attachID, nodeName, attachedSpec.spec.Name())
 				attachment.Status.Attached = attachedSpec.attached
 				_, err := csiAttacher.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, metav1.CreateOptions{})
@@ -815,13 +815,13 @@ func TestAttacherDetach(t *testing.T) {
 		reactor      func(action core.Action) (handled bool, ret runtime.Object, err error)
 		watchTimeout time.Duration
 	}{
-		{name: "normal test", volID: "vol-001", attachID: getAttachmentName("vol-001", testDriver, nodeName)},
-		{name: "normal test 2", volID: "vol-002", attachID: getAttachmentName("vol-002", testDriver, nodeName)},
-		{name: "object not found", volID: "vol-non-existing", attachID: getAttachmentName("vol-003", testDriver, nodeName)},
+		{name: "normal test", volID: "vol-001", attachID: GetVolumeAttachmentName("vol-001", testDriver, nodeName)},
+		{name: "normal test 2", volID: "vol-002", attachID: GetVolumeAttachmentName("vol-002", testDriver, nodeName)},
+		{name: "object not found", volID: "vol-non-existing", attachID: GetVolumeAttachmentName("vol-003", testDriver, nodeName)},
 		{
 			name:       "API error",
 			volID:      "vol-004",
-			attachID:   getAttachmentName("vol-004", testDriver, nodeName),
+			attachID:   GetVolumeAttachmentName("vol-004", testDriver, nodeName),
 			shouldFail: true, // All other API errors should be propagated to caller
 			reactor: func(action core.Action) (handled bool, ret runtime.Object, err error) {
 				// return Forbidden to all DELETE requests
@@ -1178,7 +1178,7 @@ func TestAttacherMountDevice(t *testing.T) {
 			}
 
 			nodeName := string(csiAttacher.plugin.host.GetNodeName())
-			attachID := getAttachmentName(tc.volName, testDriver, nodeName)
+			attachID := GetVolumeAttachmentName(tc.volName, testDriver, nodeName)
 
 			if tc.createAttachment {
 				// Set up volume attachment
@@ -1396,7 +1396,7 @@ func TestAttacherMountDeviceWithInline(t *testing.T) {
 			}
 
 			nodeName := string(csiAttacher.plugin.host.GetNodeName())
-			attachID := getAttachmentName(tc.volName, testDriver, nodeName)
+			attachID := GetVolumeAttachmentName(tc.volName, testDriver, nodeName)
 
 			// Set up volume attachment
 			attachment := makeTestAttachment(attachID, nodeName, pvName)

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -204,8 +204,7 @@ func TestAttacherAttach(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("test case: %s", tc.name)
 			fakeClient := fakeclient.NewSimpleClientset()
-			plug, tmpDir := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
-			defer os.RemoveAll(tmpDir)
+			plug, _ := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
 
 			attacher, err := plug.NewAttacher()
 			if err != nil {
@@ -291,8 +290,7 @@ func TestAttacherAttachWithInline(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("test case: %s", tc.name)
 			fakeClient := fakeclient.NewSimpleClientset()
-			plug, tmpDir := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
-			defer os.RemoveAll(tmpDir)
+			plug, _ := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
 
 			attacher, err := plug.NewAttacher()
 			if err != nil {
@@ -364,8 +362,7 @@ func TestAttacherWithCSIDriver(t *testing.T) {
 				getTestCSIDriver("attachable", nil, &bTrue, nil),
 				getTestCSIDriver("nil", nil, nil, nil),
 			)
-			plug, tmpDir := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
-			defer os.RemoveAll(tmpDir)
+			plug, _ := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
 
 			attacher, err := plug.NewAttacher()
 			if err != nil {
@@ -457,8 +454,7 @@ func TestAttacherWaitForVolumeAttachmentWithCSIDriver(t *testing.T) {
 					Spec: v1.NodeSpec{},
 				},
 			)
-			plug, tmpDir := newTestPlugin(t, fakeClient)
-			defer os.RemoveAll(tmpDir)
+			plug, _ := newTestPlugin(t, fakeClient)
 
 			attacher, err := plug.NewAttacher()
 			if err != nil {
@@ -533,8 +529,7 @@ func TestAttacherWaitForAttach(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := fakeclient.NewSimpleClientset()
-			plug, tmpDir := newTestPlugin(t, fakeClient)
-			defer os.RemoveAll(tmpDir)
+			plug, _ := newTestPlugin(t, fakeClient)
 
 			attacher, err := plug.NewAttacher()
 			if err != nil {
@@ -615,8 +610,7 @@ func TestAttacherWaitForAttachWithInline(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := fakeclient.NewSimpleClientset()
-			plug, tmpDir := newTestPlugin(t, fakeClient)
-			defer os.RemoveAll(tmpDir)
+			plug, _ := newTestPlugin(t, fakeClient)
 
 			attacher, err := plug.NewAttacher()
 			if err != nil {
@@ -696,8 +690,7 @@ func TestAttacherVolumesAreAttached(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			plug, tmpDir := newTestPluginWithAttachDetachVolumeHost(t, nil)
-			defer os.RemoveAll(tmpDir)
+			plug, _ := newTestPluginWithAttachDetachVolumeHost(t, nil)
 
 			attacher, err := plug.NewAttacher()
 			if err != nil {
@@ -767,8 +760,7 @@ func TestAttacherVolumesAreAttachedWithInline(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			plug, tmpDir := newTestPlugin(t, nil)
-			defer os.RemoveAll(tmpDir)
+			plug, _ := newTestPlugin(t, nil)
 
 			attacher, err := plug.NewAttacher()
 			if err != nil {
@@ -845,8 +837,7 @@ func TestAttacherDetach(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("running test: %v", tc.name)
 			fakeClient := fakeclient.NewSimpleClientset()
-			plug, tmpDir := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
-			defer os.RemoveAll(tmpDir)
+			plug, _ := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
 
 			if tc.reactor != nil {
 				fakeClient.PrependReactor("*", "*", tc.reactor)
@@ -895,8 +886,7 @@ func TestAttacherGetDeviceMountPath(t *testing.T) {
 	// Setup
 	// Create a new attacher
 	fakeClient := fakeclient.NewSimpleClientset()
-	plug, tmpDir := newTestPlugin(t, fakeClient)
-	defer os.RemoveAll(tmpDir)
+	plug, _ := newTestPlugin(t, fakeClient)
 	attacher, err0 := plug.NewAttacher()
 	if err0 != nil {
 		t.Fatalf("failed to create new attacher: %v", err0)
@@ -1173,7 +1163,6 @@ func TestAttacherMountDevice(t *testing.T) {
 			// Create a new attacher
 			fakeClient := fakeclient.NewSimpleClientset()
 			plug, tmpDir := newTestPlugin(t, fakeClient)
-			defer os.RemoveAll(tmpDir)
 
 			attacher, err0 := plug.NewAttacher()
 			if err0 != nil {
@@ -1391,7 +1380,6 @@ func TestAttacherMountDeviceWithInline(t *testing.T) {
 			// Create a new attacher
 			fakeClient := fakeclient.NewSimpleClientset()
 			plug, tmpDir := newTestPlugin(t, fakeClient)
-			defer os.RemoveAll(tmpDir)
 
 			fakeWatcher := watch.NewRaceFreeFake()
 			fakeClient.Fake.PrependWatchReactor("volumeattachments", core.DefaultWatchReactor(fakeWatcher, nil))
@@ -1536,7 +1524,6 @@ func TestAttacherUnmountDevice(t *testing.T) {
 			// Create a new attacher
 			fakeClient := fakeclient.NewSimpleClientset()
 			plug, tmpDir := newTestPlugin(t, fakeClient)
-			defer os.RemoveAll(tmpDir)
 			attacher, err0 := plug.NewAttacher()
 			if err0 != nil {
 				t.Fatalf("failed to create new attacher: %v", err0)

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csi
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"fmt"
@@ -25,6 +26,7 @@ import (
 	"path/filepath"
 	"reflect"
 	goruntime "runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -35,13 +37,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	core "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	fakecsi "k8s.io/kubernetes/pkg/volume/csi/fake"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -203,7 +208,7 @@ func TestAttacherAttach(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("test case: %s", tc.name)
-			fakeClient := fakeclient.NewSimpleClientset()
+			fakeClient := fakeclient.NewSimpleClientset(specPVObjects(tc.spec)...)
 			plug, _ := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
 
 			attacher, err := plug.NewAttacher()
@@ -289,7 +294,7 @@ func TestAttacherAttachWithInline(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Logf("test case: %s", tc.name)
-			fakeClient := fakeclient.NewSimpleClientset()
+			fakeClient := fakeclient.NewSimpleClientset(specPVObjects(tc.spec)...)
 			plug, _ := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
 
 			attacher, err := plug.NewAttacher()
@@ -326,6 +331,429 @@ func TestAttacherAttachWithInline(t *testing.T) {
 	}
 }
 
+// TestAttacherAttachWithPVBeingDeleted covers volumes whose VolumeAttachment refers to a
+// PersistentVolume that is being deleted. Because the name of a VolumeAttachment is derived
+// from the volume handle and not from the PV name, several PVs sharing a volume handle map
+// to the same VolumeAttachment on a node, and a leftover VolumeAttachment of a deleted PV
+// would otherwise block attaching the current PV forever.
+func TestAttacherAttachWithPVBeingDeleted(t *testing.T) {
+	const (
+		driverName   = "driver01"
+		volumeHandle = "vol01"
+		nodeName     = "node01"
+		currentPV    = "pv-current"
+		stalePV      = "pv-stale"
+		// existingUID marks the VolumeAttachment a case starts with, so that an object that
+		// was deleted and created again can be told from one that was kept.
+		existingUID = "existing-uid"
+	)
+	attachID := GetVolumeAttachmentName(volumeHandle, driverName, nodeName)
+	// Messages of the two waits that Attach can time out in: for the VolumeAttachment to
+	// become attached, and for a VolumeAttachment that is being deleted to be gone.
+	attachTimeout := fmt.Sprintf("timed out waiting for external-attacher of %s CSI driver to attach volume", driverName)
+	detachTimeout := fmt.Sprintf("timed out waiting for external-attacher of %s CSI driver to detach volume", driverName)
+
+	makePV := func(name string, terminating bool) *v1.PersistentVolume {
+		pv := makeTestPV(name, 10, driverName, volumeHandle)
+		if terminating {
+			pv.DeletionTimestamp = new(metav1.Now())
+			pv.Finalizers = []string{"external-attacher/" + driverName}
+		}
+		return pv
+	}
+	// makeAttachment returns a VolumeAttachment that external-attacher has reported an
+	// attach error for, so no publish is in flight for it. It is marked attached on top of
+	// that when asked to: external-attacher does not report both, but status.attached must
+	// win over the error for an attacher that does.
+	makeAttachment := func(attached bool) *storage.VolumeAttachment {
+		attachment := makeTestAttachment(attachID, nodeName, stalePV)
+		attachment.UID = existingUID
+		attachment.Spec.Attacher = driverName
+		attachment.Status.Attached = attached
+		attachment.Status.AttachError = &storage.VolumeError{
+			Message: fmt.Sprintf("PersistentVolume %q is marked for deletion", stalePV),
+		}
+		return attachment
+	}
+	// makeAttachingAttachment returns a VolumeAttachment that external-attacher has not
+	// reported on yet, as if ControllerPublishVolume were still running for it.
+	makeAttachingAttachment := func() *storage.VolumeAttachment {
+		attachment := makeAttachment(false)
+		attachment.Status.AttachError = nil
+		return attachment
+	}
+	makeDeletedAttachment := func() *storage.VolumeAttachment {
+		attachment := makeAttachment(false)
+		attachment.DeletionTimestamp = new(metav1.Now())
+		return attachment
+	}
+	makeInlineAttachment := func() *storage.VolumeAttachment {
+		attachment := makeAttachment(false)
+		pvSpec := makePV(stalePV, true).Spec
+		attachment.Spec.Source = storage.VolumeAttachmentSource{InlineVolumeSpec: &pvSpec}
+		return attachment
+	}
+
+	testCases := []struct {
+		name string
+		// objs is what the API contains when the case starts, besides the PV to attach,
+		// which the harness adds. A PV that is missing from it is gone.
+		objs               []runtime.Object
+		existingAttachment *storage.VolumeAttachment
+		injectDeleteError  error
+		// injectVAFinalizer holds the VolumeAttachment Terminating when the attacher deletes
+		// it, the way external-attacher's finalizer does.
+		injectVAFinalizer bool
+		// specPVTerminating gives the PV to attach a deletionTimestamp.
+		specPVTerminating bool
+		// specPVGone keeps the PV to attach out of the API, as if its deletion had completed
+		// already.
+		specPVGone bool
+		// specInline attaches the spec as a migrated inline volume, whose PV is
+		// synthesized by the CSI translation and exists nowhere else.
+		specInline bool
+		// watchTimeout is how long Attach waits for the VolumeAttachment to reach the
+		// state it needs. Cases that expect it to give up cut it short: what they assert
+		// is decided before the wait starts, and the wait checks nothing before its first
+		// backoff expires anyway.
+		watchTimeout time.Duration
+		// expectAttachedPV is the PV that the VolumeAttachment is expected to refer to
+		// once it is attached. Empty means that the VolumeAttachment source is an inline
+		// volume spec.
+		expectAttachedPV   string
+		expectNoAttachment bool
+		// expectVAKept asserts that the VolumeAttachment the case started with is still the
+		// same object, rather than one that was deleted and created again.
+		expectVAKept       bool
+		expectErrorMessage string
+	}{
+		{
+			name:               "stale PV gone, replace VA",
+			existingAttachment: makeAttachment(false),
+			expectAttachedPV:   currentPV,
+		},
+		{
+			name:               "stale PV terminating, replace VA",
+			objs:               []runtime.Object{makePV(stalePV, true)},
+			existingAttachment: makeAttachment(false),
+			expectAttachedPV:   currentPV,
+		},
+		{
+			name:               "stale PV terminating, VA attached, keep",
+			objs:               []runtime.Object{makePV(stalePV, true)},
+			existingAttachment: makeAttachment(true),
+			expectAttachedPV:   stalePV,
+			expectVAKept:       true,
+		},
+		{
+			name:               "stale PV terminating, publish in flight, keep",
+			objs:               []runtime.Object{makePV(stalePV, true)},
+			existingAttachment: makeAttachingAttachment(),
+			expectAttachedPV:   stalePV,
+			expectVAKept:       true,
+			// lets Attach time out instead of attaching the volume as the other cases do:
+			// marking the VolumeAttachment attached would make it pass without the attacher
+			// ever having looked at it.
+			expectErrorMessage: attachTimeout,
+			watchTimeout:       10 * time.Millisecond,
+		},
+		{
+			name:               "stale PV alive, keep VA",
+			objs:               []runtime.Object{makePV(stalePV, false)},
+			existingAttachment: makeAttachment(false),
+			expectAttachedPV:   stalePV,
+			expectVAKept:       true,
+		},
+		{
+			name:       "inline spec, no PV lookup",
+			specInline: true,
+		},
+		{
+			name:               "VA with inline source, keep",
+			existingAttachment: makeInlineAttachment(),
+			expectVAKept:       true,
+		},
+		{
+			name:               "VA already deleting, wait for detach",
+			objs:               []runtime.Object{makePV(stalePV, true)},
+			existingAttachment: makeDeletedAttachment(),
+			expectAttachedPV:   stalePV,
+			expectVAKept:       true,
+			expectErrorMessage: detachTimeout,
+			watchTimeout:       10 * time.Millisecond,
+		},
+		{
+			name:               "spec PV terminating, no VA created",
+			specPVTerminating:  true,
+			expectNoAttachment: true,
+			expectErrorMessage: fmt.Sprintf("PersistentVolume %q is marked for deletion", currentPV),
+		},
+		{
+			name:               "spec PV gone, no VA created",
+			specPVGone:         true,
+			expectNoAttachment: true,
+			expectErrorMessage: fmt.Sprintf("persistentvolume %q not found", currentPV),
+		},
+		{
+			name:               "spec PV terminating, delete VA, no wait, create none",
+			specPVTerminating:  true,
+			existingAttachment: makeAttachment(false),
+			injectVAFinalizer:  true,
+			expectAttachedPV:   stalePV,
+			expectVAKept:       true,
+			expectErrorMessage: fmt.Sprintf("PersistentVolume %q is marked for deletion", currentPV),
+		},
+		{
+			name:               "delete conflict, keep VA",
+			existingAttachment: makeAttachment(false),
+			injectDeleteError:  apierrors.NewConflict(storage.Resource("volumeattachments"), attachID, fmt.Errorf("precondition failed")),
+			expectAttachedPV:   stalePV,
+			expectVAKept:       true,
+			expectErrorMessage: "failed to delete stale VolumeAttachment",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			specPV := makePV(currentPV, tc.specPVTerminating)
+			objs := tc.objs
+			if !tc.specPVGone && !tc.specInline {
+				objs = append(objs, specPV)
+			}
+			fakeClient := fakeclient.NewSimpleClientset(objs...)
+			fakeClient.PrependReactor("delete", "volumeattachments", func(action core.Action) (bool, runtime.Object, error) {
+				del := action.(core.DeleteActionImpl)
+				// A VolumeAttachment may only be deleted with preconditions, so that one that
+				// changed since it was read from the cache, and is attached by now, is not.
+				preconditions := del.DeleteOptions.Preconditions
+				if preconditions == nil || preconditions.ResourceVersion == nil || ptr.Deref(preconditions.UID, "") != existingUID {
+					t.Errorf("expecting UID %q and resourceVersion preconditions on the delete, got %+v", existingUID, preconditions)
+				}
+				switch {
+				case tc.injectDeleteError != nil:
+					return true, nil, tc.injectDeleteError
+				case tc.injectVAFinalizer:
+					markVolumeAttachmentTerminating(t, fakeClient, del)
+					return true, nil, nil
+				default:
+					return false, nil, nil
+				}
+			})
+
+			plug, _ := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
+
+			if tc.existingAttachment != nil {
+				// Create the VolumeAttachment through the client instead of seeding it into
+				// the fake client, and wait for the informer to serve it.
+				// Workaround lost delete events to informer #141528
+				if _, err := fakeClient.StorageV1().VolumeAttachments().Create(t.Context(), tc.existingAttachment, metav1.CreateOptions{}); err != nil {
+					t.Fatalf("failed to create the existing VolumeAttachment: %v", err)
+				}
+				if err := wait.PollUntilContextTimeout(t.Context(), time.Millisecond, wait.ForeverTestTimeout, true,
+					func(context.Context) (bool, error) {
+						_, err := plug.volumeAttachmentLister.Get(attachID)
+						return err == nil, nil
+					}); err != nil {
+					t.Fatalf("the informer did not observe the existing VolumeAttachment: %v", err)
+				}
+			}
+
+			attacher, err := plug.NewAttacher()
+			if err != nil {
+				t.Fatalf("failed to create new attacher: %v", err)
+			}
+			csiAttacher := getCsiAttacherFromVolumeAttacher(attacher, cmp.Or(tc.watchTimeout, testWatchFailTimeout))
+
+			var wg sync.WaitGroup
+			if tc.expectErrorMessage == "" {
+				wg.Go(func() {
+					// Let the Attach call finish by attaching the VolumeAttachment that it
+					// is waiting for, like external-attacher would.
+					markMatchingVolumeAttached(t, fakeClient, attachID, tc.expectAttachedPV)
+				})
+			}
+			spec := volume.NewSpecFromPersistentVolume(specPV, false)
+			spec.InlineVolumeSpecForCSIMigration = tc.specInline
+			_, err = csiAttacher.Attach(spec, types.NodeName(nodeName))
+			switch {
+			case tc.expectErrorMessage == "" && err != nil:
+				t.Errorf("expecting no failure, but got err: %v", err)
+			case tc.expectErrorMessage != "" && err == nil:
+				t.Errorf("expecting failure with %q, but got no err", tc.expectErrorMessage)
+			case tc.expectErrorMessage != "" && !strings.Contains(err.Error(), tc.expectErrorMessage):
+				t.Errorf("expecting failure with %q, but got err: %v", tc.expectErrorMessage, err)
+			}
+			wg.Wait()
+
+			attachment, err := fakeClient.StorageV1().VolumeAttachments().Get(t.Context(), attachID, metav1.GetOptions{})
+			if tc.expectNoAttachment {
+				if !apierrors.IsNotFound(err) {
+					t.Errorf("expecting no VolumeAttachment %s, got %+v (err: %v)", attachID, attachment, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("failed to get VolumeAttachment %s: %v", attachID, err)
+			}
+			if tc.expectAttachedPV == "" {
+				if attachment.Spec.Source.InlineVolumeSpec == nil {
+					t.Errorf("expecting VolumeAttachment with an inline volume spec, got %+v", attachment.Spec.Source)
+				}
+			} else if ptr.Deref(attachment.Spec.Source.PersistentVolumeName, "") != tc.expectAttachedPV {
+				t.Errorf("expecting VolumeAttachment of PV %q, got %+v", tc.expectAttachedPV, attachment.Spec.Source)
+			}
+			if tc.injectVAFinalizer && attachment.DeletionTimestamp == nil {
+				t.Errorf("expecting the stale VolumeAttachment to be deleted, but no delete was issued")
+			}
+			if (attachment.UID == existingUID) != tc.expectVAKept {
+				if tc.expectVAKept {
+					t.Errorf("expecting the existing VolumeAttachment to be kept, but it was recreated")
+				} else {
+					t.Errorf("expecting the existing VolumeAttachment to be replaced, but it was kept")
+				}
+			}
+		})
+	}
+}
+
+// flippingPVLister reports the named PersistentVolume as it is on the first Get and
+// terminating on every Get after that, as if it had been marked for deletion in between.
+// It is not safe for concurrent use.
+type flippingPVLister struct {
+	corelisters.PersistentVolumeLister
+	name string
+	seen bool
+}
+
+func (l *flippingPVLister) Get(name string) (*v1.PersistentVolume, error) {
+	pv, err := l.PersistentVolumeLister.Get(name)
+	if err != nil || name != l.name || !l.seen {
+		l.seen = l.seen || name == l.name
+		return pv, err
+	}
+	pv = pv.DeepCopy()
+	pv.DeletionTimestamp = new(metav1.Now())
+	return pv, nil
+}
+
+// TestAttacherAttachWithPVTerminatingBetweenReads covers a VolumeAttachment that refers to
+// the very PersistentVolume being attached, the one case in which Attach asks the lister
+// about the same PV twice. Both answers must come from the same read, so that this attempt
+// cannot delete the object because the PV is dying and then create a new one for that same
+// PV as if it were alive.
+func TestAttacherAttachWithPVTerminatingBetweenReads(t *testing.T) {
+	const (
+		driverName   = "driver01"
+		volumeHandle = "vol01"
+		nodeName     = "node01"
+		pvName       = "pv01"
+		existingUID  = "existing-uid"
+	)
+	attachID := GetVolumeAttachmentName(volumeHandle, driverName, nodeName)
+	pv := makeTestPV(pvName, 10, driverName, volumeHandle)
+
+	fakeClient := fakeclient.NewSimpleClientset(pv)
+	plug, _ := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
+
+	// A VolumeAttachment for this PV that external-attacher has already failed to attach.
+	attachment := makeTestAttachment(attachID, nodeName, pvName)
+	attachment.UID = existingUID
+	attachment.Spec.Attacher = driverName
+	attachment.Status.AttachError = &storage.VolumeError{Message: "mock error"}
+	if _, err := fakeClient.StorageV1().VolumeAttachments().Create(t.Context(), attachment, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to create the existing VolumeAttachment: %v", err)
+	}
+	if err := wait.PollUntilContextTimeout(t.Context(), time.Millisecond, wait.ForeverTestTimeout, true,
+		func(context.Context) (bool, error) {
+			_, err := plug.volumeAttachmentLister.Get(attachID)
+			return err == nil, nil
+		}); err != nil {
+		t.Fatalf("the informer did not observe the existing VolumeAttachment: %v", err)
+	}
+	plug.persistentVolumeLister = &flippingPVLister{PersistentVolumeLister: plug.persistentVolumeLister, name: pvName}
+
+	attacher, err := plug.NewAttacher()
+	if err != nil {
+		t.Fatalf("failed to create new attacher: %v", err)
+	}
+	// The attach cannot succeed: the PV looked alive when Attach decided to wait for the
+	// existing VolumeAttachment, and nothing attaches it. Give up quickly.
+	csiAttacher := getCsiAttacherFromVolumeAttacher(attacher, 10*time.Millisecond)
+	_, err = csiAttacher.Attach(volume.NewSpecFromPersistentVolume(pv, false), nodeName)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expecting a timeout waiting for the VolumeAttachment to be attached, got err: %v", err)
+	}
+
+	attachment, err = fakeClient.StorageV1().VolumeAttachments().Get(t.Context(), attachID, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get VolumeAttachment %s: %v", attachID, err)
+	}
+	if attachment.UID != existingUID {
+		t.Errorf("expecting the existing VolumeAttachment to be kept, but it was replaced")
+	}
+}
+
+// specPVObjects returns the PersistentVolume of the given spec, to be stored in a fake
+// client, if the spec has one that exists in the API. The synthesized PV of a migrated
+// inline volume does not: it is built by the CSI translation and never created anywhere.
+func specPVObjects(spec *volume.Spec) []runtime.Object {
+	if spec == nil || spec.PersistentVolume == nil || spec.InlineVolumeSpecForCSIMigration {
+		return nil
+	}
+	return []runtime.Object{spec.PersistentVolume}
+}
+
+// markVolumeAttachmentTerminating gives the VolumeAttachment of a delete request a
+// deletionTimestamp instead of removing it, the way the API server holds an object that a
+// finalizer still refers to. The fake client does not implement finalizers itself.
+func markVolumeAttachmentTerminating(t *testing.T, client *fakeclient.Clientset, del core.DeleteActionImpl) {
+	t.Helper()
+	obj, err := client.Tracker().Get(del.Resource, del.Namespace, del.Name)
+	if err != nil {
+		t.Errorf("failed to get VolumeAttachment %s: %v", del.Name, err)
+		return
+	}
+	attachment := obj.(*storage.VolumeAttachment)
+	attachment.DeletionTimestamp = new(metav1.Now())
+	if err := client.Tracker().Update(del.Resource, attachment, del.Namespace); err != nil {
+		t.Errorf("failed to mark VolumeAttachment %s Terminating: %v", del.Name, err)
+	}
+}
+
+// markMatchingVolumeAttached waits for a VolumeAttachment that refers to the given PV
+// (or, when pvName is empty, to an inline volume spec) and marks it as attached.
+func markMatchingVolumeAttached(t *testing.T, client clientset.Interface, attachID, pvName string) {
+	t.Helper()
+	err := wait.PollUntilContextTimeout(t.Context(), 10*time.Millisecond, testWatchTimeout, true,
+		func(ctx context.Context) (bool, error) {
+			attachment, err := client.StorageV1().VolumeAttachments().Get(ctx, attachID, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			if ptr.Deref(attachment.Spec.Source.PersistentVolumeName, "") != pvName {
+				return false, nil
+			}
+			if attachment.Status.Attached {
+				return true, nil
+			}
+			attachment.Status.Attached = true
+			attachment.Status.AttachError = nil
+			if _, err := client.StorageV1().VolumeAttachments().Update(ctx, attachment, metav1.UpdateOptions{}); err != nil {
+				if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
+					return false, nil
+				}
+				return false, err
+			}
+			return true, nil
+		})
+	if err != nil {
+		t.Errorf("failed to mark VolumeAttachment %s of PV %q attached: %v", attachID, pvName, err)
+	}
+}
+
 func TestAttacherWithCSIDriver(t *testing.T) {
 	tests := []struct {
 		name                   string
@@ -357,11 +785,12 @@ func TestAttacherWithCSIDriver(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fakeClient := fakeclient.NewSimpleClientset(
+			spec := volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, test.driver, "test-vol"), false)
+			fakeClient := fakeclient.NewSimpleClientset(append(specPVObjects(spec),
 				getTestCSIDriver("not-attachable", nil, &bFalse, nil),
 				getTestCSIDriver("attachable", nil, &bTrue, nil),
 				getTestCSIDriver("nil", nil, nil, nil),
-			)
+			)...)
 			plug, _ := newTestPluginWithAttachDetachVolumeHost(t, fakeClient)
 
 			attacher, err := plug.NewAttacher()
@@ -369,7 +798,6 @@ func TestAttacherWithCSIDriver(t *testing.T) {
 				t.Fatalf("failed to create new attacher: %v", err)
 			}
 			csiAttacher := getCsiAttacherFromVolumeAttacher(attacher, test.watchTimeout)
-			spec := volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, test.driver, "test-vol"), false)
 
 			pluginCanAttach, err := plug.CanAttach(spec)
 			if err != nil {

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -300,7 +300,7 @@ func (m *csiBlockMapper) SetUpDevice() (string, error) {
 	if !skip {
 		// Search for attachment by VolumeAttachment.Spec.Source.PersistentVolumeName
 		nodeName := string(m.plugin.host.GetNodeName())
-		attachID := getAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
+		attachID := GetVolumeAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
 		attachment, err = m.k8s.StorageV1().VolumeAttachments().Get(context.TODO(), attachID, meta.GetOptions{})
 		if err != nil {
 			return "", volumetypes.NewTransientOperationFailure(log("blockMapper.SetupDevice failed to get volume attachment [id=%v]: %v", attachID, err))
@@ -362,7 +362,7 @@ func (m *csiBlockMapper) MapPodDevice() (string, error) {
 	if !skip {
 		// Search for attachment by VolumeAttachment.Spec.Source.PersistentVolumeName
 		nodeName := string(m.plugin.host.GetNodeName())
-		attachID := getAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
+		attachID := GetVolumeAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
 		attachment, err = m.k8s.StorageV1().VolumeAttachments().Get(context.TODO(), attachID, meta.GetOptions{})
 		if err != nil {
 			return "", volumetypes.NewTransientOperationFailure(log("blockMapper.MapPodDevice failed to get volume attachment [id=%v]: %v", attachID, err))

--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -213,7 +213,7 @@ func TestBlockMapperSetupDevice(t *testing.T) {
 
 	csiMapper.csiClient = setupClient(t, true)
 
-	attachID := getAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), string(nodeName))
+	attachID := GetVolumeAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), string(nodeName))
 	attachment := makeTestAttachment(attachID, nodeName, pvName)
 	attachment.Status.Attached = true
 	_, err = csiMapper.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, metav1.CreateOptions{})
@@ -254,7 +254,7 @@ func TestBlockMapperSetupDeviceError(t *testing.T) {
 	fClient := csiMapper.csiClient.(*fakeCsiDriverClient)
 	fClient.nodeClient.SetNextError(status.Error(codes.InvalidArgument, "mock final error"))
 
-	attachID := getAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), string(nodeName))
+	attachID := GetVolumeAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), string(nodeName))
 	attachment := makeTestAttachment(attachID, nodeName, pvName)
 	attachment.Status.Attached = true
 	_, err = csiMapper.k8s.StorageV1().VolumeAttachments().Create(context.Background(), attachment, metav1.CreateOptions{})
@@ -299,7 +299,7 @@ func TestBlockMapperSetupDeviceNoClientError(t *testing.T) {
 
 	csiMapper.csiClient = setupClient(t, true)
 
-	attachID := getAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), string(nodeName))
+	attachID := GetVolumeAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), string(nodeName))
 	attachment := makeTestAttachment(attachID, nodeName, pvName)
 	attachment.Status.Attached = true
 	_, err = csiMapper.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, metav1.CreateOptions{})
@@ -337,7 +337,7 @@ func TestBlockMapperMapPodDevice(t *testing.T) {
 
 	csiMapper.csiClient = setupClient(t, true)
 
-	attachID := getAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), nodeName)
+	attachID := GetVolumeAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), nodeName)
 	attachment := makeTestAttachment(attachID, nodeName, pvName)
 	attachment.Status.Attached = true
 	_, err = csiMapper.k8s.StorageV1().VolumeAttachments().Create(context.Background(), attachment, metav1.CreateOptions{})
@@ -468,7 +468,7 @@ func TestBlockMapperMapPodDeviceNoClientError(t *testing.T) {
 
 	csiMapper.csiClient = setupClient(t, true)
 
-	attachID := getAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), nodeName)
+	attachID := GetVolumeAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), nodeName)
 	attachment := makeTestAttachment(attachID, nodeName, pvName)
 	attachment.Status.Attached = true
 	_, err = csiMapper.k8s.StorageV1().VolumeAttachments().Create(context.Background(), attachment, metav1.CreateOptions{})
@@ -516,7 +516,7 @@ func TestBlockMapperMapPodDeviceGetStageSecretsError(t *testing.T) {
 
 	csiMapper.csiClient = setupClient(t, true)
 
-	attachID := getAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), nodeName)
+	attachID := GetVolumeAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), nodeName)
 	attachment := makeTestAttachment(attachID, nodeName, pvName)
 	attachment.Status.Attached = true
 	if _, err = csiMapper.k8s.StorageV1().VolumeAttachments().Create(context.Background(), attachment, metav1.CreateOptions{}); err != nil {
@@ -663,7 +663,7 @@ func TestVolumeSetupTeardown(t *testing.T) {
 
 	csiMapper.csiClient = setupClient(t, true)
 
-	attachID := getAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), string(nodeName))
+	attachID := GetVolumeAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), string(nodeName))
 	attachment := makeTestAttachment(attachID, nodeName, pvName)
 	attachment.Status.Attached = true
 	_, err = csiMapper.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, metav1.CreateOptions{})
@@ -778,7 +778,7 @@ func TestUnmapPodDeviceNoClientError(t *testing.T) {
 
 	csiMapper.csiClient = setupClient(t, true)
 
-	attachID := getAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), string(nodeName))
+	attachID := GetVolumeAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), string(nodeName))
 	attachment := makeTestAttachment(attachID, nodeName, pvName)
 	attachment.Status.Attached = true
 	_, err = csiMapper.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, metav1.CreateOptions{})

--- a/pkg/volume/csi/csi_mounter.go
+++ b/pkg/volume/csi/csi_mounter.go
@@ -281,7 +281,7 @@ func (c *csiMountMgr) SetUpAt(dir string, mounterArgs volume.MounterArgs) error 
 		volDataKey.driverName:          string(c.driverName),
 		volDataKey.nodeName:            nodeName,
 		volDataKey.volumeLifecycleMode: string(c.volumeLifecycleMode),
-		volDataKey.attachmentID:        getAttachmentName(volumeHandle, string(c.driverName), nodeName),
+		volDataKey.attachmentID:        GetVolumeAttachmentName(volumeHandle, string(c.driverName), nodeName),
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.SELinuxMountReadWriteOncePod) && selinuxLabelMount {

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -71,7 +71,7 @@ func prepareVolumeInfoFile(mountPath string, plug *csiPlugin, specVolumeName, vo
 		volDataKey.volHandle:           volumeID,
 		volDataKey.driverName:          driverName,
 		volDataKey.nodeName:            nodeName,
-		volDataKey.attachmentID:        getAttachmentName(volumeID, driverName, nodeName),
+		volDataKey.attachmentID:        GetVolumeAttachmentName(volumeID, driverName, nodeName),
 		volDataKey.volumeLifecycleMode: lifecycleMode,
 		volDataKey.seLinuxMountContext: seLinuxMountContext,
 	}
@@ -263,7 +263,7 @@ func TestMounterSetUp(t *testing.T) {
 			csiMounter := mounter.(*csiMountMgr)
 			csiMounter.csiClient = setupClient(t, true)
 
-			attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
+			attachID := GetVolumeAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
 
 			attachment := &storage.VolumeAttachment{
 				ObjectMeta: meta.ObjectMeta{
@@ -451,7 +451,7 @@ func TestMounterSetupJsonFileHandling(t *testing.T) {
 			csiMounter := mounter.(*csiMountMgr)
 			csiMounter.csiClient = setupClient(t, true)
 
-			attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
+			attachID := GetVolumeAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
 			attachment := makeTestAttachment(attachID, "test-node", csiMounter.spec.Name())
 			_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{})
 			if err != nil {
@@ -592,7 +592,7 @@ func TestMounterSetUpSimple(t *testing.T) {
 				t.Fatal("unexpected volume mode: ", csiMounter.volumeLifecycleMode)
 			}
 
-			attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
+			attachID := GetVolumeAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
 			attachment := makeTestAttachment(attachID, "test-node", csiMounter.spec.Name())
 			_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{})
 			if err != nil {
@@ -767,7 +767,7 @@ func TestMounterSetupWithStatusTracking(t *testing.T) {
 			}
 
 			if tc.createAttachment {
-				attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
+				attachID := GetVolumeAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
 				attachment := makeTestAttachment(attachID, "test-node", csiMounter.spec.Name())
 				_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{})
 				if err != nil {
@@ -878,7 +878,7 @@ func TestMounterSetUpWithInline(t *testing.T) {
 			}
 
 			if csiMounter.volumeLifecycleMode == storage.VolumeLifecyclePersistent {
-				attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
+				attachID := GetVolumeAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
 				attachment := makeTestAttachment(attachID, "test-node", csiMounter.spec.Name())
 				_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{})
 				if err != nil {
@@ -1138,7 +1138,7 @@ func TestMounterSetUpWithFSGroup(t *testing.T) {
 		csiMounter := mounter.(*csiMountMgr)
 		csiMounter.csiClient = setupClientWithVolumeMountGroup(t, true /* stageUnstageSet */, tc.driverSupportsVolumeMountGroup)
 
-		attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
+		attachID := GetVolumeAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
 		attachment := makeTestAttachment(attachID, "test-node", pvName)
 
 		_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{})
@@ -1253,7 +1253,7 @@ func TestMounterSetUpFWithNodePublishFinalError(t *testing.T) {
 			csiMounter := mounter.(*csiMountMgr)
 			csiMounter.csiClient = setupClient(t, true)
 
-			attachID := getAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
+			attachID := GetVolumeAttachmentName(csiMounter.volumeID, string(csiMounter.driverName), string(plug.host.GetNodeName()))
 			attachment := makeTestAttachment(attachID, "test-node", csiMounter.spec.Name())
 			_, err = csiMounter.k8s.StorageV1().VolumeAttachments().Create(context.TODO(), attachment, meta.CreateOptions{})
 			if err != nil {

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
 	storagelisters "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
 	csitranslationplugins "k8s.io/csi-translation-lib/plugins"
@@ -69,6 +70,10 @@ type csiPlugin struct {
 	csiDriverInformer         cache.SharedIndexInformer
 	serviceAccountTokenGetter func(namespace, name string, tr *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 	volumeAttachmentLister    storagelisters.VolumeAttachmentLister
+	// persistentVolumeLister is only set when the plugin runs in the
+	// attach/detach controller. It is used to tell whether a PV that a
+	// VolumeAttachment refers to is being deleted.
+	persistentVolumeLister corelisters.PersistentVolumeLister
 }
 
 // ProbeVolumePlugins returns implemented plugins
@@ -299,6 +304,10 @@ func (p *csiPlugin) Init(host volume.VolumeHost) error {
 			if p.volumeAttachmentLister == nil {
 				klog.Error(log("VolumeAttachmentLister not found on AttachDetachVolumeHost"))
 			}
+			p.persistentVolumeLister = adcHost.PersistentVolumeLister()
+			if p.persistentVolumeLister == nil {
+				klog.Error(log("PersistentVolumeLister not found on AttachDetachVolumeHost"))
+			}
 		}
 		kletHost, ok := host.(volume.KubeletVolumeHost)
 		if ok {
@@ -312,6 +321,9 @@ func (p *csiPlugin) Init(host volume.VolumeHost) error {
 			}
 			// We don't run the volumeAttachmentLister in the kubelet context
 			p.volumeAttachmentLister = nil
+			// Attaching is not supported from the kubelet, so the kubelet has no
+			// use for the PersistentVolume lister either.
+			p.persistentVolumeLister = nil
 
 			informerFactory := kletHost.GetInformerFactory()
 			if informerFactory == nil {

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -214,7 +214,7 @@ func (p *csiPlugin) VerifyExhaustedResource(spec *volume.Spec) bool {
 	}
 
 	volumeHandle := spec.PersistentVolume.Spec.CSI.VolumeHandle
-	attachmentName := getAttachmentName(volumeHandle, pluginName, string(p.host.GetNodeName()))
+	attachmentName := GetVolumeAttachmentName(volumeHandle, pluginName, string(p.host.GetNodeName()))
 	kubeClient := p.host.GetKubeClient()
 
 	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
@@ -785,7 +785,7 @@ func (p *csiPlugin) NewBlockVolumeMapper(spec *volume.Spec, podRef *api.Pod) (vo
 
 	// persist volume info data for teardown
 	node := string(p.host.GetNodeName())
-	attachID := getAttachmentName(pvSource.VolumeHandle, pvSource.Driver, node)
+	attachID := GetVolumeAttachmentName(pvSource.VolumeHandle, pvSource.Driver, node)
 	volData := map[string]string{
 		volDataKey.specVolID:    spec.Name(),
 		volDataKey.volHandle:    pvSource.VolumeHandle,
@@ -924,7 +924,7 @@ func (p *csiPlugin) getPublishContext(client clientset.Interface, handle, driver
 		return nil, nil
 	}
 
-	attachID := getAttachmentName(handle, driver, nodeName)
+	attachID := GetVolumeAttachmentName(handle, driver, nodeName)
 
 	// search for attachment by VolumeAttachment.Spec.Source.PersistentVolumeName
 	attachment, err := client.StorageV1().VolumeAttachments().Get(context.TODO(), attachID, meta.GetOptions{})

--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -34,7 +34,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
-	utiltesting "k8s.io/client-go/util/testing"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/volume"
@@ -57,10 +56,7 @@ func newTestPluginWithAttachDetachVolumeHost(t *testing.T, client *fakeclient.Cl
 
 // create a plugin mgr to load plugins and setup a fake client
 func newTestPluginWithVolumeHost(t *testing.T, client *fakeclient.Clientset, hostType int) (*csiPlugin, string) {
-	tmpDir, err := utiltesting.MkTmpdir("csi-test")
-	if err != nil {
-		t.Fatalf("can't create temp dir: %v", err)
-	}
+	tmpDir := t.TempDir()
 
 	if client == nil {
 		client = fakeclient.NewSimpleClientset()
@@ -951,11 +947,7 @@ func TestPluginFindAttachablePlugin(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tmpDir, err := utiltesting.MkTmpdir("csi-test")
-			if err != nil {
-				t.Fatalf("can't create temp dir: %v", err)
-			}
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			client := fakeclient.NewSimpleClientset(
 				getTestCSIDriver(test.driverName, nil, &test.canAttach, nil),
@@ -1077,11 +1069,7 @@ func TestPluginFindDeviceMountablePluginBySpec(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tmpDir, err := utiltesting.MkTmpdir("csi-test")
-			if err != nil {
-				t.Fatalf("can't create temp dir: %v", err)
-			}
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			client := fakeclient.NewSimpleClientset(
 				&api.Node{

--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -75,10 +75,11 @@ func newTestPluginWithVolumeHost(t *testing.T, client *fakeclient.Clientset, hos
 	csiDriverLister := csiDriverInformer.Lister()
 	volumeAttachmentInformer := factory.Storage().V1().VolumeAttachments()
 	volumeAttachmentLister := volumeAttachmentInformer.Lister()
+	pvLister := factory.Core().V1().PersistentVolumes().Lister()
 
 	factory.Start(wait.NeverStop)
 	syncedTypes := factory.WaitForCacheSync(wait.NeverStop)
-	if len(syncedTypes) != 2 {
+	if len(syncedTypes) != 3 {
 		t.Fatalf("informers are not synced")
 	}
 	for ty, ok := range syncedTypes {
@@ -115,6 +116,7 @@ func newTestPluginWithVolumeHost(t *testing.T, client *fakeclient.Clientset, hos
 			"fakeNode",
 			csiDriverLister,
 			volumeAttachmentLister,
+			pvLister,
 		)
 	default:
 		t.Fatalf("Unsupported volume host type")

--- a/pkg/volume/csi/csi_test.go
+++ b/pkg/volume/csi/csi_test.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -249,7 +250,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 
 			factory := informers.NewSharedInformerFactory(client, time.Hour /* disable resync */)
 			csiDriverInformer := factory.Storage().V1().CSIDrivers()
-			volumeAttachmentInformer := factory.Storage().V1().VolumeAttachments()
+			vaLister := factory.Storage().V1().VolumeAttachments().Lister()
 			if driverInfo != nil {
 				csiDriverInformer.Informer().GetStore().Add(driverInfo)
 			}
@@ -263,7 +264,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 				ProbeVolumePlugins(),
 				"fakeNode",
 				csiDriverInformer.Lister(),
-				volumeAttachmentInformer.Lister(),
+				vaLister,
 			)
 			attachDetachPlugMgr := attachDetachVolumeHost.GetPluginMgr()
 			csiClient := setupClient(t, true)
@@ -305,14 +306,15 @@ func TestCSI_VolumeAll(t *testing.T) {
 				}
 
 				// creates VolumeAttachment and blocks until it is marked attached (done by external attacher)
-				go func() {
+				var attachWG sync.WaitGroup
+				attachWG.Go(func() {
 					attachID, err := volAttacher.Attach(volSpec, attachDetachVolumeHost.GetNodeName())
 					if err != nil {
 						t.Errorf("csiTest.VolumeAll attacher.Attach failed: %s", err)
 						return
 					}
 					t.Logf("csiTest.VolumeAll got attachID %s", attachID)
-				}()
+				})
 
 				// Simulates external-attacher and marks VolumeAttachment.Status.Attached = true
 				markVolumeAttached(t, attachDetachVolumeHost.GetKubeClient(), nil, attachName, storage.VolumeAttachmentStatus{Attached: true})
@@ -329,6 +331,9 @@ func TestCSI_VolumeAll(t *testing.T) {
 
 				t.Log("csiTest.VolumeAll attacher.WaitForAttach succeeded OK, attachment ID:", devicePath)
 
+				// Wait for the attach goroutine to observe the attachment before Detach deletes it.
+				attachWG.Wait()
+
 			} else {
 				t.Log("csiTest.VolumeAll volume attacher not found, skipping attachment")
 			}
@@ -342,7 +347,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 				ProbeVolumePlugins(),
 				"fakeNode",
 				csiDriverInformer.Lister(),
-				volumeAttachmentInformer.Lister(),
+				vaLister,
 			)
 			kubeletPlugMgr := kubeletVolumeHost.GetPluginMgr()
 

--- a/pkg/volume/csi/csi_test.go
+++ b/pkg/volume/csi/csi_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
-	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -222,11 +221,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tmpDir, err := utiltesting.MkTmpdir("csi-test")
-			if err != nil {
-				t.Fatalf("can't create temp dir: %v", err)
-			}
-			defer os.RemoveAll(tmpDir)
+			tmpDir := t.TempDir()
 
 			var driverInfo *storage.CSIDriver
 			objs := []runtime.Object{}

--- a/pkg/volume/csi/csi_test.go
+++ b/pkg/volume/csi/csi_test.go
@@ -241,6 +241,11 @@ func TestCSI_VolumeAll(t *testing.T) {
 				Spec: api.NodeSpec{},
 			})
 
+			volSpec := test.specFunc(test.specName, test.driver, test.volName)
+			if volSpec != nil && volSpec.PersistentVolume != nil {
+				objs = append(objs, volSpec.PersistentVolume)
+			}
+
 			client := fakeclient.NewSimpleClientset(objs...)
 
 			factory := informers.NewSharedInformerFactory(client, time.Hour /* disable resync */)
@@ -266,7 +271,6 @@ func TestCSI_VolumeAll(t *testing.T) {
 			attachDetachPlugMgr := attachDetachVolumeHost.GetPluginMgr()
 			csiClient := setupClient(t, true)
 
-			volSpec := test.specFunc(test.specName, test.driver, test.volName)
 			pod := test.podFunc()
 			attachName := GetVolumeAttachmentName(test.volName, test.driver, string(attachDetachVolumeHost.GetNodeName()))
 			t.Log("csiTest.VolumeAll starting...")

--- a/pkg/volume/csi/csi_test.go
+++ b/pkg/volume/csi/csi_test.go
@@ -246,6 +246,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 			factory := informers.NewSharedInformerFactory(client, time.Hour /* disable resync */)
 			csiDriverInformer := factory.Storage().V1().CSIDrivers()
 			vaLister := factory.Storage().V1().VolumeAttachments().Lister()
+			pvLister := factory.Core().V1().PersistentVolumes().Lister()
 			if driverInfo != nil {
 				csiDriverInformer.Informer().GetStore().Add(driverInfo)
 			}
@@ -260,6 +261,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 				"fakeNode",
 				csiDriverInformer.Lister(),
 				vaLister,
+				pvLister,
 			)
 			attachDetachPlugMgr := attachDetachVolumeHost.GetPluginMgr()
 			csiClient := setupClient(t, true)

--- a/pkg/volume/csi/csi_test.go
+++ b/pkg/volume/csi/csi_test.go
@@ -268,7 +268,7 @@ func TestCSI_VolumeAll(t *testing.T) {
 
 			volSpec := test.specFunc(test.specName, test.driver, test.volName)
 			pod := test.podFunc()
-			attachName := getAttachmentName(test.volName, test.driver, string(attachDetachVolumeHost.GetNodeName()))
+			attachName := GetVolumeAttachmentName(test.volName, test.driver, string(attachDetachVolumeHost.GetNodeName()))
 			t.Log("csiTest.VolumeAll starting...")
 
 			// *************** Attach/Mount volume resources ****************//

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
 	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -340,6 +341,8 @@ type AttachDetachVolumeHost interface {
 	CSINodeLister() storagelistersv1.CSINodeLister
 	// VolumeAttachmentLister returns the informer lister for the VolumeAttachment API Object
 	VolumeAttachmentLister() storagelistersv1.VolumeAttachmentLister
+	// PersistentVolumeLister returns the informer lister for the PersistentVolume API Object
+	PersistentVolumeLister() corelistersv1.PersistentVolumeLister
 	// IsAttachDetachController is an interface marker to strictly tie AttachDetachVolumeHost
 	// to the attachDetachController
 	IsAttachDetachController() bool

--- a/pkg/volume/testing/volume_host.go
+++ b/pkg/volume/testing/volume_host.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
 	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -66,6 +67,7 @@ type fakeVolumeHost struct {
 	node                   *v1.Node
 	csiDriverLister        storagelistersv1.CSIDriverLister
 	volumeAttachmentLister storagelistersv1.VolumeAttachmentLister
+	persistentVolumeLister corelistersv1.PersistentVolumeLister
 	informerFactory        informers.SharedInformerFactory
 	kubeletErr             error
 	mux                    sync.Mutex
@@ -229,17 +231,18 @@ type fakeAttachDetachVolumeHost struct {
 var _ AttachDetachVolumeHost = &fakeAttachDetachVolumeHost{}
 var _ FakeVolumeHost = &fakeAttachDetachVolumeHost{}
 
-func NewFakeAttachDetachVolumeHostWithCSINodeName(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, nodeName string, driverLister storagelistersv1.CSIDriverLister, volumeAttachLister storagelistersv1.VolumeAttachmentLister) FakeVolumeHost {
-	return newFakeAttachDetachVolumeHost(t, rootDir, kubeClient, plugins, nil, nodeName, driverLister, volumeAttachLister)
+func NewFakeAttachDetachVolumeHostWithCSINodeName(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, nodeName string, driverLister storagelistersv1.CSIDriverLister, volumeAttachLister storagelistersv1.VolumeAttachmentLister, pvLister corelistersv1.PersistentVolumeLister) FakeVolumeHost {
+	return newFakeAttachDetachVolumeHost(t, rootDir, kubeClient, plugins, nil, nodeName, driverLister, volumeAttachLister, pvLister)
 }
 
-func newFakeAttachDetachVolumeHost(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, pathToTypeMap map[string]hostutil.FileType, nodeName string, driverLister storagelistersv1.CSIDriverLister, volumeAttachLister storagelistersv1.VolumeAttachmentLister) FakeVolumeHost {
+func newFakeAttachDetachVolumeHost(t *testing.T, rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, pathToTypeMap map[string]hostutil.FileType, nodeName string, driverLister storagelistersv1.CSIDriverLister, volumeAttachLister storagelistersv1.VolumeAttachmentLister, pvLister corelistersv1.PersistentVolumeLister) FakeVolumeHost {
 	host := &fakeAttachDetachVolumeHost{}
 	host.rootDir = rootDir
 	host.kubeClient = kubeClient
 	host.nodeName = nodeName
 	host.csiDriverLister = driverLister
 	host.volumeAttachmentLister = volumeAttachLister
+	host.persistentVolumeLister = pvLister
 	host.mounter = mount.NewFakeMounter(nil)
 	host.hostUtil = hostutil.NewFakeHostUtil(pathToTypeMap)
 	host.pluginMgr = &VolumePluginMgr{}
@@ -286,6 +289,10 @@ func (f *fakeAttachDetachVolumeHost) CSIDriverLister() storagelistersv1.CSIDrive
 
 func (f *fakeAttachDetachVolumeHost) VolumeAttachmentLister() storagelistersv1.VolumeAttachmentLister {
 	return f.volumeAttachmentLister
+}
+
+func (f *fakeAttachDetachVolumeHost) PersistentVolumeLister() corelistersv1.PersistentVolumeLister {
+	return f.persistentVolumeLister
 }
 
 func (f *fakeAttachDetachVolumeHost) IsAttachDetachController() bool {

--- a/test/integration/volume/attach_detach_csi_test.go
+++ b/test/integration/volume/attach_detach_csi_test.go
@@ -1,0 +1,299 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoinformers "k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/pkg/controller/volume/attachdetach"
+	csiplugin "k8s.io/kubernetes/pkg/volume/csi"
+	"k8s.io/kubernetes/pkg/volume/util"
+	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	csiDriverName   = "csi-test-driver"
+	csiVolumeHandle = "test-volume-handle"
+	// testNodeName aligns with fakePodWithPVC.
+	testNodeName     = "node-sandbox"
+	stalePVFinalizer = "integration.test.k8s.io/keep-terminating"
+)
+
+// csiTestPV builds a PersistentVolume for the volume handle the tests share. Only the name
+// differs between the PVs they build, so they are all the same underlying volume and map to
+// one VolumeAttachment name on a node.
+func csiTestPV(name string) *v1.PersistentVolume {
+	return &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			Capacity: v1.ResourceList{
+				v1.ResourceStorage: resource.MustParse("5Gi"),
+			},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					Driver:       csiDriverName,
+					VolumeHandle: csiVolumeHandle,
+				},
+			},
+		},
+	}
+}
+
+// TestVolumeAttachmentOfTerminatingPVIsReplaced covers a workload whose PersistentVolume is
+// recreated under a new name for the same volume, as statically provisioned PVs are when the
+// workload is restarted. Two PVs then map to one VolumeAttachment, because its name is derived
+// from the volume handle and not from the PV.
+//
+// The attach of the first PV is still queued when that PV is deleted. external-attacher
+// refuses it from then on, so the VolumeAttachment created for it can never attach, and its
+// spec is immutable, so the controller has to delete it and create it again for the PV of the
+// new pod.
+func TestVolumeAttachmentOfTerminatingPVIsReplaced(t *testing.T) {
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	tCtx := ktesting.Init(t)
+	defer tCtx.Cancel("test has completed")
+
+	testClient, ctrl, informers := createCSIAdClients(tCtx, t, server)
+
+	ns := framework.CreateNamespaceOrDie(testClient, "test-previous-volumeattachment", t)
+	defer framework.DeleteNamespaceOrDie(testClient, ns, t)
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testNodeName,
+			Annotations: map[string]string{
+				util.ControllerManagedAttachAnnotation: "true",
+			},
+		},
+	}
+	if _, err := testClient.CoreV1().Nodes().Create(tCtx, node, metav1.CreateOptions{}); err != nil {
+		tCtx.Fatalf("Failed to create node: %v", err)
+	}
+
+	// The workload as it runs before it is restarted.
+	previousPV, previousPVC := createBoundCSIPVAndPVC(tCtx, testClient, ns.Name, "test-pv-previous", "test-pvc-previous")
+	previousPod := createCSITestPod(tCtx, testClient, ns.Name, "test-pod-previous", previousPVC.Name)
+
+	informers.Start(tCtx.Done())
+	informers.WaitForCacheSync(tCtx.Done())
+	go ctrl.Run(tCtx)
+
+	// The controller creates a VolumeAttachment for the PV of that pod and waits for
+	// external-attacher to attach it.
+	previousAttachment := waitForVolumeAttachment(tCtx, testClient, previousPV.Name)
+
+	// The workload is restarted while the volume is still not attached: its pod is
+	// replaced and its PV is recreated under a new name for the same volume handle.
+	if err := testClient.CoreV1().Pods(ns.Name).Delete(tCtx, previousPod.Name, *metav1.NewDeleteOptions(0)); err != nil {
+		tCtx.Fatalf("Failed to delete the pod of the previous generation: %v", err)
+	}
+	currentPV, currentPVC := createBoundCSIPVAndPVC(tCtx, testClient, ns.Name, "test-pv-current", "test-pvc-current")
+	currentPod := createCSITestPod(tCtx, testClient, ns.Name, "test-pod-current", currentPVC.Name)
+	terminatePV(tCtx, testClient, previousPV.Name)
+
+	// external-attacher refuses to attach a PV that is being deleted. This also ends the
+	// wait of the attach that is in flight, which would otherwise hold the volume for the
+	// CSI timeout.
+	refuseAttachment(tCtx, testClient, previousAttachment, previousPV.Name)
+
+	// The controller is expected to record the PV of the new pod, to replace the
+	// VolumeAttachment it created for the PV that is now being deleted, and to attach the
+	// volume for the pod that is left.
+	newAttachment := waitForVolumeAttachment(tCtx, testClient, currentPV.Name)
+	attachVolume(tCtx, testClient, newAttachment)
+	waitForVolumeToBeAttached(tCtx, t, testClient, currentPod.Name, testNodeName)
+}
+
+// createBoundCSIPVAndPVC creates a PersistentVolume for the volume handle the tests share
+// and a PersistentVolumeClaim bound to it, as the PV controller would leave them.
+func createBoundCSIPVAndPVC(tCtx ktesting.TContext, client clientset.Interface, namespace, pvName, pvcName string) (*v1.PersistentVolume, *v1.PersistentVolumeClaim) {
+	tCtx.Helper()
+
+	pv := csiTestPV(pvName)
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      pvcName,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
+			VolumeName:       pv.Name,
+			StorageClassName: new(""),
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("5Gi"),
+				},
+			},
+		},
+	}
+	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(tCtx, pvc, metav1.CreateOptions{})
+	if err != nil {
+		tCtx.Fatalf("Failed to create PVC %s: %v", pvcName, err)
+	}
+	pv.Spec.ClaimRef = &v1.ObjectReference{
+		Kind:      "PersistentVolumeClaim",
+		Namespace: namespace,
+		Name:      pvc.Name,
+		UID:       pvc.UID,
+	}
+	pv, err = client.CoreV1().PersistentVolumes().Create(tCtx, pv, metav1.CreateOptions{})
+	if err != nil {
+		tCtx.Fatalf("Failed to create PV %s: %v", pvName, err)
+	}
+	pvc.Status.Phase = v1.ClaimBound
+	pvc, err = client.CoreV1().PersistentVolumeClaims(namespace).UpdateStatus(tCtx, pvc, metav1.UpdateOptions{})
+	if err != nil {
+		tCtx.Fatalf("Failed to bind PVC %s: %v", pvcName, err)
+	}
+	return pv, pvc
+}
+
+// createCSITestPod creates a pod that is scheduled to the test node and uses the given
+// claim.
+func createCSITestPod(tCtx ktesting.TContext, client clientset.Interface, namespace, name, pvcName string) *v1.Pod {
+	tCtx.Helper()
+
+	// The claim of the fixture is not used, the tests create and bind their own.
+	pod, _ := fakePodWithPVC(name, pvcName, namespace)
+	pod, err := client.CoreV1().Pods(namespace).Create(tCtx, pod, metav1.CreateOptions{})
+	if err != nil {
+		tCtx.Fatalf("Failed to create pod %s: %v", name, err)
+	}
+	return pod
+}
+
+// terminatePV deletes the PersistentVolume but holds it in Terminating, the way the
+// external-attacher finalizer does while a VolumeAttachment still refers to it.
+func terminatePV(tCtx ktesting.TContext, client clientset.Interface, pvName string) {
+	tCtx.Helper()
+
+	pv, err := client.CoreV1().PersistentVolumes().Get(tCtx, pvName, metav1.GetOptions{})
+	if err != nil {
+		tCtx.Fatalf("Failed to get PV %s: %v", pvName, err)
+	}
+	pv.Finalizers = append(pv.Finalizers, stalePVFinalizer)
+	if _, err := client.CoreV1().PersistentVolumes().Update(tCtx, pv, metav1.UpdateOptions{}); err != nil {
+		tCtx.Fatalf("Failed to add a finalizer to PV %s: %v", pvName, err)
+	}
+	if err := client.CoreV1().PersistentVolumes().Delete(tCtx, pvName, metav1.DeleteOptions{}); err != nil {
+		tCtx.Fatalf("Failed to delete PV %s: %v", pvName, err)
+	}
+}
+
+func refuseAttachment(tCtx ktesting.TContext, client clientset.Interface, attachment *storagev1.VolumeAttachment, pvName string) {
+	tCtx.Helper()
+
+	attachment.Status.AttachError = &storagev1.VolumeError{
+		Time:    metav1.Now(),
+		Message: fmt.Sprintf("PersistentVolume %q is marked for deletion", pvName),
+	}
+	if _, err := client.StorageV1().VolumeAttachments().UpdateStatus(tCtx, attachment, metav1.UpdateOptions{}); err != nil {
+		tCtx.Fatalf("Failed to set the attach error on VolumeAttachment %s: %v", attachment.Name, err)
+	}
+}
+
+// waitForVolumeAttachment waits for the VolumeAttachment of the volume handle the tests
+// share to refer to the named PersistentVolume. Its spec is immutable, so an object that
+// refers to that PV is one that was created for it.
+func waitForVolumeAttachment(tCtx ktesting.TContext, client clientset.Interface, pvName string) *storagev1.VolumeAttachment {
+	tCtx.Helper()
+
+	attachmentName := csiplugin.GetVolumeAttachmentName(csiVolumeHandle, csiDriverName, testNodeName)
+	var attachment, lastSeen *storagev1.VolumeAttachment
+	err := wait.PollUntilContextTimeout(tCtx, 100*time.Millisecond, 30*time.Second, true,
+		func(ctx context.Context) (bool, error) {
+			found, err := client.StorageV1().VolumeAttachments().Get(ctx, attachmentName, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				lastSeen = nil
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			lastSeen = found
+			if ptr.Deref(found.Spec.Source.PersistentVolumeName, "") != pvName {
+				return false, nil
+			}
+			attachment = found
+			return true, nil
+		})
+	if err != nil {
+		tCtx.Fatalf("No VolumeAttachment %s referring to PV %s: %v, last seen: %+v",
+			attachmentName, pvName, err, lastSeen)
+	}
+	return attachment
+}
+
+// attachVolume marks the VolumeAttachment attached, the way external-attacher would.
+// Which volume the node reports as attached does not tell the PersistentVolumes of one
+// volume handle apart, they all map to one unique volume name, so it is the source of the
+// VolumeAttachment that the tests assert on.
+func attachVolume(tCtx ktesting.TContext, client clientset.Interface, attachment *storagev1.VolumeAttachment) {
+	tCtx.Helper()
+
+	attachment.Status.Attached = true
+	if _, err := client.StorageV1().VolumeAttachments().UpdateStatus(tCtx, attachment, metav1.UpdateOptions{}); err != nil {
+		tCtx.Fatalf("Failed to mark VolumeAttachment %s attached: %v", attachment.Name, err)
+	}
+}
+
+// createCSIAdClients creates an attach/detach controller that runs the CSI volume plugin.
+func createCSIAdClients(ctx context.Context, t *testing.T, server *kubeapiservertesting.TestServer) (*clientset.Clientset, attachdetach.AttachDetachController, clientgoinformers.SharedInformerFactory) {
+	testClient := clientset.NewForConfigOrDie(server.ClientConfig)
+	informers := clientgoinformers.NewSharedInformerFactory(testClient, 12*time.Hour)
+
+	ctrl, err := attachdetach.NewAttachDetachController(
+		ctx,
+		testClient,
+		informers.Core().V1().Pods(),
+		informers.Core().V1().Nodes(),
+		informers.Core().V1().PersistentVolumeClaims(),
+		informers.Core().V1().PersistentVolumes(),
+		informers.Storage().V1().CSINodes(),
+		informers.Storage().V1().CSIDrivers(),
+		informers.Storage().V1().VolumeAttachments(),
+		csiplugin.ProbeVolumePlugins(),
+		nil, /* prober */
+		false,
+		5*time.Second,
+		false,
+		defaultTimerConfig,
+	)
+	if err != nil {
+		t.Fatalf("Error creating AttachDetachController: %v", err)
+	}
+	return testClient, ctrl, informers
+}

--- a/test/integration/volume/attach_detach_csi_test.go
+++ b/test/integration/volume/attach_detach_csi_test.go
@@ -115,13 +115,16 @@ func TestVolumeAttachmentOfTerminatingPVIsReplaced(t *testing.T) {
 	// external-attacher to attach it.
 	previousAttachment := waitForVolumeAttachment(tCtx, testClient, previousPV.Name)
 
-	// The workload is restarted while the volume is still not attached: its pod is
-	// replaced and its PV is recreated under a new name for the same volume handle.
+	// The workload is restarted while the volume is still not attached: its PV is recreated
+	// under a new name for the same volume handle, and its pod is replaced by one that
+	// arrives before it is gone. The volume therefore never leaves the desired state of
+	// world, so the controller has to replace the PersistentVolume recorded for it rather
+	// than record the new one when the volume is added.
+	currentPV, currentPVC := createBoundCSIPVAndPVC(tCtx, testClient, ns.Name, "test-pv-current", "test-pvc-current")
+	currentPod := createCSITestPod(tCtx, testClient, ns.Name, "test-pod-current", currentPVC.Name)
 	if err := testClient.CoreV1().Pods(ns.Name).Delete(tCtx, previousPod.Name, *metav1.NewDeleteOptions(0)); err != nil {
 		tCtx.Fatalf("Failed to delete the pod of the previous generation: %v", err)
 	}
-	currentPV, currentPVC := createBoundCSIPVAndPVC(tCtx, testClient, ns.Name, "test-pv-current", "test-pvc-current")
-	currentPod := createCSITestPod(tCtx, testClient, ns.Name, "test-pod-current", currentPVC.Name)
 	terminatePV(tCtx, testClient, previousPV.Name)
 
 	// external-attacher refuses to attach a PV that is being deleted. This also ends the

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -690,17 +690,14 @@ func waitForPodDeletionTimestampToSet(tCtx context.Context, t *testing.T, testin
 
 // Wait for VolumeAttach added to node
 func waitForVolumeToBeAttached(ctx context.Context, t *testing.T, testingClient *clientset.Clientset, podName, nodeName string) {
-	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 120*time.Second, false, func(context.Context) (bool, error) {
-		node, err := testingClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
-		if len(node.Status.VolumesAttached) >= 1 {
-			return true, nil
-		}
+	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 120*time.Second, false, func(ctx context.Context) (bool, error) {
+		node, err := testingClient.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
 		if err != nil {
-			t.Fatalf("Failed to get the node : %v", err)
+			return false, err
 		}
-		return false, nil
+		return len(node.Status.VolumesAttached) >= 1, nil
 	}); err != nil {
-		t.Fatalf("Failed to attach volume to pod: %s for node: %s", podName, nodeName)
+		t.Fatalf("Failed to attach volume to pod: %s for node: %s: %v", podName, nodeName, err)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A `VolumeAttachment` is named `csi-<sha256(volumeHandle + driver + nodeName)>` — the PV name does not take part in it — while `spec.source.persistentVolumeName` is immutable. Several PVs can therefore map to one `VolumeAttachment` name on a node, which is exactly what happens when a workload controller recreates its PVs under new names on every restart, a common pattern for statically provisioned RWX volumes: the PV name changes, the volume handle does not.

If such a PV is deleted while its attach is still queued, external-attacher [refuses it](https://github.com/kubernetes-csi/external-attacher/blob/v4.9.0/pkg/controller/csi_handler.go#L452-L455) before it publishes anything or adds any finalizer, and the never-attached `VolumeAttachment` outlives the PV:

```
attachError: PersistentVolume "pv-of-the-previous-generation" is marked for deletion
```

From then on it blocks attaching *every* later PV that shares the volume handle on that node: `csiAttacher.Attach` finds an object with the expected name, skips creation, and waits for a `status.attached` that can never be set. The controller cannot recover on its own, because the only code that deletes the object is the detach path, and that path is not evaluated while a pod keeps the volume in the desired state of world (the `MountedByNode` check sits *inside* `reconciler.go`'s `!dsw.VolumeExists(...)` branch). A pod scheduled onto such a node stays `Pending` until something external deletes the object.

Two things have to change for the controller to recover on its own.

**The CSI attacher stops keeping, and creating, objects that can never attach.**

- **Delete a `VolumeAttachment` that refers to a PV that is being deleted or gone, is not attached, and records an attach error**, then create one for the PV that is actually being attached. Deleting is safe precisely because it is not attached: the kubelet gates `NodeStageVolume`/`NodePublishVolume` on `status.attached`, so the volume was never mounted through this object. Once the PV is marked for deletion, external-attacher refuses every further attempt, so the error appears and the object is replaced on the next attach attempt. By checking `attachError` we try not to abort an attach that is in flight, which may still succeed.
- **Do not create a `VolumeAttachment` for a PV that is being deleted or already gone.** This ensures we at most delete `VolumeAttachment` once per PV with above feature. i.e., it is self-limiting and cannot issue unbounded numbers of API calls. The VA would achieve nothing anyway, but poison the next PV for the same volume handle. The pod's `FailedAttachVolume` event is worded as external-attacher words them.

Both checks read the PV from the attach/detach controller's existing informer: no new informer, no API call per attach attempt.

**The desired state of world stops handing the attacher a PV that cannot be attached.** `AddPod` recorded the volume spec only when it inserted the volume, so the PV of whichever pod got there first decided which PV the attacher references, for as long as any pod kept the volume on the node — including after that pod, and its PV, were gone. It now records the spec of the pod being processed, unless that PV is being deleted: a `deletionTimestamp` is never cleared, so a PV that cannot be attached never displaces one that can, and the volume never goes back to a PV of a previous generation. 25 lines in one file, no new dependency, and the recorded spec stops being frozen at the revision the first pod observed, which the multi-attach and attachability checks read.

Seven commits, the last two independently reviewable and revertable:

1. register the VolumeAttachment informer before the factory starts in `TestCSI_VolumeAll`, and wait for the attach goroutine before detaching — a test-only fix the rest of the series builds on
2. switch the CSI volume tests to `t.TempDir`, so the attacher commit's new test call sites need no `defer os.RemoveAll` (an errcheck requirement)
3. plumb the attach/detach controller's PV lister into the CSI volume plugin
4. rename `getAttachmentName` to `GetVolumeAttachmentName`, so the integration test does not carry a second copy of the hash
5. fix the `waitForVolumeToBeAttached` integration helper this PR starts using
6. the attacher change
7. the desired state of world change

#### Which issue(s) this PR is related to:

N/A

Related to #141385 ("Remove optimistic `MountedByNode` default in `AddVolumeNode`"), which covers the complementary half of this failure mode: that one lets the controller detach and rebind a stale `VolumeAttachment` while no pod wants the volume, the last commit here handles the case where a pod is already back on the node and the detach path is therefore never reached. Neither subsumes the other.

#### Special notes for your reviewer:

We check `VolumeAttachment` for `attached == false` and `attachError != nil`, which means external-attacher has already tried at least once to attach the volume but failed.
- An already-attached `VolumeAttachment` is deliberately left alone, so the legitimate case keeps working: old PVs stuck in Terminating while new Pods keep running on the node.
- A `VolumeAttachment` with `attachError == nil` is also kept: an attach may be in flight, so we wait and see whether it becomes attached. `waitForVolumeAttachmentWithLister` already exits the loop on either outcome.

**Behaviour change to weigh.** A `VolumeAttachment` we delete would most likely never have succeeded anyway, since its PV is marked for deletion. But there is one case we still miss: publish start -> publish failed -> publish retry -> delete PV -> publish success. In this case, before the change, the VA could reach the attached state, but with this change we delete the VA after the PV is marked for deletion. If the pod still references a live PV, the volume is unpublished and published once more, and that the pod waits for the desired state of world to record a PV that can be attached: at most one populator pass, 3 minutes by default, plus one attach retry backoff. Otherwise, if the pod references no live PV, it will stuck forever. I think this is already racing and narrow enough to just accept.

**The PV recorded for a volume is now unstable.** While two pods on a node disagree about which PV backs one volume, the last one processed wins. Only the multi-attach check can observe that, by reading the access modes of either PV — two PVs of one handle that disagree on them is a misconfiguration that arrival order already decided before this PR. Nothing else compares PV names: the `VolumeAttachment`, `node.status.volumesAttached` and the kubelet's `WaitForAttach` are keyed on the volume handle, the attacher replaces an object on the deletion of the PV it refers to rather than on its name, and attach operations stay serialised because an operation key with an empty node name matches every node for the volume.

**We cannot lift the limit from external-attacher.** That refusal ([csi_handler.go:452-454](https://github.com/kubernetes-csi/external-attacher/blob/v4.9.0/pkg/controller/csi_handler.go#L452-L454)) is not incidental: together with the PV finalizer it maintains the invariant that *the PV named by a `VolumeAttachment` exists for as long as that `VolumeAttachment` does*. The finalizer holds a PV that is being deleted in place while any object still references it, and the refusal stops new references from appearing — which matters because the sidecar drops the finalizer as soon as the last reference goes, and the PV object disappears with it. A `VolumeAttachment` naming a PV that is already gone can never be detached, because the detach path needs the PV to build the unpublish request ([csi_handler.go:552-554](https://github.com/kubernetes-csi/external-attacher/blob/v4.9.0/pkg/controller/csi_handler.go#L552-L554)). A sidecar that attached PVs marked for deletion would therefore be breaking that invariant.

<details>
<summary><b>Alternative considered: keep the desired state of world stable, and delete the object when it names a different PV</b></summary>

The same guards carry over — delete only an object that is not attached and records an attach error — so this is not mainly about safety, but about where the rule lives.

- **It makes the attacher depend on an invariant that cannot hold.** A `deletionTimestamp` is set once and never cleared, so keying on it costs at most one create and one delete per PV generation, for the life of the cluster: the decision is a pure function of the object and its own PV. A name rule is bounded only while the cache keeps what it records stable — which cannot survive a restart: the desired state of world is rebuilt from whichever pod is processed first, so wherever two pods on a node disagree the PV it records is arbitrary again. Every restart can then delete and recreate the objects that lost that coin flip, a burst with no bound over time, and none of that work can achieve anything: an object that names a live PV of the same handle is already as good as the one that would replace it.
- **It cleans up later.** Deleting on PV deletion happens on the first attach attempt after the PV is marked for deletion. A name rule waits for a pod that brings a different PV, so an object that can never attach survives until then, and external-attacher keeps picking it up to rewrite the same `attachError` — 18% of its API budget in the incident below.
- **It puts the informer read in the component that had none.** The attacher already reads `VolumeAttachment`s and `CSIDriver`s from listers; the desired state of world holds no external state at all, and a cache that has to stay stable would need a PV lister of its own to see that the PV it recorded is gone while no pod references it.
</details>

**Tests.**

- `TestAttacherAttachWithPVBeingDeleted` tables the states a `VolumeAttachment` and the two PersistentVolumes it can be caught between are in — referenced PV alive, terminating or gone; object attached, failed, publishing or already being deleted; source a PV name or an inline spec. Every guard in the new code has a case that fails when that guard is removed, so the table is the specification.
- Two properties are about sequence rather than state, so they sit outside it: one case's delete only marks the object `Terminating`, as external-attacher's finalizer does, and pins that no attach waits for a detach it does not need; `TestAttacherAttachWithPVTerminatingBetweenReads` reports the PV alive on the first read and terminating afterwards, pinning that both decisions about one PersistentVolume come from one read of it.
- `Test_AddPod_Positive_SeveralPVsOfOneVolume` tables the pairs of specs that can reach one volume: some of its cases fail if the recorded spec is never replaced, the rest if it is always replaced.
- `TestVolumeAttachmentOfTerminatingPVIsReplaced` covers the recovery against an apiserver, with the real attach/detach controller and CSI volume plugin: a pod whose attach is still queued when its PV is deleted, and a second pod that needs the same volume handle through a PV of its own. The attacher commit adds it with the first pod gone before the second arrives, which the attacher alone recovers from. The last commit only moves the second pod ahead of that deletion, so that the volume never leaves the desired state of world, and the test then fails without the change under it. Neutering the PV lookup fails it in either arrangement.

**Where this came from.** A 2300-pod gang job on a 10000-node cluster, RWX volumes whose PVs are recreated on every job restart. Deleting one PV invalidated the queued attach of 2304 nodes at once; external-attacher was API-QPS-bound at ~22 attaches/s with ~100s of queue latency, so 1629 of 4187 `VolumeAttachment`s created in that round were processed after their PV had been deleted. 439 were cleaned up before the next pod arrived; the other 1190 had a pod back on the node first and never recovered — 710 pods, none of which ever started. The stale objects also spent 18% of the sidecar's API budget rewriting `attachError` (6.8 rewrites per object) without making progress, and operators eventually cleared PV finalizers by hand, which wedged the volumes permanently in `attached=true` with `detachError: persistentvolume not found`. These changes remove the leftover objects that made those failures outlast the pods that caused them, and with them the reason to clear a PV finalizer by hand.

This PR was written in part with the assistance of generative AI. I reviewed and fully understand each change.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where a CSI volume could never be attached on a node again once a PersistentVolume was deleted while its attach was still queued, leaving pods that use another PersistentVolume for the same volume stuck in Pending with FailedAttachVolume events. This can happen when PersistentVolumes are recreated under new names for the same underlying volume.
```
