### PR TITLE
kubelet: avoid unsafe Node Allocatable memory.max updates

### DIFF
--- a/pkg/kubelet/cm/node_container_manager_linux.go
+++ b/pkg/kubelet/cm/node_container_manager_linux.go
@@ -107,7 +107,7 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups(logger klog.Logger
 	if len(cm.cgroupRoot) > 0 {
 		go func() {
 			for {
-				err := cm.cgroupManager.Update(logger, cgroupConfig)
+				err := cm.updateNodeAllocatableCgroup(logger, cgroupConfig)
 				if err == nil {
 					cm.recorder.Event(nodeRef, v1.EventTypeNormal, events.SuccessfulNodeAllocatableEnforcement, "Updated Node Allocatable limit across pods")
 					return
@@ -158,6 +158,23 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups(logger klog.Logger
 		cm.recorder.Eventf(nodeRef, v1.EventTypeNormal, events.SuccessfulNodeAllocatableEnforcement, "Updated limits on kube reserved cgroup %v", nc.KubeReservedCgroupName)
 	}
 	return nil
+}
+
+// updateNodeAllocatableCgroup avoids lowering a cgroup v2 memory limit below
+// current usage. cgroup v2 may reclaim memory and invoke the memcg OOM killer
+// when memory.max is lowered below usage instead of rejecting the update.
+// The check is best-effort because usage may change before the cgroup update.
+func (cm *containerManagerImpl) updateNodeAllocatableCgroup(logger klog.Logger, config *CgroupConfig) error {
+	if cm.cgroupManager.Version() == 2 && config.ResourceParameters != nil && config.ResourceParameters.Memory != nil {
+		usage, err := cm.cgroupManager.MemoryUsage(config.Name)
+		if err != nil {
+			return fmt.Errorf("failed to read current Node Allocatable memory usage for cgroup %q: %w", config.Name, err)
+		}
+		if usage > *config.ResourceParameters.Memory {
+			return fmt.Errorf("current memory usage %d exceeds requested limit %d", usage, *config.ResourceParameters.Memory)
+		}
+	}
+	return cm.cgroupManager.Update(logger, config)
 }
 
 // enforceExistingCgroup updates the limits `rl` on existing cgroup `cName` using `cgroupManager` interface.

--- a/pkg/kubelet/cm/node_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/node_container_manager_linux_test.go
@@ -19,13 +19,53 @@ limitations under the License.
 package cm
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	ktesting "k8s.io/klog/v2/ktesting"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
 )
+
+func TestUpdateNodeAllocatableCgroup(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
+	limit := int64(100)
+	config := &CgroupConfig{
+		Name:               CgroupName{"kubepods"},
+		ResourceParameters: &ResourceConfig{Memory: &limit},
+	}
+
+	tests := []struct {
+		name       string
+		version    int
+		usage      int64
+		usageErr   error
+		wantUpdate bool
+		wantErr    bool
+	}{
+		{name: "v2 usage above limit", version: 2, usage: 101, wantErr: true},
+		{name: "v2 usage at limit", version: 2, usage: 100, wantUpdate: true},
+		{name: "v1 keeps existing update behavior", version: 1, usage: 101, wantUpdate: true},
+		{name: "usage read failure", version: 2, usageErr: errors.New("read failed"), wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := &fakeCgroupManager{version: tc.version, usage: tc.usage, usageErr: tc.usageErr}
+			cm := &containerManagerImpl{cgroupManager: manager}
+			err := cm.updateNodeAllocatableCgroup(logger, config)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.wantUpdate, len(manager.updates) == 1)
+		})
+	}
+}
 
 func TestNodeAllocatableReservationForScheduling(t *testing.T) {
 	memoryEvictionThreshold := resource.MustParse("100Mi")

--- a/pkg/kubelet/cm/qos_container_manager_linux_test.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux_test.go
@@ -455,9 +455,13 @@ func TestQoSContainerCgroupWithMemoryReservationPolicyNone(t *testing.T) {
 // CgroupManager. All methods are stubbed so that Start() can
 // complete successfully without using real cgroups.
 type fakeCgroupManager struct {
-	mutex   sync.Mutex
-	created []*CgroupConfig
-	updates []*CgroupConfig
+	mutex     sync.Mutex
+	created   []*CgroupConfig
+	updates   []*CgroupConfig
+	version   int
+	usage     int64
+	usageErr  error
+	updateErr error
 }
 
 // Update() is the observation point for this test.
@@ -468,7 +472,7 @@ func (f *fakeCgroupManager) Update(logger klog.Logger, config *CgroupConfig) err
 
 	copiedConfig := *config
 	f.updates = append(f.updates, &copiedConfig)
-	return nil
+	return f.updateErr
 }
 
 // Create() must succeed for Start() to construct QoS cgroups.
@@ -493,14 +497,19 @@ func (f *fakeCgroupManager) Pids(logger klog.Logger, name CgroupName) []int { re
 func (f *fakeCgroupManager) ReduceCPULimits(logger klog.Logger, cgroupName CgroupName) error {
 	return nil
 }
-func (f *fakeCgroupManager) MemoryUsage(name CgroupName) (int64, error) { return int64(0), nil }
+func (f *fakeCgroupManager) MemoryUsage(name CgroupName) (int64, error) { return f.usage, f.usageErr }
 func (f *fakeCgroupManager) GetCgroupConfig(name CgroupName, resource v1.ResourceName) (*ResourceConfig, error) {
 	return nil, nil
 }
 func (f *fakeCgroupManager) SetCgroupConfig(logger klog.Logger, name CgroupName, resourceConfig *ResourceConfig) error {
 	return nil
 }
-func (f *fakeCgroupManager) Version() int { return 1 }
+func (f *fakeCgroupManager) Version() int {
+	if f.version == 0 {
+		return 1
+	}
+	return f.version
+}
 
 // TestQOSCPUConfigUpdate verifies that UpdateCgroups() computes and
 // updates the correct CPU shares for each QoS class based on the


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node

#### What this PR does / why we need it:

On cgroup v2, lowering the Node Allocatable pod cgroup memory.max while memory.current is already above the target can trigger reclaim and memcg OOM before eviction completes. Check current usage before updating and defer the update when usage is too high or cannot be read, so the existing retry loop can try again later. cgroup v1 behavior is unchanged.

#### Which issue(s) this PR is related to:

Fixes #141609

#### Special notes for your reviewer:

The usage check is best effort because usage may change between the read and the cgroup update.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```