### PR TITLE
[release-1.34] test(utils): bump agnhost image tag to 2.66.1

### DIFF
--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -220,7 +220,7 @@ const (
 
 func initImageConfigs(list RegistryList) (map[ImageID]Config, map[ImageID]Config) {
 	configs := map[ImageID]Config{}
-	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.56"}
+	configs[Agnhost] = Config{list.PromoterE2eRegistry, "agnhost", "2.66.1"}
 	configs[AgnhostPrivate] = Config{list.PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{list.GcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[APIServer] = Config{list.PromoterE2eRegistry, "sample-apiserver", "1.29.2"}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Bumps the `Agnhost` image tag to `2.66.1` in `test/utils/image/manifest.go` on the `release-1.34` branch to consume the updated pre-built e2e test image.

Thanks @liggitt and @BenTheElder for the guidance!

#### Which issue(s) this PR fixes:
Refers to #141396

#### Special notes for your reviewer:
Manual backport of the agnhost image bump to release-1.35.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```