### PR TITLE
fix(kubectl): stop drain eviction retry loop when pod is recreated or rescheduled

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -344,8 +344,18 @@ func (d *Helper) evictPods(pods []corev1.Pod, evictionGroupVersion schema.GroupV
 				}
 
 				freshPod, err := getPodFn(activePod.Namespace, activePod.Name)
+				if apierrors.IsNotFound(err) {
+					returnCh <- nil
+					return
+				}
 				// we ignore errors and let eviction sort it out with the original pod.
-				if err == nil {
+				if err == nil && freshPod != nil {
+					// If the pod has been recreated with a different UID or rescheduled to a different node,
+					// the original pod on the draining node has already been terminated.
+					if freshPod.ObjectMeta.UID != pod.ObjectMeta.UID || (len(pod.Spec.NodeName) > 0 && len(freshPod.Spec.NodeName) > 0 && freshPod.Spec.NodeName != pod.Spec.NodeName) {
+						returnCh <- nil
+						return
+					}
 					activePod = *freshPod
 				}
 			}

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -701,3 +701,110 @@ func TestEvictDuringNamespaceTerminating(t *testing.T) {
 		})
 	}
 }
+
+func TestEvictDuringRetryPodRecreatedOrRescheduled(t *testing.T) {
+	testPodUID := types.UID("test-uid-1")
+	testPodName := "test-pod"
+	testNamespace := "default"
+	targetNodeName := "node-1"
+
+	retryDelay := 5 * time.Millisecond
+	globalTimeout := 20 * retryDelay
+
+	tests := []struct {
+		description string
+		getPodFn    func(callCount int) (*corev1.Pod, error)
+		expectErr   bool
+	}{
+		{
+			description: "Pod recreated with different UID during eviction retry",
+			getPodFn: func(callCount int) (*corev1.Pod, error) {
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testPodName,
+						Namespace: testNamespace,
+						UID:       types.UID("test-uid-2-recreated"),
+					},
+					Spec: corev1.PodSpec{
+						NodeName: targetNodeName,
+					},
+				}, nil
+			},
+			expectErr: false,
+		},
+		{
+			description: "Pod rescheduled to different node during eviction retry",
+			getPodFn: func(callCount int) (*corev1.Pod, error) {
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testPodName,
+						Namespace: testNamespace,
+						UID:       testPodUID,
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node-2-other",
+					},
+				}, nil
+			},
+			expectErr: false,
+		},
+		{
+			description: "Pod deleted (NotFound) during eviction retry",
+			getPodFn: func(callCount int) (*corev1.Pod, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, testPodName)
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			initialPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					UID:       testPodUID,
+				},
+				Spec: corev1.PodSpec{
+					NodeName: targetNodeName,
+				},
+			}
+
+			evictPods := []corev1.Pod{*initialPod}
+			k := fake.NewClientset(initialPod)
+			addEvictionSupport(t, k, "v1")
+
+			// Eviction always returns TooManyRequests (e.g. PDB violation)
+			k.PrependReactor("create", "pods", func(action ktest.Action) (bool, runtime.Object, error) {
+				if action.GetSubresource() != "eviction" {
+					return false, nil, nil
+				}
+				return true, nil, apierrors.NewTooManyRequests("Cannot evict pod as it would violate disruption budget", 0)
+			})
+
+			callCount := 0
+			k.PrependReactor("get", "pods", func(action ktest.Action) (bool, runtime.Object, error) {
+				callCount++
+				pod, err := test.getPodFn(callCount)
+				return true, pod, err
+			})
+
+			h := &Helper{
+				Client:               k,
+				DisableEviction:      false,
+				Out:                  os.Stdout,
+				ErrOut:               os.Stderr,
+				Timeout:              globalTimeout,
+				EvictErrorRetryDelay: retryDelay,
+			}
+
+			err := h.DeleteOrEvictPods(evictPods)
+			if test.expectErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !test.expectErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

When `kubectl drain` attempts to evict a pod and receives an eviction error (such as `TooManyRequests` due to a `PodDisruptionBudget`), it enters a retry loop. If the target pod on the draining node is deleted and recreated (e.g. by a StatefulSet or Deployment) under the same name with a new UID, or scheduled to a different node, the retry loop updates `activePod` to the new pod instance and continues trying to evict it. This leaves `kubectl drain` stuck indefinitely in an eviction loop for a pod that is no longer running on the node being drained.

## Root Cause

In `staging/src/k8s.io/kubectl/pkg/drain/drain.go`, `evictPods` refreshes the pod via `getPodFn` during retries and assigns `activePod = *freshPod` without checking if the pod was deleted (`apierrors.IsNotFound`), recreated with a new UID (`freshPod.UID != pod.UID`), or relocated to another node (`freshPod.Spec.NodeName != pod.Spec.NodeName`).

## Solution

* Check `apierrors.IsNotFound(err)` on pod refresh during eviction retries and return success if the pod is gone.
* Check if `freshPod.ObjectMeta.UID != pod.ObjectMeta.UID` or if `freshPod.Spec.NodeName != pod.Spec.NodeName`; if so, recognize that the pod on the draining node has terminated and complete eviction cleanly.
* Added comprehensive unit tests in `drain_test.go` covering UID changes, node reassignments, and `NotFound` responses during eviction retries.

## Testing

* Added unit test `TestEvictDuringRetryPodRecreatedOrRescheduled` in `staging/src/k8s.io/kubectl/pkg/drain/drain_test.go`.
* Verified all tests in `k8s.io/kubectl/pkg/drain` pass.

## Risk

Low. Preserves existing eviction behavior while preventing infinite retry loops on rescheduled/recreated pods.

## Issue

Closes #138229
