### PR TITLE
Added tests for SetMemoryReserve under Qos Container Manager

### DIFF
--- a/pkg/kubelet/cm/qos_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux_test.go
@@ -821,3 +821,97 @@ func TestQOSCPUConfigUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestSetMemoryReservation(t *testing.T) {
+	const (
+		guaranteedBytes  = 128 * 1024 * 1024      // 128Mi
+		burstableBytes   = 384 * 1024 * 1024      // 384Mi
+		allocatableBytes = 2 * 1024 * 1024 * 1024 // 2Gi
+	)
+	tests := []struct {
+		name string
+
+		pods               []*v1.Pod
+		allocatable        v1.ResourceList
+		percentReserve     int64
+		expectedBurstable  int64
+		expectedBestEffort int64
+	}{
+		{
+			name: "Memory with 20% reserve",
+			pods: activeTestPods(),
+			allocatable: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			percentReserve:     20,
+			expectedBurstable:  allocatableBytes - (guaranteedBytes * 20 / 100),
+			expectedBestEffort: allocatableBytes - (guaranteedBytes * 20 / 100) - (burstableBytes * 20 / 100),
+		},
+		{
+			name: "Memory with 100% reserve",
+			pods: activeTestPods(),
+			allocatable: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			percentReserve:     100,
+			expectedBurstable:  allocatableBytes - (guaranteedBytes * 100 / 100),
+			expectedBestEffort: allocatableBytes - (guaranteedBytes * 100 / 100) - (burstableBytes * 100 / 100),
+		},
+		{
+			name: "Memory with 33% reserve (integer division truncation)",
+			pods: activeTestPods(),
+			allocatable: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			percentReserve:     33,
+			expectedBurstable:  allocatableBytes - (guaranteedBytes * 33 / 100),
+			expectedBestEffort: allocatableBytes - (guaranteedBytes * 33 / 100) - (burstableBytes * 33 / 100),
+		},
+		{
+			name: "Only guaranteed pods, no burstable",
+			pods: activeTestPods()[:1], // only the guaranteed pod
+			allocatable: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			percentReserve:     100,
+			expectedBurstable:  allocatableBytes - guaranteedBytes,
+			expectedBestEffort: allocatableBytes - guaranteedBytes, // burstable request = 0, so no further reserve
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
+
+			m, err := createTestQOSContainerManager(logger)
+			require.NoError(t, err)
+
+			m.activePods = func() []*v1.Pod {
+				return tc.pods
+			}
+			m.getNodeAllocatable = func() v1.ResourceList {
+				return tc.allocatable
+			}
+
+			configs := map[v1.PodQOSClass]*CgroupConfig{
+				v1.PodQOSBurstable: {
+					ResourceParameters: &ResourceConfig{},
+				},
+				v1.PodQOSBestEffort: {
+					ResourceParameters: &ResourceConfig{},
+				},
+			}
+
+			m.setMemoryReserve(logger, configs, tc.percentReserve)
+			
+
+			logger.V(2).Info("Memory reservation test", "expectedBurstable", tc.expectedBurstable, "actualBurstable", *configs[v1.PodQOSBurstable].ResourceParameters.Memory)
+			assert.Equal(t, tc.expectedBurstable, *configs[v1.PodQOSBurstable].ResourceParameters.Memory)
+			
+			logger.V(2).Info("Memory reservation test", "expectedBestEffort", tc.expectedBestEffort, "actualBestEffort", *configs[v1.PodQOSBestEffort].ResourceParameters.Memory)
+			assert.Equal(t, tc.expectedBestEffort, *configs[v1.PodQOSBestEffort].ResourceParameters.Memory)
+
+		})
+	}
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
Improve tests in qos container manager for linux under for testing memory reservation

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Add tests for `setMemoryReserve` in qos manager for linux

#### Which issue(s) this PR is related to:

linked to #109717
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

setMemoryReserver was shown to be outside test coverage. I have added the test with varied memory reserve percentages, while also using the exisiting activePods

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NA
```
