### PR TITLE
DRA ResourceSlice + ResourceClaim[Template]: reject qualified names with more than one slash

### DIFF
--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1169,15 +1169,20 @@ func validateNodeAllocatableResources(mappings map[corev1.ResourceName]resource.
 func validateNodeAllocatableMapping(mapping *resource.NodeAllocatableMapping, capacities map[resource.QualifiedName]resource.DeviceCapacity, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if mapping.CapacityKey != nil {
+		keyPath := fldPath.Child("capacityKey")
 		if *mapping.CapacityKey == "" {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("capacityKey"), "", "capacityKey must not be an empty string"))
+			allErrs = append(allErrs, field.Invalid(keyPath, "", "capacityKey must not be an empty string"))
+		} else if nameErrs := validateQualifiedName(*mapping.CapacityKey, keyPath); len(nameErrs) > 0 {
+			// A key which is not a valid name cannot be a key of the capacity
+			// map either, so report the format problem instead of "not found".
+			allErrs = append(allErrs, nameErrs...)
 		} else {
 			var exists bool
 			if capacities != nil {
 				_, exists = capacities[*mapping.CapacityKey]
 			}
 			if !exists {
-				allErrs = append(allErrs, field.NotFound(fldPath.Child("capacityKey"), *mapping.CapacityKey))
+				allErrs = append(allErrs, field.NotFound(keyPath, *mapping.CapacityKey))
 			}
 		}
 		if mapping.CapacityMultiplier == nil {

--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1073,7 +1073,13 @@ func validateDevice(device resource.Device, oldDevice *resource.Device, fldPath 
 		allErrs = append(allErrs, field.Invalid(fldPath, numAttributeValues, fmt.Sprintf("the total number of attribute values must not exceed %d", resource.ResourceSliceMaxAttributeValuesPerDevice)))
 	}
 
-	allErrs = append(allErrs, validateMap(device.Attributes, -1, attributeAndCapacityMaxKeyLength, validateQualifiedName, validateDeviceAttribute, fldPath.Child("attributes"))...)
+	// If the entire set of attributes is the same as before then validation can
+	// be skipped. This ratchets the key format: a slice which already stores a
+	// key that today's validation rejects can still be updated, as long as the
+	// attributes themselves are left alone.
+	if oldDevice == nil || !apiequality.Semantic.DeepEqual(oldDevice.Attributes, device.Attributes) {
+		allErrs = append(allErrs, validateMap(device.Attributes, -1, attributeAndCapacityMaxKeyLength, validateQualifiedName, validateDeviceAttribute, fldPath.Child("attributes"))...)
+	}
 	// If the entire capacity is the same as before then validation can be skipped.
 	// We could also do the DeepEqual on the entire spec, but here it is a bit cheaper.
 	if oldDevice == nil || !apiequality.Semantic.DeepEqual(oldDevice.Capacity, device.Capacity) {
@@ -1626,17 +1632,8 @@ func validateQualifiedName(name resource.QualifiedName, fldPath *field.Path) fie
 		} else {
 			allErrs = append(allErrs, validateCIdentifier(parts[1], fldPath)...)
 		}
-		// TODO: This validation is incomplete. It should reject qualified names
-		// that contain more than one slash. Currently, names like "a/b/c" are not
-		// handled and are implicitly accepted.
-		//
-		// This needs to be fixed in two places:
-		// 1. Here in this function.
-		// 2. In the corresponding declarative validation utility `resourcesQualifiedName`
-		//    in `staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go`.
-		//
-		// The fix should be introduced carefully, possibly using ratcheting to avoid
-		// breaking existing, non-compliant objects.
+	default:
+		allErrs = append(allErrs, field.Invalid(fldPath, string(name), "must not contain more than one slash"))
 	}
 
 	return allErrs

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -2119,6 +2119,19 @@ func TestValidateResourceSliceUpdate(t *testing.T) {
 				return slice
 			},
 		},
+		// The handwritten validation only consults the name format to decide
+		// whether looking for the attribute on each device is worthwhile, so a
+		// stored malformed name produces no error here. The declarative side
+		// skips the field because it is unchanged.
+		"valid-update-keeps-stored-partition-type-attribute-with-extra-slash": {
+			oldResourceSlice: func() *resourceapi.ResourceSlice {
+				slice := validResourceSlice.DeepCopy()
+				slice.Spec.Devices[0].ConsumesCounters = createConsumesCounters(1)
+				slice.Spec.PartitionTypeAttribute = ptr.To(resourceapi.FullyQualifiedName("x.example.com/y/z"))
+				return slice
+			}(),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice { return slice },
+		},
 		"invalid-update-nodename": {
 			wantFailures:     field.ErrorList{field.Invalid(field.NewPath("spec", "nodeName"), ptr.To(name+"-updated"), "field is immutable")},
 			oldResourceSlice: validResourceSlice,

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -1715,6 +1715,44 @@ func TestValidateResourceSlice(t *testing.T) {
 			}(),
 			enableDRANodeAllocatableResourcesFeatureGate: true,
 		},
+		"bad-node-allocatable-resources-capacity-key-extra-slash": {
+			// A malformed key can never be found in the capacity map, so the
+			// format problem is reported instead of "not found".
+			wantFailures: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "devices").Index(0).Child("nodeAllocatableResources").Key(string(v1.ResourceCPU)).Child("mapping").Child("capacityKey"), "dra.example.com/cpu/extra", "must not contain more than one slash"),
+			},
+			slice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSliceWithNodeAllocatableResources(goodName, goodName, driverName, 1)
+				slice.Spec.Devices[0].NodeAllocatableResources = map[v1.ResourceName]resourceapi.NodeAllocatableResource{
+					v1.ResourceCPU: {
+						Mapping: &resourceapi.NodeAllocatableMapping{
+							CapacityKey:        ptr.To[resourceapi.QualifiedName]("dra.example.com/cpu/extra"),
+							CapacityMultiplier: ptr.To(resource.MustParse("1")),
+						},
+					},
+				}
+				return slice
+			}(),
+			enableDRANodeAllocatableResourcesFeatureGate: true,
+		},
+		"bad-node-allocatable-resources-capacity-key-bad-name": {
+			wantFailures: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "devices").Index(0).Child("nodeAllocatableResources").Key(string(v1.ResourceCPU)).Child("mapping").Child("capacityKey"), "1cpu", "a valid C identifier must start with alphabetic character or '_', followed by a string of alphanumeric characters or '_' (e.g. 'my_name',  or 'MY_NAME',  or 'MyName', regex used for validation is '[A-Za-z_][A-Za-z0-9_]*')"),
+			},
+			slice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSliceWithNodeAllocatableResources(goodName, goodName, driverName, 1)
+				slice.Spec.Devices[0].NodeAllocatableResources = map[v1.ResourceName]resourceapi.NodeAllocatableResource{
+					v1.ResourceCPU: {
+						Mapping: &resourceapi.NodeAllocatableMapping{
+							CapacityKey:        ptr.To[resourceapi.QualifiedName]("dra.example.com/1cpu"),
+							CapacityMultiplier: ptr.To(resource.MustParse("1")),
+						},
+					},
+				}
+				return slice
+			}(),
+			enableDRANodeAllocatableResourcesFeatureGate: true,
+		},
 		"bad-node-allocatable-resources-invalid-device-multiplier-negative": {
 			wantFailures: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "devices").Index(0).Child("nodeAllocatableResources").Key(string(v1.ResourceCPU)).Child("mapping").Child("deviceMultiplier"), "-1", "must be positive"),

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -797,6 +797,18 @@ func TestValidateResourceSlice(t *testing.T) {
 				return slice
 			}(),
 		},
+		"bad-attribute-extra-slash": {
+			wantFailures: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "devices").Index(1).Child("attributes"), "x.example.com/y/z", "must not contain more than one slash"),
+			},
+			slice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSlice(goodName, goodName, goodName, 2)
+				slice.Spec.Devices[1].Attributes = map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					resourceapi.QualifiedName("x.example.com/y/z"): {StringValue: ptr.To("z")},
+				}
+				return slice
+			}(),
+		},
 		"combined-attributes-capacity-length": {
 			wantFailures: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "devices").Index(3), resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice+1, fmt.Sprintf("the total number of attributes and capacities must not exceed %d", resourceapi.ResourceSliceMaxAttributesAndCapacitiesPerDevice)),
@@ -2076,6 +2088,36 @@ func TestValidateResourceSliceUpdate(t *testing.T) {
 				return slice
 			},
 			wantFailures: field.ErrorList{field.Invalid(field.NewPath("metadata", "name"), name+"-update", "field is immutable")},
+		},
+		"valid-update-keeps-stored-attribute-name-with-extra-slash": {
+			// A slice stored before the key format was enforced keeps working
+			// as long as its attributes are not touched.
+			oldResourceSlice: func() *resourceapi.ResourceSlice {
+				slice := validResourceSlice.DeepCopy()
+				slice.Spec.Devices[0].Attributes = map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					resourceapi.QualifiedName("x.example.com/y/z"): {StringValue: ptr.To("v")},
+				}
+				return slice
+			}(),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice { return slice },
+		},
+		"invalid-update-touches-stored-attribute-name-with-extra-slash": {
+			// Rewriting the attributes re-validates them, so the stored key is
+			// reported.
+			wantFailures: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "devices").Index(0).Child("attributes"), "x.example.com/y/z", "must not contain more than one slash"),
+			},
+			oldResourceSlice: func() *resourceapi.ResourceSlice {
+				slice := validResourceSlice.DeepCopy()
+				slice.Spec.Devices[0].Attributes = map[resourceapi.QualifiedName]resourceapi.DeviceAttribute{
+					resourceapi.QualifiedName("x.example.com/y/z"): {StringValue: ptr.To("v")},
+				}
+				return slice
+			}(),
+			update: func(slice *resourceapi.ResourceSlice) *resourceapi.ResourceSlice {
+				slice.Spec.Devices[0].Attributes[resourceapi.QualifiedName("x.example.com/other")] = resourceapi.DeviceAttribute{StringValue: ptr.To("v")}
+				return slice
+			},
 		},
 		"invalid-update-nodename": {
 			wantFailures:     field.ErrorList{field.Invalid(field.NewPath("spec", "nodeName"), ptr.To(name+"-updated"), "field is immutable")},

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go
@@ -262,7 +262,8 @@ func ExtendedResourceName[T ~string](_ context.Context, op operation.Operation, 
 // resourcesQualifiedName verifies that the specified value is a valid Kubernetes resources
 // qualified name.
 //   - must not be empty
-//   - must be composed of an optional prefix and a name, separated by a slash (e.g., "prefix/name")
+//   - must be composed of an optional prefix and a name, separated by a single
+//     slash (e.g., "prefix/name")
 //   - the prefix, if specified, must be a DNS subdomain
 //   - the name part must be a C identifier
 //   - the name part must be no more than 32 characters
@@ -273,9 +274,6 @@ func resourcesQualifiedName[T ~string](ctx context.Context, op operation.Operati
 	var allErrs field.ErrorList
 	s := string(*value)
 	parts := strings.Split(s, "/")
-	// TODO: This validation and the corresponding handwritten validation validateQualifiedName in
-	// pkg/apis/resource/validation/validation.go are not validating whether there are more than 1
-	// slash. This should be fixed in both places.
 	switch len(parts) {
 	case 1:
 		allErrs = append(allErrs, validateCIdentifier(parts[0], resourceDeviceMaxLength, fldPath)...)
@@ -293,6 +291,8 @@ func resourcesQualifiedName[T ~string](ctx context.Context, op operation.Operati
 		} else {
 			allErrs = append(allErrs, validateCIdentifier(parts[1], resourceDeviceMaxLength, fldPath)...)
 		}
+	default:
+		allErrs = append(allErrs, field.Invalid(fldPath, s, "must not contain more than one slash"))
 	}
 	return allErrs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt_test.go
@@ -922,9 +922,29 @@ func TestResourceFullyQualifiedName(t *testing.T) {
 		input:    "prefix.com/Name",
 		wantErrs: nil, // no errors, C-identifiers can have uppercase letters
 	}, {
-		name:     "invalid: more than one slash",
-		input:    "prefix.com/name/extra",
-		wantErrs: nil, // This is not validated, yet.
+		name:  "invalid: more than one slash",
+		input: "prefix.com/name/extra",
+		wantErrs: field.ErrorList{
+			field.Invalid(fldPath, "prefix.com/name/extra", "must not contain more than one slash").WithOrigin("format=k8s-resource-fully-qualified-name"),
+		},
+	}, {
+		name:  "invalid: trailing slash after a qualified name",
+		input: "prefix.com/name/",
+		wantErrs: field.ErrorList{
+			field.Invalid(fldPath, "prefix.com/name/", "must not contain more than one slash").WithOrigin("format=k8s-resource-fully-qualified-name"),
+		},
+	}, {
+		name:  "invalid: empty segment between slashes",
+		input: "prefix.com//name",
+		wantErrs: field.ErrorList{
+			field.Invalid(fldPath, "prefix.com//name", "must not contain more than one slash").WithOrigin("format=k8s-resource-fully-qualified-name"),
+		},
+	}, {
+		name:  "invalid: leading slash before a qualified name",
+		input: "/prefix.com/name",
+		wantErrs: field.ErrorList{
+			field.Invalid(fldPath, "/prefix.com/name", "must not contain more than one slash").WithOrigin("format=k8s-resource-fully-qualified-name"),
+		},
 	}, {
 		name:  "invalid: empty name",
 		input: "prefix.com/",

--- a/test/declarative_validation/resource/resourceslice/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceslice/declarative_validation_test.go
@@ -310,6 +310,16 @@ func TestDeclarativeValidate(t *testing.T) {
 						field.Invalid(field.NewPath("spec", "partitionTypeAttribute"), nil, "").WithOrigin("format=k8s-resource-fully-qualified-name"),
 					},
 				},
+				"invalid: partitionTypeAttribute with more than one slash": {
+					input: mkResourceSliceWithDevices(
+						tweakDeviceCounter(counters("valid-key")),
+						tweakPartitionTypeAttribute("gpu.example.com/profile/full"),
+					),
+					enablePartitionTypeAttr: true,
+					expectedErrs: field.ErrorList{
+						field.Invalid(field.NewPath("spec", "partitionTypeAttribute"), nil, "").WithOrigin("format=k8s-resource-fully-qualified-name"),
+					},
+				},
 				"invalid: partitionTypeAttribute with feature disabled": {
 					input: mkResourceSliceWithDevices(
 						tweakDeviceCounter(counters("valid-key")),


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`validateQualifiedName` (handwritten) and `resourcesQualifiedName` (declarative)
both split a `resource.k8s.io` qualified name on `/` and switch on the number of
parts, handling only 1 and 2. A value with two or more slashes matches neither
case and is returned with an empty error list, so it bypasses every check the
two-part case performs -- not only the slash count, but the empty-prefix and
empty-name checks as well.

Both validators currently accept all of these:

| input | errors before | errors after |
| --- | --- | --- |
| `a/b/c` | 0 | 1 |
| `a/b/c/d` | 0 | 1 |
| `/a/b` | 0 | 1 |
| `a//b` | 0 | 1 |

The two validators do not cover the same fields on `resource.k8s.io/v1`.

Handwritten `validateQualifiedName` is called on the `Device.Attributes` and
`Device.Capacity` map keys only. Through `validateFullyQualifiedName` it also
reaches `matchAttribute`, `distinctAttribute` and `partitionTypeAttribute`.
`capacityKey`, `requests` and `consumedCapacity` are typed `QualifiedName` but
nothing called the function on them and they carry no format marker either.
`capacityKey` is now checked in `validateNodeAllocatableMapping`, so a malformed
key reports the format error rather than `NotFound`. `requests` and
`consumedCapacity` are left alone, they are covered by #140563.

Declarative `resourcesQualifiedName` is unexported and is only called from
`ResourceFullyQualifiedName`, so it reaches just the three fields tagged
`+k8s:format=k8s-resource-fully-qualified-name`: `matchAttribute`,
`distinctAttribute`, and `partitionTypeAttribute` (that one behind
`DRAPartitionableDevicesType`). `type QualifiedName` carries no format marker, so
the map keys and `capacityKey` have no declarative counterpart at all.

`DeclarativeValidationBeta` has defaulted on since 1.36, so where the two do
overlap both are active and neither backstops the other.

It is not only cosmetic. `parseQualifiedName` in
`staging/src/k8s.io/dynamic-resource-allocation/cel/compile.go` splits on the
first slash only, so a stored `a/b/c` attribute key is exposed to CEL as domain
`a` and identifier `b/c` -- an identifier that still contains a slash, which a
device selector cannot address.

Both functions get the missing `default` case, emitting the same message, so the
two stay equivalent and the declarative/handwritten mismatch metric stays at 0.

On ratcheting: the declarative path already skips unchanged values, since the
generated validators short-circuit on `oldValueCorrelated && op.Type == Update`.
That covers `matchAttribute`, `distinctAttribute` and `partitionTypeAttribute`.

On the handwritten side the ratchet sits on `spec.devices`. That list is
`+listType=atomic`, so the generated validation compares the whole list and
revalidates every device once anything in it changes; the handwritten validation
now does the same, and the two agree on what an update grandfathers. A
ResourceSlice that already stores a non-compliant key stays updatable while its
device list is untouched, for example when only the pool generation changes.
Adding or changing any device reports the stored key. The per-device comparisons
of `attributes`, `capacity` and `taints` are subsumed by the list comparison and
are gone.

The other two handwritten call sites need nothing. `validateDeviceConstraint`
runs on create only, because `validateDeviceClaim` is reached from
`ValidateResourceClaim` and `ValidateResourceClaimTemplate` and both update
validators treat the spec as immutable. In `validatePartitionTypeAttribute` the
`validateFullyQualifiedName` call is a guard rather than a check: it returns
early and appends nothing, so a stored malformed name produces no error. All
three cases have update tests.

The two TODOs describing this gap, added in #134602, are removed.

#### Which issue(s) this PR is related to:

No issue filed; the gap was documented in-tree by the TODOs this PR removes.

#### Special notes for your reviewer:

Beyond the tightening itself, the only behavior change is where the update
ratchet sits: `capacity` and `taints` were compared per device, and are now
covered by the one comparison of `spec.devices`.

#### Does this PR introduce a user-facing change?

```release-note
Creating or updating a resource.k8s.io object with a qualified name that contains more than one slash, such as a device attribute key `a/b/c`, is now rejected. Objects that already store such a name remain updatable as long as the field holding it is left unchanged; for a ResourceSlice, as long as `spec.devices` is unchanged, since any change to that atomic list revalidates every device in it.
```

/sig api-machinery
/sig node
/wg device-management
/area api-validation






