### PR TITLE
apiextensions-apiserver: use etcdOptionsCopy in NewCRDRESTOptionsGetter

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go
@@ -156,7 +156,7 @@ func NewCRDRESTOptionsGetter(etcdOptions genericoptions.EtcdOptions, resourceTra
 	etcdOptionsCopy.StorageConfig.StorageObjectCountTracker = tracker
 	etcdOptionsCopy.WatchCacheSizes = nil // this control is not provided for custom resources
 
-	return etcdOptions.CreateRESTOptionsGetter(&genericoptions.SimpleStorageFactory{StorageConfig: etcdOptionsCopy.StorageConfig}, resourceTransformers)
+	return etcdOptionsCopy.CreateRESTOptionsGetter(&genericoptions.SimpleStorageFactory{StorageConfig: etcdOptionsCopy.StorageConfig}, resourceTransformers)
 }
 
 type serviceResolver struct {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericregistry "k8s.io/apiserver/pkg/registry/generic"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
+	flowcontrolrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
+)
+
+func TestNewCRDRESTOptionsGetterWatchCacheSizes(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		enableWatchCache     bool
+		watchCacheSizes      []string
+		resource             schema.GroupResource
+		expectStorageCacher  bool
+		expectUndecorated    bool
+	}{
+		{
+			name:                "watch cache enabled, watch-cache-sizes has #0 for this CRD: should still use watch cache",
+			enableWatchCache:    true,
+			watchCacheSizes:     []string{"crontabs.stable.example.com#0"},
+			resource:            schema.GroupResource{Group: "stable.example.com", Resource: "crontabs"},
+			expectStorageCacher: true,
+			expectUndecorated:   false,
+		},
+		{
+			name:                "watch cache enabled, watch-cache-sizes has #0 for multiple CRDs: should still use watch cache",
+			enableWatchCache:    true,
+			watchCacheSizes:     []string{"crontabs.stable.example.com#0", "foos.custom.example.com#0"},
+			resource:            schema.GroupResource{Group: "custom.example.com", Resource: "foos"},
+			expectStorageCacher: true,
+			expectUndecorated:   false,
+		},
+		{
+			name:                "watch cache enabled, watch-cache-sizes is nil: should use watch cache",
+			enableWatchCache:    true,
+			watchCacheSizes:     nil,
+			resource:            schema.GroupResource{Group: "stable.example.com", Resource: "crontabs"},
+			expectStorageCacher: true,
+			expectUndecorated:   false,
+		},
+		{
+			name:                "watch cache disabled: should use undecorated storage",
+			enableWatchCache:    false,
+			watchCacheSizes:     []string{"crontabs.stable.example.com#0"},
+			resource:            schema.GroupResource{Group: "stable.example.com", Resource: "crontabs"},
+			expectStorageCacher: false,
+			expectUndecorated:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			etcdOptions := genericoptions.EtcdOptions{
+				StorageConfig: storagebackend.Config{
+					Type:   "etcd3",
+					Prefix: "/registry",
+					Transport: storagebackend.TransportConfig{
+						ServerList: []string{"http://127.0.0.1:2379"},
+					},
+					CompactionInterval:    storagebackend.DefaultCompactInterval,
+					CountMetricPollPeriod: time.Minute,
+				},
+				DefaultStorageMediaType: "application/json",
+				DeleteCollectionWorkers: 1,
+				EnableGarbageCollection: true,
+				EnableWatchCache:        tc.enableWatchCache,
+				WatchCacheSizes:         tc.watchCacheSizes,
+			}
+
+			getter := NewCRDRESTOptionsGetter(etcdOptions, nil, nil)
+			restOptions, err := getter.GetRESTOptions(tc.resource, nil)
+			if err != nil {
+				t.Fatalf("unexpected error from GetRESTOptions: %v", err)
+			}
+
+			isUndecorated := reflect.ValueOf(restOptions.Decorator).Pointer() == reflect.ValueOf(genericregistry.UndecoratedStorage).Pointer()
+			if tc.expectUndecorated && !isUndecorated {
+				t.Errorf("expected UndecoratedStorage decorator, got %v", restOptions.Decorator)
+			}
+			if tc.expectStorageCacher && isUndecorated {
+				t.Errorf("expected decorated StorageWithCacher decorator, but got UndecoratedStorage (watch cache was unexpectedly disabled by WatchCacheSizes)")
+			}
+		})
+	}
+}
+
+func TestNewCRDRESTOptionsGetterStorageObjectCountTracker(t *testing.T) {
+	tracker := flowcontrolrequest.NewStorageObjectCountTracker()
+	etcdOptions := genericoptions.EtcdOptions{
+		StorageConfig: storagebackend.Config{
+			Type:   "etcd3",
+			Prefix: "/registry",
+			Transport: storagebackend.TransportConfig{
+				ServerList: []string{"http://127.0.0.1:2379"},
+			},
+			CompactionInterval:    storagebackend.DefaultCompactInterval,
+			CountMetricPollPeriod: time.Minute,
+		},
+		DefaultStorageMediaType: "application/json",
+		EnableWatchCache:        true,
+	}
+
+	getter := NewCRDRESTOptionsGetter(etcdOptions, nil, tracker)
+	restOptions, err := getter.GetRESTOptions(schema.GroupResource{Group: "stable.example.com", Resource: "crontabs"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error from GetRESTOptions: %v", err)
+	}
+
+	if restOptions.StorageConfig.StorageObjectCountTracker != tracker {
+		t.Errorf("expected StorageConfig.StorageObjectCountTracker to match provided tracker, got %v", restOptions.StorageConfig.StorageObjectCountTracker)
+	}
+	if restOptions.StorageObjectCountTracker != tracker {
+		t.Errorf("expected restOptions.StorageObjectCountTracker to match provided tracker, got %v", restOptions.StorageObjectCountTracker)
+	}
+	if restOptions.StorageConfig.Codec == nil {
+		t.Errorf("expected StorageConfig.Codec to be configured, got nil")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

In `staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/options.go`, `NewCRDRESTOptionsGetter` prepares `etcdOptionsCopy` with custom resource storage codecs, count tracking (`StorageConfig.StorageObjectCountTracker`), and explicitly clears `WatchCacheSizes = nil` (as noted by the comment `// this control is not provided for custom resources`).

However, `NewCRDRESTOptionsGetter` was calling `etcdOptions.CreateRESTOptionsGetter(...)` on the original `etcdOptions` receiver rather than `etcdOptionsCopy`. Because `genericoptions.EtcdOptions` is a struct passed by value, `StorageFactoryRestOptionsFactory` retained the original `etcdOptions` containing `WatchCacheSizes` instead of the modified copy with `WatchCacheSizes` cleared.

This PR fixes `NewCRDRESTOptionsGetter` to call `CreateRESTOptionsGetter` on `etcdOptionsCopy` and adds unit test coverage for `NewCRDRESTOptionsGetter`.

#### Which issue(s) this PR is related to:

Fixes #141217

#### Special notes for your reviewer:

- Adds `options_test.go` covering `NewCRDRESTOptionsGetter` to verify that `WatchCacheSizes` does not disable watch caching on custom resources and that storage object count tracking is preserved.
- Package tests verified locally via `go test -v ./staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/options/...`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where the `--watch-cache-sizes` command line option was unintentionally applied to CustomResourceDefinitions in `apiextensions-apiserver`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES - An AI assistant was used to help locate the dead assignment, draft the fix, and create the unit test cases in `options_test.go`. All tests were run locally and the human author has reviewed and is responsible for all submitted changes in accordance with CONTRIBUTING.md.
