### PR TITLE
Run PreEnqueueCheck per entity in scheduling queue

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -83,9 +83,9 @@ const (
 )
 
 // PreEnqueueCheck is a function type. It's used to build functions that
-// run against a Pod and the caller can choose to enqueue or skip the Pod
+// run against an entity and the caller can choose to enqueue or skip the entity
 // by the checking result.
-type PreEnqueueCheck func(pod *v1.Pod) bool
+type PreEnqueueCheck func(entity framework.QueuedEntityInfo) bool
 
 // PodSigner creates a scheduling signature for a pod that represents its scheduling requirements.
 // The signature is used by the opportunistic batching feature (KEP-5598) to reuse scheduling decisions.
@@ -1714,7 +1714,7 @@ func (p *PriorityQueue) collectEntitiesToEvaluate(logger klog.Logger, event fwk.
 		for nn := range hintKeys.candidatePods {
 			entityKey := fwk.PodKey(nn.Namespace, nn.Name).String()
 			if entity, exists := p.unschedulableEntities.entityInfoMap[entityKey]; exists {
-				if preCheck == nil || preCheck(entity.(*framework.QueuedPodInfo).Pod) {
+				if preCheck == nil || preCheck(entity) {
 					entities = append(entities, entity)
 				}
 				continue
@@ -1730,9 +1730,7 @@ func (p *PriorityQueue) collectEntitiesToEvaluate(logger klog.Logger, event fwk.
 					entityKey = fwk.PodGroupKey(nn.Namespace, *pod.Spec.SchedulingGroup.PodGroupName).String()
 					if entity, exists := p.unschedulableEntities.entityInfoMap[entityKey]; exists && !seen[entityKey] {
 						seen[entityKey] = true
-						// Only preCheck the specific pod identified by PreQueueingHint,
-						// not all members of the PodGroup.
-						if preCheck == nil || preCheck(pod) {
+						if preCheck == nil || preCheck(entity) {
 							entities = append(entities, entity)
 						}
 					}
@@ -1745,13 +1743,9 @@ func (p *PriorityQueue) collectEntitiesToEvaluate(logger klog.Logger, event fwk.
 	// No narrowing — evaluate all unschedulable entities.
 	entities := make([]framework.QueuedEntityInfo, 0, len(p.unschedulableEntities.entityInfoMap))
 	for _, entity := range p.unschedulableEntities.entityInfoMap {
-		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
-			if preCheck == nil || preCheck(pInfo.Pod) {
-				entities = append(entities, entity)
-				return false
-			}
-			return true
-		})
+		if preCheck == nil || preCheck(entity) {
+			entities = append(entities, entity)
+		}
 	}
 	return entities, nil
 }

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -5416,17 +5416,21 @@ func TestMoveAllToActiveOrBackoffQueue_PreEnqueueChecks(t *testing.T) {
 			want:     sets.New("p0", "p1", "p2", "p3", "p4"),
 		},
 		{
-			name:            "move Pods with priority greater than 2",
-			podInfos:        podInfos,
-			event:           framework.EventUnschedulableTimeout,
-			preEnqueueCheck: func(pod *v1.Pod) bool { return *pod.Spec.Priority >= 2 },
-			want:            sets.New("p2", "p3", "p4"),
+			name:     "move Pods with priority greater than 2",
+			podInfos: podInfos,
+			event:    framework.EventUnschedulableTimeout,
+			preEnqueueCheck: func(entity framework.QueuedEntityInfo) bool {
+				pod := entity.(*framework.QueuedPodInfo).Pod
+				return *pod.Spec.Priority >= 2
+			},
+			want: sets.New("p2", "p3", "p4"),
 		},
 		{
 			name:     "move Pods with even priority and greater than 2",
 			podInfos: podInfos,
 			event:    framework.EventUnschedulableTimeout,
-			preEnqueueCheck: func(pod *v1.Pod) bool {
+			preEnqueueCheck: func(entity framework.QueuedEntityInfo) bool {
+				pod := entity.(*framework.QueuedPodInfo).Pod
 				return *pod.Spec.Priority%2 == 0 && *pod.Spec.Priority >= 2
 			},
 			want: sets.New("p2", "p4"),
@@ -5435,7 +5439,8 @@ func TestMoveAllToActiveOrBackoffQueue_PreEnqueueChecks(t *testing.T) {
 			name:     "move Pods with even and negative priority",
 			podInfos: podInfos,
 			event:    framework.EventUnschedulableTimeout,
-			preEnqueueCheck: func(pod *v1.Pod) bool {
+			preEnqueueCheck: func(entity framework.QueuedEntityInfo) bool {
+				pod := entity.(*framework.QueuedPodInfo).Pod
 				return *pod.Spec.Priority%2 == 0 && *pod.Spec.Priority < 0
 			},
 		},
@@ -5443,7 +5448,7 @@ func TestMoveAllToActiveOrBackoffQueue_PreEnqueueChecks(t *testing.T) {
 			name:     "preCheck isn't called if the event is not interested by any plugins",
 			podInfos: podInfos,
 			event:    pvAdd, // No plugin is interested in this event.
-			preEnqueueCheck: func(pod *v1.Pod) bool {
+			preEnqueueCheck: func(entity framework.QueuedEntityInfo) bool {
 				panic("preCheck shouldn't be called")
 			},
 		},
@@ -7361,6 +7366,28 @@ func TestMoveAllToActiveOrBackoffQueuePodGroupMember(t *testing.T) {
 			event:             fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add},
 			expectedInActiveQ: true,
 			expectedGroupSize: 2,
+		},
+		{
+			name:         "event of interest moves ungated pod group from unschedulableEntities to activeQ, with preCheck",
+			initialPods:  []*v1.Pod{p1, p2},
+			initialState: stateUnschedulable,
+			event:        fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add},
+			preCheck: func(_ framework.QueuedEntityInfo) bool {
+				return true
+			},
+			expectedInActiveQ: true,
+			expectedGroupSize: 2,
+		},
+		{
+			name:         "event of interest would move ungated pod group from unschedulableEntities to activeQ, but preCheck filtered it",
+			initialPods:  []*v1.Pod{p1, p2},
+			initialState: stateUnschedulable,
+			event:        fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.Add},
+			preCheck: func(_ framework.QueuedEntityInfo) bool {
+				return false
+			},
+			expectedInUnschedulable: true,
+			expectedGroupSize:       2,
 		},
 		{
 			name:                    "event not of interest keeps pod group in unschedulableEntities",
@@ -10071,65 +10098,6 @@ func TestPreQueueingHint_ErrorFallback(t *testing.T) {
 	}
 }
 
-func TestPreQueueingHint_PodGroupPreCheck(t *testing.T) {
-	// Verify that preCheck is applied to PodGroup entities in the narrowed path.
-	// When preCheck rejects all member pods, the PodGroup entity should not be moved.
-	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
-		features.SchedulerPreQueueingHints: true,
-		features.GenericWorkload:           true,
-	})
-	logger, ctx := ktesting.NewTestContext(t)
-
-	pgName := "test-pg"
-	pod1 := st.MakePod().Name("pgpod1").Namespace("ns1").UID("pgpod1").Label("block", "").PodGroupName(pgName).Obj()
-	pod2 := st.MakePod().Name("pgpod2").Namespace("ns1").UID("pgpod2").Label("block", "").PodGroupName(pgName).Obj()
-	podGroup := &schedulingv1beta1.PodGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: pgName, Namespace: "ns1", UID: "pg-uid"},
-		Spec:       schedulingv1beta1.PodGroupSpec{},
-	}
-
-	preQueueingHintFn := func(logger klog.Logger, oldObj, newObj interface{}) (fwk.PreQueueingHintResult, error) {
-		return fwk.PreQueueingHintResult{
-			Pods: []types.NamespacedName{{Name: "pgpod1", Namespace: "ns1"}},
-		}, nil
-	}
-
-	m := makeEmptyQueueingHintMapPerProfile()
-	m[""][nodeAdd] = []*QueueingHintFunction{
-		{
-			PluginName:        "testPlugin",
-			QueueingHintFn:    queueHintReturnQueue,
-			PreQueueingHintFn: preQueueingHintFn,
-		},
-	}
-
-	q := NewTestQueue(ctx, newDefaultQueueSort(), WithQueueingHintMapPerProfile(m))
-
-	// Set up pod group in unschedulable state.
-	setupInitialPodGroupState(t, ctx, q, []*v1.Pod{pod1, pod2}, stateUnschedulable, podGroup)
-
-	pgLookup := newQueuedPodGroupInfoForLookup("ns1", pgName, fwk.PodGroupKeyType)
-	entity := q.unschedulableEntities.get(pgLookup)
-	if entity == nil {
-		t.Fatal("pod group not found in unschedulable entities")
-	}
-	entity.(*framework.QueuedPodGroupInfo).UnschedulablePlugins = sets.New[string]("testPlugin")
-
-	// preCheck rejects pods with label "block"
-	preCheck := func(pod *v1.Pod) bool {
-		_, hasBlock := pod.Labels["block"]
-		return !hasBlock
-	}
-
-	// Trigger event with preCheck that blocks all PodGroup member pods.
-	q.MoveAllToActiveOrBackoffQueue(logger, nodeAdd, nil, st.MakeNode().Name("node1").Obj(), preCheck)
-
-	// PodGroup should remain in unschedulable because preCheck rejected all members.
-	if q.unschedulableEntities.get(pgLookup) == nil {
-		t.Errorf("pod group should remain in unschedulable when preCheck rejects all members")
-	}
-}
-
 func TestPreQueueingHint_CPGDisablesNarrowing(t *testing.T) {
 	// When CompositePodGroup feature gate is enabled, PreQueueingHint
 	// narrowing is disabled to avoid missing CPG entities.
@@ -10303,19 +10271,3 @@ func TestPreQueueingHint_PerPluginNarrowing(t *testing.T) {
 		t.Errorf("pluginB QueueingHintFn should be called for pod2, called for: %v", pluginBQueueingHintCalled)
 	}
 }
-
-/*
-Copyright 2017 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -391,10 +391,10 @@ func (sched *Scheduler) deletePodFromSchedulingQueue(pod *v1.Pod, inBinding bool
 	}
 }
 
-// getLEPriorityPreCheck is a PreEnqueueCheck function that selects only lower or equal priority pods.
+// getLEPriorityPreCheck is a PreEnqueueCheck function that selects only lower or equal priority entities.
 func getLEPriorityPreCheck(priority int32) queue.PreEnqueueCheck {
-	return func(pod *v1.Pod) bool {
-		return corev1helpers.PodPriority(pod) <= priority
+	return func(entity framework.QueuedEntityInfo) bool {
+		return entity.GetPriority() <= priority
 	}
 }
 

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -28,6 +28,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -39,6 +40,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/scheduler/backend/queue"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
 	"k8s.io/kubernetes/pkg/scheduler/framework/parallelize"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/dynamicresources"
@@ -526,15 +528,29 @@ func (sched *Scheduler) handleBindingCycleError(
 		// It's intentional to "defer" this operation; otherwise MoveAllToActiveOrBackoffQueue() would
 		// add this event to in-flight events and thus move the assumed pod to backoffQ anyways if the plugins don't have appropriate QueueingHint.
 		if status.IsRejected() {
-			defer sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, framework.EventAssignedPodDelete, assumedPod, nil, func(pod *v1.Pod) bool {
-				return assumedPod.UID != pod.UID
-			})
+			defer sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, framework.EventAssignedPodDelete, assumedPod, nil, getDifferentUIDPreCheck(assumedPod.UID))
 		} else {
 			sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, framework.EventAssignedPodDelete, assumedPod, nil, nil)
 		}
 	}
 
 	sched.FailureHandler(ctx, fwk, podInfo, status, clearNominatedNode, start)
+}
+
+// getDifferentUIDPreCheck is a PreEnqueueCheck function that selects only entities
+// that don't contain a pod with a specific UID.
+func getDifferentUIDPreCheck(uid types.UID) queue.PreEnqueueCheck {
+	return func(entity framework.QueuedEntityInfo) bool {
+		matchesUID := false
+		entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+			if pInfo.Pod.UID == uid {
+				matchesUID = true
+				return false
+			}
+			return true
+		})
+		return !matchesUID
+	}
 }
 
 func (sched *Scheduler) frameworkForPod(pod *v1.Pod) (framework.Framework, error) {

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -5562,3 +5562,72 @@ func TestSchedulePodWithOpportunisticBatching(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDifferentUIDPreCheck(t *testing.T) {
+	targetUID := types.UID("target-pod-uid")
+	otherUID := types.UID("other-pod-uid")
+
+	targetPod := st.MakePod().Name("target-pod").UID(string(targetUID)).PodGroupName("pg-with-target").Obj()
+	otherPod1 := st.MakePod().Name("other-pod1").UID(string(otherUID)).PodGroupName("pg-with-target").Obj()
+	otherPod2 := st.MakePod().Name("other-pod2").UID("another-uid").PodGroupName("pg-without-target").Obj()
+	otherPod3 := st.MakePod().Name("other-pod3").UID(string(otherUID)).PodGroupName("pg-without-target").Obj()
+
+	targetPodInfo := &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(t, targetPod)}
+	otherPodInfo1 := &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(t, otherPod1)}
+	otherPodInfo2 := &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(t, otherPod2)}
+	otherPodInfo3 := &framework.QueuedPodInfo{PodInfo: mustNewPodInfo(t, otherPod3)}
+
+	pgWithTarget := st.MakePodGroup().Name("pg-with-target").Obj()
+	pgWithTargetPod := &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			GenericPodGroup: framework.NewGenericPodGroup(pgWithTarget),
+		},
+	}
+	pgWithTargetPod.AddPod(otherPodInfo1)
+	pgWithTargetPod.AddPod(targetPodInfo)
+
+	pgWithoutTarget := st.MakePodGroup().Name("pg-without-target").Obj()
+	pgWithoutTargetPod := &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			GenericPodGroup: framework.NewGenericPodGroup(pgWithoutTarget),
+		},
+	}
+	pgWithoutTargetPod.AddPod(otherPodInfo2)
+	pgWithoutTargetPod.AddPod(otherPodInfo3)
+
+	tests := []struct {
+		name     string
+		entity   framework.QueuedEntityInfo
+		expected bool
+	}{
+		{
+			name:     "standalone pod matching UID is filtered out",
+			entity:   targetPodInfo,
+			expected: false,
+		},
+		{
+			name:     "standalone pod not matching UID passes",
+			entity:   otherPodInfo1,
+			expected: true,
+		},
+		{
+			name:     "pod group containing pod with UID is filtered out",
+			entity:   pgWithTargetPod,
+			expected: false,
+		},
+		{
+			name:     "pod group not containing pod with UID passes",
+			entity:   pgWithoutTargetPod,
+			expected: true,
+		},
+	}
+
+	preCheck := getDifferentUIDPreCheck(targetUID)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := preCheck(tt.entity); got != tt.expected {
+				t.Errorf("Unexpected getDifferentUIDPreCheck result for %s: want %v, got %v", tt.name, tt.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR removed the unnecessary iteration over all member pods when handling incoming events in scheduling queue with preCheck. PreCheck is now executed per-entity, not per-pod.

It also modifies the behavior of getDifferentUIDPreCheck, where the preCheck should filter the whole entity once it contains the pod with a matching UID.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Generative AI was used in the PR preparation. Changes were carefully reviewed before pushing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
