### PR TITLE
scheduler: deep copy pod before mutating NominatedNodeName in test hook

### DIFF
--- a/test/integration/scheduler/preemption/nominatednodename/nominatednodename_test.go
+++ b/test/integration/scheduler/preemption/nominatednodename/nominatednodename_test.go
@@ -331,6 +331,7 @@ func initTestPreferNominatedNode(t *testing.T, nsPrefix string, opts ...schedule
 		// Scheduler.NextEntity() may return nil when scheduler is shutting down.
 		if entity != nil {
 			entity.ForEachPodInfo(func(pInfo *framework.QueuedPodInfo) bool {
+				pInfo.Pod = pInfo.Pod.DeepCopy()
 				pInfo.Pod.Status.NominatedNodeName = "node-1"
 				return true
 			})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig scheduling

#### What this PR does / why we need it:

In `test/integration/scheduler/preemption/nominatednodename/nominatednodename_test.go`, `initTestPreferNominatedNode` wraps `testCtx.Scheduler.NextEntity` and modifies `pInfo.Pod.Status.NominatedNodeName = "node-1"` directly on the object.

Because `pInfo.Pod` references the `*v1.Pod` from the informer cache, mutating it in-place without a deep copy causes client-go's cache mutation detector to detect cache corruption and panic (`panic: cache *v1.Pod modified`).

This change performs a `DeepCopy()` on `pInfo.Pod` before modifying `NominatedNodeName`, preventing cache mutation during the test run.

#### Which issue(s) this PR is related to:

Fixes #141578

#### Special notes for your reviewer:

None.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
