### PR TITLE
Clarify godoc for LimitRange default is limits not requests

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -8049,7 +8049,8 @@ type LimitRangeItem struct {
 	// Min usage constraints on this kind by resource name.
 	// +optional
 	Min ResourceList `json:"min,omitempty" protobuf:"bytes,3,rep,name=min,casttype=ResourceList,castkey=ResourceName"`
-	// Default resource requirement limit value by resource name if resource limit is omitted.
+	// Default is the default value applied to a container's resource limits (not requests) for the named resource, if the container does not specify its own limit.
+	// See DefaultRequest for the request equivalent.
 	// +optional
 	Default ResourceList `json:"default,omitempty" protobuf:"bytes,4,rep,name=default,casttype=ResourceList,castkey=ResourceName"`
 	// DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.


### PR DESCRIPTION
## Problem

The `LimitRangeItem.Default` field (`spec.limits[].default` in a LimitRange manifest) sets the default *limit* for a resource when a container omits one — but the field name `default` alone doesn't make that clear, especially sitting next to a sibling field named `defaultRequest`. New users commonly read `default` as “the default for everything” rather than specifically “default limit,” and only understand the distinction after trial and error or reading external blog posts.

Current godoc:

> Default resource requirement limit value by resource name if resource limit is omitted.

Suggested (from the issue):

> Default is the default value applied to a container's resource *limits* (not requests) for the named resource, if the container does not specify its own limit. See DefaultRequest for the request equivalent.

Fixes #141565

## Change

Update the godoc comment on `LimitRangeItem.Default` in `staging/src/k8s.io/api/core/v1/types.go` to make the limit/request distinction explicit and cross-reference `DefaultRequest`.

Single-file, 2-line docs change.

## Why this approach

The API type's godoc is the source for the generated API reference. Clarifying it there fixes both the source and the docs site. No behavioral change.

## Testing

```text
command: git diff --check
result: clean

command: go vet ./staging/src/k8s.io/api/...
result: ok (no logic change)
```

## Documentation and release impact

- [x] User-facing documentation updated (API godoc)
- [ ] Changelog — docs-only

## Review notes

- Follow-up: none
- Security: no

## AI disclosure

Muse Spark assisted in analysis and fix drafting; all changes reviewed and tested manually. Co-authored-by trailers included for Pair Extraordinaire.

Co-authored-by: Muse Spark <muse-spark@users.noreply.github.com>
Co-authored-by: Aryan Singh K <70511529+aryansk@users.noreply.github.com>
