### PR TITLE
[release-1.35] test(utils): bump agnhost image tag to 2.66.1

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -209,7 +209,7 @@ const (
 func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
 	configs := map[ImageID]Config{}
 	configs[AgnhostPrev] = Config{list.PromoterE2eRegistry, "agnhost", "2.55"}
-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.59"}
+	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.66.1"}
 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}
 	configs[AppArmorLoader] = Config{list.PromoterE2eRegistry, "apparmor-loader", "1.4"}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Bumps the `Agnhost` image tag to `2.66.1` in `test/utils/image/manifest.go` on the `release-1.35` branch to consume the updated pre-built e2e test image.

Thanks @liggitt and @BenTheElder for the guidance!

#### Which issue(s) this PR fixes:
Refers to #141396

#### Special notes for your reviewer:
Manual backport of the agnhost image bump to release-1.35.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```