### PR TITLE
Fix(kubelet) dra reprepare on cdi failure

### DIFF
--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -145,6 +145,12 @@ type ContainerManager interface {
 	// UnprepareDynamicResources unprepares dynamic pod resources
 	UnprepareDynamicResources(context.Context, *v1.Pod) error
 
+	// InvalidatePreparedDynamicResources clears the prepared state for a pod's
+	// DRA claims so that the next PrepareDynamicResources call re-invokes the
+	// driver. Use when container creation fails due to CDI device resolution
+	// errors after a node or runtime restart.
+	InvalidatePreparedDynamicResources(*v1.Pod)
+
 	// PodMightNeedToUnprepareResources returns true if the pod with the given UID
 	// might need to unprepare resources.
 	PodMightNeedToUnprepareResources(UID types.UID) bool

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -1141,6 +1141,10 @@ func (cm *containerManagerImpl) UnprepareDynamicResources(ctx context.Context, p
 	return cm.draManager.UnprepareResources(ctx, pod)
 }
 
+func (cm *containerManagerImpl) InvalidatePreparedDynamicResources(pod *v1.Pod) {
+	cm.draManager.InvalidatePreparedResources(pod)
+}
+
 func (cm *containerManagerImpl) PodMightNeedToUnprepareResources(UID types.UID) bool {
 	return cm.draManager.PodMightNeedToUnprepareResources(UID)
 }

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -197,6 +197,9 @@ func (cm *containerManagerStub) UnprepareDynamicResources(_ context.Context, _ *
 	return nil
 }
 
+func (cm *containerManagerStub) InvalidatePreparedDynamicResources(pod *v1.Pod) {
+}
+
 func (cm *containerManagerStub) PodMightNeedToUnprepareResources(_ types.UID) bool {
 	return false
 }

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -388,6 +388,9 @@ func (cm *containerManagerImpl) UnprepareDynamicResources(ctx context.Context, p
 	return nil
 }
 
+func (cm *containerManagerImpl) InvalidatePreparedDynamicResources(pod *v1.Pod) {
+}
+
 func (cm *containerManagerImpl) PodMightNeedToUnprepareResources(UID types.UID) bool {
 	return false
 }

--- a/pkg/kubelet/cm/dra/claiminfo.go
+++ b/pkg/kubelet/cm/dra/claiminfo.go
@@ -194,6 +194,15 @@ func (info *ClaimInfo) setPrepared() {
 	info.prepared = true
 }
 
+// clearPrepared resets the prepared state so that the next
+// PrepareResources call will re-invoke NodePrepareResources.
+// This is used when container creation fails due to CDI device
+// resolution errors, indicating that the preparation result
+// (e.g., CDI spec files) may be stale or missing.
+func (info *ClaimInfo) clearPrepared() {
+	info.prepared = false
+}
+
 // isPrepared checks if claim info is prepared or not.
 func (info *ClaimInfo) isPrepared() bool {
 	return info.prepared

--- a/pkg/kubelet/cm/dra/manager.go
+++ b/pkg/kubelet/cm/dra/manager.go
@@ -602,6 +602,38 @@ func (m *Manager) GetResources(pod *v1.Pod, container *v1.Container) (*Container
 	return &ContainerInfo{CDIDevices: cdiDevices}, nil
 }
 
+// InvalidatePreparedResources clears the prepared state for all claims
+// referenced by the given pod. This causes the next PrepareResources call
+// to re-invoke NodePrepareResources on the DRA driver, giving the driver
+// a chance to re-establish any artifacts (e.g., CDI spec files) that may
+// have been lost during a node or runtime restart.
+//
+// This should be called when container creation fails due to CDI device
+// resolution errors, which indicates that the driver's preparation result
+// is no longer valid even though the kubelet believes it was prepared.
+func (m *Manager) InvalidatePreparedResources(pod *v1.Pod) {
+	logger := klog.Background().WithName("dra-manager")
+	m.cache.withLock(logger, func() error {
+		for i := range pod.Spec.ResourceClaims {
+			podClaim := &pod.Spec.ResourceClaims[i]
+			claimName, _, err := resourceclaim.Name(pod, podClaim)
+			if err != nil || claimName == nil {
+				continue
+			}
+			claimInfo, exists := m.cache.get(*claimName, pod.Namespace)
+			if !exists {
+				continue
+			}
+			if claimInfo.isPrepared() && !claimInfo.isUnpreparing() {
+				claimInfo.clearPrepared()
+				logger.V(3).Info("Invalidated prepared state for claim due to CDI failure",
+					"pod", klog.KObj(pod), "claim", *claimName)
+			}
+		}
+		return nil
+	})
+}
+
 // UnprepareResources calls a driver's NodeUnprepareResource API for each resource claim owned by a pod.
 // This function is idempotent and may be called multiple times against the same pod.
 // As such, calls to the underlying NodeUnprepareResource API are skipped for claims that have

--- a/pkg/kubelet/cm/dra/manager_test.go
+++ b/pkg/kubelet/cm/dra/manager_test.go
@@ -3261,3 +3261,117 @@ func TestPrepareUnprepareResourcesSkipNodeOperations(t *testing.T) {
 		})
 	})
 }
+
+// TestInvalidatePreparedResources verifies that InvalidatePreparedResources
+// clears the prepared state of a pod's DRA claims so that the next
+// PrepareResources call re-invokes NodePrepareResources on the driver.
+//
+// This is a regression test for https://github.com/kubernetes/kubernetes/issues/141433
+// where a pod using DRA got permanently stuck in CreateContainerError after a
+// node reboot because kubelet never re-prepared claims whose CDI spec files
+// were lost.
+func TestInvalidatePreparedResources(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	fakeKubeClient := fake.NewSimpleClientset()
+
+	draManager, err := NewManager(tCtx.Logger(), fakeKubeClient, t.TempDir())
+	require.NoError(t, err)
+	defer draManager.Stop()
+
+	claimInfo := genTestClaimInfo(claimUID, []string{podUID}, true /* prepared */, nil)
+	draManager.cache.add(claimInfo)
+
+	info, exists := draManager.cache.get(claimName, namespace)
+	require.True(t, exists, "claim should exist in cache")
+	assert.True(t, info.isPrepared(), "claim should be prepared initially")
+
+	pod := genTestPod()
+
+	draManager.InvalidatePreparedResources(pod)
+
+	// Verify the claim is no longer prepared.
+	info, exists = draManager.cache.get(claimName, namespace)
+	require.True(t, exists, "claim should still exist in cache after invalidation")
+	assert.False(t, info.isPrepared(), "claim should NOT be prepared after InvalidatePreparedResources")
+}
+
+// TestInvalidatePreparedResourcesSkipsUnpreparing verifies that
+// InvalidatePreparedResources does not interfere with claims that are
+// currently being unprepared (to avoid race conditions).
+func TestInvalidatePreparedResourcesSkipsUnpreparing(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	fakeKubeClient := fake.NewSimpleClientset()
+
+	draManager, err := NewManager(tCtx.Logger(), fakeKubeClient, t.TempDir())
+	require.NoError(t, err)
+	defer draManager.Stop()
+
+	// Pre-populate the cache with a prepared + unpreparing claim.
+	claimInfo := genTestClaimInfo(claimUID, []string{podUID}, true /* prepared */, nil)
+	claimInfo.setUnpreparing()
+	draManager.cache.add(claimInfo)
+
+	pod := genTestPod()
+
+	// Call InvalidatePreparedResources — should not clear prepared state
+	// because the claim is being torn down.
+	draManager.InvalidatePreparedResources(pod)
+
+	// Verify claim is still marked as prepared (untouched).
+	info, exists := draManager.cache.get(claimName, namespace)
+	require.True(t, exists)
+	assert.True(t, info.isPrepared(), "claim being unprepared should not have its prepared state cleared")
+}
+
+// TestInvalidatePreparedResourcesTriggersReprepare is an integration-style
+// test verifying that after InvalidatePreparedResources, calling
+// PrepareResources actually invokes NodePrepareResources on the driver
+// (instead of skipping due to the cached prepared state).
+func TestInvalidatePreparedResourcesTriggersReprepare(t *testing.T) {
+	logger, tCtx := ktesting.NewTestContext(t)
+	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DynamicResourceAllocation, true)
+
+	fakeKubeClient := fake.NewClientset()
+	pod := genTestPod()
+	claim := genTestClaim(claimName, driverName, deviceName, podUID)
+	_, err := fakeKubeClient.ResourceV1().ResourceClaims(namespace).Create(tCtx, claim, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	resp := genPrepareResourcesResponse(claimUID)
+	draServerInfo, err := setupFakeDRADriverGRPCServer(tCtx, false, nil, resp, nil, nil)
+	require.NoError(t, err)
+	defer draServerInfo.teardownFn()
+
+	draManager, err := NewManager(logger, fakeKubeClient, t.TempDir())
+	require.NoError(t, err)
+	defer draManager.Stop()
+	draManager.initDRAPluginManager(tCtx, getFakeNode, time.Second)
+
+	plg := draManager.GetWatcherHandler()
+	require.NoError(t, plg.RegisterPlugin(tCtx, driverName, draServerInfo.socketName, []string{drapb.DRAPluginService}, nil))
+
+	// First prepare: should call the driver.
+	err = draManager.PrepareResources(tCtx, pod)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), draServerInfo.server.prepareResourceCalls.Load(),
+		"first PrepareResources should invoke NodePrepareResources")
+
+	info, exists := draManager.cache.get(claimName, namespace)
+	require.True(t, exists)
+	assert.True(t, info.isPrepared())
+
+	// Second prepare without invalidation: should skip (already prepared).
+	err = draManager.PrepareResources(tCtx, pod)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), draServerInfo.server.prepareResourceCalls.Load(),
+		"second PrepareResources should skip because claim is already prepared")
+
+	draManager.InvalidatePreparedResources(pod)
+	assert.False(t, info.isPrepared(), "claim should not be prepared after invalidation")
+
+	// Third prepare after invalidation: should call the driver again.
+	err = draManager.PrepareResources(tCtx, pod)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), draServerInfo.server.prepareResourceCalls.Load(),
+		"PrepareResources after invalidation should re-invoke NodePrepareResources")
+}

--- a/pkg/kubelet/cm/fake_container_manager.go
+++ b/pkg/kubelet/cm/fake_container_manager.go
@@ -291,6 +291,9 @@ func (cm *FakeContainerManager) UnprepareDynamicResources(context.Context, *v1.P
 	return nil
 }
 
+func (cm *FakeContainerManager) InvalidatePreparedDynamicResources(pod *v1.Pod) {
+}
+
 func (cm *FakeContainerManager) PodMightNeedToUnprepareResources(_ types.UID) bool {
 	return false
 }

--- a/pkg/kubelet/cm/testing/mocks.go
+++ b/pkg/kubelet/cm/testing/mocks.go
@@ -1810,6 +1810,39 @@ func (_c *MockContainerManager_UnprepareDynamicResources_Call) RunAndReturn(run 
 	return _c
 }
 
+// InvalidatePreparedDynamicResources provides a mock function for the type MockContainerManager
+func (_mock *MockContainerManager) InvalidatePreparedDynamicResources(pod *v1.Pod) {
+	_mock.Called(pod)
+}
+
+// MockContainerManager_InvalidatePreparedDynamicResources_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'InvalidatePreparedDynamicResources'
+type MockContainerManager_InvalidatePreparedDynamicResources_Call struct {
+	*mock.Call
+}
+
+// InvalidatePreparedDynamicResources is a helper method to define mock.On call
+//   - pod *v1.Pod
+func (_e *MockContainerManager_Expecter) InvalidatePreparedDynamicResources(pod interface{}) *MockContainerManager_InvalidatePreparedDynamicResources_Call {
+	return &MockContainerManager_InvalidatePreparedDynamicResources_Call{Call: _e.mock.On("InvalidatePreparedDynamicResources", pod)}
+}
+
+func (_c *MockContainerManager_InvalidatePreparedDynamicResources_Call) Run(run func(pod *v1.Pod)) *MockContainerManager_InvalidatePreparedDynamicResources_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*v1.Pod))
+	})
+	return _c
+}
+
+func (_c *MockContainerManager_InvalidatePreparedDynamicResources_Call) Return() *MockContainerManager_InvalidatePreparedDynamicResources_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockContainerManager_InvalidatePreparedDynamicResources_Call) RunAndReturn(run func(pod *v1.Pod)) *MockContainerManager_InvalidatePreparedDynamicResources_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateAllocatedDevices provides a mock function for the type MockContainerManager
 func (_mock *MockContainerManager) UpdateAllocatedDevices(logger klog.Logger) {
 	_mock.Called(logger)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -1842,6 +1842,18 @@ func (m *kubeGenericRuntimeManager) SyncPod(ctx context.Context, pod *v1.Pod, po
 				metrics.StartedHostProcessContainersErrorsTotal.WithLabelValues(metricLabel, err.Error()).Inc()
 			}
 			startContainerResult.Fail(err, msg)
+
+			// If container creation failed due to CDI device resolution errors,
+			// invalidate the DRA prepared state so the next syncPod re-prepares
+			// the claims and offer the CDI driver a chance to re-establish CDI spec files.
+			if errors.Is(err, ErrCreateContainer) && isCDIResolutionError(msg) {
+				if utilfeature.DefaultFeatureGate.Enabled(features.DynamicResourceAllocation) {
+					m.containerManager.InvalidatePreparedDynamicResources(pod)
+					logger.V(2).Info("Invalidated DRA prepared state due to CDI resolution failure",
+						"pod", klog.KObj(pod), "container", spec.container.Name, "message", msg)
+				}
+			}
+
 			// known errors that are logged in other places are logged at higher levels here to avoid
 			// repetitive log spam
 			switch {
@@ -2463,4 +2475,19 @@ func isResizableContainer(container *v1.Container, containerType podutil.Contain
 	default:
 		return false
 	}
+}
+
+// isCDIResolutionError returns true if the error message from container
+// creation indicates a CDI device resolution failure. This typically happens
+// when CDI spec files are missing or stale after a node/runtime restart,
+// even though the DRA driver reported successful preparation.
+//
+// These strings originate from the CNCF CDI library (cache.go:InjectDevices).
+// If the library changes these messages, this detection gracefully degrades
+// to the pre-fix behavior (no automatic re-preparation). These error strings
+// have remained stable since the CDI library was created in 2021.
+func isCDIResolutionError(msg string) bool {
+	// containerd and CRI-O both report CDI failures with these patterns.
+	return strings.Contains(msg, "unresolvable CDI devices") ||
+		strings.Contains(msg, "CDI device injection failed")
 }

--- a/test/e2e/dra/test-driver/app/kubeletplugin.go
+++ b/test/e2e/dra/test-driver/app/kubeletplugin.go
@@ -347,7 +347,15 @@ func (ex *ExamplePlugin) nodePrepareResource(ctx context.Context, claim *resourc
 
 	claimID := ClaimID{Name: claim.Name, UID: claim.UID}
 	if result, ok := ex.prepared[claimID]; ok {
-		// Idempotent call, nothing to do.
+		// Idempotent call: re-write CDI spec files to ensure they exist
+		// on disk (they may have been lost during a node/runtime restart),
+		// then return the cached result.
+		if err := ex.ensureCDISpecFiles(claim); err != nil {
+			logger.Error(err, "Failed to re-establish CDI spec files for already-prepared claim", "claim", claim.Name)
+			// Remove from prepared map so next call does full preparation.
+			delete(ex.prepared, claimID)
+			return nil, err
+		}
 		return result, nil
 	}
 
@@ -380,11 +388,6 @@ func (ex *ExamplePlugin) nodePrepareResource(ctx context.Context, claim *resourc
 		claimReqName = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString(claimReqName, "_")
 		env[claimReqName] = "true"
 
-		deviceName := "claim-" + string(claim.UID) + "-" + baseRequestName
-		vendor := ex.driverName
-		class := "test"
-		cdiDeviceID := vendor + "/" + class + "=" + deviceName
-
 		// CDI wants env variables as set of strings.
 		envs := []string{}
 		for key, val := range env {
@@ -401,29 +404,9 @@ func (ex *ExamplePlugin) nodePrepareResource(ctx context.Context, claim *resourc
 			continue
 		}
 
-		spec := &cdi.Spec{
-			Kind: vendor + "/" + class,
-			Devices: []cdi.Device{
-				{
-					Name: deviceName,
-					ContainerEdits: cdi.ContainerEdits{
-						Env: envs,
-					},
-				},
-			},
-		}
-		minVersion, err := cdi.MinimumRequiredVersion(spec)
+		cdiDeviceID, err := ex.writeCDISpecFile(claim.UID, baseRequestName, envs)
 		if err != nil {
-			return nil, fmt.Errorf("determine CDI spec version: %w", err)
-		}
-		spec.Version = minVersion
-		filePath := ex.getJSONFilePath(claim.UID, baseRequestName)
-		buffer, err := json.Marshal(spec)
-		if err != nil {
-			return nil, fmt.Errorf("marshal spec: %w", err)
-		}
-		if err := ex.fileOps.Create(filePath, buffer); err != nil {
-			return nil, fmt.Errorf("failed to write CDI file: %w", err)
+			return nil, err
 		}
 		device := kubeletplugin.Device{
 			PoolName:     result.Pool,
@@ -464,6 +447,85 @@ func extractParameters(parameters runtime.RawExtension, env *map[string]string, 
 	}
 	for key, value := range data {
 		(*env)[kind+"_"+key] = value
+	}
+	return nil
+}
+
+// writeCDISpecFile builds a CDI spec from the given environment variables and
+// writes it to the appropriate JSON file. This is the shared implementation
+// used by both the initial preparation path and the idempotent re-write path.
+func (ex *ExamplePlugin) writeCDISpecFile(claimUID types.UID, baseRequestName string, envs []string) (string, error) {
+	deviceName := "claim-" + string(claimUID) + "-" + baseRequestName
+	vendor := ex.driverName
+	class := "test"
+
+	spec := &cdi.Spec{
+		Kind: vendor + "/" + class,
+		Devices: []cdi.Device{
+			{
+				Name: deviceName,
+				ContainerEdits: cdi.ContainerEdits{
+					Env: envs,
+				},
+			},
+		},
+	}
+	minVersion, err := cdi.MinimumRequiredVersion(spec)
+	if err != nil {
+		return "", fmt.Errorf("determine CDI spec version: %w", err)
+	}
+	spec.Version = minVersion
+	filePath := ex.getJSONFilePath(claimUID, baseRequestName)
+	buffer, err := json.Marshal(spec)
+	if err != nil {
+		return "", fmt.Errorf("marshal spec: %w", err)
+	}
+	if err := ex.fileOps.Create(filePath, buffer); err != nil {
+		return "", fmt.Errorf("failed to write CDI file: %w", err)
+	}
+
+	cdiDeviceID := vendor + "/" + class + "=" + deviceName
+	return cdiDeviceID, nil
+}
+
+// ensureCDISpecFiles re-creates the CDI spec files for an already-prepared claim.
+// This handles the case where CDI spec files were lost during a node or runtime
+// restart, but the driver still considers the claim prepared (idempotent replay).
+func (ex *ExamplePlugin) ensureCDISpecFiles(claim *resourceapi.ResourceClaim) error {
+	for _, result := range claim.Status.Allocation.Devices.Results {
+		if ex.driverName != result.Driver {
+			continue
+		}
+
+		baseRequestName := resourceclaim.BaseRequestRef(result.Request)
+		configs := resourceclaim.ConfigForResult(claim.Status.Allocation.Devices.Config, result)
+		env := make(map[string]string)
+		for i, config := range configs {
+			if config.Opaque.Driver != ex.driverName {
+				continue
+			}
+			if err := extractParameters(config.Opaque.Parameters, &env, config.Source == resourceapi.AllocationConfigSourceClass); err != nil {
+				return fmt.Errorf("parameters in config #%d: %w", i, err)
+			}
+		}
+
+		claimReqName := "claim_" + claim.Name + "_" + baseRequestName
+		claimReqName = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString(claimReqName, "_")
+		env[claimReqName] = "true"
+
+		envs := []string{}
+		for key, val := range env {
+			envs = append(envs, key+"="+val)
+		}
+		sort.Strings(envs)
+
+		if len(envs) == 0 {
+			continue
+		}
+
+		if _, err := ex.writeCDISpecFile(claim.UID, baseRequestName, envs); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
check issue #141433, during dra resource preparation stage, kubelet call the dra driver interface  NodePrepareResources() and mark claim as "prepared" permanently (state stored on the disk). when node restarted, cdi device file may lost. as a result, kubelet will runs in permanent failure status

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
Fixes #141433

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

Fixed bug #141433 where pods using DRA claims would permanently fail with CreateContainerError after a node restart when CDI device spec files were lost. 
Main reason: 
- kubelet's checkpoint mechanism skips CDI spec file validation after restart
- kubelet did not parse CDI spec resolution errors raised by the container runtime, preventing recovery. 
The kubelet now detects CDI resolution failures and re-invokes NodePrepareResources to give DRA driver a chance to recreate missing CDI spec files.

```
No
#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
