### PR TITLE
pkg/scheduler: track in-flight pod updates and introduce two-phase cycle completion

### DIFF
--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -518,13 +518,13 @@ func (aq *activeQueue) addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []f
 	return aq.unlockedQueue.addEventsIfPodInFlight(oldPod, newPod, events)
 }
 
-// addEventIfAnyInFlight adds clusterEvent to inFlightEvents if any pod is in inFlightPods.
+// addEventIfAnyInFlight adds clusterEvent to inFlightEvents if any pod is in its scheduling cycle (with a non-nil eventsMarker).
 // It returns true if pushed the event to the inFlightEvents.
 func (aq *activeQueue) addEventIfAnyInFlight(oldObj, newObj interface{}, event fwk.ClusterEvent) bool {
 	aq.lock.Lock()
 	defer aq.lock.Unlock()
 
-	if len(aq.inFlightPods) != 0 {
+	if aq.hasInFlightSchedulingPods() {
 		aq.metricsRecorder.ObserveInFlightEventsAsync(event.Label(), 1, false)
 		aq.inFlightEvents.PushBack(&clusterEvent{
 			event:  event,
@@ -532,6 +532,15 @@ func (aq *activeQueue) addEventIfAnyInFlight(oldObj, newObj interface{}, event f
 			newObj: newObj,
 		})
 		return true
+	}
+	return false
+}
+
+func (aq *activeQueue) hasInFlightSchedulingPods() bool {
+	for _, entry := range aq.inFlightPods {
+		if entry.eventsMarker != nil {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/scheduler/backend/queue/active_queue.go
+++ b/pkg/scheduler/backend/queue/active_queue.go
@@ -56,6 +56,8 @@ type activeQueuer interface {
 
 	listInFlightEvents() []interface{}
 	listInFlightPods() []*v1.Pod
+	inFlightPod(uid types.UID) *v1.Pod
+	deleteInFlight(uid types.UID)
 	clusterEventsForPod(logger klog.Logger, pInfo *framework.QueuedPodInfo) ([]*clusterEvent, error)
 	addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []fwk.ClusterEvent) bool
 	addEventIfAnyInFlight(oldObj, newObj interface{}, event fwk.ClusterEvent) bool
@@ -64,6 +66,7 @@ type activeQueuer interface {
 	clearPoppedEntity()
 
 	schedulingCycle() int64
+	doneSchedulingCycle(pod types.UID)
 	done(pod types.UID)
 	close()
 	broadcast()
@@ -76,6 +79,9 @@ type unlockedActiveQueuer interface {
 	// update updates the pod in activeQ if oldEntity is already in the queue and the pod is present there.
 	// It returns new pod info if updated, nil otherwise.
 	update(newPod *v1.Pod, oldEntity framework.QueuedEntityInfo) *framework.QueuedPodInfo
+	// updateInFlightPod updates the *v1.Pod stored for an in-flight pod.
+	// It returns true if the pod was found in inFlightPods and updated, false otherwise.
+	updateInFlightPod(newPod *v1.Pod) bool
 	// addEventsIfPodInFlight adds events to inFlightEvents if the newPod is in inFlightPods.
 	// It returns true if pushed the event to the inFlightEvents.
 	addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []fwk.ClusterEvent) bool
@@ -88,18 +94,30 @@ type unlockedActiveQueueReader interface {
 	// Returns false if the entity doesn't exist in the queue.
 	// This method should be called in activeQueue.underLock() or activeQueue.underRLock().
 	get(entityLookup framework.QueuedEntityInfo) (framework.QueuedEntityInfo, bool)
+	// inFlightPod returns the *v1.Pod for the given UID if it is currently in flight.
+	inFlightPod(uid types.UID) *v1.Pod
+}
+
+// inFlightPodEntry holds tracking information for a pod that is currently in-flight.
+type inFlightPodEntry struct {
+	// pod is the latest version of the in-flight pod.
+	pod *v1.Pod
+	// eventsMarker is the entry of this pod in the inFlightEvents list.
+	// The value of that entry is the *v1.Pod at the time that scheduling of that
+	// pod started, which can be useful for logging or debugging.
+	eventsMarker *list.Element
 }
 
 // unlockedActiveQueue defines activeQ methods that are not protected by the lock itself.
 // activeQueue.underLock() or activeQueue.underRLock() method should be used to protect these methods.
 type unlockedActiveQueue struct {
 	queue           *heap.Heap[framework.QueuedEntityInfo]
-	inFlightPods    map[types.UID]*list.Element
+	inFlightPods    map[types.UID]*inFlightPodEntry
 	inFlightEvents  *list.List
 	metricsRecorder *metrics.MetricAsyncRecorder
 }
 
-func newUnlockedActiveQueue(queue *heap.Heap[framework.QueuedEntityInfo], inFlightPods map[types.UID]*list.Element, inFlightEvents *list.List, metricsRecorder *metrics.MetricAsyncRecorder) *unlockedActiveQueue {
+func newUnlockedActiveQueue(queue *heap.Heap[framework.QueuedEntityInfo], inFlightPods map[types.UID]*inFlightPodEntry, inFlightEvents *list.List, metricsRecorder *metrics.MetricAsyncRecorder) *unlockedActiveQueue {
 	return &unlockedActiveQueue{
 		queue:           queue,
 		inFlightPods:    inFlightPods,
@@ -122,11 +140,30 @@ func (uaq *unlockedActiveQueue) update(newPod *v1.Pod, oldEntity framework.Queue
 	return nil
 }
 
+// updateInFlightPod updates the *v1.Pod stored for an in-flight pod.
+// It returns true if the pod was found in inFlightPods and updated, false otherwise.
+func (uaq *unlockedActiveQueue) updateInFlightPod(newPod *v1.Pod) bool {
+	entry, ok := uaq.inFlightPods[newPod.UID]
+	if ok {
+		entry.pod = newPod
+		return true
+	}
+	return false
+}
+
+// inFlightPod returns the *v1.Pod for the given UID if it is currently in flight.
+func (uaq *unlockedActiveQueue) inFlightPod(uid types.UID) *v1.Pod {
+	if entry, ok := uaq.inFlightPods[uid]; ok {
+		return entry.pod
+	}
+	return nil
+}
+
 // addEventsIfPodInFlight adds events to inFlightEvents if the newPod is in inFlightPods.
 // It returns true if pushed the event to the inFlightEvents.
 func (uaq *unlockedActiveQueue) addEventsIfPodInFlight(oldPod, newPod *v1.Pod, events []fwk.ClusterEvent) bool {
-	_, ok := uaq.inFlightPods[newPod.UID]
-	if ok {
+	entry, ok := uaq.inFlightPods[newPod.UID]
+	if ok && entry.eventsMarker != nil {
 		for _, event := range events {
 			uaq.metricsRecorder.ObserveInFlightEventsAsync(event.Label(), 1, false)
 			uaq.inFlightEvents.PushBack(&clusterEvent{
@@ -181,11 +218,7 @@ type activeQueue struct {
 	// inFlightPods holds the UID of all pods which have been popped out for which Done
 	// hasn't been called yet - in other words, all pods that are currently being
 	// processed (being scheduled, in permit, or in the binding cycle).
-	//
-	// The values in the map are the entry of each pod in the inFlightEvents list.
-	// The value of that entry is the *v1.Pod at the time that scheduling of that
-	// pod started, which can be useful for logging or debugging.
-	inFlightPods map[types.UID]*list.Element
+	inFlightPods map[types.UID]*inFlightPodEntry
 
 	// inFlightEvents holds the events received by the scheduling queue
 	// (entry value is clusterEvent) together with in-flight pods (entry
@@ -225,7 +258,7 @@ type activeQueue struct {
 func newActiveQueue(queue *heap.Heap[framework.QueuedEntityInfo], metricRecorder *metrics.MetricAsyncRecorder, backoffQPopper backoffQPopper) *activeQueue {
 	aq := &activeQueue{
 		queue:           queue,
-		inFlightPods:    make(map[types.UID]*list.Element),
+		inFlightPods:    make(map[types.UID]*inFlightPodEntry),
 		inFlightEvents:  list.New(),
 		metricsRecorder: metricRecorder,
 		backoffQPopper:  backoffQPopper,
@@ -277,7 +310,11 @@ func (aq *activeQueue) unlockedMoveEntityToInFlight(logger klog.Logger, entity f
 		}
 
 		aq.metricsRecorder.ObserveInFlightEventsAsync(metrics.PodPoppedInFlightEvent, 1, false)
-		aq.inFlightPods[pInfo.Pod.UID] = aq.inFlightEvents.PushBack(pInfo.Pod)
+		event := aq.inFlightEvents.PushBack(pInfo.Pod)
+		aq.inFlightPods[pInfo.Pod.UID] = &inFlightPodEntry{
+			pod:          pInfo.Pod,
+			eventsMarker: event,
+		}
 	}
 	if len(podsToDiscard) > 0 {
 		switch specificEntity := entity.(type) {
@@ -434,8 +471,8 @@ func (aq *activeQueue) listInFlightPods() []*v1.Pod {
 	aq.lock.RLock()
 	defer aq.lock.RUnlock()
 	var pods []*v1.Pod
-	for _, obj := range aq.inFlightPods {
-		pods = append(pods, obj.Value.(*v1.Pod))
+	for _, entry := range aq.inFlightPods {
+		pods = append(pods, entry.pod)
 	}
 	return pods
 }
@@ -454,9 +491,14 @@ func (aq *activeQueue) clusterEventsForPod(logger klog.Logger, pInfo *framework.
 	if !ok {
 		return nil, fmt.Errorf("in flight entity isn't found in the scheduling queue. If you see this error log, it's likely a bug in the scheduler")
 	}
+	// When DoneSchedulingCycle was called (e.g. pod is in the binding cycle), eventsMarker is nil
+	// because cluster events are only tracked during the scheduling cycle (up to Permit).
+	if inFlightPod.eventsMarker == nil {
+		return nil, nil
+	}
 
 	var events []*clusterEvent
-	for event := inFlightPod.Next(); event != nil; event = event.Next() {
+	for event := inFlightPod.eventsMarker.Next(); event != nil; event = event.Next() {
 		e, ok := event.Value.(*clusterEvent)
 		if !ok {
 			// Must be another in-flight Pod (*v1.Pod). Can be ignored.
@@ -500,6 +542,40 @@ func (aq *activeQueue) schedulingCycle() int64 {
 	return aq.schedCycle
 }
 
+// inFlightPod returns the *v1.Pod for the given UID if it is currently in flight.
+func (aq *activeQueue) inFlightPod(uid types.UID) *v1.Pod {
+	aq.lock.RLock()
+	defer aq.lock.RUnlock()
+
+	return aq.unlockedQueue.inFlightPod(uid)
+}
+
+// deleteInFlight removes the in-flight pod from tracking if present.
+func (aq *activeQueue) deleteInFlight(uid types.UID) {
+	aq.lock.Lock()
+	defer aq.lock.Unlock()
+
+	aq.unlockedDone(uid)
+}
+
+// doneSchedulingCycle is called when a pod finishes its scheduling cycle (after Permit).
+// It removes the pod's marker from inFlightEvents so cluster events are no longer accumulated for this pod,
+// while keeping the pod in inFlightPods until done is called at the end of the binding cycle or on failure.
+func (aq *activeQueue) doneSchedulingCycle(podUID types.UID) {
+	aq.lock.Lock()
+	defer aq.lock.Unlock()
+
+	aq.unlockedDoneSchedulingCycle(podUID)
+}
+
+func (aq *activeQueue) unlockedDoneSchedulingCycle(podUID types.UID) {
+	inFlightEntity, ok := aq.inFlightPods[podUID]
+	if !ok {
+		return
+	}
+	aq.unlockedRemoveEventsMarker(inFlightEntity)
+}
+
 // done must be called for pod returned by Pop. This allows the queue to
 // keep track of which pods are currently being processed.
 func (aq *activeQueue) done(podUID types.UID) {
@@ -518,10 +594,18 @@ func (aq *activeQueue) unlockedDone(podUID types.UID) {
 		return
 	}
 	delete(aq.inFlightPods, podUID)
+	aq.unlockedRemoveEventsMarker(inFlightEntity)
+}
 
-	// Remove the entity from the list.
-	aq.inFlightEvents.Remove(inFlightEntity)
+func (aq *activeQueue) unlockedRemoveEventsMarker(inFlightEntity *inFlightPodEntry) {
+	if inFlightEntity.eventsMarker != nil {
+		aq.inFlightEvents.Remove(inFlightEntity.eventsMarker)
+		inFlightEntity.eventsMarker = nil
+		aq.pruneInFlightEvents()
+	}
+}
 
+func (aq *activeQueue) pruneInFlightEvents() {
 	aggrMetricsCounter := map[string]int{}
 	// Remove events which are only referred to by this Pod
 	// so that the inFlightEvents list doesn't grow infinitely.

--- a/pkg/scheduler/backend/queue/active_queue_test.go
+++ b/pkg/scheduler/backend/queue/active_queue_test.go
@@ -172,3 +172,82 @@ func TestActiveQueue_InFlightPods(t *testing.T) {
 		})
 	}
 }
+
+func TestActiveQueue_AddEventIfAnyInFlight(t *testing.T) {
+	tests := []struct {
+		name               string
+		initialPods        []*v1.Pod
+		popCount           int
+		callDoneSchedCycle []types.UID
+		wantAdded          bool
+		wantInFlightEvents int
+	}{
+		{
+			name: "no pods in flight",
+			initialPods: []*v1.Pod{
+				st.MakePod().Namespace("ns").Name("p1").UID("p1").Obj(),
+			},
+			popCount:           0,
+			wantAdded:          false,
+			wantInFlightEvents: 0,
+		},
+		{
+			name: "pod in scheduling cycle (has eventsMarker)",
+			initialPods: []*v1.Pod{
+				st.MakePod().Namespace("ns").Name("p1").UID("p1").Obj(),
+			},
+			popCount:           1,
+			wantAdded:          true,
+			wantInFlightEvents: 2, // 1 marker + 1 cluster event
+		},
+		{
+			name: "pod in binding cycle (eventsMarker removed by doneSchedulingCycle)",
+			initialPods: []*v1.Pod{
+				st.MakePod().Namespace("ns").Name("p1").UID("p1").Obj(),
+			},
+			popCount:           1,
+			callDoneSchedCycle: []types.UID{"p1"},
+			wantAdded:          false,
+			wantInFlightEvents: 0,
+		},
+		{
+			name: "one pod binding and one pod scheduling",
+			initialPods: []*v1.Pod{
+				st.MakePod().Namespace("ns").Name("p1").UID("p1").Obj(),
+				st.MakePod().Namespace("ns").Name("p2").UID("p2").Obj(),
+			},
+			popCount:           2,
+			callDoneSchedCycle: []types.UID{"p1"},
+			wantAdded:          true,
+			wantInFlightEvents: 2, // p2 marker + 1 cluster event
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			rr := metrics.NewMetricsAsyncRecorder(10, time.Second, ctx.Done())
+			aq := newActiveQueue(heap.NewWithRecorder(queuedEntityKeyFunc, heap.LessFunc[framework.QueuedEntityInfo](convertLessFn(newDefaultQueueSort())), metrics.NewActiveEntitiesRecorder()), rr, nil)
+
+			for _, pod := range tt.initialPods {
+				aq.add(logger, &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: pod}}, framework.EventUnscheduledPodAdd.Label(), nil)
+			}
+			for i := 0; i < tt.popCount; i++ {
+				if _, err := aq.pop(logger); err != nil {
+					t.Fatalf("pop failed: %v", err)
+				}
+			}
+			for _, uid := range tt.callDoneSchedCycle {
+				aq.doneSchedulingCycle(uid)
+			}
+
+			gotAdded := aq.addEventIfAnyInFlight(nil, nil, nodeAdd)
+			if gotAdded != tt.wantAdded {
+				t.Fatalf("expected addEventIfAnyInFlight to return %v, got %v", tt.wantAdded, gotAdded)
+			}
+			if len(aq.listInFlightEvents()) != tt.wantInFlightEvents {
+				t.Fatalf("expected %d in-flight events, got %d", tt.wantInFlightEvents, len(aq.listInFlightEvents()))
+			}
+		})
+	}
+}

--- a/pkg/scheduler/backend/queue/active_queue_test.go
+++ b/pkg/scheduler/backend/queue/active_queue_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kubernetes/pkg/scheduler/backend/heap"
 	"k8s.io/kubernetes/pkg/scheduler/framework"
@@ -63,5 +65,110 @@ func TestClose(t *testing.T) {
 
 	if len(aq.listInFlightPods()) != 0 {
 		t.Fatalf("in-flight pods should be cleaned up, but %v pod(s) is remaining", len(aq.listInFlightPods()))
+	}
+}
+
+func TestActiveQueue_InFlightPods(t *testing.T) {
+	tests := []struct {
+		name                 string
+		initialPods          []*v1.Pod
+		popCount             int
+		updatePod            *v1.Pod
+		callDoneSchedCycle   types.UID
+		callDone             types.UID
+		callDelete           types.UID
+		wantInFlightPodLabel map[string]string
+		wantInFlightCount    int
+		wantInFlightEvents   int
+	}{
+		{
+			name: "update in-flight pod updates pod content",
+			initialPods: []*v1.Pod{
+				st.MakePod().Namespace("ns").Name("p1").UID("p1").Label("version", "v1").Obj(),
+			},
+			popCount:             1,
+			updatePod:            st.MakePod().Namespace("ns").Name("p1").UID("p1").Label("version", "v2").Obj(),
+			wantInFlightPodLabel: map[string]string{"version": "v2"},
+			wantInFlightCount:    1,
+		},
+		{
+			name: "doneSchedulingCycle removes events marker but keeps pod in-flight",
+			initialPods: []*v1.Pod{
+				st.MakePod().Namespace("ns").Name("p1").UID("p1").Label("version", "v1").Obj(),
+			},
+			popCount:             1,
+			callDoneSchedCycle:   "p1",
+			wantInFlightPodLabel: map[string]string{"version": "v1"},
+			wantInFlightCount:    1,
+			wantInFlightEvents:   0,
+		},
+		{
+			name: "delete in-flight pod removes it completely",
+			initialPods: []*v1.Pod{
+				st.MakePod().Namespace("ns").Name("p1").UID("p1").Label("version", "v1").Obj(),
+			},
+			popCount:          1,
+			callDelete:        "p1",
+			wantInFlightCount: 0,
+		},
+		{
+			name: "done on in-flight pod removes it completely",
+			initialPods: []*v1.Pod{
+				st.MakePod().Namespace("ns").Name("p1").UID("p1").Label("version", "v1").Obj(),
+			},
+			popCount:          1,
+			callDone:          "p1",
+			wantInFlightCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			rr := metrics.NewMetricsAsyncRecorder(10, time.Second, ctx.Done())
+			aq := newActiveQueue(heap.NewWithRecorder(queuedEntityKeyFunc, heap.LessFunc[framework.QueuedEntityInfo](convertLessFn(newDefaultQueueSort())), metrics.NewActiveEntitiesRecorder()), rr, nil)
+
+			for _, pod := range tt.initialPods {
+				aq.add(logger, &framework.QueuedPodInfo{PodInfo: &framework.PodInfo{Pod: pod}}, framework.EventUnscheduledPodAdd.Label(), nil)
+			}
+			for i := 0; i < tt.popCount; i++ {
+				if _, err := aq.pop(logger); err != nil {
+					t.Fatalf("pop failed: %v", err)
+				}
+			}
+
+			if tt.updatePod != nil {
+				aq.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
+					unlockedActiveQ.updateInFlightPod(tt.updatePod)
+				})
+			}
+			if tt.callDoneSchedCycle != "" {
+				aq.doneSchedulingCycle(tt.callDoneSchedCycle)
+			}
+			if tt.callDone != "" {
+				aq.done(tt.callDone)
+			}
+			if tt.callDelete != "" {
+				aq.deleteInFlight(tt.callDelete)
+			}
+
+			if len(aq.listInFlightPods()) != tt.wantInFlightCount {
+				t.Fatalf("expected %d in-flight pods, got %d", tt.wantInFlightCount, len(aq.listInFlightPods()))
+			}
+			if tt.wantInFlightPodLabel != nil {
+				pod := aq.inFlightPod(tt.initialPods[0].UID)
+				if pod == nil {
+					t.Fatalf("expected inFlightPod to find pod %s", tt.initialPods[0].UID)
+				}
+				for k, v := range tt.wantInFlightPodLabel {
+					if pod.Labels[k] != v {
+						t.Fatalf("expected label %s=%s, got %s", k, v, pod.Labels[k])
+					}
+				}
+			}
+			if tt.callDoneSchedCycle != "" && len(aq.listInFlightEvents()) != tt.wantInFlightEvents {
+				t.Fatalf("expected %d in-flight events, got %d", tt.wantInFlightEvents, len(aq.listInFlightEvents()))
+			}
+		})
 	}
 }

--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -121,10 +121,16 @@ type SchedulingQueue interface {
 	// cached by scheduling queue. Normally, incrementing this number whenever
 	// a pod is popped (e.g. called Pop()) is enough.
 	SchedulingCycle() int64
+	// InFlightPod returns the *v1.Pod for the given UID if it is currently in flight.
+	InFlightPod(types.UID) *v1.Pod
 	// Pop removes the head of the queue and returns it. It blocks if the
 	// queue is empty and waits until a new item is added to the queue.
 	Pop(logger klog.Logger) (framework.QueuedEntityInfo, error)
-	// Done must be called for pod returned by Pop. This allows the queue to
+	// DoneSchedulingCycle must be called for a pod when its scheduling cycle finishes (after Permit).
+	// It stops accumulating in-flight cluster events for the pod, but keeps the pod tracked as in-flight
+	// until Done is called at the end of the binding cycle or on failure.
+	DoneSchedulingCycle(types.UID)
+	// Done must be called for pod returned by Pop when processing finishes. This allows the queue to
 	// keep track of which pods are currently being processed.
 	Done(types.UID)
 	Update(ctx context.Context, oldPod, newPod *v1.Pod)
@@ -1088,6 +1094,17 @@ func (p *PriorityQueue) AddUnschedulablePodIfNotPresent(logger klog.Logger, pInf
 		}
 	}()
 
+	// Refresh the pod from inFlightPods if present, which contains the latest version delivered by Update events
+	// while the pod was in-flight (preventing stale informer reads from overwriting concurrent updates).
+	//
+	// TODO: Consider strictly requiring inFlightPod != nil here (and aborting if the pod is no longer in-flight,
+	// e.g. deleted or assigned). That would make queue state management fully strict, but requires auditing all callers
+	// and refactoring synthetic unit tests that invoke AddUnschedulablePodIfNotPresent directly without calling Pop().
+	if inFlightPod := p.activeQ.inFlightPod(pInfo.Pod.UID); inFlightPod != nil {
+		pInfo.PodInfo, _ = framework.NewPodInfo(inFlightPod)
+		pInfo.PodSignature = p.signPod(klog.NewContext(context.Background(), logger), inFlightPod)
+	}
+
 	pod := pInfo.Pod
 	if p.unschedulableEntities.get(pInfo) != nil {
 		return fmt.Errorf("Pod %v is already present in unschedulable queue", klog.KObj(pod))
@@ -1344,10 +1361,22 @@ func (p *PriorityQueue) Pop(logger klog.Logger) (framework.QueuedEntityInfo, err
 	return p.activeQ.pop(logger)
 }
 
-// Done must be called for pod returned by Pop. This allows the queue to
+// DoneSchedulingCycle must be called for a pod when its scheduling cycle finishes (after Permit).
+// It stops accumulating in-flight cluster events for the pod, but keeps the pod tracked as in-flight
+// until Done is called at the end of the binding cycle or on failure.
+func (p *PriorityQueue) DoneSchedulingCycle(pod types.UID) {
+	p.activeQ.doneSchedulingCycle(pod)
+}
+
+// Done must be called for pod returned by Pop when processing finishes. This allows the queue to
 // keep track of which pods are currently being processed.
 func (p *PriorityQueue) Done(pod types.UID) {
 	p.activeQ.done(pod)
+}
+
+// InFlightPod returns the *v1.Pod for the given UID if it is currently in flight.
+func (p *PriorityQueue) InFlightPod(uid types.UID) *v1.Pod {
+	return p.activeQ.inFlightPod(uid)
 }
 
 func (p *PriorityQueue) InFlightPods() []*v1.Pod {
@@ -1387,12 +1416,9 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 	// Locking only the part of Update method is sufficient, because in the other part the entity is in the unschedulableEntities,
 	// which is protected by p.lock anyway.
 	p.activeQ.underLock(func(unlockedActiveQ unlockedActiveQueuer) {
-		// The inflight pod will be requeued using the latest version from the informer cache, which matches what the event delivers.
-		// Record this Pod update because
-		// this update may make the Pod schedulable in case it gets rejected and comes back to the queue.
-		// We can clean it up once we change updatePodInSchedulingQueue to call MoveAllToActiveOrBackoffQueue.
-		// See https://github.com/kubernetes/kubernetes/pull/125578#discussion_r1648338033 for more context.
-		if exists := unlockedActiveQ.addEventsIfPodInFlight(oldPod, newPod, events); exists {
+		if unlockedActiveQ.updateInFlightPod(newPod) {
+			unlockedActiveQ.addEventsIfPodInFlight(oldPod, newPod, events)
+			p.UpdateNominatedPod(logger, oldPod, &framework.PodInfo{Pod: newPod})
 			logger.V(6).Info("The pod doesn't need to be queued for now because it's being scheduled and will be queued back if necessary", "pod", klog.KObj(newPod))
 			updated = true
 			return
@@ -1508,6 +1534,7 @@ func (p *PriorityQueue) deletePodGroupMember(logger klog.Logger, pod *v1.Pod) {
 	if entity == nil {
 		pInfo := p.pendingPodGroupPods.delete(pod)
 		if pInfo == nil {
+			p.activeQ.deleteInFlight(pod.UID)
 			return
 		}
 
@@ -1562,7 +1589,11 @@ func (p *PriorityQueue) deletePod(pod *v1.Pod) {
 		p.unschedulableEntities.delete(pInfoLookup, entity.Gated())
 		// Drop metric for deleted pod.
 		decreaseUnschedulableReasonMetric(entity)
+		return
 	}
+
+	// Check inFlightPods
+	p.activeQ.deleteInFlight(pod.UID)
 }
 
 // AddGenericPodGroup adds a PodGroup or CompositePodGroup object to the queue,

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -10368,3 +10368,61 @@ func TestPriorityQueue_InFlightPods(t *testing.T) {
 		})
 	}
 }
+
+func TestPriorityQueue_MoveAllToActiveOrBackoffQueue_InFlight(t *testing.T) {
+	tests := []struct {
+		name               string
+		initialPods        []*v1.Pod
+		popCount           int
+		callDoneSchedCycle []types.UID
+		clusterEvent       fwk.ClusterEvent
+		wantInFlightEvents int
+	}{
+		{
+			name: "cluster event recorded when pod in scheduling cycle",
+			initialPods: []*v1.Pod{
+				st.MakePod().Namespace("ns").Name("p1").UID("p1").Obj(),
+			},
+			popCount:           1,
+			clusterEvent:       framework.EventUnschedulableTimeout,
+			wantInFlightEvents: 2, // 1 marker + 1 cluster event
+		},
+		{
+			name: "cluster event not recorded when pod in binding cycle (doneSchedulingCycle called)",
+			initialPods: []*v1.Pod{
+				st.MakePod().Namespace("ns").Name("p1").UID("p1").Obj(),
+			},
+			popCount:           1,
+			callDoneSchedCycle: []types.UID{"p1"},
+			clusterEvent:       framework.EventUnschedulableTimeout,
+			wantInFlightEvents: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			q := NewTestQueue(ctx, newDefaultQueueSort())
+			for _, pod := range tt.initialPods {
+				q.Add(ctx, pod)
+			}
+			for i := 0; i < tt.popCount; i++ {
+				if _, err := q.Pop(logger); err != nil {
+					t.Fatalf("Pop failed: %v", err)
+				}
+			}
+			for _, uid := range tt.callDoneSchedCycle {
+				q.DoneSchedulingCycle(uid)
+			}
+
+			q.MoveAllToActiveOrBackoffQueue(logger, tt.clusterEvent, nil, nil, nil)
+
+			if got := len(q.activeQ.listInFlightEvents()); got != tt.wantInFlightEvents {
+				t.Fatalf("expected %d in-flight events, got %d", tt.wantInFlightEvents, got)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -10261,3 +10261,110 @@ func TestPreQueueingHint_PerPluginNarrowing(t *testing.T) {
 		t.Errorf("pluginB QueueingHintFn should be called for pod2, called for: %v", pluginBQueueingHintCalled)
 	}
 }
+
+func TestPriorityQueue_InFlightPods(t *testing.T) {
+	tests := []struct {
+		name                 string
+		initialPod           *v1.Pod
+		updatePod            *v1.Pod
+		deletePod            *v1.Pod
+		callDoneSchedCycle   bool
+		requeue              bool
+		wantInQueue          bool
+		wantInFlight         bool
+		wantPodLabelInQueue  map[string]string
+		wantRequeuedPodLabel map[string]string
+	}{
+		{
+			name:                 "update in-flight pod refreshes pod on requeue",
+			initialPod:           st.MakePod().Namespace("ns").Name("p1").UID("p1").Label("foo", "bar").Obj(),
+			updatePod:            st.MakePod().Namespace("ns").Name("p1").UID("p1").Label("foo", "baz").Obj(),
+			requeue:              true,
+			wantInQueue:          true,
+			wantInFlight:         false,
+			wantPodLabelInQueue:  map[string]string{"foo": "baz"},
+			wantRequeuedPodLabel: map[string]string{"foo": "baz"},
+		},
+		{
+			name:         "delete in-flight pod removes from in-flight",
+			initialPod:   st.MakePod().Namespace("ns").Name("p1").UID("p1").Obj(),
+			deletePod:    st.MakePod().Namespace("ns").Name("p1").UID("p1").Obj(),
+			requeue:      false,
+			wantInQueue:  false,
+			wantInFlight: false,
+		},
+		{
+			name:                 "doneSchedulingCycle keeps pod in-flight during binding until requeue",
+			initialPod:           st.MakePod().Namespace("ns").Name("p1").UID("p1").Label("foo", "bar").Obj(),
+			updatePod:            st.MakePod().Namespace("ns").Name("p1").UID("p1").Label("foo", "baz").Obj(),
+			callDoneSchedCycle:   true,
+			requeue:              true,
+			wantInQueue:          true,
+			wantInFlight:         false,
+			wantPodLabelInQueue:  map[string]string{"foo": "baz"},
+			wantRequeuedPodLabel: map[string]string{"foo": "baz"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			q := NewTestQueue(ctx, newDefaultQueueSort())
+			q.Add(ctx, tt.initialPod)
+
+			popped, err := q.Pop(logger)
+			if err != nil {
+				t.Fatalf("Pop failed: %v", err)
+			}
+
+			if tt.updatePod != nil {
+				q.Update(ctx, tt.initialPod, tt.updatePod)
+			}
+			if tt.deletePod != nil {
+				q.Delete(logger, tt.deletePod)
+			}
+			if tt.callDoneSchedCycle {
+				q.DoneSchedulingCycle(tt.initialPod.UID)
+			}
+
+			if tt.requeue {
+				pInfo := popped.(*framework.QueuedPodInfo)
+				if err := q.AddUnschedulablePodIfNotPresent(logger, pInfo, q.SchedulingCycle()); err != nil {
+					t.Fatalf("AddUnschedulablePodIfNotPresent: %v", err)
+				}
+				if tt.wantRequeuedPodLabel != nil {
+					for k, v := range tt.wantRequeuedPodLabel {
+						if pInfo.Pod.Labels[k] != v {
+							t.Fatalf("expected label %s=%s, got %s", k, v, pInfo.Pod.Labels[k])
+						}
+					}
+				}
+			}
+
+			if tt.wantInFlight {
+				if q.activeQ.inFlightPod(tt.initialPod.UID) == nil {
+					t.Fatalf("expected pod %s to be in flight", tt.initialPod.UID)
+				}
+			} else {
+				if q.activeQ.inFlightPod(tt.initialPod.UID) != nil {
+					t.Fatalf("expected pod %s not to be in flight", tt.initialPod.UID)
+				}
+			}
+
+			gotPInfo, ok := q.GetPod(tt.initialPod.Name, tt.initialPod.Namespace, nil)
+			if ok != tt.wantInQueue {
+				t.Fatalf("expected inQueue=%v, got %v", tt.wantInQueue, ok)
+			}
+			if ok && tt.wantPodLabelInQueue != nil {
+				for k, v := range tt.wantPodLabelInQueue {
+					if gotPInfo.Pod.Labels[k] != v {
+						t.Fatalf("expected queue pod label %s=%s, got %s", k, v, gotPInfo.Pod.Labels[k])
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/scheduler/schedule_one.go
+++ b/pkg/scheduler/schedule_one.go
@@ -452,9 +452,9 @@ func (sched *Scheduler) bindingCycle(
 	// We define the Pod as "unschedulable" only when Pods are rejected at specific extension points, and Permit is the last one in the scheduling/binding cycle.
 	// If a Pod fails on PreBind or Bind, it should be moved to BackoffQ for retry.
 	//
-	// We can call Done() here because
-	// we can free the cluster events stored in the scheduling queue sooner, which is worth for busy clusters memory consumption wise.
-	sched.SchedulingQueue.Done(assumedPod.UID)
+	// We call DoneSchedulingCycle() here to free the cluster events stored in the scheduling queue sooner,
+	// while keeping the pod tracked in in-flight pods until binding finishes.
+	sched.SchedulingQueue.DoneSchedulingCycle(assumedPod.UID)
 
 	// If we are going to run prebind plugins we put the pod in binding map to optimize preemption.
 	if preFlightStatus.IsSuccess() {
@@ -495,6 +495,9 @@ func (sched *Scheduler) bindingCycle(
 	}
 	// Run "postbind" plugins.
 	schedFramework.RunPostBindPlugins(ctx, state, assumedPod, scheduleResult.SuggestedHost)
+
+	// Mark pod as done in scheduling queue after successful binding.
+	sched.SchedulingQueue.Done(assumedPod.UID)
 
 	// At the end of a successful binding cycle, move up Pods if needed.
 	if len(podsToActivate.Map) != 0 {
@@ -1230,6 +1233,12 @@ func (sched *Scheduler) handleSchedulingFailure(ctx context.Context, podFwk fram
 				logger.V(2).Info("Pod was recreated while handling scheduling failure. Skip requeueing and status updates.", "pod", klog.KObj(pod), "oldUID", podInfo.Pod.UID, "newUID", cachedPod.UID)
 				return
 			}
+			// TODO: As the scheduling queue now tracks in-flight pods and automatically refreshes
+			// podInfo from the latest in-flight version during AddUnschedulablePodIfNotPresent,
+			// refreshing from the informer cache here might no longer be necessary.
+			// However, fully removing the informer lookup here requires auditing other consumers
+			// (e.g. nominator, patch) and refactoring associated unit tests.
+			//
 			// As <cachedPod> is from SharedInformer, we need to do a DeepCopy() here.
 			// ignore this err since apiserver doesn't properly validate affinity terms
 			// and we can't fix the validation for backwards compatibility.

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -1857,21 +1857,22 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 	assignedTestPod := podWithID("foo", testNode.Name)
 
 	table := []struct {
-		name                                string
-		sendPod                             *v1.Pod
-		registerPluginFuncs                 []tf.RegisterPluginFunc
-		injectSchedulingError               error
-		injectBindError                     error
-		mockScheduleResult                  ScheduleResult
-		mockWaitOnPermitResult              *fwk.Status
-		mockRunPreBindPluginsResult         *fwk.Status
-		expectErrorPod                      *v1.Pod
-		expectAssumedPod                    *v1.Pod
-		expectError                         error
-		expectBind                          *v1.Binding
-		eventReason                         string
-		expectPodIsInFlightAtFailureHandler bool
-		expectPodIsInFlightAtWaitOnPermit   bool
+		name                                   string
+		sendPod                                *v1.Pod
+		registerPluginFuncs                    []tf.RegisterPluginFunc
+		injectSchedulingError                  error
+		injectBindError                        error
+		mockScheduleResult                     ScheduleResult
+		mockWaitOnPermitResult                 *fwk.Status
+		mockRunPreBindPluginsResult            *fwk.Status
+		expectErrorPod                         *v1.Pod
+		expectAssumedPod                       *v1.Pod
+		expectError                            error
+		expectBind                             *v1.Binding
+		eventReason                            string
+		expectPodIsInFlightAtFailureHandler    bool
+		expectPodIsInFlightAtWaitOnPermit      bool
+		expectPodIsInFlightAtRunPreBindPlugins bool
 	}{
 		{
 			name:               "error on permit",
@@ -1936,26 +1937,28 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 			registerPluginFuncs: []tf.RegisterPluginFunc{
 				tf.RegisterPreBindPlugin("FakePreBind", tf.NewFakePreBindPlugin(nil, fwk.NewStatus(fwk.Unschedulable))),
 			},
-			mockWaitOnPermitResult:              fwk.NewStatus(fwk.Success),
-			mockRunPreBindPluginsResult:         fwk.NewStatus(fwk.Unschedulable, preBindErr.Error()),
-			expectErrorPod:                      assignedTestPod,
-			expectAssumedPod:                    assignedTestPod,
-			expectError:                         preBindErr,
-			eventReason:                         "FailedScheduling",
-			expectPodIsInFlightAtFailureHandler: false,
-			expectPodIsInFlightAtWaitOnPermit:   true,
+			mockWaitOnPermitResult:                 fwk.NewStatus(fwk.Success),
+			mockRunPreBindPluginsResult:            fwk.NewStatus(fwk.Unschedulable, preBindErr.Error()),
+			expectErrorPod:                         assignedTestPod,
+			expectAssumedPod:                       assignedTestPod,
+			expectError:                            preBindErr,
+			eventReason:                            "FailedScheduling",
+			expectPodIsInFlightAtFailureHandler:    true,
+			expectPodIsInFlightAtWaitOnPermit:      true,
+			expectPodIsInFlightAtRunPreBindPlugins: true,
 		},
 		{
-			name:                                "bind assumed pod scheduled",
-			sendPod:                             testPod,
-			mockScheduleResult:                  scheduleResultOk,
-			expectBind:                          bindingOk,
-			expectAssumedPod:                    assignedTestPod,
-			mockWaitOnPermitResult:              fwk.NewStatus(fwk.Success),
-			mockRunPreBindPluginsResult:         fwk.NewStatus(fwk.Success),
-			eventReason:                         "Scheduled",
-			expectPodIsInFlightAtFailureHandler: false,
-			expectPodIsInFlightAtWaitOnPermit:   true,
+			name:                                   "bind assumed pod scheduled",
+			sendPod:                                testPod,
+			mockScheduleResult:                     scheduleResultOk,
+			expectBind:                             bindingOk,
+			expectAssumedPod:                       assignedTestPod,
+			mockWaitOnPermitResult:                 fwk.NewStatus(fwk.Success),
+			mockRunPreBindPluginsResult:            fwk.NewStatus(fwk.Success),
+			eventReason:                            "Scheduled",
+			expectPodIsInFlightAtFailureHandler:    false,
+			expectPodIsInFlightAtWaitOnPermit:      true,
+			expectPodIsInFlightAtRunPreBindPlugins: true,
 		},
 		{
 			name:                                "error pod failed scheduling",
@@ -1968,19 +1971,20 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 			expectPodIsInFlightAtFailureHandler: true,
 		},
 		{
-			name:                                "error bind forget pod failed scheduling",
-			sendPod:                             testPod,
-			mockScheduleResult:                  scheduleResultOk,
-			mockWaitOnPermitResult:              fwk.NewStatus(fwk.Success),
-			mockRunPreBindPluginsResult:         fwk.NewStatus(fwk.Success),
-			expectBind:                          bindingOk,
-			expectAssumedPod:                    assignedTestPod,
-			injectBindError:                     bindingErr,
-			expectError:                         fmt.Errorf("running Bind plugin %q: %w", "DefaultBinder", bindingErr),
-			expectErrorPod:                      assignedTestPod,
-			eventReason:                         "FailedScheduling",
-			expectPodIsInFlightAtFailureHandler: false,
-			expectPodIsInFlightAtWaitOnPermit:   true,
+			name:                                   "error bind forget pod failed scheduling",
+			sendPod:                                testPod,
+			mockScheduleResult:                     scheduleResultOk,
+			mockWaitOnPermitResult:                 fwk.NewStatus(fwk.Success),
+			mockRunPreBindPluginsResult:            fwk.NewStatus(fwk.Success),
+			expectBind:                             bindingOk,
+			expectAssumedPod:                       assignedTestPod,
+			injectBindError:                        bindingErr,
+			expectError:                            fmt.Errorf("running Bind plugin %q: %w", "DefaultBinder", bindingErr),
+			expectErrorPod:                         assignedTestPod,
+			eventReason:                            "FailedScheduling",
+			expectPodIsInFlightAtFailureHandler:    true,
+			expectPodIsInFlightAtWaitOnPermit:      true,
+			expectPodIsInFlightAtRunPreBindPlugins: true,
 		},
 		{
 			name:                                "deleting pod",
@@ -2141,8 +2145,9 @@ func TestScheduleOneMarksPodAsProcessedBeforePreBind(t *testing.T) {
 					t.Errorf("unexpected pod being in flight at start of WaitOnPermit, expected %v but got %v",
 						item.expectPodIsInFlightAtWaitOnPermit, gotPodIsInFlightAtWaitOnPermit)
 				}
-				if gotPodIsInFlightAtRunPreBindPlugins {
-					t.Errorf("unexpected pod being in flight at start of RunPreBindPlugins")
+				if item.expectPodIsInFlightAtRunPreBindPlugins != gotPodIsInFlightAtRunPreBindPlugins {
+					t.Errorf("unexpected pod being in flight at start of RunPreBindPlugins, expected %v but got %v",
+						item.expectPodIsInFlightAtRunPreBindPlugins, gotPodIsInFlightAtRunPreBindPlugins)
 				}
 				// We have to use wait here
 				// because the Pod goes to the binding cycle in some test cases and the inflight pods might not be empty immediately at this point in such case.
@@ -2190,6 +2195,149 @@ func podListContainsPod(list []*v1.Pod, pod *v1.Pod) bool {
 		}
 	}
 	return false
+}
+
+func TestScheduleOne_PodUpdateDuringBindingCycle(t *testing.T) {
+	testNode := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "machine1", UID: types.UID("machine1")}}
+	scheduleResultOk := ScheduleResult{SuggestedHost: testNode.Name}
+	bindingOk := &v1.Binding{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod1", UID: types.UID("pod1")}, Target: v1.ObjectReference{Kind: "Node", Name: testNode.Name}}
+
+	tests := []struct {
+		name                  string
+		preBindStatus         *fwk.Status
+		expectInActiveQCount  int
+		expectInBackoffQCount int
+		expectBackoffPodLabel map[string]string
+		expectBind            *v1.Binding
+	}{
+		{
+			name:                  "pod updated during binding and prebind fails, pod is moved to backoff with updated version and not activeQ",
+			preBindStatus:         fwk.NewStatus(fwk.Unschedulable, "prebind failure"),
+			expectInActiveQCount:  0,
+			expectInBackoffQCount: 1,
+			expectBackoffPodLabel: map[string]string{"version": "v2"},
+		},
+		{
+			name:                  "pod updated during binding and binding succeeds, pod is completed and not in any queue",
+			preBindStatus:         fwk.NewStatus(fwk.Success),
+			expectInActiveQCount:  0,
+			expectInBackoffQCount: 0,
+			expectBind:            bindingOk,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, ctx := ktesting.NewTestContext(t)
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			initialPod := st.MakePod().Namespace("ns").Name("pod1").UID("pod1").SchedulerName(testSchedulerName).Label("version", "v1").Obj()
+			updatedPod := st.MakePod().Namespace("ns").Name("pod1").UID("pod1").SchedulerName(testSchedulerName).Label("version", "v2").Obj()
+
+			client := clientsetfake.NewSimpleClientset(initialPod, &testNode)
+			informerFactory := informers.NewSharedInformerFactory(client, 0)
+			eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1()})
+
+			cache := internalcache.New(ctx, nil, false, false)
+			ar := metrics.NewMetricsAsyncRecorder(10, time.Second, ctx.Done())
+			queue := internalqueue.NewSchedulingQueue(nil, informerFactory, internalqueue.WithMetricsRecorder(ar))
+
+			informerFactory.Start(ctx.Done())
+			informerFactory.WaitForCacheSync(ctx.Done())
+
+			schedFramework, err := NewFakeFramework(
+				ctx,
+				queue,
+				[]tf.RegisterPluginFunc{
+					tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
+					tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
+				},
+				testSchedulerName,
+				frameworkruntime.WithClientSet(client),
+				frameworkruntime.WithInformerFactory(informerFactory),
+				frameworkruntime.WithEventRecorder(eventBroadcaster.NewRecorder(scheme.Scheme, testSchedulerName)),
+				frameworkruntime.WithWaitingPods(frameworkruntime.NewWaitingPodsMap()),
+				frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			schedFramework.waitOnPermitFn = func(_ context.Context, _ *v1.Pod) *fwk.Status {
+				return fwk.NewStatus(fwk.Success)
+			}
+
+			schedFramework.runPreBindPluginsFn = func(ctx context.Context, _ fwk.CycleState, pod *v1.Pod, _ string) *fwk.Status {
+				if _, err := client.CoreV1().Pods(updatedPod.Namespace).Update(ctx, updatedPod, metav1.UpdateOptions{}); err != nil {
+					t.Fatalf("failed to update pod in fake client: %v", err)
+				}
+				if err := informerFactory.Core().V1().Pods().Informer().GetStore().Update(updatedPod); err != nil {
+					t.Fatalf("failed to update pod in informer store: %v", err)
+				}
+				queue.Update(ctx, initialPod, updatedPod)
+
+				if inFlight := queue.InFlightPod(initialPod.UID); inFlight == nil || inFlight.Labels["version"] != "v2" {
+					t.Errorf("expected in-flight pod to be updated with label v2, got %v", inFlight)
+				}
+				if activePods := queue.PodsInActiveQ(); len(activePods) != 0 {
+					t.Errorf("expected pod not to be added to activeQ while in flight, got %v", activePods)
+				}
+				return tt.preBindStatus
+			}
+
+			var gotBinding *v1.Binding
+			client.PrependReactor("create", "pods", func(action clienttesting.Action) (bool, runtime.Object, error) {
+				if action.GetSubresource() == "binding" {
+					gotBinding = action.(clienttesting.CreateAction).GetObject().(*v1.Binding)
+					return true, gotBinding, nil
+				}
+				return false, nil, nil
+			})
+
+			sched := &Scheduler{
+				Cache:            cache,
+				client:           client,
+				NextEntity:       queue.Pop,
+				SchedulingQueue:  queue,
+				Profiles:         profile.Map{testSchedulerName: schedFramework},
+				nodeInfoSnapshot: internalcache.NewEmptySnapshot(),
+			}
+			sched.FailureHandler = sched.handleSchedulingFailure
+			sched.SchedulePod = func(ctx context.Context, fwk framework.Framework, state fwk.CycleState, podInfo *framework.QueuedPodInfo) (ScheduleResult, error) {
+				return scheduleResultOk, nil
+			}
+
+			queue.Add(ctx, initialPod)
+			sched.ScheduleOne(ctx)
+
+			if err := wait.PollUntilContextTimeout(ctx, time.Millisecond*50, wait.ForeverTestTimeout, false, func(context.Context) (bool, error) {
+				return len(queue.InFlightPods()) == 0, nil
+			}); err != nil {
+				t.Errorf("expected in-flight pods to be 0 after ScheduleOne, got %v", queue.InFlightPods())
+			}
+
+			if got := len(queue.PodsInActiveQ()); got != tt.expectInActiveQCount {
+				t.Errorf("expected %d pods in activeQ, got %d", tt.expectInActiveQCount, got)
+			}
+			if got := len(queue.PodsInBackoffQ()); got != tt.expectInBackoffQCount {
+				t.Errorf("expected %d pods in backoffQ, got %d", tt.expectInBackoffQCount, got)
+			}
+			if tt.expectBackoffPodLabel != nil {
+				backoffPods := queue.PodsInBackoffQ()
+				if len(backoffPods) > 0 {
+					for k, v := range tt.expectBackoffPodLabel {
+						if backoffPods[0].Labels[k] != v {
+							t.Errorf("expected backoff pod label %s=%s, got %s", k, v, backoffPods[0].Labels[k])
+						}
+					}
+				}
+			}
+			if diff := cmp.Diff(tt.expectBind, gotBinding); diff != "" {
+				t.Errorf("Unexpected binding (-want,+got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {


### PR DESCRIPTION
#### What this PR does / why we need it
This PR fixes two race conditions in the scheduler related to in-flight pod state tracking and cycle completion:

1. **Race Condition 1 (Concurrent Pod Update during scheduling attempt):**
   * **Problem:** When an in-flight pod receives an `Update` event while being scheduled (or between reading from the informer cache in `handleSchedulingFailure` and adding it back to the queue in `AddUnschedulablePodIfNotPresent`), `PriorityQueue.Update` ignored the update because the pod was tracked in `inFlightPods`. When `AddUnschedulablePodIfNotPresent` was called, it requeued the stale version of the pod, losing concurrent updates.
   * **Fix:** The queue now tracks in-flight pods via `inFlightPodEntry{pod *v1.Pod, eventsMarker *list.Element}` and updates the in-flight pod object on `PriorityQueue.Update`. When `AddUnschedulablePodIfNotPresent` is executed under queue lock, it refreshes `pInfo.PodInfo` and `pInfo.PodSignature` from the latest in-flight pod version before requeueing.

2. **Race Condition 2 (Concurrent Pod Update during binding cycle bypassing backoff):**
   * **Problem:** To reduce memory consumption of cluster events in large clusters, PR #129967 moved `SchedulingQueue.Done(podUID)` to right after `Permit` (before `PreBind`). However, completely removing the pod from `inFlightPods` meant that any `Update` event arriving while the pod was executing `PreBind` or `Bind` was treated as an update to an idle pod, immediately adding it to `activeQ` and completely bypassing `backoffQ`.
   * **Fix:** Introduced a two-phase cycle completion:
     * `DoneSchedulingCycle(podUID)` is called after `Permit`: it removes the pod's `eventsMarker` and calls `pruneInFlightEvents()`, freeing cluster events from memory (preserving the memory optimization from #129967).
     * The pod remains tracked in `inFlightPods` throughout `bindingCycle` (PreBind, Bind, PostBind). Any update received during binding updates `inFlightPods` without pushing the pod to `activeQ`.
     * `Done(podUID)` is called at the end of the binding cycle (after `RunPostBindPlugins`) or in `handleSchedulingFailure` if binding fails (moving the updated pod to `backoffQ` with proper backoff delay).

---

#### Summary of changes
* **`pkg/scheduler/backend/queue/active_queue.go`**:
  * Replaced `inFlightPods map[types.UID]*list.Element` with `map[types.UID]*inFlightPodEntry`.
  * Added `updateInFlightPod(newPod *v1.Pod) bool` and `doneSchedulingCycle(podUID types.UID)`.
* **`pkg/scheduler/backend/queue/scheduling_queue.go`**:
  * Extended `SchedulingQueue` interface with `DoneSchedulingCycle(types.UID)` and `InFlightPod(types.UID) *v1.Pod`.
  * In `AddUnschedulablePodIfNotPresent`, refresh `pInfo` from `inFlightPods` if present.
* **`pkg/scheduler/schedule_one.go`**:
  * In `bindingCycle`, call `DoneSchedulingCycle` after `Permit` and `Done` after `RunPostBindPlugins`.
* **Unit Tests**:
  * Added table-driven tests in `active_queue_test.go` (`TestActiveQueue_InFlightPods`) and `scheduling_queue_test.go` (`TestPriorityQueue_InFlightPods`).
  * Added scheduler integration test in `schedule_one_test.go` (`TestScheduleOne_PodUpdateDuringBindingCycle`).
  * Updated assertions in `TestScheduleOneMarksPodAsProcessedBeforePreBind`.


#### Release Notes

```release-note
Fixed race conditions in kube-scheduler where concurrent pod updates while the pod is in flight could be ignored or bypass backoff queueing.
```

/kind bug
/sig scheduling