### PR TITLE
informer-gen: use plural-exceptions-aware namer for GVR resource name

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
@@ -256,17 +256,17 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -256,17 +256,17 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/mutatingadmissionpolicy.go
@@ -115,7 +115,7 @@ func NewMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, 
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) MutatingAdmissionPolicyIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingadmissionpolicys"}
+	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "mutatingadmissionpolicies"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.MutatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1/validatingadmissionpolicy.go
@@ -115,7 +115,7 @@ func NewValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ValidatingAdmissionPolicyIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingadmissionpolicys"}
+	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1", Resource: "validatingadmissionpolicies"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1.ValidatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/mutatingadmissionpolicy.go
@@ -115,7 +115,7 @@ func NewMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, 
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) MutatingAdmissionPolicyIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "mutatingadmissionpolicys"}
+	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "mutatingadmissionpolicies"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.MutatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/validatingadmissionpolicy.go
@@ -115,7 +115,7 @@ func NewValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ValidatingAdmissionPolicyIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "validatingadmissionpolicys"}
+	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Resource: "validatingadmissionpolicies"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1alpha1.ValidatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/mutatingadmissionpolicy.go
@@ -115,7 +115,7 @@ func NewMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, 
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedMutatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) MutatingAdmissionPolicyIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingadmissionpolicys"}
+	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "mutatingadmissionpolicies"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.MutatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1beta1/validatingadmissionpolicy.go
@@ -115,7 +115,7 @@ func NewValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedValidatingAdmissionPolicyInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ValidatingAdmissionPolicyIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicys"}
+	gvr := schema.GroupVersionResource{Group: "admissionregistration.k8s.io", Version: "v1beta1", Resource: "validatingadmissionpolicies"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apiadmissionregistrationv1beta1.ValidatingAdmissionPolicy](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
@@ -115,7 +115,7 @@ func NewComponentStatusInformerWithOptions(client kubernetes.Interface, options 
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedComponentStatusInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) ComponentStatusIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "componentstatuss"}
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "componentstatuses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apicorev1.ComponentStatus](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
@@ -116,7 +116,7 @@ func NewEndpointsInformerWithOptions(client kubernetes.Interface, namespace stri
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedEndpointsInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) EndpointsIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpointss"}
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "endpoints"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apicorev1.Endpoints](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
@@ -116,7 +116,7 @@ func NewIngressInformerWithOptions(client kubernetes.Interface, namespace string
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedIngressInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) IngressIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "ingresss"}
+	gvr := schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "ingresses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.Ingress](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/networkpolicy.go
@@ -116,7 +116,7 @@ func NewNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace 
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) NetworkPolicyIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "networkpolicys"}
+	gvr := schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "networkpolicies"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apiextensionsv1beta1.NetworkPolicy](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -276,17 +276,17 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ingress.go
@@ -116,7 +116,7 @@ func NewIngressInformerWithOptions(client kubernetes.Interface, namespace string
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedIngressInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) IngressIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresss"}
+	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.Ingress](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ingressclass.go
@@ -115,7 +115,7 @@ func NewIngressClassInformerWithOptions(client kubernetes.Interface, options int
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedIngressClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) IngressClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingressclasss"}
+	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingressclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.IngressClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/networking/v1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/ipaddress.go
@@ -115,7 +115,7 @@ func NewIPAddressInformerWithOptions(client kubernetes.Interface, options intern
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedIPAddressInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) IPAddressIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ipaddresss"}
+	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ipaddresses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.IPAddress](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
@@ -116,7 +116,7 @@ func NewNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace 
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) NetworkPolicyIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicys"}
+	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apinetworkingv1.NetworkPolicy](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingress.go
@@ -116,7 +116,7 @@ func NewIngressInformerWithOptions(client kubernetes.Interface, namespace string
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedIngressInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) IngressIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ingresss"}
+	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ingresses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.Ingress](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingressclass.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ingressclass.go
@@ -115,7 +115,7 @@ func NewIngressClassInformerWithOptions(client kubernetes.Interface, options int
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedIngressClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) IngressClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ingressclasss"}
+	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ingressclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.IngressClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/networking/v1beta1/ipaddress.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1beta1/ipaddress.go
@@ -115,7 +115,7 @@ func NewIPAddressInformerWithOptions(client kubernetes.Interface, options intern
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedIPAddressInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) IPAddressIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ipaddresss"}
+	gvr := schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1beta1", Resource: "ipaddresses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apinetworkingv1beta1.IPAddress](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/node/v1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1/runtimeclass.go
@@ -115,7 +115,7 @@ func NewRuntimeClassInformerWithOptions(client kubernetes.Interface, options int
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedRuntimeClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) RuntimeClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1", Resource: "runtimeclasss"}
+	gvr := schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1", Resource: "runtimeclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apinodev1.RuntimeClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1alpha1/runtimeclass.go
@@ -115,7 +115,7 @@ func NewRuntimeClassInformerWithOptions(client kubernetes.Interface, options int
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedRuntimeClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) RuntimeClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1alpha1", Resource: "runtimeclasss"}
+	gvr := schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1alpha1", Resource: "runtimeclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apinodev1alpha1.RuntimeClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/informers/node/v1beta1/runtimeclass.go
@@ -115,7 +115,7 @@ func NewRuntimeClassInformerWithOptions(client kubernetes.Interface, options int
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedRuntimeClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) RuntimeClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1beta1", Resource: "runtimeclasss"}
+	gvr := schema.GroupVersionResource{Group: "node.k8s.io", Version: "v1beta1", Resource: "runtimeclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apinodev1beta1.RuntimeClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/resource/v1/deviceclass.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1/deviceclass.go
@@ -115,7 +115,7 @@ func NewDeviceClassInformerWithOptions(client kubernetes.Interface, options inte
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedDeviceClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) DeviceClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1", Resource: "deviceclasss"}
+	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1", Resource: "deviceclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apiresourcev1.DeviceClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta1/deviceclass.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta1/deviceclass.go
@@ -115,7 +115,7 @@ func NewDeviceClassInformerWithOptions(client kubernetes.Interface, options inte
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedDeviceClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) DeviceClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta1", Resource: "deviceclasss"}
+	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta1", Resource: "deviceclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta1.DeviceClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/resource/v1beta2/deviceclass.go
+++ b/staging/src/k8s.io/client-go/informers/resource/v1beta2/deviceclass.go
@@ -115,7 +115,7 @@ func NewDeviceClassInformerWithOptions(client kubernetes.Interface, options inte
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedDeviceClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) DeviceClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta2", Resource: "deviceclasss"}
+	gvr := schema.GroupVersionResource{Group: "resource.k8s.io", Version: "v1beta2", Resource: "deviceclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apiresourcev1beta2.DeviceClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1/priorityclass.go
@@ -115,7 +115,7 @@ func NewPriorityClassInformerWithOptions(client kubernetes.Interface, options in
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedPriorityClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) PriorityClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasss"}
+	gvr := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apischedulingv1.PriorityClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1beta1/priorityclass.go
@@ -115,7 +115,7 @@ func NewPriorityClassInformerWithOptions(client kubernetes.Interface, options in
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedPriorityClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) PriorityClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1beta1", Resource: "priorityclasss"}
+	gvr := schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1beta1", Resource: "priorityclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apischedulingv1beta1.PriorityClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/storage/v1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/csistoragecapacity.go
@@ -116,7 +116,7 @@ func NewCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, names
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) CSIStorageCapacityIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csistoragecapacitys"}
+	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "csistoragecapacities"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apistoragev1.CSIStorageCapacity](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
@@ -115,7 +115,7 @@ func NewStorageClassInformerWithOptions(client kubernetes.Interface, options int
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedStorageClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) StorageClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasss"}
+	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apistoragev1.StorageClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/storage/v1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/volumeattributesclass.go
@@ -115,7 +115,7 @@ func NewVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, op
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) VolumeAttributesClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "volumeattributesclasss"}
+	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1", Resource: "volumeattributesclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apistoragev1.VolumeAttributesClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/csistoragecapacity.go
@@ -116,7 +116,7 @@ func NewCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, names
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) CSIStorageCapacityIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1alpha1", Resource: "csistoragecapacitys"}
+	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1alpha1", Resource: "csistoragecapacities"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.CSIStorageCapacity](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1alpha1/volumeattributesclass.go
@@ -115,7 +115,7 @@ func NewVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, op
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) VolumeAttributesClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1alpha1", Resource: "volumeattributesclasss"}
+	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1alpha1", Resource: "volumeattributesclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apistoragev1alpha1.VolumeAttributesClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/csistoragecapacity.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/csistoragecapacity.go
@@ -116,7 +116,7 @@ func NewCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, names
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedCSIStorageCapacityInformerWithOptions(client kubernetes.Interface, namespace string, options internalinterfaces.InformerOptions) CSIStorageCapacityIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "csistoragecapacitys"}
+	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "csistoragecapacities"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.CSIStorageCapacity](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
@@ -115,7 +115,7 @@ func NewStorageClassInformerWithOptions(client kubernetes.Interface, options int
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedStorageClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) StorageClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "storageclasss"}
+	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "storageclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.StorageClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattributesclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/volumeattributesclass.go
@@ -115,7 +115,7 @@ func NewVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, op
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
 func NewTypedVolumeAttributesClassInformerWithOptions(client kubernetes.Interface, options internalinterfaces.InformerOptions) VolumeAttributesClassIndexInformer {
-	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "volumeattributesclasss"}
+	gvr := schema.GroupVersionResource{Group: "storage.k8s.io", Version: "v1beta1", Resource: "volumeattributesclasses"}
 	identifier := options.InformerName.WithResource(gvr)
 	tweakListOptions := options.TweakListOptions
 	return cache.NewTypedSharedIndexInformer[*apistoragev1beta1.VolumeAttributesClass](cache.NewSharedIndexInformerWithOptions(

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
@@ -334,17 +334,17 @@ var sharedInformerFactoryInterface = `
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
@@ -27,6 +27,7 @@ import (
 
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
+	codegennamer "k8s.io/code-generator/pkg/namer"
 
 	"k8s.io/klog/v2"
 )
@@ -44,6 +45,7 @@ type informerGenerator struct {
 	clientSetPackage          string
 	listersPackage            string
 	internalInterfacesPackage string
+	pluralExceptions          map[string]string
 }
 
 var _ generator.Generator = &informerGenerator{}
@@ -111,7 +113,7 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 		"namespaceAll":                                c.Universe.Type(metav1NamespaceAll),
 		"namespaced":                                  !tags.NonNamespaced,
 		"newLister":                                   c.Universe.Function(types.Name{Package: listerPackage, Name: "New" + t.Name.Name + "Lister"}),
-		"resourceName":                                strings.ToLower(t.Name.Name) + "s",
+		"resourceName":                                codegennamer.NewTagOverrideNamer("resourceName", namer.NewAllLowercasePluralNamer(g.pluralExceptions)).Name(t),
 		"runtimeObject":                               c.Universe.Type(runtimeObject),
 		"schemaGroupVersionResource":                  c.Universe.Type(schemaGroupVersionResource),
 		"timeDuration":                                c.Universe.Type(timeDuration),

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/targets.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/targets.go
@@ -214,14 +214,16 @@ func GetTargets(context *generator.Context, args *args.Args) []generator.Target 
 					internalVersionOutputDir, internalVersionOutputPkg,
 					groupPackageName, gv, groupGoNames[groupPackageName],
 					boilerplate, typesToGenerate,
-					args.InternalClientSetPackage, args.ListersPackage))
+					args.InternalClientSetPackage, args.ListersPackage,
+					genutil.PluralExceptionListToMapOrDie(args.PluralExceptions)))
 		} else {
 			targetList = append(targetList,
 				versionTarget(
 					externalVersionOutputDir, externalVersionOutputPkg,
 					groupPackageName, gv, groupGoNames[groupPackageName],
 					boilerplate, typesToGenerate,
-					args.VersionedClientSetPackage, args.ListersPackage))
+					args.VersionedClientSetPackage, args.ListersPackage,
+					genutil.PluralExceptionListToMapOrDie(args.PluralExceptions)))
 		}
 	}
 
@@ -348,7 +350,7 @@ func groupTarget(outputDirBase, outputPackageBase string, groupVersions clientge
 	}
 }
 
-func versionTarget(outputDirBase, outputPkgBase string, groupPkgName string, gv clientgentypes.GroupVersion, groupGoName string, boilerplate []byte, typesToGenerate []*types.Type, clientSetPackage, listersPackage string) generator.Target {
+func versionTarget(outputDirBase, outputPkgBase string, groupPkgName string, gv clientgentypes.GroupVersion, groupGoName string, boilerplate []byte, typesToGenerate []*types.Type, clientSetPackage, listersPackage string, pluralExceptions map[string]string) generator.Target {
 	subdir := []string{groupPkgName, strings.ToLower(gv.Version.NonEmpty())}
 	outputDir := filepath.Join(outputDirBase, filepath.Join(subdir...))
 	outputPkg := path.Join(outputPkgBase, path.Join(subdir...))
@@ -383,6 +385,7 @@ func versionTarget(outputDirBase, outputPkgBase string, groupPkgName string, gv 
 					clientSetPackage:          clientSetPackage,
 					listersPackage:            listersPackage,
 					internalInterfacesPackage: path.Join(outputPkgBase, subdirForInternalInterfaces),
+					pluralExceptions:          pluralExceptions,
 				})
 			}
 			return generators

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
@@ -256,17 +256,17 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
@@ -256,17 +256,17 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
@@ -259,17 +259,17 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
@@ -259,17 +259,17 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
@@ -256,17 +256,17 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -256,17 +256,17 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
@@ -256,17 +256,17 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
@@ -256,17 +256,17 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 //	defer factory.Shutdown()    // Returns immediately if nothing was started.
 //	genericInformer := factory.ForResource(resource)
 //	typedInformer := factory.SomeAPIGroup().V1().SomeType()
-//	handle, err := typeInformer.Informer().AddEventHandler(...)
+//	handle, err := typedInformer.Informer().AddEventHandler(...)
 //	if err != nil {
 //	    return fmt.Errorf("register event handler: %v", err)
 //	}
-//	defer typeInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
+//	defer typedInformer.Informer().RemoveEventHandler(handle) // Avoids leaking goroutines.
 //	factory.StartWithContext(ctx)                            // Start processing these informers.
 //	synced := factory.WaitForCacheSyncWithContext(ctx)
 //	if err := synced.AsError(); err != nil {
 //	    return err
 //	}
-//	for v := range synced {
+//	for v := range synced.Synced {
 //	    // Only if desired log some information similar to this.
 //	    fmt.Fprintf(os.Stdout, "cache synced: %s", v)
 //	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`informer-gen` formed the GVR resource name used by `WithInformerName` by blindly appending `"s"` to the lowercased type name:

```go
"resourceName": strings.ToLower(t.Name.Name) + "s",
```

For API types whose plural is not `name + "s"` (e.g. `Endpoints`, `NetworkPolicy`, `ComponentStatus`), this produced wrong resources such as `endpointss`, `networkpolicys` and `componentstatuss` in the generated informer code.

This was inconsistent with the same generator's `generic.go` template, which already uses the `--plural-exceptions`-aware `AllLowercasePluralNamer`. This PR reuses that namer for `resourceName` in `informer.go`, so generated informers carry the correct GVR. The client-go informers are regenerated with the fixed generator (33 files corrected).

The second commit fixes two godoc bugs in the generated informer factory template: the example referenced a non-existent `typeInformer` variable (defined as `typedInformer`) and ranged over `synced` instead of its `Synced` channel, so the example could not compile as written.

#### Which issue(s) this PR fixes:

Fixes #139383

#### Special notes for your reviewer:

- The generator change and the regenerated output are split into two self-contained commits: one for the pluralization fix, one for the factory godoc fix.
- Verified end-to-end: rebuilt `informer-gen` from staging (the exact path `hack/update-codegen.sh` uses via the `replace` directive), deleted and regenerated all client-go informers; only the 33 expected GVR lines and the factory godoc lines changed.
- `staging/src/k8s.io/code-generator` build/vet/tests pass; `client-go` builds.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs, usage documentation, etc.:

```docs
NONE
```
