### PR TITLE
kube-controller-manager: use contextual logging in clustertrustbundle publisher controller

### DIFF
--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -351,7 +351,7 @@ func newKubeAPIServerSignerClusterTrustBundledPublisherController(
 	}
 
 	if runner == nil {
-		klog.Info("no known scheme version was found for clustertrustbundles, cannot start kube-apiserver-serving-clustertrustbundle-publisher-controller")
+		klog.FromContext(ctx).Info("no known scheme version was found for clustertrustbundles, cannot start kube-apiserver-serving-clustertrustbundle-publisher-controller")
 		return nil, nil
 	}
 

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -351,6 +351,7 @@ linters:
             contextual k8s.io/sample-apiserver/.*
             contextual k8s.io/sample-cli-plugin/.*
             contextual k8s.io/sample-controller/.*
+            contextual k8s.io/kubernetes/cmd/kube-controller-manager/.*
             contextual k8s.io/kubernetes/cmd/kube-proxy/.*
             contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
             contextual k8s.io/kubernetes/cmd/kubelet/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -364,6 +364,7 @@ linters:
             contextual k8s.io/sample-apiserver/.*
             contextual k8s.io/sample-cli-plugin/.*
             contextual k8s.io/sample-controller/.*
+            contextual k8s.io/kubernetes/cmd/kube-controller-manager/.*
             contextual k8s.io/kubernetes/cmd/kube-proxy/.*
             contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
             contextual k8s.io/kubernetes/cmd/kubelet/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -41,6 +41,7 @@ contextual k8s.io/kube-scheduler/.*
 contextual k8s.io/sample-apiserver/.*
 contextual k8s.io/sample-cli-plugin/.*
 contextual k8s.io/sample-controller/.*
+contextual k8s.io/kubernetes/cmd/kube-controller-manager/.*
 contextual k8s.io/kubernetes/cmd/kube-proxy/.*
 contextual k8s.io/kubernetes/cmd/kube-scheduler/.*
 contextual k8s.io/kubernetes/cmd/kubelet/.*


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Migrates the last non-contextual logging call in `cmd/kube-controller-manager` (`klog.Info` in the kube-apiserver-serving-clustertrustbundle-publisher controller constructor) to contextual logging via `klog.FromContext(ctx)`, and enforces contextual logging for the whole package by adding it to `hack/logcheck.conf`. All other files in the package already use contextual logging.

Part of #126379 (add and use alternative APIs which support contextual logging).

#### Which issue(s) this PR fixes:

Part of #126379

#### Special notes for your reviewer:

`go build ./cmd/kube-controller-manager/...` and `go test ./cmd/kube-controller-manager/...` pass locally.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

N/A