### PR TITLE
core/v1: fix the protobuf wire type in the PodLogOptions.Stream struct tag

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -7711,7 +7711,7 @@ type PodLogOptions struct {
 	// Note that when "TailLines" is specified, "Stream" can only be set to nil or "All".
 	// +featureGate=PodLogsQuerySplitStreams
 	// +optional
-	Stream *string `json:"stream,omitempty" protobuf:"varint,10,opt,name=stream"`
+	Stream *string `json:"stream,omitempty" protobuf:"bytes,10,opt,name=stream"`
 }
 
 // +k8s:conversion-gen:explicit-from=net/url.Values


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`PodLogOptions.Stream` is a `*string` but its protobuf struct tag says `varint`. The generated proto and marshaller already treat it as a string, so this is a tag-only fix with no wire change; it stops libraries that derive descriptors from struct tags (e.g. google.golang.org/protobuf's legacy path, as used by grpc-gateway v2) from panicking on the field.

#### Which issue(s) this PR is related to:

Fixes #141594

This is the minimal fix, my expectation is that we discard this and merge #141596 instead

#### Special notes for your reviewer:

Prepared with the assistance of generative AI (Claude); the change and its verification were reviewed by me. Other tag/type mismatches will follow in a separate PR.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
