### PR TITLE
scheduler: refine SchedulingAlgorithm surface and decouple cache vs snapshot placement

### DIFF
--- a/pkg/scheduler/algorithm.go
+++ b/pkg/scheduler/algorithm.go
@@ -110,7 +110,11 @@ func WithCurrentCycleProvider(cycleProvider func() int64) AlgorithmOption {
 
 // NewSchedulingAlgorithm creates a scheduling algorithm operating on the given snapshot and cache.
 func NewSchedulingAlgorithm(snapshot *internalcache.Snapshot, cache internalcache.Cache,
-	opts ...AlgorithmOption) *SchedulingAlgorithm {
+	opts ...AlgorithmOption) (*SchedulingAlgorithm, error) {
+	if cache == nil {
+		return nil, errors.New("cache is required")
+	}
+
 	a := &SchedulingAlgorithm{
 		nodeInfoSnapshot:         snapshot,
 		cache:                    cache,
@@ -119,7 +123,7 @@ func NewSchedulingAlgorithm(snapshot *internalcache.Snapshot, cache internalcach
 	for _, opt := range opts {
 		opt(a)
 	}
-	return a
+	return a, nil
 }
 
 // opportunisticBatchingEnabled reports whether opportunistic batching can run. It needs both the
@@ -189,34 +193,140 @@ func (a *SchedulingAlgorithm) SchedulePod(ctx context.Context, schedFramework fr
 	}, err
 }
 
-// findNodesThatFitPod filters the nodes to find the ones that fit the pod based on the framework
-// filter plugins and filter extenders.
-func (a *SchedulingAlgorithm) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) ([]fwk.NodeInfo, framework.Diagnosis, string, error) {
+// preFilterOutcome captures the state and intermediate results produced while running
+// PreFilter plugins for a pod. It aggregates node candidates and plugin diagnoses so
+// downstream candidate selection and filtering can proceed without re-evaluating cluster
+// snapshots or dropping diagnostic context needed for preemption.
+type preFilterOutcome struct {
+	// result is the optional node subset returned by PreFilter plugins. When non-nil
+	// and containing a specific node set, getCandidateNodes restricts filter evaluations
+	// to only these nodes instead of scanning the full cluster snapshot.
+	result *fwk.PreFilterResult
+
+	// allNodes holds the complete list of nodes in the placement snapshot prior to
+	// plugin narrowing. The algorithm retains this full set so it can accurately
+	// advance nextStartNodeIndex across cycles to prevent node starvation.
+	allNodes []fwk.NodeInfo
+
+	// diagnosis accumulates rejection reasons, messages, and plugin failure statuses
+	// encountered during PreFilter. It is propagated to the caller and preemption
+	// logic if no candidate nodes fit the pod.
+	diagnosis *framework.Diagnosis
+}
+
+// prefilterNodes runs PreFilter plugins against the current cluster placement snapshot and captures
+// the outcome for downstream filtering.
+//
+// It retains the complete snapshot node list so nextStartNodeIndex can advance uniformly across
+// cycles even if PreFilter restricts candidate nodes. When a plugin explicitly rejects the pod,
+// the rejection status is broadcast across all absent nodes in Diagnosis.NodeToStatus so preemption
+// (PostFilter) has the necessary diagnostic context without triggering a full filter pass.
+func (a *SchedulingAlgorithm) prefilterNodes(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, pod *v1.Pod) (preFilterOutcome, *fwk.Status) {
 	logger := klog.FromContext(ctx)
 	diagnosis := framework.Diagnosis{
 		NodeToStatus: framework.NewDefaultNodeToStatus(),
 	}
-	allNodes, err := a.nodeInfoSnapshot.ListNodesInPlacement()
-	if err != nil {
-		return nil, diagnosis, "", err
+	prefilterOutcome := preFilterOutcome{
+		diagnosis: &diagnosis,
 	}
-	// Run "prefilter" plugins.
-	pod := podInfo.Pod
-	preRes, s, unscheduledPlugins := schedFramework.RunPreFilterPlugins(ctx, state, pod)
-	diagnosis.UnschedulablePlugins = unscheduledPlugins
-	if !s.IsSuccess() {
-		if !s.IsRejected() {
-			return nil, diagnosis, "", s.AsError()
-		}
-		// All nodes in NodeToStatus will have the same status so that they can be handled in the preemption.
-		diagnosis.NodeToStatus.SetAbsentNodesStatus(s)
+	allNodes, err := a.nodeInfoSnapshot.ListNodesInPlacement()
+	prefilterOutcome.allNodes = allNodes
+	if err != nil {
+		return prefilterOutcome, fwk.AsStatus(err)
+	}
 
-		// Record the messages from PreFilter in Diagnosis.PreFilterMsg.
-		msg := s.Message()
-		diagnosis.PreFilterMsg = msg
-		logger.V(5).Info("Status after running PreFilter plugins for pod", "pod", klog.KObj(pod), "status", msg)
-		diagnosis.AddPluginStatus(s)
-		return nil, diagnosis, "", nil
+	// Run "prefilter" plugins.
+	preRes, s, unscheduledPlugins := schedFramework.RunPreFilterPlugins(ctx, state, pod)
+	prefilterOutcome.result = preRes
+	diagnosis.UnschedulablePlugins = unscheduledPlugins
+
+	if s.IsSuccess() {
+		return prefilterOutcome, nil
+	}
+
+	if !s.IsRejected() {
+		return prefilterOutcome, s
+	}
+
+	// All nodes in NodeToStatus will have the same status so that they can be handled in the preemption.
+	diagnosis.NodeToStatus.SetAbsentNodesStatus(s)
+
+	// Record the messages from PreFilter in Diagnosis.PreFilterMsg.
+	msg := s.Message()
+	diagnosis.PreFilterMsg = msg
+	logger.V(5).Info("Status after running PreFilter plugins for pod", "pod", klog.KObj(pod), "status", msg)
+	diagnosis.AddPluginStatus(s)
+	return prefilterOutcome, s
+
+}
+
+// getCandidateNodes derives the subset of nodes to evaluate in Filter from the PreFilter outcome.
+//
+// When PreFilter plugins return a restricted set of node names, each name is validated against
+// the placement snapshot to prevent invalid or out-of-placement references from entering parallel
+// filter workers. Any cluster nodes omitted by PreFilter are marked UnschedulableAndUnresolvable
+// in Diagnosis.NodeToStatus so preemption avoids attempting unresolvable evictions on them.
+func (a *SchedulingAlgorithm) getCandidateNodes(preFilterOutcome preFilterOutcome) []fwk.NodeInfo {
+	preRes := preFilterOutcome.result
+	if preRes.AllNodes() {
+		return preFilterOutcome.allNodes
+	}
+
+	diagnosis := preFilterOutcome.diagnosis
+	nodes := make([]fwk.NodeInfo, 0, len(preRes.NodeNames))
+	for nodeName := range preRes.NodeNames {
+		// PreRes may return nodeName(s) which do not exist; we verify
+		// node exists in the Snapshot within the selected placement.
+		if nodeInfo, err := a.nodeInfoSnapshot.GetNodeInPlacement(nodeName); err == nil {
+			nodes = append(nodes, nodeInfo)
+		}
+	}
+	diagnosis.NodeToStatus.SetAbsentNodesStatus(fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("node(s) didn't satisfy plugin(s) %v", sets.List(diagnosis.UnschedulablePlugins))))
+
+	return nodes
+}
+
+// filterWithExtenders filters candidate nodes through configured scheduling extenders and updates
+// diagnostic accounting for queue requeueing.
+//
+// Because external extenders lack event-driven requeueing hooks (EnqueueExtensions), any extender
+// rejection that reduces the feasible set adds framework.ExtenderName to Diagnosis.UnschedulablePlugins.
+// This ensures unschedulable pods are retried on any cluster event rather than waiting for plugin-specific
+// triggers.
+func (a *SchedulingAlgorithm) filterWithExtenders(ctx context.Context, schedFramework framework.Framework, pod *v1.Pod, feasibleNodes []fwk.NodeInfo, diagnosis *framework.Diagnosis) ([]fwk.NodeInfo, error) {
+	feasibleNodesAfterExtender, err := findNodesThatPassExtenders(ctx, schedFramework.Extenders(), pod, feasibleNodes, diagnosis.NodeToStatus)
+	if err != nil {
+		return nil, err
+	}
+	if len(feasibleNodesAfterExtender) != len(feasibleNodes) {
+		// Extenders filtered out some nodes.
+		//
+		// Extender doesn't support any kind of requeueing feature like EnqueueExtensions in the scheduling framework.
+		// When Extenders reject some Nodes and the pod ends up being unschedulable,
+		// we put fwk.ExtenderName to pInfo.UnschedulablePlugins.
+		// This Pod will be requeued from unschedulable pod pool to activeQ/backoffQ
+		// by any kind of cluster events.
+		// https://github.com/kubernetes/kubernetes/issues/122019
+		if diagnosis.UnschedulablePlugins == nil {
+			diagnosis.UnschedulablePlugins = sets.New[string]()
+		}
+		diagnosis.UnschedulablePlugins.Insert(framework.ExtenderName)
+	}
+
+	return feasibleNodesAfterExtender, nil
+}
+
+// findNodesThatFitPod filters the nodes to find the ones that fit the pod based on the framework
+// filter plugins and filter extenders.
+func (a *SchedulingAlgorithm) findNodesThatFitPod(ctx context.Context, schedFramework framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) ([]fwk.NodeInfo, framework.Diagnosis, string, error) {
+	pod := podInfo.Pod
+	preFilterOutcome, status := a.prefilterNodes(ctx, schedFramework, state, pod)
+	diagnosis := preFilterOutcome.diagnosis
+	if !status.IsSuccess() {
+		if status.IsRejected() {
+			return nil, *diagnosis, "", nil
+		}
+		return nil, *diagnosis, "", status.AsError()
 	}
 
 	var nodeHint string
@@ -236,56 +346,37 @@ func (a *SchedulingAlgorithm) findNodesThatFitPod(ctx context.Context, schedFram
 		}
 		// Nominated node passes all the filters, scheduler is good to assign this node to the pod.
 		if len(feasibleNodes) != 0 {
-			return feasibleNodes, diagnosis, nodeHint, nil
+			return feasibleNodes, *diagnosis, nodeHint, nil
 		}
 	}
 
-	nodes := allNodes
-	if !preRes.AllNodes() {
-		nodes = make([]fwk.NodeInfo, 0, len(preRes.NodeNames))
-		for nodeName := range preRes.NodeNames {
-			// PreRes may return nodeName(s) which do not exist; we verify
-			// node exists in the Snapshot within the selected placement.
-			if nodeInfo, err := a.nodeInfoSnapshot.GetNodeInPlacement(nodeName); err == nil {
-				nodes = append(nodes, nodeInfo)
-			}
-		}
-		diagnosis.NodeToStatus.SetAbsentNodesStatus(fwk.NewStatus(fwk.UnschedulableAndUnresolvable, fmt.Sprintf("node(s) didn't satisfy plugin(s) %v", sets.List(unscheduledPlugins))))
+	nodes := a.getCandidateNodes(preFilterOutcome)
+	if len(nodes) == 0 {
+		return nil, *diagnosis, nodeHint, nil
 	}
-	feasibleNodes, err := a.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, nodes)
+
+	// The budget is computed from the candidate list, which PreFilter may have narrowed —
+	// not from allNodes. findAll mode takes every candidate and skips the budget entirely.
+	numNodesToFind := a.numNodesToFind(schedFramework, int32(len(nodes)))
+	feasibleNodes, err := a.findNodesThatPassFilters(ctx, schedFramework, state, pod, diagnosis, nodes, numNodesToFind)
 	// always try to update the a.nextStartNodeIndex regardless of whether an error has occurred
 	// this is helpful to make sure that all the nodes have a chance to be searched
 	processedNodes := len(feasibleNodes) + diagnosis.NodeToStatus.Len()
-	if len(allNodes) > 0 {
-		a.nextStartNodeIndex = (a.nextStartNodeIndex + processedNodes) % len(allNodes)
+	if len(preFilterOutcome.allNodes) > 0 {
+		a.nextStartNodeIndex = (a.nextStartNodeIndex + processedNodes) % len(preFilterOutcome.allNodes)
 	}
 	if err != nil {
-		return nil, diagnosis, nodeHint, err
+		return nil, *diagnosis, nodeHint, err
 	}
 
-	feasibleNodesAfterExtender, err := findNodesThatPassExtenders(ctx, schedFramework.Extenders(), pod, feasibleNodes, diagnosis.NodeToStatus)
+	feasibleNodes, err = a.filterWithExtenders(ctx, schedFramework, pod, feasibleNodes, diagnosis)
 	if err != nil {
-		return nil, diagnosis, nodeHint, err
+		return nil, *diagnosis, nodeHint, err
 	}
-	if len(feasibleNodesAfterExtender) != len(feasibleNodes) {
-		// Extenders filtered out some nodes.
-		//
-		// Extender doesn't support any kind of requeueing feature like EnqueueExtensions in the scheduling framework.
-		// When Extenders reject some Nodes and the pod ends up being unschedulable,
-		// we put fwk.ExtenderName to pInfo.UnschedulablePlugins.
-		// This Pod will be requeued from unschedulable pod pool to activeQ/backoffQ
-		// by any kind of cluster events.
-		// https://github.com/kubernetes/kubernetes/issues/122019
-		if diagnosis.UnschedulablePlugins == nil {
-			diagnosis.UnschedulablePlugins = sets.New[string]()
-		}
-		diagnosis.UnschedulablePlugins.Insert(framework.ExtenderName)
-	}
-
-	return feasibleNodesAfterExtender, diagnosis, nodeHint, nil
+	return feasibleNodes, *diagnosis, nodeHint, nil
 }
 
-func (a *SchedulingAlgorithm) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, schedFramework framework.Framework, state fwk.CycleState, nodeHint string, diagnosis framework.Diagnosis) ([]fwk.NodeInfo, error) {
+func (a *SchedulingAlgorithm) evaluateNominatedNode(ctx context.Context, pod *v1.Pod, schedFramework framework.Framework, state fwk.CycleState, nodeHint string, diagnosis *framework.Diagnosis) ([]fwk.NodeInfo, error) {
 	// In the future we could potentially use the hint if the nominated node failed.
 	// https://github.com/kubernetes/kubernetes/issues/135163
 	nnn := pod.Status.NominatedNodeName
@@ -305,7 +396,7 @@ func (a *SchedulingAlgorithm) evaluateNominatedNode(ctx context.Context, pod *v1
 		return nil, nil
 	}
 	node := []fwk.NodeInfo{nodeInfo}
-	feasibleNodes, err := a.findNodesThatPassFilters(ctx, schedFramework, state, pod, &diagnosis, node)
+	feasibleNodes, err := a.findNodesThatPassFilters(ctx, schedFramework, state, pod, diagnosis, node, int32(len(node)))
 	if err != nil {
 		return nil, err
 	}
@@ -325,11 +416,11 @@ func (a *SchedulingAlgorithm) findNodesThatPassFilters(
 	state fwk.CycleState,
 	pod *v1.Pod,
 	diagnosis *framework.Diagnosis,
-	nodes []fwk.NodeInfo) ([]fwk.NodeInfo, error) {
+	nodes []fwk.NodeInfo,
+	numNodesToFind int32) ([]fwk.NodeInfo, error) {
 	numAllNodes := len(nodes)
-	numNodesToFind := a.numFeasibleNodesToFind(schedFramework.PercentageOfNodesToScore(), int32(numAllNodes))
-	if !hasExtenderFilters(schedFramework) && !hasScoring(schedFramework) {
-		numNodesToFind = 1
+	if numAllNodes == 0 {
+		return nil, nil
 	}
 
 	// Create feasible list with enough space to avoid growing it
@@ -404,6 +495,21 @@ func (a *SchedulingAlgorithm) findNodesThatPassFilters(
 	return feasibleNodes, nil
 }
 
+// numNodesToFind decides how many feasible nodes Filter should collect, following
+// kube-scheduler's percentageOfNodesToScore policy. A profile that neither filters
+// through extenders nor scores has no use for a second candidate, so one is enough.
+func (a *SchedulingAlgorithm) numNodesToFind(schedFramework framework.Framework, numAllNodes int32) int32 {
+	if numAllNodes == 0 {
+		return 0
+	}
+
+	n := a.numFeasibleNodesToFind(schedFramework.PercentageOfNodesToScore(), numAllNodes)
+	if !hasExtenderFilters(schedFramework) && !hasScoring(schedFramework) {
+		n = 1
+	}
+	return n
+}
+
 // numFeasibleNodesToFind returns the number of feasible nodes that once found, the scheduler stops
 // its search for more feasible nodes.
 func (a *SchedulingAlgorithm) numFeasibleNodesToFind(percentageOfNodesToScore *int32, numAllNodes int32) (numNodes int32) {
@@ -431,13 +537,13 @@ func (a *SchedulingAlgorithm) numFeasibleNodesToFind(percentageOfNodesToScore *i
 	return numNodes
 }
 
-// assume signals to the cache that a pod is already in the cache, so that binding can be asynchronous.
-// When called during pod group scheduling cycle, pod is assumed in the snapshot instead.
-func (a *SchedulingAlgorithm) assume(logger klog.Logger, schedFramework framework.Framework, state fwk.CycleState, assumedPodInfo *framework.QueuedPodInfo, host string) error {
-	// Optimistically assume that the binding will succeed and send it to apiserver
-	// in the background.
-	// If the binding fails, scheduler will release resources allocated to assumed pod
-	// immediately.
+// prepareAssumedPod returns the copy of podInfo that will be recorded as assumed:
+// bound to host and carrying the DRA allocations computed for this cycle. It
+// touches no store — the caller decides where the result is recorded.
+func (a *SchedulingAlgorithm) prepareAssumedPod(logger klog.Logger, state fwk.CycleState,
+	podInfo *framework.QueuedPodInfo, host string) *framework.QueuedPodInfo {
+
+	assumedPodInfo := podInfo.DeepCopy()
 	assumedPodInfo.Pod.Spec.NodeName = host
 	if utilfeature.DefaultFeatureGate.Enabled(features.DRANodeAllocatableResources) {
 		// If DRANodeAllocatableResources is enabled, copy the calculated node allocatable resource claim status
@@ -447,126 +553,148 @@ func (a *SchedulingAlgorithm) assume(logger klog.Logger, schedFramework framewor
 		// Any potential NodeAllocatableResourceClaimStatuses from a previously failed scheduling attempt is overwritten.
 		// This field is not explicitly cleared as the Pod object is reconstructed in handleSchedulingFailure()
 		// before re-queueing.
-		assumedPodInfo.Pod.Status.NodeAllocatableResourceClaimStatuses = dynamicresources.ExtractPodNodeAllocatableResourceClaimStatus(logger, state, host)
+		assumedPodInfo.Pod.Status.NodeAllocatableResourceClaimStatuses =
+			dynamicresources.ExtractPodNodeAllocatableResourceClaimStatus(logger, state, host)
 	}
-
-	if state.IsPodGroupSchedulingCycle() {
-		err := a.nodeInfoSnapshot.AssumePod(assumedPodInfo.PodInfo)
-		if err != nil {
-			logger.Error(err, "Scheduler snapshot AssumePod failed")
-			return err
-		}
-	} else {
-		if err := a.cache.AssumePod(logger, assumedPodInfo.Pod); err != nil {
-			logger.Error(err, "Scheduler cache AssumePod failed")
-			return err
-		}
-	}
-	// if "assumed" is a nominated pod, we should remove it from internal cache
-	schedFramework.DeleteNominatedPodIfExists(assumedPodInfo.Pod)
-
-	return nil
+	return assumedPodInfo
 }
 
-// assumeAndReserve assumes and reserves the pod in scheduler's memory.
-func (a *SchedulingAlgorithm) assumeAndReserve(
-	ctx context.Context,
-	state fwk.CycleState,
-	schedFramework framework.Framework,
-	podInfo *framework.QueuedPodInfo,
-	scheduleResult ScheduleResult,
-) (*framework.QueuedPodInfo, *fwk.Status) {
-	logger := klog.FromContext(ctx)
-	// Tell the cache to assume that a pod now is running on a given node, even though it hasn't been bound yet.
-	// This allows us to keep scheduling without waiting on binding to occur.
-	assumedPodInfo := podInfo.DeepCopy()
-	assumedPod := assumedPodInfo.Pod
-	// assume modifies `assumedPod` by setting NodeName=scheduleResult.SuggestedHost
-	err := a.assume(logger, schedFramework, state, assumedPodInfo, scheduleResult.SuggestedHost)
-	if err != nil {
-		// This is most probably result of a BUG in retrying logic.
-		// We report an error here so that pod scheduling can be retried.
-		// This relies on the fact that Error will check if the pod has been bound
-		// to a node and if so will not add it back to the unscheduled pods queue
-		// (otherwise this would cause an infinite loop).
-		return assumedPodInfo, fwk.AsStatus(err)
-	}
-
-	// Run the Reserve method of reserve plugins.
-	if sts := schedFramework.RunReservePluginsReserve(ctx, state, assumedPod, scheduleResult.SuggestedHost); !sts.IsSuccess() {
-		// trigger un-reserve to clean up state associated with the reserved Pod
-		err := a.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
-		if err != nil {
-			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
-		}
-
-		if sts.IsRejected() {
+// reserve runs Reserve plugins for the assumed pod and converts plugin rejections
+// into a single-node FitError.
+func (a *SchedulingAlgorithm) reserve(ctx context.Context, state fwk.CycleState,
+	schedFramework framework.Framework, assumedPodInfo *framework.QueuedPodInfo,
+	origPod *v1.Pod, host string) *fwk.Status {
+	if status := schedFramework.RunReservePluginsReserve(ctx, state, assumedPodInfo.Pod, host); !status.IsSuccess() {
+		if status.IsRejected() {
 			fitErr := &framework.FitError{
 				NumAllNodes: 1,
-				Pod:         podInfo.Pod,
+				Pod:         origPod,
 				Diagnosis: framework.Diagnosis{
 					NodeToStatus: framework.NewDefaultNodeToStatus(),
 				},
 			}
-			fitErr.Diagnosis.NodeToStatus.Set(scheduleResult.SuggestedHost, sts)
-			fitErr.Diagnosis.AddPluginStatus(sts)
-			return assumedPodInfo, fwk.NewStatus(sts.Code()).WithError(fitErr)
+			fitErr.Diagnosis.NodeToStatus.Set(host, status)
+			fitErr.Diagnosis.AddPluginStatus(status)
+			return fwk.NewStatus(status.Code()).WithError(fitErr)
 		}
-		return assumedPodInfo, sts
+		return status
+	}
+	return nil
+}
+
+// FindAllNodesThatFitPod evaluates all placement nodes without early-exit shortcuts
+// so callers inspecting cluster capacity or running custom batching receive exhaustive results.
+func (a *SchedulingAlgorithm) FindAllNodesThatFitPod(ctx context.Context, state fwk.CycleState, schedFramework framework.Framework, podInfo *framework.QueuedPodInfo) ([]fwk.NodeInfo, framework.Diagnosis, error) {
+	pod := podInfo.Pod
+	preFilterOutcome, status := a.prefilterNodes(ctx, schedFramework, state, pod)
+	diagnosis := preFilterOutcome.diagnosis
+	if !status.IsSuccess() {
+		if status.IsRejected() {
+			return nil, *diagnosis, nil
+		}
+		return nil, *diagnosis, status.AsError()
+	}
+
+	nodes := a.getCandidateNodes(preFilterOutcome)
+	if len(nodes) == 0 {
+		return nil, *diagnosis, nil
+	}
+
+	feasibleNodes, err := a.findNodesThatPassFilters(ctx, schedFramework, state, pod, diagnosis, nodes, int32(len(nodes)))
+	if err != nil {
+		return nil, *diagnosis, err
+	}
+	feasibleNodes, err = a.filterWithExtenders(ctx, schedFramework, pod, feasibleNodes, diagnosis)
+
+	return feasibleNodes, *diagnosis, err
+}
+
+// AssumeAndReserveInCache assumes the pod into the scheduler cache and runs Reserve plugins.
+// If Reserve plugins fail, the assumption is rolled back from the cache.
+func (a *SchedulingAlgorithm) AssumeAndReserveInCache(ctx context.Context, state fwk.CycleState,
+	schedFramework framework.Framework, podInfo *framework.QueuedPodInfo,
+	scheduleResult ScheduleResult) (*framework.QueuedPodInfo, *fwk.Status) {
+
+	logger := klog.FromContext(ctx)
+	host := scheduleResult.SuggestedHost
+	assumedPodInfo := a.prepareAssumedPod(logger, state, podInfo, host)
+	if err := a.cache.AssumePod(logger, assumedPodInfo.Pod); err != nil {
+		logger.Error(err, "Scheduler cache AssumePod failed")
+		return assumedPodInfo, fwk.AsStatus(err)
+	}
+	schedFramework.DeleteNominatedPodIfExists(assumedPodInfo.Pod)
+
+	if status := a.reserve(ctx, state, schedFramework, assumedPodInfo, podInfo.Pod, host); status != nil {
+		if err := a.UnreserveAndForgetFromCache(ctx, state, schedFramework, assumedPodInfo, host); err != nil {
+			utilruntime.HandleErrorWithContext(ctx, err, "UnreserveAndForgetFromCache failed")
+		}
+		return assumedPodInfo, status
 	}
 	return assumedPodInfo, nil
 }
 
-// unreserveAndForget unreserves and forgets the pod from scheduler's memory.
-// This function shouldn't be called during binding cycle with a state, where IsPodGroupSchedulingCycle is set to true,
-// but this shouldn't happen, because such pods with such state cannot reach binding.
-func (a *SchedulingAlgorithm) unreserveAndForget(
-	ctx context.Context,
-	state fwk.CycleState,
-	schedFramework framework.Framework,
-	assumedPodInfo *framework.QueuedPodInfo,
-	nodeName string,
-) error {
-	logger := klog.FromContext(ctx)
+// UnreserveAndForgetFromCache runs Unreserve plugins and forgets the pod from the scheduler cache.
+func (a *SchedulingAlgorithm) UnreserveAndForgetFromCache(ctx context.Context, state fwk.CycleState,
+	schedFramework framework.Framework, assumedPodInfo *framework.QueuedPodInfo, nodeName string) error {
 
+	logger := klog.FromContext(ctx)
 	schedFramework.RunReservePluginsUnreserve(ctx, state, assumedPodInfo.Pod, nodeName)
-	if state.IsPodGroupSchedulingCycle() {
-		err := a.nodeInfoSnapshot.ForgetPod(logger, assumedPodInfo.Pod)
-		if err != nil {
-			return err
-		}
-		if assumedPodInfo.Pod.Status.NominatedNodeName != "" {
-			// Assume method removed the nomination, but since we are reverting that stage for pod groups,
-			// we need to revert that operation as well.
-			nominatingInfo := &fwk.NominatingInfo{
-				NominatedNodeName: assumedPodInfo.Pod.Status.NominatedNodeName,
-				NominatingMode:    fwk.ModeOverride,
-			}
-			// AssumedPodInfo can be used here, because the whole pod object is not stored in the nominator.
-			schedFramework.AddNominatedPod(logger, assumedPodInfo.PodInfo, nominatingInfo)
-		}
-		return nil
-	}
+	// No nomination restore here: a pod that fails after a cache assume goes back
+	// through handleSchedulingFailure, which re-adds the nomination itself.
 	return a.cache.ForgetPod(logger, assumedPodInfo.Pod)
 }
 
-// assumeAndReserveWithRevert assumes and reserves the pod, returning a function that
-// reverts both steps. It is used by pod group scheduling, where a placement stays
-// tentative until the whole group is submitted.
-func (a *SchedulingAlgorithm) assumeAndReserveWithRevert(ctx context.Context,
-	state fwk.CycleState,
-	schedFramework framework.Framework,
-	podInfo *framework.QueuedPodInfo,
-	scheduleResult ScheduleResult,
-) (*fwk.Status, func()) {
-	assumedPodInfo, assumeStatus := a.assumeAndReserve(ctx, state, schedFramework, podInfo, scheduleResult)
-	if !assumeStatus.IsSuccess() {
-		return assumeStatus, nil
+// AssumeAndReserveInSnapshot assumes the pod into the transient node snapshot and runs Reserve plugins.
+// Returns a revert function to roll back the assumption and reservation from the snapshot if needed.
+//
+// This method mutates shared snapshot structures (nodeInfoSnapshot) without internal mutex locks.
+// It is not thread-safe; concurrent calls on the same snapshot are unsupported and callers must ensure
+// exclusive access.
+func (a *SchedulingAlgorithm) AssumeAndReserveInSnapshot(ctx context.Context, state fwk.CycleState,
+	schedFramework framework.Framework, podInfo *framework.QueuedPodInfo,
+	scheduleResult ScheduleResult) (*fwk.Status, func()) {
+
+	logger := klog.FromContext(ctx)
+	host := scheduleResult.SuggestedHost
+
+	assumedPodInfo := a.prepareAssumedPod(logger, state, podInfo, host)
+	if err := a.nodeInfoSnapshot.AssumePod(assumedPodInfo.PodInfo); err != nil {
+		logger.Error(err, "Scheduler snapshot AssumePod failed")
+		return fwk.AsStatus(err), nil
 	}
-	return assumeStatus, func() {
-		err := a.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
-		if err != nil {
+	schedFramework.DeleteNominatedPodIfExists(assumedPodInfo.Pod)
+
+	revert := func() {
+		if err := a.unreserveAndForgetFromSnapshot(ctx, state, schedFramework, assumedPodInfo, host); err != nil {
 			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
 		}
 	}
+	if status := a.reserve(ctx, state, schedFramework, assumedPodInfo, podInfo.Pod, host); status != nil {
+		revert()
+		return status, nil
+	}
+	return nil, revert
+}
+
+// unreserveAndForgetFromSnapshot runs Unreserve plugins, forgets the pod from the node snapshot,
+// and restores any existing pod nomination.
+//
+// This method mutates shared snapshot structures (nodeInfoSnapshot) without internal mutex locks.
+// It is not thread-safe; concurrent calls on the same snapshot are unsupported.
+func (a *SchedulingAlgorithm) unreserveAndForgetFromSnapshot(ctx context.Context, state fwk.CycleState,
+	schedFramework framework.Framework, assumedPodInfo *framework.QueuedPodInfo, nodeName string) error {
+
+	logger := klog.FromContext(ctx)
+	schedFramework.RunReservePluginsUnreserve(ctx, state, assumedPodInfo.Pod, nodeName)
+	if err := a.nodeInfoSnapshot.ForgetPod(logger, assumedPodInfo.Pod); err != nil {
+		return err
+	}
+	if assumedPodInfo.Pod.Status.NominatedNodeName != "" {
+		// The assume removed the nomination; reverting a tentative assume restores it.
+		schedFramework.AddNominatedPod(logger, assumedPodInfo.PodInfo, &fwk.NominatingInfo{
+			NominatedNodeName: assumedPodInfo.Pod.Status.NominatedNodeName,
+			NominatingMode:    fwk.ModeOverride,
+		})
+	}
+	return nil
 }

--- a/pkg/scheduler/algorithm_test.go
+++ b/pkg/scheduler/algorithm_test.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -50,8 +51,7 @@ import (
 // test controls, and the algorithm under test.
 type assumeReserveFixture struct {
 	algorithm *SchedulingAlgorithm
-
-	fwk framework.Framework
+	fwk       framework.Framework
 }
 
 func newAssumeReserveFixture(t *testing.T, ctx context.Context, node *v1.Node,
@@ -102,15 +102,17 @@ func newAssumeReserveFixture(t *testing.T, ctx context.Context, node *v1.Node,
 		t.Fatalf("Failed to update snapshot: %v", err)
 	}
 
+	algorithm, _ := NewSchedulingAlgorithm(snapshot, cache)
+
 	return &assumeReserveFixture{
-		algorithm: NewSchedulingAlgorithm(snapshot, cache),
+		algorithm: algorithm,
 		fwk:       schedFwk,
 	}
 }
 
-// TestAssumeAndReserve covers the ordinary scheduling cycle, where the placement is
-// recorded in the scheduler cache and survives the next snapshot refresh.
-func TestAssumeAndReserve(t *testing.T) {
+// TestAssumeAndReserveInCache covers the ordinary scheduling cycle, where the
+// placement is recorded in the scheduler cache and survives the next snapshot refresh.
+func TestAssumeAndReserveInCache(t *testing.T) {
 	node1 := st.MakeNode().Name("node1").Obj()
 	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("pod1").Obj()
 
@@ -160,7 +162,7 @@ func TestAssumeAndReserve(t *testing.T) {
 				t.Fatalf("SuggestedHost = %q, want %q", scheduleResult.SuggestedHost, node1.Name)
 			}
 
-			assumedPodInfo, status := f.algorithm.assumeAndReserve(ctx, state, f.fwk, queuedPodInfo, scheduleResult)
+			assumedPodInfo, status := f.algorithm.AssumeAndReserveInCache(ctx, state, f.fwk, queuedPodInfo, scheduleResult)
 			if status.Code() != tt.wantStatusCode {
 				t.Errorf("status.Code() = %v, want %v", status.Code(), tt.wantStatusCode)
 			}
@@ -194,18 +196,18 @@ func TestAssumeAndReserve(t *testing.T) {
 				if plugin.unreserved {
 					t.Error("expected Unreserve not to be called yet")
 				}
-				if err := f.algorithm.unreserveAndForget(ctx, state, f.fwk, assumedPodInfo, scheduleResult.SuggestedHost); err != nil {
-					t.Errorf("unreserveAndForget error: %v", err)
+				if err := f.algorithm.UnreserveAndForgetFromCache(ctx, state, f.fwk, assumedPodInfo, scheduleResult.SuggestedHost); err != nil {
+					t.Errorf("UnreserveAndForgetFromCache error: %v", err)
 				}
 				isAssumed, err = f.algorithm.cache.IsAssumedPod(pod1)
 				if err != nil {
 					t.Fatalf("cache.IsAssumedPod() error after unreserve: %v", err)
 				}
 				if isAssumed {
-					t.Error("pod still assumed in the cache after unreserveAndForget")
+					t.Error("Pod still assumed in the cache after UnreserveAndForgetFromCache")
 				}
 				if !plugin.unreserved {
-					t.Error("expected Unreserve to be called")
+					t.Error("Expected Unreserve to be called")
 				}
 			} else if !plugin.unreserved {
 				t.Error("expected Unreserve to be called on reserve failure")
@@ -214,10 +216,10 @@ func TestAssumeAndReserve(t *testing.T) {
 	}
 }
 
-// TestAssumeAndReserveWithRevert covers the pod group scheduling cycle, where the
+// TestAssumeAndReserveInSnapshot covers the pod group scheduling cycle, where the
 // placement is only tentative: it goes into the snapshot rather than the cache, and
 // the returned revert function has to undo every part of it.
-func TestAssumeAndReserveWithRevert(t *testing.T) {
+func TestAssumeAndReserveInSnapshot(t *testing.T) {
 	node1 := st.MakeNode().Name("node1").Obj()
 	pod1 := st.MakePod().Name("pod1").Namespace("default").UID("pod1").Obj()
 	podWithNomination := st.MakePod().Name("pod-nominated").Namespace("default").UID("pod-nominated").NominatedNodeName("node1").Obj()
@@ -227,7 +229,7 @@ func TestAssumeAndReserveWithRevert(t *testing.T) {
 		pod  *v1.Pod
 	}{
 		{
-			name: "pod group cycle: assumed in the snapshot only",
+			name: "pod group cycle with cache: still assumed in the snapshot only",
 			pod:  pod1,
 		},
 		{
@@ -268,12 +270,12 @@ func TestAssumeAndReserveWithRevert(t *testing.T) {
 				t.Fatalf("schedulePod failed: %v", err)
 			}
 
-			status, revertFn := f.algorithm.assumeAndReserveWithRevert(ctx, state, f.fwk, queuedPodInfo, scheduleResult)
+			status, revertFn := f.algorithm.AssumeAndReserveInSnapshot(ctx, state, f.fwk, queuedPodInfo, scheduleResult)
 			if !status.IsSuccess() {
-				t.Fatalf("assumeAndReserveWithRevert status = %v, want success", status)
+				t.Fatalf("AssumeAndReserveInSnapshot status = %v, want success", status)
 			}
 			if revertFn == nil {
-				t.Fatal("assumeAndReserveWithRevert returned no revert function on success")
+				t.Fatal("AssumeAndReserveInSnapshot returned no revert function on success")
 			}
 
 			// The pod group cycle keeps its tentative placement out of the shared cache.
@@ -362,8 +364,14 @@ func TestAssumeAndReserveSnapshotSync(t *testing.T) {
 				t.Fatalf("schedulePod failed for pod1: %v", err)
 			}
 
-			if _, status := f.algorithm.assumeAndReserve(ctx, state, f.fwk, queuedPodInfo, scheduleResult); !status.IsSuccess() {
-				t.Fatalf("assumeAndReserve failed for pod1: %v", status)
+			if state.IsPodGroupSchedulingCycle() {
+				if status, _ := f.algorithm.AssumeAndReserveInSnapshot(ctx, state, f.fwk, queuedPodInfo, scheduleResult); !status.IsSuccess() {
+					t.Fatalf("AssumeAndReserveInSnapshot failed for pod1: %v", status)
+				}
+			} else {
+				if _, status := f.algorithm.AssumeAndReserveInCache(ctx, state, f.fwk, queuedPodInfo, scheduleResult); !status.IsSuccess() {
+					t.Fatalf("AssumeAndReserveInCache failed for pod1: %v", status)
+				}
 			}
 
 			if got := isPodInSnapshot(f.algorithm.nodeInfoSnapshot, node1.Name, pod1.Name); got != tt.wantInSnapshotBeforeUpdate {
@@ -491,7 +499,7 @@ func TestSchedulingAlgorithmDriver(t *testing.T) {
 				Cache:            cache,
 				nodeInfoSnapshot: snapshot,
 			}
-			sched.initAlgorithm()
+			sched.initAlgorithm(ctx)
 			sched.applyDefaultHandlers()
 
 			state := framework.NewCycleState()
@@ -514,10 +522,198 @@ func TestSchedulingAlgorithmDriver(t *testing.T) {
 	}
 }
 
-// TestFindNodesThatPassFiltersBudget covers the early exit: the search stops once it
-// has enough feasible nodes, and "enough" collapses to a single node for profiles
-// that neither score nor run extender filters, since there is nothing left to choose
-// between the candidates.
+// TestFindAllNodesThatFitPod covers the exhaustive search: every node that fits comes
+// back, with none of the shortcuts a scheduling cycle is allowed to take.
+func TestFindAllNodesThatFitPod(t *testing.T) {
+	allNodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+		st.MakeNode().Name("node3").Obj(),
+	}
+
+	tests := []struct {
+		name                     string
+		nodes                    []*v1.Node
+		pod                      *v1.Pod
+		registerPlugins          []tf.RegisterPluginFunc
+		extenders                []fwk.Extender
+		wantNodeNames            []string
+		wantUnschedulablePlugins sets.Set[string]
+	}{
+		{
+			name:  "N nodes, Filter plugin admitting a named subset",
+			nodes: allNodes,
+			pod:   st.MakePod().Name("pod1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterFilterPlugin("SubsetFilter", tf.NewFakeFilterPlugin(map[string]fwk.Code{
+					"node2": fwk.Unschedulable,
+				})),
+			},
+			wantUnschedulablePlugins: sets.New("FakeFilter"),
+			wantNodeNames:            []string{"node1", "node3"},
+		},
+		{
+			name:  "Pod with nominated node name does not take shortcut and returns all feasible nodes",
+			nodes: allNodes[:2],
+			pod:   st.MakePod().Name("pod1").NominatedNodeName("node1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+			},
+			wantNodeNames: []string{"node1", "node2"},
+		},
+		{
+			name:  "Profile with no score plugins returns all feasible nodes",
+			nodes: allNodes,
+			pod:   st.MakePod().Name("pod1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+			},
+			wantNodeNames: []string{"node1", "node2", "node3"},
+		},
+		{
+			name:  "PreFilter plugin returning node subset respects narrowing",
+			nodes: allNodes,
+			pod:   st.MakePod().Name("pod1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterPreFilterPlugin("SubsetPreFilter", tf.NewFakePreFilterPlugin("SubsetPreFilter", &fwk.PreFilterResult{
+					NodeNames: sets.New("node2", "node3"),
+				}, nil)),
+				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+			},
+			wantUnschedulablePlugins: sets.New("SubsetPreFilter"),
+			wantNodeNames:            []string{"node2", "node3"},
+		},
+		{
+			name:  "Filter extender rejecting one node excludes node and adds ExtenderName to UnschedulablePlugins",
+			nodes: allNodes[:2],
+			pod:   st.MakePod().Name("pod1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+			},
+			extenders: []fwk.Extender{
+				&tf.FakeExtender{
+					ExtenderName: "FakeExtender",
+					Predicates:   []tf.FitPredicate{tf.Node2PredicateExtender},
+				},
+			},
+			wantNodeNames:            []string{"node2"},
+			wantUnschedulablePlugins: sets.New(string(framework.ExtenderName)),
+		},
+		{
+			name:  "Empty snapshot with zero nodes returns empty result without error",
+			nodes: nil,
+			pod:   st.MakePod().Name("pod1").Obj(),
+			registerPlugins: []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
+			},
+			wantNodeNames: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			snapshot := internalcache.NewSnapshot(nil, tt.nodes)
+			schedFwk, err := tf.NewFramework(ctx, tt.registerPlugins, "default-scheduler",
+				frameworkruntime.WithSnapshotSharedLister(snapshot),
+				frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+				frameworkruntime.WithExtenders(tt.extenders),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			algo, _ := NewSchedulingAlgorithm(snapshot, internalcache.New(ctx, nil, true, false))
+			podInfo, err := framework.NewPodInfo(tt.pod)
+			if err != nil {
+				t.Fatalf("Failed to create PodInfo: %v", err)
+			}
+			queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+			nodes, diagnosis, err := algo.FindAllNodesThatFitPod(ctx, framework.NewCycleState(), schedFwk, queuedPodInfo)
+			if err != nil {
+				t.Fatalf("FindAllNodesThatFitPod returned unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.wantNodeNames, nodeNamesFromNodeInfos(nodes)); diff != "" {
+				t.Errorf("FindAllNodesThatFitPod() returned unexpected nodes (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.wantUnschedulablePlugins, diagnosis.UnschedulablePlugins); diff != "" {
+				t.Errorf("Unexpected UnschedulablePlugins (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestFindAllNodesThatFitPodIdempotency is the counterpart to the scheduling path:
+// the exhaustive search must leave the round-robin cursor where it found it, so
+// repeated calls on one instance answer the same thing.
+func TestFindAllNodesThatFitPodIdempotency(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	allNodes := []*v1.Node{
+		st.MakeNode().Name("node1").Obj(),
+		st.MakeNode().Name("node2").Obj(),
+		st.MakeNode().Name("node3").Obj(),
+		st.MakeNode().Name("node4").Obj(),
+		st.MakeNode().Name("node5").Obj(),
+	}
+
+	snapshot := internalcache.NewSnapshot(nil, allNodes)
+	schedFwk, err := tf.NewFramework(ctx, []tf.RegisterPluginFunc{
+		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+	}, "default-scheduler",
+		frameworkruntime.WithSnapshotSharedLister(snapshot),
+		frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+	)
+	if err != nil {
+		t.Fatalf("Failed to create framework: %v", err)
+	}
+
+	algo, _ := NewSchedulingAlgorithm(snapshot, internalcache.New(ctx, nil, true, false))
+	pod := st.MakePod().Name("pod-double").Obj()
+	podInfo, err := framework.NewPodInfo(pod)
+	if err != nil {
+		t.Fatalf("Failed to create PodInfo: %v", err)
+	}
+	queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
+
+	nodes1, _, err := algo.FindAllNodesThatFitPod(ctx, framework.NewCycleState(), schedFwk, queuedPodInfo)
+	if err != nil {
+		t.Fatalf("first FindAllNodesThatFitPod call failed: %v", err)
+	}
+	if algo.nextStartNodeIndex != 0 {
+		t.Errorf("After first call nextStartNodeIndex = %d, want 0", algo.nextStartNodeIndex)
+	}
+
+	nodes2, _, err := algo.FindAllNodesThatFitPod(ctx, framework.NewCycleState(), schedFwk, queuedPodInfo)
+	if err != nil {
+		t.Fatalf("second FindAllNodesThatFitPod call failed: %v", err)
+	}
+	if algo.nextStartNodeIndex != 0 {
+		t.Errorf("After second call nextStartNodeIndex = %d, want 0", algo.nextStartNodeIndex)
+	}
+
+	if diff := cmp.Diff(nodeNamesInOrder(nodes1), nodeNamesInOrder(nodes2)); diff != "" {
+		t.Errorf("Consecutive calls returned different results (-first,+second):\n%s", diff)
+	}
+}
+
+// TestFindNodesThatPassFiltersBudget checks that the search honours the budget it is
+// given, and that a budget wider than the candidate list neither over-allocates the
+// result nor wraps around into duplicates.
 func TestFindNodesThatPassFiltersBudget(t *testing.T) {
 	pod := st.MakePod().Name("pod1").Obj()
 	allNodes := []*v1.Node{
@@ -530,25 +726,39 @@ func TestFindNodesThatPassFiltersBudget(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		withScoring      bool
+		numNodesToFind   int32
 		withFilterPlugin bool
 		wantCount        int
 	}{
 		{
-			name:             "no scoring and no extenders stops at the first feasible node",
+			name:             "budget smaller than the node count stops at the budget",
+			numNodesToFind:   3,
 			withFilterPlugin: true,
-			wantCount:        1,
+			wantCount:        3,
 		},
 		{
-			name:             "scoring profile keeps every feasible node to choose from",
-			withScoring:      true,
+			name:             "budget equal to the node count evaluates all nodes",
+			numNodesToFind:   int32(len(allNodes)),
 			withFilterPlugin: true,
 			wantCount:        len(allNodes),
 		},
 		{
-			name:        "profile without filter plugins still honours the budget",
-			withScoring: true,
-			wantCount:   len(allNodes),
+			name:             "single node budget stops after finding first feasible node",
+			numNodesToFind:   1,
+			withFilterPlugin: true,
+			wantCount:        1,
+		},
+		{
+			name:             "budget smaller than the node count without filter plugins takes budget subset",
+			numNodesToFind:   3,
+			withFilterPlugin: false,
+			wantCount:        3,
+		},
+		{
+			name:             "budget equal to the node count without filter plugins takes all nodes",
+			numNodesToFind:   int32(len(allNodes)),
+			withFilterPlugin: false,
+			wantCount:        len(allNodes),
 		},
 	}
 
@@ -564,10 +774,6 @@ func TestFindNodesThatPassFiltersBudget(t *testing.T) {
 			if tt.withFilterPlugin {
 				registerPlugins = append(registerPlugins, tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin))
 			}
-			if tt.withScoring {
-				registerPlugins = append(registerPlugins,
-					tf.RegisterScorePlugin("FakeScore", tf.NewFakePreScoreAndScorePlugin("FakeScore", 1, nil, nil), 1))
-			}
 			schedFwk, err := tf.NewFramework(ctx, registerPlugins, "default-scheduler",
 				frameworkruntime.WithSnapshotSharedLister(snapshot),
 				frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
@@ -576,7 +782,7 @@ func TestFindNodesThatPassFiltersBudget(t *testing.T) {
 				t.Fatalf("Failed to create framework: %v", err)
 			}
 
-			algo := NewSchedulingAlgorithm(snapshot, nil)
+			algo, _ := NewSchedulingAlgorithm(snapshot, internalcache.New(ctx, nil, true, false))
 
 			nodes, err := snapshot.ListNodesInPlacement()
 			if err != nil {
@@ -586,7 +792,8 @@ func TestFindNodesThatPassFiltersBudget(t *testing.T) {
 				NodeToStatus: framework.NewDefaultNodeToStatus(),
 			}
 
-			got, err := algo.findNodesThatPassFilters(ctx, schedFwk, framework.NewCycleState(), pod, &diagnosis, nodes)
+			got, err := algo.findNodesThatPassFilters(
+				ctx, schedFwk, framework.NewCycleState(), pod, &diagnosis, nodes, tt.numNodesToFind)
 			if err != nil {
 				t.Fatalf("findNodesThatPassFilters returned error: %v", err)
 			}
@@ -598,7 +805,7 @@ func TestFindNodesThatPassFiltersBudget(t *testing.T) {
 			for _, n := range got {
 				name := n.Node().Name
 				if seen.Has(name) {
-					t.Errorf("duplicate node name in result: %q", name)
+					t.Errorf("Duplicate node name in result: %q", name)
 				}
 				seen.Insert(name)
 			}
@@ -607,40 +814,58 @@ func TestFindNodesThatPassFiltersBudget(t *testing.T) {
 }
 
 // TestFindNodesThatPassFiltersEmptyNodes covers an empty candidate list, which
-// PreFilter can produce by narrowing to nodes that are not in the placement.
-//
-// Only the filter-plugin path is exercised: a profile with no filter plugins takes
-// the shortcut loop, which indexes nodes[(nextStartNodeIndex+i)%len(nodes)] against
-// a budget that the n = 1 rule raises above the empty candidate list, and divides by
-// zero. That is pre-existing behaviour, unchanged by this commit, so it is not
-// covered here.
+// PreFilter can produce by narrowing to nodes that are not in the placement. Both
+// paths have to survive it: the shortcut loop for profiles without filter plugins
+// indexes nodes modulo their count, so an unclamped budget would divide by zero.
 func TestFindNodesThatPassFiltersEmptyNodes(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
 	pod := st.MakePod().Name("pod1").Obj()
+	_, ctx := ktesting.NewTestContext(t)
 
 	snapshot := internalcache.NewSnapshot(nil, nil)
-	algo := NewSchedulingAlgorithm(snapshot, nil)
+	algo, _ := NewSchedulingAlgorithm(snapshot, internalcache.New(ctx, nil, true, false))
 
-	schedFwk, err := tf.NewFramework(ctx, []tf.RegisterPluginFunc{
-		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
-		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
-		tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
-	}, "default-scheduler",
-		frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
-	)
-	if err != nil {
-		t.Fatalf("Failed to create framework: %v", err)
+	tests := []struct {
+		name        string
+		withFilters bool
+	}{
+		{
+			name:        "with filter plugins on empty or nil nodes",
+			withFilters: true,
+		},
+		{
+			name:        "without filter plugins on empty or nil nodes",
+			withFilters: false,
+		},
 	}
 
-	diagnosis := framework.Diagnosis{
-		NodeToStatus: framework.NewDefaultNodeToStatus(),
-	}
-	res, err := algo.findNodesThatPassFilters(ctx, schedFwk, framework.NewCycleState(), pod, &diagnosis, nil)
-	if err != nil {
-		t.Fatalf("findNodesThatPassFilters returned unexpected error: %v", err)
-	}
-	if len(res) != 0 {
-		t.Errorf("expected empty result, got %d nodes", len(res))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			registerPlugins := []tf.RegisterPluginFunc{
+				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+			}
+			if tt.withFilters {
+				registerPlugins = append(registerPlugins, tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin))
+			}
+			schedFwk, err := tf.NewFramework(ctx, registerPlugins, "default-scheduler",
+				frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
+			)
+			if err != nil {
+				t.Fatalf("Failed to create framework: %v", err)
+			}
+
+			diagnosis := framework.Diagnosis{
+				NodeToStatus: framework.NewDefaultNodeToStatus(),
+			}
+			res, err := algo.findNodesThatPassFilters(ctx, schedFwk, framework.NewCycleState(), pod, &diagnosis, nil, 1)
+			if err != nil {
+				t.Fatalf("findNodesThatPassFilters returned unexpected error: %v", err)
+			}
+			if len(res) != 0 {
+				t.Errorf("Expected empty result, got %d nodes", len(res))
+			}
+		})
 	}
 }
 
@@ -655,14 +880,13 @@ func TestCycleProvider(t *testing.T) {
 		st.MakeNode().Name("node1").Obj(),
 	}
 	snapshot := internalcache.NewSnapshot(nil, allNodes)
-	algo := NewSchedulingAlgorithm(snapshot, nil, WithCurrentCycleProvider(func() int64 { return 42 }))
+	algo, _ := NewSchedulingAlgorithm(snapshot, internalcache.New(ctx, nil, true, false), WithCurrentCycleProvider(func() int64 { return 42 }))
 
-	registerPlugins := []tf.RegisterPluginFunc{
+	schedFwk, err := tf.NewFramework(ctx, []tf.RegisterPluginFunc{
 		tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 		tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
 		tf.RegisterFilterPlugin("TrueFilter", tf.NewTrueFilterPlugin),
-	}
-	schedFwk, err := tf.NewFramework(ctx, registerPlugins, "default-scheduler",
+	}, "default-scheduler",
 		frameworkruntime.WithSnapshotSharedLister(snapshot),
 		frameworkruntime.WithPodNominator(internalqueue.NewTestQueue(ctx, nil)),
 	)
@@ -679,6 +903,8 @@ func TestCycleProvider(t *testing.T) {
 	}
 	queuedPodInfo := &framework.QueuedPodInfo{PodInfo: podInfo}
 
+	// The scheduling path asks the batch for a hint, and must pass it the cycle the
+	// provider reports.
 	if _, _, _, err := algo.findNodesThatFitPod(ctx, recordingFwk, framework.NewCycleState(), queuedPodInfo); err != nil {
 		t.Fatalf("findNodesThatFitPod returned unexpected error: %v", err)
 	}
@@ -687,6 +913,16 @@ func TestCycleProvider(t *testing.T) {
 	}
 	if recordingFwk.recordedCycle != 42 {
 		t.Errorf("GetNodeHint received cycleCount = %d, want 42", recordingFwk.recordedCycle)
+	}
+
+	// The exhaustive path must not touch the batch at all: taking a hint pops a
+	// candidate that the next scheduling cycle would have used.
+	recordingFwk.hintRequested = false
+	if _, _, err := algo.FindAllNodesThatFitPod(ctx, framework.NewCycleState(), recordingFwk, queuedPodInfo); err != nil {
+		t.Fatalf("FindAllNodesThatFitPod returned unexpected error: %v", err)
+	}
+	if recordingFwk.hintRequested {
+		t.Error("FindAllNodesThatFitPod asked for a node hint, want no batch interaction")
 	}
 }
 
@@ -738,4 +974,23 @@ func newPodGroupCycleState() *framework.CycleState {
 	state := framework.NewCycleState()
 	state.SetPodGroupSchedulingCycle(framework.NewCycleState())
 	return state
+}
+
+// nodeNamesInOrder keeps the order the search returned, for the callers that care
+// about it; nodeNamesFromNodeInfos sorts, for the ones that only care about the set.
+func nodeNamesInOrder(nodes []fwk.NodeInfo) []string {
+	if len(nodes) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		names = append(names, n.Node().Name)
+	}
+	return names
+}
+
+func nodeNamesFromNodeInfos(nodes []fwk.NodeInfo) []string {
+	names := nodeNamesInOrder(nodes)
+	sort.Strings(names)
+	return names
 }

--- a/pkg/scheduler/extender_test.go
+++ b/pkg/scheduler/extender_test.go
@@ -354,7 +354,7 @@ func TestSchedulerWithExtenders(t *testing.T) {
 				nodeInfoSnapshot: emptySnapshot,
 				logger:           logger,
 			}
-			sched.initAlgorithm()
+			sched.initAlgorithm(ctx)
 			sched.applyDefaultHandlers()
 
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -197,7 +197,7 @@ func (sched *Scheduler) prepareForBindingCycle(
 	podsToActivate *framework.PodsToActivate,
 	scheduleResult ScheduleResult,
 ) (*framework.QueuedPodInfo, *fwk.Status) {
-	assumedPodInfo, status := sched.algorithm.assumeAndReserve(ctx, state, schedFramework, podInfo, scheduleResult)
+	assumedPodInfo, status := sched.algorithm.AssumeAndReserveInCache(ctx, state, schedFramework, podInfo, scheduleResult)
 	if !status.IsSuccess() {
 		return assumedPodInfo, status
 	}
@@ -209,7 +209,7 @@ func (sched *Scheduler) prepareForBindingCycle(
 		schedFramework.AddWaitingPod(assumedPod, pluginsWaitTime)
 	} else if !runPermitStatus.IsSuccess() {
 		// trigger un-reserve plugins to clean up state associated with the reserved Pod
-		err := sched.algorithm.unreserveAndForget(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
+		err := sched.algorithm.UnreserveAndForgetFromCache(ctx, state, schedFramework, assumedPodInfo, scheduleResult.SuggestedHost)
 		if err != nil {
 			utilruntime.HandleErrorWithContext(ctx, err, "ForgetPod failed")
 		}
@@ -428,7 +428,7 @@ func (sched *Scheduler) handleBindingCycleError(
 
 	assumedPod := podInfo.Pod
 	// trigger un-reserve plugins to clean up state associated with the reserved Pod
-	if forgetErr := sched.algorithm.unreserveAndForget(ctx, state, fwk, podInfo, scheduleResult.SuggestedHost); forgetErr != nil {
+	if forgetErr := sched.algorithm.UnreserveAndForgetFromCache(ctx, state, fwk, podInfo, scheduleResult.SuggestedHost); forgetErr != nil {
 		utilruntime.HandleErrorWithContext(ctx, forgetErr, "ForgetPod failed")
 	} else {
 		// "Forget"ing an assumed Pod in binding cycle should be treated as a PodDelete event,

--- a/pkg/scheduler/schedule_one_podgroup.go
+++ b/pkg/scheduler/schedule_one_podgroup.go
@@ -545,43 +545,47 @@ func podGroupPotentiallyFeasible(ctx context.Context, schedFwk framework.Framewo
 // It returns the algorithm result together with the revert function.
 // The returned revert function rolls back tentative node reservations for the pod if the overall
 // pod group fails to schedule.
-func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework, placementCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo, podInfo *framework.QueuedPodInfo) (algorithmResult, func()) {
+//
+// Pods of a pod group are assumed into the snapshot rather than the cache: the group's placement
+// stays tentative until the whole group is submitted, and a snapshot assume is dropped by the
+// next UpdateSnapshot instead of outliving the cycle.
+func (sched *Scheduler) podGroupPodSchedulingAlgorithm(ctx context.Context, schedFwk framework.Framework,
+	placementCycleState *framework.CycleState, podGroupInfo *framework.PodGroupInfo,
+	podInfo *framework.QueuedPodInfo) (algorithmResult, func()) {
+
 	pod := podInfo.Pod
 	podCtx := initPodSchedulingContext(ctx, pod, placementCycleState)
 	logger := podCtx.logger
 	ctx = klog.NewContext(ctx, logger)
 	start := time.Now()
 
-	logger.V(4).Info("Attempting to schedule a pod belonging to a pod group", "podGroup", klog.KObj(podGroupInfo), "pod", klog.KObj(pod))
+	logger.V(4).Info("Attempting to schedule a pod belonging to a pod group",
+		"podGroup", klog.KObj(podGroupInfo), "pod", klog.KObj(pod))
 
 	scheduleResult, status := sched.schedulingAlgorithm(ctx, podCtx.state, schedFwk, podInfo, start)
-	if !status.IsSuccess() {
-		return algorithmResult{
-			podInfo:            podInfo,
-			scheduleResult:     scheduleResult,
-			podCtx:             podCtx,
-			schedulingDuration: time.Since(start),
-			status:             status,
-		}, nil
-	}
-	assumeStatus, revertFn := sched.algorithm.assumeAndReserveWithRevert(ctx, podCtx.state, schedFwk, podInfo, scheduleResult)
-	if !assumeStatus.IsSuccess() {
-		return algorithmResult{
-			podInfo:            podInfo,
-			scheduleResult:     ScheduleResult{nominatingInfo: clearNominatedNode},
-			podCtx:             podCtx,
-			schedulingDuration: time.Since(start),
-			status:             assumeStatus,
-		}, nil
-	}
 
-	return algorithmResult{
+	algorithmResult := algorithmResult{
 		podInfo:            podInfo,
 		scheduleResult:     scheduleResult,
 		podCtx:             podCtx,
 		schedulingDuration: time.Since(start),
 		status:             status,
-	}, revertFn
+	}
+
+	if !status.IsSuccess() {
+		return algorithmResult, nil
+	}
+
+	assumeStatus, revertFn := sched.algorithm.AssumeAndReserveInSnapshot(
+		ctx, podCtx.state, schedFwk, podInfo, scheduleResult)
+	if !assumeStatus.IsSuccess() {
+		// The evaluation succeeded but the placement could not be held: drop the
+		// result and clear the nomination, as the single-pod cycle does.
+		algorithmResult.scheduleResult = ScheduleResult{nominatingInfo: clearNominatedNode}
+		algorithmResult.status = assumeStatus
+	}
+
+	return algorithmResult, revertFn
 }
 
 // completePodGroupAlgorithmResult ensures that the podGroupAlgorithmResult contains the same number of podResults as there are pods in QueuedPodInfos.
@@ -1296,7 +1300,7 @@ func (sched *Scheduler) assumeSubtreeWithRevert(ctx context.Context, schedFwk fr
 			if !podResult.status.IsSuccess() || podResult.GetNodeName() == "" {
 				continue
 			}
-			status, revert := sched.algorithm.assumeAndReserveWithRevert(ctx, podResult.podCtx.state, schedFwk, podResult.podInfo, podResult.scheduleResult)
+			status, revert := sched.algorithm.AssumeAndReserveInSnapshot(ctx, podResult.podCtx.state, schedFwk, podResult.podInfo, podResult.scheduleResult)
 			if revert != nil {
 				revertFns = append(revertFns, revert)
 			}

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -767,7 +767,7 @@ func TestScheduleOnePodGroup_FinishesAttemptWhenAllPoppedPodsAreAssumed(t *testi
 				nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
 				SchedulingQueue:  queue,
 			}
-			sched.initAlgorithm()
+			sched.initAlgorithm(ctx)
 			sched.scheduleOnePodGroup(ctx, podGroupInfo)
 
 			if !tt.memberArrivesWhileInFlight {
@@ -862,7 +862,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 			}
 		},
 	}
-	sched.initAlgorithm()
+	sched.initAlgorithm(ctx)
 
 	sched.scheduleOnePodGroup(ctx, podGroupInfo)
 
@@ -961,7 +961,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 		t.Fatalf("Failed to update snapshot: %v", err)
 	}
-	initTestAlgorithm(sched)
+	initTestAlgorithm(ctx, sched)
 
 	resultsMap := sched.runRootSchedulingAlgorithm(ctx, schedFwk, framework.NewCycleState(), podGroupInfo)
 	schedulePodResult := resultsMap[podGroupInfo.PodGroupInfo.GetKey()]
@@ -1138,7 +1138,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 				},
 			}
 
-			initTestAlgorithm(sched)
+			initTestAlgorithm(ctx, sched)
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
 			}
@@ -1488,7 +1488,7 @@ func TestPodGroupSchedulingAlgorithm(t *testing.T) {
 						SchedulingQueue:  queue,
 						Profiles:         profile.Map{"test-scheduler": schedFwk},
 					}
-					initTestAlgorithm(sched)
+					initTestAlgorithm(ctx, sched)
 
 					if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 						t.Fatalf("Failed to update snapshot: %v", err)
@@ -1921,7 +1921,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 					}
 				},
 			}
-			sched.initAlgorithm()
+			sched.initAlgorithm(ctx)
 
 			// Create the pod group and add the pods to queue and pop the group to set up internal queue state correctly.
 			schedulingQueue.AddGenericPodGroup(logger, apg)
@@ -2876,7 +2876,7 @@ func TestPodGroupSchedulingPlacementAlgorithm(t *testing.T) {
 					SchedulingQueue:  queue,
 					Profiles:         profile.Map{"test-scheduler": schedFwk},
 				}
-				initTestAlgorithm(sched)
+				initTestAlgorithm(ctx, sched)
 
 				if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 					t.Fatalf("Failed to update snapshot: %v", err)
@@ -3081,7 +3081,7 @@ func TestPodGroupSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 					SchedulingQueue:  queue,
 					Profiles:         profile.Map{"test-scheduler": schedFwk},
 				}
-				initTestAlgorithm(sched)
+				initTestAlgorithm(ctx, sched)
 
 				if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 					t.Fatalf("Failed to update snapshot: %v", err)
@@ -3251,7 +3251,7 @@ func TestPlacementCycleStateLifecycle(t *testing.T) {
 				SchedulingQueue:  queue,
 				Profiles:         profile.Map{"test-scheduler": schedFwk},
 			}
-			initTestAlgorithm(sched)
+			initTestAlgorithm(ctx, sched)
 
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
@@ -3499,7 +3499,7 @@ func TestPlacementCycleStateLifecycle_MultiLevel(t *testing.T) {
 		SchedulingQueue:  queue,
 		Profiles:         profile.Map{"test-scheduler": schedFwk},
 	}
-	initTestAlgorithm(sched)
+	initTestAlgorithm(ctx, sched)
 
 	if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 		t.Fatalf("Failed to update snapshot: %v", err)
@@ -4019,7 +4019,7 @@ func TestCPGSchedulingPlacementAlgorithm(t *testing.T) {
 				SchedulingQueue:  queue,
 				Profiles:         profile.Map{"test-scheduler": schedFwk},
 			}
-			initTestAlgorithm(sched)
+			initTestAlgorithm(ctx, sched)
 
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
@@ -4298,7 +4298,7 @@ func TestCPGSchedulingPlacementAlgorithm_Scoring(t *testing.T) {
 				SchedulingQueue:  queue,
 				Profiles:         profile.Map{"test-scheduler": schedFwk},
 			}
-			initTestAlgorithm(sched)
+			initTestAlgorithm(ctx, sched)
 
 			if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 				t.Fatalf("Failed to update snapshot: %v", err)
@@ -4415,7 +4415,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 		client:           client,
 		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
 	}
-	sched.initAlgorithm()
+	sched.initAlgorithm(ctx)
 
 	// Mock SchedulePod to return Unschedulable initially, and success on subsequent calls
 	callCount := 0
@@ -4521,7 +4521,7 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 		client:                 client,
 		genericWorkloadEnabled: true,
 	}
-	sched.initAlgorithm()
+	sched.initAlgorithm(ctx)
 	sched.FailureHandler = sched.handleSchedulingFailure
 
 	sched.scheduleOnePodGroup(ctx, podGroupInfo)
@@ -4610,7 +4610,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 		FailureHandler: func(ctx context.Context, fwk framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, ni *fwk.NominatingInfo, start time.Time) {
 		},
 	}
-	sched.initAlgorithm()
+	sched.initAlgorithm(ctx)
 
 	sched.scheduleOnePodGroup(ctx, podGroupInfo)
 
@@ -4830,7 +4830,7 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 					failedPodsMu.Unlock()
 				},
 			}
-			sched.initAlgorithm()
+			sched.initAlgorithm(ctx)
 			sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
 				return ScheduleResult{SuggestedHost: "node1"}, nil
 			}
@@ -5002,7 +5002,7 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 		client:           client,
 		SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
 	}
-	sched.initAlgorithm()
+	sched.initAlgorithm(ctx)
 	schedFwk.SetPodNominator(sched.SchedulingQueue)
 
 	// Mock SchedulePod to return success for all pods
@@ -5284,7 +5284,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 			handledPods[p.Pod.Name] = status
 		},
 	}
-	initTestAlgorithm(sched)
+	initTestAlgorithm(ctx, sched)
 
 	// Run the scheduling cycle
 	if err := cache.UpdateSnapshot(logger, snapshot); err != nil {
@@ -5509,7 +5509,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 			handledPods[p.Pod.Name] = status
 		},
 	}
-	initTestAlgorithm(sched)
+	initTestAlgorithm(ctx, sched)
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
@@ -5729,7 +5729,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 			handledPods[p.Pod.Name] = status
 		},
 	}
-	initTestAlgorithm(sched)
+	initTestAlgorithm(ctx, sched)
 
 	podGroupInfo := &framework.QueuedPodGroupInfo{
 		QueuedPodInfos: queuedPodInfos,
@@ -7348,7 +7348,7 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 						client:           client,
 						nodeInfoSnapshot: snapshot,
 					}
-					sched.initAlgorithm()
+					sched.initAlgorithm(ctx)
 					sched.SchedulePod = sched.algorithm.SchedulePod
 					sched.FailureHandler = sched.handleSchedulingFailure
 

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -5217,7 +5217,11 @@ func TestEvaluateNominatedNode(t *testing.T) {
 			sched := &Scheduler{
 				nodeInfoSnapshot: snapshot,
 			}
+<<<<<<< HEAD
 			initTestAlgorithm(sched)
+=======
+			sched.initAlgorithm()
+>>>>>>> 22ab867be53 (scheduler: move in-memory scheduling onto internal SchedulingAlgorithm type)
 
 			gotNodes, err := sched.algorithm.evaluateNominatedNode(ctx, tt.pod, fw, framework.NewCycleState(), "", framework.Diagnosis{})
 

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1165,7 +1165,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			nodeInfoSnapshot:                       internalcache.NewEmptySnapshot(),
 			nominatedNodeNameForExpectationEnabled: features.nominatedNodeNameForExpectationEnabled,
 		}
-		initTestAlgorithm(sched)
+		initTestAlgorithm(ctx, sched)
 		informerFactory.Start(ctx.Done())
 		informerFactory.WaitForCacheSync(ctx.Done())
 
@@ -2082,7 +2082,7 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 					APIDispatcher:    apiDispatcher,
 					nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
 				}
-				initTestAlgorithm(sched)
+				initTestAlgorithm(ctx, sched)
 				queue.Add(ctx, item.sendPod)
 
 				sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
@@ -3972,7 +3972,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 				Cache:            cache,
 				nodeInfoSnapshot: snapshot,
 			}
-			initTestAlgorithm(sched)
+			initTestAlgorithm(ctx, sched)
 			sched.applyDefaultHandlers()
 
 			informerFactory.Start(ctx.Done())
@@ -4793,8 +4793,22 @@ func TestFairEvaluationForNodes(t *testing.T) {
 		if len(nodesThatFit) != nodesToFind {
 			t.Errorf("got %d nodes filtered, want %d", len(nodesThatFit), nodesToFind)
 		}
-		if sched.algorithm.nextStartNodeIndex != (i+1)*nodesToFind%numAllNodes {
-			t.Errorf("got %d lastProcessedNodeIndex, want %d", sched.algorithm.nextStartNodeIndex, (i+1)*nodesToFind%numAllNodes)
+		expectedNextStartNodeIndex := (i + 1) * nodesToFind % numAllNodes
+		if sched.algorithm.nextStartNodeIndex != expectedNextStartNodeIndex {
+			t.Errorf("got %d lastProcessedNodeIndex, want %d", sched.algorithm.nextStartNodeIndex, expectedNextStartNodeIndex)
+		}
+
+		// Interleave a FindAllNodesThatFitPod call between normal cycles and assert nextStartNodeIndex
+		// advances exactly as if the findAll call never happened.
+		allNodesThatFit, _, err := sched.algorithm.FindAllNodesThatFitPod(ctx, framework.NewCycleState(), fwk, podInfo)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if len(allNodesThatFit) != numAllNodes {
+			t.Errorf("got %d nodes filtered, want %d", len(allNodesThatFit), numAllNodes)
+		}
+		if sched.algorithm.nextStartNodeIndex != expectedNextStartNodeIndex {
+			t.Errorf("got %d lastProcessedNodeIndex, want %d", sched.algorithm.nextStartNodeIndex, expectedNextStartNodeIndex)
 		}
 	}
 }
@@ -4867,7 +4881,7 @@ func TestPreferNominatedNodeFilterCallCounts(t *testing.T) {
 				Cache:            cache,
 				nodeInfoSnapshot: snapshot,
 			}
-			initTestAlgorithm(sched)
+			initTestAlgorithm(ctx, sched)
 			sched.applyDefaultHandlers()
 
 			podInfo := queuedPodInfoForPod(test.pod)
@@ -4918,8 +4932,8 @@ func makeNodeList(nodeNames []string) []*v1.Node {
 // does: it builds the scheduling algorithm from the fields already set and points
 // SchedulePod at it. Unlike applyDefaultHandlers it leaves FailureHandler alone,
 // so it is safe for tests that install their own.
-func initTestAlgorithm(sched *Scheduler) {
-	sched.initAlgorithm()
+func initTestAlgorithm(ctx context.Context, sched *Scheduler) {
+	sched.initAlgorithm(ctx)
 	sched.SchedulePod = sched.algorithm.SchedulePod
 }
 
@@ -4935,7 +4949,7 @@ func makeScheduler(ctx context.Context, nodes []*v1.Node) *Scheduler {
 		Cache:            cache,
 		nodeInfoSnapshot: emptySnapshot,
 	}
-	initTestAlgorithm(sched)
+	initTestAlgorithm(ctx, sched)
 	sched.applyDefaultHandlers()
 	cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot)
 	return sched
@@ -5054,7 +5068,7 @@ func setupTestScheduler(ctx context.Context, t *testing.T, client clientset.Inte
 		Profiles:        profile.Map{testSchedulerName: schedFramework},
 	}
 
-	initTestAlgorithm(sched)
+	initTestAlgorithm(ctx, sched)
 	sched.FailureHandler = func(ctx context.Context, _ framework.Framework, p *framework.QueuedPodInfo, status *fwk.Status, _ *fwk.NominatingInfo, _ time.Time) {
 		err := status.AsError()
 		errChan <- err
@@ -5215,15 +5229,12 @@ func TestEvaluateNominatedNode(t *testing.T) {
 				t.Fatalf("NewFramework failed: %v", err)
 			}
 			sched := &Scheduler{
+				Cache:            internalcache.New(ctx, nil, true, false),
 				nodeInfoSnapshot: snapshot,
 			}
-<<<<<<< HEAD
-			initTestAlgorithm(sched)
-=======
-			sched.initAlgorithm()
->>>>>>> 22ab867be53 (scheduler: move in-memory scheduling onto internal SchedulingAlgorithm type)
+			initTestAlgorithm(ctx, sched)
 
-			gotNodes, err := sched.algorithm.evaluateNominatedNode(ctx, tt.pod, fw, framework.NewCycleState(), "", framework.Diagnosis{})
+			gotNodes, err := sched.algorithm.evaluateNominatedNode(ctx, tt.pod, fw, framework.NewCycleState(), "", &framework.Diagnosis{})
 
 			if (err != nil) != tt.wantError {
 				t.Errorf("Unexpected error, want error: %v, got: %v", tt.wantError, err)
@@ -5303,7 +5314,7 @@ func TestScheduler_DeferredResizePluginSkipping(t *testing.T) {
 		Cache:            cache,
 		nodeInfoSnapshot: snapshot,
 	}
-	initTestAlgorithm(sched)
+	initTestAlgorithm(ctx, sched)
 
 	informerFactory.Start(ctx.Done())
 	informerFactory.WaitForCacheSync(ctx.Done())
@@ -5514,7 +5525,7 @@ func TestSchedulePodWithOpportunisticBatching(t *testing.T) {
 				nodeInfoSnapshot: snapshot,
 				SchedulingQueue:  internalqueue.NewTestQueue(ctx, nil),
 			}
-			initTestAlgorithm(sched)
+			initTestAlgorithm(ctx, sched)
 			sched.applyDefaultHandlers()
 
 			informerFactory.Start(ctx.Done())

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/dynamic/dynamicinformer"
@@ -383,7 +384,7 @@ func New(ctx context.Context,
 		genericWorkloadEnabled:                 feature.DefaultFeatureGate.Enabled(features.GenericWorkload),
 		inPlacePodVerticalScalingSchedulerPreemptionEnabled: feature.DefaultFeatureGate.Enabled(features.InPlacePodVerticalScalingSchedulerPreemption),
 	}
-	sched.initAlgorithm(WithAlgorithmPercentageOfNodesToScore(options.percentageOfNodesToScore))
+	sched.initAlgorithm(ctx, WithAlgorithmPercentageOfNodesToScore(options.percentageOfNodesToScore))
 	sched.NextEntity = podQueue.Pop
 	sched.applyDefaultHandlers()
 
@@ -604,6 +605,12 @@ func (sched *Scheduler) CurrentCycle() int64 {
 //
 // CurrentCycle is passed as a bound method value, so a SchedulingQueue installed
 // after this call is still picked up.
-func (sched *Scheduler) initAlgorithm(opts ...AlgorithmOption) {
-	sched.algorithm = NewSchedulingAlgorithm(sched.nodeInfoSnapshot, sched.Cache, append(opts, WithCurrentCycleProvider(sched.CurrentCycle))...)
+func (sched *Scheduler) initAlgorithm(ctx context.Context, opts ...AlgorithmOption) {
+	algorithm, err := NewSchedulingAlgorithm(sched.nodeInfoSnapshot, sched.Cache, append(opts, WithCurrentCycleProvider(sched.CurrentCycle))...)
+
+	if err != nil {
+		utilruntime.HandleErrorWithContext(ctx, err, "Scheduler cache must be instantiated before calling initAlgorithm")
+	}
+
+	sched.algorithm = algorithm
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -529,7 +529,7 @@ func initScheduler(ctx context.Context, cache internalcache.Cache, queue interna
 		Profiles:        profile.Map{testSchedulerName: fwk},
 		logger:          logger,
 	}
-	s.initAlgorithm()
+	s.initAlgorithm(ctx)
 	s.applyDefaultHandlers()
 
 	return s, fwk, nil


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Follow-up to #141020, which moved node selection and in-memory placement onto [`SchedulingAlgorithm`](pkg/scheduler/algorithm.go). This PR refines its surface so callers (including out-of-tree simulators and pod group scheduling) can drive node filtering and placement directly without a `Scheduler` instance:

- Exports the entry points needed to drive the algorithm standalone: `FindAllNodesThatFitPod`, `AssumeAndReserveInCache` / `UnreserveAndForgetFromCache`, and `AssumeAndReserveInSnapshot` (returning a `revert` closure backed by `unreserveAndForgetFromSnapshot`).
- Decouples cache placement (`AssumeAndReserveInCache` / `UnreserveAndForgetFromCache`) from tentative snapshot placement (`AssumeAndReserveInSnapshot` / `unreserveAndForgetFromSnapshot`) instead of branching on `state.IsPodGroupSchedulingCycle()`, while sharing common setup and plugin execution via `prepareAssumedPod` and `reserve`.
- Splits PreFilter, candidate selection, and extender filtering into `prefilterNodes` (`preFilterOutcome`), `getCandidateNodes`, and `filterWithExtenders` so `findNodesThatFitPod` (early-exit, nominated/hinted node fast path, `nextStartNodeIndex` rotation) and `FindAllNodesThatFitPod` (exhaustive evaluation) share building blocks without boolean flags.
- Updates `NewSchedulingAlgorithm` to validate non-nil `snapshot` and `cache` arguments and return `(*SchedulingAlgorithm, error)`.

#### Which issue(s) this PR is related to:
Follow-up to #141020

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```