### PR TITLE
apiserver: extend BenchmarkSerializeObject with the HTTP write path

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	_ "embed"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -655,69 +654,87 @@ func BenchmarkChunkingGzip(b *testing.B) {
 	}
 }
 
-func toProtoBuf(b *testing.B, list *v1.PodList) []byte {
-	out, err := list.Marshal()
-	if err != nil {
-		b.Fatalf("Failed to marshal list to protobuf: %v", err)
-	}
-	return out
-}
-
-func toJSON(b *testing.B, list *v1.PodList) []byte {
-	out, err := json.Marshal(list)
-	if err != nil {
-		b.Fatalf("Failed to marshal list to json: %v", err)
-	}
-	return out
-}
-
-func benchmarkSerializeObject(b *testing.B, payload []byte, gzip bool) {
-	req := &http.Request{
-		URL: &url.URL{Path: "/path"},
-	}
-	if gzip {
-		req.Header = http.Header{
-			"Accept-Encoding": []string{"gzip"},
-		}
-	}
-
+// benchmarkSerializeObject serves one response per iteration from a loopback
+// HTTPS server, with an in-process client reading the body back: the cost of
+// serialization plus net/http's write path, which the streaming collection
+// encoders drive one write per item.
+func benchmarkSerializeObject(b *testing.B, mediaType string, encoder runtime.Encoder, object runtime.Object, gzip, http2 bool) {
 	featuregatetesting.SetFeatureGateDuringTest(b, utilfeature.DefaultFeatureGate, features.APIResponseCompression, true)
 
-	encoder := &fakeEncoder{
-		buf: payload,
-	}
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		SerializeObject(mediaType, encoder, w, req, http.StatusOK, object)
+	}))
+	server.EnableHTTP2 = http2
+	server.StartTLS()
+	b.Cleanup(server.Close)
+	client := server.Client()
+	// Keep the transport from negotiating and transparently undoing gzip on
+	// its own: compression is a benchmark dimension.
+	client.Transport.(*http.Transport).DisableCompression = true
 
+	b.ReportAllocs()
 	b.ResetTimer()
-	responseBytesTotal := 0
+	var responseBytesTotal int64
 	for b.Loop() {
-		recorder := httptest.NewRecorder()
-		SerializeObject("application/json", encoder, recorder, req, http.StatusOK, nil /* object */)
-		result := recorder.Result()
-		if result.StatusCode != http.StatusOK {
-			b.Fatalf("incorrect status code: got %v;  want: %v", result.StatusCode, http.StatusOK)
+		req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+		if err != nil {
+			b.Fatal(err)
 		}
-		responseBytesTotal += recorder.Body.Len()
+		if gzip {
+			req.Header.Set("Accept-Encoding", "gzip")
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		n, err := io.Copy(io.Discard, resp.Body)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := resp.Body.Close(); err != nil {
+			b.Fatal(err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			b.Fatalf("incorrect status code: got %v;  want: %v", resp.StatusCode, http.StatusOK)
+		}
+		if (resp.ProtoMajor == 2) != http2 {
+			b.Fatalf("got %s, want HTTP/2=%v", resp.Proto, http2)
+		}
+		if contentEncoding := resp.Header.Get("Content-Encoding"); (contentEncoding == "gzip") != gzip {
+			b.Fatalf("Content-Encoding %q, want gzip=%v", contentEncoding, gzip)
+		}
+		responseBytesTotal += n
 	}
-	b.ReportMetric(float64(responseBytesTotal/b.N), "writtenBytes/op")
+	b.ReportMetric(float64(responseBytesTotal/int64(b.N)), "writtenBytes/op")
 }
 
+// BenchmarkSerializeObject serves LIST responses of 100 to 100k exemplar Pods
+// through the streaming JSON and protobuf encoders, with and without gzip,
+// over loopback HTTPS with HTTP/1.1 and HTTP/2.
 func BenchmarkSerializeObject(b *testing.B) {
-	for _, count := range []int{1_000, 10_000, 100_000} {
+	scheme := runtime.NewScheme()
+	if err := v1.AddToScheme(scheme); err != nil {
+		b.Fatal(err)
+	}
+	medias := []struct {
+		name, mediaType string
+		encoder         runtime.Encoder
+	}{
+		{"Json", "application/json", jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, scheme, scheme, jsonserializer.SerializerOptions{StreamingCollectionsEncoding: true})},
+		{"Protobuf", "application/vnd.kubernetes.protobuf", protobuf.NewSerializerWithOptions(scheme, scheme, protobuf.SerializerOptions{StreamingCollectionsEncoding: true})},
+	}
+	for _, count := range []int{100, 1_000, 10_000, 100_000} {
 		b.Run(fmt.Sprintf("Count=%d", count), func(b *testing.B) {
-			medias := []struct {
-				name    string
-				convert func(*testing.B, *v1.PodList) []byte
-			}{
-				{"Json", toJSON},
-				{"Protobuf", toProtoBuf},
-			}
 			podList := benchmarkItems(b, count)
 			for _, media := range medias {
 				b.Run(fmt.Sprintf("MediaType=%s", media.name), func(b *testing.B) {
-					payload := media.convert(b, podList)
 					for _, gzip := range []bool{true, false} {
 						b.Run(fmt.Sprintf("Compression=%v", gzip), func(b *testing.B) {
-							benchmarkSerializeObject(b, payload, gzip)
+							for _, protocol := range []string{"HTTP1", "HTTP2"} {
+								b.Run(fmt.Sprintf("Protocol=%s", protocol), func(b *testing.B) {
+									benchmarkSerializeObject(b, media.mediaType, media.encoder, podList, gzip, protocol == "HTTP2")
+								})
+							}
 						})
 					}
 				})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

`BenchmarkSerializeObject` writes a pre-serialized payload in one call through a fake encoder, so it doesn't cover what the streaming collection encoders' one-write-per-item pattern costs once it reaches net/http. This extends it to use the real streaming JSON and protobuf encoders over 100–100k exemplar Pods, with and without gzip, served from loopback HTTPS servers speaking HTTP/1.1 and HTTP/2.

```
go test ./staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/ -run '^$' -bench 'BenchmarkSerializeObject$' -benchmem
```

(~1.5 minutes)

<details>
<summary>Results on master (Go 1.26.6, 32-core x86-64)</summary>

```
BenchmarkSerializeObject/Count=100/MediaType=Json/Compression=true/Protocol=HTTP1-32         	     120	   9870261 ns/op	    107392 writtenBytes/op	 1447227 B/op	    9545 allocs/op
BenchmarkSerializeObject/Count=100/MediaType=Json/Compression=true/Protocol=HTTP2-32         	     122	   9802596 ns/op	    107392 writtenBytes/op	 1339450 B/op	    9662 allocs/op
BenchmarkSerializeObject/Count=100/MediaType=Json/Compression=false/Protocol=HTTP1-32        	     171	   6898032 ns/op	   1444826 writtenBytes/op	  344889 B/op	    9641 allocs/op
BenchmarkSerializeObject/Count=100/MediaType=Json/Compression=false/Protocol=HTTP2-32        	     148	   8017203 ns/op	   1444826 writtenBytes/op	  405396 B/op	   10349 allocs/op
BenchmarkSerializeObject/Count=100/MediaType=Protobuf/Compression=true/Protocol=HTTP1-32     	     414	   2880952 ns/op	     46352 writtenBytes/op	  959114 B/op	     381 allocs/op
BenchmarkSerializeObject/Count=100/MediaType=Protobuf/Compression=true/Protocol=HTTP2-32     	     378	   3154733 ns/op	     46352 writtenBytes/op	  996236 B/op	     433 allocs/op
BenchmarkSerializeObject/Count=100/MediaType=Protobuf/Compression=false/Protocol=HTTP1-32    	     636	   1871004 ns/op	   1010626 writtenBytes/op	   52021 B/op	     694 allocs/op
BenchmarkSerializeObject/Count=100/MediaType=Protobuf/Compression=false/Protocol=HTTP2-32    	     272	   4397061 ns/op	   1010626 writtenBytes/op	  106619 B/op	    1577 allocs/op
BenchmarkSerializeObject/Count=1000/MediaType=Json/Compression=true/Protocol=HTTP1-32        	      13	  92719107 ns/op	   1072146 writtenBytes/op	 4111539 B/op	   94022 allocs/op
BenchmarkSerializeObject/Count=1000/MediaType=Json/Compression=true/Protocol=HTTP2-32        	      12	  93596403 ns/op	   1072146 writtenBytes/op	 4254836 B/op	   95116 allocs/op
BenchmarkSerializeObject/Count=1000/MediaType=Json/Compression=false/Protocol=HTTP1-32       	      16	  66634564 ns/op	  14448026 writtenBytes/op	 3103155 B/op	   95335 allocs/op
BenchmarkSerializeObject/Count=1000/MediaType=Json/Compression=false/Protocol=HTTP2-32       	      14	  78214219 ns/op	  14448026 writtenBytes/op	 3435669 B/op	  102272 allocs/op
BenchmarkSerializeObject/Count=1000/MediaType=Protobuf/Compression=true/Protocol=HTTP1-32    	      43	  24542043 ns/op	    444212 writtenBytes/op	 1158570 B/op	    2488 allocs/op
BenchmarkSerializeObject/Count=1000/MediaType=Protobuf/Compression=true/Protocol=HTTP2-32    	      42	  26964336 ns/op	    444212 writtenBytes/op	 1103353 B/op	    2927 allocs/op
BenchmarkSerializeObject/Count=1000/MediaType=Protobuf/Compression=false/Protocol=HTTP1-32   	      70	  16741575 ns/op	  10106027 writtenBytes/op	  434976 B/op	    5955 allocs/op
BenchmarkSerializeObject/Count=1000/MediaType=Protobuf/Compression=false/Protocol=HTTP2-32   	      27	  40616133 ns/op	  10106027 writtenBytes/op	  859365 B/op	   14487 allocs/op
BenchmarkSerializeObject/Count=10000/MediaType=Json/Compression=true/Protocol=HTTP1-32       	       2	 900343586 ns/op	  10672472 writtenBytes/op	31245160 B/op	  938482 allocs/op
BenchmarkSerializeObject/Count=10000/MediaType=Json/Compression=true/Protocol=HTTP2-32       	       2	 924668508 ns/op	  10672472 writtenBytes/op	32454052 B/op	  949031 allocs/op
BenchmarkSerializeObject/Count=10000/MediaType=Json/Compression=false/Protocol=HTTP1-32      	       2	 668320484 ns/op	 144480026 writtenBytes/op	30430116 B/op	  951388 allocs/op
BenchmarkSerializeObject/Count=10000/MediaType=Json/Compression=false/Protocol=HTTP2-32      	       2	 778433898 ns/op	 144480026 writtenBytes/op	32962536 B/op	 1020738 allocs/op
BenchmarkSerializeObject/Count=10000/MediaType=Protobuf/Compression=true/Protocol=HTTP1-32   	       4	 272735246 ns/op	   4409496 writtenBytes/op	 4936234 B/op	   23626 allocs/op
BenchmarkSerializeObject/Count=10000/MediaType=Protobuf/Compression=true/Protocol=HTTP2-32   	       4	 300054519 ns/op	   4409496 writtenBytes/op	 5172212 B/op	   27978 allocs/op
BenchmarkSerializeObject/Count=10000/MediaType=Protobuf/Compression=false/Protocol=HTTP1-32  	       6	 194751268 ns/op	 101060027 writtenBytes/op	 4302322 B/op	   59820 allocs/op
BenchmarkSerializeObject/Count=10000/MediaType=Protobuf/Compression=false/Protocol=HTTP2-32  	       3	 459078115 ns/op	 101060027 writtenBytes/op	 8293506 B/op	  144619 allocs/op
BenchmarkSerializeObject/Count=100000/MediaType=Json/Compression=true/Protocol=HTTP1-32      	       1	8760209287 ns/op	 106576553 writtenBytes/op	300894768 B/op	 9379341 allocs/op
BenchmarkSerializeObject/Count=100000/MediaType=Json/Compression=true/Protocol=HTTP2-32      	       1	9432773369 ns/op	 106576553 writtenBytes/op	306198160 B/op	 9483504 allocs/op
BenchmarkSerializeObject/Count=100000/MediaType=Json/Compression=false/Protocol=HTTP1-32     	       1	6631533845 ns/op	1444800026 writtenBytes/op	302452568 B/op	 9516263 allocs/op
BenchmarkSerializeObject/Count=100000/MediaType=Json/Compression=false/Protocol=HTTP2-32     	       1	7936297984 ns/op	1444800026 writtenBytes/op	325846544 B/op	10202409 allocs/op
BenchmarkSerializeObject/Count=100000/MediaType=Protobuf/Compression=true/Protocol=HTTP1-32  	       1	2758084756 ns/op	  44167101 writtenBytes/op	38509456 B/op	  233497 allocs/op
BenchmarkSerializeObject/Count=100000/MediaType=Protobuf/Compression=true/Protocol=HTTP2-32  	       1	3014184280 ns/op	  44167101 writtenBytes/op	40741800 B/op	  276832 allocs/op
BenchmarkSerializeObject/Count=100000/MediaType=Protobuf/Compression=false/Protocol=HTTP1-32 	       1	1985098360 ns/op	1010600028 writtenBytes/op	42567328 B/op	  595169 allocs/op
BenchmarkSerializeObject/Count=100000/MediaType=Protobuf/Compression=false/Protocol=HTTP2-32 	       1	4638617455 ns/op	1010600028 writtenBytes/op	81454736 B/op	 1439675 allocs/op
```

</details>

Reading it: for 10k protobuf pods, serializing alone takes ~86ms (`BenchmarkStreamingProtobufPodListAllocatorReuse`), serving over HTTP/1.1 ~194ms, over HTTP/2 ~460ms; the gap is the per-item write path, which I'd like to improve in a follow-up that this benchmark will measure.

#### Which issue(s) this PR is related to:

N/A. Related review discussion that asked for buffering on this path: https://github.com/kubernetes/kubernetes/pull/130281#discussion_r1964531348 and https://github.com/kubernetes/kubernetes/pull/129407#discussion_r1989625640.

#### Special notes for your reviewer:

This PR was written in part with the assistance of generative AI.

Per review: this extends the existing benchmark instead of adding one, and uses only the exemplar Pod (the synthetic ConfigMaps are gone).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
