### PR TITLE
nodelifecycle: don't panic when exiting disruption mode for a Node with no health entry

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -844,7 +844,11 @@ func isNodeExcludedFromDisruptionChecks(node *v1.Node) bool {
 func (nc *Controller) tryUpdateNodeHealth(ctx context.Context, node *v1.Node) (time.Duration, v1.NodeCondition, *v1.NodeCondition, error) {
 	nodeHealth := nc.nodeHealthMap.getDeepCopy(node.Name)
 	defer func() {
-		nc.nodeHealthMap.set(node.Name, nodeHealth)
+		// Don't store an explicit nil for a Node that has no entry yet, e.g.
+		// when the short circuit below returns before health data is built.
+		if nodeHealth != nil {
+			nc.nodeHealthMap.set(node.Name, nodeHealth)
+		}
 	}()
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.NodeControllerLeaseCircuitBreaker) {
@@ -1112,6 +1116,11 @@ func (nc *Controller) handleDisruption(ctx context.Context, zoneToNodeConditions
 			now := nc.now()
 			for i := range nodes {
 				v := nc.nodeHealthMap.getDeepCopy(nodes[i].Name)
+				if v == nil {
+					// No health data yet for this Node; it will be built on
+					// the next successful monitoring cycle.
+					continue
+				}
 				v.probeTimestamp = now
 				v.readyTransitionTimestamp = now
 				nc.nodeHealthMap.set(nodes[i].Name, v)

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	testcore "k8s.io/client-go/testing"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	nodetopology "k8s.io/component-helpers/node/topology"
 	kubeletapis "k8s.io/kubelet/pkg/apis"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/nodelifecycle/scheduler"
@@ -4094,4 +4095,63 @@ func TestProcessPodMarkPodNotReady(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestHandleDisruptionExitDoesNotPanicOnMissingNodeHealthEntry reproduces
+// https://github.com/kubernetes/kubernetes/issues/141572: a Node that has no
+// nodeHealthMap entry (e.g. because a previous cycle's health update was
+// short circuited by the lease cache consistency check) must not cause a nil
+// pointer dereference when the controller exits master disruption mode.
+func TestHandleDisruptionExitDoesNotPanicOnMissingNodeHealthEntry(t *testing.T) {
+	fakeNow := metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC)
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node0",
+			CreationTimestamp: fakeNow,
+		},
+		Status: v1.NodeStatus{
+			Conditions: []v1.NodeCondition{
+				{
+					Type:               v1.NodeReady,
+					Status:             v1.ConditionTrue,
+					LastHeartbeatTime:  fakeNow,
+					LastTransitionTime: fakeNow,
+				},
+			},
+		},
+	}
+
+	logger, ctx := ktesting.NewTestContext(t)
+	nodeController, err := newNodeLifecycleControllerFromClient(
+		ctx,
+		fake.NewSimpleClientset(),
+		testRateLimiterQPS,
+		testRateLimiterQPS,
+		testLargeClusterThreshold,
+		testUnhealthyThreshold,
+		testNodeMonitorGracePeriod,
+		testNodeStartupGracePeriod,
+		testNodeMonitorPeriod,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	nodeController.now = func() metav1.Time { return fakeNow }
+
+	// Register the zone as classifyNodes normally would, then force it into
+	// full disruption mode, as if the cluster is recovering from an outage.
+	nodeController.addPodEvictorForNewZone(logger, node)
+	zone := nodetopology.GetZoneKey(node)
+	nodeController.zoneStates[zone] = stateFullDisruption
+
+	// Deliberately leave nodeHealthMap empty: this Node has no entry, as
+	// happens when its update was skipped in an earlier cycle.
+	_, currentReadyCondition := controllerutil.GetNodeCondition(&node.Status, v1.NodeReady)
+	zoneToNodeConditions := map[string][]*v1.NodeCondition{
+		zone: {currentReadyCondition},
+	}
+
+	// Must not panic: exiting master disruption mode has to tolerate Nodes
+	// without a nodeHealthMap entry.
+	nodeController.handleDisruption(ctx, zoneToNodeConditions, []*v1.Node{node})
 }


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it:

When `NodeControllerLeaseCircuitBreaker` short circuits `tryUpdateNodeHealth`
because the lease cache is stale, its deferred writeback stores an explicit
`nil` into `nodeHealthMap` for any Node that doesn't already have an entry.

`handleDisruption`'s exit-disruption-mode loop then dereferences whatever
`nodeHealthMap.getDeepCopy` returns without a nil check:

```go
v := nc.nodeHealthMap.getDeepCopy(nodes[i].Name)
v.probeTimestamp = now   // nil deref when the node has no entry
```

A Node whose health update was skipped in the cycle that observes recovery
reaches that loop with no entry (or an explicit nil one), and the resulting
panic takes down the whole `kube-controller-manager` process. This is most
likely to happen exactly when a cluster is recovering from a large outage,
which is also when the lease cache is behind and disruption mode is active.

This is a two-part fix:
1. `tryUpdateNodeHealth`'s deferred writeback no longer stores an explicit
   `nil` for a Node that has no entry yet.
2. `handleDisruption`'s exit-disruption loop skips Nodes with no health data
   instead of dereferencing them; their entry is built on the next
   successful monitoring cycle.

## Which issue(s) this PR fixes:

Fixes #141572

## Special notes for your reviewer:

Added `TestHandleDisruptionExitDoesNotPanicOnMissingNodeHealthEntry`, which
reproduces the panic against the pre-fix code (verified locally by reverting
the production change and confirming the test panics at the documented line)
and passes after the fix.

## Does this PR introduce a user-facing change?

```release-note
Fixed a bug in the node lifecycle controller that could crash
kube-controller-manager with a nil pointer dereference when exiting master
disruption mode while some Nodes have no recorded health data (most likely
during recovery from a large outage with NodeControllerLeaseCircuitBreaker
enabled).
```