### PR TITLE
Automated cherry pick of #141554: conformance: demote guaranteed pod resize tests to e2e

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -2455,35 +2455,6 @@
     status.
   release: v1.35
   file: test/e2e/common/node/pod_resize.go
-- testname: In-place Pod Resize, guaranteed pods with multiple containers, net increase
-  codename: '[sig-node] Pod InPlace Resize Container guaranteed pods with multiple
-    containers 3 containers - increase cpu & mem on c1, c2, decrease cpu & mem on
-    c3 - net increase [MinimumKubeletVersion:1.34] [Conformance]'
-  description: Issuing an in-place Pod Resize request via the Pod Resize subresource
-    patch endpoint to modify CPU and memory requests and limits for a guaranteed pod
-    with 3 containers with a net increase MUST result in the Pod resources being updated
-    as expected.
-  release: v1.35
-  file: test/e2e/common/node/pod_resize.go
-- testname: In-place Pod Resize, guaranteed pods with multiple containers, net decrease
-  codename: '[sig-node] Pod InPlace Resize Container guaranteed pods with multiple
-    containers 3 containers - increase cpu & mem on c1, decrease cpu & mem on c2,
-    c3 - net decrease [MinimumKubeletVersion:1.34] [Conformance]'
-  description: Issuing an in-place Pod Resize request via the Pod Resize subresource
-    patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers
-    with a net decrease MUST result in the Pod resources being updated as expected.
-  release: v1.35
-  file: test/e2e/common/node/pod_resize.go
-- testname: In-place Pod Resize, guaranteed pods with multiple containers, various
-    operations
-  codename: '[sig-node] Pod InPlace Resize Container guaranteed pods with multiple
-    containers 3 containers - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU
-    (c2) [MinimumKubeletVersion:1.34] [Conformance]'
-  description: Issuing an in-place Pod Resize request via the Pod Resize subresource
-    patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers
-    with various operations MUST result in the Pod resources being updated as expected.
-  release: v1.35
-  file: test/e2e/common/node/pod_resize.go
 - testname: In-place Pod Resize, read and replace endpoints
   codename: '[sig-node] Pod InPlace Resize Container resize pod via the replace endpoint
     [MinimumKubeletVersion:1.34] [Conformance]'

--- a/test/e2e/common/node/pod_resize.go
+++ b/test/e2e/common/node/pod_resize.go
@@ -137,12 +137,7 @@ func doGuaranteedPodResizeTests(f *framework.Framework) {
 	// All tests will perform the requested resize, and once completed, will roll back the change.
 	// This results in coverage of both the operation as described, and its reverse.
 	ginkgo.Describe("guaranteed pods with multiple containers", func() {
-		/*
-			Release: v1.35
-			Testname: In-place Pod Resize, guaranteed pods with multiple containers, net increase
-			Description: Issuing an in-place Pod Resize request via the Pod Resize subresource patch endpoint to modify CPU and memory requests and limits for a guaranteed pod with 3 containers with a net increase MUST result in the Pod resources being updated as expected.
-		*/
-		framework.ConformanceIt("3 containers - increase cpu & mem on c1, c2, decrease cpu & mem on c3 - net increase [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
+		ginkgo.It("3 containers - increase cpu & mem on c1, c2, decrease cpu & mem on c3 - net increase [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
 			originalContainers := makeGuaranteedContainers(3, v1.NotRequired, v1.NotRequired, false, false, originalCPU, originalMem)
 			for i := range originalContainers {
 				originalContainers[i].CPUPolicy = nil
@@ -167,12 +162,7 @@ func doGuaranteedPodResizeTests(f *framework.Framework) {
 			doPatchAndRollback(ctx, f, originalContainers, expectedContainers, nil, nil, true, false)
 		})
 
-		/*
-			Release: v1.35
-			Testname: In-place Pod Resize, guaranteed pods with multiple containers, net decrease
-			Description: Issuing an in-place Pod Resize request via the Pod Resize subresource patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers with a net decrease MUST result in the Pod resources being updated as expected.
-		*/
-		framework.ConformanceIt("3 containers - increase cpu & mem on c1, decrease cpu & mem on c2, c3 - net decrease [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
+		ginkgo.It("3 containers - increase cpu & mem on c1, decrease cpu & mem on c2, c3 - net decrease [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
 			originalContainers := makeGuaranteedContainers(3, v1.NotRequired, v1.NotRequired, false, false, originalCPU, originalMem)
 			for i := range originalContainers {
 				originalContainers[i].CPUPolicy = nil
@@ -197,12 +187,7 @@ func doGuaranteedPodResizeTests(f *framework.Framework) {
 			doPatchAndRollback(ctx, f, originalContainers, expectedContainers, nil, nil, true, false)
 		})
 
-		/*
-			Release: v1.35
-			Testname: In-place Pod Resize, guaranteed pods with multiple containers, various operations
-			Description: Issuing an in-place Pod Resize request via the Pod Resize subresource patch endpoint to modify CPU and memory requests and limits for a pod with 3 containers with various operations MUST result in the Pod resources being updated as expected.
-		*/
-		framework.ConformanceIt("3 containers - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU (c2) [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
+		ginkgo.It("3 containers - increase: CPU (c1,c3), memory (c2, c3) ; decrease: CPU (c2) [MinimumKubeletVersion:1.34]", func(ctx context.Context) {
 			originalContainers := makeGuaranteedContainers(3, v1.NotRequired, v1.NotRequired, false, false, originalCPU, originalMem)
 			for i := range originalContainers {
 				originalContainers[i].CPUPolicy = nil


### PR DESCRIPTION
Cherry pick of #141554 on release-1.35.

#141554: conformance: demote guaranteed pod resize tests to e2e

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind failing-test
/kind regression


```release-note
Three conformance tests added in 1.35 that are not interoperable with static CPU manager are demoted to regular e2e tests
```