### PR TITLE
conformance: demote guaranteed pod resize tests to e2e

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2669,35 +2669,6 @@
     status.
   release: v1.35
   file: test/e2e/common/node/pod_resize.go
-- testname: In-place Pod Resize, guaranteed pods with multiple containers, net increase
-  codename: '[sig-node] Pod InPlace Resize Container guaranteed pods with multiple
-    containers 3 containers - increase cpu & mem on c1, c2, decrease cpu & mem on
-    c3 - net increase [MinimumKubeletVersion:1.34] [Conformance]'
-  description: Issuing an in-place Pod Resize request via the Pod Resize subresource
-    patch endpoint to modify CPU and memory requests and limits for a guaranteed pod
-    with 3 containers with a net increase MUST result in the Pod resources being updated
-    as expected.
-  release: v1.35
-  file: test/e2e/common/node/pod_resize.go
-- testname: In-place Pod Resize, guaranteed pods with multiple containers, net decrease
-  codename: '[sig-node] Pod InPlace Resize Container guaranteed pods with multiple
-    containers 3 containers - increase cpu & mem on c1, decrease cpu & mem on c2,
-    c3 - net decrease [MinimumKubeletVersion:1.34] [Conformance]'
-  description: Issuing an in-place Pod Resize request via the Pod Resize subresource
-    patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers
-    with a net decrease MUST result in the Pod resources being updated as expected.
-  release: v1.35
-  file: test/e2e/common/node/pod_resize.go
-- testname: In-place Pod Resize, guaranteed pods with multiple containers, various
-    operations
-  codename: '[sig-node] Pod InPlace Resize Container guaranteed pods with multiple
-    containers 3 containers - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU
-    (c2) [MinimumKubeletVersion:1.34] [Conformance]'
-  description: Issuing an in-place Pod Resize request via the Pod Resize subresource
-    patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers
-    with various operations MUST result in the Pod resources being updated as expected.
-  release: v1.35
-  file: test/e2e/common/node/pod_resize.go
 - testname: In-place Pod Resize, read and replace endpoints
   codename: '[sig-node] Pod InPlace Resize Container resize pod via the replace endpoint
     [MinimumKubeletVersion:1.34] [Conformance]'

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -140,12 +140,7 @@ func doGuaranteedPodResizeTests(f *framework.Framework) {
 	// All tests will perform the requested resize, and once completed, will roll back the change.
 	// This results in coverage of both the operation as described, and its reverse.
 	ginkgo.Describe("guaranteed pods with multiple containers", func() {
-		/*
-			Release: v1.35
-			Testname: In-place Pod Resize, guaranteed pods with multiple containers, net increase
-			Description: Issuing an in-place Pod Resize request via the Pod Resize subresource patch endpoint to modify CPU and memory requests and limits for a guaranteed pod with 3 containers with a net increase MUST result in the Pod resources being updated as expected.
-		*/
-		framework.ConformanceIt("3 containers - increase cpu & mem on c1, c2, decrease cpu & mem on c3 - net increase [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
+		ginkgo.It("3 containers - increase cpu & mem on c1, c2, decrease cpu & mem on c3 - net increase [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
 			originalContainers := makeGuaranteedContainers(3, v1.NotRequired, v1.NotRequired, false, false, originalCPU, originalMem)
 			for i := range originalContainers {
 				originalContainers[i].CPUPolicy = nil
@@ -170,12 +165,7 @@ func doGuaranteedPodResizeTests(f *framework.Framework) {
 			doPatchAndRollback(ctx, f, originalContainers, expectedContainers, nil, nil, true, false)
 		})
 
-		/*
-			Release: v1.35
-			Testname: In-place Pod Resize, guaranteed pods with multiple containers, net decrease
-			Description: Issuing an in-place Pod Resize request via the Pod Resize subresource patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers with a net decrease MUST result in the Pod resources being updated as expected.
-		*/
-		framework.ConformanceIt("3 containers - increase cpu & mem on c1, decrease cpu & mem on c2, c3 - net decrease [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
+		ginkgo.It("3 containers - increase cpu & mem on c1, decrease cpu & mem on c2, c3 - net decrease [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
 			originalContainers := makeGuaranteedContainers(3, v1.NotRequired, v1.NotRequired, false, false, originalCPU, originalMem)
 			for i := range originalContainers {
 				originalContainers[i].CPUPolicy = nil
@@ -200,12 +190,7 @@ func doGuaranteedPodResizeTests(f *framework.Framework) {
 			doPatchAndRollback(ctx, f, originalContainers, expectedContainers, nil, nil, true, false)
 		})
 
-		/*
-			Release: v1.35
-			Testname: In-place Pod Resize, guaranteed pods with multiple containers, various operations
-			Description: Issuing an in-place Pod Resize request via the Pod Resize subresource patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers with various operations MUST result in the Pod resources being updated as expected.
-		*/
-		framework.ConformanceIt("3 containers - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU (c2) [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
+		ginkgo.It("3 containers - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU (c2) [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
 			originalContainers := makeGuaranteedContainers(3, v1.NotRequired, v1.NotRequired, false, false, originalCPU, originalMem)
 			for i := range originalContainers {
 				originalContainers[i].CPUPolicy = nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test
/kind regression

#### What this PR does / why we need it:

Drop guaranteed pod resize tests from the conformance suite.

This will be backported into 1.35 and 1.36. 

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/kubernetes/kubernetes/issues/141064
https://kubernetes.slack.com/archives/C0BP8PW9G/p1785341300484119

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Three conformance tests added in 1.35 that are not interoperable with static CPU manager are demoted to regular e2e tests
```
