### PR TITLE
api: fix protobuf wire types in struct tags that disagree with the Go field type

### DIFF
--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -142,7 +142,7 @@ type RollingUpdateStatefulSetStrategy struct {
 	//
 	// +featureGate=MaxUnavailableStatefulSet
 	// +optional
-	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty" protobuf:"varint,2,opt,name=maxUnavailable"`
+	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty" protobuf:"bytes,2,opt,name=maxUnavailable"`
 }
 
 // PersistentVolumeClaimRetentionPolicyType is a string enumeration of the policies that will determine

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -181,7 +181,7 @@ type RollingUpdateStatefulSetStrategy struct {
 	//
 	// +featureGate=MaxUnavailableStatefulSet
 	// +optional
-	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty" protobuf:"varint,2,opt,name=maxUnavailable"`
+	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty" protobuf:"bytes,2,opt,name=maxUnavailable"`
 }
 
 // PersistentVolumeClaimRetentionPolicyType is a string enumeration of the policies that will determine

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -188,7 +188,7 @@ type RollingUpdateStatefulSetStrategy struct {
 	//
 	// +featureGate=MaxUnavailableStatefulSet
 	// +optional
-	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty" protobuf:"varint,2,opt,name=maxUnavailable"`
+	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty" protobuf:"bytes,2,opt,name=maxUnavailable"`
 }
 
 // PersistentVolumeClaimRetentionPolicyType is a string enumeration of the policies that will determine

--- a/staging/src/k8s.io/api/authorization/v1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1/types.go
@@ -330,7 +330,7 @@ type SubjectRulesReviewStatus struct {
 	// incomplete is true when the rules returned by this call are incomplete. This is most commonly
 	// encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
 	// +optional
-	Incomplete bool `json:"incomplete" protobuf:"bytes,3,rep,name=incomplete"`
+	Incomplete bool `json:"incomplete" protobuf:"varint,3,rep,name=incomplete"`
 	// evaluationError can appear in combination with Rules. It indicates an error occurred during
 	// rule evaluation, such as an authorizer that doesn't support rule evaluation, and that
 	// ResourceRules and/or NonResourceRules may be incomplete.

--- a/staging/src/k8s.io/api/authorization/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/types.go
@@ -285,7 +285,7 @@ type SubjectRulesReviewStatus struct {
 	// incomplete is true when the rules returned by this call are incomplete. This is most commonly
 	// encountered when an authorizer, such as an external authorizer, doesn't support rules evaluation.
 	// +optional
-	Incomplete bool `json:"incomplete" protobuf:"bytes,3,rep,name=incomplete"`
+	Incomplete bool `json:"incomplete" protobuf:"varint,3,rep,name=incomplete"`
 	// evaluationError can appear in combination with Rules. It indicates an error occurred during
 	// rule evaluation, such as an authorizer that doesn't support rule evaluation, and that
 	// ResourceRules and/or NonResourceRules may be incomplete.

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -508,7 +508,7 @@ type ResourceMetricStatus struct {
 	// present if `targetAverageValue` was set in the corresponding metric
 	// specification.
 	// +optional
-	CurrentAverageUtilization *int32 `json:"currentAverageUtilization,omitempty" protobuf:"bytes,2,opt,name=currentAverageUtilization"`
+	CurrentAverageUtilization *int32 `json:"currentAverageUtilization,omitempty" protobuf:"varint,2,opt,name=currentAverageUtilization"`
 
 	// currentAverageValue is the current value of the average of the
 	// resource metric across all relevant pods, as a raw value (instead of as
@@ -532,7 +532,7 @@ type ContainerResourceMetricStatus struct {
 	// present if `targetAverageValue` was set in the corresponding metric
 	// specification.
 	// +optional
-	CurrentAverageUtilization *int32 `json:"currentAverageUtilization,omitempty" protobuf:"bytes,2,opt,name=currentAverageUtilization"`
+	CurrentAverageUtilization *int32 `json:"currentAverageUtilization,omitempty" protobuf:"varint,2,opt,name=currentAverageUtilization"`
 
 	// currentAverageValue is the current value of the average of the
 	// resource metric across all relevant pods, as a raw value (instead of as

--- a/staging/src/k8s.io/api/autoscaling/v2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2/types.go
@@ -387,7 +387,7 @@ type MetricTarget struct {
 	// the requested value of the resource for the pods.
 	// Currently only valid for Resource metric source type
 	// +optional
-	AverageUtilization *int32 `json:"averageUtilization,omitempty" protobuf:"bytes,4,opt,name=averageUtilization"`
+	AverageUtilization *int32 `json:"averageUtilization,omitempty" protobuf:"varint,4,opt,name=averageUtilization"`
 }
 
 // MetricTargetType specifies the type of metric being targeted, and should be either
@@ -608,7 +608,7 @@ type MetricValueStatus struct {
 	// resource metric across all relevant pods, represented as a percentage of
 	// the requested value of the resource for the pods.
 	// +optional
-	AverageUtilization *int32 `json:"averageUtilization,omitempty" protobuf:"bytes,3,opt,name=averageUtilization"`
+	AverageUtilization *int32 `json:"averageUtilization,omitempty" protobuf:"varint,3,opt,name=averageUtilization"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1588,7 +1588,7 @@ type SecretVolumeSource struct {
 	// This might be in conflict with other options that affect the file
 	// mode, like fsGroup, and the result can be other mode bits set.
 	// +optional
-	DefaultMode *int32 `json:"defaultMode,omitempty" protobuf:"bytes,3,opt,name=defaultMode"`
+	DefaultMode *int32 `json:"defaultMode,omitempty" protobuf:"varint,3,opt,name=defaultMode"`
 	// optional field specify whether the Secret or its keys must be defined
 	// +optional
 	Optional *bool `json:"optional,omitempty" protobuf:"varint,4,opt,name=optional"`
@@ -2957,7 +2957,7 @@ type TCPSocketAction struct {
 // GRPCAction specifies an action involving a GRPC service.
 type GRPCAction struct {
 	// Port number of the gRPC service. Number must be in the range 1 to 65535.
-	Port int32 `json:"port" protobuf:"bytes,1,opt,name=port"`
+	Port int32 `json:"port" protobuf:"varint,1,opt,name=port"`
 
 	// Service is the name of the service to place in the gRPC HealthCheckRequest
 	// (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
@@ -3004,7 +3004,7 @@ type ExecAction struct {
 // SleepAction describes a "sleep" action.
 type SleepAction struct {
 	// Seconds is the number of seconds to sleep.
-	Seconds int64 `json:"seconds" protobuf:"bytes,1,opt,name=seconds"`
+	Seconds int64 `json:"seconds" protobuf:"varint,1,opt,name=seconds"`
 }
 
 // Probe describes a health check to be performed against a container to determine whether it is
@@ -4609,7 +4609,7 @@ type PodSpec struct {
 	// this field from PriorityClassName.
 	// The higher the value, the higher the priority.
 	// +optional
-	Priority *int32 `json:"priority,omitempty" protobuf:"bytes,25,opt,name=priority"`
+	Priority *int32 `json:"priority,omitempty" protobuf:"varint,25,opt,name=priority"`
 	// Specifies the DNS parameters of a pod.
 	// Parameters specified here will be merged to the generated DNS
 	// configuration based on DNSPolicy.
@@ -4711,7 +4711,7 @@ type PodSpec struct {
 	// mitigating container breakout vulnerabilities even allowing users to run their
 	// containers as root without actually having root privileges on the host.
 	// +optional
-	HostUsers *bool `json:"hostUsers,omitempty" protobuf:"bytes,37,opt,name=hostUsers"`
+	HostUsers *bool `json:"hostUsers,omitempty" protobuf:"varint,37,opt,name=hostUsers"`
 
 	// SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
 	// If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
@@ -6491,7 +6491,7 @@ type ServiceSpec struct {
 	// when updating a Service to no longer need it (e.g. changing type).
 	// This field cannot be updated once set.
 	// +optional
-	HealthCheckNodePort int32 `json:"healthCheckNodePort,omitempty" protobuf:"bytes,12,opt,name=healthCheckNodePort"`
+	HealthCheckNodePort int32 `json:"healthCheckNodePort,omitempty" protobuf:"varint,12,opt,name=healthCheckNodePort"`
 
 	// publishNotReadyAddresses indicates that any agent which deals with endpoints for this
 	// Service should disregard any indications of ready/not-ready.
@@ -6553,7 +6553,7 @@ type ServiceSpec struct {
 	// This field may only be set for services with type LoadBalancer and will
 	// be cleared if the type is changed to any other type.
 	// +optional
-	AllocateLoadBalancerNodePorts *bool `json:"allocateLoadBalancerNodePorts,omitempty" protobuf:"bytes,20,opt,name=allocateLoadBalancerNodePorts"`
+	AllocateLoadBalancerNodePorts *bool `json:"allocateLoadBalancerNodePorts,omitempty" protobuf:"varint,20,opt,name=allocateLoadBalancerNodePorts"`
 
 	// loadBalancerClass is the class of the load balancer implementation this Service belongs to.
 	// If specified, the value of this field must be a label-style identifier, with an optional prefix,
@@ -7711,7 +7711,7 @@ type PodLogOptions struct {
 	// Note that when "TailLines" is specified, "Stream" can only be set to nil or "All".
 	// +featureGate=PodLogsQuerySplitStreams
 	// +optional
-	Stream *string `json:"stream,omitempty" protobuf:"varint,10,opt,name=stream"`
+	Stream *string `json:"stream,omitempty" protobuf:"bytes,10,opt,name=stream"`
 }
 
 // +k8s:conversion-gen:explicit-from=net/url.Values
@@ -8829,7 +8829,7 @@ type WindowsSecurityContextOptions struct {
 	// (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
 	// In addition, if HostProcess is true then HostNetwork must also be set to true.
 	// +optional
-	HostProcess *bool `json:"hostProcess,omitempty" protobuf:"bytes,4,opt,name=hostProcess"`
+	HostProcess *bool `json:"hostProcess,omitempty" protobuf:"varint,4,opt,name=hostProcess"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/api/discovery/v1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1/types.go
@@ -151,7 +151,7 @@ type EndpointConditions struct {
 	// be overridden in some cases, such as when the associated Service has
 	// set the publishNotReadyAddresses flag.
 	// +optional
-	Ready *bool `json:"ready,omitempty" protobuf:"bytes,1,name=ready"`
+	Ready *bool `json:"ready,omitempty" protobuf:"varint,1,name=ready"`
 
 	// serving indicates that this endpoint is able to receive traffic,
 	// according to whatever system is managing the endpoint. For endpoints
@@ -159,12 +159,12 @@ type EndpointConditions struct {
 	// as serving if the pod's Ready condition is True. A nil value should be
 	// interpreted as "true".
 	// +optional
-	Serving *bool `json:"serving,omitempty" protobuf:"bytes,2,name=serving"`
+	Serving *bool `json:"serving,omitempty" protobuf:"varint,2,name=serving"`
 
 	// terminating indicates that this endpoint is terminating. A nil value
 	// should be interpreted as "false".
 	// +optional
-	Terminating *bool `json:"terminating,omitempty" protobuf:"bytes,3,name=terminating"`
+	Terminating *bool `json:"terminating,omitempty" protobuf:"varint,3,name=terminating"`
 }
 
 // EndpointHints provides hints describing how an endpoint should be consumed.
@@ -220,7 +220,7 @@ type EndpointPort struct {
 	// to the service's target port. EndpointSlices used for other purposes may have
 	// a nil port.
 	// +optional
-	Port *int32 `json:"port,omitempty" protobuf:"bytes,3,opt,name=port"`
+	Port *int32 `json:"port,omitempty" protobuf:"varint,3,opt,name=port"`
 
 	// The application protocol for this port.
 	// This is used as a hint for implementations to offer richer behavior for protocols that they understand.

--- a/staging/src/k8s.io/api/discovery/v1beta1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1beta1/types.go
@@ -150,20 +150,20 @@ type EndpointConditions struct {
 	// unknown state as ready. For compatibility reasons, ready should never be
 	// "true" for terminating endpoints.
 	// +optional
-	Ready *bool `json:"ready,omitempty" protobuf:"bytes,1,name=ready"`
+	Ready *bool `json:"ready,omitempty" protobuf:"varint,1,name=ready"`
 
 	// serving is identical to ready except that it is set regardless of the
 	// terminating state of endpoints. This condition should be set to true for
 	// a ready endpoint that is terminating. If nil, consumers should defer to
 	// the ready condition.
 	// +optional
-	Serving *bool `json:"serving,omitempty" protobuf:"bytes,2,name=serving"`
+	Serving *bool `json:"serving,omitempty" protobuf:"varint,2,name=serving"`
 
 	// terminating indicates that this endpoint is terminating. A nil value
 	// indicates an unknown state. Consumers should interpret this unknown state
 	// to mean that the endpoint is not terminating.
 	// +optional
-	Terminating *bool `json:"terminating,omitempty" protobuf:"bytes,3,name=terminating"`
+	Terminating *bool `json:"terminating,omitempty" protobuf:"varint,3,name=terminating"`
 }
 
 // EndpointHints provides hints describing how an endpoint should be consumed.
@@ -217,7 +217,7 @@ type EndpointPort struct {
 	// If this is not specified, ports are not restricted and must be
 	// interpreted in the context of the specific consumer.
 	// +optional
-	Port *int32 `json:"port,omitempty" protobuf:"bytes,3,opt,name=port"`
+	Port *int32 `json:"port,omitempty" protobuf:"varint,3,opt,name=port"`
 
 	// appProtocol represents the application protocol for this port.
 	// This field follows standard Kubernetes label syntax.

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -1206,7 +1206,7 @@ type NetworkPolicyPort struct {
 	// is not defined or if the port field is defined as a named (string) port.
 	// The endPort must be equal or greater than port.
 	// +optional
-	EndPort *int32 `json:"endPort,omitempty" protobuf:"bytes,3,opt,name=endPort"`
+	EndPort *int32 `json:"endPort,omitempty" protobuf:"varint,3,opt,name=endPort"`
 }
 
 // DEPRECATED 1.9 - This group version of IPBlock is deprecated by networking/v1/IPBlock.

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -173,7 +173,7 @@ type NetworkPolicyPort struct {
 	// is not defined or if the port field is defined as a named (string) port.
 	// The endPort must be equal or greater than port.
 	// +optional
-	EndPort *int32 `json:"endPort,omitempty" protobuf:"bytes,3,opt,name=endPort"`
+	EndPort *int32 `json:"endPort,omitempty" protobuf:"varint,3,opt,name=endPort"`
 }
 
 // IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed
@@ -551,7 +551,7 @@ type ServiceBackendPort struct {
 	// number is the numerical port number (e.g. 80) on the Service.
 	// This is a mutually exclusive setting with "Name".
 	// +optional
-	Number int32 `json:"number,omitempty" protobuf:"bytes,2,opt,name=number"`
+	Number int32 `json:"number,omitempty" protobuf:"varint,2,opt,name=number"`
 }
 
 // +genclient

--- a/staging/src/k8s.io/api/protobuf_tags_test.go
+++ b/staging/src/k8s.io/api/protobuf_tags_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// expectedProtobufWireType returns the wire type word that a protobuf struct
+// tag must carry for a field of the given Go type, or "" if the type is not
+// something the protobuf generator maps.
+func expectedProtobufWireType(t reflect.Type) string {
+	switch t.Kind() {
+	case reflect.Pointer:
+		return expectedProtobufWireType(t.Elem())
+	case reflect.Slice:
+		if t.Elem().Kind() == reflect.Uint8 {
+			return "bytes"
+		}
+		return expectedProtobufWireType(t.Elem())
+	case reflect.Map, reflect.Struct, reflect.Interface, reflect.String:
+		return "bytes"
+	case reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return "varint"
+	case reflect.Float64:
+		return "fixed64"
+	case reflect.Float32:
+		return "fixed32"
+	}
+	return ""
+}
+
+// TestProtobufTagWireTypes checks that the wire type in every `protobuf:"..."`
+// struct tag matches the Go type of the field. The generated marshallers do
+// not read these tags, so a wrong wire type does not change the wire format,
+// but libraries that derive protobuf descriptors from struct tags at runtime
+// (for example google.golang.org/protobuf's legacy message support) trust the
+// tag and fail when it disagrees with the Go type.
+func TestProtobufTagWireTypes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	for _, builder := range groups {
+		if err := builder.AddToScheme(scheme); err != nil {
+			t.Fatalf("unexpected error adding to scheme: %v", err)
+		}
+	}
+
+	visited := map[reflect.Type]bool{}
+	var mismatches []string
+	var visit func(t reflect.Type)
+	visit = func(t reflect.Type) {
+		for t.Kind() == reflect.Pointer || t.Kind() == reflect.Slice || t.Kind() == reflect.Map {
+			t = t.Elem()
+		}
+		if t.Kind() != reflect.Struct || visited[t] {
+			return
+		}
+		visited[t] = true
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			visit(f.Type)
+			tag, ok := f.Tag.Lookup("protobuf")
+			if !ok || tag == "-" {
+				continue
+			}
+			got, _, _ := strings.Cut(tag, ",")
+			want := expectedProtobufWireType(f.Type)
+			if want != "" && got != want {
+				mismatches = append(mismatches, t.PkgPath()+"."+t.Name()+"."+f.Name+": Go type "+f.Type.String()+" needs protobuf wire type "+want+", tag says "+got)
+			}
+		}
+	}
+	for _, typ := range scheme.AllKnownTypes() {
+		visit(typ)
+	}
+	sort.Strings(mismatches)
+	for _, m := range mismatches {
+		t.Error(m)
+	}
+}

--- a/staging/src/k8s.io/api/resource/v1/types.go
+++ b/staging/src/k8s.io/api/resource/v1/types.go
@@ -168,7 +168,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +oneOf=NodeSelection
-	AllNodes *bool `json:"allNodes,omitempty" protobuf:"bytes,5,opt,name=allNodes"`
+	AllNodes *bool `json:"allNodes,omitempty" protobuf:"varint,5,opt,name=allNodes"`
 
 	// Devices lists some or all of the devices in this pool.
 	//
@@ -192,7 +192,7 @@ type ResourceSliceSpec struct {
 	// +optional
 	// +oneOf=NodeSelection
 	// +featureGate=DRAPartitionableDevices
-	PerDeviceNodeSelection *bool `json:"perDeviceNodeSelection,omitempty" protobuf:"bytes,7,name=perDeviceNodeSelection"`
+	PerDeviceNodeSelection *bool `json:"perDeviceNodeSelection,omitempty" protobuf:"varint,7,name=perDeviceNodeSelection"`
 
 	// SharedCounters defines a list of counter sets, each of which
 	// has a name and a list of counters available.
@@ -325,7 +325,7 @@ type ResourcePool struct {
 	// in an incomplete state.
 	//
 	// +required
-	Generation int64 `json:"generation" protobuf:"bytes,2,name=generation"`
+	Generation int64 `json:"generation" protobuf:"varint,2,name=generation"`
 
 	// ResourceSliceCount is the total number of ResourceSlices in the pool at this
 	// generation number. Must be greater than zero.
@@ -334,7 +334,7 @@ type ResourcePool struct {
 	// belonging to the same pool.
 	//
 	// +required
-	ResourceSliceCount int64 `json:"resourceSliceCount" protobuf:"bytes,3,name=resourceSliceCount"`
+	ResourceSliceCount int64 `json:"resourceSliceCount" protobuf:"varint,3,name=resourceSliceCount"`
 }
 
 const ResourceSliceMaxSharedCapacity = 128
@@ -447,7 +447,7 @@ type Device struct {
 	// +optional
 	// +oneOf=DeviceNodeSelection
 	// +featureGate=DRAPartitionableDevices
-	AllNodes *bool `json:"allNodes,omitempty" protobuf:"bytes,7,opt,name=allNodes"`
+	AllNodes *bool `json:"allNodes,omitempty" protobuf:"varint,7,opt,name=allNodes"`
 
 	// If specified, these are the driver-defined taints.
 	//
@@ -520,7 +520,7 @@ type Device struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	AllowMultipleAllocations *bool `json:"allowMultipleAllocations,omitempty" protobuf:"bytes,12,opt,name=allowMultipleAllocations"`
+	AllowMultipleAllocations *bool `json:"allowMultipleAllocations,omitempty" protobuf:"varint,12,opt,name=allowMultipleAllocations"`
 
 	// NodeAllocatableResourceMappings is tombstoned as it got replaced with NodeAllocatableResources.
 	// NodeAllocatableResourceMappings map[v1.ResourceName]NodeAllocatableResourceMapping `json:"nodeAllocatableResourceMappings,omitempty" protobuf:"bytes,13,opt,name=nodeAllocatableResourceMappings"`
@@ -1392,7 +1392,7 @@ type ExactDeviceRequest struct {
 	//
 	// +optional
 	// +oneOf=AllocationMode
-	Count int64 `json:"count,omitempty" protobuf:"bytes,4,opt,name=count"`
+	Count int64 `json:"count,omitempty" protobuf:"varint,4,opt,name=count"`
 
 	// AdminAccess indicates that this is a claim for administrative access
 	// to the device(s). Claims with AdminAccess are expected to be used for
@@ -1405,7 +1405,7 @@ type ExactDeviceRequest struct {
 	//
 	// +optional
 	// +featureGate=DRAAdminAccess
-	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"bytes,5,opt,name=adminAccess"`
+	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"varint,5,opt,name=adminAccess"`
 
 	// If specified, the request's tolerations.
 	//
@@ -1550,7 +1550,7 @@ type DeviceSubRequest struct {
 	//
 	// +optional
 	// +oneOf=AllocationMode
-	Count int64 `json:"count,omitempty" protobuf:"bytes,5,opt,name=count"`
+	Count int64 `json:"count,omitempty" protobuf:"varint,5,opt,name=count"`
 
 	// If specified, the request's tolerations.
 	//
@@ -2256,7 +2256,7 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +optional
 	// +featureGate=DRAAdminAccess
-	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"bytes,5,opt,name=adminAccess"`
+	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"varint,5,opt,name=adminAccess"`
 
 	// A copy of all tolerations specified in the request at the time
 	// when the device got allocated.

--- a/staging/src/k8s.io/api/resource/v1beta1/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta1/types.go
@@ -153,7 +153,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +oneOf=NodeSelection
-	AllNodes bool `json:"allNodes,omitempty" protobuf:"bytes,5,opt,name=allNodes"`
+	AllNodes bool `json:"allNodes,omitempty" protobuf:"varint,5,opt,name=allNodes"`
 
 	// Devices lists some or all of the devices in this pool.
 	//
@@ -177,7 +177,7 @@ type ResourceSliceSpec struct {
 	// +optional
 	// +oneOf=NodeSelection
 	// +featureGate=DRAPartitionableDevices
-	PerDeviceNodeSelection *bool `json:"perDeviceNodeSelection,omitempty" protobuf:"bytes,7,name=perDeviceNodeSelection"`
+	PerDeviceNodeSelection *bool `json:"perDeviceNodeSelection,omitempty" protobuf:"varint,7,name=perDeviceNodeSelection"`
 
 	// SharedCounters defines a list of counter sets, each of which
 	// has a name and a list of counters available.
@@ -318,7 +318,7 @@ type ResourcePool struct {
 	// in an incomplete state.
 	//
 	// +required
-	Generation int64 `json:"generation" protobuf:"bytes,2,name=generation"`
+	Generation int64 `json:"generation" protobuf:"varint,2,name=generation"`
 
 	// ResourceSliceCount is the total number of ResourceSlices in the pool at this
 	// generation number. Must be greater than zero.
@@ -327,7 +327,7 @@ type ResourcePool struct {
 	// belonging to the same pool.
 	//
 	// +required
-	ResourceSliceCount int64 `json:"resourceSliceCount" protobuf:"bytes,3,name=resourceSliceCount"`
+	ResourceSliceCount int64 `json:"resourceSliceCount" protobuf:"varint,3,name=resourceSliceCount"`
 }
 
 const ResourceSliceMaxSharedCapacity = 128
@@ -449,7 +449,7 @@ type BasicDevice struct {
 	// +optional
 	// +oneOf=DeviceNodeSelection
 	// +featureGate=DRAPartitionableDevices
-	AllNodes *bool `json:"allNodes,omitempty" protobuf:"bytes,6,opt,name=allNodes"`
+	AllNodes *bool `json:"allNodes,omitempty" protobuf:"varint,6,opt,name=allNodes"`
 
 	// If specified, these are the driver-defined taints.
 	//
@@ -522,7 +522,7 @@ type BasicDevice struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	AllowMultipleAllocations *bool `json:"allowMultipleAllocations,omitempty" protobuf:"bytes,11,opt,name=allowMultipleAllocations"`
+	AllowMultipleAllocations *bool `json:"allowMultipleAllocations,omitempty" protobuf:"varint,11,opt,name=allowMultipleAllocations"`
 
 	// NodeAllocatableResourceMappings is tombstoned as it got replaced with NodeAllocatableResources.
 	// NodeAllocatableResourceMappings map[v1.ResourceName]NodeAllocatableResourceMapping `json:"nodeAllocatableResourceMappings,omitempty" protobuf:"bytes,12,opt,name=nodeAllocatableResourceMappings"`
@@ -1200,7 +1200,7 @@ type DeviceRequest struct {
 	//
 	// +optional
 	// +oneOf=AllocationMode
-	Count int64 `json:"count,omitempty" protobuf:"bytes,5,opt,name=count"`
+	Count int64 `json:"count,omitempty" protobuf:"varint,5,opt,name=count"`
 
 	// AdminAccess indicates that this is a claim for administrative access
 	// to the device(s). Claims with AdminAccess are expected to be used for
@@ -1217,7 +1217,7 @@ type DeviceRequest struct {
 	//
 	// +optional
 	// +featureGate=DRAAdminAccess
-	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"bytes,6,opt,name=adminAccess"`
+	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"varint,6,opt,name=adminAccess"`
 
 	// FirstAvailable contains subrequests, of which exactly one will be
 	// satisfied by the scheduler to satisfy this request. It tries to
@@ -1393,7 +1393,7 @@ type DeviceSubRequest struct {
 	//
 	// +optional
 	// +oneOf=AllocationMode
-	Count int64 `json:"count,omitempty" protobuf:"bytes,5,opt,name=count"`
+	Count int64 `json:"count,omitempty" protobuf:"varint,5,opt,name=count"`
 
 	// If specified, the request's tolerations.
 	//
@@ -2100,7 +2100,7 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +optional
 	// +featureGate=DRAAdminAccess
-	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"bytes,5,opt,name=adminAccess"`
+	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"varint,5,opt,name=adminAccess"`
 
 	// A copy of all tolerations specified in the request at the time
 	// when the device got allocated.

--- a/staging/src/k8s.io/api/resource/v1beta2/types.go
+++ b/staging/src/k8s.io/api/resource/v1beta2/types.go
@@ -153,7 +153,7 @@ type ResourceSliceSpec struct {
 	//
 	// +optional
 	// +oneOf=NodeSelection
-	AllNodes *bool `json:"allNodes,omitempty" protobuf:"bytes,5,opt,name=allNodes"`
+	AllNodes *bool `json:"allNodes,omitempty" protobuf:"varint,5,opt,name=allNodes"`
 
 	// Devices lists some or all of the devices in this pool.
 	//
@@ -177,7 +177,7 @@ type ResourceSliceSpec struct {
 	// +optional
 	// +oneOf=NodeSelection
 	// +featureGate=DRAPartitionableDevices
-	PerDeviceNodeSelection *bool `json:"perDeviceNodeSelection,omitempty" protobuf:"bytes,7,name=perDeviceNodeSelection"`
+	PerDeviceNodeSelection *bool `json:"perDeviceNodeSelection,omitempty" protobuf:"varint,7,name=perDeviceNodeSelection"`
 
 	// SharedCounters defines a list of counter sets, each of which
 	// has a name and a list of counters available.
@@ -310,7 +310,7 @@ type ResourcePool struct {
 	// in an incomplete state.
 	//
 	// +required
-	Generation int64 `json:"generation" protobuf:"bytes,2,name=generation"`
+	Generation int64 `json:"generation" protobuf:"varint,2,name=generation"`
 
 	// ResourceSliceCount is the total number of ResourceSlices in the pool at this
 	// generation number. Must be greater than zero.
@@ -319,7 +319,7 @@ type ResourcePool struct {
 	// belonging to the same pool.
 	//
 	// +required
-	ResourceSliceCount int64 `json:"resourceSliceCount" protobuf:"bytes,3,name=resourceSliceCount"`
+	ResourceSliceCount int64 `json:"resourceSliceCount" protobuf:"varint,3,name=resourceSliceCount"`
 }
 
 const ResourceSliceMaxSharedCapacity = 128
@@ -432,7 +432,7 @@ type Device struct {
 	// +optional
 	// +oneOf=DeviceNodeSelection
 	// +featureGate=DRAPartitionableDevices
-	AllNodes *bool `json:"allNodes,omitempty" protobuf:"bytes,7,opt,name=allNodes"`
+	AllNodes *bool `json:"allNodes,omitempty" protobuf:"varint,7,opt,name=allNodes"`
 
 	// If specified, these are the driver-defined taints.
 	//
@@ -505,7 +505,7 @@ type Device struct {
 	//
 	// +optional
 	// +featureGate=DRAConsumableCapacity
-	AllowMultipleAllocations *bool `json:"allowMultipleAllocations,omitempty" protobuf:"bytes,12,opt,name=allowMultipleAllocations"`
+	AllowMultipleAllocations *bool `json:"allowMultipleAllocations,omitempty" protobuf:"varint,12,opt,name=allowMultipleAllocations"`
 
 	// NodeAllocatableResourceMappings is tombstoned as it got replaced with NodeAllocatableResources.
 	// NodeAllocatableResourceMappings map[v1.ResourceName]NodeAllocatableResourceMapping `json:"nodeAllocatableResourceMappings,omitempty" protobuf:"bytes,13,opt,name=nodeAllocatableResourceMappings"`
@@ -1380,7 +1380,7 @@ type ExactDeviceRequest struct {
 	//
 	// +optional
 	// +oneOf=AllocationMode
-	Count int64 `json:"count,omitempty" protobuf:"bytes,4,opt,name=count"`
+	Count int64 `json:"count,omitempty" protobuf:"varint,4,opt,name=count"`
 
 	// AdminAccess indicates that this is a claim for administrative access
 	// to the device(s). Claims with AdminAccess are expected to be used for
@@ -1394,7 +1394,7 @@ type ExactDeviceRequest struct {
 	//
 	// +optional
 	// +featureGate=DRAAdminAccess
-	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"bytes,5,opt,name=adminAccess"`
+	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"varint,5,opt,name=adminAccess"`
 
 	// If specified, the request's tolerations.
 	//
@@ -1539,7 +1539,7 @@ type DeviceSubRequest struct {
 	//
 	// +optional
 	// +oneOf=AllocationMode
-	Count int64 `json:"count,omitempty" protobuf:"bytes,5,opt,name=count"`
+	Count int64 `json:"count,omitempty" protobuf:"varint,5,opt,name=count"`
 
 	// If specified, the request's tolerations.
 	//
@@ -2246,7 +2246,7 @@ type DeviceRequestAllocationResult struct {
 	//
 	// +optional
 	// +featureGate=DRAAdminAccess
-	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"bytes,5,opt,name=adminAccess"`
+	AdminAccess *bool `json:"adminAccess,omitempty" protobuf:"varint,5,opt,name=adminAccess"`
 
 	// A copy of all tolerations specified in the request at the time
 	// when the device got allocated.

--- a/staging/src/k8s.io/api/scheduling/v1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1/types.go
@@ -38,7 +38,7 @@ type PriorityClass struct {
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
 	// +optional
-	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
+	Value int32 `json:"value" protobuf:"varint,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as
 	// the default priority for pods that do not have any priority class.
@@ -46,7 +46,7 @@ type PriorityClass struct {
 	// one PriorityClasses exists with their `globalDefault` field set to true,
 	// the smallest value of such global default PriorityClasses will be used as the default priority.
 	// +optional
-	GlobalDefault bool `json:"globalDefault,omitempty" protobuf:"bytes,3,opt,name=globalDefault"`
+	GlobalDefault bool `json:"globalDefault,omitempty" protobuf:"varint,3,opt,name=globalDefault"`
 
 	// description is an arbitrary string that usually provides guidelines on
 	// when this priority class should be used.

--- a/staging/src/k8s.io/api/scheduling/v1beta1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1beta1/types.go
@@ -42,7 +42,7 @@ type PriorityClass struct {
 	// value represents the integer value of this priority class. This is the actual priority that pods
 	// receive when they have the name of this class in their pod spec.
 	// +optional
-	Value int32 `json:"value" protobuf:"bytes,2,opt,name=value"`
+	Value int32 `json:"value" protobuf:"varint,2,opt,name=value"`
 
 	// globalDefault specifies whether this PriorityClass should be considered as
 	// the default priority for pods that do not have any priority class.
@@ -50,7 +50,7 @@ type PriorityClass struct {
 	// one PriorityClasses exists with their `globalDefault` field set to true,
 	// the smallest value of such global default PriorityClasses will be used as the default priority.
 	// +optional
-	GlobalDefault bool `json:"globalDefault,omitempty" protobuf:"bytes,3,opt,name=globalDefault"`
+	GlobalDefault bool `json:"globalDefault,omitempty" protobuf:"varint,3,opt,name=globalDefault"`
 
 	// description is an arbitrary string that usually provides guidelines on
 	// when this priority class should be used.

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -344,7 +344,7 @@ type CSIDriverSpec struct {
 	// This field was immutable in Kubernetes < 1.29 and now is mutable.
 	//
 	// +optional
-	PodInfoOnMount *bool `json:"podInfoOnMount,omitempty" protobuf:"bytes,2,opt,name=podInfoOnMount"`
+	PodInfoOnMount *bool `json:"podInfoOnMount,omitempty" protobuf:"varint,2,opt,name=podInfoOnMount"`
 
 	// volumeLifecycleModes defines what kind of volumes this CSI volume driver supports.
 	// The default if the list is empty is "Persistent", which is the usage defined by the
@@ -384,7 +384,7 @@ type CSIDriverSpec struct {
 	//
 	// +optional
 	// +featureGate=CSIStorageCapacity
-	StorageCapacity *bool `json:"storageCapacity,omitempty" protobuf:"bytes,4,opt,name=storageCapacity"`
+	StorageCapacity *bool `json:"storageCapacity,omitempty" protobuf:"varint,4,opt,name=storageCapacity"`
 
 	// fsGroupPolicy defines if the underlying volume supports changing ownership and
 	// permission of the volume before being mounted.

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -358,7 +358,7 @@ type CSIDriverSpec struct {
 	// This field is immutable.
 	//
 	// +optional
-	PodInfoOnMount *bool `json:"podInfoOnMount,omitempty" protobuf:"bytes,2,opt,name=podInfoOnMount"`
+	PodInfoOnMount *bool `json:"podInfoOnMount,omitempty" protobuf:"varint,2,opt,name=podInfoOnMount"`
 
 	// volumeLifecycleModes defines what kind of volumes this CSI volume driver supports.
 	// The default if the list is empty is "Persistent", which is the usage defined by the
@@ -397,7 +397,7 @@ type CSIDriverSpec struct {
 	// This field was immutable in Kubernetes <= 1.22 and now is mutable.
 	//
 	// +optional
-	StorageCapacity *bool `json:"storageCapacity,omitempty" protobuf:"bytes,4,opt,name=storageCapacity"`
+	StorageCapacity *bool `json:"storageCapacity,omitempty" protobuf:"varint,4,opt,name=storageCapacity"`
 
 	// fsGroupPolicy defines if the underlying volume supports changing ownership and
 	// permission of the volume before being mounted.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -91,7 +91,7 @@ type ListMeta struct {
 	// The intended use of the remainingItemCount is *estimating* the size of a collection. Clients
 	// should not rely on the remainingItemCount to be set or to be exact.
 	// +optional
-	RemainingItemCount *int64 `json:"remainingItemCount,omitempty" protobuf:"bytes,4,opt,name=remainingItemCount"`
+	RemainingItemCount *int64 `json:"remainingItemCount,omitempty" protobuf:"varint,4,opt,name=remainingItemCount"`
 
 	// shardInfo is set when the list is a filtered subset of the full collection,
 	// as selected by a shard selector on the request. It echoes back the selector
@@ -603,7 +603,7 @@ type DeleteOptions struct {
 	// 'Foreground' - a cascading policy that deletes all dependents in the
 	// foreground.
 	// +optional
-	PropagationPolicy *DeletionPropagation `json:"propagationPolicy,omitempty" protobuf:"varint,4,opt,name=propagationPolicy"`
+	PropagationPolicy *DeletionPropagation `json:"propagationPolicy,omitempty" protobuf:"bytes,4,opt,name=propagationPolicy"`
 
 	// When present, indicates that modifications should not be
 	// persisted. An invalid or unrecognized dryRun directive will


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This is a follow up to #141595. Rationale is the same as for that PR, the proto fields don't match the go types. It includes the code change from that PR (due to the new test).

Fixes 69 mismatches, and includes a regression test for 67 of them.

I'm unsure if we want a release note for this, please guide me. I've written one.

#### Which issue(s) this PR is related to:

Issue #141594 - this is a sweep of the rest of the codebase.

#### Special notes for your reviewer:

Includes a regression test which catches 67/69 of the fixed cases

`autoscaling/v1.ResourceMetricStatus/ContainerResourceMetricStatus.CurrentAverageUtilization` is an annotation, so not reachable in the test setup.

Prepared with the assistance of generative AI (Claude); the change and its verification were reviewed by me.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed protobuf struct tags in k8s.io/api and k8s.io/apimachinery whose wire type did not match the field's Go type. The wire format is unchanged; only libraries that derive protobuf descriptors from struct tags at runtime are affected.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```
