### PR TITLE
DRA: fix extended resources when DRANodeAllocatableResources is enabled

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -6334,6 +6334,14 @@ func validateNodeAllocatableResourceClaimStatus(podStatus core.PodStatus, podSpe
 				}
 			}
 		}
+		// Extended resources backed by DRA are satisfied by a scheduler-created
+		// ResourceClaim that is not referenced in podSpec.ResourceClaims nor in
+		// podStatus.ResourceClaimStatuses. Its name is recorded in
+		// podStatus.ExtendedResourceClaimStatus instead.
+		if !found && podStatus.ExtendedResourceClaimStatus != nil &&
+			podStatus.ExtendedResourceClaimStatus.ResourceClaimName == nodeAllocatableStatus.ResourceClaimName {
+			found = true
+		}
 
 		if !found {
 			allErrs = append(allErrs, field.Invalid(statusFldPath.Child("resourceClaimName"), nodeAllocatableStatus.ResourceClaimName, "no mapping found in pod reference"))

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -17569,6 +17569,55 @@ func TestValidateNodeAllocatableResourceClaimStatus(t *testing.T) {
 			errorField:  "status.nodeAllocatableResourceClaimStatuses[0].overhead[0].name",
 			errorMsg:    "must be a node allocatable resource name",
 		},
+		{
+			name: "Valid ResourceClaimName from ExtendedResourceClaimStatus",
+			spec: core.PodSpec{
+				Containers: []core.Container{
+					{Name: "c1", Image: "image"},
+				},
+			},
+			podStatus: core.PodStatus{
+				ExtendedResourceClaimStatus: &core.PodExtendedResourceClaimStatus{
+					ResourceClaimName: "extended-claim1",
+				},
+				NodeAllocatableResourceClaimStatuses: []core.NodeAllocatableResourceClaimStatus{
+					{
+						ResourceClaimName: "extended-claim1",
+						Containers:        []string{"c1"},
+						Mapping: []core.NodeAllocatableMappedResources{
+							{Name: core.ResourceCPU, Quantity: new(resource.MustParse("1"))},
+						},
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "Invalid ResourceClaimName not matching ExtendedResourceClaimStatus",
+			spec: core.PodSpec{
+				Containers: []core.Container{
+					{Name: "c1", Image: "image"},
+				},
+			},
+			podStatus: core.PodStatus{
+				ExtendedResourceClaimStatus: &core.PodExtendedResourceClaimStatus{
+					ResourceClaimName: "extended-claim1",
+				},
+				NodeAllocatableResourceClaimStatuses: []core.NodeAllocatableResourceClaimStatus{
+					{
+						ResourceClaimName: "some-other-claim",
+						Containers:        []string{"c1"},
+						Mapping: []core.NodeAllocatableMappedResources{
+							{Name: core.ResourceCPU, Quantity: new(resource.MustParse("1"))},
+						},
+					},
+				},
+			},
+			expectError: true,
+			errorType:   field.ErrorTypeInvalid,
+			errorField:  "status.nodeAllocatableResourceClaimStatuses[0].resourceClaimName",
+			errorMsg:    "no mapping found in pod reference",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources.go
@@ -1696,7 +1696,7 @@ func (pl *DynamicResources) PreBind(ctx context.Context, cs fwk.CycleState, pod 
 	if pl.fts.EnableDRANodeAllocatableResources {
 		nodeAllocations, ok := state.nodeAllocations[nodeName]
 		if ok && len(nodeAllocations.nodeAllocatableResourceClaimStatuses) > 0 {
-			if status := pl.patchNodeAllocatableResourceClaimStatus(ctx, pod, nodeAllocations.nodeAllocatableResourceClaimStatuses); status != nil {
+			if status := pl.patchNodeAllocatableResourceClaimStatus(ctx, pod, nodeAllocations.nodeAllocatableResourceClaimStatuses, state.claims.extendedResourceClaim()); status != nil {
 				return status
 			}
 		}

--- a/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources.go
@@ -39,7 +39,13 @@ import (
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
 )
 
-// ExtractPodNodeAllocatableResourceClaimStatus returns the pod nodeAllocatable claim status stored in state
+// ExtractPodNodeAllocatableResourceClaimStatus returns a copy of the node-allocatable
+// claim status stored in state for the given node.
+//
+// A copy is required because assume() assigns the result onto the cached pod.
+// Sharing the cycle-state slice would make later in-place updates (replacing the
+// extended-resource placeholder claim name) silently mutate the scheduler cache
+// and would make the DeepEqual check in patchNodeAllocatableResourceClaimStatus a no-op.
 func ExtractPodNodeAllocatableResourceClaimStatus(logger klog.Logger, state fwk.CycleState, nodeName string) []v1.NodeAllocatableResourceClaimStatus {
 	s, err := state.Read(names.DynamicResources)
 	if err != nil {
@@ -54,10 +60,21 @@ func ExtractPodNodeAllocatableResourceClaimStatus(logger klog.Logger, state fwk.
 	}
 
 	if nodeAlloc, exists := draState.nodeAllocations[nodeName]; exists {
-		return nodeAlloc.nodeAllocatableResourceClaimStatuses
+		return cloneNodeAllocatableResourceClaimStatuses(nodeAlloc.nodeAllocatableResourceClaimStatuses)
 	}
 
 	return nil
+}
+
+func cloneNodeAllocatableResourceClaimStatuses(in []v1.NodeAllocatableResourceClaimStatus) []v1.NodeAllocatableResourceClaimStatus {
+	if in == nil {
+		return nil
+	}
+	out := make([]v1.NodeAllocatableResourceClaimStatus, len(in))
+	for i := range in {
+		in[i].DeepCopyInto(&out[i])
+	}
+	return out
 }
 
 // calculateAndCheckNodeAllocatableResources calculates the total node-allocatable resources (e.g., CPU, memory)
@@ -607,7 +624,27 @@ func (pl *DynamicResources) nodeFitsResources(nodeInfo fwk.NodeInfo, podRequest 
 	return nil
 }
 
-func (pl *DynamicResources) patchNodeAllocatableResourceClaimStatus(ctx context.Context, pod *v1.Pod, nodeAllocatableClaimStatus []v1.NodeAllocatableResourceClaimStatus) *fwk.Status {
+// replaceSpecialClaimNameInStatus rewrites the in-memory placeholder claim name
+// specialClaimInMemName ("<extended-resources>") in the given node-allocatable
+// statuses to the actual name of the extended-resource ResourceClaim created in
+// the API server during PreBind.
+//
+// It is a no-op when there is no extended-resource claim (extendedClaim == nil)
+// or the claim has not yet been created in the API server (its name is still a
+// special claim name). Statuses that do not carry the placeholder name are left
+// untouched. The statuses slice is mutated in place.
+func replaceSpecialClaimNameInStatus(extendedClaim *resourceapi.ResourceClaim, statuses []v1.NodeAllocatableResourceClaimStatus) {
+	if extendedClaim == nil || isSpecialClaimName(extendedClaim.Name) {
+		return
+	}
+	for i := range statuses {
+		if statuses[i].ResourceClaimName == specialClaimInMemName {
+			statuses[i].ResourceClaimName = extendedClaim.Name
+		}
+	}
+}
+
+func (pl *DynamicResources) patchNodeAllocatableResourceClaimStatus(ctx context.Context, pod *v1.Pod, nodeAllocatableClaimStatus []v1.NodeAllocatableResourceClaimStatus, extendedClaim *resourceapi.ResourceClaim) *fwk.Status {
 
 	if len(nodeAllocatableClaimStatus) == 0 {
 		return nil
@@ -623,6 +660,15 @@ func (pl *DynamicResources) patchNodeAllocatableResourceClaimStatus(ctx context.
 		logger.V(5).Info("NodeAllocatableResourceClaimStatuses difference: assumed pod status does not match calculated status", "pod", klog.KObj(pod))
 		return statusError(logger, errors.New("assumed pod status does not match calculated status to be patched"))
 	}
+
+	// After bindClaim, the in-memory placeholder "<extended-resources>" must be
+	// replaced with the real claim name before the status is persisted. This
+	// must run after the DeepEqual check: assume() copied the Filter-time
+	// status (still using the placeholder) onto the cached pod, so comparing
+	// after the rename would fail even when the assumed and calculated
+	// allocations match.
+	replaceSpecialClaimNameInStatus(extendedClaim, nodeAllocatableClaimStatus)
+
 	baseStatus.NodeAllocatableResourceClaimStatuses = nil
 
 	targetStatus := pod.Status.DeepCopy()

--- a/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/nodeallocatabledynamicresources_test.go
@@ -1356,14 +1356,91 @@ func TestBuildNodeAllocatableDRAInfo(t *testing.T) {
 	}
 }
 
+func TestExtractPodNodeAllocatableResourceClaimStatus(t *testing.T) {
+	logger := klog.TODO()
+	nodeName := "node-a"
+	original := []v1.NodeAllocatableResourceClaimStatus{
+		{
+			ResourceClaimName: specialClaimInMemName,
+			Containers:        []string{"c1"},
+			Mapping: []v1.NodeAllocatableMappedResources{{
+				Name:     v1.ResourceCPU,
+				Quantity: new(resource.MustParse("1")),
+			}},
+		},
+	}
+
+	t.Run("no cycle state", func(t *testing.T) {
+		got := ExtractPodNodeAllocatableResourceClaimStatus(logger, framework.NewCycleState(), nodeName)
+		if got != nil {
+			t.Errorf("ExtractPodNodeAllocatableResourceClaimStatus() = %v, want nil", got)
+		}
+	})
+
+	t.Run("unknown node", func(t *testing.T) {
+		state := framework.NewCycleState()
+		state.Write(stateKey, &stateData{
+			nodeAllocations: map[string]nodeAllocation{
+				nodeName: {nodeAllocatableResourceClaimStatuses: cloneNodeAllocatableResourceClaimStatuses(original)},
+			},
+		})
+		got := ExtractPodNodeAllocatableResourceClaimStatus(logger, state, "other-node")
+		if got != nil {
+			t.Errorf("ExtractPodNodeAllocatableResourceClaimStatus() = %v, want nil", got)
+		}
+	})
+
+	t.Run("returns a copy not the cycle-state slice", func(t *testing.T) {
+		state := framework.NewCycleState()
+		draState := &stateData{
+			nodeAllocations: map[string]nodeAllocation{
+				nodeName: {nodeAllocatableResourceClaimStatuses: cloneNodeAllocatableResourceClaimStatuses(original)},
+			},
+		}
+		state.Write(stateKey, draState)
+
+		got := ExtractPodNodeAllocatableResourceClaimStatus(logger, state, nodeName)
+		if diff := cmp.Diff(original, got); diff != "" {
+			t.Errorf("ExtractPodNodeAllocatableResourceClaimStatus() diff (-want +got):\n%s", diff)
+		}
+		if len(got) == 0 {
+			t.Fatal("ExtractPodNodeAllocatableResourceClaimStatus() returned empty status")
+		}
+
+		got[0].ResourceClaimName = "mutated-by-caller"
+		got[0].Mapping[0].Quantity.Add(resource.MustParse("1"))
+
+		inState := draState.nodeAllocations[nodeName].nodeAllocatableResourceClaimStatuses
+		if diff := cmp.Diff(original, inState); diff != "" {
+			t.Errorf("mutating extracted status changed cycle state (-want +got):\n%s", diff)
+		}
+	})
+}
+
 func TestPatchNodeAllocatableResourceClaimStatus(t *testing.T) {
 	pod := st.MakePod().Name("test-pod").Namespace("test-ns").UID("pod-uid").Obj()
+	placeholderStatus := []v1.NodeAllocatableResourceClaimStatus{
+		{
+			ResourceClaimName: specialClaimInMemName,
+			Containers:        []string{"c1"},
+			Mapping: []v1.NodeAllocatableMappedResources{{
+				Name:     v1.ResourceCPU,
+				Quantity: new(resource.MustParse("1")),
+			}},
+		},
+	}
+	realClaim := &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: "real-claim-name"}}
 
 	tests := []struct {
 		name                               string
 		assumedPodStatus                   v1.PodStatus
 		finalPodNodeAllocatableClaimStatus []v1.NodeAllocatableResourceClaimStatus
+		extendedClaim                      *resourceapi.ResourceClaim
 		wantPatch                          bool
+		wantClaimNameInPatch               string
+		wantClaimNameNotInPatch            string
+		wantAssumedClaimName               string
+		wantComputedClaimName              string
 		setPatchError                      error
 		wantStatus                         *fwk.Status
 	}{
@@ -1454,6 +1531,37 @@ func TestPatchNodeAllocatableResourceClaimStatus(t *testing.T) {
 			setPatchError: errors.New("inject patch error"),
 			wantStatus:    statusError(klog.TODO(), fmt.Errorf("updating pod test-ns/test-pod NodeAllocatableResourceClaimStatuses: %w", errors.New("inject patch error"))),
 		},
+		{
+			name:                               "placeholder rewritten after DeepEqual, assumed pod unchanged",
+			assumedPodStatus:                   v1.PodStatus{NodeAllocatableResourceClaimStatuses: placeholderStatus},
+			finalPodNodeAllocatableClaimStatus: cloneNodeAllocatableResourceClaimStatuses(placeholderStatus),
+			extendedClaim:                      realClaim,
+			wantPatch:                          true,
+			wantClaimNameInPatch:               "real-claim-name",
+			wantClaimNameNotInPatch:            specialClaimInMemName,
+			wantAssumedClaimName:               specialClaimInMemName,
+			wantComputedClaimName:              "real-claim-name",
+			wantStatus:                         nil,
+		},
+		{
+			name:             "mismatch still fails when a real extended claim exists",
+			assumedPodStatus: v1.PodStatus{NodeAllocatableResourceClaimStatuses: placeholderStatus},
+			finalPodNodeAllocatableClaimStatus: []v1.NodeAllocatableResourceClaimStatus{
+				{
+					ResourceClaimName: specialClaimInMemName,
+					Containers:        []string{"c1"},
+					Mapping: []v1.NodeAllocatableMappedResources{{
+						Name:     v1.ResourceCPU,
+						Quantity: new(resource.MustParse("2")),
+					}},
+				},
+			},
+			extendedClaim:         realClaim,
+			wantPatch:             false,
+			wantAssumedClaimName:  specialClaimInMemName,
+			wantComputedClaimName: specialClaimInMemName,
+			wantStatus:            statusError(klog.TODO(), errors.New("assumed pod status does not match calculated status to be patched")),
+		},
 	}
 
 	for _, tt := range tests {
@@ -1473,7 +1581,7 @@ func TestPatchNodeAllocatableResourceClaimStatus(t *testing.T) {
 					return true, nil, tt.setPatchError
 				})
 			}
-			status := pl.patchNodeAllocatableResourceClaimStatus(ctx, podToUpdate, tt.finalPodNodeAllocatableClaimStatus)
+			status := pl.patchNodeAllocatableResourceClaimStatus(ctx, podToUpdate, tt.finalPodNodeAllocatableClaimStatus, tt.extendedClaim)
 
 			if tt.wantStatus != nil && status != nil {
 				if tt.wantStatus.Code() != status.Code() {
@@ -1488,15 +1596,35 @@ func TestPatchNodeAllocatableResourceClaimStatus(t *testing.T) {
 
 			actions := fakeClient.Actions()
 			gotPatch := false
+			var patchBody string
 			for _, action := range actions {
 				if action.Matches("patch", "pods") && action.GetSubresource() == "status" {
 					gotPatch = true
+					patchBody = string(action.(clienttesting.PatchAction).GetPatch())
 					break
 				}
 			}
 
 			if gotPatch != tt.wantPatch {
 				t.Errorf("patchNodeAllocatableResourceClaimStatus() gotPatch = %v, want %v", gotPatch, tt.wantPatch)
+			}
+			if tt.wantClaimNameInPatch != "" && !strings.Contains(patchBody, tt.wantClaimNameInPatch) {
+				t.Errorf("patch %s does not contain claim name %q", patchBody, tt.wantClaimNameInPatch)
+			}
+			if tt.wantClaimNameNotInPatch != "" && strings.Contains(patchBody, tt.wantClaimNameNotInPatch) {
+				t.Errorf("patch %s still contains claim name %q", patchBody, tt.wantClaimNameNotInPatch)
+			}
+			if tt.wantAssumedClaimName != "" {
+				got := podToUpdate.Status.NodeAllocatableResourceClaimStatuses[0].ResourceClaimName
+				if got != tt.wantAssumedClaimName {
+					t.Errorf("assumed pod ResourceClaimName = %q, want %q", got, tt.wantAssumedClaimName)
+				}
+			}
+			if tt.wantComputedClaimName != "" {
+				got := tt.finalPodNodeAllocatableClaimStatus[0].ResourceClaimName
+				if got != tt.wantComputedClaimName {
+					t.Errorf("computed status ResourceClaimName = %q, want %q", got, tt.wantComputedClaimName)
+				}
 			}
 		})
 	}
@@ -2160,6 +2288,71 @@ func TestFilterSlicesForNode(t *testing.T) {
 
 			if diff := cmp.Diff(tt.wantNames, gotNames); diff != "" {
 				t.Errorf("filterSlicesForNode() diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestReplaceSpecialClaimNameInStatus(t *testing.T) {
+	claim := func(name string) *resourceapi.ResourceClaim {
+		return &resourceapi.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	}
+
+	tests := []struct {
+		name          string
+		extendedClaim *resourceapi.ResourceClaim
+		statuses      []v1.NodeAllocatableResourceClaimStatus
+		want          []v1.NodeAllocatableResourceClaimStatus
+	}{
+		{
+			name:          "placeholder replaced with real claim name",
+			extendedClaim: claim("real-claim-name"),
+			statuses: []v1.NodeAllocatableResourceClaimStatus{
+				{ResourceClaimName: specialClaimInMemName},
+			},
+			want: []v1.NodeAllocatableResourceClaimStatus{
+				{ResourceClaimName: "real-claim-name"},
+			},
+		},
+		{
+			name:          "only placeholder entries are rewritten",
+			extendedClaim: claim("real-claim-name"),
+			statuses: []v1.NodeAllocatableResourceClaimStatus{
+				{ResourceClaimName: "user-claim"},
+				{ResourceClaimName: specialClaimInMemName},
+			},
+			want: []v1.NodeAllocatableResourceClaimStatus{
+				{ResourceClaimName: "user-claim"},
+				{ResourceClaimName: "real-claim-name"},
+			},
+		},
+		{
+			name:          "nil extended claim is a no-op",
+			extendedClaim: nil,
+			statuses: []v1.NodeAllocatableResourceClaimStatus{
+				{ResourceClaimName: specialClaimInMemName},
+			},
+			want: []v1.NodeAllocatableResourceClaimStatus{
+				{ResourceClaimName: specialClaimInMemName},
+			},
+		},
+		{
+			name:          "claim not yet created in API server is a no-op",
+			extendedClaim: claim(specialClaimInMemName),
+			statuses: []v1.NodeAllocatableResourceClaimStatus{
+				{ResourceClaimName: specialClaimInMemName},
+			},
+			want: []v1.NodeAllocatableResourceClaimStatus{
+				{ResourceClaimName: specialClaimInMemName},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			replaceSpecialClaimNameInStatus(tt.extendedClaim, tt.statuses)
+			if diff := cmp.Diff(tt.want, tt.statuses); diff != "" {
+				t.Errorf("replaceSpecialClaimNameInStatus() diff (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/test/integration/dra/node_allocatable_resources.go
+++ b/test/integration/dra/node_allocatable_resources.go
@@ -57,6 +57,7 @@ func testNodeAllocatableResources(tCtx ktesting.TContext, enabled bool) {
 	tCtx.Run("OverheadMappingsBoth", testNodeAllocatableResourcesWithOverheadBoth)
 	tCtx.Run("OverheadMappingsInsufficient", testNodeAllocatableResourcesWithOverheadInsufficient)
 	tCtx.Run("ClaimSharingOverhead", testNodeAllocatableResourceClaimSharingOverhead)
+	tCtx.Run("ExtendedResource", testNodeAllocatableExtendedResource)
 }
 
 func setupTestEnv(tCtx ktesting.TContext, nodeNum int) *testEnv {
@@ -904,6 +905,70 @@ func testNodeAllocatableResourcesWithOverheadInsufficient(tCtx ktesting.TContext
 	pod, _ := createPodWithNodeAllocatableClaim(tCtx, env, claimName, podName, 1)
 
 	expectPodUnschedulable(tCtx, pod, "Insufficient memory")
+}
+
+// testNodeAllocatableExtendedResource is a regression test for
+// https://github.com/kubernetes/kubernetes/issues/141467. It exercises the
+// intersection of two features: an extended resource backed by DRA (the
+// scheduler creates the ResourceClaim during PreBind) and a device that
+// contributes node allocatable resources. Before the fix, PreBind left the
+// in-memory placeholder claim name "<extended-resources>" in the node
+// allocatable claim status and the API server rejected the pod status patch, so
+// the pod never got scheduled.
+func testNodeAllocatableExtendedResource(tCtx ktesting.TContext) {
+	tCtx.Parallel()
+	env := setupTestEnv(tCtx, 2)
+
+	// Implicit extended resource name derived from the DeviceClass. The pod
+	// requests this instead of referencing a ResourceClaim directly, so the
+	// scheduler creates the claim during PreBind.
+	resourceName := resourceapi.ResourceDeviceClassPrefix + env.class.Name
+
+	cpuMultiplier := resource.MustParse("1")
+	devices := []resourceapi.Device{
+		{
+			Name: "extended-node-allocatable-device",
+			NodeAllocatableResources: map[v1.ResourceName]resourceapi.NodeAllocatableResource{
+				v1.ResourceCPU: {Mapping: &resourceapi.NodeAllocatableMapping{DeviceMultiplier: &cpuMultiplier}},
+			},
+		},
+	}
+	slice := makeSlice(env, devices)
+	env.poolName = env.namespace + "-pool-extended"
+	slice.Spec.Pool.Name = env.poolName
+	createSliceAndStartScheduler(tCtx, slice)
+
+	podName := "pod-extended-node-allocatable"
+	pod := st.MakePod().Name(podName).Namespace(env.namespace).Container("test-container").Obj()
+	pod.Spec.NodeSelector = map[string]string{"kubernetes.io/hostname": env.nodeName}
+	pod = createPodWithExtendedResource(tCtx, env.namespace, resourceName, "1", pod)
+
+	// With the fix, PreBind succeeds and the pod is scheduled. Without it, the
+	// pod stays unschedulable because the pod status patch fails validation.
+	waitForPodScheduled(tCtx, env.namespace, pod.Name)
+
+	// The node allocatable status must reference the real extended-resource
+	// claim name (recorded in ExtendedResourceClaimStatus), never the in-memory
+	// placeholder "<extended-resources>".
+	tCtx.Eventually(func(tCtx ktesting.TContext) error {
+		p, err := tCtx.Client().CoreV1().Pods(env.namespace).Get(tCtx, pod.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if p.Status.ExtendedResourceClaimStatus == nil {
+			return fmt.Errorf("pod has no ExtendedResourceClaimStatus yet")
+		}
+		realClaimName := p.Status.ExtendedResourceClaimStatus.ResourceClaimName
+		if len(p.Status.NodeAllocatableResourceClaimStatuses) == 0 {
+			return fmt.Errorf("pod has no NodeAllocatableResourceClaimStatuses yet")
+		}
+		for _, s := range p.Status.NodeAllocatableResourceClaimStatuses {
+			if s.ResourceClaimName != realClaimName {
+				return fmt.Errorf("node allocatable status references claim name %q, want real extended resource claim name %q", s.ResourceClaimName, realClaimName)
+			}
+		}
+		return nil
+	}).WithTimeout(30*time.Second).WithPolling(200*time.Millisecond).Should(gomega.Succeed(), "node allocatable status should reference the real extended resource claim name")
 }
 
 func testNodeAllocatableResourceClaimSharingOverhead(tCtx ktesting.TContext) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Pods requesting extended resources backed by DRA fail to schedule when the `DRANodeAllocatableResources` feature gate is enabled. During PreBind the scheduler leaves the in memory placeholder claim name `<extended-resources>` in the node allocatable claim status, and the API server then rejects the pod status patch.

This PR fixes the problem in two places:

1. Scheduler: after the real ResourceClaim is created during PreBind, the placeholder name in `nodeAllocatableResourceClaimStatuses` is replaced with the actual claim name. The logic is extracted into a helper, `replaceSpecialClaimNameInStatus`, so PreBind and its unit test exercise the same code.
2. API validation: `validateNodeAllocatableResourceClaimStatus` now also accepts a claim name recorded in `podStatus.ExtendedResourceClaimStatus`, which is where the scheduler stores the extended resource claim name. Previously it consulted only `podSpec.ResourceClaims` and `podStatus.ResourceClaimStatuses`, so a valid extended resource claim name was rejected with "no mapping found in pod reference".

Tests added:

* Unit tests for the scheduler helper and the validation change.
* An integration regression test (`test/integration/dra`) covering the intersection of extended resources backed by DRA and a device that contributes node allocatable resources. The existing suites cover each feature separately but never together, which is why this bug shipped.

#### Which issue(s) this PR is related to:

Fixes #141467

#### Special notes for your reviewer:

The second fix (API validation) is not obvious from the issue report, which shows only the scheduler symptom. It surfaced once the placeholder rename was in place: the API server still rejected the real claim name because validation did not consult `ExtendedResourceClaimStatus`.

AI Usage: AI was used to help write the unit and integration tests and to autonomously validate the fix, including reproducing the failure on a kind cluster built from these changes and confirming the new integration test fails without the fix and passes with it.

<details>
<summary>Integration test verification</summary>

The new test is `TestDRA/all/DRANodeAllocatableResources/ExtendedResource`.

Without the fix, the pod never schedules and the scheduler logs the exact failure from the issue:

```console
$ go test ./test/integration/dra/all/ -run 'TestDRA/all/DRANodeAllocatableResources/ExtendedResource'
scheduler: Plugin failed err="... status.nodeAllocatableResourceClaimStatuses[0].resourceClaimName: Invalid value: \"<extended-resources>\": no mapping found in pod reference" plugin="DynamicResources"
    Pod pod-extended-node-allocatable should have been scheduled.
--- FAIL: TestDRA/all/DRANodeAllocatableResources/ExtendedResource
```

With the fix, the pod schedules and the node allocatable status references the real claim name:

```console
$ go test ./test/integration/dra/all/ -run 'TestDRA/all/DRANodeAllocatableResources/ExtendedResource'
--- PASS: TestDRA/all/DRANodeAllocatableResources/ExtendedResource
ok  	k8s.io/kubernetes/test/integration/dra/all
```

</details>

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where pods requesting extended resources backed by DRA failed to schedule when the DRA devices also contributed node allocatable resources (with the alpha DRANodeAllocatableResources feature gate enabled).
```
