### PR TITLE
fix(tainteviction): retry failed pod deletions

### DIFF
--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -141,7 +141,7 @@ func (tc *Controller) deletePodHandler() func(ctx context.Context, fireAt time.T
 			if err == nil {
 				if deleted {
 					metrics.PodDeletionsTotal.Inc()
-					metrics.PodDeletionsLatency.Observe(float64(time.Since(fireAt) * time.Second))
+					metrics.PodDeletionsLatency.Observe(time.Since(fireAt).Seconds())
 				}
 				return nil
 			}
@@ -538,7 +538,7 @@ func (tc *Controller) processPodEvictionRetry(ctx context.Context, item podEvict
 		}
 		if deleted {
 			metrics.PodDeletionsTotal.Inc()
-			metrics.PodDeletionsLatency.Observe(float64(time.Since(item.fireAt) * time.Second))
+			metrics.PodDeletionsLatency.Observe(time.Since(item.fireAt).Seconds())
 		}
 		tc.forgetPodEvictionRetry(item)
 		return nil

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -69,6 +69,28 @@ type podUpdateItem struct {
 	nodeName     string
 }
 
+type podEvictionItem struct {
+	podRef    NamespacedObject
+	createdAt time.Time
+	fireAt    time.Time
+}
+
+type podEvictionDecisionKind int
+
+const (
+	podEvictionNone podEvictionDecisionKind = iota
+	podEvictionNow
+	podEvictionLater
+)
+
+type podEvictionDecision struct {
+	kind            podEvictionDecisionKind
+	startTime       time.Time
+	triggerTime     time.Time
+	keepExisting    bool
+	cancelScheduled bool
+}
+
 func hash(val string, max int) int {
 	hasher := fnv.New32a()
 	io.WriteString(hasher, val)
@@ -100,37 +122,51 @@ type Controller struct {
 	nodeUpdateChannels []chan nodeUpdateItem
 	podUpdateChannels  []chan podUpdateItem
 
-	nodeUpdateQueue workqueue.TypedInterface[nodeUpdateItem]
-	podUpdateQueue  workqueue.TypedInterface[podUpdateItem]
+	nodeUpdateQueue   workqueue.TypedInterface[nodeUpdateItem]
+	podUpdateQueue    workqueue.TypedInterface[podUpdateItem]
+	podEvictionQueue  workqueue.TypedRateLimitingInterface[podEvictionItem]
+	podEvictionLock   sync.Mutex
+	podEvictionTokens map[string]podEvictionItem
 }
 
-func deletePodHandler(c clientset.Interface, emitEventFunc func(types.NamespacedName), controllerName string) func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
+func (tc *Controller) deletePodHandler() func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
 	return func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
-		ns := args.Object.Namespace
-		name := args.Object.Name
-		klog.FromContext(ctx).Info("Deleting pod", "controller", controllerName, "pod", args.Object)
-		if emitEventFunc != nil {
-			emitEventFunc(args.Object.NamespacedName)
-		}
+		klog.FromContext(ctx).Info("Deleting pod", "controller", tc.name, "pod", args.Object)
+		tc.emitPodDeletionEvent(args.Object.NamespacedName)
+
 		var err error
 		for i := 0; i < retries; i++ {
-			err = addConditionAndDeletePod(ctx, c, name, ns)
+			var deleted bool
+			deleted, err = tc.addConditionAndDeletePod(ctx, args.Object)
 			if err == nil {
-				metrics.PodDeletionsTotal.Inc()
-				metrics.PodDeletionsLatency.Observe(float64(time.Since(fireAt) * time.Second))
-				break
+				if deleted {
+					metrics.PodDeletionsTotal.Inc()
+					metrics.PodDeletionsLatency.Observe(float64(time.Since(fireAt) * time.Second))
+				}
+				return nil
 			}
 			time.Sleep(10 * time.Millisecond)
 		}
+		tc.addPodEvictionRetry(args.Object, args.CreatedAt, fireAt)
 		return err
 	}
 }
 
-func addConditionAndDeletePod(ctx context.Context, c clientset.Interface, name, ns string) (err error) {
-	pod, err := c.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		return err
+func (tc *Controller) addConditionAndDeletePod(ctx context.Context, podRef NamespacedObject) (bool, error) {
+	pod, err := tc.client.CoreV1().Pods(podRef.Namespace).Get(ctx, podRef.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return false, nil
 	}
+	if err != nil {
+		return false, err
+	}
+	if podRef.UID != "" && pod.UID != podRef.UID {
+		return false, nil
+	}
+	if pod.DeletionTimestamp != nil {
+		return false, nil
+	}
+
 	newStatus := pod.Status.DeepCopy()
 	updated := apipod.UpdatePodCondition(newStatus, &v1.PodCondition{
 		Type:               v1.DisruptionTarget,
@@ -140,11 +176,70 @@ func addConditionAndDeletePod(ctx context.Context, c clientset.Interface, name, 
 		Message:            "Taint manager: deleting due to NoExecute taint",
 	})
 	if updated {
-		if _, _, _, err := utilpod.PatchPodStatus(ctx, c, pod.Namespace, pod.Name, pod.UID, pod.Status, *newStatus); err != nil {
-			return err
+		if _, _, _, err := utilpod.PatchPodStatus(ctx, tc.client, pod.Namespace, pod.Name, pod.UID, pod.Status, *newStatus); err != nil {
+			return false, err
 		}
 	}
-	return c.CoreV1().Pods(ns).Delete(ctx, name, metav1.DeleteOptions{})
+	deleteOptions := metav1.DeleteOptions{}
+	if podRef.UID != "" {
+		deleteOptions.Preconditions = &metav1.Preconditions{UID: &podRef.UID}
+	}
+	if err := tc.client.CoreV1().Pods(podRef.Namespace).Delete(ctx, podRef.Name, deleteOptions); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (tc *Controller) addPodEvictionRetry(podRef NamespacedObject, createdAt, fireAt time.Time) (podEvictionItem, bool) {
+	key := podRef.NamespacedName.String()
+	item := podEvictionItem{podRef: podRef, createdAt: createdAt, fireAt: fireAt}
+	tc.podEvictionLock.Lock()
+	if current, ok := tc.podEvictionTokens[key]; ok && item.createdAt.Before(current.createdAt) {
+		tc.podEvictionLock.Unlock()
+		return item, false
+	}
+	tc.podEvictionTokens[key] = item
+	tc.podEvictionLock.Unlock()
+
+	tc.podEvictionQueue.AddRateLimited(item)
+	return item, true
+}
+
+func (tc *Controller) cancelPodEvictionRetry(nsName types.NamespacedName) bool {
+	key := nsName.String()
+	tc.podEvictionLock.Lock()
+	defer tc.podEvictionLock.Unlock()
+	if _, ok := tc.podEvictionTokens[key]; !ok {
+		return false
+	}
+	delete(tc.podEvictionTokens, key)
+	return true
+}
+
+func (tc *Controller) podEvictionRetryMatches(item podEvictionItem) bool {
+	key := item.podRef.NamespacedName.String()
+	tc.podEvictionLock.Lock()
+	defer tc.podEvictionLock.Unlock()
+	current, ok := tc.podEvictionTokens[key]
+	return ok && current == item
+}
+
+func (tc *Controller) hasPodEvictionRetryForPod(podRef NamespacedObject) bool {
+	key := podRef.NamespacedName.String()
+	tc.podEvictionLock.Lock()
+	defer tc.podEvictionLock.Unlock()
+	current, ok := tc.podEvictionTokens[key]
+	return ok && current.podRef == podRef
+}
+
+func (tc *Controller) forgetPodEvictionRetry(item podEvictionItem) {
+	key := item.podRef.NamespacedName.String()
+	tc.podEvictionLock.Lock()
+	defer tc.podEvictionLock.Unlock()
+	current, ok := tc.podEvictionTokens[key]
+	if ok && current == item {
+		delete(tc.podEvictionTokens, key)
+	}
 }
 
 func getNoExecuteTaints(taints []v1.Taint) []v1.Taint {
@@ -215,12 +310,17 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 			}
 			return pods, nil
 		},
-		taintedNodes: make(map[string][]v1.Taint),
+		taintedNodes:      make(map[string][]v1.Taint),
+		podEvictionTokens: make(map[string]podEvictionItem),
 
 		nodeUpdateQueue: workqueue.NewTypedWithConfig(workqueue.TypedQueueConfig[nodeUpdateItem]{Name: "noexec_taint_node"}),
 		podUpdateQueue:  workqueue.NewTypedWithConfig(workqueue.TypedQueueConfig[podUpdateItem]{Name: "noexec_taint_pod"}),
+		podEvictionQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[podEvictionItem](),
+			workqueue.TypedRateLimitingQueueConfig[podEvictionItem]{Name: "noexec_taint_pod_eviction"},
+		),
 	}
-	tm.taintEvictionQueue = CreateWorkerQueue(deletePodHandler(c, tm.emitPodDeletionEvent, tm.name))
+	tm.taintEvictionQueue = CreateWorkerQueue(tm.deletePodHandler())
 
 	_, err := podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
@@ -293,6 +393,7 @@ func (tc *Controller) Run(ctx context.Context) {
 		logger.Info("Shutting down controller", "controller", tc.name)
 		tc.nodeUpdateQueue.ShutDown()
 		tc.podUpdateQueue.ShutDown()
+		tc.podEvictionQueue.ShutDown()
 		tc.taintEvictionQueue.CancelAndWait()
 		wg.Wait()
 	}()
@@ -351,7 +452,101 @@ func (tc *Controller) Run(ctx context.Context) {
 			tc.worker(ctx, i)
 		})
 	}
+	for i := 0; i < UpdateWorkerSize; i++ {
+		wg.Go(func() {
+			tc.podEvictionWorker(ctx)
+		})
+	}
 	<-ctx.Done()
+}
+
+func (tc *Controller) podEvictionWorker(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	for {
+		item, shutdown := tc.podEvictionQueue.Get()
+		if shutdown {
+			return
+		}
+
+		func() {
+			defer tc.podEvictionQueue.Done(item)
+
+			if !tc.podEvictionRetryMatches(item) {
+				tc.podEvictionQueue.Forget(item)
+				return
+			}
+
+			if err := tc.processPodEvictionRetry(ctx, item); err != nil {
+				logger.V(3).Info("Pod eviction failed, will retry", "pod", item.podRef, "err", err)
+				tc.podEvictionQueue.AddRateLimited(item)
+				return
+			}
+			tc.podEvictionQueue.Forget(item)
+		}()
+	}
+}
+
+func (tc *Controller) processPodEvictionRetry(ctx context.Context, item podEvictionItem) error {
+	logger := klog.FromContext(ctx)
+	podRef := item.podRef
+	pod, err := tc.podLister.Pods(podRef.Namespace).Get(podRef.Name)
+	if apierrors.IsNotFound(err) {
+		tc.forgetPodEvictionRetry(item)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if pod.UID != podRef.UID || pod.DeletionTimestamp != nil || pod.Spec.NodeName == "" {
+		tc.forgetPodEvictionRetry(item)
+		return nil
+	}
+	taints, ok := func() ([]v1.Taint, bool) {
+		tc.taintedNodesLock.Lock()
+		defer tc.taintedNodesLock.Unlock()
+		taints, ok := tc.taintedNodes[pod.Spec.NodeName]
+		return taints, ok
+	}()
+	if !ok || len(taints) == 0 {
+		tc.forgetPodEvictionRetry(item)
+		return nil
+	}
+
+	decision := tc.getPodEvictionDecision(logger, podRef, pod.Spec.Tolerations, taints, time.Now())
+	switch decision.kind {
+	case podEvictionNone:
+		tc.forgetPodEvictionRetry(item)
+		return nil
+	case podEvictionLater:
+		if decision.keepExisting {
+			tc.forgetPodEvictionRetry(item)
+			return nil
+		}
+		if decision.cancelScheduled {
+			tc.cancelWorkWithEvent(logger, podRef.NamespacedName)
+		}
+		tc.taintEvictionQueue.AddWork(ctx, NewWorkArgsWithUID(podRef.Name, podRef.Namespace, podRef.UID), decision.startTime, decision.triggerTime)
+		if tc.taintEvictionQueue.GetWorkerUnsafe(podRef.NamespacedName.String()) != nil {
+			tc.forgetPodEvictionRetry(item)
+			return nil
+		}
+		return fmt.Errorf("pod eviction retry for %s could not schedule future eviction", podRef)
+	case podEvictionNow:
+		deleted, err := tc.addConditionAndDeletePod(ctx, podRef)
+		if err != nil {
+			return err
+		}
+		if deleted {
+			metrics.PodDeletionsTotal.Inc()
+			metrics.PodDeletionsLatency.Observe(float64(time.Since(item.fireAt) * time.Second))
+		}
+		tc.forgetPodEvictionRetry(item)
+		return nil
+	default:
+		utilruntime.HandleError(fmt.Errorf("unexpected pod eviction decision for %s: %d", podRef, decision.kind))
+		tc.forgetPodEvictionRetry(item)
+		return nil
+	}
 }
 
 func (tc *Controller) worker(ctx context.Context, worker int) {
@@ -443,50 +638,94 @@ func (tc *Controller) NodeUpdated(oldNode *v1.Node, newNode *v1.Node) {
 }
 
 func (tc *Controller) cancelWorkWithEvent(logger klog.Logger, nsName types.NamespacedName) {
-	if tc.taintEvictionQueue.CancelWork(logger, nsName.String()) {
+	cancelledTimedWork, cancelledRetry := tc.cancelWork(logger, nsName)
+	if cancelledTimedWork || cancelledRetry {
 		tc.emitCancelPodDeletionEvent(nsName)
 	}
 }
 
+func (tc *Controller) cancelWork(logger klog.Logger, nsName types.NamespacedName) (bool, bool) {
+	cancelledTimedWork := tc.taintEvictionQueue.CancelWork(logger, nsName.String())
+	cancelledRetry := tc.cancelPodEvictionRetry(nsName)
+	return cancelledTimedWork, cancelledRetry
+}
+
+func (tc *Controller) getPodEvictionDecision(logger klog.Logger, podRef NamespacedObject, tolerations []v1.Toleration, taints []v1.Taint, now time.Time) podEvictionDecision {
+	if len(taints) == 0 {
+		return podEvictionDecision{kind: podEvictionNone}
+	}
+	allTolerated, usedTolerations := v1helper.GetMatchingTolerations(logger, taints, tolerations)
+	if !allTolerated {
+		return podEvictionDecision{kind: podEvictionNow}
+	}
+	minTolerationTime := getMinTolerationTime(usedTolerations)
+	// getMinTolerationTime returns negative value to denote infinite toleration.
+	if minTolerationTime < 0 {
+		return podEvictionDecision{kind: podEvictionNone}
+	}
+	if minTolerationTime == 0 {
+		return podEvictionDecision{kind: podEvictionNow}
+	}
+
+	startTime := now
+	triggerTime := startTime.Add(minTolerationTime)
+	scheduledEviction := tc.taintEvictionQueue.GetWorkerUnsafe(podRef.NamespacedName.String())
+	if scheduledEviction == nil {
+		return podEvictionDecision{kind: podEvictionLater, startTime: startTime, triggerTime: triggerTime}
+	}
+	if scheduledEviction.WorkItem.Object.UID != podRef.UID {
+		return podEvictionDecision{kind: podEvictionLater, startTime: startTime, triggerTime: triggerTime, cancelScheduled: true}
+	}
+
+	startTime = scheduledEviction.CreatedAt
+	if startTime.Add(minTolerationTime).Before(triggerTime) {
+		return podEvictionDecision{kind: podEvictionLater, startTime: startTime, triggerTime: scheduledEviction.FireAt, keepExisting: true}
+	}
+	return podEvictionDecision{kind: podEvictionLater, startTime: startTime, triggerTime: triggerTime, cancelScheduled: true}
+}
+
 func (tc *Controller) processPodOnNode(
 	ctx context.Context,
-	podNamespacedName types.NamespacedName,
+	podRef NamespacedObject,
 	nodeName string,
 	tolerations []v1.Toleration,
 	taints []v1.Taint,
 	now time.Time,
 ) {
 	logger := klog.FromContext(ctx)
-	if len(taints) == 0 {
+	podNamespacedName := podRef.NamespacedName
+	decision := tc.getPodEvictionDecision(logger, podRef, tolerations, taints, now)
+	switch decision.kind {
+	case podEvictionNone:
+		logger.V(4).Info("Current tolerations for pod tolerate forever or node has no taints, cancelling any scheduled deletion", "pod", podNamespacedName.String())
 		tc.cancelWorkWithEvent(logger, podNamespacedName)
-	}
-	allTolerated, usedTolerations := v1helper.GetMatchingTolerations(logger, taints, tolerations)
-	if !allTolerated {
+		return
+	case podEvictionNow:
 		logger.V(2).Info("Not all taints are tolerated after update for pod on node", "pod", podNamespacedName.String(), "node", klog.KRef("", nodeName))
-		// We're canceling scheduled work (if any), as we're going to delete the Pod right away.
-		tc.cancelWorkWithEvent(logger, podNamespacedName)
-		tc.taintEvictionQueue.AddWork(ctx, NewWorkArgs(podNamespacedName.Name, podNamespacedName.Namespace), now, now)
-		return
-	}
-	minTolerationTime := getMinTolerationTime(usedTolerations)
-	// getMinTolerationTime returns negative value to denote infinite toleration.
-	if minTolerationTime < 0 {
-		logger.V(4).Info("Current tolerations for pod tolerate forever, cancelling any scheduled deletion", "pod", podNamespacedName.String())
-		tc.cancelWorkWithEvent(logger, podNamespacedName)
-		return
-	}
-
-	startTime := now
-	triggerTime := startTime.Add(minTolerationTime)
-	scheduledEviction := tc.taintEvictionQueue.GetWorkerUnsafe(podNamespacedName.String())
-	if scheduledEviction != nil {
-		startTime = scheduledEviction.CreatedAt
-		if startTime.Add(minTolerationTime).Before(triggerTime) {
+		if tc.taintEvictionQueue.CancelWork(logger, podNamespacedName.String()) {
+			tc.emitCancelPodDeletionEvent(podNamespacedName)
+		}
+		if tc.hasPodEvictionRetryForPod(podRef) {
 			return
 		}
-		tc.cancelWorkWithEvent(logger, podNamespacedName)
+		tc.cancelPodEvictionRetry(podNamespacedName)
+		tc.taintEvictionQueue.AddWork(ctx, NewWorkArgsWithUID(podNamespacedName.Name, podNamespacedName.Namespace, podRef.UID), now, now)
+		return
+	case podEvictionLater:
+		if decision.keepExisting {
+			tc.cancelPodEvictionRetry(podNamespacedName)
+			return
+		}
+		if decision.cancelScheduled {
+			tc.cancelWorkWithEvent(logger, podNamespacedName)
+		}
+		tc.taintEvictionQueue.AddWork(ctx, NewWorkArgsWithUID(podNamespacedName.Name, podNamespacedName.Namespace, podRef.UID), decision.startTime, decision.triggerTime)
+		if tc.taintEvictionQueue.GetWorkerUnsafe(podNamespacedName.String()) != nil {
+			tc.cancelPodEvictionRetry(podNamespacedName)
+		}
+	default:
+		utilruntime.HandleError(fmt.Errorf("unexpected pod eviction decision for %s: %d", podRef, decision.kind))
 	}
-	tc.taintEvictionQueue.AddWork(ctx, NewWorkArgs(podNamespacedName.Name, podNamespacedName.Namespace), startTime, triggerTime)
 }
 
 func (tc *Controller) handlePodUpdate(ctx context.Context, podUpdate podUpdateItem) {
@@ -514,6 +753,7 @@ func (tc *Controller) handlePodUpdate(ctx context.Context, podUpdate podUpdateIt
 	logger.V(4).Info("Noticed pod update", "pod", podNamespacedName)
 	nodeName := pod.Spec.NodeName
 	if nodeName == "" {
+		tc.cancelWorkWithEvent(logger, podNamespacedName)
 		return
 	}
 	taints, ok := func() ([]v1.Taint, bool) {
@@ -525,9 +765,10 @@ func (tc *Controller) handlePodUpdate(ctx context.Context, podUpdate podUpdateIt
 	// It's possible that Node was deleted, or Taints were removed before, which triggered
 	// eviction cancelling if it was needed.
 	if !ok {
+		tc.cancelWorkWithEvent(logger, podNamespacedName)
 		return
 	}
-	tc.processPodOnNode(ctx, podNamespacedName, nodeName, pod.Spec.Tolerations, taints, time.Now())
+	tc.processPodOnNode(ctx, NamespacedObject{NamespacedName: podNamespacedName, UID: pod.UID}, nodeName, pod.Spec.Tolerations, taints, time.Now())
 }
 
 func (tc *Controller) handleNodeUpdate(ctx context.Context, nodeUpdate nodeUpdateItem) {
@@ -583,7 +824,7 @@ func (tc *Controller) handleNodeUpdate(ctx context.Context, nodeUpdate nodeUpdat
 	now := time.Now()
 	for _, pod := range pods {
 		podNamespacedName := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
-		tc.processPodOnNode(ctx, podNamespacedName, node.Name, pod.Spec.Tolerations, taints, now)
+		tc.processPodOnNode(ctx, NamespacedObject{NamespacedName: podNamespacedName, UID: pod.UID}, node.Name, pod.Spec.Tolerations, taints, now)
 	}
 }
 

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -452,7 +452,7 @@ func (tc *Controller) Run(ctx context.Context) {
 			tc.worker(ctx, i)
 		})
 	}
-	for i := 0; i < UpdateWorkerSize; i++ {
+	for range UpdateWorkerSize {
 		wg.Go(func() {
 			tc.podEvictionWorker(ctx)
 		})

--- a/pkg/controller/tainteviction/taint_eviction_test.go
+++ b/pkg/controller/tainteviction/taint_eviction_test.go
@@ -136,7 +136,7 @@ func currentPodEvictionRetry(controller *Controller, podNamespacedName types.Nam
 
 func waitForPodEvictionRetry(controller *Controller, podRef NamespacedObject) (podEvictionItem, error) {
 	var item podEvictionItem
-	err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 		var ok bool
 		item, ok = currentPodEvictionRetry(controller, podRef.NamespacedName)
 		return ok && item.podRef == podRef, nil
@@ -146,9 +146,9 @@ func waitForPodEvictionRetry(controller *Controller, podRef NamespacedObject) (p
 
 func waitForTimedWorkerAfterRetry(controller *Controller, fakeClock *testingclock.FakeClock, podNamespacedName types.NamespacedName, delay time.Duration) error {
 	var lastErr error
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		fakeClock.Step(time.Second)
-		if err := wait.PollImmediate(10*time.Millisecond, 200*time.Millisecond, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 200*time.Millisecond, true, func(context.Context) (bool, error) {
 			worker := controller.taintEvictionQueue.GetWorkerUnsafe(podNamespacedName.String())
 			return worker != nil && worker.FireAt.Sub(worker.CreatedAt) == delay, nil
 		}); err == nil {
@@ -319,7 +319,7 @@ func TestPodEvictionDeletionFailureRetriesDurably(t *testing.T) {
 	}
 	controller.PodUpdated(nil, pod)
 
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 		return deleteAttempts.Load() >= 1, nil
 	}); err != nil {
 		t.Fatalf("Timed out waiting for first delete attempt: %v", err)
@@ -333,7 +333,7 @@ func TestPodEvictionDeletionFailureRetriesDurably(t *testing.T) {
 	for deleteAttempts.Load() <= deniedAttempts {
 		previous := deleteAttempts.Load()
 		fakeClock.Step(time.Second)
-		if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 			return deleteAttempts.Load() > previous, nil
 		}); err != nil {
 			t.Fatalf("Timed out waiting for durable retry after %d attempts: %v", previous, err)
@@ -394,7 +394,7 @@ func TestPodEvictionDurableRetryKeepsRateLimiterState(t *testing.T) {
 	for i, step := range []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second} {
 		fakeClock.Step(step)
 		wantAttempts := int32(retries + i + 1)
-		if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 			return deleteAttempts.Load() == wantAttempts, nil
 		}); err != nil {
 			t.Fatalf("Timed out waiting for durable retry %d after %s: %v", i+1, step, err)
@@ -532,7 +532,7 @@ func TestPodEvictionDurableRetryWithZeroSecondTolerationDeletesDirectly(t *testi
 	}
 
 	fakeClock.Step(time.Second)
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 		return deleteAttempts.Load() == int32(retries+1), nil
 	}); err != nil {
 		t.Fatalf("Timed out waiting for one durable retry delete attempt: %v", err)
@@ -553,7 +553,7 @@ func TestPodEvictionDurableRetryWithZeroSecondTolerationDeletesDirectly(t *testi
 	}
 
 	fakeClock.Step(2 * time.Second)
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 		return deleteAttempts.Load() == int32(retries+2), nil
 	}); err != nil {
 		t.Fatalf("Timed out waiting for second durable retry delete attempt: %v", err)
@@ -620,7 +620,7 @@ func TestPodEvictionRetryDoesNotDeleteReplacementPod(t *testing.T) {
 	}
 
 	fakeClock.Step(time.Second)
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 		_, ok := currentPodEvictionRetry(controller, podRef.NamespacedName)
 		return !ok, nil
 	}); err != nil {
@@ -668,7 +668,7 @@ func TestPodEvictionRetryCancelledWhenTaintRemoved(t *testing.T) {
 	}
 	controller.PodUpdated(nil, pod)
 
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 		return deleteAttempts.Load() == retries, nil
 	}); err != nil {
 		t.Fatalf("Timed out waiting for initial delete attempts: %v", err)
@@ -681,7 +681,7 @@ func TestPodEvictionRetryCancelledWhenTaintRemoved(t *testing.T) {
 
 	fakeClock.Step(time.Second)
 	podRef := NamespacedObject{NamespacedName: types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, UID: pod.UID}
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 		_, ok := currentPodEvictionRetry(controller, podRef.NamespacedName)
 		return !ok, nil
 	}); err != nil {
@@ -729,7 +729,7 @@ func TestPodEvictionRetrySchedulesNewDeadlineForFiniteToleration(t *testing.T) {
 	}
 	controller.PodUpdated(nil, pod)
 
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 		return deleteAttempts.Load() == retries, nil
 	}); err != nil {
 		t.Fatalf("Timed out waiting for initial delete attempts: %v", err)
@@ -761,14 +761,14 @@ func TestPodEvictionRetrySchedulesNewDeadlineForFiniteToleration(t *testing.T) {
 	}
 
 	fakeClock.Step(time.Second)
-	if err := wait.PollImmediate(10*time.Millisecond, 200*time.Millisecond, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 200*time.Millisecond, true, func(context.Context) (bool, error) {
 		return deleteAttempts.Load() == retries, nil
 	}); err != nil {
 		t.Fatalf("Pod was deleted before the new toleration deadline: %v", err)
 	}
 
 	fakeClock.Step(time.Duration(tolerationSeconds) * time.Second)
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 		return deleteAttempts.Load() > retries, nil
 	}); err != nil {
 		t.Fatalf("Timed out waiting for delete after new toleration deadline: %v", err)
@@ -843,14 +843,14 @@ func TestPodEvictionRetrySchedulesNewDeadlineForChangedTaint(t *testing.T) {
 	}
 
 	fakeClock.Step(time.Second)
-	if err := wait.PollImmediate(10*time.Millisecond, 200*time.Millisecond, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, 200*time.Millisecond, true, func(context.Context) (bool, error) {
 		return deleteAttempts.Load() == retries, nil
 	}); err != nil {
 		t.Fatalf("Pod was deleted before the new taint deadline: %v", err)
 	}
 
 	fakeClock.Step(time.Duration(tolerationSeconds) * time.Second)
-	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+	if err := wait.PollUntilContextTimeout(context.Background(), 10*time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
 		return deleteAttempts.Load() > retries, nil
 	}); err != nil {
 		t.Fatalf("Timed out waiting for delete after new taint deadline: %v", err)

--- a/pkg/controller/tainteviction/taint_eviction_test.go
+++ b/pkg/controller/tainteviction/taint_eviction_test.go
@@ -22,22 +22,28 @@ import (
 	goruntime "runtime"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/controller/testutil"
+	testingclock "k8s.io/utils/clock/testing"
 )
 
 var timeForControllerToProgressForSanityCheck = 20 * time.Millisecond
@@ -103,6 +109,55 @@ func setupNewController(ctx context.Context, fakeClientSet *fake.Clientset) (*Co
 	mgr.nodeListerSynced = alwaysReady
 	mgr.getPodsAssignedToNode = getPodsAssignedToNode(ctx, fakeClientSet)
 	return mgr, podIndexer, nodeIndexer
+}
+
+func useFakePodEvictionQueue(controller *Controller, fakeClock *testingclock.FakeClock) {
+	useFakePodEvictionQueueWithBackoff(controller, fakeClock, time.Second, time.Second)
+}
+
+func useFakePodEvictionQueueWithBackoff(controller *Controller, fakeClock *testingclock.FakeClock, baseDelay, maxDelay time.Duration) {
+	controller.podEvictionQueue.ShutDown()
+	controller.podEvictionQueue = workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.NewTypedItemExponentialFailureRateLimiter[podEvictionItem](baseDelay, maxDelay),
+		workqueue.TypedRateLimitingQueueConfig[podEvictionItem]{
+			Name:  "test_noexec_taint_pod_eviction",
+			Clock: fakeClock,
+		},
+	)
+	controller.taintEvictionQueue.clock = fakeClock
+}
+
+func currentPodEvictionRetry(controller *Controller, podNamespacedName types.NamespacedName) (podEvictionItem, bool) {
+	controller.podEvictionLock.Lock()
+	defer controller.podEvictionLock.Unlock()
+	item, ok := controller.podEvictionTokens[podNamespacedName.String()]
+	return item, ok
+}
+
+func waitForPodEvictionRetry(controller *Controller, podRef NamespacedObject) (podEvictionItem, error) {
+	var item podEvictionItem
+	err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		var ok bool
+		item, ok = currentPodEvictionRetry(controller, podRef.NamespacedName)
+		return ok && item.podRef == podRef, nil
+	})
+	return item, err
+}
+
+func waitForTimedWorkerAfterRetry(controller *Controller, fakeClock *testingclock.FakeClock, podNamespacedName types.NamespacedName, delay time.Duration) error {
+	var lastErr error
+	for i := 0; i < 3; i++ {
+		fakeClock.Step(time.Second)
+		if err := wait.PollImmediate(10*time.Millisecond, 200*time.Millisecond, func() (bool, error) {
+			worker := controller.taintEvictionQueue.GetWorkerUnsafe(podNamespacedName.String())
+			return worker != nil && worker.FireAt.Sub(worker.CreatedAt) == delay, nil
+		}); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+	}
+	return lastErr
 }
 
 type timestampedPod struct {
@@ -173,6 +228,15 @@ func TestCreatePod(t *testing.T) {
 			expectDelete: false,
 		},
 		{
+			description: "schedule on tainted Node with zero-second toleration",
+			pod:         addToleration(testutil.NewPod("pod1", "node1"), 1, 0),
+			taintedNodes: map[string][]corev1.Taint{
+				"node1": {createNoExecuteTaint(1)},
+			},
+			expectPatch:  true,
+			expectDelete: true,
+		},
+		{
 			description: "schedule on tainted Node with infinite toleration",
 			pod:         addToleration(testutil.NewPod("pod1", "node1"), 1, -1),
 			taintedNodes: map[string][]corev1.Taint{
@@ -214,6 +278,582 @@ func TestCreatePod(t *testing.T) {
 
 			cancel()
 		})
+	}
+}
+
+func TestPodEvictionDeletionFailureRetriesDurably(t *testing.T) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := testutil.NewPod("pod1", "node1")
+	pod.UID = "pod1-uid"
+	fakeClientset := fake.NewSimpleClientset(pod)
+	var deleteAttempts atomic.Int32
+	// The old implementation gave up after five immediate attempts.
+	deniedAttempts := int32(6)
+	fakeClientset.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		attempt := deleteAttempts.Add(1)
+		if attempt <= deniedAttempts {
+			deleteAction := action.(clienttesting.DeleteAction)
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, deleteAction.GetName(), fmt.Errorf("denied by test"))
+		}
+		return false, nil, nil
+	})
+
+	controller, podIndexer, _ := setupNewController(ctx, fakeClientset)
+	controller.recorder = testutil.NewFakeRecorder()
+	controller.taintedNodes = map[string][]corev1.Taint{
+		"node1": {createNoExecuteTaint(1)},
+	}
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	useFakePodEvictionQueue(controller, fakeClock)
+
+	wg.Go(func() {
+		controller.Run(ctx)
+	})
+
+	if err := podIndexer.Add(pod); err != nil {
+		t.Fatalf("Failed to add pod to indexer: %v", err)
+	}
+	controller.PodUpdated(nil, pod)
+
+	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		return deleteAttempts.Load() >= 1, nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for first delete attempt: %v", err)
+	}
+
+	podRef := NamespacedObject{NamespacedName: types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, UID: pod.UID}
+	if _, err := waitForPodEvictionRetry(controller, podRef); err != nil {
+		t.Fatalf("Timed out waiting for durable retry handoff: %v", err)
+	}
+
+	for deleteAttempts.Load() <= deniedAttempts {
+		previous := deleteAttempts.Load()
+		fakeClock.Step(time.Second)
+		if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+			return deleteAttempts.Load() > previous, nil
+		}); err != nil {
+			t.Fatalf("Timed out waiting for durable retry after %d attempts: %v", previous, err)
+		}
+	}
+
+	if got, want := deleteAttempts.Load(), deniedAttempts+1; got != want {
+		t.Fatalf("Unexpected delete attempts: got %d, want %d", got, want)
+	}
+}
+
+func TestPodEvictionDurableRetryKeepsRateLimiterState(t *testing.T) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := testutil.NewPod("pod1", "node1")
+	pod.UID = "pod1-uid"
+	fakeClientset := fake.NewSimpleClientset(pod)
+	var deleteAttempts atomic.Int32
+	fakeClientset.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		deleteAction := action.(clienttesting.DeleteAction)
+		deleteAttempts.Add(1)
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, deleteAction.GetName(), fmt.Errorf("denied by test"))
+	})
+
+	controller, podIndexer, _ := setupNewController(ctx, fakeClientset)
+	recorder := testutil.NewFakeRecorder()
+	controller.recorder = recorder
+	controller.taintedNodes = map[string][]corev1.Taint{
+		"node1": {createNoExecuteTaint(1)},
+	}
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	useFakePodEvictionQueueWithBackoff(controller, fakeClock, time.Second, 10*time.Second)
+
+	wg.Go(func() {
+		controller.Run(ctx)
+	})
+
+	if err := podIndexer.Add(pod); err != nil {
+		t.Fatalf("Failed to add pod to indexer: %v", err)
+	}
+	controller.PodUpdated(nil, pod)
+
+	podRef := NamespacedObject{NamespacedName: types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, UID: pod.UID}
+	item, err := waitForPodEvictionRetry(controller, podRef)
+	if err != nil {
+		t.Fatalf("Timed out waiting for durable retry handoff: %v", err)
+	}
+	if got, want := deleteAttempts.Load(), int32(retries); got != want {
+		t.Fatalf("Initial timed worker should perform the legacy burst: got %d delete attempts, want %d", got, want)
+	}
+	if got := controller.podEvictionQueue.NumRequeues(item); got != 1 {
+		t.Fatalf("Unexpected initial NumRequeues: got %d, want 1", got)
+	}
+
+	for i, step := range []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second} {
+		fakeClock.Step(step)
+		wantAttempts := int32(retries + i + 1)
+		if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+			return deleteAttempts.Load() == wantAttempts, nil
+		}); err != nil {
+			t.Fatalf("Timed out waiting for durable retry %d after %s: %v", i+1, step, err)
+		}
+
+		current, ok := currentPodEvictionRetry(controller, podRef.NamespacedName)
+		if !ok {
+			t.Fatalf("Durable retry state disappeared after retry %d", i+1)
+		}
+		if current != item {
+			t.Fatalf("Durable retry item changed after retry %d: got %#v, want %#v", i+1, current, item)
+		}
+		if got, want := controller.podEvictionQueue.NumRequeues(item), i+2; got != want {
+			t.Fatalf("Unexpected NumRequeues after retry %d: got %d, want %d", i+1, got, want)
+		}
+	}
+
+	recorder.Lock()
+	defer recorder.Unlock()
+	deletionEvents := 0
+	for _, event := range recorder.Events {
+		if event.Message == "Marking for deletion Pod default/pod1" {
+			deletionEvents++
+		}
+	}
+	if deletionEvents != 1 {
+		t.Fatalf("Unexpected deletion event count after initial burst and durable retries: got %d, want 1", deletionEvents)
+	}
+}
+
+func TestPodEvictionRetryRejectsOlderProducer(t *testing.T) {
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	controller := &Controller{
+		podEvictionTokens: make(map[string]podEvictionItem),
+		podEvictionQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.NewTypedItemExponentialFailureRateLimiter[podEvictionItem](time.Second, 10*time.Second),
+			workqueue.TypedRateLimitingQueueConfig[podEvictionItem]{
+				Name:  "test_noexec_taint_pod_eviction",
+				Clock: fakeClock,
+			},
+		),
+	}
+
+	podRef := NamespacedObject{NamespacedName: types.NamespacedName{Namespace: "default", Name: "pod1"}, UID: "pod1-uid"}
+	olderCreatedAt := fakeClock.Now()
+	olderFireAt := olderCreatedAt.Add(10 * time.Second)
+	newerCreatedAt := olderCreatedAt.Add(time.Second)
+	newerFireAt := olderCreatedAt.Add(5 * time.Second)
+
+	newerItem, added := controller.addPodEvictionRetry(podRef, newerCreatedAt, newerFireAt)
+	if !added {
+		t.Fatalf("Expected newer retry producer to be accepted")
+	}
+	olderItem, added := controller.addPodEvictionRetry(podRef, olderCreatedAt, olderFireAt)
+	if added {
+		t.Fatalf("Expected older retry producer to be rejected")
+	}
+
+	current, ok := currentPodEvictionRetry(controller, podRef.NamespacedName)
+	if !ok {
+		t.Fatalf("Expected durable retry state to remain")
+	}
+	if current != newerItem {
+		t.Fatalf("Older producer replaced newer retry state: got %#v, want %#v", current, newerItem)
+	}
+	if controller.podEvictionRetryMatches(olderItem) {
+		t.Fatalf("Older retry item unexpectedly matched current retry state")
+	}
+	if !controller.podEvictionRetryMatches(newerItem) {
+		t.Fatalf("Newer retry item did not match current retry state")
+	}
+	if got := controller.podEvictionQueue.NumRequeues(newerItem); got != 1 {
+		t.Fatalf("Unexpected newer item NumRequeues: got %d, want 1", got)
+	}
+	if got := controller.podEvictionQueue.NumRequeues(olderItem); got != 0 {
+		t.Fatalf("Older item should not have been rate limited: got NumRequeues %d, want 0", got)
+	}
+}
+
+func TestPodEvictionDurableRetryWithZeroSecondTolerationDeletesDirectly(t *testing.T) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := testutil.NewPod("pod1", "node1")
+	pod.UID = "pod1-uid"
+	fakeClientset := fake.NewSimpleClientset(pod)
+	var deleteAttempts atomic.Int32
+	fakeClientset.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		deleteAction := action.(clienttesting.DeleteAction)
+		deleteAttempts.Add(1)
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, deleteAction.GetName(), fmt.Errorf("denied by test"))
+	})
+
+	controller, podIndexer, _ := setupNewController(ctx, fakeClientset)
+	controller.recorder = testutil.NewFakeRecorder()
+	controller.taintedNodes = map[string][]corev1.Taint{
+		"node1": {createNoExecuteTaint(1)},
+	}
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	useFakePodEvictionQueueWithBackoff(controller, fakeClock, time.Second, 10*time.Second)
+
+	wg.Go(func() {
+		controller.Run(ctx)
+	})
+
+	if err := podIndexer.Add(pod); err != nil {
+		t.Fatalf("Failed to add pod to indexer: %v", err)
+	}
+	controller.PodUpdated(nil, pod)
+
+	podRef := NamespacedObject{NamespacedName: types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, UID: pod.UID}
+	item, err := waitForPodEvictionRetry(controller, podRef)
+	if err != nil {
+		t.Fatalf("Timed out waiting for durable retry handoff: %v", err)
+	}
+	if got, want := deleteAttempts.Load(), int32(retries); got != want {
+		t.Fatalf("Initial timed worker should perform the legacy burst: got %d delete attempts, want %d", got, want)
+	}
+
+	zero := int64(0)
+	zeroToleratingPod := pod.DeepCopy()
+	zeroToleratingPod.Spec.Tolerations = []corev1.Toleration{{
+		Key:               "testTaint1",
+		Value:             "test1",
+		Effect:            corev1.TaintEffectNoExecute,
+		TolerationSeconds: &zero,
+	}}
+	if _, err := fakeClientset.CoreV1().Pods(zeroToleratingPod.Namespace).Update(ctx, zeroToleratingPod, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Failed to update pod in fake client: %v", err)
+	}
+	if err := podIndexer.Update(zeroToleratingPod); err != nil {
+		t.Fatalf("Failed to update pod in indexer: %v", err)
+	}
+
+	fakeClock.Step(time.Second)
+	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		return deleteAttempts.Load() == int32(retries+1), nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for one durable retry delete attempt: %v", err)
+	}
+
+	current, ok := currentPodEvictionRetry(controller, podRef.NamespacedName)
+	if !ok {
+		t.Fatalf("Durable retry state disappeared after zero-second toleration retry")
+	}
+	if current != item {
+		t.Fatalf("Durable retry item changed after zero-second toleration retry: got %#v, want %#v", current, item)
+	}
+	if got := controller.taintEvictionQueue.GetWorkerUnsafe(podRef.NamespacedName.String()); got != nil {
+		t.Fatalf("Unexpected timed worker handoff for zero-second toleration retry: %#v", got)
+	}
+	if got, want := controller.podEvictionQueue.NumRequeues(item), 2; got != want {
+		t.Fatalf("Unexpected NumRequeues after zero-second toleration retry: got %d, want %d", got, want)
+	}
+
+	fakeClock.Step(2 * time.Second)
+	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		return deleteAttempts.Load() == int32(retries+2), nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for second durable retry delete attempt: %v", err)
+	}
+	if got := controller.taintEvictionQueue.GetWorkerUnsafe(podRef.NamespacedName.String()); got != nil {
+		t.Fatalf("Unexpected timed worker after second zero-second toleration retry: %#v", got)
+	}
+	if current, ok := currentPodEvictionRetry(controller, podRef.NamespacedName); !ok || current != item {
+		t.Fatalf("Durable retry item changed or disappeared after second zero-second toleration retry: got %#v, ok=%v, want %#v", current, ok, item)
+	}
+	if got, want := controller.podEvictionQueue.NumRequeues(item), 3; got != want {
+		t.Fatalf("Unexpected NumRequeues after second zero-second toleration retry: got %d, want %d", got, want)
+	}
+}
+
+func TestPodEvictionRetryDoesNotDeleteReplacementPod(t *testing.T) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := testutil.NewPod("pod1", "node1")
+	pod.UID = "pod1-uid"
+	fakeClientset := fake.NewSimpleClientset(pod)
+	var deleteAttempts atomic.Int32
+	fakeClientset.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		attempt := deleteAttempts.Add(1)
+		if attempt <= retries {
+			deleteAction := action.(clienttesting.DeleteAction)
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, deleteAction.GetName(), fmt.Errorf("denied by test"))
+		}
+		return false, nil, nil
+	})
+
+	controller, podIndexer, _ := setupNewController(ctx, fakeClientset)
+	controller.recorder = testutil.NewFakeRecorder()
+	controller.taintedNodes = map[string][]corev1.Taint{
+		"node1": {createNoExecuteTaint(1)},
+	}
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	useFakePodEvictionQueue(controller, fakeClock)
+
+	wg.Go(func() {
+		controller.Run(ctx)
+	})
+
+	if err := podIndexer.Add(pod); err != nil {
+		t.Fatalf("Failed to add pod to indexer: %v", err)
+	}
+	controller.PodUpdated(nil, pod)
+
+	podRef := NamespacedObject{NamespacedName: types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, UID: pod.UID}
+	if _, err := waitForPodEvictionRetry(controller, podRef); err != nil {
+		t.Fatalf("Timed out waiting for durable retry handoff: %v", err)
+	}
+
+	replacement := pod.DeepCopy()
+	replacement.UID = "pod1-replacement-uid"
+	if _, err := fakeClientset.CoreV1().Pods(replacement.Namespace).Update(ctx, replacement, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Failed to replace pod in fake client: %v", err)
+	}
+	if err := podIndexer.Update(replacement); err != nil {
+		t.Fatalf("Failed to replace pod in indexer: %v", err)
+	}
+
+	fakeClock.Step(time.Second)
+	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		_, ok := currentPodEvictionRetry(controller, podRef.NamespacedName)
+		return !ok, nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for stale retry to be forgotten: %v", err)
+	}
+
+	if got := deleteAttempts.Load(); got != retries {
+		t.Fatalf("Unexpected delete retry for replacement pod: got %d delete attempts, want %d", got, retries)
+	}
+}
+
+func TestPodEvictionRetryCancelledWhenTaintRemoved(t *testing.T) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := testutil.NewPod("pod1", "node1")
+	pod.UID = "pod1-uid"
+	fakeClientset := fake.NewSimpleClientset(pod)
+	var deleteAttempts atomic.Int32
+	fakeClientset.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		attempt := deleteAttempts.Add(1)
+		if attempt <= retries {
+			deleteAction := action.(clienttesting.DeleteAction)
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, deleteAction.GetName(), fmt.Errorf("denied by test"))
+		}
+		return false, nil, nil
+	})
+
+	controller, podIndexer, nodeIndexer := setupNewController(ctx, fakeClientset)
+	controller.recorder = testutil.NewFakeRecorder()
+	controller.taintedNodes = map[string][]corev1.Taint{
+		"node1": {createNoExecuteTaint(1)},
+	}
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	useFakePodEvictionQueue(controller, fakeClock)
+
+	wg.Go(func() {
+		controller.Run(ctx)
+	})
+
+	if err := podIndexer.Add(pod); err != nil {
+		t.Fatalf("Failed to add pod to indexer: %v", err)
+	}
+	controller.PodUpdated(nil, pod)
+
+	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		return deleteAttempts.Load() == retries, nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for initial delete attempts: %v", err)
+	}
+
+	if err := nodeIndexer.Add(testutil.NewNode("node1")); err != nil {
+		t.Fatalf("Failed to add node to indexer: %v", err)
+	}
+	controller.handleNodeUpdate(ctx, nodeUpdateItem{"node1"})
+
+	fakeClock.Step(time.Second)
+	podRef := NamespacedObject{NamespacedName: types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, UID: pod.UID}
+	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		_, ok := currentPodEvictionRetry(controller, podRef.NamespacedName)
+		return !ok, nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for retry cancellation: %v", err)
+	}
+
+	if got := deleteAttempts.Load(); got != retries {
+		t.Fatalf("Unexpected delete retry after taint removal: got %d delete attempts, want %d", got, retries)
+	}
+}
+
+func TestPodEvictionRetrySchedulesNewDeadlineForFiniteToleration(t *testing.T) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := testutil.NewPod("pod1", "node1")
+	pod.UID = "pod1-uid"
+	fakeClientset := fake.NewSimpleClientset(pod)
+	var deleteAttempts atomic.Int32
+	fakeClientset.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		attempt := deleteAttempts.Add(1)
+		if attempt <= retries {
+			deleteAction := action.(clienttesting.DeleteAction)
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, deleteAction.GetName(), fmt.Errorf("denied by test"))
+		}
+		return false, nil, nil
+	})
+
+	controller, podIndexer, _ := setupNewController(ctx, fakeClientset)
+	controller.recorder = testutil.NewFakeRecorder()
+	controller.taintedNodes = map[string][]corev1.Taint{
+		"node1": {createNoExecuteTaint(1)},
+	}
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	useFakePodEvictionQueue(controller, fakeClock)
+
+	wg.Go(func() {
+		controller.Run(ctx)
+	})
+
+	if err := podIndexer.Add(pod); err != nil {
+		t.Fatalf("Failed to add pod to indexer: %v", err)
+	}
+	controller.PodUpdated(nil, pod)
+
+	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		return deleteAttempts.Load() == retries, nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for initial delete attempts: %v", err)
+	}
+
+	tolerationSeconds := int64(5)
+	toleratingPod := pod.DeepCopy()
+	toleratingPod.Spec.Tolerations = []corev1.Toleration{{
+		Key:               "testTaint1",
+		Value:             "test1",
+		Effect:            corev1.TaintEffectNoExecute,
+		TolerationSeconds: &tolerationSeconds,
+	}}
+	if _, err := fakeClientset.CoreV1().Pods(toleratingPod.Namespace).Update(ctx, toleratingPod, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Failed to update pod in fake client: %v", err)
+	}
+	if err := podIndexer.Update(toleratingPod); err != nil {
+		t.Fatalf("Failed to update pod in indexer: %v", err)
+	}
+	controller.handlePodUpdate(ctx, podUpdateItem{
+		podName:      toleratingPod.Name,
+		podNamespace: toleratingPod.Namespace,
+		nodeName:     toleratingPod.Spec.NodeName,
+	})
+
+	podNamespacedName := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+	if err := waitForTimedWorkerAfterRetry(controller, fakeClock, podNamespacedName, time.Duration(tolerationSeconds)*time.Second); err != nil {
+		t.Fatalf("Timed out waiting for new finite toleration deadline: %v", err)
+	}
+
+	fakeClock.Step(time.Second)
+	if err := wait.PollImmediate(10*time.Millisecond, 200*time.Millisecond, func() (bool, error) {
+		return deleteAttempts.Load() == retries, nil
+	}); err != nil {
+		t.Fatalf("Pod was deleted before the new toleration deadline: %v", err)
+	}
+
+	fakeClock.Step(time.Duration(tolerationSeconds) * time.Second)
+	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		return deleteAttempts.Load() > retries, nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for delete after new toleration deadline: %v", err)
+	}
+}
+
+func TestPodEvictionRetrySchedulesNewDeadlineForChangedTaint(t *testing.T) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	pod := testutil.NewPod("pod1", "node1")
+	pod.UID = "pod1-uid"
+	fakeClientset := fake.NewSimpleClientset(pod)
+	var deleteAttempts atomic.Int32
+	fakeClientset.PrependReactor("delete", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		attempt := deleteAttempts.Add(1)
+		if attempt <= retries {
+			deleteAction := action.(clienttesting.DeleteAction)
+			return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, deleteAction.GetName(), fmt.Errorf("denied by test"))
+		}
+		return false, nil, nil
+	})
+
+	controller, podIndexer, nodeIndexer := setupNewController(ctx, fakeClientset)
+	controller.recorder = testutil.NewFakeRecorder()
+	controller.taintedNodes = map[string][]corev1.Taint{
+		"node1": {createNoExecuteTaint(1)},
+	}
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	useFakePodEvictionQueue(controller, fakeClock)
+
+	wg.Go(func() {
+		controller.Run(ctx)
+	})
+
+	if err := podIndexer.Add(pod); err != nil {
+		t.Fatalf("Failed to add pod to indexer: %v", err)
+	}
+	controller.PodUpdated(nil, pod)
+
+	podRef := NamespacedObject{NamespacedName: types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, UID: pod.UID}
+	if _, err := waitForPodEvictionRetry(controller, podRef); err != nil {
+		t.Fatalf("Timed out waiting for durable retry handoff: %v", err)
+	}
+
+	tolerationSeconds := int64(5)
+	toleratingPod := pod.DeepCopy()
+	toleratingPod.Spec.Tolerations = []corev1.Toleration{{
+		Key:               "testTaint2",
+		Value:             "test2",
+		Effect:            corev1.TaintEffectNoExecute,
+		TolerationSeconds: &tolerationSeconds,
+	}}
+	if _, err := fakeClientset.CoreV1().Pods(toleratingPod.Namespace).Update(ctx, toleratingPod, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Failed to update pod in fake client: %v", err)
+	}
+	if err := podIndexer.Update(toleratingPod); err != nil {
+		t.Fatalf("Failed to update pod in indexer: %v", err)
+	}
+
+	newNode := addTaintsToNode(testutil.NewNode("node1"), "testTaint2", "taint2", []int{2})
+	if err := nodeIndexer.Add(newNode); err != nil {
+		t.Fatalf("Failed to add node to indexer: %v", err)
+	}
+	controller.handleNodeUpdate(ctx, nodeUpdateItem{nodeName: newNode.Name})
+
+	podNamespacedName := types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}
+	if err := waitForTimedWorkerAfterRetry(controller, fakeClock, podNamespacedName, time.Duration(tolerationSeconds)*time.Second); err != nil {
+		t.Fatalf("Timed out waiting for new taint deadline: %v", err)
+	}
+
+	fakeClock.Step(time.Second)
+	if err := wait.PollImmediate(10*time.Millisecond, 200*time.Millisecond, func() (bool, error) {
+		return deleteAttempts.Load() == retries, nil
+	}); err != nil {
+		t.Fatalf("Pod was deleted before the new taint deadline: %v", err)
+	}
+
+	fakeClock.Step(time.Duration(tolerationSeconds) * time.Second)
+	if err := wait.PollImmediate(10*time.Millisecond, time.Second, func() (bool, error) {
+		return deleteAttempts.Load() > retries, nil
+	}); err != nil {
+		t.Fatalf("Timed out waiting for delete after new taint deadline: %v", err)
 	}
 }
 

--- a/pkg/controller/tainteviction/timed_workers.go
+++ b/pkg/controller/tainteviction/timed_workers.go
@@ -31,6 +31,8 @@ import (
 type WorkArgs struct {
 	// Object is the work item. The UID is only set if it was set when adding the work item.
 	Object NamespacedObject
+	// CreatedAt is set when the work item is accepted into the queue.
+	CreatedAt time.Time
 }
 
 // KeyFromWorkArgs creates a key for the given `WorkArgs`.
@@ -49,6 +51,13 @@ func NewWorkArgs(name, namespace string) *WorkArgs {
 	}
 }
 
+// NewWorkArgsWithUID is a helper function to create new `WorkArgs` with a UID.
+func NewWorkArgsWithUID(name, namespace string, uid types.UID) *WorkArgs {
+	return &WorkArgs{
+		Object: NamespacedObject{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}, UID: uid},
+	}
+}
+
 // TimedWorker is a responsible for executing a function no earlier than at FireAt time.
 type TimedWorker struct {
 	WorkItem  *WorkArgs
@@ -56,6 +65,15 @@ type TimedWorker struct {
 	FireAt    time.Time
 	Timer     clock.Timer
 	cancelled atomic.Bool
+}
+
+type timedWorkerToken struct {
+	_ byte
+}
+
+type timedWorkerEntry struct {
+	worker *TimedWorker
+	token  *timedWorkerToken
 }
 
 // createWorker creates a TimedWorker that will execute `f` not earlier than `fireAt`.
@@ -111,8 +129,8 @@ func (w *TimedWorker) Cancel() {
 type TimedWorkerQueue struct {
 	sync.Mutex
 	// map of workers keyed by string returned by 'KeyFromWorkArgs' from the given worker.
-	// Entries may be nil if the work didn't need a timer and is already running.
-	workers  map[string]*TimedWorker
+	// Entry workers may be nil if the work didn't need a timer and is already running.
+	workers  map[string]timedWorkerEntry
 	workerWG sync.WaitGroup
 	workFunc func(ctx context.Context, fireAt time.Time, args *WorkArgs) error
 	clock    clock.WithDelayedExecution
@@ -122,21 +140,25 @@ type TimedWorkerQueue struct {
 // given function `f`.
 func CreateWorkerQueue(f func(ctx context.Context, fireAt time.Time, args *WorkArgs) error) *TimedWorkerQueue {
 	return &TimedWorkerQueue{
-		workers:  make(map[string]*TimedWorker),
+		workers:  make(map[string]timedWorkerEntry),
 		workFunc: f,
 		clock:    clock.RealClock{},
 	}
 }
 
-func (q *TimedWorkerQueue) getWrappedWorkerFunc(key string) func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
+func (q *TimedWorkerQueue) getWrappedWorkerFunc(key string, token *timedWorkerToken) func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
 	return func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
 		logger := klog.FromContext(ctx)
 		logger.V(4).Info("Firing worker", "item", key, "firedTime", fireAt)
 		err := q.workFunc(ctx, fireAt, args)
 		q.Lock()
 		defer q.Unlock()
-		logger.V(4).Info("Worker finished, removing", "item", key, "err", err)
-		delete(q.workers, key)
+		if entry, exists := q.workers[key]; exists && entry.token == token {
+			logger.V(4).Info("Worker finished, removing", "item", key, "err", err)
+			delete(q.workers, key)
+		} else {
+			logger.V(4).Info("Worker finished, already replaced", "item", key, "err", err)
+		}
 		return err
 	}
 }
@@ -155,8 +177,10 @@ func (q *TimedWorkerQueue) AddWork(ctx context.Context, args *WorkArgs, createdA
 		return
 	}
 	logger.V(4).Info("Adding TimedWorkerQueue item and to be fired at firedTime", "item", key, "createTime", createdAt, "firedTime", fireAt)
-	worker := createWorker(ctx, &q.workerWG, args, createdAt, fireAt, q.getWrappedWorkerFunc(key), q.clock)
-	q.workers[key] = worker
+	args.CreatedAt = createdAt
+	token := &timedWorkerToken{}
+	worker := createWorker(ctx, &q.workerWG, args, createdAt, fireAt, q.getWrappedWorkerFunc(key, token), q.clock)
+	q.workers[key] = timedWorkerEntry{worker: worker, token: token}
 }
 
 // UpdateWork adds or replaces a work item such that it will be executed not earlier than `fireAt`.
@@ -167,21 +191,23 @@ func (q *TimedWorkerQueue) UpdateWork(ctx context.Context, args *WorkArgs, creat
 
 	q.Lock()
 	defer q.Unlock()
-	if worker, exists := q.workers[key]; exists {
-		if worker == nil {
+	if entry, exists := q.workers[key]; exists {
+		if entry.worker == nil {
 			logger.V(4).Info("Keeping existing work, already in progress", "item", key)
 			return
 		}
-		if worker.FireAt.Compare(fireAt) == 0 {
-			logger.V(4).Info("Keeping existing work, same time", "item", key, "createTime", worker.CreatedAt, "firedTime", worker.FireAt)
+		if entry.worker.FireAt.Compare(fireAt) == 0 {
+			logger.V(4).Info("Keeping existing work, same time", "item", key, "createTime", entry.worker.CreatedAt, "firedTime", entry.worker.FireAt)
 			return
 		}
-		logger.V(4).Info("Replacing existing work", "item", key, "createTime", worker.CreatedAt, "firedTime", worker.FireAt)
-		worker.Cancel()
+		logger.V(4).Info("Replacing existing work", "item", key, "createTime", entry.worker.CreatedAt, "firedTime", entry.worker.FireAt)
+		entry.worker.Cancel()
 	}
 	logger.V(4).Info("Adding TimedWorkerQueue item and to be fired at firedTime", "item", key, "createTime", createdAt, "firedTime", fireAt)
-	worker := createWorker(ctx, &q.workerWG, args, createdAt, fireAt, q.getWrappedWorkerFunc(key), q.clock)
-	q.workers[key] = worker
+	args.CreatedAt = createdAt
+	token := &timedWorkerToken{}
+	worker := createWorker(ctx, &q.workerWG, args, createdAt, fireAt, q.getWrappedWorkerFunc(key, token), q.clock)
+	q.workers[key] = timedWorkerEntry{worker: worker, token: token}
 }
 
 // CancelWork removes scheduled function execution from the queue. Returns true if work was cancelled.
@@ -190,13 +216,13 @@ func (q *TimedWorkerQueue) UpdateWork(ctx context.Context, args *WorkArgs, creat
 func (q *TimedWorkerQueue) CancelWork(logger klog.Logger, key string) bool {
 	q.Lock()
 	defer q.Unlock()
-	worker, found := q.workers[key]
+	entry, found := q.workers[key]
 	result := false
 	if found {
 		logger.V(4).Info("Cancelling TimedWorkerQueue item", "item", key, "time", time.Now())
-		if worker != nil {
+		if entry.worker != nil {
 			result = true
-			worker.Cancel()
+			entry.worker.Cancel()
 		}
 		delete(q.workers, key)
 	}
@@ -208,7 +234,7 @@ func (q *TimedWorkerQueue) CancelWork(logger klog.Logger, key string) bool {
 func (q *TimedWorkerQueue) GetWorkerUnsafe(key string) *TimedWorker {
 	q.Lock()
 	defer q.Unlock()
-	return q.workers[key]
+	return q.workers[key].worker
 }
 
 // CancelAndWait cancels all workers and waits for all running threads to terminate before returning.
@@ -217,8 +243,10 @@ func (q *TimedWorkerQueue) CancelAndWait() {
 	defer q.workerWG.Wait()
 	q.Lock()
 	defer q.Unlock()
-	for _, worker := range q.workers {
-		worker.Cancel()
+	for _, entry := range q.workers {
+		if entry.worker != nil {
+			entry.worker.Cancel()
+		}
 	}
-	q.workers = make(map[string]*TimedWorker)
+	q.workers = make(map[string]timedWorkerEntry)
 }

--- a/pkg/controller/tainteviction/timed_workers_test.go
+++ b/pkg/controller/tainteviction/timed_workers_test.go
@@ -150,3 +150,87 @@ func TestCancelAndRead(t *testing.T) {
 		t.Errorf("Expected testVal = 4, got %v", lastVal)
 	}
 }
+
+func TestRunningWorkerCompletionDoesNotRemoveReplacement(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		startFirstWorker      func(context.Context, *TimedWorkerQueue, *testingclock.FakeClock, time.Time, *WorkArgs)
+		expectCancelToSucceed bool
+	}{
+		{
+			name: "immediate worker",
+			startFirstWorker: func(ctx context.Context, queue *TimedWorkerQueue, fakeClock *testingclock.FakeClock, now time.Time, args *WorkArgs) {
+				queue.AddWork(ctx, args, now, now)
+			},
+			expectCancelToSucceed: false,
+		},
+		{
+			name: "scheduled worker already firing",
+			startFirstWorker: func(ctx context.Context, queue *TimedWorkerQueue, fakeClock *testingclock.FakeClock, now time.Time, args *WorkArgs) {
+				queue.AddWork(ctx, args, now, now.Add(time.Second))
+				fakeClock.Step(time.Second)
+			},
+			expectCancelToSucceed: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			now := time.Now()
+			fakeClock := testingclock.NewFakeClock(now)
+			started := make(chan struct{})
+			release := make(chan struct{})
+			startOnce := sync.Once{}
+
+			queue := CreateWorkerQueue(func(ctx context.Context, fireAt time.Time, args *WorkArgs) error {
+				startOnce.Do(func() {
+					close(started)
+				})
+				<-release
+				return nil
+			})
+			queue.clock = fakeClock
+
+			args := NewWorkArgs("pod", "namespace")
+			key := args.KeyFromWorkArgs()
+			tc.startFirstWorker(ctx, queue, fakeClock, now, args)
+			select {
+			case <-started:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed worker did not start")
+			}
+
+			if got := queue.CancelWork(logger, key); got != tc.expectCancelToSucceed {
+				t.Fatalf("CancelWork() = %v, want %v", got, tc.expectCancelToSucceed)
+			}
+
+			replacementFireAt := now.Add(10 * time.Second)
+			queue.AddWork(ctx, NewWorkArgs("pod", "namespace"), now.Add(2*time.Second), replacementFireAt)
+			replacement := queue.GetWorkerUnsafe(key)
+			if replacement == nil {
+				t.Fatal("replacement worker was not added")
+			}
+			if replacement.FireAt != replacementFireAt {
+				t.Fatalf("replacement worker FireAt = %v, want %v", replacement.FireAt, replacementFireAt)
+			}
+
+			close(release)
+			queue.workerWG.Wait()
+
+			replacement = queue.GetWorkerUnsafe(key)
+			if replacement == nil {
+				t.Fatal("running worker removed replacement worker on completion")
+			}
+			if replacement.FireAt != replacementFireAt {
+				t.Fatalf("replacement worker FireAt after stale completion = %v, want %v", replacement.FireAt, replacementFireAt)
+			}
+			if !queue.CancelWork(logger, key) {
+				t.Fatal("replacement worker was not cancellable after stale worker completed")
+			}
+			if got := queue.GetWorkerUnsafe(key); got != nil {
+				t.Fatalf("worker still present after cancellation: %#v", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The taint eviction controller can lose a pod eviction when the pod deletion fails after the initial deletion attempts are exhausted.

This change makes failed pod deletions durable by scheduling them on a rate-limited retry queue. Retry state is tracked per pod so stale retries do not interfere with newer eviction decisions.

The deletion path also:
- verifies the pod still exists and matches the expected UID before deletion
- avoids repeating deletion for pods that are already being deleted
- preserves the existing disruption condition handling
- uses UID preconditions when deleting a pod
- cleans up retry state when the eviction is no longer applicable

Additional unit tests cover the retry, cancellation, stale retry, pod identity, and deletion behavior.

#### Which issue(s) this PR is related to:

Fixes #140639

#### Special notes for your reviewer:

The change is scoped to the taint eviction controller and its timed worker support.

Validation performed locally:

- `GOCACHE=/tmp/k8s-go-build-cache go test ./pkg/controller/tainteviction -race -count=1`
- `git diff --check`

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug in the taint-eviction controller where pod eviction could be permanently lost after all initial pod deletion attempts failed. Failed evictions are now retried using a durable, rate-limited retry queue.
```

## Additional fixes

The `PodDeletionsLatency` metric was corrected to use
`time.Since(fireAt).Seconds()` instead of multiplying a `time.Duration`
by `time.Second`. This correction is orthogonal to the durable retry
queue implementation.

The retry path for Pods with finite `TolerationSeconds` was also corrected
so that an already-expired toleration window is not restarted during retry.
Concurrent `NotFound` responses from Pod deletion are treated as a
successful outcome rather than triggering unnecessary retry cycles.