### PR TITLE
persistentvolume: compare storage sizes with Quantity.Cmp

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -261,7 +261,6 @@ func (ctrl *PersistentVolumeController) syncClaim(ctx context.Context, claim *v1
 // checkVolumeSatisfyClaim checks if the volume requested by the claim satisfies the requirements of the claim
 func checkVolumeSatisfyClaim(volume *v1.PersistentVolume, claim *v1.PersistentVolumeClaim) error {
 	requestedQty := claim.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
-	requestedSize := requestedQty.Value()
 
 	// check if PV's DeletionTimeStamp is set, if so, return error.
 	if volume.ObjectMeta.DeletionTimestamp != nil {
@@ -269,8 +268,8 @@ func checkVolumeSatisfyClaim(volume *v1.PersistentVolume, claim *v1.PersistentVo
 	}
 
 	volumeQty := volume.Spec.Capacity[v1.ResourceStorage]
-	volumeSize := volumeQty.Value()
-	if volumeSize < requestedSize {
+	// Cmp rather than Value(): a size past int64 overflows and misorders the comparison.
+	if volumeQty.Cmp(requestedQty) < 0 {
 		return fmt.Errorf("requested PV is too small")
 	}
 

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
@@ -854,4 +855,47 @@ func TestAssumeOwnWrites(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotContains(t, cached.Annotations, volume.AnnSelectedNode)
 	})
+}
+
+// The size check has to order capacities and requests that do not fit in int64,
+// where Value() wraps to a negative number or to zero and compares them wrongly.
+func TestCheckVolumeSatisfyClaim(t *testing.T) {
+	tests := []struct {
+		name         string
+		pvCapacity   string
+		claimRequest string
+		wantTooSmall bool
+	}{
+		{name: "capacity-past-int64-small-request", pvCapacity: "9223372036854775808", claimRequest: "1Gi", wantTooSmall: false},
+		{name: "small-capacity-request-past-int64", pvCapacity: "1Gi", claimRequest: "9223372036854775808", wantTooSmall: true},
+		{name: "capacity-wraps-to-zero-small-request", pvCapacity: "18446744073709551616", claimRequest: "1Gi", wantTooSmall: false},
+		{name: "small-capacity-request-wraps-to-zero", pvCapacity: "1Gi", claimRequest: "18446744073709551616", wantTooSmall: true},
+		{name: "capacity-at-int64-max-request-one-larger", pvCapacity: "9223372036854775807", claimRequest: "9223372036854775808", wantTooSmall: true},
+		{name: "both-past-int64-capacity-smaller", pvCapacity: "9223372036854775808", claimRequest: "18446744073709551616", wantTooSmall: true},
+		{name: "both-past-int64-equal", pvCapacity: "9223372036854775808", claimRequest: "9223372036854775808", wantTooSmall: false},
+		{name: "ordinary-capacity-larger-than-request", pvCapacity: "10Gi", claimRequest: "1Gi", wantTooSmall: false},
+		{name: "ordinary-capacity-smaller-than-request", pvCapacity: "1Gi", claimRequest: "10Gi", wantTooSmall: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			volume := &v1.PersistentVolume{
+				Spec: v1.PersistentVolumeSpec{
+					Capacity: v1.ResourceList{v1.ResourceStorage: resource.MustParse(tc.pvCapacity)},
+				},
+			}
+			claim := &v1.PersistentVolumeClaim{
+				Spec: v1.PersistentVolumeClaimSpec{
+					Resources: v1.VolumeResourceRequirements{
+						Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse(tc.claimRequest)},
+					},
+				},
+			}
+			err := checkVolumeSatisfyClaim(volume, claim)
+			if tc.wantTooSmall {
+				require.EqualError(t, err, "requested PV is too small")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig storage

#### What this PR does / why we need it:

`checkVolumeSatisfyClaim` compares a PV's capacity against a claim's request with `Quantity.Value()`, which projects the quantity onto int64. A storage quantity can be larger than int64, and `Value()` overflows once it is, so the comparison can order two such quantities wrongly. This is the check that runs when a PVC names a specific PV through `spec.volumeName`.

The automatic path does not have this problem. `FindMatchingVolume` compares the same capacity and request with `Quantity.Cmp` in `pv_helpers.go`, and its tests already pass quantities like `800E` that sit far outside int64. This PR makes the explicit-binding check use `Cmp` the same way.

**What goes wrong today**

`Value()` fails in two different ways depending on the size. A capacity of `9223372036854775808` (2^63) reads back as a negative number, so a `1Gi` claim naming it is rejected with `requested PV is too small` and stays Pending even though the volume is far larger. A capacity of `18446744073709551616` (2^64) reads back as zero, which produces the same wrong rejection by a different route.

The reverse direction is worse: a request past int64 wraps the same way, so `volumeSize < requestedSize` is false and a PV smaller than the request passes the size check.

The boundary is one unit wide. A capacity of `MaxInt64` against a request of `MaxInt64 + 1` compares as `9223372036854775807 < -9223372036854775808`, which is false, so the undersized volume is accepted.

Neither value is something a normal cluster produces, but both are reachable. #141169 changed `validateBasicResource` to accept a PV capacity of 2^63, and the automatic path already treats these quantities as valid, so the two binding paths should not disagree about them.

#### Which issue(s) this PR is related to:

Fixes #141617

#### Special notes for your reviewer:

**Testing**

`TestCheckVolumeSatisfyClaim` covers both wrap modes in both directions, along with the boundary itself. Reverting the production change turns five rows red:

```
--- FAIL: TestCheckVolumeSatisfyClaim/capacity-past-int64-small-request
--- FAIL: TestCheckVolumeSatisfyClaim/small-capacity-request-past-int64
--- FAIL: TestCheckVolumeSatisfyClaim/capacity-wraps-to-zero-small-request
--- FAIL: TestCheckVolumeSatisfyClaim/small-capacity-request-wraps-to-zero
--- FAIL: TestCheckVolumeSatisfyClaim/capacity-at-int64-max-request-one-larger
```

The four remaining rows hold ordinary sizes and two quantities that both sit past int64. They pass either way and are there to keep the ordinary path covered. The rest of `pkg/controller/volume/persistentvolume` passes unchanged, `go vet` is clean, and `hack/verify-golangci-lint.sh -n` reports nothing.

**Scope**

This is one caller from the Quantity int64 overflow burndown in #141166. The comparison is an ordering test, so it needs `Cmp`; a checked or saturating accessor would still collapse two distinct large quantities onto the same value. With this change there is no `Value()` or `MilliValue()` left in `pkg/controller/volume/persistentvolume` outside tests. #140721 is refactoring `checkVolumeSatisfyClaim` in parallel, so this change stays limited to the size comparison to keep the overlap small.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where binding a PersistentVolumeClaim to a PersistentVolume by name could misjudge whether the volume was large enough when the capacity or the request was larger than a 64-bit integer.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. AI-assisted tools were used during implementation, test planning, and review; I reviewed and validated the final change.
