### PR TITLE
scheduler: deflake TestRequeueByPermitRejection

### DIFF
--- a/test/integration/scheduler/queueing/queue_test.go
+++ b/test/integration/scheduler/queueing/queue_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,6 +37,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog/v2"
 	configv1 "k8s.io/kube-scheduler/config/v1"
 	fwk "k8s.io/kube-scheduler/framework"
@@ -454,16 +457,16 @@ func (p *firstFailBindPlugin) Bind(ctx context.Context, state fwk.CycleState, po
 }
 
 // TestRequeueByPermitRejection verify Pods failed by permit plugins in the binding cycle are
-// put back to the queue, according to the correct scheduling cycle number.
+// put back to the queue
 func TestRequeueByPermitRejection(t *testing.T) {
-	queueingHintCalledCounter := 0
+	var queueingHintCalledCounter atomic.Int32
 	fakePermit := &fakePermitPlugin{}
 	registry := frameworkruntime.Registry{
 		fakePermitPluginName: func(ctx context.Context, o runtime.Object, fh fwk.Handle) (fwk.Plugin, error) {
 			fakePermit = &fakePermitPlugin{
 				frameworkHandler: fh,
 				schedulingHint: func(logger klog.Logger, pod *v1.Pod, oldObj, newObj interface{}) (fwk.QueueingHint, error) {
-					queueingHintCalledCounter++
+					queueingHintCalledCounter.Add(1)
 					return fwk.Queue, nil
 				},
 			}
@@ -507,59 +510,93 @@ func TestRequeueByPermitRejection(t *testing.T) {
 		t.Fatalf("Failed to create Pod %q: %v", pod.Name, err)
 	}
 
+	// Wait for pod-1 to reach the Permit extension point before triggering the NodeUpdate event.
+	// The scheduling queue only records cluster events as in-flight while at least one Pod is
+	// in-flight, and a Pod is in-flight only after it has been popped off the activeQ. If the
+	// NodeUpdate event below were handled before pod-1 got popped, the queue would drop it, and the
+	// Permit rejection would then leave pod-1 in the unschedulable pod pool forever because no
+	// further event would requeue it.
+	waitForPodAtPermit(ctx, t, fakePermit, "pod-1")
+
+	// Snapshot how many NodeUpdate events the scheduler has handled so far. The metrics registry is
+	// global and shared with the other tests in this package, so the count isn't necessarily zero.
+	nodeLabelUpdate := fwk.ClusterEvent{Resource: fwk.Node, ActionType: fwk.UpdateNodeLabel}
+	handledEventsBefore := eventHandlingSampleCount(nodeLabelUpdate)
+
 	// update node label. (causes the NodeUpdate event)
 	node.Labels = map[string]string{"updated": ""}
 	if _, err := cs.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{}); err != nil {
 		t.Fatalf("Failed to add labels to the node: %v", err)
 	}
 
-	// create a pod to increment the scheduling cycle number in the scheduling queue.
-	// We can make sure NodeUpdate event, that has happened in the previous scheduling cycle, makes Pod to be enqueued to activeQ via the scheduling queue.
-	pod = st.MakePod().Namespace(ns).Name("pod-2").Container(imageutils.GetPauseImageName()).Obj()
-	if _, err := cs.CoreV1().Pods(ns).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Pod %q: %v", pod.Name, err)
+	// Wait until the scheduler has finished handling the NodeUpdate event, which is when the event
+	// gets recorded as in-flight for pod-1. Rejecting pod-1 before that happens would make the queue
+	// observe no cluster event for pod-1 and keep it unschedulable.
+	if err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+		return eventHandlingSampleCount(nodeLabelUpdate) > handledEventsBefore, nil
+	}); err != nil {
+		t.Fatalf("Expect the scheduler to handle the %s event: %v", nodeLabelUpdate.Label(), err)
 	}
 
-	// reject pod-1 to simulate the failure in Permit plugins.
-	// This pod-1 should be enqueued to activeQ because the NodeUpdate event has happened.
+	// Reject pod-1 to simulate a rejection by a Permit plugin. Because the NodeUpdate event above was
+	// recorded while pod-1 was in-flight, the queueing hint has to be consulted for that event and
+	// move pod-1 back to the activeQ.
 	fakePermit.frameworkHandler.IterateOverWaitingPods(func(wp fwk.WaitingPod) {
 		if wp.GetPod().Name == "pod-1" {
 			wp.Reject(fakePermitPluginName, "fakePermitPlugin rejects the Pod")
-			return
 		}
 	})
 
-	// Wait for pod-2 to be scheduled.
-	err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (done bool, err error) {
-		fakePermit.frameworkHandler.IterateOverWaitingPods(func(wp fwk.WaitingPod) {
-			if wp.GetPod().Name == "pod-2" {
-				wp.Allow(fakePermitPluginName)
-			}
-		})
-
-		return testutils.PodScheduled(cs, ns, "pod-2")(ctx)
-	})
-	if err != nil {
-		t.Fatalf("Expect pod-2 to be scheduled")
-	}
-
-	err = wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (done bool, err error) {
-		pod1Found := false
+	// Wait for pod-1 to be scheduled, which can only happen once the rejection above requeued it and
+	// it reached Permit a second time.
+	if err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
 		fakePermit.frameworkHandler.IterateOverWaitingPods(func(wp fwk.WaitingPod) {
 			if wp.GetPod().Name == "pod-1" {
-				pod1Found = true
 				wp.Allow(fakePermitPluginName)
 			}
 		})
-		return pod1Found, nil
-	})
-	if err != nil {
-		t.Fatal("Expect pod-1 to be scheduled again")
+		return testutils.PodScheduled(cs, ns, "pod-1")(ctx)
+	}); err != nil {
+		t.Fatalf("Expect pod-1 to be scheduled again: %v", err)
 	}
 
-	if queueingHintCalledCounter != 1 {
-		t.Fatalf("Expected the scheduling hint to be called 1 time, but %v", queueingHintCalledCounter)
+	if got := queueingHintCalledCounter.Load(); got != 1 {
+		t.Fatalf("Expected the scheduling hint to be called 1 time, but %v", got)
 	}
+}
+
+// waitForPodAtPermit waits until the Pod named podName is waiting at the Permit extension point.
+// Reaching Permit implies the Pod has already been popped off the activeQ, and hence that the
+// scheduling queue tracks it as in-flight and records the cluster events happening from now on for
+// it.
+func waitForPodAtPermit(ctx context.Context, t *testing.T, plugin *fakePermitPlugin, podName string) {
+	t.Helper()
+
+	if err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+		found := false
+		plugin.frameworkHandler.IterateOverWaitingPods(func(wp fwk.WaitingPod) {
+			if wp.GetPod().Name == podName {
+				found = true
+			}
+		})
+		return found, nil
+	}); err != nil {
+		t.Fatalf("Expect Pod %q to be waiting at the Permit extension point: %v", podName, err)
+	}
+}
+
+// eventHandlingSampleCount returns the number of times the scheduler has finished handling the given
+// cluster event. The scheduler observes this metric after the event has been fully processed by the
+// scheduling queue, which makes it a reliable signal that the event is visible to the queue.
+func eventHandlingSampleCount(event fwk.ClusterEvent) uint64 {
+	vec, err := testutil.GetHistogramVecFromGatherer(legacyregistry.DefaultGatherer, "scheduler_event_handling_duration_seconds", map[string]string{
+		"event": event.Label(),
+	})
+	if err != nil {
+		// The metric isn't reported at all until the scheduler handles such an event for the first time.
+		return 0
+	}
+	return vec.GetAggregatedSampleCount()
 }
 
 type fakePermitPlugin struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

This PR synchronizes pod scheduling, NodeUpdate handling, and Permit rejection so the node label update is recorded while pod-1 is in flight and causes it to be requeued after rejection.

Previously, the test created the pod and immediately triggered NodeUpdate, relying on scheduler timing to record the event before the subsequent Permit rejection.

This PR also makes the queueing-hint invocation counter atomic so it can be safely updated by the scheduler goroutine and read by the test goroutine without a data race.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
