### PR TITLE
validation-gen: lint requiredness tags on non-pointer struct fields

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_rules.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/code-generator/cmd/validation-gen/util"
 	"k8s.io/code-generator/cmd/validation-gen/validators"
 	"k8s.io/gengo/v2/codetags"
 	"k8s.io/gengo/v2/types"
@@ -324,7 +325,8 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 			return "", nil
 		}
 
-		// Skip non-pointer structs (and aliases to them) as they don't support requiredness tags.
+		// Skip non-pointer structs (and aliases to them): their requiredness is
+		// handled by nonPointerStructRequiredness.
 		underlying := t
 		for underlying.Kind == types.Alias {
 			underlying = underlying.Underlying
@@ -370,10 +372,84 @@ func requiredAndOptional(extractor validators.ValidationExtractor) lintRule {
 	}
 }
 
+// isImplicitlyRequired returns true if a struct has a member tagged
+// +k8s:required or +k8s:unionMember, directly or in a struct it contains by
+// value. Such a struct rejects its own zero value, which makes a non-pointer
+// field of that type required in effect.
+func isImplicitlyRequired(extractor validators.ValidationExtractor, t *types.Type) (bool, error) {
+	st := util.NativeType(t)
+	if st.Kind != types.Struct {
+		return false, nil
+	}
+	for _, m := range st.Members {
+		mTags, err := extractor.ExtractTags(validators.Context{Scope: validators.ScopeField, Type: m.Type}, m.CommentLines)
+		if err != nil {
+			return false, err
+		}
+		if hasTag(mTags, "k8s:required") || hasTag(mTags, "k8s:unionMember") {
+			return true, nil
+		}
+		// An opaque member's own validations are ignored.
+		if hasTag(mTags, "k8s:opaqueType") {
+			continue
+		}
+		// Only descend by value: an unset pointer, slice or map member is nil,
+		// so nothing inside it is validated. Go forbids value cycles, so this
+		// terminates without cycle detection.
+		if nested, err := isImplicitlyRequired(extractor, m.Type); err != nil || nested {
+			return nested, err
+		}
+	}
+	return false, nil
+}
+
+// nonPointerStructRequiredness enforces that +k8s:required and +k8s:optional on
+// a non-pointer struct field match the struct's implicit requiredness. Neither
+// tag emits a presence check there (an unset struct is indistinguishable from a
+// zero-valued one), so the field is required exactly when the struct is.
+func nonPointerStructRequiredness(extractor validators.ValidationExtractor) lintRule {
+	return func(container *types.Type, t *types.Type, tags []codetags.Tag) (string, error) {
+		// We only care about fields in a struct. Skip if linting the struct itself.
+		if container == nil || container.Kind != types.Struct || container == t {
+			return "", nil
+		}
+		if util.NativeType(t).Kind != types.Struct {
+			return "", nil
+		}
+
+		isRequired, isOptional := hasTag(tags, "k8s:required"), hasTag(tags, "k8s:optional")
+		if !isRequired && !isOptional {
+			return "", nil
+		}
+
+		// An opaque type's validations are ignored, so nothing inside it can
+		// make the field required.
+		if hasTag(tags, "k8s:opaqueType") {
+			if isRequired {
+				return fmt.Sprintf("+k8s:required on non-pointer opaque struct %s: its validations are ignored, so the field is effectively optional", t.Name), nil
+			}
+			return "", nil
+		}
+
+		implied, err := isImplicitlyRequired(extractor, t)
+		if err != nil {
+			return "", err
+		}
+		switch {
+		case isRequired && !implied:
+			return fmt.Sprintf("+k8s:required on non-pointer struct %s: it has no required or union member, so the field is effectively optional", t.Name), nil
+		case isOptional && implied:
+			return fmt.Sprintf("+k8s:optional on non-pointer struct %s: it has a required or union member, so the field is effectively required", t.Name), nil
+		}
+		return "", nil
+	}
+}
+
 func lintRules(extractor validators.ValidationExtractor) []lintRule {
 	return []lintRule{
 		alphaBetaPrefix(),
 		validationStability(),
 		requiredAndOptional(extractor),
+		nonPointerStructRequiredness(extractor),
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/lint_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -945,6 +946,162 @@ func TestLintRequiredness(t *testing.T) {
 			}
 			if gotError != tt.wantError {
 				t.Errorf("lintRequiredness() error = %q, want %q", gotError, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestLintNonPointerStructRequiredness(t *testing.T) {
+	const requiredErr = "field Foo: +k8s:required on non-pointer struct %s: it has no required or union member, so the field is effectively optional"
+	const optionalErr = "field Foo: +k8s:optional on non-pointer struct %s: it has a required or union member, so the field is effectively required"
+	const opaqueErr = "field Foo: +k8s:required on non-pointer opaque struct %s: its validations are ignored, so the field is effectively optional"
+
+	// All-optional struct: its zero value is valid.
+	optionalOnly := func() *types.Type {
+		return testStruct("Inner", []types.Member{
+			testField("Bar", testPtr(testType("string")), "+k8s:optional", "+k8s:minLength=1"),
+		})
+	}
+	// Struct with a required member: its zero value is rejected.
+	withRequired := func() *types.Type {
+		return testStruct("Inner", []types.Member{
+			testField("Bar", testPtr(testType("string")), "+k8s:required"),
+		})
+	}
+
+	tests := []struct {
+		name       string
+		typeToLint *types.Type
+		wantError  string
+	}{
+		{
+			name: "non-pointer struct field without requiredness - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", optionalOnly()),
+			}),
+			wantError: "",
+		},
+		{
+			name: "pointer struct field with +k8s:required - rule does not apply",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testPtr(optionalOnly()), "+k8s:required"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "+k8s:required on struct with a required member - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", withRequired(), "+k8s:required"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "+k8s:required on all-optional struct - error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", optionalOnly(), "+k8s:required"),
+			}),
+			wantError: fmt.Sprintf(requiredErr, "pkg.Inner"),
+		},
+		{
+			name: "+k8s:optional on all-optional struct - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", optionalOnly(), "+k8s:optional"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "+k8s:optional on struct with a required member - error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", withRequired(), "+k8s:optional"),
+			}),
+			wantError: fmt.Sprintf(optionalErr, "pkg.Inner"),
+		},
+		{
+			name: "+k8s:required on union struct - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testStruct("Inner", []types.Member{
+					testField("A", testPtr(testType("string")), "+k8s:optional", "+k8s:unionMember"),
+					testField("B", testPtr(testType("string")), "+k8s:optional", "+k8s:unionMember"),
+				}), "+k8s:required"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "+k8s:required on zero-or-one-of struct - error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testStruct("Inner", []types.Member{
+					testField("A", testPtr(testType("string")), "+k8s:optional", "+k8s:zeroOrOneOfMember"),
+					testField("B", testPtr(testType("string")), "+k8s:optional", "+k8s:zeroOrOneOfMember"),
+				}), "+k8s:required"),
+			}),
+			wantError: fmt.Sprintf(requiredErr, "pkg.Inner"),
+		},
+		{
+			name: "+k8s:required on alias to all-optional struct - error names the alias",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testAlias("MyAlias", optionalOnly()), "+k8s:required"),
+			}),
+			wantError: fmt.Sprintf(requiredErr, "pkg.MyAlias"),
+		},
+		{
+			name: "+k8s:required on struct whose non-pointer struct member has a required member - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testStruct("Outer", []types.Member{
+					testField("Nested", withRequired()),
+				}), "+k8s:required"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "+k8s:required on struct whose optional pointer struct member has a required member - error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testStruct("Outer", []types.Member{
+					testField("Nested", testPtr(withRequired()), "+k8s:optional"),
+				}), "+k8s:required"),
+			}),
+			wantError: fmt.Sprintf(requiredErr, "pkg.Outer"),
+		},
+		{
+			name: "+k8s:required on opaque struct with a required member - error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", withRequired(), "+k8s:required", "+k8s:opaqueType"),
+			}),
+			wantError: fmt.Sprintf(opaqueErr, "pkg.Inner"),
+		},
+		{
+			name: "+k8s:optional on opaque struct with a required member - no error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", withRequired(), "+k8s:optional", "+k8s:opaqueType"),
+			}),
+			wantError: "",
+		},
+		{
+			name: "+k8s:required on struct whose opaque member has a required member - error",
+			typeToLint: testStruct("T", []types.Member{
+				testField("Foo", testStruct("Outer", []types.Member{
+					testField("Nested", withRequired(), "+k8s:opaqueType"),
+				}), "+k8s:required"),
+			}),
+			wantError: fmt.Sprintf(requiredErr, "pkg.Outer"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := newLinter(nonPointerStructRequiredness(validator))
+			if err := l.lintType(tt.typeToLint); err != nil {
+				t.Fatalf("lintType() unexpected error: %v", err)
+			}
+			errs := l.lintErrors[tt.typeToLint]
+			if len(errs) > 1 {
+				t.Fatalf("got %d errors, but expected 0 or 1 error: %v", len(errs), errs)
+			}
+			var gotError string
+			if len(errs) == 1 {
+				gotError = errs[0].Error()
+			}
+			if gotError != tt.wantError {
+				t.Errorf("lintNonPointerStructRequiredness() error = %q, want %q", gotError, tt.wantError)
 			}
 		})
 	}


### PR DESCRIPTION
+k8s:required and +k8s:optional emit no presence check there, so the field is required iff the struct has a +k8s:required or +k8s:unionMember member. Flag tags that contradict that. An +k8s:opaqueType field is always effectively optional.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:
`+k8s:required` and `+k8s:optional` emit no presence check on a non-pointer struct field, since an unset struct is indistinguishable from a zero-valued one. Such a field is required exactly when the struct rejects its own zero value, i.e. when it has a member tagged `+k8s:required` or `+k8s:unionMember` (directly, or in a struct it contains by value).

Adds a validation-gen lint rule flagging the two mismatches:

- `+k8s:required` on a struct with no such member — the field is effectively optional
- `+k8s:optional` on a struct that has one — the field is effectively required

A field tagged `+k8s:opaqueType` is always effectively optional, since the referenced type's validations are ignored.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
