### PR TITLE
Stop running PreEnqueue plugins after first gated pod in pod group

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -696,26 +696,33 @@ func queueingHintToLabel(hint fwk.QueueingHint, err error) string {
 // Note: we need to associate the failed plugin to `entity`, so that the entity can be moved back
 // to activeQ by related cluster event.
 func (p *PriorityQueue) runPreEnqueuePlugins(ctx context.Context, entity framework.QueuedEntityInfo) {
-	var anyGatedPodInfo *framework.QueuedPodInfo
-	// Run PreEnqueue plugins for each pod, even if it could stop after the first being gated,
-	// as we need to populate any per-pod metrics.
+	// Run PreEnqueue plugins for each pod until the first gets gated.
+	// Breaking after the first gated pod is sufficient,
+	// because in case of pod groups, this specific pod has to be ungated before ungating the group.
+	// Gating conditions for other pods, even if caused by different plugins,
+	// will be handled in later runs.
+	//
+	// Note: As a consequence, the `unschedulable_pods` metric will only reflect the gating
+	// reason of the first gated pod in the group rather than all gated members simultaneously.
+	// However, the group is still accurately tracked in `pending_pods{queue="gated"}` /
+	// `pending_entities`, and gating reasons for subsequent pods will be recorded in later
+	// passes once preceding pods are ungated.
 	for pInfo := range entity.ForEachPodInfo() {
 		p.runPreEnqueuePluginsForPod(ctx, pInfo)
 		if pInfo.Gated() {
 			// If any pod is gated, the whole entity is gated.
 			// Otherwise, such gated pod would have to be put in a separate entity object
 			// and tracked individually, complicating the flow.
-			anyGatedPodInfo = pInfo
+			//
+			// Copying the gating plugin info only from a single pod is sufficient,
+			// because if the entity is a pod group, all pods should be ungated before the entire pod group can be ungated,
+			// including this pod.
+			entity.SetGatingPlugin(pInfo.QueueingParams.GatingPlugin, pInfo.QueueingParams.GatingPluginEvents)
+			return
 		}
 	}
-	if anyGatedPodInfo != nil {
-		// Copying the gating plugin info only from a single pod is sufficient,
-		// because if the entity is a pod group, all pods should be ungated before the entire pod group can be ungated,
-		// including this pod.
-		entity.SetGatingPlugin(anyGatedPodInfo.QueueingParams.GatingPlugin, anyGatedPodInfo.QueueingParams.GatingPluginEvents)
-	} else {
-		entity.SetGatingPlugin("", nil)
-	}
+	// If no pod is gated, clear the gating plugin info from the entity.
+	entity.SetGatingPlugin("", nil)
 }
 
 func (p *PriorityQueue) runPreEnqueuePluginsForPod(ctx context.Context, pInfo *framework.QueuedPodInfo) {

--- a/test/integration/scheduler/preemption/asyncframework/async_framework.go
+++ b/test/integration/scheduler/preemption/asyncframework/async_framework.go
@@ -397,15 +397,23 @@ func podGatedInQueue(testCtx *testutils.TestContext, t *testing.T, podName strin
 	if pod == nil {
 		t.Fatalf("Expected the pod %s to be in the queue", podName)
 	}
-
 	// Make sure this Pod is gated by the preemption at PreEnqueue extension point
 	// by activating the Pod and see if it's still in the unsched pod pool.
 	testCtx.Scheduler.SchedulingQueue.Activate(logger, map[string]*v1.Pod{podName: pod})
 	if !PodInUnschedulablePodPool(t, testCtx.Scheduler.SchedulingQueue, podName) {
 		t.Fatalf("Expected the pod %s to be in the queue even after the activation", podName)
 	}
-	if pInfo, _ := testCtx.Scheduler.SchedulingQueue.GetPod(podName, testCtx.NS.Name, pod.Spec.SchedulingGroup); pInfo == nil || !pInfo.Gated() {
-		t.Fatalf("Expected the pod %s to be gated", podName)
+	if pod.Spec.SchedulingGroup != nil && pod.Spec.SchedulingGroup.PodGroupName != nil {
+		// If the pod is member of pod group, we should check if the whole pod group is gated,
+		// because due to optimization, the pod might not have the Gated() flag set.
+		podGroupName := *pod.Spec.SchedulingGroup.PodGroupName
+		if pgInfo, _ := testCtx.Scheduler.SchedulingQueue.GetPodGroup(podGroupName, testCtx.NS.Name); pgInfo == nil || !pgInfo.Gated() {
+			t.Fatalf("Expected the pod %s (pod group %s) to be gated", podName, podGroupName)
+		}
+	} else {
+		if pInfo, _ := testCtx.Scheduler.SchedulingQueue.GetPod(podName, testCtx.NS.Name, pod.Spec.SchedulingGroup); pInfo == nil || !pInfo.Gated() {
+			t.Fatalf("Expected the pod %s to be gated", podName)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This PR removed the unnecessary iteration over all member pods when handling incoming events in scheduling queue. This fix is particularly important when creating large pod groups, for which, each pod creation caused a sequential, linear scan over all previous pods. This PR stops iterating over per-pod PreEnqueue once a single pod is rejected.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

Generative AI was used in the PR preparation. Changes were carefully reviewed before pushing.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a performance degradation in scheduling queue, when PodGroups are waiting for quorum and large quantity of events arrive to scheduler.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
