### PR TITLE
e2e_node: print only the image fields used for selection

### DIFF
--- a/test/e2e_node/remote/gce/gce_runner.go
+++ b/test/e2e_node/remote/gce/gce_runner.go
@@ -201,7 +201,8 @@ func (g *GCERunner) getGCEImage(imageRegex, imageFamily string, project string) 
 
 // gceImageListArgs returns the gcloud arguments to list candidate images.
 func gceImageListArgs(project, imageFamily string) []string {
-	args := []string{"compute", "images", "list", "--format=json", "--project=" + project}
+	// Print only the fields pickNewestImage reads, so the runner buffers less.
+	args := []string{"compute", "images", "list", "--format=json(name,family,creationTimestamp)", "--project=" + project}
 	if imageFamily != "" {
 		// Narrow to the family so gcloud does not return the whole project.
 		// For large projects that can take a long time and consume significant

--- a/test/e2e_node/remote/gce/gce_runner_test.go
+++ b/test/e2e_node/remote/gce/gce_runner_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gce
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -121,12 +122,12 @@ func TestGCEImageListArgs(t *testing.T) {
 			name:        "a family adds a server-side filter",
 			project:     "proj",
 			imageFamily: "fam",
-			want:        []string{"compute", "images", "list", "--format=json", "--project=proj", "--filter=family=fam"},
+			want:        []string{"compute", "images", "list", "--format=json(name,family,creationTimestamp)", "--project=proj", "--filter=family=fam"},
 		},
 		{
 			name:    "no family adds no filter",
 			project: "proj",
-			want:    []string{"compute", "images", "list", "--format=json", "--project=proj"},
+			want:    []string{"compute", "images", "list", "--format=json(name,family,creationTimestamp)", "--project=proj"},
 		},
 	}
 	for _, tc := range tests {
@@ -135,5 +136,22 @@ func TestGCEImageListArgs(t *testing.T) {
 				t.Errorf("gceImageListArgs() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestProjectedGCEImageJSON(t *testing.T) {
+	// The --format keys in gceImageListArgs must match gceImage's json tags,
+	// or the runner would decode empty image data.
+	data := []byte(`[{"name":"ubuntu-x","family":"pipeline-1-34-amd64","creationTimestamp":"2026-08-27T00:00:00Z"}]`)
+	var images []gceImage
+	if err := json.Unmarshal(data, &images); err != nil {
+		t.Fatalf("json.Unmarshal() unexpected error: %v", err)
+	}
+	if len(images) != 1 {
+		t.Fatalf("decoded %d images, want 1", len(images))
+	}
+	got := images[0]
+	if got.Name != "ubuntu-x" || got.Family != "pipeline-1-34-amd64" || got.CreationTimestamp != "2026-08-27T00:00:00Z" {
+		t.Errorf("decoded %+v, want name, family, and creationTimestamp populated", got)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/sig node

#### What this PR does / why we need it:

`getGCEImage` reads the whole `gcloud compute images list` output into the runner with `exec.Output()`. Only `name`, `family`, and `creationTimestamp` are ever read, in `pickNewestImage`. This projects the output to those three with `--format=json(name,family,creationTimestamp)`, so gcloud prints a smaller list. Those three are the `gceImage` json tags of the fields the runner reads; the struct's fourth field, `id`, is read nowhere, so the selection does not change.

The scope is small. `--format` is client-side output formatting: gcloud still enumerates the family (or the whole project, on a regex-only config outside the tree), the runner still buffers the whole result in `exec.Output`, and the number of images is not capped. All current test-infra image configs that set `image_regex` also set `image_family`, so #141590 already narrows the listing for the in-tree jobs; this drops the fields of each returned image that the runner never reads. I have not measured the byte difference on a real listing.

#### Which issue(s) this PR is related to:

Part of #141434.

#### Special notes for your reviewer:

**Testing**

- `TestGCEImageListArgs` checks the projected `--format` in the argv for the family and no-family cases.
- `TestProjectedGCEImageJSON` decodes a sample with only those three keys and checks that `name`, `family`, and `creationTimestamp` populate `gceImage`.

`go test ./test/e2e_node/remote/gce/` and `go vet` pass. The node-e2e presubmits ran the projected command against GCE.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. AI-assisted tools were used during implementation, test planning, and review; I reviewed and validated the final change.