### PR TITLE
ktesting: cancel the TContext as soon as the test is done

### DIFF
--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -26,6 +26,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math"
 	"math/big"
@@ -33,6 +34,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -40,7 +42,7 @@ import (
 	"go.etcd.io/etcd/client/pkg/v3/transport"
 	clientv3 "go.etcd.io/etcd/client/v3"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -110,6 +112,14 @@ type TestServerInstanceOptions struct {
 	BinaryVersion string
 	// Set non-default request timeout in the server.
 	RequestTimeout time.Duration
+
+	// observeTearDown, if non-nil, gets called with tCtx right after it
+	// gets canceled during tear-down. It is used only by StartTestServer's
+	// own tests, to verify that the context is canceled (Err() ==
+	// context.Canceled) with the intended cause (parent context
+	// cancellation, explicit tear-down, or test completion), obtainable
+	// via context.Cause(tCtx).
+	observeTearDown func(ctx context.Context)
 }
 
 // TestServer return values supplied by kube-test-ApiServer
@@ -153,6 +163,10 @@ func NewDefaultTestServerOptions() *TestServerInstanceOptions {
 // Note: we return a tear-down func instead of a stop channel because the later will leak temporary
 // files that because Golang testing's call to os.Exit will not give a stop channel go routine
 // enough time to remove temporary files.
+//
+// The servers run until one of these happen:
+//   - test ends and cleanup starts
+//   - the tear-down func is called (blocks)
 func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, customFlags []string, storageConfig *storagebackend.Config) (result TestServer, err error) {
 	// Some callers may have initialize ktesting already.
 	tCtx, ok := t.(ktesting.TContext)
@@ -163,6 +177,17 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	} else {
 		tCtx = ktesting.Init(t)
 	}
+	// This code manages the lifecycle of tCtx itself, via the explicit
+	// tCtx.Cancel("tearing down") call in tearDown below. This ensures that
+	// the metrics invariant check below runs before context cancellation.
+	//
+	// While starting up, ctx cancellation gets propagated directly, without going through
+	// the full teardown.
+	parentCtx := tCtx
+	tCtx = tCtx.WithoutCancel()
+	stopCtxPropagation := context.AfterFunc(parentCtx, func() {
+		tCtx.CancelBecause(context.Cause(parentCtx))
+	})
 
 	if instanceOptions == nil {
 		instanceOptions = NewDefaultTestServerOptions()
@@ -174,10 +199,13 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 	}
 
 	var errCh chan error
-	tearDown := func() {
+	tearDown := func(cause error) {
 		// Cancel is stopping apiserver and cleaning up
 		// after itself, including shutting down its storage layer.
-		tCtx.Cancel("tearing down")
+		tCtx.CancelBecause(cause)
+		if instanceOptions.observeTearDown != nil {
+			instanceOptions.observeTearDown(tCtx)
+		}
 
 		// If the apiserver was started, let's wait for it to
 		// shutdown clearly.
@@ -190,8 +218,9 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 		os.RemoveAll(result.TmpDir)
 	}
 	defer func() {
+		// In case of a premature exit, tearn down immediately before returning.
 		if result.TearDownFn == nil {
-			tearDown()
+			tearDown(errors.New("server startup failed"))
 		}
 	}()
 
@@ -507,7 +536,7 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 		}
 
 		if _, err := client.CoreV1().Namespaces().Get(context.TODO(), "default", metav1.GetOptions{}); err != nil {
-			if !errors.IsNotFound(err) {
+			if !apierrors.IsNotFound(err) {
 				t.Logf("Unable to get default namespace: %v", err)
 			}
 			return false, nil
@@ -523,31 +552,47 @@ func StartTestServer(t ktesting.TB, instanceOptions *TestServerInstanceOptions, 
 		return result, fmt.Errorf("create etcd client: %w", err)
 	}
 
-	// from here the caller must call tearDown
 	result.ClientConfig = restclient.CopyConfig(server.GenericAPIServer.LoopbackClientConfig)
 	result.ClientConfig.QPS = 1000
 	result.ClientConfig.Burst = 10000
 	result.ServerOpts = s
-	result.TearDownFn = func() {
+	// etcdClient.Close fails when called more than once.
+	// Checking metrics also is needed only once.
+	var tearDownOnce sync.Once
+	tearDownAll := func(cause error) {
 		defer func() {
 			if err := etcdClient.Close(); err != nil {
 				tCtx.Errorf("Failed to close etcd client: %v", err)
 			}
 		}()
-		defer tearDown()
+		defer tearDown(cause)
 		if instanceOptions.DisableInvariantChecks {
 			return
 		}
+		// Might have been canceled while removing the ctx forwarding.
 		if tCtx.Err() != nil {
-			tCtx.Logf("Skipping metrics scrape because context is already canceled: %v", tCtx.Err())
+			tCtx.Logf("Skipping metrics scrape because context is already canceled: %v", context.Cause(tCtx))
 			return
 		}
 		if err := metrics.CheckMetricInvariants(tCtx, client, false); err != nil {
 			tCtx.Errorf("Invariant check failed (if the test intentionally breaks metrics/auth, consider setting DisableInvariantChecks: true in TestServerInstanceOptions): %v", err)
 		}
 	}
+	// From now on we stop the ctx forwarding and rely only on
+	// proper tear-down at the test end or an explicit request.
+	// Removal races with parent context cancellation, so it it
+	// is possible that tear-down starts while the context is
+	// already canceled.
+	stopCtxPropagation()
+
+	result.TearDownFn = func() {
+		tearDownOnce.Do(func() { tearDownAll(errors.New("tear-down requested")) })
+	}
 	result.EtcdClient = etcdClient
 	result.EtcdStoragePrefix = storageConfig.Prefix
+	t.Cleanup(func() {
+		tearDownOnce.Do(func() { tearDownAll(errors.New("test has completed")) })
+	})
 
 	return result, nil
 }

--- a/cmd/kube-apiserver/app/testing/testserver_test.go
+++ b/cmd/kube-apiserver/app/testing/testserver_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+// TestStartTestServerTearDownCauseOnTestCompletion verifies that when a test
+// simply ends without calling the returned TearDownFn explicitly, the
+// server's internal context gets canceled (with context.Canceled as its
+// Err()) and with a cause that indicates normal test completion.
+func TestStartTestServerTearDownCauseOnTestCompletion(t *testing.T) {
+	var observedErr, observedCause error
+
+	// Run in a sub-test so that its t.Cleanup callbacks (including the
+	// one registered by StartTestServer) run to completion before t.Run
+	// returns here, without any extra synchronization.
+	//
+	// WithoutCancel avoids racing ktesting's auto-cancellation against the
+	// "test has completed" trigger this test verifies.
+	t.Run("server", func(t *testing.T) {
+		tCtx := ktesting.Init(t).WithoutCancel()
+		_, storageConfig := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
+
+		instanceOptions := NewDefaultTestServerOptions()
+		instanceOptions.observeTearDown = func(ctx context.Context) {
+			observedErr = ctx.Err()
+			observedCause = context.Cause(ctx)
+		}
+		if _, err := StartTestServer(tCtx, instanceOptions, nil, storageConfig); err != nil {
+			t.Fatalf("failed to start test server: %v", err)
+		}
+	})
+
+	if !errors.Is(observedErr, context.Canceled) {
+		t.Errorf("expected the internal context to be canceled with context.Canceled, got: %v", observedErr)
+	}
+	if observedCause == nil || observedCause.Error() != "test has completed" {
+		t.Errorf("expected cause to indicate test completion, got: %v", observedCause)
+	}
+}
+
+// TestStartTestServerTearDownCauseOnExplicitTearDown verifies that calling
+// the returned TearDownFn explicitly cancels the server's internal context
+// (with context.Canceled as its Err()) with a cause that indicates an
+// explicit tear-down request.
+func TestStartTestServerTearDownCauseOnExplicitTearDown(t *testing.T) {
+	var observedErr, observedCause error
+
+	_, storageConfig := etcd3testing.NewUnsecuredEtcd3TestClientServer(t)
+
+	instanceOptions := NewDefaultTestServerOptions()
+	instanceOptions.observeTearDown = func(ctx context.Context) {
+		observedErr = ctx.Err()
+		observedCause = context.Cause(ctx)
+	}
+	result, err := StartTestServer(t, instanceOptions, nil, storageConfig)
+	if err != nil {
+		t.Fatalf("failed to start test server: %v", err)
+	}
+	result.TearDownFn()
+
+	if !errors.Is(observedErr, context.Canceled) {
+		t.Errorf("expected the internal context to be canceled with context.Canceled, got: %v", observedErr)
+	}
+	if observedCause == nil || observedCause.Error() != "tear-down requested" {
+		t.Errorf("expected cause to indicate an explicit tear-down request, got: %v", observedCause)
+	}
+}

--- a/pkg/kubelet/cm/dra/plugin/registration_test.go
+++ b/pkg/kubelet/cm/dra/plugin/registration_test.go
@@ -258,7 +258,12 @@ func TestRegistrationHandler(t *testing.T) {
 			}
 			plugin := draPlugins.get(test.driverName)
 			require.NotNil(t, plugin, "plugin should be registered")
-			t.Cleanup(func() {
+			// This runs as a defer instead of a t.Cleanup/tCtx.Cleanup callback
+			// because it depends on tCtx and draPlugins' background wiping
+			// (which uses tCtx as its context) still being active. By the time
+			// Cleanup callbacks run, tCtx is already canceled; a defer in the
+			// test function itself still executes beforehand.
+			defer func() {
 				if client != nil {
 					// Create the slice as if the plugin had done that while it runs.
 					_, err := client.ResourceV1().ResourceSlices().Create(tCtx, slice, metav1.CreateOptions{})
@@ -272,7 +277,7 @@ func TestRegistrationHandler(t *testing.T) {
 				if test.withClient {
 					requireNoSlices(tCtx)
 				}
-			})
+			}()
 			// Which plugin was chosen is random in this test: it depends on which plugin was detected as connected,
 			// which can be both, one, or none at this point. Some attributes are common to both.
 			assert.Equal(t, test.driverName, plugin.driverName, "DRA driver driver name")

--- a/test/integration/framework/main_test.go
+++ b/test/integration/framework/main_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	EtcdMain(m.Run)
+}

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -18,11 +18,13 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -69,14 +71,40 @@ type TestServerSetup struct {
 	ModifyServerConfig     func(*controlplane.Config)
 	// DisableInvariantChecks skips the invariant checks at the end of the test.
 	DisableInvariantChecks bool
+
+	// observeTearDown, if non-nil, gets called with the server's internal
+	// context right after it gets canceled during tear-down. It is used
+	// only by StartTestServer's own tests, to verify that the context is
+	// canceled (ctx.Err() == context.Canceled) with the intended cause
+	// (parent context cancellation, explicit tear-down, or test
+	// completion), obtainable via context.Cause(ctx).
+	observeTearDown func(ctx context.Context)
 }
 
 type TearDownFunc func()
 
 // StartTestServer runs a kube-apiserver, optionally calling out to the setup.ModifyServerRunOptions and setup.ModifyServerConfig functions
 // TODO (pohly): convert to ktesting contexts
+//
+// The kube-apiserver runs until one of the following happens:
+//   - ctx cancellation
+//   - TearDownFunc gets called (blocks until shutdown is complete)
+//   - the test ends and cleanup starts
 func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (client.Interface, *rest.Config, TearDownFunc) {
-	ctx, cancel := context.WithCancel(ctx)
+	// This code manages the lifecycle of ctx itself, via the explicit
+	// cancel call in tearDown below. It must not get canceled
+	// automatically once the test ends because TearDownFn still needs a
+	// working context at that point, in particular for the metrics
+	// invariant check below.
+	//
+	// While starting up, ctx cancellation gets propagated directly, without going through
+	// the full teardown.
+	parentCtx := ctx
+	ctx = context.WithoutCancel(ctx)
+	ctx, cancel := context.WithCancelCause(ctx)
+	stopCtxPropagation := context.AfterFunc(parentCtx, func() {
+		cancel(context.Cause(parentCtx))
+	})
 
 	certDir, err := os.MkdirTemp("", "test-integration-"+strings.ReplaceAll(t.Name(), "/", "_"))
 	if err != nil {
@@ -264,11 +292,17 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 		t.Fatal(err)
 	}
 
-	tearDownFn := func() {
+	// tearDown runs exactly once, either triggered by
+	// the parent context cancellation (context.AfterFunc), test cleanup
+	// or an explicit request to tear down.
+	var tearDownOnce sync.Once
+	tearDown := func(cause error) {
 		// Scrape metrics before stopping
 		if !setup.DisableInvariantChecks {
+			// Context cancellation might have been propagated during startup,
+			// therefore the context might be canceled already.
 			if ctx.Err() != nil {
-				t.Logf("Skipping metrics scrape because context is already canceled: %v", ctx.Err())
+				t.Logf("Skipping metrics scrape because context is already canceled: %v", context.Cause(ctx))
 			} else {
 				if err := metrics.CheckMetricInvariants(ctx, kubeAPIServerClient, false); err != nil {
 					t.Errorf("Invariant check failed (if the test intentionally breaks metrics/auth, consider setting DisableInvariantChecks: true in TestServerSetup): %v", err)
@@ -277,7 +311,10 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 		}
 		// Calling cancel function is stopping apiserver and cleaning up
 		// after itself, including shutting down its storage layer.
-		cancel()
+		cancel(cause)
+		if setup.observeTearDown != nil {
+			setup.observeTearDown(ctx)
+		}
 
 		// If the apiserver was started, let's wait for it to
 		// shutdown clearly.
@@ -291,6 +328,22 @@ func StartTestServer(ctx context.Context, t testing.TB, setup TestServerSetup) (
 			t.Log(err)
 		}
 	}
+	tearDownFn := func(cause error) {
+		tearDownOnce.Do(func() { tearDown(cause) })
+	}
+	t.Cleanup(func() {
+		tearDownFn(errors.New("test has completed"))
+	})
 
-	return kubeAPIServerClient, kubeAPIServerClientConfig, tearDownFn
+	// Swap the simple cancellation propagation with the more complete tear-down.
+	// This is not atomic, so tear-down has to be prepared for ctx to be canceled
+	// already when it starts.
+	context.AfterFunc(parentCtx, func() {
+		tearDownFn(context.Cause(parentCtx))
+	})
+	stopCtxPropagation()
+
+	return kubeAPIServerClient, kubeAPIServerClientConfig, func() {
+		tearDownFn(errors.New("tear-down requested"))
+	}
 }

--- a/test/integration/framework/test_server_test.go
+++ b/test/integration/framework/test_server_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/test/utils/ktesting"
+)
+
+// TestStartTestServerTearDownCauseOnTestCompletion verifies that when a test
+// simply ends without calling the returned TearDownFunc explicitly, the
+// server's internal context gets canceled (with context.Canceled as its
+// Err()) and with a cause that indicates normal test completion.
+func TestStartTestServerTearDownCauseOnTestCompletion(t *testing.T) {
+	var observedErr, observedCause error
+
+	// Run in a sub-test so that its t.Cleanup callbacks (including the
+	// one registered by StartTestServer) run to completion before t.Run
+	// returns here, without any extra synchronization.
+	//
+	// context.Background() (not a TContext derived from t) avoids racing
+	// the auto-cancellation path against the "test has completed" trigger
+	// this test verifies.
+	t.Run("server", func(t *testing.T) {
+		StartTestServer(context.Background(), t, TestServerSetup{
+			observeTearDown: func(ctx context.Context) {
+				observedErr = ctx.Err()
+				observedCause = context.Cause(ctx)
+			},
+		})
+	})
+
+	if !errors.Is(observedErr, context.Canceled) {
+		t.Errorf("expected the internal context to be canceled with context.Canceled, got: %v", observedErr)
+	}
+	if observedCause == nil || observedCause.Error() != "test has completed" {
+		t.Errorf("expected cause to indicate test completion, got: %v", observedCause)
+	}
+}
+
+// TestStartTestServerTearDownCauseOnExplicitTearDown verifies that calling
+// the returned TearDownFunc explicitly cancels the server's internal context
+// (with context.Canceled as its Err()) with a cause that indicates an
+// explicit tear-down request.
+func TestStartTestServerTearDownCauseOnExplicitTearDown(t *testing.T) {
+	var observedErr, observedCause error
+
+	tCtx := ktesting.Init(t)
+	_, _, tearDownFn := StartTestServer(tCtx, t, TestServerSetup{
+		observeTearDown: func(ctx context.Context) {
+			observedErr = ctx.Err()
+			observedCause = context.Cause(ctx)
+		},
+	})
+	tearDownFn()
+
+	if !errors.Is(observedErr, context.Canceled) {
+		t.Errorf("expected the internal context to be canceled with context.Canceled, got: %v", observedErr)
+	}
+	if observedCause == nil || observedCause.Error() != "tear-down requested" {
+		t.Errorf("expected cause to indicate an explicit tear-down request, got: %v", observedCause)
+	}
+}
+
+// TestStartTestServerTearDownCauseOnParentCancellation is a regression test
+// for https://github.com/kubernetes/kubernetes/pull/141545#discussion_r3901822871:
+// when the context passed into StartTestServer gets canceled with some
+// application-specific cause *after* the server has started, that same cause
+// must be the one which ends up canceling the server's internal context
+// (whose Err() must still be context.Canceled). The cause must not get
+// replaced by a generic, hard-coded error.
+func TestStartTestServerTearDownCauseOnParentCancellation(t *testing.T) {
+	const sentinel = "sentinel: parent context canceled after start"
+	type observation struct {
+		err   error
+		cause error
+	}
+	observationCh := make(chan observation, 1)
+
+	tCtx := ktesting.Init(t)
+
+	_, _, _ = StartTestServer(tCtx, t, TestServerSetup{
+		observeTearDown: func(ctx context.Context) {
+			select {
+			case observationCh <- observation{err: ctx.Err(), cause: context.Cause(ctx)}:
+			default:
+			}
+		},
+	})
+
+	// Cancellation is propagated asynchronously (context.AfterFunc), so
+	// tear-down may not have completed by the time this call returns.
+	tCtx.Cancel(sentinel)
+
+	select {
+	case obs := <-observationCh:
+		if !errors.Is(obs.err, context.Canceled) {
+			t.Errorf("expected the internal context to be canceled with context.Canceled, got: %v", obs.err)
+		}
+		if obs.cause == nil || obs.cause.Error() != sentinel {
+			t.Errorf("expected the sentinel error to be preserved as the tear-down cause, got: %v", obs.cause)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("tear-down was not observed after canceling the parent context")
+	}
+}

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -28,6 +28,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	nodectlr "k8s.io/kubernetes/pkg/controller/nodelifecycle"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 // CreateNamespaceOrDie creates a namespace.
@@ -41,7 +42,7 @@ func CreateNamespaceOrDie(c clientset.Interface, baseName string, t testing.TB) 
 }
 
 // DeleteNamespaceOrDie deletes a namespace.
-func DeleteNamespaceOrDie(c clientset.Interface, ns *v1.Namespace, t testing.TB) {
+func DeleteNamespaceOrDie(c clientset.Interface, ns *v1.Namespace, t ktesting.TB) {
 	err := c.CoreV1().Namespaces().Delete(context.TODO(), ns.Name, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("Failed to delete namespace: %v", err)

--- a/test/integration/scheduler/preemption/asyncframework/async_framework.go
+++ b/test/integration/scheduler/preemption/asyncframework/async_framework.go
@@ -51,6 +51,7 @@ import (
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testutils "k8s.io/kubernetes/test/integration/util"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 const (
@@ -582,8 +583,8 @@ func nodeCreation(testCtx *testutils.TestContext, t *testing.T, nodeName string,
 	if _, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, newNode, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Failed to create an initial Node %q: %v", newNode.Name, err)
 	}
-	t.Cleanup(func() {
-		if err := cs.CoreV1().Nodes().Delete(testCtx.Ctx, newNode.Name, metav1.DeleteOptions{}); err != nil {
+	ktesting.Init(t).CleanupCtx(func(tCtx ktesting.TContext) {
+		if err := cs.CoreV1().Nodes().Delete(tCtx, newNode.Name, metav1.DeleteOptions{}); err != nil {
 			t.Fatalf("Failed to delete the Node %q: %v", newNode.Name, err)
 		}
 	})

--- a/test/integration/scheduler/queueing/queue_test.go
+++ b/test/integration/scheduler/queueing/queue_test.go
@@ -49,8 +49,8 @@ import (
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testfwk "k8s.io/kubernetes/test/integration/framework"
 	testutils "k8s.io/kubernetes/test/integration/util"
+	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -211,6 +211,8 @@ func (f *fakeCRPlugin) EventsToRegister(_ context.Context) ([]fwk.ClusterEventWi
 // TestCustomResourceEnqueue constructs a fake plugin that registers custom resources
 // to verify Pods failed by this plugin can be moved properly upon CR events.
 func TestCustomResourceEnqueue(t *testing.T) {
+	tCtx := ktesting.Init(t)
+
 	// Start API Server with apiextensions supported.
 	server := apiservertesting.StartTestServerOrDie(
 		t, apiservertesting.NewDefaultTestServerOptions(),
@@ -302,7 +304,7 @@ func TestCustomResourceEnqueue(t *testing.T) {
 	)
 	testutils.SyncSchedulerInformerFactory(testCtx)
 
-	defer testutils.CleanupTest(t, testCtx)
+	defer testutils.CleanupTest(tCtx, testCtx)
 
 	cs, ns, ctx := testCtx.ClientSet, testCtx.NS.Name, testCtx.Ctx
 	// Create one Node.

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -35,6 +35,7 @@ import (
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testutils "k8s.io/kubernetes/test/integration/util"
+	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -46,6 +47,7 @@ import (
 // For example, in scheduler integration tests, recreating apiserver is performance consuming,
 // then shutdown the scheduler and recreate it between each test case is a better approach.
 func InitTestSchedulerForFrameworkTest(t *testing.T, testCtx *testutils.TestContext, nodeCount int, runScheduler bool, opts ...scheduler.Option) (*testutils.TestContext, testutils.ShutdownFunc) {
+	tCtx := ktesting.Init(t)
 	testCtx = testutils.InitTestSchedulerWithOptions(t, testCtx, 0, opts...)
 	testutils.SyncSchedulerInformerFactory(testCtx)
 	if runScheduler {
@@ -55,7 +57,7 @@ func InitTestSchedulerForFrameworkTest(t *testing.T, testCtx *testutils.TestCont
 	if nodeCount > 0 {
 		if _, err := testutils.CreateAndWaitForNodesInCache(testCtx, "test-node", st.MakeNode(), nodeCount); err != nil {
 			// Make sure to cleanup the resources when initializing error.
-			testutils.CleanupTest(t, testCtx)
+			testutils.CleanupTest(tCtx, testCtx)
 			t.Fatal(err)
 		}
 	}

--- a/test/integration/util/main_test.go
+++ b/test/integration/util/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -278,6 +278,9 @@ type TestContext struct {
 	DynInformerFactory dynamicinformer.DynamicSharedInformerFactory
 	Scheduler          *scheduler.Scheduler
 	// This is the top context when initializing the test environment.
+	// Note that this will be canceled at the time that cleanup callbacks
+	// run! Use [TContext.CleanupCtx] to schedule callbacks which have
+	// their own fresh context.
 	Ctx context.Context
 	// CloseFn will stop the apiserver and clean up the resources
 	// after itself, including shutting down its storage layer.
@@ -355,13 +358,14 @@ func SyncSchedulerInformerFactory(testCtx *TestContext) {
 	}
 }
 
-// CleanupTest cleans related resources which were created during integration test
-func CleanupTest(t *testing.T, testCtx *TestContext) {
+// CleanupTest cleans related resources which were created during integration test.
+// May only be called once and with a tCtx which is not already canceled.
+func CleanupTest(tCtx ktesting.TContext, testCtx *TestContext) {
 	// Cleanup nodes and namespaces.
-	if err := testCtx.ClientSet.CoreV1().Nodes().DeleteCollection(testCtx.Ctx, *metav1.NewDeleteOptions(0), metav1.ListOptions{}); err != nil {
-		t.Errorf("error while cleaning up nodes, error: %v", err)
+	if err := testCtx.ClientSet.CoreV1().Nodes().DeleteCollection(tCtx, *metav1.NewDeleteOptions(0), metav1.ListOptions{}); err != nil {
+		tCtx.Errorf("error while cleaning up nodes, error: %v", err)
 	}
-	framework.DeleteNamespaceOrDie(testCtx.ClientSet, testCtx.NS, t)
+	framework.DeleteNamespaceOrDie(testCtx.ClientSet, testCtx.NS, tCtx)
 	// Terminate the scheduler and apiserver.
 	testCtx.CloseFn()
 }
@@ -518,7 +522,21 @@ func UpdateNodeStatus(cs clientset.Interface, node *v1.Node) error {
 // no need to do this again.
 func InitTestAPIServer(t *testing.T, nsPrefix string, admission admission.Interface) *TestContext {
 	tCtx := ktesting.Init(t)
-	testCtx := &TestContext{Ctx: tCtx}
+	// We need to intercept context cancellation, otherwise
+	// CleanupTest cannot succeed. CleanupTest calls
+	// testCtx.CloseFn, which then explicitly shuts down
+	// the server and cancels the context. The latter is
+	// important because the caller might start more goroutines
+	// which use the context.
+	//
+	// Cancellation gets propagated to the test server only during the startup
+	// phase.
+	parentCtx := tCtx
+	tCtx = tCtx.WithoutCancel()
+	stopCtxPropagation := context.AfterFunc(parentCtx, func() {
+		tCtx.CancelBecause(context.Cause(parentCtx))
+	})
+	testCtx := &TestContext{Ctx: parentCtx}
 
 	testCtx.ClientSet, testCtx.KubeConfig, testCtx.CloseFn = framework.StartTestServer(tCtx, t, framework.TestServerSetup{
 		ModifyServerRunOptions: func(options *options.ServerRunOptions) {
@@ -560,7 +578,11 @@ func InitTestAPIServer(t *testing.T, nsPrefix string, admission admission.Interf
 
 	oldCloseFn := testCtx.CloseFn
 	testCtx.CloseFn = func() {
-		tCtx.Cancel("tearing down apiserver")
+		// Shutdown of additional goroutines and of the apiserver run in parallel.
+		// parentCtx (== testCtx.Ctx) is the context that callers and their
+		// goroutines were given, so it must be canceled here, not the
+		// detached tCtx which only governs the apiserver's own shutdown.
+		parentCtx.Cancel("must shut down, apiserver is being torn down")
 		oldCloseFn()
 	}
 
@@ -570,8 +592,9 @@ func InitTestAPIServer(t *testing.T, nsPrefix string, admission admission.Interf
 		testCtx.NS = framework.CreateNamespaceOrDie(testCtx.ClientSet, "default", t)
 	}
 
-	t.Cleanup(func() {
-		CleanupTest(t, testCtx)
+	stopCtxPropagation()
+	tCtx.CleanupCtx(func(tCtx ktesting.TContext) {
+		CleanupTest(tCtx, testCtx)
 	})
 
 	return testCtx

--- a/test/integration/util/util_test.go
+++ b/test/integration/util/util_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestInitTestAPIServerContextCanceledBeforeCleanup verifies the normal
+// (non-explicit) shutdown path: testCtx.Ctx gets canceled as soon as the
+// test function returns. The cancellation itself runs via
+// context.AfterFunc, in parallel with (not necessarily before) any
+// t.Cleanup callback, so a cleanup callback which depends on it must wait
+// for it instead of checking it just once.
+func TestInitTestAPIServerContextCanceledBeforeCleanup(t *testing.T) {
+	testCtx := InitTestAPIServer(t, "normal-shutdown", nil)
+
+	t.Cleanup(func() {
+		select {
+		case <-testCtx.Ctx.Done():
+			// Canceled, as expected.
+		case <-time.After(30 * time.Second):
+			t.Error("testCtx.Ctx was not canceled by the time cleanup ran")
+		}
+	})
+}
+
+// TestInitTestAPIServerCloseFnCancelsCallerContext verifies that calling
+// testCtx.CloseFn explicitly (i.e. before the test itself ends and the
+// top-level context gets canceled through test cleanup) cancels
+// testCtx.Ctx. Callers rely on that context to know when to stop any
+// goroutines they started with it, so CloseFn must cancel it directly
+// instead of only canceling the apiserver's own, detached context.
+//
+// Note that this is not properly supported by InitTestAPIServer: the
+// automatic cleanup in CleanupTest fails when tests call CloseFn (API server
+// shuts down before cleanup) or CleanupTest itself (cleanup runs twice,
+// second invocation fails). The test works around that with a fake client.
+func TestInitTestAPIServerCloseFnCancelsCallerContext(t *testing.T) {
+	testCtx := InitTestAPIServer(t, "close-fn-cancel", nil)
+
+	// Explicit shutdown, simulating a caller which stops the server
+	// before its test function returns.
+	testCtx.CloseFn()
+
+	select {
+	case <-testCtx.Ctx.Done():
+		// Canceled, as expected.
+	case <-time.After(30 * time.Second):
+		t.Fatal("testCtx.Ctx was not canceled by CloseFn")
+	}
+
+	// Prevent failures when CleanupTest runs as cleanup callback.
+	testCtx.ClientSet = fake.NewClientset(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testCtx.NS.Name}})
+}

--- a/test/utils/ktesting/contexthelper.go
+++ b/test/utils/ktesting/contexthelper.go
@@ -36,6 +36,55 @@ func (c canceledError) Is(target error) bool {
 	return target == context.Canceled
 }
 
+// testContext returns the context associated with tb, as implemented by
+// [testing.T], [testing.B] and [testing.F] via their Context method. It
+// returns nil when tb doesn't support that, for example for Ginkgo.
+//
+// That context gets canceled by the "testing" package itself as soon as the
+// test function returns, before its Cleanup-registered functions run.
+func testContext(tb TB) context.Context {
+	if withCtx, ok := tb.(interface{ Context() context.Context }); ok {
+		return withCtx.Context()
+	}
+	return nil
+}
+
+// runWhenDone arranges for the callback to be invoked once as soon as possible after
+// the test represented by tb is done, ideally already before its
+// Cleanup-registered functions run. This is possible when tb's own test
+// context can be observed (see [testContext]) because that one gets
+// canceled at exactly that point. A final tb.Cleanup callback guarantees
+// that cancel really does get called (also for TB implementations without
+// their own context).
+func runWhenDone(tb TB, cb func()) {
+	if tbCtx := testContext(tb); tbCtx != nil {
+		done := make(chan struct{})
+		run := func() {
+			defer close(done)
+			cb()
+		}
+		stop := context.AfterFunc(tbCtx, run)
+		tb.Cleanup(func() {
+			// If tbCtx isn't canceled yet, cancel it ourselves instead of
+			// waiting for done. This is needed for TB implementations
+			// (like Ginkgo's, arguably a bug there) which cancel tbCtx
+			// via their own Cleanup, which runs after ours (LIFO order)
+			// and thus would never unblock <-done.
+			if stop() {
+				run()
+				return
+			}
+			// Wait for execution via AfterFunc.
+			<-done
+		})
+		return
+	}
+	// Fallback: run it as cleanup.
+	tb.Cleanup(func() {
+		cb()
+	})
+}
+
 // withTimeout corresponds to [context.WithTimeout]. In contrast to
 // [context.WithTimeout], it automatically cancels during test cleanup, provides
 // the given cause when the deadline is reached, and its cancel function
@@ -50,12 +99,15 @@ func withTimeout(ctx context.Context, tb TB, timeout time.Duration, timeoutCause
 	stopCtx, stop := context.WithCancel(ctx) // Only used internally, doesn't need a cause.
 	done := make(chan struct{})
 	tb.Cleanup(func() {
-		cancel(cleanupErr(tb.Name()))
+		// This gets registered before cancel and thus runs after it.
 		stop()
 		// Wait for goroutine termination. This is important because
 		// otherwise the goroutine might log through tb *after* the
 		// test has already finished, which causes a panic.
 		<-done
+	})
+	runWhenDone(tb, func() {
+		cancel(cleanupErr(tb.Name()))
 	})
 	go func() {
 		defer close(done)

--- a/test/utils/ktesting/contexthelper.go
+++ b/test/utils/ktesting/contexthelper.go
@@ -40,7 +40,7 @@ func (c canceledError) Is(target error) bool {
 // [context.WithTimeout], it automatically cancels during test cleanup, provides
 // the given cause when the deadline is reached, and its cancel function
 // requires a cause.
-func withTimeout(ctx context.Context, tb TB, timeout time.Duration, timeoutCause string) (context.Context, func(cause string)) {
+func withTimeout(ctx context.Context, tb TB, timeout time.Duration, timeoutCause string) (context.Context, func(cause error)) {
 	tb.Helper()
 
 	now := time.Now()
@@ -86,13 +86,7 @@ func withTimeout(ctx context.Context, tb TB, timeout time.Duration, timeoutCause
 	}
 
 	// We always have a deadline.
-	return deadlineContext{Context: cancelCtx, deadline: deadline}, func(cause string) {
-		var cancelCause error
-		if cause != "" {
-			cancelCause = canceledError(cause)
-		}
-		cancel(cancelCause)
-	}
+	return deadlineContext{Context: cancelCtx, deadline: deadline}, cancel
 }
 
 type deadlineContext struct {

--- a/test/utils/ktesting/contexthelper_test.go
+++ b/test/utils/ktesting/contexthelper_test.go
@@ -19,12 +19,76 @@ package ktesting
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"testing/synctest"
 	"time"
 
 	"github.com/onsi/gomega"
 )
+
+// cleanupDrivenContextTB embeds *testing.T for all the boilerplate TB
+// methods, but reimplements Cleanup and Context to mimic Ginkgo's testing
+// proxy: Context() creates a context and registers its own cancel func via
+// Cleanup instead of canceling it independently when the test is done.
+// Cleanup callbacks run in LIFO order, exactly like both "testing" and
+// Ginkgo do it.
+type cleanupDrivenContextTB struct {
+	*testing.T
+
+	mu       sync.Mutex
+	cleanups []func()
+}
+
+func (tb *cleanupDrivenContextTB) Cleanup(f func()) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	tb.cleanups = append(tb.cleanups, f)
+}
+
+// runCleanups simulates the end of the test: all callbacks registered via
+// Cleanup run now, in LIFO order.
+func (tb *cleanupDrivenContextTB) runCleanups() {
+	for {
+		tb.mu.Lock()
+		if len(tb.cleanups) == 0 {
+			tb.mu.Unlock()
+			return
+		}
+		f := tb.cleanups[len(tb.cleanups)-1]
+		tb.cleanups = tb.cleanups[:len(tb.cleanups)-1]
+		tb.mu.Unlock()
+		f()
+	}
+}
+
+func (tb *cleanupDrivenContextTB) Context() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	tb.Cleanup(cancel)
+	return ctx
+}
+
+// TestRunWhenDoneCleanupDrivenContext ensures that there's no deadlock
+// with TB implementations (like Ginkgo's) which cancel their Context() from
+// their own Cleanup instead of independently, which runs after (LIFO order)
+// runWhenDone's own Cleanup and thus could have blocked it forever.
+func TestRunWhenDoneCleanupDrivenContext(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fake := &cleanupDrivenContextTB{T: t}
+
+		var called bool
+		runWhenDone(fake, func() {
+			called = true
+		})
+
+		// If this deadlocks, synctest reports it as a test failure.
+		fake.runCleanups()
+
+		if !called {
+			t.Error("runWhenDone's callback was not invoked")
+		}
+	})
+}
 
 func TestCleanupErr(t *testing.T) {
 	actual := cleanupErr(t.Name())

--- a/test/utils/ktesting/contexthelper_test.go
+++ b/test/utils/ktesting/contexthelper_test.go
@@ -35,6 +35,8 @@ func TestCleanupErr(t *testing.T) {
 
 func TestCause(t *testing.T) {
 	timeoutCause := canceledError("I timed out")
+	cancelText := "I got canceled"
+	var cancelCause error = canceledError(cancelText)
 	parentCause := errors.New("parent canceled")
 
 	contextBackground := func(t *testing.T) context.Context {
@@ -45,7 +47,8 @@ func TestCause(t *testing.T) {
 		parentCtx              func(t *testing.T) context.Context
 		timeout                time.Duration
 		sleep                  time.Duration
-		cancelCause            string
+		cancelCause            *error
+		cancelText             *string
 		expectErr, expectCause error
 		expectDeadline         time.Duration
 	}{
@@ -106,16 +109,48 @@ func TestCause(t *testing.T) {
 			timeout:        time.Minute,
 			expectDeadline: time.Minute,
 		},
+		"cancelCause": {
+			parentCtx:   contextBackground,
+			cancelCause: &cancelCause,
+			expectErr:   context.Canceled,
+			expectCause: cancelCause,
+		},
+		"cancelText": {
+			parentCtx:   contextBackground,
+			cancelText:  &cancelText,
+			expectErr:   context.Canceled,
+			expectCause: cancelCause,
+		},
+		"cancelEmptyText": {
+			// Canceling with an empty string must preserve the standard
+			// context.Canceled cause, just like context.CancelFunc does.
+			parentCtx:   contextBackground,
+			cancelText:  new(string),
+			expectErr:   context.Canceled,
+			expectCause: context.Canceled,
+		},
+		"cancelBecauseNil": {
+			// CancelBecause is a transparent pass-through to
+			// context.CancelCauseFunc, so nil must also result in the
+			// standard context.Canceled cause.
+			parentCtx:   contextBackground,
+			cancelCause: new(error),
+			expectErr:   context.Canceled,
+			expectCause: context.Canceled,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
 				tCtx := Init(t)
-				ctx, cancel := withTimeout(tt.parentCtx(t), t, tt.timeout, timeoutCause.Error())
-				if tt.cancelCause != "" {
-					cancel(tt.cancelCause)
+				tCtx = tCtx.WithContext(tt.parentCtx(t)).WithTimeout(tt.timeout, timeoutCause.Error())
+				if tt.cancelCause != nil {
+					tCtx.CancelBecause(*tt.cancelCause)
+				}
+				if tt.cancelText != nil {
+					tCtx.Cancel(*tt.cancelText)
 				}
 				if tt.expectDeadline != 0 {
-					actualDeadline, ok := ctx.Deadline()
+					actualDeadline, ok := tCtx.Deadline()
 					if !ok {
 						tCtx.Error("should have a deadline and hasn't")
 					} else {
@@ -127,8 +162,8 @@ func TestCause(t *testing.T) {
 				// Wait for them to do their work.
 				synctest.Wait()
 				// Now check.
-				actualErr := ctx.Err()
-				actualCause := context.Cause(ctx)
+				actualErr := tCtx.Err()
+				actualCause := context.Cause(tCtx)
 				if tt.expectErr == nil {
 					tCtx.Assert(actualErr).To(gomega.Succeed(), "ctx.Err()")
 				} else {

--- a/test/utils/ktesting/tcontext.go
+++ b/test/utils/ktesting/tcontext.go
@@ -99,7 +99,17 @@ type ContextTB interface {
 // Init can be called in a unit or integration test to create
 // a test context which:
 // - has a per-test logger with verbosity derived from the -v command line flag
-// - gets canceled when the test finishes (via [TB.Cleanup])
+// - gets canceled automatically when the test ends
+//
+// Note that "test ends" is defined as "main test function returned".
+// In other words, the test execution order is:
+//   - test function
+//   - all defer callbacks in that function
+//   - automatic TContext cancellation is triggered (i.e. not guaranteed to
+//     be instantaneous, but cleanup callbacks can rely on it to happen)
+//   - all [Cleanup] and [CleanupCtx] callbacks in LIFO order;
+//     they can still log to tb and record additional failures
+//   - underlying tb gets finalized, making it unusable
 //
 // Note that the test context supports the interfaces of [TB] and
 // [context.Context] and thus can be used like one of those where needed.
@@ -112,9 +122,13 @@ type ContextTB interface {
 // the context passed into that callback. This can be used to let
 // Ginkgo create a fresh context for cleanup code.
 //
-// Can be called more than once per test to get different contexts with
-// independent cancellation. The default behavior described above can be
+// The default behavior described above can be
 // modified via optional functional options defined in [initoption].
+// Can be called more than once per test to get different contexts with
+// independent cancellation: Cancel only affects the instance it is
+// called on. The automatic cancellation is triggered for all instances
+// when the test ends (as defined above), regardless of when Init was called.
+// Each instance can have a different configuration.
 //
 // Can be called inside a synctest bubble. Signal handling (cleaning up on
 // SIGINT, progress reporting on SIGUSR1) then does not get initialized because
@@ -196,7 +210,7 @@ func Init(tb TB, opts ...InitOption) TContext {
 		tCtx.cancel = cancelTimeout
 	} else {
 		tCtx = tCtx.WithCancel()
-		tCtx.Cleanup(func() {
+		runWhenDone(tb, func() {
 			tCtx.Cancel(cleanupErr(tCtx.Name()).Error())
 		})
 	}

--- a/test/utils/ktesting/tcontext.go
+++ b/test/utils/ktesting/tcontext.go
@@ -181,7 +181,7 @@ func Init(tb TB, opts ...InitOption) TContext {
 		gracePeriod = DefaultCleanupGracePeriod
 	}
 
-	var cancelTimeout func(cause string)
+	var cancelTimeout func(cause error)
 	if deadline != nil {
 		timeLeft := time.Until(*deadline)
 		timeLeft -= gracePeriod
@@ -413,7 +413,7 @@ type TContext struct {
 	perTestHeader func() string
 
 	// for Cancel
-	cancel func(cause string)
+	cancel func(cause error)
 
 	// steps is a concatenation ("step1: step2: step3: ") of steps passed to WithStep.
 	// It's empty if there are no steps.
@@ -477,6 +477,20 @@ func (tCtx TContext) Parallel() {
 // to context.Canceled. context.Cause will return that error for the
 // context.
 func (tCtx TContext) Cancel(cause string) {
+	if tCtx.cancel != nil {
+		var cancelCause error
+		if cause != "" {
+			cancelCause = canceledError(cause)
+		}
+		// nil is okay here, context.Canceled will be used instead.
+		tCtx.cancel(cancelCause)
+	}
+}
+
+// CancelBecause is like Cancel except that it directly uses
+// the provided error. It is up to the caller whether that
+// error is a context.Canceled error.
+func (tCtx TContext) CancelBecause(cause error) {
 	if tCtx.cancel != nil {
 		tCtx.cancel(cause)
 	}

--- a/test/utils/ktesting/tcontext_test.go
+++ b/test/utils/ktesting/tcontext_test.go
@@ -18,6 +18,7 @@ package ktesting_test
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -54,6 +55,42 @@ func TestCancelAutomatic(t *testing.T) {
 		// Blocks until the context gets canceled automatically.
 		<-tCtx.Done()
 	}()
+}
+
+func TestCancelBeforeCleanup(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Blocks until the context gets canceled automatically.
+		<-tCtx.Done()
+	}()
+
+	// This gets registered *after* Init and thus, due to the usual LIFO
+	// order of Cleanup callbacks, runs *before* ktesting's own internal
+	// callback which guarantees eventual cancellation as a fallback.
+	// Nonetheless, tCtx must already be canceled here: like
+	// [testing.T.Context], it gets derived from testing.T's own context,
+	// which the "testing" package cancels before any Cleanup-registered
+	// function runs, this one included.
+	t.Cleanup(func() {
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			// Propagating the test context cancellation is not immediate because
+			// context.AfterFunc runs our callback in a goroutine, therefore
+			// we need the additional 10 second grace period.
+			t.Fatal("tCtx should already have been canceled by the time this Cleanup function runs")
+		}
+
+		// The explanation must be more useful than the generic
+		// "context canceled" which a plain [testing.T.Context] would
+		// provide.
+		cause := context.Cause(tCtx)
+		if expected := fmt.Sprintf("test %s is cleaning up", t.Name()); cause == nil || cause.Error() != expected {
+			t.Errorf("expected cancellation cause %q, got: %v", expected, cause)
+		}
+	})
 }
 
 func TestSyncTestInit(t *testing.T) {

--- a/test/utils/ktesting/withcontext.go
+++ b/test/utils/ktesting/withcontext.go
@@ -30,13 +30,7 @@ func (tCtx TContext) WithCancel() TContext {
 	ctx, cancel := context.WithCancelCause(tCtx)
 
 	tCtx.Context = ctx
-	tCtx.cancel = func(cause string) {
-		var cancelCause error
-		if cause != "" {
-			cancelCause = canceledError(cause)
-		}
-		cancel(cancelCause)
-	}
+	tCtx.cancel = cancel
 	return tCtx
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Canceling the TContext as soon as the test is done makes TContext consistent with testing.T and in several cases simplifies tests. Canceling exactly when the test ends is more natural because then all cleanup functions registered by a test can wait for code started inside the test to stop without having to call tCtx.Cancel explicitly first. Those workarounds will removed separately, they remain valid because TContext.Cancel is idempotent.

This became possible when Context was added to the testing package. Before, Init could only cancel the context when its cleanup function was invoked, which is after the test ended.

However, this is still a breaking change for code which depends on the TContext *not* being canceled yet when a TContext.Cleanup callback is invoked. Such code must be moved into a defer callback of the main test function. In more complicated cases when a helper wants to run such code, it has to manage the cancellation order itself.

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
