### PR TITLE
Promote RBAC beta declarative validation tags to stable 

### DIFF
--- a/pkg/apis/rbac/v1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1/zz_generated.validations.go
@@ -147,7 +147,7 @@ func Validate_ClusterRole(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -285,7 +285,7 @@ func Validate_PolicyRule(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -351,7 +351,7 @@ func Validate_Role(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1alpha1/zz_generated.validations.go
@@ -147,7 +147,7 @@ func Validate_ClusterRole(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -285,7 +285,7 @@ func Validate_PolicyRule(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -351,7 +351,7 @@ func Validate_Role(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/rbac/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/rbac/v1beta1/zz_generated.validations.go
@@ -147,7 +147,7 @@ func Validate_ClusterRole(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {
@@ -285,7 +285,7 @@ func Validate_PolicyRule(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}
@@ -351,7 +351,7 @@ func Validate_Role(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.OptionalSlice(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				earlyReturn = true
 			}
 			if earlyReturn {

--- a/pkg/apis/rbac/validation/validation.go
+++ b/pkg/apis/rbac/validation/validation.go
@@ -103,9 +103,7 @@ func ValidateClusterRoleUpdate(role *rbac.ClusterRole, oldRole *rbac.ClusterRole
 // ValidatePolicyRule is exported to allow types outside of the RBAC API group to embed a rbac.PolicyRule and reuse this validation logic
 func ValidatePolicyRule(rule rbac.PolicyRule, isNamespaced bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if len(rule.Verbs) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("verbs"), "verbs must contain at least one value").MarkCoveredByDeclarative())
-	}
+	// Required verbs check has been migrated to declarative validation.
 
 	if len(rule.NonResourceURLs) > 0 {
 		if isNamespaced {

--- a/pkg/apis/rbac/validation/validation_test.go
+++ b/pkg/apis/rbac/validation/validation_test.go
@@ -430,23 +430,6 @@ func TestValidateRoleNamespacedNonResourceURL(t *testing.T) {
 	}.test(t)
 }
 
-func TestValidateRoleNonResourceURLNoVerbs(t *testing.T) {
-	ValidateClusterRoleTest{
-		role: rbac.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "default",
-			},
-			Rules: []rbac.PolicyRule{{
-				Verbs:           []string{},
-				NonResourceURLs: []string{"/*"},
-			}},
-		},
-		wantErr: true,
-		errType: field.ErrorTypeRequired,
-		field:   "rules[0].verbs",
-	}.test(t)
-}
-
 func TestValidateRoleMixedNonResourceAndResource(t *testing.T) {
 	ValidateRoleTest{
 		role: rbac.Role{

--- a/staging/src/k8s.io/api/rbac/v1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1/generated.proto
@@ -46,7 +46,7 @@ message ClusterRole {
   // rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
-  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 
   // aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -103,7 +103,7 @@ message PolicyRule {
   // verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:required
   repeated string verbs = 1;
 
   // apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -139,7 +139,7 @@ message Role {
   // rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
-  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 }
 

--- a/staging/src/k8s.io/api/rbac/v1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1/types.go
@@ -50,7 +50,7 @@ type PolicyRule struct {
 	// verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -127,7 +127,7 @@ type Role struct {
 	// rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
-	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -201,7 +201,7 @@ type ClusterRole struct {
 	// rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
-	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
 	// aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.

--- a/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/generated.proto
@@ -47,7 +47,7 @@ message ClusterRole {
   // rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
-  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 
   // aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -106,7 +106,7 @@ message PolicyRule {
   // verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:required
   repeated string verbs = 1;
 
   // apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -143,7 +143,7 @@ message Role {
   // rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
-  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 }
 

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -50,7 +50,7 @@ type PolicyRule struct {
 	// verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -126,7 +126,7 @@ type Role struct {
 	// rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
-	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -199,7 +199,7 @@ type ClusterRole struct {
 	// rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
-	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 
 	// aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.

--- a/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/rbac/v1beta1/generated.proto
@@ -47,7 +47,7 @@ message ClusterRole {
   // rules holds all the PolicyRules for this ClusterRole
   // +optional
   // +listType=atomic
-  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 
   // aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
@@ -106,7 +106,7 @@ message PolicyRule {
   // verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
   // +listType=atomic
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:required
   repeated string verbs = 1;
 
   // apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -144,7 +144,7 @@ message Role {
   // rules holds all the PolicyRules for this Role
   // +optional
   // +listType=atomic
-  // +k8s:beta(since: "1.37")=+k8s:optional
+  // +k8s:optional
   repeated PolicyRule rules = 2;
 }
 

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -50,7 +50,7 @@ type PolicyRule struct {
 	// verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 	// +listType=atomic
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:required
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
 
 	// apiGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
@@ -130,7 +130,7 @@ type Role struct {
 	// rules holds all the PolicyRules for this Role
 	// +optional
 	// +listType=atomic
-	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
@@ -219,7 +219,7 @@ type ClusterRole struct {
 	// rules holds all the PolicyRules for this ClusterRole
 	// +optional
 	// +listType=atomic
-	// +k8s:beta(since: "1.37")=+k8s:optional
+	// +k8s:optional
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 	// aggregationRule is an optional field that describes how to build the Rules for this ClusterRole.
 	// If AggregationRule is set, then the Rules are controller managed and direct changes to Rules will be

--- a/test/declarative_validation/rbac/clusterrole/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/clusterrole/declarative_validation_test.go
@@ -51,13 +51,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid ClusterRole missing verbs": {
 			input: mkValidClusterRole(tweakVerbs(nil)),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
 			},
 		},
 		"invalid ClusterRole empty verbs": {
 			input: mkValidClusterRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
 			},
 		},
 		// TODO: Add more test cases
@@ -98,7 +98,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			old:    mkValidClusterRole(),
 			update: mkValidClusterRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
 			},
 		},
 		// TODO: Add more test cases

--- a/test/declarative_validation/rbac/role/declarative_validation_test.go
+++ b/test/declarative_validation/rbac/role/declarative_validation_test.go
@@ -57,13 +57,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"invalid Role missing verbs": {
 			input: mkValidRole(tweakVerbs(nil)),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
 			},
 		},
 		"invalid Role empty verbs": {
 			input: mkValidRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
 			},
 		},
 		// TODO: Add more test cases
@@ -110,7 +110,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			old:    mkValidRole(),
 			update: mkValidRole(tweakVerbs([]string{})),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("rules").Index(0).Child("verbs"), "").MarkBeta(),
+				field.Required(field.NewPath("rules").Index(0).Child("verbs"), ""),
 			},
 		},
 		// TODO: Add more test cases


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature
/area api-validation

#### What this PR does / why we need it:

This PR promotes declarative validation tags to stable for `Role` and `ClusterRole`.

Promoted `PolicyRule.Verbs`, `Role.Rules` and `ClusterRole.Rules` to stable

#### Which issue(s) this PR is related to:

#### Special notes for your reviewer:
I've graduated `Role` and `ClusterRole` together here because they share the embedded `PolicyRule` struct and its `Verbs` validation.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```