### PR TITLE
kubectl: e2e test for kubectl exec with `--proxy-url`

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -531,6 +531,38 @@ var _ = SIGDescribe("Kubectl client", func() {
 			}
 		})
 
+		ginkgo.It("should support exec with an explicit proxy URL", func(ctx context.Context) {
+			// testContextHost is a KUBECONFIG URL
+			testContextHost := getTestContextHost()
+
+			// an explicit proxy-url can be used even when the API server is on localhost.
+			ginkgo.By("Starting a test HTTP proxy")
+			var proxyLogs bytes.Buffer
+			testSrv := httptest.NewServer(utilnettesting.NewHTTPProxyHandler(ginkgo.GinkgoTB(), func(req *http.Request) bool {
+				fmt.Fprintf(&proxyLogs, "Proxy received %s request for %s\n", req.Method, req.Host)
+				return true
+			}))
+			defer testSrv.Close()
+			proxyAddr := testSrv.URL
+
+			ginkgo.By("Executing kubectl with an explicit proxy URL")
+			output := e2ekubectl.NewKubectlCommand(ns, "--proxy-url="+proxyAddr, "exec", podRunningTimeoutArg, simplePodName, "--", "echo", "running", "in", "container").ExecOrDie(ns)
+
+			// Verify the exec request completed successfully.
+			expectedExecOutput := "running in container\n"
+			if output != expectedExecOutput {
+				framework.Failf("Unexpected kubectl exec output. Wanted %q, got %q", expectedExecOutput, output)
+			}
+
+			// Verify that the request to the API server went through the proxy.
+			expectedProxyLog := fmt.Sprintf("Proxy received CONNECT request for %s", strings.TrimSuffix(strings.TrimPrefix(testContextHost, "https://"), "/api"))
+
+			proxyLog := proxyLogs.String()
+			if !strings.Contains(proxyLog, expectedProxyLog) {
+				framework.Failf("Expected proxy connection was not observed. Wanted %q in proxy logs but got %q", expectedProxyLog, proxyLog)
+			}
+		})
+
 		// https://issues.k8s.io/128314
 		f.It(f.WithSlow(), "should support exec idle connections", func(ctx context.Context) {
 			ginkgo.By("executing a command in the container")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds an e2e test to verify that `kubectl exec` works through an HTTP proxy when using the `--proxy-url` flag.

Unlike proxy environment variables, which are ignored for localhost and loopback addresses(ref: https://github.com/kubernetes/kubernetes/pull/131462) , `--proxy-url` explicitly configures the proxy and can be tested with local clusters. The test verifies that `kubectl exec` succeeds and that the connection to the API server is observed by the configured HTTP proxy.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
