### PR TITLE
Mark pods NotReady on NotReady->Unknown node transition

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -753,10 +753,10 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 			pods, err := nc.getPodsAssignedToNode(node.Name)
 			if err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Unable to list pods of node", node.Name)
-				if currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue {
-					// If error happened during node status transition (Ready -> NotReady)
-					// we need to mark node for retry to force MarkPodsNotReady execution
-					// in the next iteration.
+				if transitionRequiresMarkingPodsNotReady(currentReadyCondition.Status, observedReadyCondition.Status) {
+					// If error happened during node status transition (Ready -> NotReady
+					// or NotReady -> Unknown) we need to mark node for retry to force
+					// MarkPodsNotReady execution in the next iteration.
 					nc.nodesToRetry.Store(node.Name, struct{}{})
 				}
 				return
@@ -768,6 +768,11 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 			case currentReadyCondition.Status != v1.ConditionTrue && observedReadyCondition.Status == v1.ConditionTrue:
 				// Report node event only once when status changed.
 				controllerutil.RecordNodeStatusChange(logger, nc.recorder, node, "NodeNotReady")
+				fallthrough
+			case transitionRequiresMarkingPodsNotReady(currentReadyCondition.Status, observedReadyCondition.Status):
+				// A NotReady -> Unknown transition means the kubelet stopped
+				// reporting, and pods it marked Ready while the node was NotReady
+				// would otherwise stay Ready forever. Mark them NotReady.
 				fallthrough
 			case needsRetry && observedReadyCondition.Status != v1.ConditionTrue:
 				if err = controllerutil.MarkPodsNotReady(ctx, nc.kubeClient, nc.recorder, pods, node.Name); err != nil {
@@ -790,6 +795,16 @@ func (nc *Controller) monitorNodeHealth(ctx context.Context) error {
 	nc.handleDisruption(ctx, zoneToNodeConditions, nodes)
 
 	return nil
+}
+
+// transitionRequiresMarkingPodsNotReady reports whether the observed->current
+// Ready condition transition requires marking all pods on the node NotReady:
+// the node left the Ready state, or a NotReady node became Unknown. In the
+// latter case the kubelet stopped reporting, so the pod readiness it last
+// reported can no longer be trusted.
+func transitionRequiresMarkingPodsNotReady(current, observed v1.ConditionStatus) bool {
+	return (current != v1.ConditionTrue && observed == v1.ConditionTrue) ||
+		(current == v1.ConditionUnknown && observed == v1.ConditionFalse)
 }
 
 func (nc *Controller) processTaintBaseEviction(ctx context.Context, node *v1.Node, currentReadyCondition *v1.NodeCondition) {

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -2127,6 +2127,55 @@ func TestMonitorNodeHealthMarkPodsNotReady(t *testing.T) {
 			},
 			expectedPodStatusUpdate: true,
 		},
+		// Node created long time ago, was NotReady with status updated recently,
+		// then stopped reporting so the controller marks it Unknown
+		// (NotReady -> Unknown transition).
+		// Expect pods status updated to NotReady.
+		{
+			fakeNodeHandler: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "node0",
+							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+						},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{
+									Type:   v1.NodeReady,
+									Status: v1.ConditionFalse,
+									// Node status has just been updated.
+									LastHeartbeatTime:  fakeNow,
+									LastTransitionTime: fakeNow,
+								},
+							},
+							Capacity: v1.ResourceList{
+								v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+								v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+							},
+						},
+					},
+				},
+				Clientset: fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testutil.NewPod("pod0", "node0")}}),
+			},
+			timeToPass: 1 * time.Minute,
+			newNodeStatus: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionFalse,
+						// Node status hasn't been updated for 1hr.
+						LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+					},
+				},
+				Capacity: v1.ResourceList{
+					v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10"),
+					v1.ResourceName(v1.ResourceMemory): resource.MustParse("10G"),
+				},
+			},
+			expectedPodStatusUpdate: true,
+		},
 	}
 
 	tCtx := ktesting.Init(t)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a node's Ready condition transitions from `False` to `Unknown` (the kubelet stops reporting after the node was already NotReady), `monitorNodeHealth` does not call `MarkPodsNotReady`: the existing switch only handles transitions out of `Ready` (and the retry path). Pods that the kubelet marked Ready again while the node was NotReady therefore stay Ready forever once the node goes Unknown, and remain in endpoints / routable.

This PR treats the `NotReady -> Unknown` transition like the other transitions into an untrusted node state: it marks all pods on the node NotReady, and extends the retry-on-error path (failed pod listing) to cover the same transition. A unit test case for the `False -> Unknown` transition is added to `TestMonitorNodeHealthMarkPodsNotReady` (it fails without the fix).

#### Which issue(s) this PR fixes:

Fixes #112733

#### Special notes for your reviewer:

The `NodeNotReady` event is intentionally NOT re-emitted on `False -> Unknown`; it was already emitted on the `True -> False` transition. Happy to generalize further (e.g. merging with #109998's scope) if maintainers prefer.

#### Does this PR introduce a user-facing change?

```release-note
kube-controller-manager: pods on a node whose Ready condition transitions from NotReady to Unknown are now marked NotReady, so they are removed from endpoints instead of staying routable with stale readiness.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A