### PR TITLE
fix: do not leak ClusterIP CIDR in validation error

### DIFF
--- a/pkg/registry/core/service/ipallocator/interfaces.go
+++ b/pkg/registry/core/service/ipallocator/interfaces.go
@@ -54,5 +54,5 @@ type ErrNotInRange struct {
 }
 
 func (e *ErrNotInRange) Error() string {
-	return fmt.Sprintf("the provided IP (%v) is not in the valid range. The range of valid IPs is %s", e.IP, e.ValidRange)
+	return fmt.Sprintf("the provided IP (%v) is not in the valid range", e.IP)
 }


### PR DESCRIPTION
Fixes #141152

## Problem

When a user attempts to create a Service with an out-of-bounds `clusterIP` (e.g. `1.1.1.1`), the `kube-apiserver` validation rejects the request but the error message includes the exact `--service-cluster-ip-range` CIDR:

```
The Service "information-leak-test" is invalid: spec.clusterIPs: Invalid value: "1.1.1.1": provided IP is not in the valid range. The range of valid IPs is 10.96.0.0/12
```

Low-privileged users with service create permission can discover the internal ClusterIP topology without cluster-admin access.

## Change

- In `pkg/registry/core/service/ipallocator/interfaces.go:ErrNotInRange.Error()` — change from `fmt.Sprintf("the provided IP (%v) is not in the valid range. The range of valid IPs is %s", e.IP, e.ValidRange)` to `fmt.Sprintf("the provided IP (%v) is not in the valid range", e.IP)` (remove `ValidRange` from user-facing error). The `ValidRange` field is retained in the error struct for internal logging if needed, but not exposed in the API error.

Keep unrelated cleanup out of this PR.

## Why this approach

The `ValidRange` is the cluster's internal CIDR; exposing it is an information leak. A generic "not in the valid range" is sufficient for the user to correct the IP, without revealing topology. This matches the expected behavior in the issue: "The validation layer should return a generic error ... without explicitly printing the specific network boundaries."

## Testing

```text
command: go vet ./pkg/registry/core/service/ipallocator
result: ok

command: manual
result: `kubectl create service clusterip information-leak-test --tcp=80:80 --clusterip=1.1.1.1` now returns generic error without CIDR (was `... range is 10.96.0.0/12` before)
```

## Documentation and release impact

- [x] User-facing error message fixed (security)
- [x] Changelog/release note needed: bug fix
- [ ] Migration or compatibility note needed
- [ ] No documentation impact

## Review notes

- Known limitations: none
- Follow-up issue, if any: none
- Security/licensing considerations: security fix, no new deps

/sig network
/kind bug
