### PR TITLE
e2e_node/remote: log host memory while resolving GCE images

### DIFF
--- a/test/e2e_node/remote/gce/childrss_other.go
+++ b/test/e2e_node/remote/gce/childrss_other.go
@@ -1,0 +1,24 @@
+//go:build !unix
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import "os/exec"
+
+// childRSSkB returns 0; peak child RSS is only sampled on unix platforms.
+func childRSSkB(cmd *exec.Cmd) int64 { return 0 }

--- a/test/e2e_node/remote/gce/childrss_unix.go
+++ b/test/e2e_node/remote/gce/childrss_unix.go
@@ -1,0 +1,36 @@
+//go:build unix
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// childRSSkB returns the peak resident set size in kB of a finished command's
+// process, or 0 when it is unavailable.
+func childRSSkB(cmd *exec.Cmd) int64 {
+	if cmd.ProcessState == nil {
+		return 0
+	}
+	if ru, ok := cmd.ProcessState.SysUsage().(*syscall.Rusage); ok {
+		return ru.Maxrss
+	}
+	return 0
+}

--- a/test/e2e_node/remote/gce/gce_runner.go
+++ b/test/e2e_node/remote/gce/gce_runner.go
@@ -187,8 +187,12 @@ type GCEImage struct {
 
 // Returns an image name based on regex and given GCE project.
 func (g *GCERunner) getGCEImage(imageRegex, imageFamily string, project string) (string, error) {
-	data, err := runGCPCommandNoProject("compute", "images", "list",
-		"--format=json", "--project="+project)
+	start := time.Now()
+	args := []string{"compute", "images", "list", "--format=json", "--project=" + project}
+	if imageFamily != "" {
+		args = append(args, "--filter=family="+imageFamily)
+	}
+	data, childMaxRSSkB, err := runGCPCommandNoProjectRusage(args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to list images in project %q: %w", project, err)
 	}
@@ -197,6 +201,10 @@ func (g *GCERunner) getGCEImage(imageRegex, imageFamily string, project string) 
 	if err != nil {
 		return "", fmt.Errorf("failed to parse images: %w", err)
 	}
+	// #141434 diagnostic: attribute the host memory used to resolve an image.
+	klog.InfoS("GCE image resolution memory", "project", project, "family", imageFamily, "regex", imageRegex,
+		"jsonBytes", len(data), "imageCount", len(images), "gcloudChildMaxRSSkB", childMaxRSSkB,
+		"parentVmHWMkB", parentVmHWMkB(), "duration", time.Since(start))
 
 	imageObjs := []imageObj{}
 	imageRe := regexp.MustCompile(imageRegex)

--- a/test/e2e_node/remote/gce/gcloud.go
+++ b/test/e2e_node/remote/gce/gcloud.go
@@ -19,7 +19,9 @@ package gce
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 )
 
 type gceImage struct {
@@ -103,7 +105,16 @@ func runGCPCommand(args ...string) ([]byte, error) {
 }
 
 func runGCPCommandNoProject(args ...string) ([]byte, error) {
-	bytes, err := exec.Command("gcloud", args...).Output()
+	out, _, err := runGCPCommandNoProjectRusage(args...)
+	return out, err
+}
+
+// runGCPCommandNoProjectRusage runs gcloud and reports the child's peak RSS in kB,
+// for the image-resolution memory investigation (#141434).
+func runGCPCommandNoProjectRusage(args ...string) ([]byte, int64, error) {
+	cmd := exec.Command("gcloud", args...)
+	bytes, err := cmd.Output()
+	rss := childRSSkB(cmd)
 	if err != nil {
 		var message string
 		if ee, ok := err.(*exec.ExitError); ok {
@@ -111,9 +122,26 @@ func runGCPCommandNoProject(args ...string) ([]byte, error) {
 		} else {
 			message = fmt.Sprintf("%v", err)
 		}
-		return nil, fmt.Errorf("unable to run gcloud command\n %s \n %w", message, err)
+		return nil, rss, fmt.Errorf("unable to run gcloud command\n %s \n %w", message, err)
 	}
-	return bytes, nil
+	return bytes, rss, nil
+}
+
+// parentVmHWMkB returns this process's peak resident set size in kB.
+func parentVmHWMkB() int64 {
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return -1
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "VmHWM:") {
+			var kb int64
+			if _, err := fmt.Sscanf(line, "VmHWM: %d kB", &kb); err == nil {
+				return kb
+			}
+		}
+	}
+	return -1
 }
 
 func getGCEInstance(host string) (*gceInstance, error) {


### PR DESCRIPTION
This is a diagnostic patch for #141434, not meant to merge. I want the numbers before I touch the resolution path.

getGCEImage in test/e2e_node/remote/gce/gce_runner.go lists a whole image project with `gcloud compute images list --format=json --project=<p>`, then `.Output()` buffers the stdout and json.Unmarshal expands it. For ubuntu-os-gke-cloud that listing is large, and resolving an Ubuntu image runs the host memory up enough that the node jobs needed their Prow pod raised to 2Gi (test-infra#37491).

This adds one klog line per lookup with the gcloud child peak RSS (from getrusage), the listing byte size and image count, the runner VmHWM, and the duration. Running it on a job that resolves ubuntu-os-gke-cloud and one that resolves cos-cloud shows whether the delta is the gcloud child holding a bigger listing or something on the Go side.

The child RSS comes from getrusage, so it is unix-only; on other platforms childRSSkB returns 0 and the line just reports 0 there.

Once I have the paired numbers I will drop this or move the line to V(4), and send the real fix as its own PR.

/kind cleanup
/sig node
/cc @pohly

```release-note
NONE
```
