### PR TITLE
kubelet: make negative eviction-max-pod-grace-period defer to pods

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -62,6 +62,11 @@ const (
 	immediateEvictionGracePeriodSeconds = 1
 )
 
+func immediateEvictionGracePeriodOverride() *int64 {
+	override := int64(immediateEvictionGracePeriodSeconds)
+	return &override
+}
+
 // managerImpl implements Manager
 type managerImpl struct {
 	//  used to track time
@@ -428,12 +433,16 @@ func (m *managerImpl) synchronize(ctx context.Context, diskInfoProvider DiskInfo
 	// we kill at most a single pod during each eviction interval
 	for i := range activePods {
 		pod := activePods[i]
-		gracePeriodOverride := int64(immediateEvictionGracePeriodSeconds)
-		if !isHardEvictionThreshold(thresholdToReclaim) {
-			gracePeriodOverride = m.config.MaxPodGracePeriodSeconds
+		// A nil override defers to the pod's terminationGracePeriodSeconds.
+		var gracePeriodOverride *int64
+		if isHardEvictionThreshold(thresholdToReclaim) {
+			gracePeriodOverride = immediateEvictionGracePeriodOverride()
+		} else if m.config.MaxPodGracePeriodSeconds >= 0 {
+			override := m.config.MaxPodGracePeriodSeconds
 			if pod.Spec.TerminationGracePeriodSeconds != nil {
-				gracePeriodOverride = min(m.config.MaxPodGracePeriodSeconds, *pod.Spec.TerminationGracePeriodSeconds)
+				override = min(override, *pod.Spec.TerminationGracePeriodSeconds)
 			}
+			gracePeriodOverride = &override
 		}
 
 		message, annotations := evictionMessage(resourceToReclaim, pod, statsFunc, thresholds, observations)
@@ -556,7 +565,7 @@ func (m *managerImpl) emptyDirLimitEviction(logger klog.Logger, podStats statsap
 			used := podVolumeUsed[pod.Spec.Volumes[i].Name]
 			if used != nil && size != nil && size.Sign() == 1 && used.Cmp(*size) > 0 {
 				// the emptyDir usage exceeds the size limit, evict the pod
-				if m.evictPod(logger, pod, immediateEvictionGracePeriodSeconds, fmt.Sprintf(emptyDirMessageFmt, pod.Spec.Volumes[i].Name, size.String()), nil, nil) {
+				if m.evictPod(logger, pod, immediateEvictionGracePeriodOverride(), fmt.Sprintf(emptyDirMessageFmt, pod.Spec.Volumes[i].Name, size.String()), nil, nil) {
 					metrics.Evictions.WithLabelValues(signalEmptyDirFsLimit).Inc()
 					return true
 				}
@@ -584,7 +593,7 @@ func (m *managerImpl) podEphemeralStorageLimitEviction(logger klog.Logger, podSt
 	if podEphemeralStorageTotalUsage.Cmp(podEphemeralStorageLimit) > 0 {
 		// the total usage of pod exceeds the total size limit of containers, evict the pod
 		message := fmt.Sprintf(podEphemeralStorageMessageFmt, podEphemeralStorageLimit.String())
-		if m.evictPod(logger, pod, immediateEvictionGracePeriodSeconds, message, nil, nil) {
+		if m.evictPod(logger, pod, immediateEvictionGracePeriodOverride(), message, nil, nil) {
 			metrics.Evictions.WithLabelValues(signalEphemeralPodFsLimit).Inc()
 			return true
 		}
@@ -619,7 +628,7 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 
 		if ephemeralStorageThreshold, ok := thresholdsMap[containerStat.Name]; ok {
 			if ephemeralStorageThreshold.Cmp(*containerUsed) < 0 {
-				if m.evictPod(logger, pod, immediateEvictionGracePeriodSeconds, fmt.Sprintf(containerEphemeralStorageMessageFmt, containerStat.Name, ephemeralStorageThreshold.String()), nil, nil) {
+				if m.evictPod(logger, pod, immediateEvictionGracePeriodOverride(), fmt.Sprintf(containerEphemeralStorageMessageFmt, containerStat.Name, ephemeralStorageThreshold.String()), nil, nil) {
 					metrics.Evictions.WithLabelValues(signalEphemeralContainerFsLimit).Inc()
 					return true
 				}
@@ -630,7 +639,7 @@ func (m *managerImpl) containerEphemeralStorageLimitEviction(logger klog.Logger,
 	return false
 }
 
-func (m *managerImpl) evictPod(logger klog.Logger, pod *v1.Pod, gracePeriodOverride int64, evictMsg string, annotations map[string]string, condition *v1.PodCondition) bool {
+func (m *managerImpl) evictPod(logger klog.Logger, pod *v1.Pod, gracePeriodOverride *int64, evictMsg string, annotations map[string]string, condition *v1.PodCondition) bool {
 	// If the pod is marked as critical and static, and support for critical pod annotations is enabled,
 	// do not evict such pods. Static pods are not re-admitted after evictions.
 	// https://github.com/kubernetes/kubernetes/issues/40573 has more details.
@@ -643,7 +652,7 @@ func (m *managerImpl) evictPod(logger klog.Logger, pod *v1.Pod, gracePeriodOverr
 	m.recorder.AnnotatedEventf(pod, annotations, v1.EventTypeWarning, Reason, "%s", evictMsg)
 	// this is a blocking call and should only return when the pod and its containers are killed.
 	logger.V(3).Info("Evicting pod", "pod", klog.KObj(pod), "podUID", pod.UID, "message", evictMsg)
-	err := m.killPodFunc(pod, true, &gracePeriodOverride, func(status *v1.PodStatus) {
+	err := m.killPodFunc(pod, true, gracePeriodOverride, func(status *v1.PodStatus) {
 		status.Phase = v1.PodFailed
 		status.Reason = Reason
 		status.Message = evictMsg

--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -886,6 +886,168 @@ func TestMemoryPressure(t *testing.T) {
 	}
 }
 
+func TestSoftEvictionNegativeMaxPodGracePeriod(t *testing.T) {
+	tests := map[string]struct {
+		terminationGracePeriodSeconds *int64
+	}{
+		"pod termination grace period set": {terminationGracePeriodSeconds: ptr.To(int64(120))},
+		"pod termination grace period nil": {},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
+			podsToMake := []podToMake{
+				{name: "guaranteed-low-priority-high-usage", priority: lowPriority, requests: newResourceList("100m", "1Gi", ""), limits: newResourceList("100m", "1Gi", ""), memoryWorkingSet: "900Mi"},
+				{name: "burstable-below-requests", priority: defaultPriority, requests: newResourceList("100m", "100Mi", ""), limits: newResourceList("200m", "1Gi", ""), memoryWorkingSet: "50Mi"},
+				{name: "burstable-above-requests", priority: defaultPriority, requests: newResourceList("100m", "100Mi", ""), limits: newResourceList("200m", "1Gi", ""), memoryWorkingSet: "400Mi"},
+				{name: "best-effort-high-priority-high-usage", priority: highPriority, requests: newResourceList("", "", ""), limits: newResourceList("", "", ""), memoryWorkingSet: "400Mi"},
+				{name: "best-effort-low-priority-low-usage", priority: lowPriority, requests: newResourceList("", "", ""), limits: newResourceList("", "", ""), memoryWorkingSet: "100Mi"},
+			}
+			pods := []*v1.Pod{}
+			podStats := map[*v1.Pod]statsapi.PodStats{}
+			for _, podToMake := range podsToMake {
+				pod, podStat := makePodWithMemoryStats(podToMake.name, podToMake.priority, podToMake.requests, podToMake.limits, podToMake.memoryWorkingSet)
+				pods = append(pods, pod)
+				podStats[pod] = podStat
+			}
+			pods[4].Spec.TerminationGracePeriodSeconds = tc.terminationGracePeriodSeconds
+			podToEvict := pods[4]
+			activePodsFunc := func() []*v1.Pod {
+				return pods
+			}
+
+			fakeClock := testingclock.NewFakeClock(time.Now())
+			podKiller := &mockPodKiller{}
+			diskInfoProvider := &mockDiskInfoProvider{dedicatedImageFs: ptr.To(false)}
+			diskGC := &mockDiskGC{err: nil}
+			nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+
+			config := Config{
+				MaxPodGracePeriodSeconds: -1,
+				PressureTransitionPeriod: time.Minute * 5,
+				Thresholds: []evictionapi.Threshold{
+					{
+						Signal:   evictionapi.SignalMemoryAvailable,
+						Operator: evictionapi.OpLessThan,
+						Value: evictionapi.ThresholdValue{
+							Quantity: quantityMustParse("1Gi"),
+						},
+						GracePeriod: time.Minute * 2,
+					},
+				},
+			}
+			summaryProvider := &fakeSummaryProvider{result: makeMemoryStats("2Gi", podStats)}
+			manager := &managerImpl{
+				clock:                        fakeClock,
+				killPodFunc:                  podKiller.killPodNow,
+				imageGC:                      diskGC,
+				containerGC:                  diskGC,
+				config:                       config,
+				recorder:                     &record.FakeRecorder{},
+				summaryProvider:              summaryProvider,
+				nodeRef:                      nodeRef,
+				nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
+				thresholdsFirstObservedAt:    thresholdsObservedAt{},
+			}
+
+			_, err := manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
+			if err != nil {
+				t.Fatalf("Manager expects no error but got %v", err)
+			}
+
+			fakeClock.Step(1 * time.Minute)
+			summaryProvider.result = makeMemoryStats("500Mi", podStats)
+			_, err = manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
+			if err != nil {
+				t.Fatalf("Manager expects no error but got %v", err)
+			}
+
+			fakeClock.Step(3 * time.Minute)
+			summaryProvider.result = makeMemoryStats("500Mi", podStats)
+			_, err = manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
+			if err != nil {
+				t.Fatalf("Manager expects no error but got %v", err)
+			}
+
+			if podKiller.pod != podToEvict {
+				t.Errorf("Manager chose to kill pod: %v, but should have chosen %v", podKiller.pod.Name, podToEvict.Name)
+			}
+			if podKiller.gracePeriodOverride != nil {
+				t.Errorf("Manager should defer to the pod spec when MaxPodGracePeriodSeconds is negative, but used grace period override: %d", *podKiller.gracePeriodOverride)
+			}
+		})
+	}
+}
+
+func TestHardEvictionWithNegativeMaxPodGracePeriod(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	podsToMake := []podToMake{
+		{name: "guaranteed-low-priority-high-usage", priority: lowPriority, requests: newResourceList("100m", "1Gi", ""), limits: newResourceList("100m", "1Gi", ""), memoryWorkingSet: "900Mi"},
+		{name: "burstable-below-requests", priority: defaultPriority, requests: newResourceList("100m", "100Mi", ""), limits: newResourceList("200m", "1Gi", ""), memoryWorkingSet: "50Mi"},
+		{name: "burstable-above-requests", priority: defaultPriority, requests: newResourceList("100m", "100Mi", ""), limits: newResourceList("200m", "1Gi", ""), memoryWorkingSet: "400Mi"},
+		{name: "best-effort-high-priority-high-usage", priority: highPriority, requests: newResourceList("", "", ""), limits: newResourceList("", "", ""), memoryWorkingSet: "400Mi"},
+		{name: "best-effort-low-priority-low-usage", priority: lowPriority, requests: newResourceList("", "", ""), limits: newResourceList("", "", ""), memoryWorkingSet: "100Mi"},
+	}
+	pods := []*v1.Pod{}
+	podStats := map[*v1.Pod]statsapi.PodStats{}
+	for _, podToMake := range podsToMake {
+		pod, podStat := makePodWithMemoryStats(podToMake.name, podToMake.priority, podToMake.requests, podToMake.limits, podToMake.memoryWorkingSet)
+		pods = append(pods, pod)
+		podStats[pod] = podStat
+	}
+	podToEvict := pods[4]
+	activePodsFunc := func() []*v1.Pod {
+		return pods
+	}
+
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	podKiller := &mockPodKiller{}
+	diskInfoProvider := &mockDiskInfoProvider{dedicatedImageFs: ptr.To(false)}
+	diskGC := &mockDiskGC{err: nil}
+	nodeRef := &v1.ObjectReference{Kind: "Node", Name: "test", UID: types.UID("test"), Namespace: ""}
+
+	config := Config{
+		MaxPodGracePeriodSeconds: -1,
+		PressureTransitionPeriod: time.Minute * 5,
+		Thresholds: []evictionapi.Threshold{
+			{
+				Signal:   evictionapi.SignalMemoryAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1500Mi"),
+				},
+			},
+		},
+	}
+	summaryProvider := &fakeSummaryProvider{result: makeMemoryStats("500Mi", podStats)}
+	manager := &managerImpl{
+		clock:                        fakeClock,
+		killPodFunc:                  podKiller.killPodNow,
+		imageGC:                      diskGC,
+		containerGC:                  diskGC,
+		config:                       config,
+		recorder:                     &record.FakeRecorder{},
+		summaryProvider:              summaryProvider,
+		nodeRef:                      nodeRef,
+		nodeConditionsLastObservedAt: nodeConditionsObservedAt{},
+		thresholdsFirstObservedAt:    thresholdsObservedAt{},
+	}
+
+	_, err := manager.synchronize(tCtx, diskInfoProvider, activePodsFunc)
+	if err != nil {
+		t.Fatalf("Manager expects no error but got %v", err)
+	}
+
+	if podKiller.pod != podToEvict {
+		t.Errorf("Manager chose to kill pod: %v, but should have chosen %v", podKiller.pod.Name, podToEvict.Name)
+	}
+	if podKiller.gracePeriodOverride == nil {
+		t.Errorf("Manager chose to kill pod but should have had a grace period override.")
+	} else if *podKiller.gracePeriodOverride != int64(1) {
+		t.Errorf("Manager chose to kill pod with incorrect grace period.  Expected: %d, actual: %d", 1, *podKiller.gracePeriodOverride)
+	}
+}
+
 func makeContainersByQOS(class v1.PodQOSClass) []v1.Container {
 	resource := newResourceList("100m", "1Gi", "")
 	switch class {

--- a/pkg/kubelet/eviction/types.go
+++ b/pkg/kubelet/eviction/types.go
@@ -48,6 +48,7 @@ type Config struct {
 	// PressureTransitionPeriod is duration the kubelet has to wait before transitioning out of a pressure condition.
 	PressureTransitionPeriod time.Duration
 	// Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
+	// A negative value defers to the pod's terminationGracePeriodSeconds.
 	MaxPodGracePeriodSeconds int64
 	// Thresholds define the set of conditions monitored to trigger eviction.
 	Thresholds []evictionapi.Threshold


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `--eviction-max-pod-grace-period` help text has always documented that a negative value defers to the pod specified termination grace period, but the eviction manager used the negative value as the grace period override itself. During a soft eviction the negative override was clamped to a small minimum downstream, so pods were killed almost immediately instead of receiving their configured termination grace period. This mismatch has been reported as surprising behavior on production clusters.

The manager now passes no override when the configured maximum is negative, which is the same path as an API initiated pod deletion, so the pod's own terminationGracePeriodSeconds applies. Zero and positive values keep their existing behavior exactly. `evictPod` now takes a pointer so nil can express "no override"; hard evictions and the ephemeral storage limit evictions still pass the immediate one second grace period.

One consequence worth calling out for operators: with this change a soft eviction of a pod with a long termination grace period blocks the eviction loop until the pod exits or its grace period elapses, matching API initiated deletion.

Regression tests cover both directions:

```
TestSoftEvictionNegativeMaxPodGracePeriod fails on unfixed code with
  Manager should defer to the pod spec when MaxPodGracePeriodSeconds is
  negative, but used grace period override: -1
and passes with the fix.
TestHardEvictionWithNegativeMaxPodGracePeriod pins that hard evictions
  still use the immediate override under a negative configuration.
```

#### Which issue(s) this PR is related to:

Fixes #118172

#### Special notes for your reviewer:

Deliberately out of scope: the KubeletConfiguration field doc comment in staging does not mention the negative semantics; updating it would regenerate the OpenAPI spec and needs an API review, so I left it alone and can follow up separately if preferred.

/sig node

#### Does this PR introduce a user-facing change?

```release-note
A negative kubelet `eviction-max-pod-grace-period` now defers to each pod's terminationGracePeriodSeconds during soft eviction, as the flag documentation always stated, instead of killing pods almost immediately.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
