### PR TITLE
e2e/windows: accept ltsc2025 sandbox error for invalid RunAsUserName

### DIFF
--- a/test/e2e/windows/security_context.go
+++ b/test/e2e/windows/security_context.go
@@ -68,7 +68,16 @@ var _ = sigDescribe(feature.Windows, "SecurityContext", skipUnlessWindows(func()
 			"involvedObject.namespace": podInvalid.Namespace,
 			"reason":                   events.FailedCreatePodSandBox,
 		}.AsSelector().String()
-		hcsschimError := "The user name or password is incorrect."
+		// An invalid RunAsUserName surfaces as different Win32 errors depending on the
+		// Windows base image's account name-resolution path, so match on any of the known
+		// messages:
+		//   - ltsc2022: ERROR_LOGON_FAILURE (1326) -> "The user name or password is incorrect."
+		//   - ltsc2025: ERROR_NO_SUCH_DOMAIN (1355) -> the local lookup falls through to a
+		//     domain-contact attempt, which fails first since the container has no domain.
+		hcsschimErrors := []string{
+			"The user name or password is incorrect.",
+			"The specified domain either does not exist or could not be contacted.",
+		}
 
 		// Hostprocess updated the cri to pass RunAsUserName to sandbox: https://github.com/kubernetes/kubernetes/pull/99576/commits/51a02fdb80cb7ba042a66362eb76facd2fd82401
 		// Some runtimes might use that and set the username on the podsandbox. Containerd 1.6+ is known to do this.
@@ -78,13 +87,15 @@ var _ = sigDescribe(feature.Windows, "SecurityContext", skipUnlessWindows(func()
 		// sandbox failed or workload pod failed.
 		framework.Logf("Waiting for pod %s to enter the error state.", podInvalid.Name)
 		gomega.Eventually(ctx, func(ctx context.Context) bool {
-			failedSandbox, err := eventOccurred(ctx, f.ClientSet, podInvalid.Namespace, failedSandboxEventSelector, hcsschimError)
-			if err != nil {
-				framework.Logf("Error retrieving events for pod. Ignoring...")
-			}
-			if failedSandbox {
-				framework.Logf("Found Expected Event 'Failed to Create Pod Sandbox' with message containing: %s", hcsschimError)
-				return true
+			for _, hcsschimError := range hcsschimErrors {
+				failedSandbox, err := eventOccurred(ctx, f.ClientSet, podInvalid.Namespace, failedSandboxEventSelector, hcsschimError)
+				if err != nil {
+					framework.Logf("Error retrieving events for pod. Ignoring...")
+				}
+				if failedSandbox {
+					framework.Logf("Found Expected Event 'Failed to Create Pod Sandbox' with message containing: %s", hcsschimError)
+					return true
+				}
 			}
 
 			framework.Logf("No Sandbox error found. Looking for failure in workload pods")


### PR DESCRIPTION
The 'unknown usernames at Pod level' test only matched the ltsc2022 hcsshim message 'The user name or password is incorrect.' (ERROR_LOGON_FAILURE, 1326). On ltsc2025 an invalid RunAsUserName instead surfaces as 'The specified domain either does not exist or could not be contacted.' (ERROR_NO_SUCH_DOMAIN, 1355) because the account lookup falls through to a domain-contact attempt.

Match on the set of known sandbox failure messages so the test passes on both base images instead of timing out with the pod stuck in ContainerCreating.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
N/A
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
