### PR TITLE
kubelet: report the requested image name when inspection fails

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -120,7 +120,7 @@ func (m *imageManager) imagePullPrecheck(
 	case v1.PullIfNotPresent, v1.PullNever:
 		imageRef, err = m.imageService.GetImageRef(ctx, *spec)
 		if err != nil {
-			msg = fmt.Sprintf("Failed to inspect image %q: %v", imageRef, err)
+			msg = fmt.Sprintf("Failed to inspect image %q: %v", requestedImage, err)
 			m.logIt(klog.FromContext(ctx), objRef, v1.EventTypeWarning, events.FailedToInspectImage, logPrefix, msg)
 			return "", nil, msg, ErrImageInspect
 		}

--- a/pkg/kubelet/images/image_manager_test.go
+++ b/pkg/kubelet/images/image_manager_test.go
@@ -200,15 +200,15 @@ func noFGPullerTestCases() []pullerTestCase {
 				{[]string{"GetImageRef"}, ErrImageInspect, false, false,
 					[]v1.Event{
 						{Reason: "InspectFailed"},
-					}, ""},
+					}, "missing_image"},
 				{[]string{"GetImageRef"}, ErrImageInspect, false, false,
 					[]v1.Event{
 						{Reason: "InspectFailed"},
-					}, ""},
+					}, "missing_image"},
 				{[]string{"GetImageRef"}, ErrImageInspect, false, false,
 					[]v1.Event{
 						{Reason: "InspectFailed"},
-					}, ""},
+					}, "missing_image"},
 			},
 			expectedEnsureImageMetrics: ensureExistsMetricForLabels("ifnotpresent", "unknown", "unknown"),
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When image inspection fails under PullIfNotPresent or PullNever, the InspectFailed event and the pod status message were formatted with `imageRef`, the out parameter that `GetImageRef` has just set to the empty string on error. Users saw:

```
Failed to inspect image "": unknown inspectError
```

with no indication of which image was affected. Before the pull precheck logic was factored into `imagePullPrecheck`, the message carried the requested reference. This formats `requestedImage` instead, restoring the useful message.

The puller table tests now assert that the message names the missing image; on unfixed code they fail with the empty-name message above, and pass with the change.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

One line plus test assertions. The event reason and error are unchanged.

/sig node

#### Does this PR introduce a user-facing change?

```release-note
The "Failed to inspect image" event and pod status message include the image name again instead of an empty string.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```
