### PR TITLE
test: cover deleted unscheduled pod resource claim

### DIFF
--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -950,6 +950,28 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			expectedMetrics: claimCreateMetrics{},
 		},
 		{
+			name: "clear-reserved-when-deleted-before-scheduling",
+			pods: func() []*v1.Pod {
+				pod := testPodWithResource.DeepCopy()
+				deleted := metav1.Now()
+				pod.DeletionTimestamp = &deleted
+				pod.Spec.NodeName = ""
+				return []*v1.Pod{pod}
+			}(),
+			key: claimKey(testClaimReserved),
+			claims: func() []*resourceapi.ResourceClaim {
+				claims := []*resourceapi.ResourceClaim{testClaimReserved.DeepCopy()}
+				claims[0].OwnerReferences = nil
+				return claims
+			}(),
+			expectedClaims: func() []resourceapi.ResourceClaim {
+				claims := []resourceapi.ResourceClaim{*testClaimAllocated.DeepCopy()}
+				claims[0].OwnerReferences = nil
+				return claims
+			}(),
+			expectedMetrics: claimCreateMetrics{},
+		},
+		{
 			name:            "remove-reserved",
 			pods:            []*v1.Pod{testPod},
 			key:             claimKey(testClaimReservedTwice),


### PR DESCRIPTION
#### What type of PR is this?
/kind test

#### What this PR does
Adds test coverage for a ResourceClaim reserved by a Pod that is deleted before being scheduled.

The test verifies that the ResourceClaim reservation is cleared when:
- the Pod has a deletion timestamp
- the Pod has not been assigned to a node

This covers the `isPodDone` condition for a deleted, unscheduled Pod.

#### Tests
- `go test ./pkg/controller/resourceclaim`
- `git diff --check`