### PR TITLE
kubeadm: remove dead code from upgrade enforceRequirements

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -68,7 +68,6 @@ type applyData struct {
 	renewCerts                bool
 	allowExperimentalUpgrades bool
 	allowRCUpgrades           bool
-	printConfig               bool
 	cfg                       *kubeadmapi.UpgradeConfiguration
 	initCfg                   *kubeadmapi.InitConfiguration
 	client                    clientset.Interface
@@ -287,7 +286,6 @@ func newApplyData(cmd *cobra.Command, args []string, applyFlags *applyFlags) (*a
 		renewCerts:                *renewCerts,
 		allowExperimentalUpgrades: *allowExperimentalUpgrades,
 		allowRCUpgrades:           *allowRCUpgrades,
-		printConfig:               *printConfig,
 		cfg:                       upgradeCfg,
 		initCfg:                   initCfg,
 		client:                    client,

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -29,7 +29,6 @@ import (
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/ptr"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmapiv1 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta4"
@@ -48,8 +47,9 @@ import (
 	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 )
 
-// enforceRequirements verifies that it's okay to upgrade and then returns the variables needed for the rest of the procedure
-func enforceRequirements(flagSet *pflag.FlagSet, flags *applyPlanFlags, args []string, dryRun bool, upgradeApply bool, printer output.Printer) (clientset.Interface, upgrade.VersionGetter, *kubeadmapi.InitConfiguration, *kubeadmapi.UpgradeConfiguration, error) {
+// enforceRequirements verifies that it's okay to upgrade and then returns the variables needed for the rest of the procedure.
+// It is only used by `kubeadm upgrade plan`, which never applies changes and therefore never dry-runs.
+func enforceRequirements(flagSet *pflag.FlagSet, flags *applyPlanFlags, args []string, printer output.Printer) (clientset.Interface, upgrade.VersionGetter, *kubeadmapi.InitConfiguration, *kubeadmapi.UpgradeConfiguration, error) {
 	externalCfg := &kubeadmapiv1.UpgradeConfiguration{}
 	opt := configutil.LoadOrDefaultConfigurationOptions{}
 	upgradeCfg, err := configutil.LoadOrDefaultUpgradeConfiguration(flags.cfgPath, externalCfg, opt)
@@ -57,34 +57,17 @@ func enforceRequirements(flagSet *pflag.FlagSet, flags *applyPlanFlags, args []s
 		return nil, nil, nil, nil, errors.Wrap(err, "[upgrade/upgrade config] FATAL")
 	}
 
-	// `dryRun` should be always be `false` for `kubeadm plan`.
-	isDryRun := ptr.To(false)
-	printConfigCfg := upgradeCfg.Plan.PrintConfig
-	ignoreErrCfg := upgradeCfg.Plan.IgnorePreflightErrors
-	ok := false
-	if upgradeApply {
-		printConfigCfg = upgradeCfg.Apply.PrintConfig
-		ignoreErrCfg = upgradeCfg.Apply.IgnorePreflightErrors
-		isDryRun, ok = cmdutil.ValueFromFlagsOrConfig(flagSet, options.DryRun, upgradeCfg.Apply.DryRun, &dryRun).(*bool)
-		if !ok {
-			return nil, nil, nil, nil, cmdutil.TypeMismatchErr("dryRun", "bool")
-		}
-	}
+	const isDryRun = false
 
-	client, err := getClient(flags.kubeConfigPath, *isDryRun, printer)
+	client, err := getClient(flags.kubeConfigPath, isDryRun, printer)
 	if err != nil {
 		return nil, nil, nil, nil, errors.Wrapf(err, "couldn't create a Kubernetes client from file %q", flags.kubeConfigPath)
 	}
 
-	ignorePreflightErrorsSet, err := validation.ValidateIgnorePreflightErrors(flags.ignorePreflightErrors, ignoreErrCfg)
+	// The union of pre-flight errors is not stored back into .Plan.IgnorePreflightErrors as it's not used.
+	ignorePreflightErrorsSet, err := validation.ValidateIgnorePreflightErrors(flags.ignorePreflightErrors, upgradeCfg.Plan.IgnorePreflightErrors)
 	if err != nil {
 		return nil, nil, nil, nil, err
-	}
-
-	// Also set the union of pre-flight errors to UpgradeConfiguration, to provide a consistent view of the runtime configuration.
-	// .Plan.IgnorePreflightErrors is not set as it's not used.
-	if upgradeApply {
-		upgradeCfg.Apply.IgnorePreflightErrors = sets.List(ignorePreflightErrorsSet)
 	}
 
 	// Ensure the user is root
@@ -101,41 +84,14 @@ func enforceRequirements(flagSet *pflag.FlagSet, flags *applyPlanFlags, args []s
 		return nil, nil, nil, nil, errors.Wrap(err, "[upgrade/init config] FATAL")
 	}
 
-	// Set the ImagePullPolicy and ImagePullSerial from the UpgradeApplyConfiguration to the InitConfiguration.
-	// These are used by preflight.RunPullImagesCheck() when running 'apply'.
-	if upgradeApply {
-		initCfg.NodeRegistration.ImagePullPolicy = upgradeCfg.Apply.ImagePullPolicy
-		initCfg.NodeRegistration.ImagePullSerial = upgradeCfg.Apply.ImagePullSerial
-	}
-
 	newK8sVersion := upgradeCfg.Plan.KubernetesVersion
-	if upgradeApply {
-		newK8sVersion = upgradeCfg.Apply.KubernetesVersion
-		// The version arg is mandatory, during upgrade apply, unless it's specified in the config file
-		if newK8sVersion == "" {
-			if err := cmdutil.ValidateExactArgNumber(args, []string{"version"}); err != nil {
-				return nil, nil, nil, nil, err
-			}
-		}
-	}
-
 	// If option was specified in both args and config file, args will overwrite the config file.
 	if len(args) == 1 {
 		newK8sVersion = args[0]
 	}
 
-	if upgradeApply {
-		// The `upgrade apply` version always overwrites the KubernetesVersion in the returned cfg with the target
-		// version. While this is not the same for `upgrade plan` where the KubernetesVersion should be the old
-		// one (because the call to getComponentConfigVersionStates requires the currently installed version).
-		// This also makes the KubernetesVersion value returned for `upgrade plan` consistent as that command
-		// allows to not specify a target version in which case KubernetesVersion will always hold the currently
-		// installed one.
-		initCfg.KubernetesVersion = newK8sVersion
-	}
-
 	// Run healthchecks against the cluster
-	if err := upgrade.CheckClusterHealth(client, &initCfg.ClusterConfiguration, ignorePreflightErrorsSet, dryRun, printer); err != nil {
+	if err := upgrade.CheckClusterHealth(client, &initCfg.ClusterConfiguration, ignorePreflightErrorsSet, isDryRun, printer); err != nil {
 		return nil, nil, nil, nil, errors.Wrap(err, "[upgrade/health] FATAL")
 	}
 
@@ -147,7 +103,7 @@ func enforceRequirements(flagSet *pflag.FlagSet, flags *applyPlanFlags, args []s
 	}
 
 	// If the user told us to print this information out; do it!
-	printConfig, ok := cmdutil.ValueFromFlagsOrConfig(flagSet, options.PrintConfig, printConfigCfg, &flags.printConfig).(*bool)
+	printConfig, ok := cmdutil.ValueFromFlagsOrConfig(flagSet, options.PrintConfig, upgradeCfg.Plan.PrintConfig, &flags.printConfig).(*bool)
 	if ok && *printConfig {
 		printConfiguration(&initCfg.ClusterConfiguration, os.Stdout, printer)
 	} else if !ok {

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -50,7 +50,6 @@ func TestEnforceRequirements(t *testing.T) {
 	tcases := []struct {
 		name               string
 		newK8sVersion      string
-		dryRun             bool
 		flags              applyPlanFlags
 		expectedErr        string
 		expectedErrNonRoot string
@@ -81,7 +80,7 @@ func TestEnforceRequirements(t *testing.T) {
 	}
 	for _, tt := range tcases {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, _, _, err := enforceRequirements(&pflag.FlagSet{}, &tt.flags, nil, tt.dryRun, false, &output.TextPrinter{})
+			_, _, _, _, err := enforceRequirements(&pflag.FlagSet{}, &tt.flags, nil, &output.TextPrinter{})
 			if err == nil && len(tt.expectedErr) != 0 {
 				t.Error("Expected error, but got success")
 			}

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -101,7 +101,7 @@ func runPlan(flagSet *pflag.FlagSet, flags *planFlags, args []string, printer ou
 	// Start with the basics, verify that the cluster is healthy, build a client and a versionGetter. Never dry-run when planning.
 	klog.V(1).Infoln("[upgrade/plan] verifying health of cluster")
 	klog.V(1).Infoln("[upgrade/plan] retrieving configuration from cluster")
-	client, versionGetter, initCfg, upgradeCfg, err := enforceRequirements(flagSet, flags.applyPlanFlags, args, false, false, printer)
+	client, versionGetter, initCfg, upgradeCfg, err := enforceRequirements(flagSet, flags.applyPlanFlags, args, printer)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

`enforceRequirements` in `cmd/kubeadm/app/cmd/upgrade/common.go` is only called from `kubeadm upgrade plan` now that `kubeadm upgrade apply` runs through the phase workflow (`newApplyData` + `cmd/phases/upgrade/apply/preflight.go`). Its `dryRun` and `upgradeApply` parameters were therefore always `false`, leaving several `if upgradeApply` branches unreachable (~40 lines of dead code).

This also removes a latent inconsistency where `getClient()` used the locally computed `isDryRun` while `CheckClusterHealth()` used the raw `dryRun` argument, which could have silently diverged if the two paths were ever exercised together.

No behavioral change: `kubeadm upgrade plan` always exercised the `upgradeApply == false` path, so the removed branches never executed.

Also drops `applyData.printConfig`, a field that was written but never read (the config print already happens inline in `newApplyData`).

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
