### PR TITLE
fix(kubectl): fix --sum column alignment when --show-swap is set

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -262,13 +262,15 @@ func printSingleMissingResource(out io.Writer) {
 }
 
 func (printer *TopCmdPrinter) printPodResourcesSum(out io.Writer, total v1.ResourceList, columnWidth int, measuredResources []v1.ResourceName) {
-	for i := 0; i < columnWidth-2; i++ {
+	nameColumns := columnWidth - len(measuredResources)
+	for range nameColumns {
 		printValue(out, "")
 	}
-	printValue(out, "________")
-	printValue(out, "________")
+	for range measuredResources {
+		printValue(out, "________")
+	}
 	fmt.Fprintf(out, "\n")
-	for i := 0; i < columnWidth-3; i++ {
+	for i := 0; i < nameColumns-1; i++ {
 		printValue(out, "")
 	}
 	printer.printMetricsLine(out, &ResourceMetricsInfo{

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer_test.go
@@ -148,6 +148,7 @@ func TestPrintPodMetrics(t *testing.T) {
 		noHeader        bool
 		sortBy          string
 		sum             bool
+		showSwap        bool
 		expectedErr     error
 		expectedOutput  string
 	}{
@@ -519,6 +520,87 @@ ns-2   test-1   200m       2048Mi
                            200m       1024Mi     
 `,
 		},
+		{
+			name: "Multiple Pods - Sum with Swap",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+								ResourceSwap:      resource.MustParse("512Mi"),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-1",
+						Namespace: "default",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("2Gi"),
+								ResourceSwap:      resource.MustParse("256Mi"),
+							},
+						},
+					},
+				},
+			},
+			sum:      true,
+			showSwap: true,
+			expectedOutput: `NAME     CPU(cores)   MEMORY(bytes)   SWAP(bytes)   
+test     200m         1024Mi          512Mi         
+test-1   200m         2048Mi          256Mi         
+         ________     ________        ________      
+         400m         3072Mi          768Mi         
+`,
+		},
+		{
+			name: "Multiple Pods - Sum with Swap, Namespace and Containers",
+			podMetric: []metricsapi.PodMetrics{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "ns-1",
+					},
+					Timestamp: metav1.Time{Time: time.Now()},
+					Window:    metav1.Duration{Duration: time.Minute},
+					Containers: []metricsapi.ContainerMetrics{
+						{
+							Name: "container1",
+							Usage: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("0.2"),
+								v1.ResourceMemory: resource.MustParse("1Gi"),
+								ResourceSwap:      resource.MustParse("512Mi"),
+							},
+						},
+					},
+				},
+			},
+			withNamespace:   true,
+			printContainers: true,
+			noHeader:        true,
+			sum:             true,
+			showSwap:        true,
+			expectedOutput: `ns-1   test   container1   200m       1024Mi     512Mi      
+                           ________   ________   ________   
+                           200m       1024Mi     512Mi      
+`,
+		},
 	}
 
 	for _, test := range tests {
@@ -526,7 +608,7 @@ ns-2   test-1   200m       2048Mi
 			// Create a new TopCmdPrinter with a test writer.
 			_, _, out, _ := genericiooptions.NewTestIOStreams()
 
-			top := NewTopCmdPrinter(out, false)
+			top := NewTopCmdPrinter(out, test.showSwap)
 			err := top.PrintPodMetrics(test.podMetric, test.printContainers,
 				test.withNamespace, test.noHeader, test.sortBy, test.sum)
 			assert.Equal(t, test.expectedErr, err)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/sig cli

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Similar to https://github.com/kubernetes/kubernetes/pull/140874, this fixes a
hard-coded layout assumption in `printPodResourcesSum` that breaks the
`kubectl top pod --sum` summary once an extra column is present -- this time
the one added by `--show-swap`.

`printPodResourcesSum` hard-codes two trailing resource columns (cpu and
memory). `--show-swap` appends swap to `measuredResources`, making it three, so
the padding no longer matches the table: the separator row loses the CPU column
and the totals row is shifted one column to the right, pushing the last value
outside the table.


#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

**Before**

```bash
z@dev:~/workspace/kubernetes/_output/bin$ ./kubectl-sum-old top pod -n kube-system --sum  --no-headers --show-swap
coredns-78f8fbd6cd-q8g6l                       1m    20Mi       0Mi        
coredns-78f8fbd6cd-txd24                       1m    19Mi       0Mi        
etcd-botnow-control-plane                      14m   316Mi      0Mi        
kindnet-wdt28                                  1m    28Mi       0Mi        
kube-apiserver-botnow-control-plane            22m   656Mi      0Mi        
kube-controller-manager-botnow-control-plane   15m   121Mi      0Mi        
kube-proxy-ppzwn                               1m    21Mi       0Mi        
kube-scheduler-botnow-control-plane            4m    40Mi       0Mi        
metrics-server-789c698459-5k27h                2m    31Mi       0Mi        
                                                     ________   ________   
                                                     57m        1256Mi     0Mi
```

**After**

```bash
z@dev:~/workspace/kubernetes/_output/bin$ ./kubectl-sum-new top pod -n kube-system --sum  --no-headers --show-swap
coredns-78f8fbd6cd-q8g6l                       1m         20Mi       0Mi        
coredns-78f8fbd6cd-txd24                       1m         19Mi       0Mi        
etcd-botnow-control-plane                      16m        317Mi      0Mi        
kindnet-wdt28                                  1m         28Mi       0Mi        
kube-apiserver-botnow-control-plane            24m        658Mi      0Mi        
kube-controller-manager-botnow-control-plane   12m        121Mi      0Mi        
kube-proxy-ppzwn                               1m         21Mi       0Mi        
kube-scheduler-botnow-control-plane            4m         41Mi       0Mi        
metrics-server-789c698459-5k27h                2m         31Mi       0Mi        
                                               ________   ________   ________   
                                               57m        1260Mi     0Mi 
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed `kubectl top pod --sum` printing the separator and totals rows misaligned by one column when `--show-swap` was also specified.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
