### PR TITLE
implement generateWorkloadName and generatePodGroupName in builder library

### DIFF
--- a/pkg/controller/job/job_scheduling_manager.go
+++ b/pkg/controller/job/job_scheduling_manager.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 
 	batch "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -29,10 +28,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/rand"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apiserver/pkg/util/feature"
 	schedulinginformers "k8s.io/client-go/informers/scheduling/v1beta1"
 	"k8s.io/client-go/tools/cache"
@@ -41,7 +38,6 @@ import (
 	jobutil "k8s.io/kubernetes/pkg/api/job"
 	apischeduling "k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/features"
-	hashutil "k8s.io/kubernetes/pkg/util/hash"
 )
 
 const (
@@ -631,59 +627,14 @@ func (jm *Controller) createPodGroup(ctx context.Context, job *batch.Job, worklo
 	return created, nil
 }
 
-// computeWorkloadName generates a deterministic name for a Workload associated with a Job.
-// The pattern is: <truncated-job-name>-<hash>
-// The hash is derived from the Job UID to ensure uniqueness and stability across restarts.
+// computeWorkloadName is kept as a controller-local adapter for existing callers.
 func computeWorkloadName(job *batch.Job) string {
-	hasher := fnv.New32a()
-	hashutil.DeepHashObject(hasher, job.UID)
-	hash := rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
-
-	// hash is ~10 chars; include separator "-"
-	maxPrefixLen := validation.DNS1123SubdomainMaxLength - len(hash) - 1
-	prefix := job.Name
-	if len(prefix) > maxPrefixLen {
-		prefix = prefix[:maxPrefixLen]
-	}
-	return fmt.Sprintf("%s-%s", prefix, hash)
+	return workloadbuilder.GenerateWorkloadName(job.Name, job.UID)
 }
 
-// computePodGroupName generates a deterministic name for a PodGroup associated with a Workload.
-// The pattern is: <truncated-workload-name>-<truncated-template-name>-<hash>
-// The hash is derived from the workload name and template name for uniqueness.
+// computePodGroupName is kept as a controller-local adapter for existing callers.
 func computePodGroupName(workloadName, templateName string) string {
-	hasher := fnv.New32a()
-	// hash the full combination for uniqueness.
-	hasher.Write([]byte(workloadName))
-	hasher.Write([]byte(templateName))
-	hash := rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
-
-	// Truncate workloadName and templateName to fit within the DNS subdomain
-	// max length, reserving space for the hash and two "-" separators.
-	maxAvailable := validation.DNS1123SubdomainMaxLength - len(hash) - 2
-	wl := workloadName
-	tpl := templateName
-
-	if len(wl)+len(tpl) > maxAvailable {
-		// only truncate the part that exceeds its fair share.
-		// give each part up to half the space; if one is short, the other
-		// gets the remainder.
-		half := maxAvailable / 2
-		switch {
-		case len(wl) <= half:
-			// workload name fits in its half, give template the rest.
-			tpl = tpl[:maxAvailable-len(wl)]
-		case len(tpl) <= half:
-			// template name fits in its half, give workload the rest.
-			wl = wl[:maxAvailable-len(tpl)]
-		default:
-			// both exceed half, split evenly (workload gets the extra char if odd).
-			wl = wl[:maxAvailable-half]
-			tpl = tpl[:half]
-		}
-	}
-
-	return fmt.Sprintf("%s-%s-%s", wl, tpl, hash)
+	return workloadbuilder.GeneratePodGroupName(workloadName, templateName)
 }
 
 // addSchedulingInformers wires up Workload and PodGroup informers

--- a/staging/src/k8s.io/component-helpers/scheduling/schedulingv1/workloadbuilder/names.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/schedulingv1/workloadbuilder/names.go
@@ -1,0 +1,95 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadbuilder
+
+import (
+	"fmt"
+	"hash/fnv"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/utils/dump"
+)
+
+// GenerateWorkloadName returns a deterministic, DNS-compatible name for a
+// Workload. ownerName is used as a prefix when it is non-empty and should be a
+// DNS-1123 subdomain. The UID is included in the hash because object names can
+// be reused after deletion, while the name remains useful to humans as a
+// prefix.
+func GenerateWorkloadName(ownerName string, ownerUID types.UID) string {
+	hasher := fnv.New32a()
+	// Use the same canonical representation as Kubernetes' DeepHashObject so
+	// moving this helper does not change names already persisted by controllers.
+	_, _ = fmt.Fprintf(hasher, "%v", dump.ForHash(ownerUID))
+	hash := rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
+
+	if ownerName == "" {
+		return hash
+	}
+
+	maxPrefixLen := validation.DNS1123SubdomainMaxLength - len(hash) - 1
+	if len(ownerName) > maxPrefixLen {
+		ownerName = ownerName[:maxPrefixLen]
+	}
+	return fmt.Sprintf("%s-%s", ownerName, hash)
+}
+
+// GeneratePodGroupName returns a deterministic, DNS-compatible name derived
+// from a Workload and its PodGroupTemplate. workloadName and templateName must
+// be non-empty DNS-1123 subdomains. Both names are retained in the prefix where
+// possible; the hash prevents collisions when truncation makes different
+// inputs share a prefix.
+func GeneratePodGroupName(workloadName, templateName string) string {
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(workloadName))
+	_, _ = hasher.Write([]byte(templateName))
+	hash := rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
+
+	maxPrefixLen := validation.DNS1123SubdomainMaxLength - len(hash) - 1
+	if workloadName == "" {
+		if templateName == "" {
+			return hash
+		}
+		if len(templateName) > maxPrefixLen {
+			templateName = templateName[:maxPrefixLen]
+		}
+		return fmt.Sprintf("%s-%s", templateName, hash)
+	}
+	if templateName == "" {
+		if len(workloadName) > maxPrefixLen {
+			workloadName = workloadName[:maxPrefixLen]
+		}
+		return fmt.Sprintf("%s-%s", workloadName, hash)
+	}
+
+	maxAvailable := validation.DNS1123SubdomainMaxLength - len(hash) - 2
+	wl, tpl := workloadName, templateName
+	if len(wl)+len(tpl) > maxAvailable {
+		half := maxAvailable / 2
+		switch {
+		case len(wl) <= half:
+			tpl = tpl[:maxAvailable-len(wl)]
+		case len(tpl) <= half:
+			wl = wl[:maxAvailable-len(tpl)]
+		default:
+			wl = wl[:maxAvailable-half]
+			tpl = tpl[:half]
+		}
+	}
+	return fmt.Sprintf("%s-%s-%s", wl, tpl, hash)
+}

--- a/staging/src/k8s.io/component-helpers/scheduling/schedulingv1/workloadbuilder/names_test.go
+++ b/staging/src/k8s.io/component-helpers/scheduling/schedulingv1/workloadbuilder/names_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workloadbuilder
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestGenerateWorkloadName(t *testing.T) {
+	testCases := []struct {
+		name string
+		job  string
+		uid  types.UID
+		want func(t *testing.T, generated string)
+	}{
+		{
+			name: "name is within the maximum length",
+			job:  strings.Repeat("job", 100),
+			uid:  types.UID("uid-1"),
+			want: func(t *testing.T, generated string) {
+				if len(generated) > validation.DNS1123SubdomainMaxLength {
+					t.Fatalf("generated name is too long: %d", len(generated))
+				}
+			},
+		},
+		{
+			name: "name is deterministic and preserves the existing format",
+			job:  "job",
+			uid:  types.UID("uid-1"),
+			want: func(t *testing.T, generated string) {
+				if generated != "job-647cf7d9" {
+					t.Fatalf("unexpected generated name: %q", generated)
+				}
+			},
+		},
+		{
+			name: "empty owner name",
+			uid:  types.UID("uid-1"),
+			want: func(t *testing.T, generated string) {
+				if generated != "647cf7d9" {
+					t.Fatalf("unexpected generated name: %q", generated)
+				}
+			},
+		},
+		{
+			name: "different UIDs produce different names",
+			job:  strings.Repeat("job", 100),
+			uid:  types.UID("uid-1"),
+			want: func(t *testing.T, generated string) {
+				if generated == GenerateWorkloadName(strings.Repeat("job", 100), types.UID("uid-2")) {
+					t.Fatal("different UIDs should produce different names")
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.want(t, GenerateWorkloadName(tc.job, tc.uid))
+		})
+	}
+}
+
+func TestGeneratePodGroupName(t *testing.T) {
+	testCases := []struct {
+		name     string
+		workload string
+		template string
+		want     func(t *testing.T, generated string)
+	}{
+		{
+			name:     "name is within the maximum length",
+			workload: strings.Repeat("workload", 40),
+			template: strings.Repeat("template", 40),
+			want: func(t *testing.T, generated string) {
+				if len(generated) > validation.DNS1123SubdomainMaxLength {
+					t.Fatalf("generated name is too long: %d", len(generated))
+				}
+			},
+		},
+		{
+			name:     "short workload keeps its full name",
+			workload: "workload",
+			template: strings.Repeat("template", 40),
+			want: func(t *testing.T, generated string) {
+				if !strings.HasPrefix(generated, "workload-") {
+					t.Fatalf("generated name should retain the workload name: %q", generated)
+				}
+				if len(generated) > validation.DNS1123SubdomainMaxLength {
+					t.Fatalf("generated name is too long: %d", len(generated))
+				}
+			},
+		},
+		{
+			name:     "short template keeps its full name",
+			workload: strings.Repeat("workload", 40),
+			template: "template",
+			want: func(t *testing.T, generated string) {
+				if !strings.Contains(generated, "-template-") {
+					t.Fatalf("generated name should retain the template name: %q", generated)
+				}
+				if len(generated) > validation.DNS1123SubdomainMaxLength {
+					t.Fatalf("generated name is too long: %d", len(generated))
+				}
+			},
+		},
+		{
+			name:     "name is deterministic",
+			workload: strings.Repeat("workload", 40),
+			template: strings.Repeat("template", 40),
+			want: func(t *testing.T, generated string) {
+				if generated != GeneratePodGroupName(strings.Repeat("workload", 40), strings.Repeat("template", 40)) {
+					t.Fatal("generated name is not deterministic")
+				}
+			},
+		},
+		{
+			name:     "different templates produce different names",
+			workload: strings.Repeat("workload", 40),
+			template: strings.Repeat("template", 40),
+			want: func(t *testing.T, generated string) {
+				if generated == GeneratePodGroupName(strings.Repeat("workload", 40), "other-template") {
+					t.Fatal("different templates should produce different names")
+				}
+			},
+		},
+		{
+			name:     "both names empty returns only the hash",
+			workload: "",
+			template: "",
+			want: func(t *testing.T, generated string) {
+				if generated != "65bb57b6b5" {
+					t.Fatalf("unexpected generated name: %q", generated)
+				}
+			},
+		},
+		{
+			name:     "empty workload keeps the template name",
+			workload: "",
+			template: "template",
+			want: func(t *testing.T, generated string) {
+				if generated != "template-5cbb944dc9" {
+					t.Fatalf("unexpected generated name: %q", generated)
+				}
+			},
+		},
+		{
+			name:     "empty template keeps the workload name",
+			workload: "workload",
+			template: "",
+			want: func(t *testing.T, generated string) {
+				if generated != "workload-c5546b9dd" {
+					t.Fatalf("unexpected generated name: %q", generated)
+				}
+			},
+		},
+		{
+			name:     "empty workload with long template stays within the maximum length",
+			workload: "",
+			template: strings.Repeat("template", 40),
+			want: func(t *testing.T, generated string) {
+				if len(generated) > validation.DNS1123SubdomainMaxLength {
+					t.Fatalf("generated name is too long: %d", len(generated))
+				}
+			},
+		},
+		{
+			name:     "empty template with long workload stays within the maximum length",
+			workload: strings.Repeat("workload", 40),
+			template: "",
+			want: func(t *testing.T, generated string) {
+				if len(generated) > validation.DNS1123SubdomainMaxLength {
+					t.Fatalf("generated name is too long: %d", len(generated))
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.want(t, GeneratePodGroupName(tc.workload, tc.template))
+		})
+	}
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Implement library for building unique names for Workloads and PodGroups.

#### Which issue(s) this PR is related to:
Fixes #141555

#### Special notes for your reviewer:

AI was used in generation of this PR.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add a library for generating unique names for workloads and podgroups with builder library
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
