### PR TITLE
Deflake networking update endpoints

### DIFF
--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -74,6 +74,14 @@ const (
 	// Number of retries to hit a given set of endpoints. Needs to be high
 	// because we verify iptables statistical rr loadbalancing.
 	testTries = 30
+	// How long a strict dial (minTries == maxTries) tolerates reaching an
+	// endpoint that is no longer part of the Service before it gives up.
+	// Removing an endpoint is not atomic: kube-proxy reprograms the dataplane
+	// asynchronously and rate limits its resyncs (--iptables-min-sync-period
+	// defaults to 10s on some providers), so traffic can legitimately still
+	// reach a removed endpoint -- or whatever else now answers on the address
+	// it used to own -- for a while after the EndpointSlice has been updated.
+	dataplaneConvergenceTimeout = 60 * time.Second
 	// Maximum number of pods in a test, to make test work in large clusters.
 	maxNetProxyPodsCount = 10
 	// SessionAffinityChecks is number of checks to hit a given set of endpoints when enable session affinity.
@@ -330,7 +338,11 @@ func makeCURLDialCommand(ipPort, dialCmd, protocol, targetIP string, targetPort 
 //
 // maxTries == minTries will confirm that we see the expected endpoints and no
 // more for maxTries. Use this if you want to eg: fail a readiness check on a
-// pod and confirm it doesn't show up as an endpoint.
+// pod and confirm it doesn't show up as an endpoint. Because that is a steady
+// state assertion, it is only meaningful once the data plane has caught up with
+// the most recent Service/EndpointSlice change; unexpected responses seen
+// within dataplaneConvergenceTimeout cause all responses collected so far to
+// be discarded and the strict dial validation to restart from its first attempt.
 // Returns nil if no error, or error message if failed after trying maxTries.
 func (config *NetworkingTestConfig) DialFromContainer(ctx context.Context, protocol, dialCommand, containerIP, targetIP string, containerHTTPPort, targetPort, maxTries, minTries int, expectedResponses sets.String) error {
 	ipPort := net.JoinHostPort(containerIP, strconv.Itoa(containerHTTPPort))
@@ -339,7 +351,14 @@ func (config *NetworkingTestConfig) DialFromContainer(ctx context.Context, proto
 
 	responses := sets.NewString()
 
-	for i := range maxTries {
+	// In the minTries == maxTries case rely upon a steady data plane state.
+	// We allow up to dataplaneConvergenceTimeout for steady state.
+	var convergenceDeadline time.Time
+	if minTries == maxTries {
+		convergenceDeadline = time.Now().Add(dataplaneConvergenceTimeout)
+	}
+
+	for i := 0; i < maxTries; i++ {
 		resp, err := config.GetResponseFromContainer(ctx, protocol, dialCommand, containerIP, targetIP, containerHTTPPort, targetPort)
 		if err != nil {
 			// A failure to kubectl exec counts as a try, not a hard fail.
@@ -354,7 +373,18 @@ func (config *NetworkingTestConfig) DialFromContainer(ctx context.Context, proto
 				responses.Insert(trimmed)
 			}
 		}
-		if responses.Difference(expectedResponses).Len() > 0 {
+		if unexpected := responses.Difference(expectedResponses); unexpected.Len() > 0 {
+			if time.Now().Before(convergenceDeadline) {
+				// We discard responses if we are within the data plane
+				// convergence tolerance window. Setting i to -1 effectively
+				// restarts the loop to the beginning.
+				framework.Logf("dial to %v reached unexpected endpoints %v, waiting for the dataplane to converge", targetIP, unexpected.List())
+				responses = sets.NewString()
+				i = -1
+				// TODO: get rid of this delay #36281
+				time.Sleep(hitEndpointRetryDelay)
+				continue
+			}
 			returnMsg := fmt.Errorf("received unexpected responses... \nAttempt %d\nCommand %v\nretrieved %v\nexpected %v", i, cmd, responses, expectedResponses)
 			framework.Logf("encountered error during dial (%v)", returnMsg)
 			return returnMsg


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

This PR adds a timeout tolerance window (a generous 60s) to enable endpoint removal during `DialFromContainer` scenario to fully converge before failing test outcome.

Inspired by https://github.com/kubernetes/kubernetes/pull/141503#issuecomment-5441761640

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
