### PR TITLE
Change QueuedEntityInfo.ForEachPodInfo to iter.Seq

### DIFF
--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -268,18 +268,17 @@ func (aq *activeQueue) delete(entityLookup framework.QueuedEntityInfo) framework
 func (aq *activeQueue) unlockedMoveEntityToInFlight(logger klog.Logger, entity framework.QueuedEntityInfo) error {
 	entity.IncAttempts()
 	var podsToDiscard []*framework.QueuedPodInfo
-	entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+	for pInfo := range entity.ForEachPodInfo() {
 		// If the pod is already in the map, we shouldn't overwrite the inFlightPods otherwise it'd lead to a memory leak.
 		// https://github.com/kubernetes/kubernetes/pull/127016
 		if _, ok := aq.inFlightPods[pInfo.Pod.UID]; ok {
 			podsToDiscard = append(podsToDiscard, pInfo)
-			return true
+			continue
 		}
 
 		aq.metricsRecorder.ObserveInFlightEventsAsync(metrics.PodPoppedInFlightEvent, 1, false)
 		aq.inFlightPods[pInfo.Pod.UID] = aq.inFlightEvents.PushBack(pInfo.Pod)
-		return true
-	})
+	}
 	if len(podsToDiscard) > 0 {
 		switch specificEntity := entity.(type) {
 		case *framework.QueuedPodInfo:
@@ -300,12 +299,11 @@ func (aq *activeQueue) unlockedMoveEntityToInFlight(logger klog.Logger, entity f
 	aq.schedCycle++
 
 	// Update metrics for unschedulable plugins.
-	entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+	for pInfo := range entity.ForEachPodInfo() {
 		for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
 			metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
 		}
-		return true
-	})
+	}
 	return nil
 }
 
@@ -381,10 +379,9 @@ func (aq *activeQueue) list() []*v1.Pod {
 	defer aq.lock.RUnlock()
 	var result []*v1.Pod
 	for _, entity := range aq.queue.List() {
-		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+		for pInfo := range entity.ForEachPodInfo() {
 			result = append(result, pInfo.Pod)
-			return true
-		})
+		}
 	}
 	return result
 }

--- a/pkg/scheduler/backend/queue/backoff_queue.go
+++ b/pkg/scheduler/backend/queue/backoff_queue.go
@@ -400,16 +400,14 @@ func (bq *backoffQueue) list() []*v1.Pod {
 
 	var result []*v1.Pod
 	for _, entity := range bq.entityBackoffQ.List() {
-		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+		for pInfo := range entity.ForEachPodInfo() {
 			result = append(result, pInfo.Pod)
-			return true
-		})
+		}
 	}
 	for _, entity := range bq.entityErrorBackoffQ.List() {
-		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+		for pInfo := range entity.ForEachPodInfo() {
 			result = append(result, pInfo.Pod)
-			return true
-		})
+		}
 	}
 	return result
 }

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -557,16 +557,15 @@ func (p *PriorityQueue) isEntityWorthRequeuing(logger klog.Logger, entity framew
 	// For pod groups, if any pod is worth requeuing, the whole group is worth it.
 	// But we should prioritize higher strategies.
 	bestStrategy := queueSkip
-	entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+	for pInfo := range entity.ForEachPodInfo() {
 		strategy := p.isPodWorthRequeuing(logger, pInfo, event, oldObj, newObj, hintKeys)
 		if strategy > bestStrategy {
 			bestStrategy = strategy
 		}
 		if bestStrategy == queueImmediately {
-			return false
+			return bestStrategy
 		}
-		return true
-	})
+	}
 	return bestStrategy
 }
 
@@ -700,7 +699,7 @@ func (p *PriorityQueue) runPreEnqueuePlugins(ctx context.Context, entity framewo
 	var anyGatedPodInfo *framework.QueuedPodInfo
 	// Run PreEnqueue plugins for each pod, even if it could stop after the first being gated,
 	// as we need to populate any per-pod metrics.
-	entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+	for pInfo := range entity.ForEachPodInfo() {
 		p.runPreEnqueuePluginsForPod(ctx, pInfo)
 		if pInfo.Gated() {
 			// If any pod is gated, the whole entity is gated.
@@ -708,8 +707,7 @@ func (p *PriorityQueue) runPreEnqueuePlugins(ctx context.Context, entity framewo
 			// and tracked individually, complicating the flow.
 			anyGatedPodInfo = pInfo
 		}
-		return true
-	})
+	}
 	if anyGatedPodInfo != nil {
 		// Copying the gating plugin info only from a single pod is sufficient,
 		// because if the entity is a pod group, all pods should be ungated before the entire pod group can be ungated,
@@ -1457,12 +1455,11 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 // decreaseUnschedulableReasonMetric decreases the metrics for the rejector plugins
 // which are both UnschedulablePlugins and PendingPlugins.
 func decreaseUnschedulableReasonMetric(entity framework.QueuedEntityInfo) {
-	entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+	for pInfo := range entity.ForEachPodInfo() {
 		for plugin := range pInfo.UnschedulablePlugins.Union(pInfo.PendingPlugins) {
 			metrics.UnschedulableReason(plugin, pInfo.Pod.Spec.SchedulerName).Dec()
 		}
-		return true
-	})
+	}
 }
 
 // Delete deletes the entity from activeQ, backoffQ or unschedulableEntities.
@@ -1848,10 +1845,9 @@ func (p *PriorityQueue) UnschedulablePods() []*v1.Pod {
 	defer p.lock.RUnlock()
 	var result []*v1.Pod
 	for _, entity := range p.unschedulableEntities.entityInfoMap {
-		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+		for pInfo := range entity.ForEachPodInfo() {
 			result = append(result, pInfo.Pod)
-			return true
-		})
+		}
 	}
 	return result
 }
@@ -1930,15 +1926,12 @@ func (p *PriorityQueue) getPod(podLookup *v1.Pod, unlockedActiveQ unlockedActive
 		}
 		return p.pendingPodGroupPods.get(podLookup)
 	}
-	var foundPodInfo *framework.QueuedPodInfo
-	entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+	for pInfo := range entity.ForEachPodInfo() {
 		if pInfo.Pod.Name == podLookup.Name && pInfo.Pod.Namespace == podLookup.Namespace {
-			foundPodInfo = pInfo
-			return false
+			return pInfo
 		}
-		return true
-	})
-	return foundPodInfo
+	}
+	return nil
 }
 
 var pendingPodsSummary = "activeQ:%v; backoffQ:%v; unschedulableEntities:%v"
@@ -1957,11 +1950,10 @@ func (p *PriorityQueue) PendingPods() ([]*v1.Pod, string) {
 	result = append(result, backoffQPods...)
 	unschedulablePodsLen := 0
 	for _, entity := range p.unschedulableEntities.entityInfoMap {
-		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+		for pInfo := range entity.ForEachPodInfo() {
 			result = append(result, pInfo.Pod)
 			unschedulablePodsLen++
-			return true
-		})
+		}
 	}
 	if !p.isGenericWorkloadEnabled {
 		return result, fmt.Sprintf(pendingPodsSummary, activeQLen, backoffQLen, unschedulablePodsLen)

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -242,12 +242,9 @@ func TestPriorityQueue_Add(t *testing.T) {
 
 			getPod := func(entity framework.QueuedEntityInfo) *v1.Pod {
 				if tt.usePodGroups {
-					var pod *v1.Pod
-					entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
-						pod = pInfo.Pod
-						return false
-					})
-					return pod
+					for pInfo := range entity.ForEachPodInfo() {
+						return pInfo.Pod
+					}
 				}
 				return entity.(*framework.QueuedPodInfo).Pod
 			}
@@ -1226,13 +1223,12 @@ func popPod(t *testing.T, logger klog.Logger, q *PriorityQueue, pod *v1.Pod) *fr
 	case *framework.QueuedPodInfo:
 		pInfo = specificEntity
 	case *framework.QueuedPodGroupInfo:
-		specificEntity.ForEachPodInfo(func(pi *framework.QueuedPodInfo) bool {
+		for pi := range specificEntity.ForEachPodInfo() {
 			if pi.Pod.UID == pod.UID {
 				pInfo = pi
-				return false
+				break
 			}
-			return true
-		})
+		}
 	default:
 		t.Fatalf("unexpected popped entity type: %T", entity)
 	}
@@ -1522,10 +1518,9 @@ func TestPriorityQueue_Pop(t *testing.T) {
 				if _, isPodGroup := gotEntity.(*framework.QueuedPodGroupInfo); isPodGroup != tt.usePodGroups {
 					t.Errorf("Expected queued pod group: %v, got: %v", tt.usePodGroups, isPodGroup)
 				}
-				gotEntity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+				for pInfo := range gotEntity.ForEachPodInfo() {
 					gotPods = append(gotPods, pInfo.Pod.Name)
-					return true
-				})
+				}
 			}
 
 			if diff := cmp.Diff(tt.wantPods, gotPods); diff != "" {
@@ -6666,13 +6661,12 @@ func TestAddPodGroupMember(t *testing.T) {
 
 				// Verify effective addition of the incoming pod
 				foundMember := false
-				entity.(*framework.QueuedPodGroupInfo).ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+				for pInfo := range entity.ForEachPodInfo() {
 					if pInfo.Pod.Name == tt.incomingPod.Name {
 						foundMember = true
-						return false
+						break
 					}
-					return true
-				})
+				}
 				if !foundMember {
 					t.Errorf("Incoming pod %s was not found in the pod group members", tt.incomingPod.Name)
 				}
@@ -6881,12 +6875,11 @@ func TestDeletePodGroupMember(t *testing.T) {
 				}
 
 				// Verify effective removal of the deleted pod
-				entity.(*framework.QueuedPodGroupInfo).ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+				for pInfo := range entity.ForEachPodInfo() {
 					if pInfo.Pod.Name == tt.podToDelete.Name {
 						t.Errorf("Deleted pod %s is still present in the pod group members", tt.podToDelete.Name)
 					}
-					return true
-				})
+				}
 			}
 
 			if pendingLen := q.pendingPodGroupPods.len(); pendingLen != tt.expectedPodsInPending {
@@ -7135,16 +7128,15 @@ func TestUpdatePodGroupMember(t *testing.T) {
 
 				// Verify effective update of the updated pod
 				foundUpdated := false
-				entity.(*framework.QueuedPodGroupInfo).ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+				for pInfo := range entity.ForEachPodInfo() {
 					if pInfo.Pod.Name == tt.newPod.Name {
 						foundUpdated = true
 						if diff := cmp.Diff(tt.newPod, pInfo.Pod); diff != "" {
 							t.Errorf("Queued member pod differs from newPod (-want +got):\n%s", diff)
 						}
-						return false
+						break
 					}
-					return true
-				})
+				}
 				if !foundUpdated {
 					t.Errorf("Updated pod %s was not found in the pod group members", tt.newPod.Name)
 				}
@@ -7511,13 +7503,12 @@ func TestMoveAllToActiveOrBackoffQueuePodGroupMember(t *testing.T) {
 
 				if tt.expectedGroupSize > 0 {
 					foundPod := false
-					entity.(*framework.QueuedPodGroupInfo).ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+					for pInfo := range entity.ForEachPodInfo() {
 						if pInfo.Pod.Name == tt.initialPods[0].Name {
 							foundPod = true
-							return false
+							break
 						}
-						return true
-					})
+					}
 					if !foundPod {
 						t.Errorf("Pod %s was not found in the pod group members", tt.initialPods[0].Name)
 					}
@@ -9411,10 +9402,9 @@ func getActivePodGroups(q *PriorityQueue) map[string][]string {
 	for _, pgInfo := range getActivePodGroupInfos(q) {
 		key := fmt.Sprintf("%s/%s", pgInfo.GetType(), pgInfo.GetName())
 		var pods []string
-		pgInfo.ForEachPodInfo(func(pi *framework.QueuedPodInfo) bool {
+		for pi := range pgInfo.ForEachPodInfo() {
 			pods = append(pods, pi.Pod.Name)
-			return true
-		})
+		}
 		result[key] = pods
 	}
 	return result

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -543,7 +543,7 @@ type QueuedEntityInfo interface {
 	GetNamespace() string
 	// ForEachPodInfo iterates over all QueuedPodInfos in the entity and applies the function fn.
 	// If fn returns false, the iteration stops.
-	ForEachPodInfo(fn func(pInfo *QueuedPodInfo) bool)
+	ForEachPodInfo() iter.Seq[*QueuedPodInfo]
 	// Update updates the specified pod in the entity and returns the updated QueuedPodInfo.
 	Update(pod *v1.Pod) (*QueuedPodInfo, error)
 	// Gated returns true if the entity is gated by any plugin at PreEnqueue.
@@ -704,8 +704,10 @@ func (pqi *QueuedPodInfo) Type() fwk.EntityKeyType {
 	return fwk.PodKeyType
 }
 
-func (pqi *QueuedPodInfo) ForEachPodInfo(fn func(pInfo *QueuedPodInfo) bool) {
-	_ = fn(pqi)
+func (pqi *QueuedPodInfo) ForEachPodInfo() iter.Seq[*QueuedPodInfo] {
+	return func(yield func(*QueuedPodInfo) bool) {
+		_ = yield(pqi)
+	}
 }
 
 // Update updates the pod in QueuedPodInfo and clears the cached PodSignature,
@@ -896,12 +898,13 @@ func PodGroupMemberPodsOrderingFunc(a, b *QueuedPodInfo) int {
 	return 0
 }
 
-func (pgqi *QueuedPodGroupInfo) ForEachPodInfo(fn func(pInfo *QueuedPodInfo) bool) {
-	for _, list := range pgqi.QueuedPodInfos {
-		for _, pInfo := range list {
-			ok := fn(pInfo)
-			if !ok {
-				return
+func (pgqi *QueuedPodGroupInfo) ForEachPodInfo() iter.Seq[*QueuedPodInfo] {
+	return func(yield func(*QueuedPodInfo) bool) {
+		for _, list := range pgqi.QueuedPodInfos {
+			for _, pInfo := range list {
+				if !yield(pInfo) {
+					return
+				}
 			}
 		}
 	}

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -22,8 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
@@ -31,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -4272,10 +4271,9 @@ func TestQueuedPodGroupInfo_ForEachPodInfo(t *testing.T) {
 	}
 
 	count := 0
-	qpgi.ForEachPodInfo(func(pInfo *QueuedPodInfo) bool {
+	for range qpgi.ForEachPodInfo() {
 		count++
-		return true
-	})
+	}
 
 	if count != 3 {
 		t.Errorf("Expected 3 pods, got %d", count)
@@ -4283,10 +4281,10 @@ func TestQueuedPodGroupInfo_ForEachPodInfo(t *testing.T) {
 
 	// Test early exit
 	count = 0
-	qpgi.ForEachPodInfo(func(pInfo *QueuedPodInfo) bool {
+	for range qpgi.ForEachPodInfo() {
 		count++
-		return false
-	})
+		break
+	}
 
 	if count != 1 {
 		t.Errorf("Expected 1 pod after early exit, got %d", count)

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -541,15 +541,12 @@ func (sched *Scheduler) handleBindingCycleError(
 // that don't contain a pod with a specific UID.
 func getDifferentUIDPreCheck(uid types.UID) queue.PreEnqueueCheck {
 	return func(entity framework.QueuedEntityInfo) bool {
-		matchesUID := false
-		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+		for pInfo := range entity.ForEachPodInfo() {
 			if pInfo.Pod.UID == uid {
-				matchesUID = true
 				return false
 			}
-			return true
-		})
-		return !matchesUID
+		}
+		return true
 	}
 }
 

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -137,18 +137,17 @@ func (sched *Scheduler) reconcilePodGroupWithSnapshot(pgi *framework.PodGroupInf
 // handlePodGroupFailureBeforeScheduling handles the failure of a (composite) pod group that occurred before scheduling.
 func (sched *Scheduler) handlePodGroupFailureBeforeScheduling(ctx context.Context, podGroupInfo *framework.QueuedPodGroupInfo, err error) {
 	logger := klog.FromContext(ctx)
-	podGroupInfo.ForEachPodInfo(func(podInfo *framework.QueuedPodInfo) bool {
+	for podInfo := range podGroupInfo.ForEachPodInfo() {
 		podFwk, podFwkErr := sched.frameworkForPod(podInfo.Pod)
 		if podFwkErr != nil {
 			// This shouldn't happen, because we only accept for scheduling the pods
 			// which specify a scheduler name that matches one of the profiles.
 			logger.Error(podFwkErr, "Error occurred")
 			sched.SchedulingQueue.Done(podInfo.Pod.UID)
-		} else {
-			sched.FailureHandler(ctx, podFwk, podInfo, fwk.AsStatus(err), clearNominatedNode, time.Now())
+			continue
 		}
-		return true
-	})
+		sched.FailureHandler(ctx, podFwk, podInfo, fwk.AsStatus(err), clearNominatedNode, time.Now())
+	}
 	sched.updatePodGroupConditionWithError(ctx, podGroupInfo.PodGroupInfo, err)
 	err = sched.SchedulingQueue.AddAttemptedPodGroupIfNeeded(logger, podGroupInfo, sched.SchedulingQueue.SchedulingCycle(), fwk.AsStatus(err))
 	if err != nil {
@@ -179,7 +178,6 @@ func (sched *Scheduler) updatePodGroupConditionWithError(ctx context.Context, pg
 func (sched *Scheduler) validatePodGroup(podGroupInfo *framework.QueuedPodGroupInfo) error {
 	schedulerName := ""
 	podGroupPriority := podGroupInfo.GetPriority()
-	var err error
 
 	var pgPreemptionPolicy v1.PreemptionPolicy
 	if utilfeature.DefaultFeatureGate.Enabled(features.PodGroupPreemptionPolicy) {
@@ -213,18 +211,17 @@ func (sched *Scheduler) validatePodGroup(podGroupInfo *framework.QueuedPodGroupI
 		}
 		return nil
 	}
-	podGroupInfo.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+	for pInfo := range podGroupInfo.ForEachPodInfo() {
 		if schedulerName == "" {
 			schedulerName = pInfo.Pod.Spec.SchedulerName
 		}
-		err = validatePod(pInfo.Pod)
-		return err == nil
-	})
-	if err != nil {
-		return err
+		err := validatePod(pInfo.Pod)
+		if err != nil {
+			return err
+		}
 	}
 
-	err = sched.validateScheduledPods(podGroupInfo.PodGroupInfo, validatePod)
+	err := sched.validateScheduledPods(podGroupInfo.PodGroupInfo, validatePod)
 	if err != nil {
 		return err
 	}
@@ -286,12 +283,10 @@ func (sched *Scheduler) validateScheduledPods(podGroupInfo *framework.PodGroupIn
 // frameworkForPodGroup obtains the concrete scheduler framework for the entire pod group.
 // Assumes [Scheduler.validatePodGroup] has been called before.
 func (sched *Scheduler) frameworkForPodGroup(podGroupInfo *framework.QueuedPodGroupInfo) framework.Framework {
-	var result framework.Framework
-	podGroupInfo.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
-		result = sched.Profiles[pInfo.Pod.Spec.SchedulerName]
-		return false
-	})
-	return result
+	for pInfo := range podGroupInfo.ForEachPodInfo() {
+		return sched.Profiles[pInfo.Pod.Spec.SchedulerName]
+	}
+	return nil
 }
 
 // skipPodGroupPodSchedule skips the scheduling of particular pods from the group when they should no longer be considered.

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1542,10 +1542,9 @@ func TestHandleSchedulingFailure_PodGroupFitErrorCloned(t *testing.T) {
 	pgInfo := entity.(*framework.QueuedPodGroupInfo)
 
 	var poppedPods []*framework.QueuedPodInfo
-	pgInfo.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+	for pInfo := range pgInfo.ForEachPodInfo() {
 		poppedPods = append(poppedPods, pInfo)
-		return true
-	})
+	}
 	if len(poppedPods) != 2 {
 		t.Fatalf("Expected 2 popped pods, got %d", len(poppedPods))
 	}

--- a/test/integration/scheduler/preemption/nominatednodename/nominatednodename_test.go
+++ b/test/integration/scheduler/preemption/nominatednodename/nominatednodename_test.go
@@ -330,11 +330,10 @@ func initTestPreferNominatedNode(t *testing.T, nsPrefix string, opts ...schedule
 		entity, _ := f(klog.FromContext(testCtx.Ctx))
 		// Scheduler.NextEntity() may return nil when scheduler is shutting down.
 		if entity != nil {
-			entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+			for pInfo := range entity.ForEachPodInfo() {
 				pInfo.Pod = pInfo.Pod.DeepCopy()
 				pInfo.Pod.Status.NominatedNodeName = "node-1"
-				return true
-			})
+			}
 		}
 		return entity, nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This PR updates the `ForEachPodInfo` method to return `iter.Seq` instead of taking a func as an argument. This improves the readability of the code, as standard `for` loop can be used to iterate over the PodInfos.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Generative AI was used in the PR preparation. Changes were carefully reviewed before pushing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
