### PR TITLE
storage: fix CSIDriver attachRequired field path

### DIFF
--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -474,7 +474,7 @@ func ValidateCSIDriverUpdate(new, old *storage.CSIDriver) field.ErrorList {
 	allErrs = append(allErrs, validateCSIDriverSpec(&new.Spec, field.NewPath("spec"))...)
 
 	// immutable fields should not be mutated.
-	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec.AttachRequired, old.Spec.AttachRequired, field.NewPath("spec", "attachedRequired"))...)
+	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec.AttachRequired, old.Spec.AttachRequired, field.NewPath("spec", "attachRequired"))...)
 	allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(new.Spec.VolumeLifecycleModes, old.Spec.VolumeLifecycleModes, field.NewPath("spec", "volumeLifecycleModes")).WithOrigin("immutable").MarkCoveredByDeclarative()...)
 
 	return allErrs
@@ -485,7 +485,7 @@ func ValidateCSIDriverUpdate(new, old *storage.CSIDriver) field.ErrorList {
 func validateCSIDriverSpec(
 	spec *storage.CSIDriverSpec, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateAttachRequired(spec.AttachRequired, fldPath.Child("attachedRequired"))...)
+	allErrs = append(allErrs, validateAttachRequired(spec.AttachRequired, fldPath.Child("attachRequired"))...)
 	allErrs = append(allErrs, validatePodInfoOnMount(spec.PodInfoOnMount, fldPath.Child("podInfoOnMount"))...)
 	allErrs = append(allErrs, validateStorageCapacity(spec.StorageCapacity, fldPath.Child("storageCapacity"))...)
 	allErrs = append(allErrs, validateFSGroupPolicy(spec.FSGroupPolicy, fldPath.Child("fsGroupPolicy"))...)

--- a/pkg/apis/storage/validation/validation_test.go
+++ b/pkg/apis/storage/validation/validation_test.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/version"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -2081,6 +2082,50 @@ func TestCSIDriverValidationUpdate(t *testing.T) {
 			if errs := ValidateCSIDriverUpdate(new, &old); len(errs) == 0 {
 				t.Errorf("Expected failure for test: %+v", new)
 			}
+		})
+	}
+}
+
+// TestCSIDriverAttachRequiredFieldPath pins the field path reported for
+// spec.attachRequired. Both call sites used to report "spec.attachedRequired",
+// which is not a field in the API; TestCSIDriverValidation and
+// TestCSIDriverValidationUpdate only assert whether an error was returned, so
+// nothing caught it.
+func TestCSIDriverAttachRequiredFieldPath(t *testing.T) {
+	driver := func(attachRequired *bool) *storage.CSIDriver {
+		return &storage.CSIDriver{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-driver", ResourceVersion: "1"},
+			Spec: storage.CSIDriverSpec{
+				AttachRequired:                attachRequired,
+				PodInfoOnMount:                ptr.To(false),
+				StorageCapacity:               ptr.To(true),
+				SELinuxMount:                  ptr.To(false),
+				PreventPodSchedulingIfMissing: ptr.To(false),
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		errs field.ErrorList
+	}{{
+		name: "immutable on update",
+		errs: ValidateCSIDriverUpdate(driver(ptr.To(true)), driver(ptr.To(false))),
+	}, {
+		name: "required on create",
+		errs: ValidateCSIDriver(driver(nil)),
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var got []string
+			for _, err := range test.errs {
+				got = append(got, err.Field)
+				if err.Field == "spec.attachRequired" {
+					return
+				}
+			}
+			t.Errorf("no error on spec.attachRequired, got errors on %v", got)
 		})
 	}
 }

--- a/pkg/apis/storage/validation/validation_test.go
+++ b/pkg/apis/storage/validation/validation_test.go
@@ -2092,15 +2092,16 @@ func TestCSIDriverValidationUpdate(t *testing.T) {
 // TestCSIDriverValidationUpdate only assert whether an error was returned, so
 // nothing caught it.
 func TestCSIDriverAttachRequiredFieldPath(t *testing.T) {
+	objectMeta := metav1.ObjectMeta{Name: "test-driver", ResourceVersion: "1"}
 	driver := func(attachRequired *bool) *storage.CSIDriver {
 		return &storage.CSIDriver{
-			ObjectMeta: metav1.ObjectMeta{Name: "test-driver", ResourceVersion: "1"},
+			ObjectMeta: objectMeta,
 			Spec: storage.CSIDriverSpec{
 				AttachRequired:                attachRequired,
-				PodInfoOnMount:                ptr.To(false),
-				StorageCapacity:               ptr.To(true),
-				SELinuxMount:                  ptr.To(false),
-				PreventPodSchedulingIfMissing: ptr.To(false),
+				PodInfoOnMount:                new(false),
+				StorageCapacity:               new(true),
+				SELinuxMount:                  new(false),
+				PreventPodSchedulingIfMissing: new(false),
 			},
 		}
 	}
@@ -2110,7 +2111,7 @@ func TestCSIDriverAttachRequiredFieldPath(t *testing.T) {
 		errs field.ErrorList
 	}{{
 		name: "immutable on update",
-		errs: ValidateCSIDriverUpdate(driver(ptr.To(true)), driver(ptr.To(false))),
+		errs: ValidateCSIDriverUpdate(driver(new(true)), driver(new(false))),
 	}, {
 		name: "required on create",
 		errs: ValidateCSIDriver(driver(nil)),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig storage

#### What this PR does / why we need it:

CSIDriver validation reports errors on `spec.attachedRequired`. That field does not
exist. The JSON name is `attachRequired`
(`staging/src/k8s.io/api/storage/v1/types.go:313`).

Both call sites were wrong:

`pkg/apis/storage/validation/validation.go:477` — the immutability check in
`ValidateCSIDriverUpdate`, so a CSI driver vendor who changes `attachRequired` on an
existing CSIDriver gets `spec.attachedRequired: Invalid value: ...: field is immutable`
and then greps their manifest for a key that isn't in it.

`pkg/apis/storage/validation/validation.go:488` — the required check reached through
`validateCSIDriverSpec`, on both create and update.

The path has been wrong since CSIDriver became a core API in bb45b8ee34f (Feb 2019).

#### Why it survived this long

`TestCSIDriverValidation` and `TestCSIDriverValidationUpdate` assert only whether an
error came back (`wantErr`, `len(errs) == 0`), never the field path, so no test could
catch it. `grep -rn attachedRequired` across the tree returns exactly the two lines this
PR changes and nothing in any test or fixture, so nothing was pinning the wrong value.

The new test asserts the path for both call sites. Against master it fails with the bug
visible:

```
=== RUN   TestCSIDriverAttachRequiredFieldPath/immutable_on_update
    validation_test.go:2128: no error on spec.attachRequired, got errors on [spec.attachedRequired]
=== RUN   TestCSIDriverAttachRequiredFieldPath/required_on_create
    validation_test.go:2128: no error on spec.attachRequired, got errors on [spec.attachedRequired]
--- FAIL: TestCSIDriverAttachRequiredFieldPath (0.00s)
```

and passes with the fix. `./pkg/apis/storage/...` and `./pkg/registry/storage/...` are
green.

#### Overlap with #136974

#136974 changes the update call site to `attachRequired` as a side effect of migrating
that check to declarative validation. It has been open since February and idle since
21 July, and it does not touch the second call site in `validateCSIDriverSpec`. I would
rather the bug not wait on the migration, so this is the standalone fix for both sites,
with no DV markers — those belong to #136974, which should stay a clean migration once
it rebases.

Happy to drop the `ValidateCSIDriverUpdate` hunk if you would rather land #136974 first.

This also unblocks the `attachRequired` entry on #136785: declarative validation emits
`spec.attachRequired`, so the equivalence test fails on the path mismatch until this
lands.

#### Which issue(s) this PR is related to:

Related to #136785

#### Special notes for your reviewer:

No generated files are affected. The markers on `CSIDriverSpec.AttachRequired` are
unchanged and no `zz_generated.validations.go` carries the path string.

I deliberately did not touch `validateAttachRequired` returning `field.Required` for a
field that is `+optional` with a default of `true`. That is a separate question about
whether the internal-type check should exist at all, and it is not a path bug.

I used AI assistance while investigating and preparing this change. I have reviewed it
and can explain every line.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the field path in CSIDriver validation errors for `spec.attachRequired`, which was previously reported as `spec.attachedRequired` — a field that does not exist in the API.
```
