### PR TITLE
EndpointSliceMirroring: Ignore NotFound Errors When Deleting EndpointSlices

### DIFF
--- a/pkg/controller/endpointslicemirroring/reconciler.go
+++ b/pkg/controller/endpointslicemirroring/reconciler.go
@@ -275,6 +275,9 @@ func (r *reconciler) finalize(ctx context.Context, endpoints *corev1.Endpoints, 
 	for _, endpointSlice := range slices.toDelete {
 		err := epsClient.Delete(ctx, endpointSlice.Name, metav1.DeleteOptions{})
 		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
 			return fmt.Errorf("failed to delete %s EndpointSlice for Endpoints %s/%s: %v", endpointSlice.Name, endpoints.Namespace, endpoints.Name, err)
 		}
 		r.endpointSliceTracker.ExpectDeletion(endpointSlice)
@@ -291,7 +294,7 @@ func (r *reconciler) deleteEndpoints(ctx context.Context, namespace, name string
 	var errs []error
 	for _, endpointSlice := range endpointSlices {
 		err := r.client.DiscoveryV1().EndpointSlices(namespace).Delete(ctx, endpointSlice.Name, metav1.DeleteOptions{})
-		if err != nil {
+		if err != nil && !errors.IsNotFound(err) {
 			errs = append(errs, err)
 		}
 	}

--- a/pkg/controller/endpointslicemirroring/reconciler_test.go
+++ b/pkg/controller/endpointslicemirroring/reconciler_test.go
@@ -1109,6 +1109,36 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+func TestFinalizeIgnoresNotFoundWhenDeletingEndpointSlice(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	r := newReconciler(tCtx, newClientset(), defaultMaxEndpointsPerSubset)
+	//nolint:staticcheck // EndpointSlice mirroring reconciles legacy Endpoints objects.
+	endpoints := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-ep", Namespace: "test"},
+	}
+	slices := slicesByAction{
+		toDelete: []*discovery.EndpointSlice{{
+			ObjectMeta: metav1.ObjectMeta{Name: "already-deleted", Namespace: endpoints.Namespace},
+		}},
+	}
+
+	if err := r.finalize(tCtx, endpoints, slices); err != nil {
+		t.Fatalf("Expected NotFound error to be ignored, got %v", err)
+	}
+}
+
+func TestDeleteEndpointsIgnoresNotFound(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	r := newReconciler(tCtx, newClientset(), defaultMaxEndpointsPerSubset)
+	endpointSlices := []*discovery.EndpointSlice{{
+		ObjectMeta: metav1.ObjectMeta{Name: "already-deleted", Namespace: "test"},
+	}}
+
+	if err := r.deleteEndpoints(tCtx, "test", "test-ep", endpointSlices); err != nil {
+		t.Fatalf("Expected NotFound error to be ignored, got %v", err)
+	}
+}
+
 // Test Helpers
 
 func newReconciler(ctx context.Context, client *fake.Clientset, maxEndpointsPerSubset int32) *reconciler {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
 
#### What this PR does / why we need it:

When `EndpointSliceMirroring` controller deletes an `EndpointSlice`, informer cache may lag behind API Server and still report an already-deleted EndpointSlice as existing. Previous logic incorrectly treated resulting `NotFound` response as deletion failure.

This could trigger up to 15 unnecessary retries and produce misleading error logs.

```
// pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go:59
MAX_RETRIES = 15
```

Optimization: Ignore `NotFound` errors and treat an already-absent EndpointSlice as successfully deleted.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
EndpointSliceMirroring: Ignore NotFound Errors When Deleting EndpointSlices
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
