### PR TITLE
e2e_node: report an invalid image_regex instead of panicking

### DIFF
--- a/test/e2e_node/remote/gce/gce_runner.go
+++ b/test/e2e_node/remote/gce/gce_runner.go
@@ -215,7 +215,11 @@ func gceImageListArgs(project, imageFamily string) []string {
 // pickNewestImage returns the name of the newest image matching imageRegex and imageFamily.
 func pickNewestImage(images []gceImage, imageRegex, imageFamily, project string) (string, error) {
 	imageObjs := []imageObj{}
-	imageRe := regexp.MustCompile(imageRegex)
+	// Compile, not MustCompile: image_regex is user config and must not panic.
+	imageRe, err := regexp.Compile(imageRegex)
+	if err != nil {
+		return "", fmt.Errorf("failed to compile image_regex %q: %w", imageRegex, err)
+	}
 	for _, instance := range images {
 		if imageRegex != "" && !imageRe.MatchString(instance.Name) {
 			continue

--- a/test/e2e_node/remote/gce/gce_runner_test.go
+++ b/test/e2e_node/remote/gce/gce_runner_test.go
@@ -90,6 +90,14 @@ func TestPickNewestImage(t *testing.T) {
 			imageFamily: "fam",
 			wantErr:     "failed to parse instance creation timestamp",
 		},
+		{
+			name: "an invalid image_regex returns an error",
+			images: []gceImage{
+				img("img", "fam", "2026-08-01T10:00:00Z"),
+			},
+			imageRegex: "[",
+			wantErr:    "failed to compile image_regex",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Part of #141624.

`pickNewestImage` compiled the config's `image_regex` with `regexp.MustCompile`. That pattern comes from a user-supplied image config file, so a typo in it triggers a panic instead of an error.

This compiles it with `regexp.Compile` and returns an error instead. An empty `image_regex` still matches every image, as before.

## Testing

`TestPickNewestImage` gains a case for an invalid pattern; the existing cases, including the empty-regex match-all path, are unchanged. `go test ./test/e2e_node/remote/gce/` and `go vet` pass.

### Does this PR introduce a user-facing change?

```release-note
NONE
```

/sig node
/kind cleanup
