### PR TITLE
kubelet: defer to pod grace period when eviction-max-pod-grace-period is negative

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -643,7 +643,14 @@ func (m *managerImpl) evictPod(logger klog.Logger, pod *v1.Pod, gracePeriodOverr
 	m.recorder.AnnotatedEventf(pod, annotations, v1.EventTypeWarning, Reason, "%s", evictMsg)
 	// this is a blocking call and should only return when the pod and its containers are killed.
 	logger.V(3).Info("Evicting pod", "pod", klog.KObj(pod), "podUID", pod.UID, "message", evictMsg)
-	err := m.killPodFunc(pod, true, &gracePeriodOverride, func(status *v1.PodStatus) {
+	// A negative grace period override defers to the pod specified
+	// termination grace period (see --eviction-max-pod-grace-period),
+	// which killPodFunc honors when the override is nil.
+	var override *int64
+	if gracePeriodOverride >= 0 {
+		override = &gracePeriodOverride
+	}
+	err := m.killPodFunc(pod, true, override, func(status *v1.PodStatus) {
 		status.Phase = v1.PodFailed
 		status.Reason = Reason
 		status.Message = evictMsg

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -900,6 +900,77 @@ func makeContainersByQOS(class v1.PodQOSClass) []v1.Container {
 	}
 }
 
+// TestSoftEvictionNegativeMaxPodGracePeriod verifies that a negative
+// --eviction-max-pod-grace-period defers to the pod specified termination
+// grace period (nil override) instead of passing the negative value down to
+// the runtime. See https://github.com/kubernetes/kubernetes/issues/118172.
+func TestSoftEvictionNegativeMaxPodGracePeriod(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	podMaker := makePodWithMemoryStats
+	summaryStatsMaker := makeMemoryStats
+	pod, podStat := podMaker("best-effort-low-priority-low-usage", lowPriority, newResourceList("", "", ""), newResourceList("", "", ""), "100Mi")
+	pods := []*v1.Pod{pod}
+	podStats := map[*v1.Pod]statsapi.PodStats{pod: podStat}
+	activePodsFunc := func() []*v1.Pod {
+		return pods
+	}
+
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	podKiller := &mockPodKiller{}
+	diskInfoProvider := &mockDiskInfoProvider{dedicatedImageFs: ptr.To(false)}
+	diskGC := &mockDiskGC{err: nil}
+	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+
+	config := Config{
+		MaxPodGracePeriodSeconds: -1,
+		PressureTransitionPeriod: time.Minute * 5,
+		Thresholds: []evictionapi.Threshold{
+			{
+				Signal:   evictionapi.SignalMemoryAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("2Gi"),
+				},
+				GracePeriod: time.Minute * 2,
+			},
+		},
+	}
+	summaryProvider := &fakeSummaryProvider{result: summaryStatsMaker("3Gi", podStats)}
+	manager := &managerImpl{
+		clock:                        fakeClock,
+		killPodFunc:                  podKiller.killPodNow,
+		imageGC:                      diskGC,
+		containerGC:                  diskGC,
+		config:                       config,
+		recorder:                     &record.FakeRecorder{},
+		summaryProvider:              summaryProvider,
+		nodeRef:                      nodeRef,
+		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
+		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+	}
+
+	// induce soft threshold
+	fakeClock.Step(1 * time.Minute)
+	summaryProvider.result = summaryStatsMaker("1500Mi", podStats)
+	if _, err := manager.synchronize(tCtx, diskInfoProvider, activePodsFunc); err != nil {
+		t.Fatalf("Manager expects no error but got %v", err)
+	}
+
+	// step forward in time past the grace period
+	fakeClock.Step(3 * time.Minute)
+	if _, err := manager.synchronize(tCtx, diskInfoProvider, activePodsFunc); err != nil {
+		t.Fatalf("Manager expects no error but got %v", err)
+	}
+
+	// verify the pod was killed deferring to the pod specified grace period.
+	if podKiller.pod != pod {
+		t.Fatalf("Manager chose to kill pod: %v, but should have chosen %v", podKiller.pod, pod.Name)
+	}
+	if podKiller.gracePeriodOverride != nil {
+		t.Errorf("Manager chose to kill pod with grace period override %d, but a negative --eviction-max-pod-grace-period must defer to the pod specified value (nil override)", *podKiller.gracePeriodOverride)
+	}
+}
+
 func TestPIDPressure(t *testing.T) {
 	testCases := []struct {
 		name                               string


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind documentation

#### What this PR does / why we need it:

The `--eviction-max-pod-grace-period` help text promises: "If negative, defer to pod specified value". In reality the negative value flows through `min(MaxPodGracePeriodSeconds, *pod.Spec.TerminationGracePeriodSeconds)` and is passed to `killPodFunc` (and thus the CRI runtime) as the grace period override `-1`, so pods are SIGKILLed immediately on soft eviction (exit 137), exactly as reported in the issue.

This PR makes `evictPod` treat a negative grace period override as "no override" (nil), so `killPodFunc` defers to the pod specified `terminationGracePeriodSeconds`, matching the documented behavior. Positive and zero values are unchanged. A regression test asserts the nil override on soft eviction with `MaxPodGracePeriodSeconds: -1` (it fails without the fix).

Note: this makes the negative setting actually behave as documented; clusters relying on the current (undocumented) immediate-kill behavior of negative values will see pods terminated with their pod-specified grace period instead.

#### Which issue(s) this PR fixes:

Fixes #118172

#### Special notes for your reviewer:

The issue discusses "fix code or fix docs"; this PR fixes the code to honor the long-documented contract. Happy to switch to a docs-only change if maintainers prefer the immediate-kill semantics for negative values.

#### Does this PR introduce a user-facing change?

```release-note
kubelet: a negative `--eviction-max-pod-grace-period` now defers to the pod specified `terminationGracePeriodSeconds` on soft eviction, as documented, instead of passing the negative value to the container runtime and killing containers immediately.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A