### PR TITLE
e2e_node/remote: filter the GCE image list by family

### DIFF
--- a/test/e2e_node/remote/gce/gce_runner.go
+++ b/test/e2e_node/remote/gce/gce_runner.go
@@ -185,10 +185,9 @@ type GCEImage struct {
 	Resources       Resources `json:"resources,omitempty"`
 }
 
-// Returns an image name based on regex and given GCE project.
+// getGCEImage returns the newest image matching imageRegex and imageFamily in project.
 func (g *GCERunner) getGCEImage(imageRegex, imageFamily string, project string) (string, error) {
-	data, err := runGCPCommandNoProject("compute", "images", "list",
-		"--format=json", "--project="+project)
+	data, err := runGCPCommandNoProject(gceImageListArgs(project, imageFamily)...)
 	if err != nil {
 		return "", fmt.Errorf("failed to list images in project %q: %w", project, err)
 	}
@@ -197,13 +196,31 @@ func (g *GCERunner) getGCEImage(imageRegex, imageFamily string, project string) 
 	if err != nil {
 		return "", fmt.Errorf("failed to parse images: %w", err)
 	}
+	return pickNewestImage(images, imageRegex, imageFamily, project)
+}
 
+// gceImageListArgs returns the gcloud arguments to list candidate images.
+func gceImageListArgs(project, imageFamily string) []string {
+	args := []string{"compute", "images", "list", "--format=json", "--project=" + project}
+	if imageFamily != "" {
+		// Narrow to the family so gcloud does not return the whole project.
+		// For large projects that can take a long time and consume significant
+		// amounts of RAM. It was the reason why the memory requirements of
+		// jobs using Ubuntu had to be raised (https://github.com/kubernetes/kubernetes/issues/141434).
+		args = append(args, "--filter=family="+imageFamily)
+	}
+	return args
+}
+
+// pickNewestImage returns the name of the newest image matching imageRegex and imageFamily.
+func pickNewestImage(images []gceImage, imageRegex, imageFamily, project string) (string, error) {
 	imageObjs := []imageObj{}
 	imageRe := regexp.MustCompile(imageRegex)
 	for _, instance := range images {
 		if imageRegex != "" && !imageRe.MatchString(instance.Name) {
 			continue
 		}
+		// gcloud's --filter=family is not guaranteed exact, so match here too.
 		if imageFamily != "" && instance.Family != imageFamily {
 			continue
 		}

--- a/test/e2e_node/remote/gce/gce_runner_test.go
+++ b/test/e2e_node/remote/gce/gce_runner_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestPickNewestImage(t *testing.T) {
+	img := func(name, family, ts string) gceImage {
+		return gceImage{Name: name, Family: family, CreationTimestamp: ts}
+	}
+	tests := []struct {
+		name        string
+		images      []gceImage
+		imageRegex  string
+		imageFamily string
+		want        string
+		wantErr     string
+	}{
+		{
+			name: "newest of the family wins",
+			images: []gceImage{
+				img("img-old", "fam", "2026-08-01T10:00:00Z"),
+				img("img-new", "fam", "2026-08-03T10:00:00Z"),
+				img("img-mid", "fam", "2026-08-02T10:00:00Z"),
+			},
+			imageFamily: "fam",
+			want:        "img-new",
+		},
+		{
+			name: "images of other families are ignored",
+			images: []gceImage{
+				img("other-newer", "other", "2026-08-09T10:00:00Z"),
+				img("fam-new", "fam", "2026-08-03T10:00:00Z"),
+				img("fam-old", "fam", "2026-08-01T10:00:00Z"),
+			},
+			imageFamily: "fam",
+			want:        "fam-new",
+		},
+		{
+			name: "regex keeps only matching names, even a newer non-match is skipped",
+			images: []gceImage{
+				img("keep-v2", "fam", "2026-08-03T10:00:00Z"),
+				img("skip-v1", "fam", "2026-08-09T10:00:00Z"),
+			},
+			imageFamily: "fam",
+			imageRegex:  "keep-.*",
+			want:        "keep-v2",
+		},
+		{
+			name: "regex without a family",
+			images: []gceImage{
+				img("keep-old", "", "2026-08-01T10:00:00Z"),
+				img("skip-newest", "", "2026-08-09T10:00:00Z"),
+				img("keep-new", "", "2026-08-03T10:00:00Z"),
+			},
+			imageRegex: "keep-.*",
+			want:       "keep-new",
+		},
+		{
+			name: "no match returns an error",
+			images: []gceImage{
+				img("other", "other", "2026-08-01T10:00:00Z"),
+			},
+			imageFamily: "fam",
+			wantErr:     "found zero images",
+		},
+		{
+			name: "a malformed timestamp returns an error",
+			images: []gceImage{
+				img("fam-x", "fam", "not-a-timestamp"),
+			},
+			imageFamily: "fam",
+			wantErr:     "failed to parse instance creation timestamp",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := pickNewestImage(tc.images, tc.imageRegex, tc.imageFamily, "proj")
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("pickNewestImage() error = %v, want it to contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("pickNewestImage() unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("pickNewestImage() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGCEImageListArgs(t *testing.T) {
+	tests := []struct {
+		name        string
+		project     string
+		imageFamily string
+		want        []string
+	}{
+		{
+			name:        "a family adds a server-side filter",
+			project:     "proj",
+			imageFamily: "fam",
+			want:        []string{"compute", "images", "list", "--format=json", "--project=proj", "--filter=family=fam"},
+		},
+		{
+			name:    "no family adds no filter",
+			project: "proj",
+			want:    []string{"compute", "images", "list", "--format=json", "--project=proj"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := gceImageListArgs(tc.project, tc.imageFamily); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("gceImageListArgs() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
getGCEImage lists a whole image project and reads all of it: exec.Output() buffers the stdout and json.Unmarshal expands it. ubuntu-os-gke-cloud is large, and that is what runs the node-e2e runner out of memory.

I measured it on pull-kubernetes-node-e2e-containerd, whose image config resolves both projects. Before, the runner lists the whole project:

- ubuntu-os-gke-cloud: 12558 images, 283 MiB of JSON, runner VmHWM 1067 MiB, 44.6s
- cos-cloud: 234 images, 1.5 MiB, runner VmHWM 43 MiB, 9.8s

After, with the family filter on the same job:

- ubuntu-os-gke-cloud (family pipeline-1-34-amd64): 407 images, 17 MiB, runner VmHWM 103 MiB, 5.8s
- cos-cloud (family cos-117-lts): 1 image, 13 KiB, runner VmHWM 39 MiB, 2.5s

The Ubuntu runner's process VmHWM drops from 1067 MiB to 103 MiB. This demonstrates the reduction in the image-resolution path; repeated 1Gi canaries with cgroup memory.peak and memory.events are still needed before lowering the Prow resource limit. kubernetes/test-infra#37491 mitigated the OOM by raising the affected jobs to 2Gi.

When the config sets a family, gceImageListArgs adds `--filter=family=<family>` so gcloud returns only that family. I kept the in-code family match, because gcloud's `=` filter is documented as not always exact, so the returned list can be a superset and the selected image does not change: the filtered run still picked the same newest image, ubuntu-gke-2404-1-34-amd64-v20260824. The unit tests cover both the argument construction and the selection.

The Ubuntu node-e2e config sets an `image_family`, so the filter covers the OOM job. A config with only `image_regex` still lists the whole project; narrowing that server-side would need gcloud's filter dialect, which is not Go's regexp, so it stays a separate follow-up.

Part of #141434.

/kind bug
/sig node
/cc @pohly

```release-note
NONE
```

