### PR TITLE
kubectl: handle equal missing sort values

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
@@ -315,10 +315,15 @@ func (r *RuntimeSort) Less(i, j int) bool {
 		klog.Fatalf("Failed to get j values for %#v using %s (%v)", jObj, r.field, err)
 	}
 
-	if len(iValues) == 0 || len(iValues[0]) == 0 {
+	iMissing := len(iValues) == 0 || len(iValues[0]) == 0
+	jMissing := len(jValues) == 0 || len(jValues[0]) == 0
+	if iMissing && jMissing {
+		return false
+	}
+	if iMissing {
 		return true
 	}
-	if len(jValues) == 0 || len(jValues[0]) == 0 {
+	if jMissing {
 		return false
 	}
 	iField := iValues[0][0]
@@ -360,10 +365,15 @@ func (t *TableSorter) Less(i, j int) bool {
 	iValues := t.parsedRows[i]
 	jValues := t.parsedRows[j]
 
-	if len(iValues) == 0 || len(iValues[0]) == 0 {
+	iMissing := len(iValues) == 0 || len(iValues[0]) == 0
+	jMissing := len(jValues) == 0 || len(jValues[0]) == 0
+	if iMissing && jMissing {
+		return false
+	}
+	if iMissing {
 		return true
 	}
-	if len(jValues) == 0 || len(jValues[0]) == 0 {
+	if jMissing {
 		return false
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter.go
@@ -317,6 +317,7 @@ func (r *RuntimeSort) Less(i, j int) bool {
 
 	iMissing := len(iValues) == 0 || len(iValues[0]) == 0
 	jMissing := len(jValues) == 0 || len(jValues[0]) == 0
+	// Two missing values are equal; returning true would violate sort.Interface.
 	if iMissing && jMissing {
 		return false
 	}
@@ -367,6 +368,7 @@ func (t *TableSorter) Less(i, j int) bool {
 
 	iMissing := len(iValues) == 0 || len(iValues[0]) == 0
 	jMissing := len(jValues) == 0 || len(jValues[0]) == 0
+	// Two missing values are equal; returning true would violate sort.Interface.
 	if iMissing && jMissing {
 		return false
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/sorter_test.go
@@ -823,3 +823,29 @@ func TestRuntimeSortLess(t *testing.T) {
 		})
 	}
 }
+
+func TestSortersTreatTwoMissingFieldValuesAsEqual(t *testing.T) {
+	objects := []runtime.Object{
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "first"}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "second"}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "labeled", Labels: map[string]string{"example": "value"}}},
+	}
+	field := "{.metadata.labels.example}"
+
+	runtimeSorter := NewRuntimeSort(field, objects)
+	if runtimeSorter.Less(0, 1) || runtimeSorter.Less(1, 0) {
+		t.Fatalf("RuntimeSort must treat two missing field values as equal")
+	}
+
+	table := &metav1.Table{}
+	for _, object := range objects {
+		table.Rows = append(table.Rows, metav1.TableRow{Object: runtime.RawExtension{Object: object}})
+	}
+	tableSorter, err := NewTableSorter(table, field)
+	if err != nil {
+		t.Fatalf("NewTableSorter() unexpected error: %v", err)
+	}
+	if tableSorter.Less(0, 1) || tableSorter.Less(1, 0) {
+		t.Fatalf("TableSorter must treat two missing field values as equal")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig cli

#### What this PR does / why we need it:

Makes the kubectl runtime and table sorters treat two missing JSONPath field values as equal. Previously both `Less(i, j)` and `Less(j, i)` returned true when both objects lacked the selected field, violating the `sort.Interface` contract and allowing inconsistent ordering.

Adds focused regression coverage for both sorting paths.

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubectl#1875

#### Special notes for your reviewer:

The focused regression test was confirmed to fail before the production change and pass afterward.

Tests run:

```text
go test ./staging/src/k8s.io/kubectl/pkg/cmd/get -count=1
go vet ./staging/src/k8s.io/kubectl/pkg/cmd/get
git diff --check
```

#### Does this PR introduce a user-facing change?

```release-note
kubectl get --sort-by now treats resources that both lack the selected sort field as equal.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs
NONE
```

#### AI usage disclosure:

YES. Generative AI assisted with issue discovery, drafting the focused regression test and implementation, and running verification. The human author is responsible for reviewing, understanding, and validating all submitted changes.