### PR TITLE
Optimize isEntityWorthRequeuing for pod groups without pending plugins

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -557,12 +557,17 @@ func (p *PriorityQueue) isEntityWorthRequeuing(logger klog.Logger, entity framew
 	// For pod groups, if any pod is worth requeuing, the whole group is worth it.
 	// But we should prioritize higher strategies.
 	bestStrategy := queueSkip
+	hasPending := entity.HasPodsWithPendingPlugins()
 	for pInfo := range entity.ForEachPodInfo() {
 		strategy := p.isPodWorthRequeuing(logger, pInfo, event, oldObj, newObj, hintKeys)
 		if strategy > bestStrategy {
 			bestStrategy = strategy
 		}
 		if bestStrategy == queueImmediately {
+			return bestStrategy
+		}
+		// If no pods have pending plugins, the best strategy is queueAfterBackoff.
+		if !hasPending && bestStrategy == queueAfterBackoff {
 			return bestStrategy
 		}
 	}

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -6237,6 +6237,307 @@ func Test_isPodWorthRequeuing(t *testing.T) {
 	}
 }
 
+func makeQueuedPodGroup(namespace, pgName string, podInfos ...*framework.QueuedPodInfo) *framework.QueuedPodGroupInfo {
+	pg := st.MakePodGroup().Namespace(namespace).Name(pgName).Obj()
+	pgqi := &framework.QueuedPodGroupInfo{
+		PodGroupInfo: &framework.PodGroupInfo{
+			GenericPodGroup: fwk.NewGenericPodGroup(pg),
+			Children:        make([]*framework.PodGroupInfo, 0),
+		},
+		QueuedPodInfos: make(map[fwk.EntityKey][]*framework.QueuedPodInfo),
+	}
+	for _, pInfo := range podInfos {
+		pgqi.AddPod(pInfo)
+	}
+	return pgqi
+}
+
+func Test_isEntityWorthRequeuing(t *testing.T) {
+	var evaluatedPods []string
+	queueHintReturnQueue := func(_ klog.Logger, pod *v1.Pod, _, _ any) (fwk.QueueingHint, error) {
+		evaluatedPods = append(evaluatedPods, pod.Name)
+		return fwk.Queue, nil
+	}
+	queueHintReturnSkip := func(_ klog.Logger, pod *v1.Pod, _, _ any) (fwk.QueueingHint, error) {
+		evaluatedPods = append(evaluatedPods, pod.Name)
+		return fwk.QueueSkip, nil
+	}
+
+	tests := []struct {
+		name                  string
+		queueingHintMap       QueueingHintMapPerProfile
+		entity                framework.QueuedEntityInfo
+		event                 fwk.ClusterEvent
+		newObj                any
+		expectedStrategy      queueingStrategy
+		expectedEvaluatedPods []string
+	}{
+		{
+			name: "single pod with unschedulable plugin returns queueAfterBackoff",
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{PluginName: "pluginA", QueueingHintFn: queueHintReturnQueue},
+					},
+				},
+			},
+			entity: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("pluginA"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("p1").Namespace("ns1").Obj()),
+			},
+			event:                 nodeAdd,
+			newObj:                st.MakeNode().Obj(),
+			expectedStrategy:      queueAfterBackoff,
+			expectedEvaluatedPods: []string{"p1"},
+		},
+		{
+			name: "single pod with pending plugin returns queueImmediately",
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{PluginName: "pluginPending", QueueingHintFn: queueHintReturnQueue},
+					},
+				},
+			},
+			entity: &framework.QueuedPodInfo{
+				PendingPlugins: sets.New("pluginPending"),
+				PodInfo:        mustNewPodInfo(st.MakePod().Name("p1").Namespace("ns1").Obj()),
+			},
+			event:                 nodeAdd,
+			newObj:                st.MakeNode().Obj(),
+			expectedStrategy:      queueImmediately,
+			expectedEvaluatedPods: []string{"p1"},
+		},
+		{
+			name: "single pod with unschedulable plugin returns queueSkip when hint returns Skip",
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{PluginName: "pluginA", QueueingHintFn: queueHintReturnSkip},
+					},
+				},
+			},
+			entity: &framework.QueuedPodInfo{
+				UnschedulablePlugins: sets.New("pluginA"),
+				PodInfo:              mustNewPodInfo(st.MakePod().Name("p1").Namespace("ns1").Obj()),
+			},
+			event:                 nodeAdd,
+			newObj:                st.MakeNode().Obj(),
+			expectedStrategy:      queueSkip,
+			expectedEvaluatedPods: []string{"p1"},
+		},
+		{
+			name: "single pod with pending plugin returns queueSkip when hint returns Skip",
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{PluginName: "pluginPending", QueueingHintFn: queueHintReturnSkip},
+					},
+				},
+			},
+			entity: &framework.QueuedPodInfo{
+				PendingPlugins: sets.New("pluginPending"),
+				PodInfo:        mustNewPodInfo(st.MakePod().Name("p1").Namespace("ns1").Obj()),
+			},
+			event:                 nodeAdd,
+			newObj:                st.MakeNode().Obj(),
+			expectedStrategy:      queueSkip,
+			expectedEvaluatedPods: []string{"p1"},
+		},
+		{
+			name: "pod group without pending plugins: first pod returns queueAfterBackoff, returns without evaluating remaining pods",
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{PluginName: "pluginA", QueueingHintFn: queueHintReturnQueue},
+					},
+				},
+			},
+			entity: makeQueuedPodGroup("ns1", "pg1",
+				&framework.QueuedPodInfo{
+					PodInfo:              mustNewPodInfo(st.MakePod().Name("p1").Namespace("ns1").PodGroupName("pg1").Obj()),
+					UnschedulablePlugins: sets.New("pluginA"),
+				},
+				&framework.QueuedPodInfo{
+					PodInfo:              mustNewPodInfo(st.MakePod().Name("p2").Namespace("ns1").PodGroupName("pg1").Obj()),
+					UnschedulablePlugins: sets.New("pluginA"),
+				},
+			),
+			event:                 nodeAdd,
+			newObj:                st.MakeNode().Obj(),
+			expectedStrategy:      queueAfterBackoff,
+			expectedEvaluatedPods: []string{"p1"},
+		},
+		{
+			name: "pod group without pending plugins: first pod returns skip, second returns queueAfterBackoff, third is not evaluated",
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{PluginName: "pluginSkip", QueueingHintFn: queueHintReturnSkip},
+						{PluginName: "pluginQueue", QueueingHintFn: queueHintReturnQueue},
+					},
+				},
+			},
+			entity: makeQueuedPodGroup("ns1", "pg1",
+				&framework.QueuedPodInfo{
+					PodInfo:              mustNewPodInfo(st.MakePod().Name("p1").Namespace("ns1").PodGroupName("pg1").Obj()),
+					UnschedulablePlugins: sets.New("pluginSkip"),
+				},
+				&framework.QueuedPodInfo{
+					PodInfo:              mustNewPodInfo(st.MakePod().Name("p2").Namespace("ns1").PodGroupName("pg1").Obj()),
+					UnschedulablePlugins: sets.New("pluginQueue"),
+				},
+				&framework.QueuedPodInfo{
+					PodInfo:              mustNewPodInfo(st.MakePod().Name("p3").Namespace("ns1").PodGroupName("pg1").Obj()),
+					UnschedulablePlugins: sets.New("pluginQueue"),
+				},
+			),
+			event:                 nodeAdd,
+			newObj:                st.MakeNode().Obj(),
+			expectedStrategy:      queueAfterBackoff,
+			expectedEvaluatedPods: []string{"p1", "p2"},
+		},
+		{
+			name: "pod group without pending plugins: all pods return queueSkip",
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{PluginName: "pluginSkip", QueueingHintFn: queueHintReturnSkip},
+					},
+				},
+			},
+			entity: makeQueuedPodGroup("ns1", "pg1",
+				&framework.QueuedPodInfo{
+					PodInfo:              mustNewPodInfo(st.MakePod().Name("p1").Namespace("ns1").PodGroupName("pg1").Obj()),
+					UnschedulablePlugins: sets.New("pluginSkip"),
+				},
+				&framework.QueuedPodInfo{
+					PodInfo:              mustNewPodInfo(st.MakePod().Name("p2").Namespace("ns1").PodGroupName("pg1").Obj()),
+					UnschedulablePlugins: sets.New("pluginSkip"),
+				},
+			),
+			event:                 nodeAdd,
+			newObj:                st.MakeNode().Obj(),
+			expectedStrategy:      queueSkip,
+			expectedEvaluatedPods: []string{"p1", "p2"},
+		},
+		{
+			name: "pod group with pending plugins: first pod returns queueAfterBackoff, does NOT return immediately, second pod returns queueImmediately",
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{PluginName: "pluginUnsched", QueueingHintFn: queueHintReturnQueue},
+						{PluginName: "pluginPending", QueueingHintFn: queueHintReturnQueue},
+					},
+				},
+			},
+			entity: makeQueuedPodGroup("ns1", "pg1",
+				&framework.QueuedPodInfo{
+					PodInfo:              mustNewPodInfo(st.MakePod().Name("p1").Namespace("ns1").PodGroupName("pg1").Obj()),
+					UnschedulablePlugins: sets.New("pluginUnsched"),
+				},
+				&framework.QueuedPodInfo{
+					PodInfo:        mustNewPodInfo(st.MakePod().Name("p2").Namespace("ns1").PodGroupName("pg1").Obj()),
+					PendingPlugins: sets.New("pluginPending"),
+				},
+			),
+			event:                 nodeAdd,
+			newObj:                st.MakeNode().Obj(),
+			expectedStrategy:      queueImmediately,
+			expectedEvaluatedPods: []string{"p1", "p2"},
+		},
+		{
+			name: "pod group with pending plugins: first pod returns queueAfterBackoff, second pod returns queueSkip, returns queueAfterBackoff",
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{PluginName: "pluginUnsched", QueueingHintFn: queueHintReturnQueue},
+						{PluginName: "pluginPending", QueueingHintFn: queueHintReturnSkip},
+					},
+				},
+			},
+			entity: makeQueuedPodGroup("ns1", "pg1",
+				&framework.QueuedPodInfo{
+					PodInfo:              mustNewPodInfo(st.MakePod().Name("p1").Namespace("ns1").PodGroupName("pg1").Obj()),
+					UnschedulablePlugins: sets.New("pluginUnsched"),
+				},
+				&framework.QueuedPodInfo{
+					PodInfo:        mustNewPodInfo(st.MakePod().Name("p2").Namespace("ns1").PodGroupName("pg1").Obj()),
+					PendingPlugins: sets.New("pluginPending"),
+				},
+			),
+			event:                 nodeAdd,
+			newObj:                st.MakeNode().Obj(),
+			expectedStrategy:      queueAfterBackoff,
+			expectedEvaluatedPods: []string{"p1", "p2"},
+		},
+		{
+			name: "pod group with pending plugins: first pod returns queueImmediately, returns immediately",
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{PluginName: "pluginPending", QueueingHintFn: queueHintReturnQueue},
+					},
+				},
+			},
+			entity: makeQueuedPodGroup("ns1", "pg1",
+				&framework.QueuedPodInfo{
+					PodInfo:        mustNewPodInfo(st.MakePod().Name("p1").Namespace("ns1").PodGroupName("pg1").Obj()),
+					PendingPlugins: sets.New("pluginPending"),
+				},
+				&framework.QueuedPodInfo{
+					PodInfo:        mustNewPodInfo(st.MakePod().Name("p2").Namespace("ns1").PodGroupName("pg1").Obj()),
+					PendingPlugins: sets.New("pluginPending"),
+				},
+			),
+			event:                 nodeAdd,
+			newObj:                st.MakeNode().Obj(),
+			expectedStrategy:      queueImmediately,
+			expectedEvaluatedPods: []string{"p1"},
+		},
+		{
+			name: "pod group with pending plugins: all pods return queueSkip",
+			queueingHintMap: QueueingHintMapPerProfile{
+				"": {
+					nodeAdd: {
+						{PluginName: "pluginSkip", QueueingHintFn: queueHintReturnSkip},
+					},
+				},
+			},
+			entity: makeQueuedPodGroup("ns1", "pg1",
+				&framework.QueuedPodInfo{
+					PodInfo:        mustNewPodInfo(st.MakePod().Name("p1").Namespace("ns1").PodGroupName("pg1").Obj()),
+					PendingPlugins: sets.New("pluginSkip"),
+				},
+				&framework.QueuedPodInfo{
+					PodInfo:        mustNewPodInfo(st.MakePod().Name("p2").Namespace("ns1").PodGroupName("pg1").Obj()),
+					PendingPlugins: sets.New("pluginSkip"),
+				},
+			),
+			event:                 nodeAdd,
+			newObj:                st.MakeNode().Obj(),
+			expectedStrategy:      queueSkip,
+			expectedEvaluatedPods: []string{"p1", "p2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluatedPods = nil // reset evaluated pods every time
+			logger, ctx := ktesting.NewTestContext(t)
+			q := NewTestQueue(ctx, newDefaultQueueSort(), WithQueueingHintMapPerProfile(tt.queueingHintMap))
+
+			gotStrategy := q.isEntityWorthRequeuing(logger, tt.entity, tt.event, nil, tt.newObj, nil)
+			if gotStrategy != tt.expectedStrategy {
+				t.Errorf("Unexpected isEntityWorthRequeuing result, want: %v, got: %v", tt.expectedStrategy, gotStrategy)
+			}
+			if diff := cmp.Diff(tt.expectedEvaluatedPods, evaluatedPods); diff != "" {
+				t.Errorf("Unexpected evaluatedPods (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func Test_queuedPodInfo_gatedSetUponCreationAndUnsetUponUpdate(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
 	plugin, _ := schedulinggates.New(ctx, nil, nil, plfeature.Features{})

--- a/pkg/scheduler/backend/queue/workload_forest.go
+++ b/pkg/scheduler/backend/queue/workload_forest.go
@@ -227,7 +227,7 @@ func (wf *workloadForest) buildPodGroupInfo(logger klog.Logger, gpg *fwk.Generic
 }
 
 // buildQueuedPodGroupInfo constructs a QueuedPodGroupInfo starting from the provided root lookup info,
-// building out the full hierarchy of PodGroupInfo nodes and initializing the QueuedPodInfos map.
+// building out the full hierarchy of PodGroupInfo nodes.
 func (wf *workloadForest) buildQueuedPodGroupInfo(logger klog.Logger, rootLookup *framework.QueuedPodGroupInfo) *framework.QueuedPodGroupInfo {
 	key := rootLookup.GetKey()
 	gpg, ok := wf.podGroups[key]
@@ -235,7 +235,6 @@ func (wf *workloadForest) buildQueuedPodGroupInfo(logger klog.Logger, rootLookup
 		return nil
 	}
 	return &framework.QueuedPodGroupInfo{
-		PodGroupInfo:   wf.buildPodGroupInfo(logger, gpg, sets.New[fwk.EntityKey]()),
-		QueuedPodInfos: make(map[fwk.EntityKey][]*framework.QueuedPodInfo),
+		PodGroupInfo: wf.buildPodGroupInfo(logger, gpg, sets.New[fwk.EntityKey]()),
 	}
 }

--- a/pkg/scheduler/backend/queue/workload_forest_test.go
+++ b/pkg/scheduler/backend/queue/workload_forest_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
 	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingv1beta1 "k8s.io/api/scheduling/v1beta1"
@@ -800,7 +801,7 @@ func TestWorkloadForest_GetRootLookupInfoForPod(t *testing.T) {
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
-			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
+			if diff := cmp.Diff(tt.wantInfo, gotInfo, cmpopts.IgnoreUnexported(framework.QueuedPodGroupInfo{})); diff != "" {
 				t.Errorf("Unexpected QueuedPodGroupInfo (-want,+got)\n%s", diff)
 			}
 		})
@@ -916,7 +917,7 @@ func TestWorkloadForest_GetRootLookupInfoForPodGroup(t *testing.T) {
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
-			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
+			if diff := cmp.Diff(tt.wantInfo, gotInfo, cmpopts.IgnoreUnexported(framework.QueuedPodGroupInfo{})); diff != "" {
 				t.Errorf("Unexpected QueuedPodGroupInfo (-want,+got)\n%s", diff)
 			}
 		})
@@ -980,7 +981,7 @@ func TestWorkloadForest_GetRootLookupInfoForCPG(t *testing.T) {
 			if wantFound := tt.wantInfo != nil; gotFound != wantFound {
 				t.Errorf("Expected found: %v, got: %v", wantFound, gotFound)
 			}
-			if diff := cmp.Diff(tt.wantInfo, gotInfo); diff != "" {
+			if diff := cmp.Diff(tt.wantInfo, gotInfo, cmpopts.IgnoreUnexported(framework.QueuedPodGroupInfo{})); diff != "" {
 				t.Errorf("Unexpected QueuedPodGroupInfo (-want,+got)\n%s", diff)
 			}
 		})

--- a/pkg/scheduler/framework/types.go
+++ b/pkg/scheduler/framework/types.go
@@ -562,6 +562,8 @@ type QueuedEntityInfo interface {
 	GetFlushTimestamp() time.Time
 	// SetFlushTimestamp sets the FlushTimestamp in QueueingParams.
 	SetFlushTimestamp(t time.Time)
+	// HasPodsWithPendingPlugins returns true if any pod in the entity has pending plugins.
+	HasPodsWithPendingPlugins() bool
 }
 
 // QueueingParams holds parameters related to the queueing status and history of an entity
@@ -778,6 +780,10 @@ func (pqi *QueuedPodInfo) SetFlushTimestamp(t time.Time) {
 	pqi.FlushTimestamp = t
 }
 
+func (pqi *QueuedPodInfo) HasPodsWithPendingPlugins() bool {
+	return pqi.PendingPlugins.Len() > 0
+}
+
 // QueuedPodGroupInfo is a PodGroupInfo wrapper with additional information related to
 // the pod group's status in the scheduling queue and stores all queued pods from that pod group.
 type QueuedPodGroupInfo struct {
@@ -787,7 +793,13 @@ type QueuedPodGroupInfo struct {
 	// This map is keyed by pod group keys in the same format as framework.PodGroupKey function.
 	// Its values are slices of corresponding leaf pod group's queued pods.
 	// The order of the pods in the slice is deterministic and based on the priority and timestamp.
+	//
+	// Note: QueuedPodGroupInfo manages QueuedPodInfos' metadata in podsWithPendingPlugins.
+	// Any mutation to QueuedPodGroupInfo should not be done directly,
+	// but through AddPod, Update and RemovePod methods.
 	QueuedPodInfos map[fwk.EntityKey][]*QueuedPodInfo
+	// podsWithPendingPlugins stores pod names for pods in this pod group that have pending plugins.
+	podsWithPendingPlugins sets.Set[string]
 }
 
 func (pgqi *QueuedPodGroupInfo) Type() fwk.EntityKeyType {
@@ -811,6 +823,13 @@ func (pgqi *QueuedPodGroupInfo) AddPod(pInfo *QueuedPodInfo) {
 
 	pgqi.QueuedPodInfos[key] = slices.Insert(pgqi.QueuedPodInfos[key], index, pInfo)
 	leafPG.UnscheduledPods = slices.Insert(leafPG.UnscheduledPods, index, pInfo.Pod)
+
+	if pInfo.PendingPlugins.Len() > 0 {
+		if pgqi.podsWithPendingPlugins == nil {
+			pgqi.podsWithPendingPlugins = sets.New[string]()
+		}
+		pgqi.podsWithPendingPlugins.Insert(pInfo.Pod.Name)
+	}
 }
 
 // RemovePod removes a pod from the queued pod group info, if the pod belongs to the pod group.
@@ -834,6 +853,10 @@ func (pgqi *QueuedPodGroupInfo) RemovePod(pod *v1.Pod) *QueuedPodInfo {
 		}
 	}
 
+	if removed != nil {
+		pgqi.removePodPendingPlugins(removed)
+	}
+
 	// Remove from leaf UnscheduledPods
 	leafPG, _ := findNodeAndParent(pgqi.PodGroupInfo, nil, *pod.Spec.SchedulingGroup.PodGroupName)
 	if leafPG == nil {
@@ -848,6 +871,19 @@ func (pgqi *QueuedPodGroupInfo) RemovePod(pod *v1.Pod) *QueuedPodInfo {
 	}
 
 	return removed
+}
+
+func (pgqi *QueuedPodGroupInfo) removePodPendingPlugins(pInfo *QueuedPodInfo) {
+	if pInfo.PendingPlugins.Len() > 0 {
+		pgqi.podsWithPendingPlugins.Delete(pInfo.Pod.Name)
+		if len(pgqi.podsWithPendingPlugins) == 0 {
+			pgqi.podsWithPendingPlugins = nil
+		}
+	}
+}
+
+func (pgqi *QueuedPodGroupInfo) HasPodsWithPendingPlugins() bool {
+	return pgqi.podsWithPendingPlugins.Len() > 0
 }
 
 func (pgqi *QueuedPodGroupInfo) HasQueuedPodInfos() bool {
@@ -1069,6 +1105,9 @@ func (pgqi *QueuedPodGroupInfo) deleteSubtreePods(curr *PodGroupInfo) []*QueuedP
 		key := fwk.PodGroupKey(curr.GetNamespace(), curr.GetName())
 		if pods, ok := pgqi.QueuedPodInfos[key]; ok {
 			removedPods = append(removedPods, pods...)
+			for _, pInfo := range pods {
+				pgqi.removePodPendingPlugins(pInfo)
+			}
 			delete(pgqi.QueuedPodInfos, key)
 		}
 		return removedPods

--- a/pkg/scheduler/framework/types_test.go
+++ b/pkg/scheduler/framework/types_test.go
@@ -360,6 +360,485 @@ func TestQueuedPodGroupInfoOrdering(t *testing.T) {
 	}
 }
 
+func TestQueuedEntityInfo_HasPodsWithPendingPlugins(t *testing.T) {
+	podWithoutPending := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod1").PodGroupName("pg1").Obj()},
+	}
+	podWithPending1 := &QueuedPodInfo{
+		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod2").PodGroupName("pg1").Obj()},
+		PendingPlugins: sets.New("pluginA"),
+	}
+	podWithPending2 := &QueuedPodInfo{
+		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod3").PodGroupName("pg1").Obj()},
+		PendingPlugins: sets.New("pluginB"),
+	}
+	nonExistentPod := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("nonexistent").PodGroupName("pg1").Obj()},
+	}
+	podGroup := st.MakePodGroup().Namespace("default").Name("pg1").Obj()
+	nonExistentPG := st.MakePodGroup().Namespace("default").Name("nonexistent-pg").Obj()
+
+	cpgRoot := st.MakeCompositePodGroup().Namespace("default").Name("cpg-root").Obj()
+	cpgChild := st.MakeCompositePodGroup().Namespace("default").Name("cpg-child").ParentCompositePodGroup("cpg-root").Obj()
+	cpgNested := st.MakeCompositePodGroup().Namespace("default").Name("cpg-nested").ParentCompositePodGroup("cpg-child").Obj()
+	nonExistentCPG := st.MakeCompositePodGroup().Namespace("default").Name("nonexistent-cpg").Obj()
+
+	pgChild1 := st.MakePodGroup().Namespace("default").Name("pg-child1").ParentCompositePodGroup("cpg-root").Obj()
+	pgChild2 := st.MakePodGroup().Namespace("default").Name("pg-child2").ParentCompositePodGroup("cpg-root").Obj()
+	pgLeaf1 := st.MakePodGroup().Namespace("default").Name("pg-leaf1").ParentCompositePodGroup("cpg-nested").Obj()
+	pgLeaf2 := st.MakePodGroup().Namespace("default").Name("pg-leaf2").ParentCompositePodGroup("cpg-nested").Obj()
+
+	podChild1WithPending := &QueuedPodInfo{
+		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-c1").PodGroupName("pg-child1").Obj()},
+		PendingPlugins: sets.New("pluginA"),
+	}
+	podChild1WithoutPending := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-c1-np").PodGroupName("pg-child1").Obj()},
+	}
+	podChild2WithPending := &QueuedPodInfo{
+		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-c2").PodGroupName("pg-child2").Obj()},
+		PendingPlugins: sets.New("pluginB"),
+	}
+	podChild2WithoutPending := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-c2-np").PodGroupName("pg-child2").Obj()},
+	}
+	podLeaf1WithPending := &QueuedPodInfo{
+		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-l1").PodGroupName("pg-leaf1").Obj()},
+		PendingPlugins: sets.New("pluginA"),
+	}
+	podLeaf2WithPending := &QueuedPodInfo{
+		PodInfo:        &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-l2").PodGroupName("pg-leaf2").Obj()},
+		PendingPlugins: sets.New("pluginB"),
+	}
+	podLeaf2WithoutPending := &QueuedPodInfo{
+		PodInfo: &PodInfo{Pod: st.MakePod().Namespace("default").Name("pod-l2-np").PodGroupName("pg-leaf2").Obj()},
+	}
+
+	tests := []struct {
+		name     string
+		entity   QueuedEntityInfo
+		expected bool
+	}{
+		{
+			name:     "single pod without pending plugins",
+			entity:   podWithoutPending,
+			expected: false,
+		},
+		{
+			name:     "single pod with pending plugins",
+			entity:   podWithPending1,
+			expected: true,
+		},
+		{
+			name: "empty pod group",
+			entity: &QueuedPodGroupInfo{
+				PodGroupInfo: &PodGroupInfo{
+					GenericPodGroup: fwk.NewGenericPodGroup(podGroup),
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "pod group with pod without pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericPodGroup(podGroup),
+					},
+				}
+				pgqi.AddPod(podWithoutPending)
+				return pgqi
+			}(),
+			expected: false,
+		},
+		{
+			name: "pod group with pod with pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericPodGroup(podGroup),
+					},
+				}
+				pgqi.AddPod(podWithPending1)
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "pod group with multiple pods with pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericPodGroup(podGroup),
+					},
+				}
+				pgqi.AddPod(podWithoutPending)
+				pgqi.AddPod(podWithPending1)
+				pgqi.AddPod(podWithPending2)
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "pod group after removing non-existent pod",
+			entity: func() *QueuedPodGroupInfo {
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericPodGroup(podGroup),
+					},
+				}
+				pgqi.AddPod(podWithPending1)
+				pgqi.RemovePod(nonExistentPod.Pod)
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "pod group after removing pod without pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericPodGroup(podGroup),
+					},
+				}
+				pgqi.AddPod(podWithoutPending)
+				pgqi.AddPod(podWithPending1)
+				pgqi.RemovePod(podWithoutPending.Pod)
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "pod group after removing one of multiple pods with pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericPodGroup(podGroup),
+					},
+				}
+				pgqi.AddPod(podWithPending1)
+				pgqi.AddPod(podWithPending2)
+				pgqi.RemovePod(podWithPending1.Pod)
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "pod group after removing all pods with pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericPodGroup(podGroup),
+					},
+				}
+				pgqi.AddPod(podWithoutPending)
+				pgqi.AddPod(podWithPending1)
+				pgqi.RemovePod(podWithPending1.Pod)
+				return pgqi
+			}(),
+			expected: false,
+		},
+		{
+			name: "pod group after re-adding pod with pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericPodGroup(podGroup),
+					},
+				}
+				pgqi.AddPod(podWithPending1)
+				pgqi.RemovePod(podWithPending1.Pod)
+				pgqi.AddPod(podWithPending1)
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "pod group with pending plugins after removing pod group",
+			entity: func() *QueuedPodGroupInfo {
+				gpg := fwk.NewGenericPodGroup(podGroup)
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: gpg,
+					},
+				}
+				pgqi.AddPod(podWithoutPending)
+				pgqi.AddPod(podWithPending1)
+				pgqi.RemoveGenericPodGroup(gpg)
+				return pgqi
+			}(),
+			expected: false,
+		},
+		{
+			name: "pod group with pending plugins after removing non-existent pod group",
+			entity: func() *QueuedPodGroupInfo {
+				gpg := fwk.NewGenericPodGroup(podGroup)
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: gpg,
+					},
+				}
+				pgqi.AddPod(podWithPending1)
+				pgqi.RemoveGenericPodGroup(fwk.NewGenericPodGroup(nonExistentPG))
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "composite pod group after removing child pod group with pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				gpgChild1 := fwk.NewGenericPodGroup(pgChild1)
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
+						Children: []*PodGroupInfo{
+							{
+								GenericPodGroup: gpgChild1,
+							},
+							{
+								GenericPodGroup: fwk.NewGenericPodGroup(pgChild2),
+							},
+						},
+					},
+				}
+				pgqi.AddPod(podChild1WithPending)
+				pgqi.AddPod(podChild2WithoutPending)
+				pgqi.RemoveGenericPodGroup(gpgChild1)
+				return pgqi
+			}(),
+			expected: false,
+		},
+		{
+			name: "composite pod group after removing child pod group with mixed pending and non-pending pods",
+			entity: func() *QueuedPodGroupInfo {
+				gpgChild1 := fwk.NewGenericPodGroup(pgChild1)
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
+						Children: []*PodGroupInfo{
+							{
+								GenericPodGroup: gpgChild1,
+							},
+							{
+								GenericPodGroup: fwk.NewGenericPodGroup(pgChild2),
+							},
+						},
+					},
+				}
+				pgqi.AddPod(podChild1WithPending)
+				pgqi.AddPod(podChild1WithoutPending)
+				pgqi.AddPod(podChild2WithoutPending)
+				pgqi.RemoveGenericPodGroup(gpgChild1)
+				return pgqi
+			}(),
+			expected: false,
+		},
+		{
+			name: "composite pod group after removing one of multiple child pod groups with pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				gpgChild1 := fwk.NewGenericPodGroup(pgChild1)
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
+						Children: []*PodGroupInfo{
+							{
+								GenericPodGroup: gpgChild1,
+							},
+							{
+								GenericPodGroup: fwk.NewGenericPodGroup(pgChild2),
+							},
+						},
+					},
+				}
+				pgqi.AddPod(podChild1WithPending)
+				pgqi.AddPod(podChild2WithPending)
+				pgqi.RemoveGenericPodGroup(gpgChild1)
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "composite pod group after removing child pod group without pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				gpgChild2 := fwk.NewGenericPodGroup(pgChild2)
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
+						Children: []*PodGroupInfo{
+							{
+								GenericPodGroup: fwk.NewGenericPodGroup(pgChild1),
+							},
+							{
+								GenericPodGroup: gpgChild2,
+							},
+						},
+					},
+				}
+				pgqi.AddPod(podChild1WithPending)
+				pgqi.AddPod(podChild2WithoutPending)
+				pgqi.RemoveGenericPodGroup(gpgChild2)
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "composite pod group after removing child composite pod group with nested subtree pods with pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				gcpgChild := fwk.NewGenericCompositePodGroup(cpgChild)
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
+						Children: []*PodGroupInfo{
+							{
+								GenericPodGroup: gcpgChild,
+								Children: []*PodGroupInfo{
+									{
+										GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgNested),
+										Children: []*PodGroupInfo{
+											{
+												GenericPodGroup: fwk.NewGenericPodGroup(pgLeaf1),
+											},
+											{
+												GenericPodGroup: fwk.NewGenericPodGroup(pgLeaf2),
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				pgqi.AddPod(podLeaf1WithPending)
+				pgqi.AddPod(podLeaf2WithPending)
+				pgqi.RemoveGenericPodGroup(gcpgChild)
+				return pgqi
+			}(),
+			expected: false,
+		},
+		{
+			name: "composite pod group after removing child composite pod group while sibling branch has pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				gcpgChild := fwk.NewGenericCompositePodGroup(cpgChild)
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
+						Children: []*PodGroupInfo{
+							{
+								GenericPodGroup: gcpgChild,
+								Children: []*PodGroupInfo{
+									{
+										GenericPodGroup: fwk.NewGenericPodGroup(pgLeaf1),
+									},
+								},
+							},
+							{
+								GenericPodGroup: fwk.NewGenericPodGroup(pgChild1),
+							},
+						},
+					},
+				}
+				pgqi.AddPod(podLeaf1WithPending)
+				pgqi.AddPod(podChild1WithPending)
+				pgqi.RemoveGenericPodGroup(gcpgChild)
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "composite pod group after removing child composite pod group without pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				gcpgChild := fwk.NewGenericCompositePodGroup(cpgChild)
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
+						Children: []*PodGroupInfo{
+							{
+								GenericPodGroup: gcpgChild,
+								Children: []*PodGroupInfo{
+									{
+										GenericPodGroup: fwk.NewGenericPodGroup(pgLeaf2),
+									},
+								},
+							},
+							{
+								GenericPodGroup: fwk.NewGenericPodGroup(pgChild1),
+							},
+						},
+					},
+				}
+				pgqi.AddPod(podLeaf2WithoutPending)
+				pgqi.AddPod(podChild1WithPending)
+				pgqi.RemoveGenericPodGroup(gcpgChild)
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "composite pod group after removing non-existent composite pod group",
+			entity: func() *QueuedPodGroupInfo {
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
+						Children: []*PodGroupInfo{
+							{
+								GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgChild),
+								Children: []*PodGroupInfo{
+									{
+										GenericPodGroup: fwk.NewGenericPodGroup(pgLeaf1),
+									},
+								},
+							},
+						},
+					},
+				}
+				pgqi.AddPod(podLeaf1WithPending)
+				pgqi.RemoveGenericPodGroup(fwk.NewGenericCompositePodGroup(nonExistentCPG))
+				return pgqi
+			}(),
+			expected: true,
+		},
+		{
+			name: "composite pod group after removing all child pod groups with pending plugins",
+			entity: func() *QueuedPodGroupInfo {
+				gpgChild1 := fwk.NewGenericPodGroup(pgChild1)
+				gpgChild2 := fwk.NewGenericPodGroup(pgChild2)
+				pgqi := &QueuedPodGroupInfo{
+					PodGroupInfo: &PodGroupInfo{
+						GenericPodGroup: fwk.NewGenericCompositePodGroup(cpgRoot),
+						Children: []*PodGroupInfo{
+							{
+								GenericPodGroup: gpgChild1,
+							},
+							{
+								GenericPodGroup: gpgChild2,
+							},
+						},
+					},
+				}
+				pgqi.AddPod(podChild1WithPending)
+				pgqi.AddPod(podChild2WithPending)
+				pgqi.RemoveGenericPodGroup(gpgChild1)
+				pgqi.RemoveGenericPodGroup(gpgChild2)
+				return pgqi
+			}(),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{
+				features.GenericWorkload:                 true,
+				features.TopologyAwareWorkloadScheduling: true,
+				features.CompositePodGroup:               true,
+			})
+			if got := tt.entity.HasPodsWithPendingPlugins(); got != tt.expected {
+				t.Errorf("Unexpected HasPodsWithPendingPlugins: %v, want: %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestResourceClone(t *testing.T) {
 	tests := []struct {
 		resource *Resource

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -293,48 +293,20 @@ func (sched *Scheduler) frameworkForPodGroup(podGroupInfo *framework.QueuedPodGr
 // This can happen when the pod is already being deleted (i.e., when its deletionTimestamp is set)
 // or when the pod has already been assumed.
 func (sched *Scheduler) skipPodGroupPodSchedule(ctx context.Context, schedFwk framework.Framework, podGroupInfo *framework.QueuedPodGroupInfo) {
-	queuedPodInfosToUpdate := map[fwk.EntityKey][]*framework.QueuedPodInfo{}
-	for pgKey, pInfos := range podGroupInfo.QueuedPodInfos {
-		filteredQueuedPodInfos := make([]*framework.QueuedPodInfo, 0, len(pInfos))
-		for _, podInfo := range pInfos {
-			if sched.skipPodSchedule(ctx, schedFwk, podInfo.Pod) {
-				// We don't put this Pod back to the queue, but we have to cleanup the in-flight pods/events.
-				sched.SchedulingQueue.Done(podInfo.Pod.UID)
-				continue
-			}
-			filteredQueuedPodInfos = append(filteredQueuedPodInfos, podInfo)
-		}
-		if len(filteredQueuedPodInfos) != len(pInfos) {
-			podGroupInfo.QueuedPodInfos[pgKey] = filteredQueuedPodInfos
-			if len(filteredQueuedPodInfos) == 0 {
-				delete(podGroupInfo.QueuedPodInfos, pgKey)
-			}
-			queuedPodInfosToUpdate[pgKey] = filteredQueuedPodInfos
+	var podsToRemove []*v1.Pod
+	for pInfo := range podGroupInfo.ForEachPodInfo() {
+		if sched.skipPodSchedule(ctx, schedFwk, pInfo.Pod) {
+			// We don't put this Pod back to the queue, but we have to cleanup the in-flight pods/events.
+			sched.SchedulingQueue.Done(pInfo.Pod.UID)
+			podsToRemove = append(podsToRemove, pInfo.Pod)
 		}
 	}
-	sched.updateUnscheduledPods(podGroupInfo.PodGroupInfo, queuedPodInfosToUpdate)
-}
-
-// updateUnscheduledPods synchronizes the list of unscheduled pods in the pod group hierarchy
-// after filtering out pods that are deleted or already assumed. It recursively traverses the
-// group hierarchy to update each leaf pod group's list of unscheduled pods.
-func (sched *Scheduler) updateUnscheduledPods(pgi *framework.PodGroupInfo, queuedPodInfosToUpdate map[fwk.EntityKey][]*framework.QueuedPodInfo) {
-	if len(queuedPodInfosToUpdate) == 0 {
-		return
-	}
-	if pgi.CompositePodGroup != nil {
-		for _, child := range pgi.GetChildGroups() {
-			sched.updateUnscheduledPods(child, queuedPodInfosToUpdate)
-		}
-		return
-	}
-	key := pgi.GetKey()
-	if podInfos, ok := queuedPodInfosToUpdate[key]; ok {
-		pgi.UnscheduledPods = make([]*v1.Pod, 0, len(podInfos))
-		for _, pInfo := range podInfos {
-			pgi.UnscheduledPods = append(pgi.UnscheduledPods, pInfo.Pod)
-		}
-		delete(queuedPodInfosToUpdate, key)
+	// The following code removes each pod from the QueuedPodGroupInfo object individually.
+	// This simplified approach may result in O(n^2) complexity. However, since
+	// it is unlikely that any given pod will be filtered out using skipPodGroupPodSchedule,
+	// such complexity is acceptable.
+	for _, pod := range podsToRemove {
+		podGroupInfo.RemovePod(pod)
 	}
 }
 

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -617,9 +617,9 @@ func TestValidatePodGroup(t *testing.T) {
 }
 
 func TestSkipPodGroupPodSchedule(t *testing.T) {
-	p1 := st.MakePod().Name("p1").UID("p1").PodGroupName("pg").Obj()
-	p2 := st.MakePod().Name("p2").UID("p2").PodGroupName("pg").Terminating().Obj()
-	p3 := st.MakePod().Name("p3").UID("p3").PodGroupName("pg").Obj()
+	p1 := st.MakePod().Name("p1").Namespace("default").UID("p1").PodGroupName("pg").Obj()
+	p2 := st.MakePod().Name("p2").Namespace("default").UID("p2").PodGroupName("pg").Terminating().Obj()
+	p3 := st.MakePod().Name("p3").Namespace("default").UID("p3").PodGroupName("pg").Obj()
 
 	qInfo1 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p1}}
 	qInfo2 := &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: p2}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR removed the unnecessary iterations over all member pods when handling incoming events in scheduling queue. It returns early from isEntityWorthRequeueing when the strategy is queueAfterBackoff and no pending plugins are registered for any pod group member (no in-tree plugins use Pending status anyway).

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Generative AI was used in the PR preparation. Changes were carefully reviewed before pushing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
