### PR TITLE
test/images: don't depend on golang:<version> docker tags

### DIFF
--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -16,6 +16,10 @@ REPO_ROOT:=${CURDIR}/../..
 REGISTRY ?= registry.k8s.io/e2e-test-images
 DOCKER_CERT_BASE_PATH ?=
 GOLANG_VERSION=$(shell cat $(REPO_ROOT)/.go-version)
+# Digest pinned so builds don't wait on a golang:$(GOLANG_VERSION) tag existing.
+# GOTOOLCHAIN selects the go version we build with.
+# This is the latest as of 2026-08-27
+GOLANG_IMAGE?=golang@sha256:0ecdc2a9f6156af6451080bfe3d8382a662fcc4e209608c6f919e643453514c1
 export
 
 ifndef WHAT

--- a/test/images/agnhost/Dockerfile
+++ b/test/images/agnhost/Dockerfile
@@ -17,11 +17,11 @@
 # is linked against musl libc.
 ARG BASEIMAGE=alpine
 
-# latest as of 2026-05-08
-FROM golang@sha256:efaccb5b497e90df3ebe5216cc25cd9f98e73874e2d638b56e38d4a3f098c41c AS preparer
+# digest pinned in test/images/Makefile, GOTOOLCHAIN selects the go version
+ARG GOLANG_IMAGE=golang:latest
+FROM ${GOLANG_IMAGE} AS preparer
 
-ARG GOLANG_VERSION
-ARG GOTOOLCHAIN=go${GOLANG_VERSION}
+ARG GOTOOLCHAIN=auto
 RUN go install github.com/google/go-containerregistry/cmd/crane@latest && \
     apt-get update && apt-get install -y jq
 

--- a/test/images/agnhost/Dockerfile_windows
+++ b/test/images/agnhost/Dockerfile_windows
@@ -15,10 +15,12 @@
 ARG BASEIMAGE
 ARG REGISTRY
 ARG OS_VERSION
-ARG GOLANG_VERSION
 
-FROM --platform=linux/$BUILDARCH golang:$GOLANG_VERSION AS prepregistry
+# digest pinned in test/images/Makefile, GOTOOLCHAIN selects the go version
+ARG GOLANG_IMAGE=golang:latest
+FROM --platform=linux/$BUILDARCH ${GOLANG_IMAGE} AS prepregistry
 
+ARG GOTOOLCHAIN=auto
 RUN go install github.com/google/go-containerregistry/cmd/crane@latest && \
     apt-get update && apt-get install -y jq
 

--- a/test/images/agnhost/Makefile
+++ b/test/images/agnhost/Makefile
@@ -16,7 +16,6 @@ SRCS=agnhost
 OS ?= linux
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
-GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 VERSION = $(shell cat VERSION)
 LD_FLAGS = -X 'main.Version=$(VERSION)'

--- a/test/images/apparmor-loader/Makefile
+++ b/test/images/apparmor-loader/Makefile
@@ -16,7 +16,6 @@ SRCS=loader
 OS ?= linux
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
-GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 export
 

--- a/test/images/busybox/Makefile
+++ b/test/images/busybox/Makefile
@@ -16,7 +16,6 @@ SRCS=hostname
 OS ?= linux
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
-GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 export
 

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -26,6 +26,13 @@ source "${KUBE_ROOT}/hack/lib/logging.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 declare -a DEFAULT_IMAGE_PLATFORMS=("linux/amd64" "linux/arm64" "linux/ppc64le" "linux/s390x")
 
+# defaults for invoking a single image's Makefile directly
+: "${GOLANG_VERSION:=$(<"${KUBE_ROOT}/.go-version")}"
+: "${GOLANG_IMAGE:=golang:latest}"
+
+# GOTOOLCHAIN, not GOLANG_IMAGE, selects the go version we build with
+GOTOOLCHAIN="go${GOLANG_VERSION}"
+
 # NOTE(claudiub): In the test image build jobs, this script is not being run in a git repository,
 # which would cause git log to fail. Instead, we can use the GIT_COMMIT_ID set in cloudbuild.yaml.
 GIT_COMMIT_ID=$(git log -1 --format=%h || echo "${GIT_COMMIT_ID}")
@@ -157,6 +164,8 @@ build() {
       --build-arg REGISTRY="${REGISTRY}"
       --build-arg OS_VERSION="${os_version}"
       --build-arg GOLANG_VERSION="${GOLANG_VERSION}"
+      --build-arg GOLANG_IMAGE="${GOLANG_IMAGE}"
+      --build-arg GOTOOLCHAIN="${GOTOOLCHAIN}"
       -t "${REGISTRY}/${image}:${TAG}-${suffix}"
       -f "${dockerfile_name}"
       --label "image_version=${TAG}"
@@ -228,7 +237,8 @@ bin() {
   for SRC in "$@";
   do
   docker run --rm -v "${TARGET}:${TARGET}:Z" -v "${KUBE_ROOT}":/go/src/k8s.io/kubernetes:Z \
-        golang:"${GOLANG_VERSION}" \
+        -e GOTOOLCHAIN="${GOTOOLCHAIN}" \
+        "${GOLANG_IMAGE}" \
         /bin/bash -c "\
                 cd /go/src/k8s.io/kubernetes/test/images/${SRC_DIR} && \
                 CGO_ENABLED=0 GOOS=${OS} GOARCH=${ARCH} go build -buildvcs=false -a -installsuffix cgo --ldflags \"-w ${LD_FLAGS:-}\" -o ${TARGET}/${SRC} ./$(dirname "${SRC}")"

--- a/test/images/nonewprivs/Makefile
+++ b/test/images/nonewprivs/Makefile
@@ -16,7 +16,6 @@ SRCS = nnp
 OS ?= linux
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
-GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 export
 

--- a/test/images/pets/peer-finder/Makefile
+++ b/test/images/pets/peer-finder/Makefile
@@ -16,7 +16,6 @@ SRCS = peer-finder
 OS ?= linux
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
-GOLANG_VERSION ?= latest
 SRC_DIR = pets/peer-finder
 export
 

--- a/test/images/pets/zookeeper-installer/Makefile
+++ b/test/images/pets/zookeeper-installer/Makefile
@@ -16,7 +16,6 @@ SRCS = peer-finder
 OS ?= linux
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
-GOLANG_VERSION ?= latest
 SRC_DIR = pets/peer-finder
 export
 

--- a/test/images/regression-issue-74839/Makefile
+++ b/test/images/regression-issue-74839/Makefile
@@ -16,7 +16,6 @@ SRCS=regression-issue-74839
 OS ?= linux
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
-GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 
 export

--- a/test/images/resource-consumer/Makefile
+++ b/test/images/resource-consumer/Makefile
@@ -16,7 +16,6 @@ SRCS = consumer consume-cpu/consume-cpu
 OS ?= linux
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
-GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 export
 

--- a/test/images/sample-apiserver/Makefile
+++ b/test/images/sample-apiserver/Makefile
@@ -15,7 +15,6 @@
 OS ?= linux
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
-GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 KUBE_CROSS_VERSION ?= $(shell cat ../../../build/build-image/cross/VERSION)
 export

--- a/test/images/sample-device-plugin/Makefile
+++ b/test/images/sample-device-plugin/Makefile
@@ -16,7 +16,6 @@ SRCS=sampledeviceplugin
 OS ?= linux
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
-GOLANG_VERSION ?= latest
 SRC_DIR = $(notdir $(shell pwd))
 export
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

#### What this PR does / why we need it:

Bumping `.go-version` can break the e2e test image build jobs when the matching `golang:<version>` tag has not been published to docker hub yet. Go images can take some time to become available after go releases new patch releases.

Instead pin the builder image by digest in one place (`GOLANG_IMAGE` in `test/images/Makefile`) and let `GOTOOLCHAIN` select the go version we actually build with.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->
fixes https://github.com/kubernetes/kubernetes/issues/141396

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->

Yes. AI assisted in authoring this change. I have reviewed and edited it.

/sig testing