### PR TITLE
fix endpointslice out of sync

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -2188,3 +2188,41 @@ func Test_dropEndpointSlicesPendingDeletion(t *testing.T) {
 		t.Errorf("EndpointSlice was unexpectedly mutated. Expected: %+v, Mutated: %+v", epSlice3, result[1])
 	}
 }
+
+func TestSyncServiceServiceRecreated(t *testing.T) {
+	oldSvc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "recreated-svc",
+			Namespace: "default",
+			UID:       "uid-1",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{{Port: 80}},
+		},
+	}
+
+	oldES := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "recreated-svc-abcde",
+			Namespace: "default",
+			UID:       "es-uid-1",
+			Labels:    map[string]string{discovery.LabelServiceName: "recreated-svc"},
+			OwnerReferences: []metav1.OwnerReference{{
+				UID: oldSvc.UID,
+			}},
+			Generation: 1,
+		},
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+	_, controller := newController(t, []string{"node-1"}, 1*time.Second)
+
+	// Simulate tracker tracking an old slice from previous service UID
+	controller.endpointSliceTracker.Update(oldES)
+
+	// Syncing recreated service with new UID must not fail with stale informer cache
+	err := controller.syncService(logger, "default/recreated-svc")
+	if err != nil {
+		t.Fatalf("Expected no error syncing recreated service, got: %v", err)
+	}
+}

--- a/staging/src/k8s.io/endpointslice/reconciler.go
+++ b/staging/src/k8s.io/endpointslice/reconciler.go
@@ -377,12 +377,17 @@ func NewReconciler(client clientset.Interface, nodeLister corelisters.NodeLister
 // placeholderSliceCompare is a conversion func for comparing two placeholder endpoint slices.
 // It only compares the specific fields we care about.
 var placeholderSliceCompare = conversion.EqualitiesOrDie(
-	func(a, b metav1.OwnerReference) bool {
-		return a.String() == b.String()
-	},
 	func(a, b metav1.ObjectMeta) bool {
 		if a.Namespace != b.Namespace {
 			return false
+		}
+		if len(a.OwnerReferences) != len(b.OwnerReferences) {
+			return false
+		}
+		for i := range a.OwnerReferences {
+			if a.OwnerReferences[i].UID != b.OwnerReferences[i].UID {
+				return false
+			}
 		}
 		for k, v := range a.Labels {
 			if b.Labels[k] != v {

--- a/staging/src/k8s.io/endpointslice/reconciler_test.go
+++ b/staging/src/k8s.io/endpointslice/reconciler_test.go
@@ -683,6 +683,35 @@ func TestPlaceHolderSliceCompare(t *testing.T) {
 			y:    &discovery.EndpointSlice{AddressType: discovery.AddressTypeIPv6},
 			want: false,
 		},
+
+		{
+			desc: "OwnerReferences with different UID",
+			x: &discovery.EndpointSlice{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{UID: "uid-1"}},
+			}},
+			y: &discovery.EndpointSlice{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{UID: "uid-2"}},
+			}},
+			want: false,
+		},
+		{
+			desc: "OwnerReferences with different length",
+			x: &discovery.EndpointSlice{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{UID: "uid-1"}},
+			}},
+			y:    &discovery.EndpointSlice{},
+			want: false,
+		},
+		{
+			desc: "OwnerReferences matching",
+			x: &discovery.EndpointSlice{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{UID: "uid-1"}},
+			}},
+			y: &discovery.EndpointSlice{ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{UID: "uid-1"}},
+			}},
+			want: true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {

--- a/staging/src/k8s.io/endpointslice/util/endpointslice_tracker.go
+++ b/staging/src/k8s.io/endpointslice/util/endpointslice_tracker.go
@@ -42,12 +42,15 @@ type EndpointSliceTracker struct {
 	// generationsByService tracks the generations of EndpointSlices for each
 	// Service.
 	generationsByService map[types.NamespacedName]GenerationsBySlice
+	// servicesByUID tracks the UID of each Service being tracked.
+	servicesByUID map[types.NamespacedName]types.UID
 }
 
 // NewEndpointSliceTracker creates and initializes a new endpointSliceTracker.
 func NewEndpointSliceTracker() *EndpointSliceTracker {
 	return &EndpointSliceTracker{
 		generationsByService: map[types.NamespacedName]GenerationsBySlice{},
+		servicesByUID:        map[types.NamespacedName]types.UID{},
 	}
 }
 
@@ -80,17 +83,31 @@ func (est *EndpointSliceTracker) ShouldSync(endpointSlice *discovery.EndpointSli
 	return !ok || endpointSlice.Generation > g
 }
 
-// StaleSlices returns true if any of the following are true:
+// StaleSlices returns true if the informer cache appears to be lagging behind
+// recent writes made by the controller for this Service. Specifically, it returns
+// true if any of the following are true:
 //  1. One or more of the provided EndpointSlices have older generations than the
 //     corresponding tracked ones.
 //  2. The tracker is expecting one or more of the provided EndpointSlices to be
 //     deleted. (EndpointSlices that have already been marked for deletion are ignored here.)
 //  3. The tracker is tracking EndpointSlices that have not been provided.
+//
+// If the Service UID has changed (e.g. the Service was deleted and recreated),
+// tracked generations from the previous Service UID represent obsolete writes and
+// are cleared so they do not block reconciliation of the new Service.
 func (est *EndpointSliceTracker) StaleSlices(service *v1.Service, endpointSlices []*discovery.EndpointSlice) bool {
 	est.lock.Lock()
 	defer est.lock.Unlock()
 
 	nn := types.NamespacedName{Name: service.Name, Namespace: service.Namespace}
+	if est.servicesByUID == nil {
+		est.servicesByUID = map[types.NamespacedName]types.UID{}
+	}
+	if trackedUID, ok := est.servicesByUID[nn]; ok && trackedUID != "" && service.UID != "" && trackedUID != service.UID {
+		delete(est.generationsByService, nn)
+	}
+	est.servicesByUID[nn] = service.UID
+
 	gfs, ok := est.generationsByService[nn]
 	if !ok {
 		return false
@@ -137,6 +154,7 @@ func (est *EndpointSliceTracker) DeleteService(namespace, name string) {
 
 	serviceNN := types.NamespacedName{Name: name, Namespace: namespace}
 	delete(est.generationsByService, serviceNN)
+	delete(est.servicesByUID, serviceNN)
 }
 
 // ExpectDeletion sets the generation to deletionExpected in this

--- a/staging/src/k8s.io/endpointslice/util/endpointslice_tracker_test.go
+++ b/staging/src/k8s.io/endpointslice/util/endpointslice_tracker_test.go
@@ -403,3 +403,111 @@ func TestEndpointSliceTrackerDeleteService(t *testing.T) {
 		})
 	}
 }
+
+func TestEndpointSliceTrackerStaleSlicesServiceRecreated(t *testing.T) {
+	epSlice1 := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "slice1",
+			Namespace: "ns1",
+			UID:       "slice-uid-1",
+			Labels: map[string]string{
+				discovery.LabelServiceName: "svc1",
+			},
+			Generation: 1,
+		},
+	}
+	epSlice2 := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "slice2",
+			Namespace: "ns1",
+			UID:       "slice-uid-2",
+			Labels: map[string]string{
+				discovery.LabelServiceName: "svc1",
+			},
+			Generation: 1,
+		},
+	}
+
+	oldService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "ns1",
+			UID:       "service-uid-old",
+		},
+	}
+	newService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc1",
+			Namespace: "ns1",
+			UID:       "service-uid-new",
+		},
+	}
+
+	testCases := []struct {
+		name         string
+		setup        func(tracker *EndpointSliceTracker)
+		serviceParam *v1.Service
+		slicesParam  []*discovery.EndpointSlice
+		expectStale  bool
+	}{{
+		name: "recreated service with residual generations and empty slices",
+		setup: func(tracker *EndpointSliceTracker) {
+			tracker.Update(epSlice1)
+			_ = tracker.StaleSlices(oldService, []*discovery.EndpointSlice{epSlice1})
+		},
+		serviceParam: newService,
+		slicesParam:  []*discovery.EndpointSlice{},
+		expectStale:  false,
+	}, {
+		name: "recreated service with residual generations and unrelated new slice",
+		setup: func(tracker *EndpointSliceTracker) {
+			tracker.Update(epSlice1)
+			_ = tracker.StaleSlices(oldService, []*discovery.EndpointSlice{epSlice1})
+		},
+		serviceParam: newService,
+		slicesParam:  []*discovery.EndpointSlice{epSlice2},
+		expectStale:  false,
+	}, {
+		name: "same service UID with missing tracked slice remains stale",
+		setup: func(tracker *EndpointSliceTracker) {
+			tracker.Update(epSlice1)
+			_ = tracker.StaleSlices(oldService, []*discovery.EndpointSlice{epSlice1})
+		},
+		serviceParam: oldService,
+		slicesParam:  []*discovery.EndpointSlice{},
+		expectStale:  true,
+	}, {
+		name: "same service UID with matching slice is not stale",
+		setup: func(tracker *EndpointSliceTracker) {
+			tracker.Update(epSlice1)
+			_ = tracker.StaleSlices(oldService, []*discovery.EndpointSlice{epSlice1})
+		},
+		serviceParam: oldService,
+		slicesParam:  []*discovery.EndpointSlice{epSlice1},
+		expectStale:  false,
+	}, {
+		name: "empty service UIDs do not clear residual generations",
+		setup: func(tracker *EndpointSliceTracker) {
+			tracker.Update(epSlice1)
+			svcNoUID := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc1", Namespace: "ns1"}}
+			_ = tracker.StaleSlices(svcNoUID, []*discovery.EndpointSlice{epSlice1})
+		},
+		serviceParam: &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc1", Namespace: "ns1"}},
+		slicesParam:  []*discovery.EndpointSlice{},
+		expectStale:  true,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := NewEndpointSliceTracker()
+			if tc.setup != nil {
+				tc.setup(tracker)
+			}
+
+			got := tracker.StaleSlices(tc.serviceParam, tc.slicesParam)
+			if got != tc.expectStale {
+				t.Errorf("StaleSlices() = %t, want %t", got, tc.expectStale)
+			}
+		})
+	}
+}

--- a/test/integration/endpointslice/endpointslice_test.go
+++ b/test/integration/endpointslice/endpointslice_test.go
@@ -54,6 +54,7 @@ func TestEndpointsControllersLabelSemantics(t *testing.T) {
 	informers := informers.NewSharedInformerFactory(client, resyncPeriod)
 
 	tCtx := ktesting.Init(t)
+	defer tCtx.Cancel("test has completed")
 	epController := endpoint.NewEndpointController(
 		tCtx,
 		informers.Core().V1().Pods(),
@@ -130,6 +131,7 @@ func TestEndpointsHeadlessLabel(t *testing.T) {
 	// Disable ServiceAccount admission plugin as we don't have serviceaccount controller running.
 	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
 	defer server.TearDownFn()
+	defer tCtx.Cancel("test has completed")
 
 	client, err := clientset.NewForConfig(server.ClientConfig)
 	if err != nil {
@@ -297,5 +299,113 @@ func validateLabelsOnEndpointAndEndpointSlice(t *testing.T, tCtx context.Context
 	})
 	if err != nil {
 		t.Fatalf("Timed out waiting for EndpointSlice labels: %v", err)
+	}
+}
+
+// TestServiceRecreationEndpointSlices tests that rapidly deleting and recreating
+// a Service with the same name correctly reconciles and creates EndpointSlices for
+// the new Service instance without getting stuck on stale tracker cache.
+func TestServiceRecreationEndpointSlices(t *testing.T) {
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	client, err := clientset.NewForConfig(server.ClientConfig)
+	if err != nil {
+		t.Fatalf("Error creating clientset: %v", err)
+	}
+
+	resyncPeriod := 12 * time.Hour
+	informers := informers.NewSharedInformerFactory(client, resyncPeriod)
+
+	tCtx := ktesting.Init(t)
+	defer tCtx.Cancel("test has completed")
+
+	epsController := endpointslice.NewController(
+		tCtx,
+		informers.Core().V1().Pods(),
+		informers.Core().V1().Services(),
+		informers.Core().V1().Nodes(),
+		informers.Discovery().V1().EndpointSlices(),
+		int32(100),
+		client,
+		0)
+
+	informers.Start(tCtx.Done())
+	go epsController.Run(tCtx, 1)
+
+	ns := framework.CreateNamespaceOrDie(client, "test-service-recreate", t)
+	defer framework.DeleteNamespaceOrDie(client, ns, t)
+
+	svcName := "test-svc-recreate"
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: svcName,
+			Labels: map[string]string{
+				"app": "test",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "test"},
+			Ports: []corev1.ServicePort{{
+				Port:       80,
+				TargetPort: intstr.FromInt(8080),
+			}},
+		},
+	}
+
+	// 1. Create first Service
+	createdSvc1, err := client.CoreV1().Services(ns.Name).Create(tCtx, svc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating service: %v", err)
+	}
+
+	// 2. Wait for EndpointSlice for first Service to be created
+	err = wait.PollUntilContextTimeout(tCtx, 200*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		lSelector := discovery.LabelServiceName + "=" + svcName
+		esList, err := client.DiscoveryV1().EndpointSlices(ns.Name).List(ctx, metav1.ListOptions{LabelSelector: lSelector})
+		if err != nil {
+			return false, err
+		}
+		if len(esList.Items) == 1 && len(esList.Items[0].OwnerReferences) > 0 && esList.Items[0].OwnerReferences[0].UID == createdSvc1.UID {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Timed out waiting for initial EndpointSlice: %v", err)
+	}
+
+	svcCopy := svc.DeepCopy()
+	// 3. Delete the first Service (do not manually delete the EndpointSlice)
+	err = client.CoreV1().Services(ns.Name).Delete(tCtx, svcName, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatalf("Error deleting service: %v", err)
+	}
+
+	// 4. Immediately recreate the Service with same name
+	createdSvc2, err := client.CoreV1().Services(ns.Name).Create(tCtx, svcCopy, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error recreating service: %v", err)
+	}
+	if createdSvc2.UID == createdSvc1.UID {
+		t.Fatalf("Expected new service to have different UID, got same UID: %s", createdSvc2.UID)
+	}
+
+	// 5. Verify that EndpointSlices are reconciled for createdSvc2 (old slice deleted, new slice owned by createdSvc2 exists)
+	err = wait.PollUntilContextTimeout(tCtx, 200*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		lSelector := discovery.LabelServiceName + "=" + svcName
+		esList, err := client.DiscoveryV1().EndpointSlices(ns.Name).List(ctx, metav1.ListOptions{LabelSelector: lSelector})
+		if err != nil {
+			return false, err
+		}
+		for _, es := range esList.Items {
+			if len(es.OwnerReferences) > 0 && es.OwnerReferences[0].UID == createdSvc2.UID {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("Timed out waiting for EndpointSlice for recreated Service: %v", err)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When a Service and its corresponding Pods are rapidly deleted and recreated, ensure the associated EndpointSlice remains correct and up-to-date.

#### Which issue(s) this PR is related to:
Fixes #141592
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #141592
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:
When a Service is rapidly deleted and recreated, a race can occur between `r.endpointSliceTracker.Update(updatedSlice) `(after an updatedSlice) https://github.com/kubernetes/kubernetes/blob/fbb9a10c7a0469a6f076873289e18bd680402c80/staging/src/k8s.io/endpointslice/reconciler.go#L460  and `c.endpointSliceTracker.HandleDeletion(endpointSlice)` https://github.com/kubernetes/kubernetes/blob/fbb9a10c7a0469a6f076873289e18bd680402c80/pkg/controller/endpointslice/endpointslice_controller.go#L585.
If c.endpointSliceTracker.HandleDeletion(endpointSlice) runs before r.endpointSliceTracker.Update(updatedSlice), residual entries remain in the endpointSliceTracker. 
This causes the EndpointSlice informer cache to stay out of date.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
When a Service and its corresponding Pods are rapidly deleted and recreated, ensure the associated EndpointSlice remains correct and up-to-date.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
