### PR TITLE
cronjob: treat NotFound on job delete as success

### DIFF
--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -766,10 +766,17 @@ func (jm *ControllerV2) removeOldestJobs(ctx context.Context, cj *batchv1.CronJo
 	return updateStatus
 }
 
-// deleteJob reaps a job, deleting the job, the pods and the reference in the active list
+// deleteJob reaps a job, deleting the job, the pods and the reference in the active list.
+// A NotFound error is treated as success: the job is already gone, which is the
+// desired state (for example a previous sync deleted it before the job informer caught up).
 func deleteJob(logger klog.Logger, cj *batchv1.CronJob, job *batchv1.Job, jc jobControlInterface, recorder record.EventRecorder) bool {
 	// delete the job itself...
 	if err := jc.DeleteJob(job.Namespace, job.Name); err != nil {
+		if errors.IsNotFound(err) {
+			logger.V(4).Info("Job has already been deleted", "job", klog.KObj(job), "cronjob", klog.KObj(cj))
+			deleteFromActiveList(cj, job.ObjectMeta.UID)
+			return true
+		}
 		recorder.Eventf(cj, corev1.EventTypeWarning, "FailedDelete", "Deleted job: %v", err)
 		logger.Error(err, "Error deleting job from cronjob", "job", klog.KObj(job), "cronjob", klog.KObj(cj))
 		return false

--- a/pkg/controller/cronjob/cronjob_controllerv2_test.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2_test.go
@@ -1946,3 +1946,65 @@ func TestControllerV2ProcessNextItemClearFailureRate(t *testing.T) {
 		}
 	})
 }
+
+func TestControllerV2DeleteJob(t *testing.T) {
+	tests := []struct {
+		name              string
+		deleteErr         error
+		expectedSucceeded bool
+		expectedActive    int
+		expectedEvents    []string
+	}{
+		{
+			name:              "job deleted successfully",
+			deleteErr:         nil,
+			expectedSucceeded: true,
+			expectedActive:    0,
+			expectedEvents:    []string{"Normal SuccessfulDelete Deleted job my-job"},
+		},
+		{
+			name:              "job already deleted",
+			deleteErr:         errors.NewNotFound(schema.GroupResource{Group: "batch", Resource: "jobs"}, "my-job"),
+			expectedSucceeded: true,
+			expectedActive:    0,
+			expectedEvents:    []string{},
+		},
+		{
+			name:              "job deletion failed",
+			deleteErr:         fmt.Errorf("api server down"),
+			expectedSucceeded: false,
+			expectedActive:    1,
+			expectedEvents:    []string{"Warning FailedDelete Deleted job: api server down"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+			cj := cronJob()
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-job",
+					Namespace: cj.Namespace,
+					UID:       types.UID("j1234"),
+				},
+			}
+			cj.Status.Active = []v1.ObjectReference{{UID: job.UID, Name: job.Name, Namespace: job.Namespace}}
+			jc := &fakeJobControl{Err: tc.deleteErr}
+			recorder := record.NewFakeRecorder(10)
+			succeeded := deleteJob(logger, &cj, job, jc, recorder)
+			if succeeded != tc.expectedSucceeded {
+				t.Errorf("deleteJob() = %t, want %t", succeeded, tc.expectedSucceeded)
+			}
+			if len(cj.Status.Active) != tc.expectedActive {
+				t.Errorf("got %d active jobs, want %d", len(cj.Status.Active), tc.expectedActive)
+			}
+			events := []string{}
+			for len(recorder.Events) > 0 {
+				events = append(events, <-recorder.Events)
+			}
+			if !reflect.DeepEqual(events, tc.expectedEvents) {
+				t.Errorf("got events %v, want %v", events, tc.expectedEvents)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #141317: the CronJob controller emitted a `FailedDelete` warning when deleting a job that was already gone (typically a follow-up sync before the job informer observed the previous delete).
- `NotFound` is treated as success: log at `V(4)`, drop the `.status.active` reference, and return true so `Replace` can continue. Other delete errors still emit `FailedDelete`.
- This is an alternative to #141319, which skips the warning but still returns false (so Replace still aborts and the stale active ref is kept).

## Test plan
- [ ] `go test ./pkg/controller/cronjob -count=1 -run TestControllerV2DeleteJob`
- [ ] Confirm the `job already deleted` case returns success, clears `.status.active`, and emits no events
- [ ] Confirm a real delete error still emits `Warning FailedDelete`