### PR TITLE
WIP: enforce usage of context-aware client-go

### DIFF
--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/bootstrap"
 )
@@ -40,6 +41,7 @@ func newBootstrapSignerController(ctx context.Context, controllerContext Control
 	}
 
 	bsc, err := bootstrap.NewSigner(
+		klog.FromContext(ctx),
 		client,
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		controllerContext.InformerFactory.Core().V1().ConfigMaps(),
@@ -68,6 +70,7 @@ func newTokenCleanerController(ctx context.Context, controllerContext Controller
 	}
 
 	tcc, err := bootstrap.NewTokenCleaner(
+		klog.FromContext(ctx),
 		client,
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		bootstrap.DefaultTokenCleanerOptions(),

--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -273,6 +273,7 @@ func newRootCACertificatePublisherController(ctx context.Context, controllerCont
 	}
 
 	sac, err := rootcacertpublisher.NewPublisher(
+		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Core().V1().ConfigMaps(),
 		controllerContext.InformerFactory.Core().V1().Namespaces(),
 		client,
@@ -295,7 +296,7 @@ func newKubeAPIServerSignerClusterTrustBundledPublisherDescriptor() *ControllerD
 	}
 }
 
-type controllerConstructor func(string, dynamiccertificates.CAContentProvider, kubernetes.Interface) (ctbpublisher.PublisherRunner, error)
+type controllerConstructor func(klog.Logger, string, dynamiccertificates.CAContentProvider, kubernetes.Interface) (ctbpublisher.PublisherRunner, error)
 
 func newKubeAPIServerSignerClusterTrustBundledPublisherController(
 	ctx context.Context, controllerContext ControllerContext, controllerName string,
@@ -340,6 +341,7 @@ func newKubeAPIServerSignerClusterTrustBundledPublisherController(
 		}
 
 		runner, err = schemaControllerMapping[gv](
+			klog.FromContext(ctx),
 			"kubernetes.io/kube-apiserver-serving",
 			servingSigners,
 			apiserverSignerClient,

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -353,7 +353,7 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 		}
 
 		// Start lease candidate controller for coordinated leader election
-		leaseCandidate, waitForSync, err := leaderelection.NewCandidate(
+		leaseCandidate, waitForSync, err := leaderelection.NewCandidateWithConfig(
 			c.Client,
 			"kube-system",
 			id,
@@ -361,6 +361,7 @@ func Run(ctx context.Context, c *config.CompletedConfig) error {
 			binaryVersion.FinalizeVersion(),
 			emulationVersion.FinalizeVersion(),
 			coordinationv1.OldestEmulationVersion,
+			leaderelection.CandidateConfig{Logger: &logger},
 		)
 		if err != nil {
 			return err

--- a/cmd/kube-controller-manager/app/rbac.go
+++ b/cmd/kube-controller-manager/app/rbac.go
@@ -19,6 +19,7 @@ package app
 import (
 	"context"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/clusterroleaggregation"
 )
@@ -38,6 +39,7 @@ func newClusterRoleAggregationController(ctx context.Context, controllerContext 
 	}
 
 	crac := clusterroleaggregation.NewClusterRoleAggregation(
+		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Rbac().V1().ClusterRoles(),
 		client.RbacV1(),
 	)

--- a/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
+++ b/cmd/kube-controller-manager/app/validatingadmissionpolicystatus.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apiserver/pkg/cel/openapi/resolver"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/component-base/featuregate"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/validatingadmissionpolicystatus"
 	"k8s.io/kubernetes/pkg/generated/openapi"
@@ -58,6 +59,7 @@ func newValidatingAdmissionPolicyStatusController(ctx context.Context, controlle
 	}
 
 	c, err := validatingadmissionpolicystatus.NewController(
+		klog.FromContext(ctx),
 		controllerContext.InformerFactory.Admissionregistration().V1().ValidatingAdmissionPolicies(),
 		client.AdmissionregistrationV1().ValidatingAdmissionPolicies(),
 		typeChecker,

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -621,9 +621,9 @@ func (s *ProxyServer) Run(ctx context.Context) error {
 	}
 	// This has to start after the calls to NewServiceConfig because that
 	// function must configure its shared informer event handlers first.
-	informerFactory.Start(wait.NeverStop)
-	endpointSliceInformerFactory.Start(wait.NeverStop)
-	serviceInformerFactory.Start(wait.NeverStop)
+	informerFactory.StartWithContext(ctx)
+	endpointSliceInformerFactory.StartWithContext(ctx)
+	serviceInformerFactory.StartWithContext(ctx)
 
 	// hollow-proxy doesn't need node config, and we don't create nodeManager for hollow-proxy.
 	if s.NodeManager != nil {

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -247,7 +247,7 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 		}
 
 		// Start lease candidate controller for coordinated leader election
-		leaseCandidate, waitForSync, err := leaderelection.NewCandidate(
+		leaseCandidate, waitForSync, err := leaderelection.NewCandidateWithConfig(
 			cc.Client,
 			metav1.NamespaceSystem,
 			cc.LeaderElection.Lock.Identity(),
@@ -255,6 +255,7 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 			binaryVersion.FinalizeVersion(),
 			emulationVersion.FinalizeVersion(),
 			coordinationv1.OldestEmulationVersion,
+			leaderelection.CandidateConfig{Logger: new(klog.FromContext(ctx))},
 		)
 		if err != nil {
 			return err

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -290,7 +290,7 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 		cc.InformerFactory.Start(ctx.Done())
 		// DynInformerFactory can be nil in tests.
 		if cc.DynInformerFactory != nil {
-			cc.DynInformerFactory.Start(ctx.Done())
+			cc.DynInformerFactory.StartWithContext(ctx)
 		}
 
 		// Wait for all caches to sync before scheduling.

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -287,7 +287,7 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 
 	startInformersAndWaitForSync := func(ctx context.Context) {
 		// Start all informers.
-		cc.InformerFactory.Start(ctx.Done())
+		cc.InformerFactory.StartWithContext(ctx)
 		// DynInformerFactory can be nil in tests.
 		if cc.DynInformerFactory != nil {
 			cc.DynInformerFactory.StartWithContext(ctx)

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -294,7 +294,7 @@ func Run(ctx context.Context, cc *schedulerserverconfig.CompletedConfig, sched *
 		}
 
 		// Wait for all caches to sync before scheduling.
-		cc.InformerFactory.WaitForCacheSync(ctx.Done())
+		cc.InformerFactory.WaitForCacheSyncWithContext(ctx)
 		// DynInformerFactory can be nil in tests.
 		if cc.DynInformerFactory != nil {
 			cc.DynInformerFactory.WaitForCacheSync(ctx.Done())

--- a/hack/golangci-hints.yaml
+++ b/hack/golangci-hints.yaml
@@ -337,6 +337,13 @@ linters:
             # those packages that were migrated. This disables the check for other files.
             -structured .*
             
+            # If contextual logging is checked, then also check that calls accepting
+            # a logger through a config struct get that logger. Off by default because
+            # it could have false positives, but in Kubernetes it works okay.
+            # Still disabled in tests because several old tests don't use contextual logging.
+            logger-constructor .*
+            -logger-constructor .*_test.go
+            
             # Now enable it again for migrated packages.
             structured k8s.io/kubernetes/pkg/kubelet/.*
             structured k8s.io/kubernetes/pkg/proxy/.*

--- a/hack/golangci.yaml
+++ b/hack/golangci.yaml
@@ -350,6 +350,13 @@ linters:
             # those packages that were migrated. This disables the check for other files.
             -structured .*
             
+            # If contextual logging is checked, then also check that calls accepting
+            # a logger through a config struct get that logger. Off by default because
+            # it could have false positives, but in Kubernetes it works okay.
+            # Still disabled in tests because several old tests don't use contextual logging.
+            logger-constructor .*
+            -logger-constructor .*_test.go
+            
             # Now enable it again for migrated packages.
             structured k8s.io/kubernetes/pkg/kubelet/.*
             structured k8s.io/kubernetes/pkg/proxy/.*

--- a/hack/logcheck.conf
+++ b/hack/logcheck.conf
@@ -13,6 +13,13 @@
 # those packages that were migrated. This disables the check for other files.
 -structured .*
 
+# If contextual logging is checked, then also check that calls accepting
+# a logger through a config struct get that logger. Off by default because
+# it relies on heuristics, but in Kubernetes it works okay.
+# Still disabled in tests because several old tests don't use contextual logging.
+logger-constructor .*
+-logger-constructor .*_test.go
+
 # Now enable it again for migrated packages.
 structured k8s.io/kubernetes/pkg/kubelet/.*
 structured k8s.io/kubernetes/pkg/proxy/.*

--- a/hack/tools/golangci-lint/go.mod
+++ b/hack/tools/golangci-lint/go.mod
@@ -223,3 +223,5 @@ require (
 	sigs.k8s.io/logtools v0.10.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace sigs.k8s.io/logtools => github.com/pohly/logtools v0.0.0-20260827112725-bf8a033b0764

--- a/hack/tools/golangci-lint/go.sum
+++ b/hack/tools/golangci-lint/go.sum
@@ -321,6 +321,8 @@ github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pohly/logtools v0.0.0-20260827112725-bf8a033b0764 h1:wpplOg89COqLhYBMezBa33HwK5wbUA75MU3HnK60b5I=
+github.com/pohly/logtools v0.0.0-20260827112725-bf8a033b0764/go.mod h1:nkFoZEUa/k2zgFzO0CNNgl86ufV69OXqLbuWHpv0ZnA=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
@@ -570,7 +572,5 @@ mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15 h1:ssMzja7PDPJV8FStj7hq9IKiu
 mvdan.cc/unparam v0.0.0-20251027182757-5beb8c8f8f15/go.mod h1:4M5MMXl2kW6fivUT6yRGpLLPNfuGtU2Z0cPvFquGDYU=
 sigs.k8s.io/kube-api-linter v0.0.0-20260716143926-092fe0c72997 h1:u5/qbXZq7YIrurEE6HiJKtjQ9ILcFPJJSHNY0Q1ZRhU=
 sigs.k8s.io/kube-api-linter v0.0.0-20260716143926-092fe0c72997/go.mod h1:5mP60UakkCye+eOcZ5p98VnV2O49qreW1gq9TdsUf7Q=
-sigs.k8s.io/logtools v0.10.1 h1:uerGjWqOnlFXjNARkbrWjSYsjC6RSKDvhwcN2rEMdaM=
-sigs.k8s.io/logtools v0.10.1/go.mod h1:nkFoZEUa/k2zgFzO0CNNgl86ufV69OXqLbuWHpv0ZnA=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/pkg/controller/bootstrap/bootstrapsigner.go
+++ b/pkg/controller/bootstrap/bootstrapsigner.go
@@ -163,7 +163,7 @@ func NewSigner(logger klog.Logger, cl clientset.Interface, secrets informers.Sec
 
 // Run runs controller loops and returns when they are done
 func (e *Signer) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.V(5).Info("Starting")

--- a/pkg/controller/bootstrap/bootstrapsigner.go
+++ b/pkg/controller/bootstrap/bootstrapsigner.go
@@ -93,7 +93,7 @@ type Signer struct {
 }
 
 // NewSigner returns a new *Signer.
-func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configMaps informers.ConfigMapInformer, options SignerOptions) (*Signer, error) {
+func NewSigner(logger klog.Logger, cl clientset.Interface, secrets informers.SecretInformer, configMaps informers.ConfigMapInformer, options SignerOptions) (*Signer, error) {
 	e := &Signer{
 		client:             cl,
 		configMapKey:       options.ConfigMapNamespace + "/" + options.ConfigMapName,
@@ -107,12 +107,13 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 		syncQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "bootstrap_signer_queue",
+				Logger: &logger,
+				Name:   "bootstrap_signer_queue",
 			},
 		),
 	}
 
-	configMaps.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = configMaps.Informer().AddEventHandlerWithOptions(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
@@ -128,10 +129,13 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 				UpdateFunc: func(_, _ interface{}) { e.pokeConfigMapSync() },
 			},
 		},
-		options.ConfigMapResync,
+		cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &options.ConfigMapResync,
+		},
 	)
 
-	secrets.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = secrets.Informer().AddEventHandlerWithOptions(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
@@ -148,7 +152,10 @@ func NewSigner(cl clientset.Interface, secrets informers.SecretInformer, configM
 				DeleteFunc: func(_ interface{}) { e.pokeConfigMapSync() },
 			},
 		},
-		options.SecretResync,
+		cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &options.SecretResync,
+		},
 	)
 
 	return e, nil

--- a/pkg/controller/bootstrap/bootstrapsigner_test.go
+++ b/pkg/controller/bootstrap/bootstrapsigner_test.go
@@ -30,17 +30,19 @@ import (
 	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 const testTokenID = "abc123"
 
-func newSigner() (*Signer, *fake.Clientset, coreinformers.SecretInformer, coreinformers.ConfigMapInformer, error) {
+func newSigner(t *testing.T) (*Signer, *fake.Clientset, coreinformers.SecretInformer, coreinformers.ConfigMapInformer, error) {
+	tCtx := ktesting.Init(t)
 	options := DefaultSignerOptions()
 	cl := fake.NewSimpleClientset()
 	informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
 	secrets := informers.Core().V1().Secrets()
 	configMaps := informers.Core().V1().ConfigMaps()
-	bsc, err := NewSigner(cl, secrets, configMaps, options)
+	bsc, err := NewSigner(tCtx.Logger(), cl, secrets, configMaps, options)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -65,7 +67,7 @@ func newConfigMap(tokenID, signature string) *v1.ConfigMap {
 }
 
 func TestNoConfigMap(t *testing.T) {
-	signer, cl, _, _, err := newSigner()
+	signer, cl, _, _, err := newSigner(t)
 	if err != nil {
 		t.Fatalf("error creating Signer: %v", err)
 	}
@@ -74,7 +76,7 @@ func TestNoConfigMap(t *testing.T) {
 }
 
 func TestSimpleSign(t *testing.T) {
-	signer, cl, secrets, configMaps, err := newSigner()
+	signer, cl, secrets, configMaps, err := newSigner(t)
 	if err != nil {
 		t.Fatalf("error creating Signer: %v", err)
 	}
@@ -98,7 +100,7 @@ func TestSimpleSign(t *testing.T) {
 }
 
 func TestNoSignNeeded(t *testing.T) {
-	signer, cl, secrets, configMaps, err := newSigner()
+	signer, cl, secrets, configMaps, err := newSigner(t)
 	if err != nil {
 		t.Fatalf("error creating Signer: %v", err)
 	}
@@ -116,7 +118,7 @@ func TestNoSignNeeded(t *testing.T) {
 }
 
 func TestUpdateSignature(t *testing.T) {
-	signer, cl, secrets, configMaps, err := newSigner()
+	signer, cl, secrets, configMaps, err := newSigner(t)
 	if err != nil {
 		t.Fatalf("error creating Signer: %v", err)
 	}
@@ -140,7 +142,7 @@ func TestUpdateSignature(t *testing.T) {
 }
 
 func TestRemoveSignature(t *testing.T) {
-	signer, cl, _, configMaps, err := newSigner()
+	signer, cl, _, configMaps, err := newSigner(t)
 	if err != nil {
 		t.Fatalf("error creating Signer: %v", err)
 	}

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -115,7 +115,7 @@ func NewTokenCleaner(logger klog.Logger, cl clientset.Interface, secrets coreinf
 
 // Run runs controller loops and returns when they are done
 func (tc *TokenCleaner) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting token cleaner controller")

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -73,7 +73,7 @@ type TokenCleaner struct {
 }
 
 // NewTokenCleaner returns a new *NewTokenCleaner.
-func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInformer, options TokenCleanerOptions) (*TokenCleaner, error) {
+func NewTokenCleaner(logger klog.Logger, cl clientset.Interface, secrets coreinformers.SecretInformer, options TokenCleanerOptions) (*TokenCleaner, error) {
 	e := &TokenCleaner{
 		client:               cl,
 		secretLister:         secrets.Lister(),
@@ -82,12 +82,13 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "token_cleaner",
+				Logger: &logger,
+				Name:   "token_cleaner",
 			},
 		),
 	}
 
-	secrets.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = secrets.Informer().AddEventHandlerWithOptions(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
@@ -103,7 +104,10 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 				UpdateFunc: func(oldSecret, newSecret interface{}) { e.enqueueSecrets(newSecret) },
 			},
 		},
-		options.SecretResync,
+		cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &options.SecretResync,
+		},
 	)
 
 	return e, nil

--- a/pkg/controller/bootstrap/tokencleaner_test.go
+++ b/pkg/controller/bootstrap/tokencleaner_test.go
@@ -29,14 +29,16 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
-func newTokenCleaner() (*TokenCleaner, *fake.Clientset, coreinformers.SecretInformer, error) {
+func newTokenCleaner(t *testing.T) (*TokenCleaner, *fake.Clientset, coreinformers.SecretInformer, error) {
+	tCtx := ktesting.Init(t)
 	options := DefaultTokenCleanerOptions()
 	cl := fake.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(cl, options.SecretResync)
 	secrets := informerFactory.Core().V1().Secrets()
-	tcc, err := NewTokenCleaner(cl, secrets, options)
+	tcc, err := NewTokenCleaner(tCtx.Logger(), cl, secrets, options)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -44,7 +46,7 @@ func newTokenCleaner() (*TokenCleaner, *fake.Clientset, coreinformers.SecretInfo
 }
 
 func TestCleanerNoExpiration(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}
@@ -60,7 +62,7 @@ func TestCleanerNoExpiration(t *testing.T) {
 }
 
 func TestCleanerExpired(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}
@@ -85,7 +87,7 @@ func TestCleanerExpired(t *testing.T) {
 }
 
 func TestCleanerNotExpired(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}
@@ -102,7 +104,7 @@ func TestCleanerNotExpired(t *testing.T) {
 }
 
 func TestCleanerExpiredAt(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}

--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -115,7 +115,7 @@ func NewCertificateController(
 
 // Run the main goroutine responsible for watching and syncing jobs.
 func (cc *CertificateController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting certificate controller", "name", cc.name)

--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -71,14 +71,15 @@ func NewCertificateController(
 				&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 			),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "certificate",
+				Logger: &logger,
+				Name:   "certificate",
 			},
 		),
 		handler: handler,
 	}
 
 	// Manage the addition/update of certificate requests
-	csrInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = csrInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			csr := obj.(*certificates.CertificateSigningRequest)
 			logger.V(4).Info("Adding certificate request", "csr", csr.Name)
@@ -106,7 +107,7 @@ func NewCertificateController(
 			logger.V(4).Info("Deleting certificate request", "csr", csr.Name)
 			cc.enqueueCertificateRequest(obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	cc.csrLister = csrInformer.Lister()
 	cc.csrsSynced = csrInformer.Informer().HasSynced
 	return cc

--- a/pkg/controller/certificates/certificate_controller_test.go
+++ b/pkg/controller/certificates/certificate_controller_test.go
@@ -66,7 +66,7 @@ func TestCertificateController(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	informerFactory.Start(stopCh)
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(stopCh)
 	wait.PollUntil(10*time.Millisecond, func() (bool, error) {
 		return controller.queue.Len() >= 1, nil

--- a/pkg/controller/certificates/certificate_controller_test.go
+++ b/pkg/controller/certificates/certificate_controller_test.go
@@ -67,7 +67,7 @@ func TestCertificateController(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(stopCh)
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	wait.PollUntil(10*time.Millisecond, func() (bool, error) {
 		return controller.queue.Len() >= 1, nil
 	}, stopCh)

--- a/pkg/controller/certificates/cleaner/cleaner.go
+++ b/pkg/controller/certificates/cleaner/cleaner.go
@@ -77,7 +77,7 @@ func NewCSRCleanerController(
 
 // Run the main goroutine responsible for watching and syncing jobs.
 func (ccc *CSRCleanerController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting CSR cleaner controller")

--- a/pkg/controller/certificates/cleaner/pcrcleaner.go
+++ b/pkg/controller/certificates/cleaner/pcrcleaner.go
@@ -63,7 +63,7 @@ func NewPCRCleanerController(
 }
 
 func (c *PCRCleanerController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PodCertificateRequest cleaner controller")

--- a/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
+++ b/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
@@ -339,7 +339,7 @@ func (p *ClusterTrustBundlePublisher[T]) caContentChangedListener() dynamiccerti
 }
 
 func (p *ClusterTrustBundlePublisher[T]) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ClusterTrustBundle CA cert publisher controller")

--- a/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
+++ b/pkg/controller/certificates/clustertrustbundlepublisher/publisher.go
@@ -197,6 +197,7 @@ func (f caContentListener) Enqueue() {
 // NewBetaClusterTrustBundlePublisher sets up a ClusterTrustBundlePublisher for the
 // v1 API
 func NewGAClusterTrustBundlePublisher(
+	logger klog.Logger,
 	signerName string,
 	caProvider dynamiccertificates.CAContentProvider,
 	kubeClient clientset.Interface,
@@ -210,6 +211,7 @@ func NewGAClusterTrustBundlePublisher(
 		})
 
 	return newClusterTrustBundlePublisher(
+		logger,
 		signerName,
 		caProvider,
 		kubeClient.CertificatesV1().ClusterTrustBundles(),
@@ -222,6 +224,7 @@ func NewGAClusterTrustBundlePublisher(
 // NewBetaClusterTrustBundlePublisher sets up a ClusterTrustBundlePublisher for the
 // v1beta1 API
 func NewBetaClusterTrustBundlePublisher(
+	logger klog.Logger,
 	signerName string,
 	caProvider dynamiccertificates.CAContentProvider,
 	kubeClient clientset.Interface,
@@ -236,6 +239,7 @@ func NewBetaClusterTrustBundlePublisher(
 		})
 
 	return newClusterTrustBundlePublisher(
+		logger,
 		signerName,
 		caProvider,
 		kubeClient.CertificatesV1beta1().ClusterTrustBundles(),
@@ -248,6 +252,7 @@ func NewBetaClusterTrustBundlePublisher(
 // NewAlphaClusterTrustBundlePublisher sets up a ClusterTrustBundlePublisher for the
 // v1alpha1 API
 func NewAlphaClusterTrustBundlePublisher(
+	logger klog.Logger,
 	signerName string,
 	caProvider dynamiccertificates.CAContentProvider,
 	kubeClient clientset.Interface,
@@ -262,6 +267,7 @@ func NewAlphaClusterTrustBundlePublisher(
 		})
 
 	return newClusterTrustBundlePublisher(
+		logger,
 		signerName,
 		caProvider,
 		kubeClient.CertificatesV1alpha1().ClusterTrustBundles(),
@@ -275,6 +281,7 @@ func NewAlphaClusterTrustBundlePublisher(
 // for a signer named `signerName`. The cluster trust bundle object contains the
 // CA from the `caProvider` in its .spec.TrustBundle.
 func newClusterTrustBundlePublisher[T clusterTrustBundle](
+	logger klog.Logger,
 	signerName string,
 	caProvider dynamiccertificates.CAContentProvider,
 	bundleClient clusterTrustBundlesClient[T],
@@ -300,12 +307,13 @@ func newClusterTrustBundlePublisher[T clusterTrustBundle](
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "ca_cert_publisher_cluster_trust_bundles",
+				Logger: &logger,
+				Name:   "ca_cert_publisher_cluster_trust_bundles",
 			},
 		),
 	}
 
-	_, err := p.ctbInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := p.ctbInformer.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			p.queue.Add("")
 		},
@@ -315,7 +323,7 @@ func newClusterTrustBundlePublisher[T clusterTrustBundle](
 		DeleteFunc: func(_ interface{}) {
 			p.queue.Add("")
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ClusterTrustBundle event handler: %w", err)
 	}

--- a/pkg/controller/certificates/clustertrustbundlepublisher/publisher_test.go
+++ b/pkg/controller/certificates/clustertrustbundlepublisher/publisher_test.go
@@ -260,11 +260,11 @@ func TestCTBPublisherSync(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			testCtx := ktesting.Init(t)
+			tCtx := ktesting.Init(t)
 
 			fakeClient := fakeKubeClientSetWithCTBList(t, testSignerName, tt.existingCTBs...)
 
-			p, err := NewGAClusterTrustBundlePublisher(testSignerName, testCAProvider, fakeClient)
+			p, err := NewGAClusterTrustBundlePublisher(tCtx.Logger(), testSignerName, testCAProvider, fakeClient)
 			if err != nil {
 				t.Fatalf("failed to set up a new cluster trust bundle publisher: %v", err)
 			}
@@ -274,12 +274,12 @@ func TestCTBPublisherSync(t *testing.T) {
 				t.Fatalf("failed to assert the controller for the beta API")
 			}
 
-			go controller.ctbInformer.RunWithContext(testCtx)
-			if !cache.WaitForCacheSync(testCtx.Done(), controller.ctbInformer.HasSynced) {
+			go controller.ctbInformer.RunWithContext(tCtx)
+			if !cache.WaitForCacheSync(tCtx.Done(), controller.ctbInformer.HasSynced) {
 				t.Fatal("timed out waiting for informer to sync")
 			}
 
-			if err := controller.syncClusterTrustBundle(testCtx); (err != nil) != tt.wantErr {
+			if err := controller.syncClusterTrustBundle(tCtx); (err != nil) != tt.wantErr {
 				t.Errorf("syncClusterTrustBundle() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -102,7 +102,7 @@ type Publisher struct {
 
 // Run starts process
 func (c *Publisher) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting root CA cert publisher controller")

--- a/pkg/controller/certificates/rootcacertpublisher/publisher.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher.go
@@ -52,29 +52,30 @@ func init() {
 // NewPublisher construct a new controller which would manage the configmap
 // which stores certificates in each namespace. It will make sure certificate
 // configmap exists in each namespace.
-func NewPublisher(cmInformer coreinformers.ConfigMapInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, rootCA []byte) (*Publisher, error) {
+func NewPublisher(logger klog.Logger, cmInformer coreinformers.ConfigMapInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, rootCA []byte) (*Publisher, error) {
 	e := &Publisher{
 		client: cl,
 		rootCA: rootCA,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "root_ca_cert_publisher",
+				Logger: &logger,
+				Name:   "root_ca_cert_publisher",
 			},
 		),
 	}
 
-	cmInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = cmInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: e.configMapDeleted,
 		UpdateFunc: e.configMapUpdated,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	e.cmLister = cmInformer.Lister()
 	e.cmListerSynced = cmInformer.Informer().HasSynced
 
-	nsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    e.namespaceAdded,
 		UpdateFunc: e.namespaceUpdated,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	e.nsListerSynced = nsInformer.Informer().HasSynced
 
 	e.syncHandler = e.syncNamespace

--- a/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
+++ b/pkg/controller/certificates/rootcacertpublisher/publisher_test.go
@@ -31,6 +31,7 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestConfigMapCreation(t *testing.T) {
@@ -122,11 +123,12 @@ func TestConfigMapCreation(t *testing.T) {
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
+			tCtx := ktesting.Init(t)
 			client := fake.NewSimpleClientset(caConfigMap, existNS)
 			informers := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), controller.NoResyncPeriodFunc())
 			cmInformer := informers.Core().V1().ConfigMaps()
 			nsInformer := informers.Core().V1().Namespaces()
-			controller, err := NewPublisher(cmInformer, nsInformer, client, fakeRootCA)
+			controller, err := NewPublisher(tCtx.Logger(), cmInformer, nsInformer, client, fakeRootCA)
 			if err != nil {
 				t.Fatalf("error creating ServiceAccounts controller: %v", err)
 			}
@@ -155,9 +157,8 @@ func TestConfigMapCreation(t *testing.T) {
 				cmStore.Add(tc.UpdatedConfigMap)
 				controller.configMapUpdated(nil, tc.UpdatedConfigMap)
 			}
-			ctx := context.TODO()
 			for controller.queue.Len() != 0 {
-				controller.processNextWorkItem(ctx)
+				controller.processNextWorkItem(tCtx)
 			}
 
 			actions := client.Actions()

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -53,7 +53,7 @@ type ClusterRoleAggregationController struct {
 }
 
 // NewClusterRoleAggregation creates a new controller
-func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInformer, clusterRoleClient rbacclient.ClusterRolesGetter) *ClusterRoleAggregationController {
+func NewClusterRoleAggregation(logger klog.Logger, clusterRoleInformer rbacinformers.ClusterRoleInformer, clusterRoleClient rbacclient.ClusterRolesGetter) *ClusterRoleAggregationController {
 	c := &ClusterRoleAggregationController{
 		clusterRoleClient:  clusterRoleClient,
 		clusterRoleLister:  clusterRoleInformer.Lister(),
@@ -62,13 +62,14 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInfo
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "ClusterRoleAggregator",
+				Logger: &logger,
+				Name:   "ClusterRoleAggregator",
 			},
 		),
 	}
 	c.syncHandler = c.syncClusterRole
 
-	clusterRoleInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = clusterRoleInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.enqueue()
 		},
@@ -78,7 +79,7 @@ func NewClusterRoleAggregation(clusterRoleInformer rbacinformers.ClusterRoleInfo
 		DeleteFunc: func(uncast interface{}) {
 			c.enqueue()
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	return c
 }
 

--- a/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
+++ b/pkg/controller/clusterroleaggregation/clusterroleaggregation_controller.go
@@ -171,7 +171,7 @@ func ruleExists(haystack []rbacv1.PolicyRule, needle rbacv1.PolicyRule) bool {
 
 // Run starts the controller and blocks until stopCh is closed.
 func (c *ClusterRoleAggregationController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ClusterRoleAggregator controller")

--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -156,7 +156,7 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 
 // Run starts the main goroutine responsible for watching and syncing jobs.
 func (jm *ControllerV2) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start event processing pipeline.
 	jm.broadcaster.StartStructuredLogging(3)

--- a/pkg/controller/cronjob/cronjob_controllerv2.go
+++ b/pkg/controller/cronjob/cronjob_controllerv2.go
@@ -94,7 +94,8 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "cronjob",
+				Logger: &logger,
+				Name:   "cronjob",
 			},
 		),
 		kubeClient:  kubeClient,
@@ -114,13 +115,13 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 		now: time.Now,
 	}
 
-	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = jobInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    jm.addJob,
 		UpdateFunc: jm.updateJob,
 		DeleteFunc: jm.deleteJob,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
-	cronJobsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = cronJobsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			jm.enqueueController(obj)
 		},
@@ -130,7 +131,7 @@ func NewControllerV2(ctx context.Context, jobInformer batchv1informers.JobInform
 		DeleteFunc: func(obj interface{}) {
 			jm.enqueueController(obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	err := jobInformer.Informer().AddIndexers(cache.Indexers{
 		jobControllerUIDIndex: func(obj interface{}) ([]string, error) {

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -209,19 +209,21 @@ func NewDaemonSetsController(
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "daemonset",
+				Logger: &logger,
+				Name:   "daemonset",
 			},
 		),
 		nodeUpdateQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "daemonset-node-updates",
+				Logger: &logger,
+				Name:   "daemonset-node-updates",
 			},
 		),
 		consistencyStore: consistencyStore,
 	}
 
-	daemonSetInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = daemonSetInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dsc.addDaemonset(logger, obj)
 		},
@@ -231,11 +233,11 @@ func NewDaemonSetsController(
 		DeleteFunc: func(obj interface{}) {
 			dsc.deleteDaemonset(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	dsc.dsLister = daemonSetInformer.Lister()
 	dsc.dsStoreSynced = daemonSetInformer.Informer().HasSynced
 
-	historyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = historyInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dsc.addHistory(logger, obj)
 		},
@@ -245,14 +247,14 @@ func NewDaemonSetsController(
 		DeleteFunc: func(obj interface{}) {
 			dsc.deleteHistory(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	dsc.historyLister = historyInformer.Lister()
 	dsc.historyStoreSynced = historyInformer.Informer().HasSynced
 
 	// Watch for creation/deletion of pods. The reason we watch is that we don't want a daemon set to create/delete
 	// more pods until all the effects (expectations) of a daemon set's create/delete have been observed.
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dsc.addPod(logger, obj)
 		},
@@ -262,14 +264,14 @@ func NewDaemonSetsController(
 		DeleteFunc: func(obj interface{}) {
 			dsc.deletePod(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	dsc.podLister = podInformer.Lister()
 	dsc.podStoreSynced = podInformer.Informer().HasSynced
 	controller.AddPodNodeNameIndexer(podInformer.Informer())
 	controller.AddPodControllerIndexer(podInformer.Informer())
 	dsc.podIndexer = podInformer.Informer().GetIndexer()
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dsc.addNode(logger, obj)
 		},
@@ -277,6 +279,7 @@ func NewDaemonSetsController(
 			dsc.updateNode(logger, oldObj, newObj)
 		},
 	},
+		cache.HandlerOptions{Logger: &logger},
 	)
 	dsc.nodeStoreSynced = nodeInformer.Informer().HasSynced
 	dsc.nodeLister = nodeInformer.Lister()

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -357,7 +357,7 @@ func (dsc *DaemonSetsController) deleteDaemonset(logger klog.Logger, obj interfa
 
 // Run begins watching and syncing daemon sets.
 func (dsc *DaemonSetsController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	dsc.eventBroadcaster.StartStructuredLogging(3)
 	dsc.eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: dsc.kubeClient.CoreV1().Events("")})

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -552,7 +552,7 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	f.Start(ctx.Done())
+	f.StartWithContext(ctx)
 	for ty, ok := range f.WaitForCacheSync(ctx.Done()) {
 		if !ok {
 			t.Fatalf("caches failed to sync: %v", ty)

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -553,7 +553,7 @@ func TestExpectationsOnRecreate(t *testing.T) {
 	}
 
 	f.StartWithContext(ctx)
-	for ty, ok := range f.WaitForCacheSync(ctx.Done()) {
+	for ty, ok := range f.WaitForCacheSyncWithContext(ctx).Synced {
 		if !ok {
 			t.Fatalf("caches failed to sync: %v", ty)
 		}

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -111,7 +111,8 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "deployment",
+				Logger: &logger,
+				Name:   "deployment",
 			},
 		),
 	}
@@ -120,7 +121,7 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 		Recorder:   dc.eventRecorder,
 	}
 
-	dInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = dInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dc.addDeployment(logger, obj)
 		},
@@ -131,8 +132,8 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 		DeleteFunc: func(obj interface{}) {
 			dc.deleteDeployment(logger, obj)
 		},
-	})
-	rsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	}, cache.HandlerOptions{Logger: &logger})
+	_, _ = rsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dc.addReplicaSet(logger, obj)
 		},
@@ -142,12 +143,12 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 		DeleteFunc: func(obj interface{}) {
 			dc.deleteReplicaSet(logger, obj)
 		},
-	})
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	}, cache.HandlerOptions{Logger: &logger})
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
 			dc.deletePod(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	dc.syncHandler = dc.syncDeployment
 	dc.enqueueDeployment = dc.enqueue

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -170,7 +170,7 @@ func NewDeploymentController(ctx context.Context, dInformer appsinformers.Deploy
 
 // Run begins watching and syncing.
 func (dc *DeploymentController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	dc.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -221,7 +221,7 @@ func (f *fixture) run_(ctx context.Context, deploymentName string, startInformer
 	if startInformers {
 		stopCh := make(chan struct{})
 		defer close(stopCh)
-		informers.Start(stopCh)
+		informers.StartWithContext(ctx)
 	}
 
 	err = c.syncDeployment(ctx, deploymentName)
@@ -497,7 +497,7 @@ func TestGetReplicaSetsForDeployment(t *testing.T) {
 	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	informers.Start(stopCh)
+	informers.StartWithContext(ctx)
 
 	rsList, err := c.getReplicaSetsForDeployment(ctx, d1)
 	if err != nil {
@@ -549,7 +549,7 @@ func TestGetReplicaSetsForDeploymentAdoptRelease(t *testing.T) {
 	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	informers.Start(stopCh)
+	informers.StartWithContext(ctx)
 
 	rsList, err := c.getReplicaSetsForDeployment(ctx, d)
 	if err != nil {
@@ -598,7 +598,7 @@ func TestGetPodMapForReplicaSets(t *testing.T) {
 	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	informers.Start(stopCh)
+	informers.StartWithContext(ctx)
 
 	podMap, err := c.getPodMapForDeployment(d, f.rsLister)
 	if err != nil {
@@ -1003,7 +1003,7 @@ func BenchmarkGetPodMapForDeployment(b *testing.B) {
 			}
 			stopCh := make(chan struct{})
 			defer close(stopCh)
-			informers.Start(stopCh)
+			informers.StartWithContext(ctx)
 
 			b.ReportAllocs()
 			b.ResetTimer()

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -432,7 +432,7 @@ func TestDeploymentController_cleanupDeployment(t *testing.T) {
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 		informers.StartWithContext(ctx)
-		informers.WaitForCacheSync(stopCh)
+		informers.WaitForCacheSyncWithContext(ctx)
 
 		t.Logf(" &test.revisionHistoryLimit: %d", test.revisionHistoryLimit)
 		d := newDeployment("foo", 1, &test.revisionHistoryLimit, nil, nil, map[string]string{"foo": "bar"})

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -431,7 +431,7 @@ func TestDeploymentController_cleanupDeployment(t *testing.T) {
 
 		stopCh := make(chan struct{})
 		defer close(stopCh)
-		informers.Start(stopCh)
+		informers.StartWithContext(ctx)
 		informers.WaitForCacheSync(stopCh)
 
 		t.Logf(" &test.revisionHistoryLimit: %d", test.revisionHistoryLimit)
@@ -567,7 +567,7 @@ func TestDeploymentController_cleanupDeploymentOrder(t *testing.T) {
 
 		stopCh := make(chan struct{})
 		defer close(stopCh)
-		informers.Start(stopCh)
+		informers.StartWithContext(ctx)
 
 		d := newDeployment("foo", 1, &test.revisionHistoryLimit, nil, nil, map[string]string{"foo": "bar"})
 		controller.cleanupDeployment(ctx, test.oldRSs, d)
@@ -635,7 +635,7 @@ func TestDeploymentController_generateReplicaSetName(t *testing.T) {
 
 		stopCh := make(chan struct{})
 		defer close(stopCh)
-		informers.Start(stopCh)
+		informers.StartWithContext(ctx)
 
 		d := newDeployment(test.deploymentName, 1, nil, nil, nil, map[string]string{"foo": "bar"})
 

--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -810,6 +810,7 @@ func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
 	tc.workqueue = workqueue.NewTypedRateLimitingQueueWithConfig(
 		workqueue.DefaultTypedControllerRateLimiter[workItem](),
 		workqueue.TypedRateLimitingQueueConfig[workItem]{
+			Logger:        &logger,
 			Name:          tc.name,
 			DelayingQueue: delayingQueue,
 		},

--- a/pkg/controller/devicetainteviction/device_taint_eviction.go
+++ b/pkg/controller/devicetainteviction/device_taint_eviction.go
@@ -780,7 +780,7 @@ func newWithFeatures(c clientset.Interface, podInformer coreinformers.PodInforme
 // Run starts the controller which will run until the context is done.
 // An error is returned for startup problems.
 func (tc *Controller) Run(ctx context.Context, numWorkers int) error {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", tc.name, "numWorkers", numWorkers)
 	defer logger.Info("Shut down controller", "controller", tc.name, "reason", context.Cause(ctx))

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -447,7 +447,7 @@ func verifyGroupKind(controllerRef *metav1.OwnerReference, expectedKind string, 
 }
 
 func (dc *DisruptionController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	// Start events processing pipeline.

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -183,6 +183,7 @@ func NewDisruptionControllerInternal(ctx context.Context,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
 				DelayingQueue: workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[string]{
 					Logger: &logger,
 					Clock:  clock,
@@ -198,6 +199,7 @@ func NewDisruptionControllerInternal(ctx context.Context,
 		stalePodDisruptionQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
 				DelayingQueue: workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[string]{
 					Logger: &logger,
 					Clock:  clock,
@@ -212,7 +214,7 @@ func NewDisruptionControllerInternal(ctx context.Context,
 
 	dc.getUpdater = func() updater { return dc.writePdbStatus }
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dc.addPod(logger, obj)
 		},
@@ -222,11 +224,11 @@ func NewDisruptionControllerInternal(ctx context.Context,
 		DeleteFunc: func(obj interface{}) {
 			dc.deletePod(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	dc.podLister = podInformer.Lister()
 	dc.podListerSynced = podInformer.Informer().HasSynced
 
-	pdbInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = pdbInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			dc.addDB(logger, obj)
 		},
@@ -236,7 +238,7 @@ func NewDisruptionControllerInternal(ctx context.Context,
 		DeleteFunc: func(obj interface{}) {
 			dc.removeDB(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	dc.pdbLister = pdbInformer.Lister()
 	dc.pdbListerSynced = pdbInformer.Informer().HasSynced
 

--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -189,7 +189,7 @@ func newFakeDisruptionControllerWithTime(ctx context.Context, now time.Time) (*d
 	dc.ssListerSynced = alwaysReady
 	dc.recorder = record.NewFakeRecorder(100)
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	return &disruptionController{
 		dc,

--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -188,7 +188,7 @@ func newFakeDisruptionControllerWithTime(ctx context.Context, now time.Time) (*d
 	dc.dListerSynced = alwaysReady
 	dc.ssListerSynced = alwaysReady
 	dc.recorder = record.NewFakeRecorder(100)
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	return &disruptionController{

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -189,7 +189,7 @@ type Controller struct {
 // Run will not return until stopCh is closed. workers determines how many
 // endpoints will be handled in parallel.
 func (e *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	e.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -79,6 +79,7 @@ const (
 // NewEndpointController returns a new *Controller.
 func NewEndpointController(ctx context.Context, podInformer coreinformers.PodInformer, serviceInformer coreinformers.ServiceInformer,
 	endpointsInformer coreinformers.EndpointsInformer, client clientset.Interface, endpointUpdatesBatchPeriod time.Duration) *Controller {
+	logger := klog.FromContext(ctx)
 	broadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: ControllerName})
 
@@ -87,34 +88,40 @@ func NewEndpointController(ctx context.Context, podInformer coreinformers.PodInf
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "endpoint",
+				Logger: &logger,
+				Name:   "endpoint",
 			},
 		),
-		podQueue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*endpointsliceutil.PodProjectionKey]()),
+		podQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[*endpointsliceutil.PodProjectionKey](),
+			workqueue.TypedRateLimitingQueueConfig[*endpointsliceutil.PodProjectionKey]{
+				Logger: &logger,
+			},
+		),
 		workerLoopPeriod: time.Second,
 	}
 
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: e.onServiceUpdate,
 		UpdateFunc: func(old, cur interface{}) {
 			e.onServiceUpdate(cur)
 		},
 		DeleteFunc: e.onServiceDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	e.serviceLister = serviceInformer.Lister()
 	e.servicesSynced = serviceInformer.Informer().HasSynced
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { e.onPodUpdate(nil, obj) },
 		UpdateFunc: e.onPodUpdate,
 		DeleteFunc: func(obj interface{}) { e.onPodUpdate(obj, nil) },
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	e.podLister = podInformer.Lister()
 	e.podsSynced = podInformer.Informer().HasSynced
 
-	endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = endpointsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: e.onEndpointsDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	e.endpointsLister = endpointsInformer.Lister()
 	e.endpointsSynced = endpointsInformer.Informer().HasSynced
 

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -282,7 +282,7 @@ type Controller struct {
 
 // Run will not return until stopCh is closed.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	c.eventBroadcaster.StartLogging(klog.Infof)

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -90,6 +90,7 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 	client clientset.Interface,
 	endpointUpdatesBatchPeriod time.Duration,
 ) *Controller {
+	logger := klog.FromContext(ctx)
 	broadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "endpoint-slice-controller"})
 
@@ -111,43 +112,55 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 				&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 			),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "endpoint_slice",
+				Logger: &logger,
+				Name:   "endpoint_slice",
 			},
 		),
-		podQueue:         workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*endpointsliceutil.PodProjectionKey]()),
-		topologyQueue:    workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		podQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[*endpointsliceutil.PodProjectionKey](),
+			workqueue.TypedRateLimitingQueueConfig[*endpointsliceutil.PodProjectionKey]{
+				Logger: &logger,
+				Name:   "endpoint_slice_pods",
+			},
+		),
+		topologyQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "endpoint_slice_topology",
+			},
+		),
 		workerLoopPeriod: time.Second,
 	}
 
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: c.onServiceUpdate,
 		UpdateFunc: func(old, cur interface{}) {
 			c.onServiceUpdate(cur)
 		},
 		DeleteFunc: c.onServiceDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	c.serviceLister = serviceInformer.Lister()
 	c.servicesSynced = serviceInformer.Informer().HasSynced
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { c.onPodUpdate(nil, obj) },
 		UpdateFunc: c.onPodUpdate,
 		DeleteFunc: func(obj interface{}) { c.onPodUpdate(obj, nil) },
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	c.podLister = podInformer.Lister()
 	c.podsSynced = podInformer.Informer().HasSynced
 
 	c.nodeLister = nodeInformer.Lister()
 	c.nodesSynced = nodeInformer.Informer().HasSynced
 
-	logger := klog.FromContext(ctx)
-	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = endpointSliceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: c.onEndpointSliceAdd,
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			c.onEndpointSliceUpdate(logger, oldObj, newObj)
 		},
 		DeleteFunc: c.onEndpointSliceDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	c.endpointSliceLister = endpointSliceInformer.Lister()
 	c.endpointSlicesSynced = endpointSliceInformer.Informer().HasSynced
@@ -162,7 +175,7 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 
 	c.endpointUpdatesBatchPeriod = endpointUpdatesBatchPeriod
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(_ interface{}) {
 			c.addNode()
 		},
@@ -172,7 +185,7 @@ func NewController(ctx context.Context, podInformer coreinformers.PodInformer,
 		DeleteFunc: func(_ interface{}) {
 			c.deleteNode()
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	c.topologyCache = topologycache.NewTopologyCache()
 
 	c.reconciler = endpointslicerec.NewReconciler(

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -216,7 +216,7 @@ type Controller struct {
 
 // Run will not return until stopCh is closed.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	c.eventBroadcaster.StartLogging(klog.Infof)

--- a/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
+++ b/pkg/controller/endpointslicemirroring/endpointslicemirroring_controller.go
@@ -96,13 +96,14 @@ func NewController(ctx context.Context, endpointsInformer coreinformers.Endpoint
 			&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 		),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "endpoint_slice_mirroring",
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "endpoint_slice_mirroring",
 			},
 		),
 		workerLoopPeriod: time.Second,
 	}
 
-	endpointsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = endpointsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.onEndpointsAdd(logger, obj)
 		},
@@ -112,17 +113,17 @@ func NewController(ctx context.Context, endpointsInformer coreinformers.Endpoint
 		DeleteFunc: func(obj interface{}) {
 			c.onEndpointsDelete(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	c.endpointsLister = endpointsInformer.Lister()
 	c.endpointsSynced = endpointsInformer.Informer().HasSynced
 
-	endpointSliceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = endpointSliceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: c.onEndpointSliceAdd,
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			c.onEndpointSliceUpdate(logger, oldObj, newObj)
 		},
 		DeleteFunc: c.onEndpointSliceDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	c.endpointSliceLister = endpointSliceInformer.Lister()
 	c.endpointSlicesSynced = endpointSliceInformer.Informer().HasSynced
@@ -130,11 +131,11 @@ func NewController(ctx context.Context, endpointsInformer coreinformers.Endpoint
 
 	c.serviceLister = serviceInformer.Lister()
 	c.servicesSynced = serviceInformer.Informer().HasSynced
-	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.onServiceAdd,
 		UpdateFunc: c.onServiceUpdate,
 		DeleteFunc: c.onServiceDelete,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	c.maxEndpointsPerSubset = maxEndpointsPerSubset
 

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -130,7 +130,7 @@ func (gc *GarbageCollector) resyncMonitors(logger klog.Logger, deletableResource
 
 // Run starts garbage collector workers.
 func (gc *GarbageCollector) Run(ctx context.Context, workers int, initialSyncTimeout time.Duration) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	gc.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -541,12 +541,12 @@ func TestProcessEvent(t *testing.T) {
 
 		dependencyGraphBuilder := &GraphBuilder{
 			informersStarted: alwaysStarted,
-			graphChanges:     workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*event]()),
+			graphChanges:     workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*event]()), //nolint:logcheck // Intentionally testing old API here.
 			uidToNode: &concurrentUIDToNode{
 				uidToNodeLock: sync.RWMutex{},
 				uidToNode:     make(map[types.UID]*node),
 			},
-			attemptToDelete:  workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*node]()),
+			attemptToDelete:  workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[*node]()), //nolint:logcheck // Intentionally testing old API here.
 			absentOwnerCache: NewReferenceCache(2),
 		}
 		for i := 0; i < len(scenario.events); i++ {

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -230,7 +230,7 @@ func setupGC(t *testing.T, config *restclient.Config) garbageCollector {
 		t.Fatal(err)
 	}
 	stop := make(chan struct{})
-	sharedInformers.Start(stop)
+	sharedInformers.StartWithContext(ctx)
 	return garbageCollector{gc, stop}
 }
 

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -133,7 +133,7 @@ type monitor struct {
 // Run is intended to be called in a goroutine. Multiple calls of this is an
 // error.
 func (m *monitor) Run() {
-	m.controller.Run(m.stopCh)
+	m.controller.RunWithContext(wait.ContextForChannel(m.stopCh))
 }
 
 type monitors map[schema.GroupVersionResource]*monitor
@@ -151,13 +151,15 @@ func NewDependencyGraphBuilder(
 	attemptToDelete := workqueue.NewTypedRateLimitingQueueWithConfig(
 		workqueue.DefaultTypedControllerRateLimiter[*node](),
 		workqueue.TypedRateLimitingQueueConfig[*node]{
-			Name: "garbage_collector_attempt_to_delete",
+			Logger: new(klog.FromContext(ctx)),
+			Name:   "garbage_collector_attempt_to_delete",
 		},
 	)
 	attemptToOrphan := workqueue.NewTypedRateLimitingQueueWithConfig(
 		workqueue.DefaultTypedControllerRateLimiter[*node](),
 		workqueue.TypedRateLimitingQueueConfig[*node]{
-			Name: "garbage_collector_attempt_to_orphan",
+			Logger: new(klog.FromContext(ctx)),
+			Name:   "garbage_collector_attempt_to_orphan",
 		},
 	)
 	absentOwnerCache := NewReferenceCache(500)
@@ -170,7 +172,8 @@ func NewDependencyGraphBuilder(
 		graphChanges: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[*event](),
 			workqueue.TypedRateLimitingQueueConfig[*event]{
-				Name: "garbage_collector_graph_changes",
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "garbage_collector_graph_changes",
 			},
 		),
 		uidToNode: &concurrentUIDToNode{
@@ -229,7 +232,13 @@ func (gb *GraphBuilder) controllerFor(logger klog.Logger, resource schema.GroupV
 	}
 	logger.V(4).Info("using a shared informer", "resource", resource, "kind", kind)
 	// need to clone because it's from a shared cache
-	shared.Informer().AddEventHandlerWithResyncPeriod(handlers, ResourceResyncTime)
+	resyncPeriod := ResourceResyncTime
+	if _, err := shared.Informer().AddEventHandlerWithOptions(handlers, cache.HandlerOptions{
+		Logger:       &logger,
+		ResyncPeriod: &resyncPeriod,
+	}); err != nil {
+		return nil, nil, err
+	}
 	return shared.Informer().GetController(), shared.Informer().GetStore(), nil
 }
 

--- a/pkg/controller/history/controller_history_test.go
+++ b/pkg/controller/history/controller_history_test.go
@@ -59,12 +59,13 @@ func TestRealHistory_ListControllerRevisions(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		for i := range test.revisions {
 			informer.Informer().GetIndexer().Add(test.revisions[i])
 		}
@@ -159,12 +160,13 @@ func TestFakeHistory_ListControllerRevisions(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		for i := range test.revisions {
 			informer.Informer().GetIndexer().Add(test.revisions[i])
 		}
@@ -261,12 +263,13 @@ func TestRealHistory_CreateControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 
 		var collisionCount int32
@@ -396,12 +399,13 @@ func TestFakeHistory_CreateControllerRevision(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewFakeHistory(informer)
 
 		var collisionCount int32
@@ -549,12 +553,13 @@ func TestRealHistory_UpdateControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
@@ -679,12 +684,13 @@ func TestFakeHistory_UpdateControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewFakeHistory(informer)
 		var collisionCount int32
 		for i := range test.existing {
@@ -770,12 +776,13 @@ func TestRealHistory_DeleteControllerRevision(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
 		for i := range test.existing {
@@ -876,12 +883,13 @@ func TestFakeHistory_DeleteControllerRevision(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewFakeHistory(informer)
 		var collisionCount int32
 		for i := range test.existing {
@@ -1016,12 +1024,13 @@ func TestRealHistory_AdoptControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
@@ -1125,12 +1134,13 @@ func TestFakeHistory_AdoptControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 
 		history := NewFakeHistory(informer)
 		var collisionCount int32
@@ -1273,12 +1283,13 @@ func TestRealHistory_ReleaseControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 
 		history := NewHistory(client, informer.Lister(), informer.Informer().GetIndexer())
 		var collisionCount int32
@@ -1398,12 +1409,13 @@ func TestFakeHistory_ReleaseControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.StartWithContext(wait.ContextForChannel(stop))
+		ctx := wait.ContextForChannel(stop)
+		informerFactory.StartWithContext(ctx)
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
 		}
-		informerFactory.WaitForCacheSync(stop)
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 		history := NewFakeHistory(informer)
 		var collisionCount int32
 		for i := range test.existing {

--- a/pkg/controller/history/controller_history_test.go
+++ b/pkg/controller/history/controller_history_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 )
 
@@ -58,7 +59,7 @@ func TestRealHistory_ListControllerRevisions(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
@@ -158,7 +159,7 @@ func TestFakeHistory_ListControllerRevisions(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
@@ -260,7 +261,7 @@ func TestRealHistory_CreateControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
@@ -395,7 +396,7 @@ func TestFakeHistory_CreateControllerRevision(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
@@ -548,7 +549,7 @@ func TestRealHistory_UpdateControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
@@ -678,7 +679,7 @@ func TestFakeHistory_UpdateControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
@@ -769,7 +770,7 @@ func TestRealHistory_DeleteControllerRevision(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
@@ -875,7 +876,7 @@ func TestFakeHistory_DeleteControllerRevision(t *testing.T) {
 
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
@@ -1015,7 +1016,7 @@ func TestRealHistory_AdoptControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
@@ -1124,7 +1125,7 @@ func TestFakeHistory_AdoptControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
@@ -1272,7 +1273,7 @@ func TestRealHistory_ReleaseControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)
@@ -1397,7 +1398,7 @@ func TestFakeHistory_ReleaseControllerRevision(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 		stop := make(chan struct{})
 		defer close(stop)
-		informerFactory.Start(stop)
+		informerFactory.StartWithContext(wait.ContextForChannel(stop))
 		informer := informerFactory.Apps().V1().ControllerRevisions()
 		if err := AddControllerRevisionControllerIndexer(informer.Informer()); err != nil {
 			t.Fatalf("failed to add indexer: %v", err)

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -331,7 +331,7 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 
 // Run the main goroutine responsible for watching and syncing jobs.
 func (jm *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	jm.broadcaster.StartStructuredLogging(3)

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -257,10 +257,18 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 			Recorder:   eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "job-controller"}),
 			OnWrite:    podWriteCallback,
 		},
-		expectations:            controller.NewControllerExpectations(),
-		finalizerExpectations:   newUIDTrackingExpectations(),
-		queue:                   workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.NewTypedItemExponentialFailureRateLimiter[string](DefaultJobApiBackOff, MaxJobApiBackOff), workqueue.TypedRateLimitingQueueConfig[string]{Name: "job", Clock: clock}),
-		orphanQueue:             workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.NewTypedItemExponentialFailureRateLimiter[orphanPodKey](DefaultJobApiBackOff, MaxJobApiBackOff), workqueue.TypedRateLimitingQueueConfig[orphanPodKey]{Name: "job_orphan_pod", Clock: clock}),
+		expectations:          controller.NewControllerExpectations(),
+		finalizerExpectations: newUIDTrackingExpectations(),
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.NewTypedItemExponentialFailureRateLimiter[string](DefaultJobApiBackOff, MaxJobApiBackOff), workqueue.TypedRateLimitingQueueConfig[string]{
+			Logger: new(klog.FromContext(ctx)),
+			Name:   "job",
+			Clock:  clock,
+		}),
+		orphanQueue: workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.NewTypedItemExponentialFailureRateLimiter[orphanPodKey](DefaultJobApiBackOff, MaxJobApiBackOff), workqueue.TypedRateLimitingQueueConfig[orphanPodKey]{
+			Logger: new(klog.FromContext(ctx)),
+			Name:   "job_orphan_pod",
+			Clock:  clock,
+		}),
 		broadcaster:             eventBroadcaster,
 		recorder:                eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "job-controller"}),
 		clock:                   clock,
@@ -269,7 +277,7 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 		consistencyStore:        consistencyStore,
 	}
 
-	if _, err := jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := jobInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			jm.addJob(logger, obj)
 		},
@@ -279,13 +287,13 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 		DeleteFunc: func(obj interface{}) {
 			jm.deleteJob(logger, obj)
 		},
-	}); err != nil {
+	}, cache.HandlerOptions{Logger: &logger}); err != nil {
 		return nil, fmt.Errorf("adding Job event handler: %w", err)
 	}
 	jm.jobLister = jobInformer.Lister()
 	jm.jobStoreSynced = jobInformer.Informer().HasSynced
 
-	if _, err := podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if _, err := podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			jm.addPod(logger, obj)
 		},
@@ -295,7 +303,7 @@ func newControllerWithClock(ctx context.Context, kubeClient clientset.Interface,
 		DeleteFunc: func(obj interface{}) {
 			jm.deletePod(logger, obj, true)
 		},
-	}); err != nil {
+	}, cache.HandlerOptions{Logger: &logger}); err != nil {
 		return nil, fmt.Errorf("adding Pod event handler: %w", err)
 	}
 	jm.podStore = podInformer.Lister()

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -2839,7 +2839,7 @@ func TestPastDeadlineJobFinished(t *testing.T) {
 		},
 	}
 	sharedInformerFactory.StartWithContext(ctx)
-	sharedInformerFactory.WaitForCacheSync(ctx.Done())
+	sharedInformerFactory.WaitForCacheSyncWithContext(ctx)
 
 	go manager.Run(ctx, 1)
 
@@ -6511,7 +6511,7 @@ func TestWatchJobs(t *testing.T) {
 	// Start only the job watcher and the workqueue, send a watch event,
 	// and make sure it hits the sync method.
 	sharedInformerFactory.StartWithContext(ctx)
-	sharedInformerFactory.WaitForCacheSync(ctx.Done())
+	sharedInformerFactory.WaitForCacheSyncWithContext(ctx)
 	go manager.Run(ctx, 1)
 
 	// We're sending new job to see if it reaches syncHandler.
@@ -7633,7 +7633,7 @@ func TestFinalizerCleanup(t *testing.T) {
 
 	// Start the Pod and Job informers.
 	sharedInformers.StartWithContext(ctx)
-	sharedInformers.WaitForCacheSync(ctx.Done())
+	sharedInformers.WaitForCacheSyncWithContext(ctx)
 	// Initialize the controller with 1 worker to make sure the
 	// pod finalizers are removed by the "syncJob" function.
 	go manager.Run(ctx, 1)
@@ -8027,7 +8027,7 @@ func TestSyncJobPodSchedulingGroup(t *testing.T) {
 			}
 
 			sharedInformers.StartWithContext(ctx)
-			sharedInformers.WaitForCacheSync(ctx.Done())
+			sharedInformers.WaitForCacheSyncWithContext(ctx)
 
 			if err := sharedInformers.Batch().V1().Jobs().Informer().GetIndexer().Add(tc.job); err != nil {
 				t.Fatalf("Failed to insert job in index: %v", err)

--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -2838,7 +2838,7 @@ func TestPastDeadlineJobFinished(t *testing.T) {
 		controller.NewControllerExpectations(), true, func() {
 		},
 	}
-	sharedInformerFactory.Start(ctx.Done())
+	sharedInformerFactory.StartWithContext(ctx)
 	sharedInformerFactory.WaitForCacheSync(ctx.Done())
 
 	go manager.Run(ctx, 1)
@@ -6510,7 +6510,7 @@ func TestWatchJobs(t *testing.T) {
 	}
 	// Start only the job watcher and the workqueue, send a watch event,
 	// and make sure it hits the sync method.
-	sharedInformerFactory.Start(ctx.Done())
+	sharedInformerFactory.StartWithContext(ctx)
 	sharedInformerFactory.WaitForCacheSync(ctx.Done())
 	go manager.Run(ctx, 1)
 
@@ -7632,7 +7632,7 @@ func TestFinalizerCleanup(t *testing.T) {
 	manager.jobStoreSynced = alwaysReady
 
 	// Start the Pod and Job informers.
-	sharedInformers.Start(ctx.Done())
+	sharedInformers.StartWithContext(ctx)
 	sharedInformers.WaitForCacheSync(ctx.Done())
 	// Initialize the controller with 1 worker to make sure the
 	// pod finalizers are removed by the "syncJob" function.
@@ -8026,7 +8026,7 @@ func TestSyncJobPodSchedulingGroup(t *testing.T) {
 				return job, nil
 			}
 
-			sharedInformers.Start(ctx.Done())
+			sharedInformers.StartWithContext(ctx)
 			sharedInformers.WaitForCacheSync(ctx.Done())
 
 			if err := sharedInformers.Batch().V1().Jobs().Informer().GetIndexer().Add(tc.job); err != nil {

--- a/pkg/controller/job/job_scheduling_manager_test.go
+++ b/pkg/controller/job/job_scheduling_manager_test.go
@@ -817,7 +817,7 @@ func TestEnsureWorkloadAndPodGroup(t *testing.T) {
 			}
 
 			sharedInformers.StartWithContext(ctx)
-			sharedInformers.WaitForCacheSync(ctx.Done())
+			sharedInformers.WaitForCacheSyncWithContext(ctx)
 
 			_, pg, err := jm.ensureWorkloadAndPodGroup(ctx, tc.job, tc.pods)
 			if tc.wantErr {

--- a/pkg/controller/job/job_scheduling_manager_test.go
+++ b/pkg/controller/job/job_scheduling_manager_test.go
@@ -816,7 +816,7 @@ func TestEnsureWorkloadAndPodGroup(t *testing.T) {
 				})
 			}
 
-			sharedInformers.Start(ctx.Done())
+			sharedInformers.StartWithContext(ctx)
 			sharedInformers.WaitForCacheSync(ctx.Done())
 
 			_, pg, err := jm.ensureWorkloadAndPodGroup(ctx, tc.job, tc.pods)

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -71,20 +71,22 @@ func NewNamespaceController(
 	namespaceInformer coreinformers.NamespaceInformer,
 	resyncPeriod time.Duration,
 	finalizerToken v1.FinalizerName) *NamespaceController {
+	logger := klog.FromContext(ctx)
 
 	// create the controller so we can inject the enqueue function
 	namespaceController := &NamespaceController{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			nsControllerRateLimiter(),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "namespace",
+				Logger: &logger,
+				Name:   "namespace",
 			},
 		),
 		namespacedResourcesDeleter: deletion.NewNamespacedResourcesDeleter(ctx, kubeClient.CoreV1().Namespaces(), metadataClient, kubeClient.CoreV1(), discoverResourcesFn, finalizerToken),
 	}
 
 	// configure the namespace informer event handlers
-	namespaceInformer.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = namespaceInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				namespace := obj.(*v1.Namespace)
@@ -95,7 +97,7 @@ func NewNamespaceController(
 				namespaceController.enqueueNamespace(ctx, namespace)
 			},
 		},
-		resyncPeriod,
+		cache.HandlerOptions{Logger: &logger, ResyncPeriod: &resyncPeriod},
 	)
 	namespaceController.lister = namespaceInformer.Lister()
 	namespaceController.listerSynced = namespaceInformer.Informer().HasSynced

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -59,7 +59,7 @@ type rangeAllocator struct {
 
 	// queues are where incoming work is placed to de-dup and to allow "easy"
 	// rate limited requeues on errors
-	queue workqueue.RateLimitingInterface
+	queue workqueue.TypedRateLimitingInterface[string]
 }
 
 var _ CIDRAllocator = &rangeAllocator{}
@@ -98,7 +98,13 @@ func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, node
 		nodesSynced:  nodeInformer.Informer().HasSynced,
 		broadcaster:  eventBroadcaster,
 		recorder:     recorder,
-		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cidrallocator_node"),
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "cidrallocator_node",
+			},
+		),
 	}
 
 	if allocatorParams.ServiceCIDR != nil {
@@ -130,7 +136,7 @@ func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, node
 		}
 	}
 
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
 			if err == nil {
@@ -163,7 +169,7 @@ func NewCIDRRangeAllocator(ctx context.Context, client clientset.Interface, node
 				utilruntime.HandleErrorWithContext(ctx, err, "Error while processing CIDR Release")
 			}
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	return ra, nil
 }
@@ -210,35 +216,20 @@ func (r *rangeAllocator) runWorker(ctx context.Context) {
 // processNextWorkItem will read a single work item off the queue and
 // attempt to process it, by calling the syncHandler.
 func (r *rangeAllocator) processNextNodeWorkItem(ctx context.Context) bool {
-	obj, shutdown := r.queue.Get()
+	key, shutdown := r.queue.Get()
 	if shutdown {
 		return false
 	}
 
 	// We wrap this block in a func so we can defer r.queue.Done.
-	err := func(logger klog.Logger, obj interface{}) error {
+	err := func(logger klog.Logger, key string) error {
 		// We call Done here so the workNodeQueue knows we have finished
 		// processing this item. We also must remember to call Forget if we
 		// do not want this work item being re-queued. For example, we do
 		// not call Forget if a transient error occurs, instead the item is
 		// put back on the queue and attempted again after a back-off
 		// period.
-		defer r.queue.Done(obj)
-		var key string
-		var ok bool
-		// We expect strings to come off the workNodeQueue. These are of the
-		// form namespace/name. We do this as the delayed nature of the
-		// workNodeQueue means the items in the informer cache may actually be
-		// more up to date that when the item was initially put onto the
-		// workNodeQueue.
-		if key, ok = obj.(string); !ok {
-			// As the item in the workNodeQueue is actually invalid, we call
-			// Forget here else we'd go into a loop of attempting to
-			// process a work item that is invalid.
-			r.queue.Forget(obj)
-			utilruntime.HandleErrorWithContext(ctx, nil, "Expected string but got unexpected type in work node queue", "type", fmt.Sprintf("%T", obj))
-			return nil
-		}
+		defer r.queue.Done(key)
 		// Run the syncHandler, passing it the namespace/name string of the
 		// Foo resource to be synced.
 		if err := r.syncNode(ctx, key); err != nil {
@@ -248,10 +239,10 @@ func (r *rangeAllocator) processNextNodeWorkItem(ctx context.Context) bool {
 		}
 		// Finally, if no error occurs we Forget this item so it does not
 		// get queue again until another change happens.
-		r.queue.Forget(obj)
+		r.queue.Forget(key)
 		logger.V(4).Info("Successfully synced", "key", key)
 		return nil
-	}(klog.FromContext(ctx), obj)
+	}(klog.FromContext(ctx), key)
 
 	if err != nil {
 		utilruntime.HandleErrorWithContext(ctx, err, "Error processing node work item")

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -357,7 +357,8 @@ func NewNodeLifecycleController(
 		podUpdateQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[podUpdateItem](),
 			workqueue.TypedRateLimitingQueueConfig[podUpdateItem]{
-				Name: "node_lifecycle_controller_pods",
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "node_lifecycle_controller_pods",
 			},
 		),
 	}
@@ -366,7 +367,7 @@ func NewNodeLifecycleController(
 	nc.enterFullDisruptionFunc = nc.HealthyQPSFunc
 	nc.computeZoneStateFunc = nc.ComputeZoneState
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*v1.Pod)
 			nc.podUpdated(nil, pod)
@@ -376,7 +377,7 @@ func NewNodeLifecycleController(
 			newPod := obj.(*v1.Pod)
 			nc.podUpdated(prevPod, newPod)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	nc.podInformerSynced = podInformer.Informer().HasSynced
 	controller.AddPodNodeNameIndexer(podInformer.Informer())
 	podIndexer := podInformer.Informer().GetIndexer()
@@ -408,7 +409,7 @@ func NewNodeLifecycleController(
 	}
 
 	logger.Info("Controller will reconcile labels")
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: controllerutil.CreateAddNodeHandler(func(node *v1.Node) error {
 			nc.nodeUpdateQueue.Add(node.Name)
 			return nil
@@ -421,7 +422,7 @@ func NewNodeLifecycleController(
 			nc.nodesToRetry.Delete(node.Name)
 			return nil
 		}),
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	nc.leaseLister = leaseInformer.Lister()
 	nc.leaseInformerSynced = leaseInformer.Informer().HasSynced

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -224,7 +224,7 @@ func NewHorizontalController(
 
 // Run begins watching and syncing.
 func (a *HorizontalController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting HPA controller")

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -150,6 +150,7 @@ func NewHorizontalController(
 	cpuInitializationPeriod,
 	delayOfInitialReadinessStatus time.Duration,
 ) *HorizontalController {
+	logger := klog.FromContext(ctx)
 	broadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	broadcaster.StartStructuredLogging(3)
 	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: evtNamespacer.Events("")})
@@ -174,7 +175,8 @@ func NewHorizontalController(
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			NewDefaultHPARateLimiter(resyncPeriod),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "horizontalpodautoscaler",
+				Logger: &logger,
+				Name:   "horizontalpodautoscaler",
 			},
 		),
 		mapper:              mapper,
@@ -193,13 +195,13 @@ func NewHorizontalController(
 		hpaController.selectorTracker = newBiMultimapSelectorTracker()
 	}
 
-	hpaInformer.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = hpaInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    hpaController.enqueueHPA,
 			UpdateFunc: hpaController.updateHPA,
 			DeleteFunc: hpaController.deleteHPA,
 		},
-		resyncPeriod,
+		cache.HandlerOptions{Logger: &logger, ResyncPeriod: &resyncPeriod},
 	)
 	hpaController.hpaLister = hpaInformer.Lister()
 	hpaController.hpaListerSynced = hpaInformer.Informer().HasSynced

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -6871,6 +6871,7 @@ func TestNoScaleDownOneMetricEmpty(t *testing.T) {
 }
 
 func TestMultipleHPAs(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	const hpaCount = 1000
 	const testNamespace = "dummy-namespace"
 
@@ -6879,8 +6880,8 @@ func TestMultipleHPAs(t *testing.T) {
 	testClient := &fake.Clientset{}
 	testScaleClient := &scalefake.FakeScaleClient{}
 	testMetricsClient := &metricsfake.Clientset{}
-	hpaWatcher := watch.NewFake()
-	podWatcher := watch.NewFake()
+	hpaWatcher := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
+	podWatcher := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 
 	testClient.AddWatchReactor("horizontalpodautoscalers", core.DefaultWatchReactor(hpaWatcher, nil))
 	testClient.AddWatchReactor("pods", core.DefaultWatchReactor(podWatcher, nil))

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -410,7 +410,7 @@ func newHorizontalSetup(t *testing.T, s *horizontalScenario, testClient *fake.Cl
 	}
 
 	informerFactory.StartWithContext(tCtx)
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	return &horizontalSetup{
 		controller:      hpaController,

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -409,7 +409,7 @@ func newHorizontalSetup(t *testing.T, s *horizontalScenario, testClient *fake.Cl
 		hpaController.recommendations["test-namespace/test-hpa"] = s.recommendations
 	}
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	informerFactory.WaitForCacheSync(tCtx.Done())
 
 	return &horizontalSetup{
@@ -1336,7 +1336,7 @@ func coolCPUCreationTime() metav1.Time {
 
 func (tc *testCase) runTestWithController(t *testing.T, hpaController *HorizontalController, informerFactory informers.SharedInformerFactory) {
 	ctx, cancel := context.WithCancel(context.Background())
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
@@ -7127,7 +7127,7 @@ func TestMultipleHPAs(t *testing.T) {
 	monitor.NumHorizontalPodAutoscalers.Set(0)
 	hpaController.monitor = monitor.New()
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	go hpaController.Run(tCtx, 5)
 
 	timeoutTime := time.After(15 * time.Second)

--- a/pkg/controller/podautoscaler/replica_calculator_test.go
+++ b/pkg/controller/podautoscaler/replica_calculator_test.go
@@ -228,7 +228,7 @@ func newReplicaCalcSetup(t *testing.T, f *calcScenario) *replicaCalcSetup {
 	calc := NewReplicaCalculator(metricsClient, informer.Lister(),
 		defaultTestingCPUInitializationPeriod, defaultTestingDelayOfInitialReadinessStatus)
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 
 	syncCtx, cancel := context.WithTimeout(tCtx, 10*time.Second)
 	defer cancel()

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -74,6 +74,7 @@ func NewPodGC(ctx context.Context, kubeClient clientset.Interface, podInformer c
 // This function is only intended for integration tests
 func NewPodGCInternal(ctx context.Context, kubeClient clientset.Interface, podInformer coreinformers.PodInformer,
 	nodeInformer coreinformers.NodeInformer, terminatedPodThreshold int, gcCheckPeriod, quarantineTime time.Duration) *PodGCController {
+
 	gcc := &PodGCController{
 		kubeClient:             kubeClient,
 		terminatedPodThreshold: terminatedPodThreshold,
@@ -81,9 +82,12 @@ func NewPodGCInternal(ctx context.Context, kubeClient clientset.Interface, podIn
 		podListerSynced:        podInformer.Informer().HasSynced,
 		nodeLister:             nodeInformer.Lister(),
 		nodeListerSynced:       nodeInformer.Informer().HasSynced,
-		nodeQueue:              workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[string]{Name: "orphaned_pods_nodes"}),
-		gcCheckPeriod:          gcCheckPeriod,
-		quarantineTime:         quarantineTime,
+		nodeQueue: workqueue.NewTypedDelayingQueueWithConfig(workqueue.TypedDelayingQueueConfig[string]{
+			Logger: new(klog.FromContext(ctx)),
+			Name:   "orphaned_pods_nodes",
+		}),
+		gcCheckPeriod:  gcCheckPeriod,
+		quarantineTime: quarantineTime,
 	}
 
 	// Register prometheus metrics

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -276,7 +276,7 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 
 // Run begins watching and syncing.
 func (rsc *ReplicaSetController) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	rsc.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -213,14 +213,17 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 		expectations:     controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: queueName},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   queueName,
+			},
 		),
 		clock:              clock.RealClock{},
 		controllerFeatures: controllerFeatures,
 		consistencyStore:   consistencyStore,
 	}
 
-	rsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = rsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			rsc.addRS(logger, obj)
 		},
@@ -230,7 +233,7 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 		DeleteFunc: func(obj interface{}) {
 			rsc.deleteRS(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	rsInformer.Informer().AddIndexers(cache.Indexers{
 		controllerUIDIndex: func(obj interface{}) ([]string, error) {
 			rs, ok := obj.(*apps.ReplicaSet)
@@ -248,7 +251,7 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 	rsc.rsLister = rsInformer.Lister()
 	rsc.rsListerSynced = rsInformer.Informer().HasSynced
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			rsc.addPod(logger, obj)
 		},
@@ -261,7 +264,7 @@ func NewBaseController(logger klog.Logger, rsInformer appsinformers.ReplicaSetIn
 		DeleteFunc: func(obj interface{}) {
 			rsc.deletePod(logger, obj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	rsc.podLister = podInformer.Lister()
 	rsc.podListerSynced = podInformer.Informer().HasSynced
 	controller.AddPodControllerIndexer(podInformer.Informer()) //nolint:errcheck

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -879,7 +879,7 @@ func TestControllerUpdateRequeue(t *testing.T) {
 	manager.podControl = &fakePodControl
 
 	// Enqueue once. Then process it. Disable rate-limiting for this.
-	manager.queue = workqueue.NewTypedRateLimitingQueue(workqueue.NewTypedMaxOfRateLimiter[string]())
+	manager.queue = workqueue.NewTypedRateLimitingQueue(workqueue.NewTypedMaxOfRateLimiter[string]()) //nolint:logcheck // Intentionally testing old API here.
 	manager.enqueueRS(rs)
 	manager.processNextWorkItem(ctx)
 	// It should have been requeued.

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -641,7 +641,7 @@ func TestWatchControllers(t *testing.T) {
 		BurstReplicas,
 	)
 	informers.StartWithContext(tCtx)
-	informers.WaitForCacheSync(stopCh)
+	informers.WaitForCacheSyncWithContext(tCtx)
 
 	var testRSSpec apps.ReplicaSet
 	received := make(chan string)
@@ -1211,7 +1211,7 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		100,
 	)
 	f.StartWithContext(tCtx)
-	f.WaitForCacheSync(stopCh)
+	f.WaitForCacheSyncWithContext(tCtx)
 	fakePodControl := controller.FakePodControl{}
 	manager.podControl = &fakePodControl
 

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -640,7 +640,7 @@ func TestWatchControllers(t *testing.T) {
 		client,
 		BurstReplicas,
 	)
-	informers.Start(stopCh)
+	informers.StartWithContext(tCtx)
 	informers.WaitForCacheSync(stopCh)
 
 	var testRSSpec apps.ReplicaSet
@@ -1210,7 +1210,7 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		client,
 		100,
 	)
-	f.Start(stopCh)
+	f.StartWithContext(tCtx)
 	f.WaitForCacheSync(stopCh)
 	fakePodControl := controller.FakePodControl{}
 	manager.podControl = &fakePodControl

--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -45,6 +45,7 @@ import (
 	appslisters "k8s.io/client-go/listers/apps/v1"
 	v1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 	appsinternal "k8s.io/kubernetes/pkg/apis/apps"
 	appsconversion "k8s.io/kubernetes/pkg/apis/apps/v1"
 	apiv1 "k8s.io/kubernetes/pkg/apis/core/v1"
@@ -58,7 +59,7 @@ type informerAdapter struct {
 }
 
 func (i informerAdapter) Informer() cache.SharedIndexInformer {
-	return conversionInformer{i.rcInformer.Informer()}
+	return conversionInformer{SharedIndexInformer: i.rcInformer.Informer(), logger: klog.Background()}
 }
 
 func (i informerAdapter) Lister() appslisters.ReplicaSetLister {
@@ -67,14 +68,22 @@ func (i informerAdapter) Lister() appslisters.ReplicaSetLister {
 
 type conversionInformer struct {
 	cache.SharedIndexInformer
+	logger klog.Logger
+}
+
+func (i conversionInformer) AddEventHandlerWithOptions(handler cache.ResourceEventHandler, options cache.HandlerOptions) (cache.ResourceEventHandlerRegistration, error) {
+	if options.Logger == nil {
+		options.Logger = &i.logger
+	}
+	return i.SharedIndexInformer.AddEventHandlerWithOptions(conversionEventHandler{handler}, options)
 }
 
 func (i conversionInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
-	return i.SharedIndexInformer.AddEventHandler(conversionEventHandler{handler})
+	return i.AddEventHandlerWithOptions(handler, cache.HandlerOptions{Logger: &i.logger})
 }
 
 func (i conversionInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) (cache.ResourceEventHandlerRegistration, error) {
-	return i.SharedIndexInformer.AddEventHandlerWithResyncPeriod(conversionEventHandler{handler}, resyncPeriod)
+	return i.AddEventHandlerWithOptions(handler, cache.HandlerOptions{Logger: &i.logger, ResyncPeriod: &resyncPeriod})
 }
 
 type conversionLister struct {

--- a/pkg/controller/resourceclaim/controller.go
+++ b/pkg/controller/resourceclaim/controller.go
@@ -237,7 +237,10 @@ func newControllerWithFeatures(
 		templatesSynced: templateInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "resource_claim"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "resource_claim",
+			},
 		),
 		deletedObjects: newUIDCache(maxUIDCacheEntries),
 	}

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -229,7 +229,7 @@ func TestCreateClaimDoesNotMutateTemplate(t *testing.T) {
 				tCtx.Cancel("stopping informers")
 				informerFactory.Shutdown()
 			}()
-			informerFactory.WaitForCacheSync(tCtx.Done())
+			informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 			// cachedTemplate is the object the controller reads from the shared informer
 			// cache; snapshot it so any in-place mutation is detectable.
@@ -1173,7 +1173,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 				informerFactory.Shutdown()
 			}
 			defer stopInformers()
-			informerFactory.WaitForCacheSync(tCtx.Done())
+			informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 			// Add claims that only exist in the mutation cache.
 			for _, claim := range tc.claimsInCache {
@@ -1350,7 +1350,7 @@ func testClaimExists(tCtx ktesting.TContext) {
 				informerFactory.Shutdown()
 			}
 			defer stopInformers()
-			informerFactory.WaitForCacheSync(tCtx.Done())
+			informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 			// Add claims that only exist in the mutation cache.
 			if claim := tc.claimInMutationCache; claim != nil {

--- a/pkg/controller/resourceclaim/controller_test.go
+++ b/pkg/controller/resourceclaim/controller_test.go
@@ -224,7 +224,7 @@ func TestCreateClaimDoesNotMutateTemplate(t *testing.T) {
 				tCtx.Fatalf("error creating controller: %v", err)
 			}
 
-			informerFactory.Start(tCtx.Done())
+			informerFactory.StartWithContext(tCtx)
 			defer func() {
 				tCtx.Cancel("stopping informers")
 				informerFactory.Shutdown()
@@ -1167,7 +1167,7 @@ func testSyncHandler(tCtx ktesting.TContext) {
 			}
 
 			// Ensure informers are up-to-date.
-			informerFactory.Start(tCtx.Done())
+			informerFactory.StartWithContext(tCtx)
 			stopInformers := func() {
 				tCtx.Cancel("stopping informers")
 				informerFactory.Shutdown()
@@ -1344,7 +1344,7 @@ func testClaimExists(tCtx ktesting.TContext) {
 			tCtx.ExpectNoError(err, "creating controller")
 
 			// Ensure informers are up-to-date.
-			informerFactory.Start(tCtx.Done())
+			informerFactory.StartWithContext(tCtx)
 			stopInformers := func() {
 				tCtx.Cancel("stopping informers")
 				informerFactory.Shutdown()
@@ -1715,7 +1715,7 @@ func testEventHandlers(tCtx ktesting.TContext) {
 			tCtx.ExpectNoError(err, "creating ephemeral controller")
 			tCtx.Cleanup(ec.queue.ShutDown)
 
-			informerFactory.Start(tCtx.Done())
+			informerFactory.StartWithContext(tCtx)
 			stopInformers := func() {
 				tCtx.Cancel("stopping informers")
 				informerFactory.Shutdown()

--- a/pkg/controller/resourcepoolstatusrequest/controller.go
+++ b/pkg/controller/resourcepoolstatusrequest/controller.go
@@ -116,7 +116,13 @@ func NewController(
 		requestSynced: requestInformer.Informer().HasSynced,
 		sliceSynced:   sliceInformer.Informer().HasSynced,
 		claimSynced:   claimInformer.Informer().HasSynced,
-		workqueue:     workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+		workqueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "resourcepoolstatusrequest",
+			},
+		),
 	}
 
 	// Only consume the DeviceTaintRule informer when the gate is enabled, so

--- a/pkg/controller/resourcepoolstatusrequest/controller.go
+++ b/pkg/controller/resourcepoolstatusrequest/controller.go
@@ -154,7 +154,7 @@ func NewController(
 
 // Run starts the controller workers.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ResourcePoolStatusRequest controller")

--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -104,6 +104,8 @@ type Controller struct {
 
 // NewController creates a quota controller with specified options
 func NewController(ctx context.Context, options *ControllerOptions) (*Controller, error) {
+	logger := klog.FromContext(ctx)
+
 	// build the resource quota controller
 	rq := &Controller{
 		rqClient:            options.QuotaClient,
@@ -111,11 +113,17 @@ func NewController(ctx context.Context, options *ControllerOptions) (*Controller
 		informerSyncedFuncs: []cache.InformerSynced{options.ResourceQuotaInformer.Informer().HasSynced},
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "resourcequota_primary"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "resourcequota_primary",
+			},
 		),
 		missingUsageQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "resourcequota_priority"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "resourcequota_priority",
+			},
 		),
 		resyncPeriod: options.ResyncPeriod,
 		registry:     options.Registry,
@@ -123,9 +131,8 @@ func NewController(ctx context.Context, options *ControllerOptions) (*Controller
 	// set the synchronization handler
 	rq.syncHandler = rq.syncResourceQuotaFromKey
 
-	logger := klog.FromContext(ctx)
-
-	options.ResourceQuotaInformer.Informer().AddEventHandlerWithResyncPeriod(
+	resyncPeriod := rq.resyncPeriod()
+	_, _ = options.ResourceQuotaInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				rq.addQuota(logger, obj)
@@ -153,11 +160,15 @@ func NewController(ctx context.Context, options *ControllerOptions) (*Controller
 				rq.enqueueResourceQuota(logger, obj)
 			},
 		},
-		rq.resyncPeriod(),
+		cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &resyncPeriod,
+		},
 	)
 
 	if options.DiscoveryFunc != nil {
 		qm := NewMonitor(
+			logger,
 			options.InformersStarted,
 			options.InformerFactory,
 			options.IgnoredResourcesFunc(),

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -134,7 +134,7 @@ func setupQuotaController(t *testing.T, kubeClient kubernetes.Interface, lister 
 		t.Fatal(err)
 	}
 	stop := make(chan struct{})
-	informerFactory.Start(stop)
+	informerFactory.StartWithContext(ctx)
 	return quotaController{qc, stop}
 }
 

--- a/pkg/controller/resourcequota/resource_quota_monitor.go
+++ b/pkg/controller/resourcequota/resource_quota_monitor.go
@@ -106,14 +106,17 @@ type QuotaMonitor struct {
 }
 
 // NewMonitor creates a new instance of a QuotaMonitor
-func NewMonitor(informersStarted <-chan struct{}, informerFactory informerfactory.InformerFactory, ignoredResources map[schema.GroupResource]struct{}, resyncPeriod controller.ResyncPeriodFunc, replenishmentFunc ReplenishmentFunc, registry quota.Registry, updateFilter UpdateFilter) *QuotaMonitor {
+func NewMonitor(logger klog.Logger, informersStarted <-chan struct{}, informerFactory informerfactory.InformerFactory, ignoredResources map[schema.GroupResource]struct{}, resyncPeriod controller.ResyncPeriodFunc, replenishmentFunc ReplenishmentFunc, registry quota.Registry, updateFilter UpdateFilter) *QuotaMonitor {
 	return &QuotaMonitor{
 		informersStarted: informersStarted,
 		informerFactory:  informerFactory,
 		ignoredResources: ignoredResources,
 		resourceChanges: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[*event](),
-			workqueue.TypedRateLimitingQueueConfig[*event]{Name: "resource_quota_controller_resource_changes"},
+			workqueue.TypedRateLimitingQueueConfig[*event]{
+				Logger: &logger,
+				Name:   "resource_quota_controller_resource_changes",
+			},
 		),
 		resyncPeriod:      resyncPeriod,
 		replenishmentFunc: replenishmentFunc,
@@ -134,7 +137,7 @@ type monitor struct {
 // Run is intended to be called in a goroutine. Multiple calls of this is an
 // error.
 func (m *monitor) Run() {
-	m.controller.Run(m.stopCh)
+	m.controller.RunWithContext(wait.ContextForChannel(m.stopCh))
 }
 
 type monitors map[schema.GroupVersionResource]*monitor
@@ -173,7 +176,11 @@ func (qm *QuotaMonitor) controllerFor(ctx context.Context, resource schema.Group
 	shared, err := qm.informerFactory.ForResource(resource)
 	if err == nil {
 		logger.V(4).Info("QuotaMonitor using a shared informer", "resource", resource.String())
-		shared.Informer().AddEventHandlerWithResyncPeriod(handlers, qm.resyncPeriod())
+		resyncPeriod := qm.resyncPeriod()
+		_, _ = shared.Informer().AddEventHandlerWithOptions(handlers, cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &resyncPeriod,
+		})
 		return shared.Informer().GetController(), nil
 	}
 	logger.V(4).Info("QuotaMonitor unable to use a shared informer", "resource", resource.String(), "err", err)

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
@@ -142,7 +142,7 @@ func addActivePodSchedulingGroupIndexer(indexer cache.Indexer) error {
 
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PodGroup protection controller")

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller.go
@@ -80,7 +80,10 @@ func NewPodGroupProtectionController(
 		podSynced:      podInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "podgroupprotection"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "podgroupprotection",
+			},
 		),
 	}
 

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -382,7 +382,7 @@ func TestPodGroupProtectionController(t *testing.T) {
 			}
 
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			go ctrl.Run(ctx, 1)
 
 			// In order to reduce test flakiness, make sure that the pod-to-delete is visible in the client set. Create a dummy pod to "warm up" the watch pipe.

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -381,7 +381,7 @@ func TestPodGroupProtectionController(t *testing.T) {
 				t.Fatalf("unexpected error creating controller: %v", err)
 			}
 
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			go ctrl.Run(ctx, 1)
 

--- a/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
+++ b/pkg/controller/scheduling/podgroupprotection/podgroup_protection_controller_test.go
@@ -260,7 +260,7 @@ func TestHandlePodChange(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := &Controller{
-				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()), //nolint:logcheck // Intentionally testing old API here.
 			}
 			defer c.queue.ShutDown()
 			c.handlePodChange(logger, tc.old, tc.new)
@@ -555,7 +555,7 @@ func TestHandlePodGroupUpdate(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := &Controller{
-				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+				queue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()), //nolint:logcheck // Intentionally testing old API here.
 			}
 			defer c.queue.ShutDown()
 			c.handlePodGroupUpdate(logger, tc.pg)

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -68,22 +68,31 @@ func NewServiceAccountsController(logger klog.Logger, saInformer coreinformers.S
 		serviceAccountsToEnsure: options.ServiceAccounts,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "serviceaccount"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "serviceaccount",
+			},
 		),
 	}
 
-	saHandler, _ := saInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+	saHandler, _ := saInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		DeleteFunc: func(obj interface{}) {
 			e.serviceAccountDeleted(logger, obj)
 		},
-	}, options.ServiceAccountResync)
+	}, cache.HandlerOptions{
+		Logger:       &logger,
+		ResyncPeriod: &options.ServiceAccountResync,
+	})
 	e.saLister = saInformer.Lister()
 	e.saListerSynced = saHandler.HasSynced
 
-	nsHandler, _ := nsInformer.Informer().AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
+	nsHandler, _ := nsInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    e.namespaceAdded,
 		UpdateFunc: e.namespaceUpdated,
-	}, options.NamespaceResync)
+	}, cache.HandlerOptions{
+		Logger:       &logger,
+		ResyncPeriod: &options.NamespaceResync,
+	})
 	e.nsLister = nsInformer.Lister()
 	e.nsListerSynced = nsHandler.HasSynced
 

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -84,11 +84,17 @@ func NewTokensController(logger klog.Logger, serviceAccounts informers.ServiceAc
 
 		syncServiceAccountQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[serviceAccountQueueKey](),
-			workqueue.TypedRateLimitingQueueConfig[serviceAccountQueueKey]{Name: "serviceaccount_tokens_service"},
+			workqueue.TypedRateLimitingQueueConfig[serviceAccountQueueKey]{
+				Logger: &logger,
+				Name:   "serviceaccount_tokens_service",
+			},
 		),
 		syncSecretQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[secretQueueKey](),
-			workqueue.TypedRateLimitingQueueConfig[secretQueueKey]{Name: "serviceaccount_tokens_service"},
+			workqueue.TypedRateLimitingQueueConfig[secretQueueKey]{
+				Logger: &logger,
+				Name:   "serviceaccount_tokens_service",
+			},
 		),
 
 		maxRetries: maxRetries,
@@ -96,13 +102,16 @@ func NewTokensController(logger klog.Logger, serviceAccounts informers.ServiceAc
 
 	e.serviceAccounts = serviceAccounts.Lister()
 	e.serviceAccountSynced = serviceAccounts.Informer().HasSynced
-	serviceAccounts.Informer().AddEventHandlerWithResyncPeriod(
+	_, _ = serviceAccounts.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    e.queueServiceAccountSync,
 			UpdateFunc: e.queueServiceAccountUpdateSync,
 			DeleteFunc: e.queueServiceAccountSync,
 		},
-		options.ServiceAccountResync,
+		cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &options.ServiceAccountResync,
+		},
 	)
 
 	e.secrets = secrets.Lister()

--- a/pkg/controller/servicecidrs/servicecidrs_controller.go
+++ b/pkg/controller/servicecidrs/servicecidrs_controller.go
@@ -74,28 +74,36 @@ func NewController(
 	ipAddressInformer networkinginformers.IPAddressInformer,
 	client clientset.Interface,
 ) *Controller {
+	logger := klog.FromContext(ctx)
 	broadcaster := record.NewBroadcaster(record.WithContext(ctx))
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerName})
 	c := &Controller{
 		client: client,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "ipaddresses"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "ipaddresses",
+			},
 		),
 		workerLoopPeriod: time.Second,
 	}
 
-	_, _ = serviceCIDRInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = serviceCIDRInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addServiceCIDR,
 		UpdateFunc: c.updateServiceCIDR,
 		DeleteFunc: c.deleteServiceCIDR,
+	}, cache.HandlerOptions{
+		Logger: &logger,
 	})
 	c.serviceCIDRLister = serviceCIDRInformer.Lister()
 	c.serviceCIDRsSynced = serviceCIDRInformer.Informer().HasSynced
 
-	_, _ = ipAddressInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = ipAddressInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addIPAddress,
 		DeleteFunc: c.deleteIPAddress,
+	}, cache.HandlerOptions{
+		Logger: &logger,
 	})
 
 	c.ipAddressLister = ipAddressInformer.Lister()

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -169,7 +169,10 @@ func NewStatefulSetController(
 		revListerSynced: revInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "statefulset"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "statefulset",
+			},
 		),
 		podControl: controller.RealPodControl{KubeClient: kubeClient, Recorder: recorder, OnWrite: podWriteCallback},
 
@@ -178,7 +181,7 @@ func NewStatefulSetController(
 		consistencyStore: consistencyStore,
 	}
 
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		// lookup the statefulset and enqueue
 		AddFunc: func(obj interface{}) {
 			ssc.addPod(logger, obj)
@@ -191,12 +194,14 @@ func NewStatefulSetController(
 		DeleteFunc: func(obj interface{}) {
 			ssc.deletePod(logger, obj)
 		},
+	}, cache.HandlerOptions{
+		Logger: &logger,
 	})
 	ssc.podLister = podInformer.Lister()
 	ssc.podListerSynced = podInformer.Informer().HasSynced
 	controller.AddPodControllerIndexer(podInformer.Informer())
 	ssc.podIndexer = podInformer.Informer().GetIndexer()
-	setInformer.Informer().AddEventHandler(
+	_, _ = setInformer.Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				ssc.enqueueStatefulSet(logger, obj)
@@ -213,6 +218,7 @@ func NewStatefulSetController(
 				ssc.enqueueStatefulSet(logger, obj)
 			},
 		},
+		cache.HandlerOptions{Logger: &logger},
 	)
 	ssc.setLister = setInformer.Lister()
 	ssc.setListerSynced = setInformer.Informer().HasSynced

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	appsinformers "k8s.io/client-go/informers/apps/v1"
@@ -994,7 +995,7 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 
 				stop := make(chan struct{})
 				defer close(stop)
-				informerFactory.Start(stop)
+				informerFactory.StartWithContext(wait.ContextForChannel(stop))
 				cache.WaitForCacheSync(
 					stop,
 					informerFactory.Apps().V1().StatefulSets().Informer().HasSynced,

--- a/pkg/controller/storageversiongc/gc_controller.go
+++ b/pkg/controller/storageversiongc/gc_controller.go
@@ -65,11 +65,17 @@ func NewStorageVersionGC(ctx context.Context, clientset kubernetes.Interface, le
 		storageVersionSynced: storageVersionInformer.Informer().HasSynced,
 		leaseQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "storage_version_garbage_collector_leases"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "storage_version_garbage_collector_leases",
+			},
 		),
 		storageVersionQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "storage_version_garbage_collector_storageversions"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "storage_version_garbage_collector_storageversions",
+			},
 		),
 	}
 	logger := klog.FromContext(ctx)

--- a/pkg/controller/storageversiongc/gc_controller.go
+++ b/pkg/controller/storageversiongc/gc_controller.go
@@ -101,7 +101,7 @@ func NewStorageVersionGC(ctx context.Context, clientset kubernetes.Interface, le
 
 // Run starts one worker.
 func (c *Controller) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting storage version garbage collector")

--- a/pkg/controller/storageversiongc/gc_controller_test.go
+++ b/pkg/controller/storageversiongc/gc_controller_test.go
@@ -42,7 +42,7 @@ func setupController(ctx context.Context, clientset kubernetes.Interface) {
 	storageVersionInformer := informerFactory.Internal().V1alpha1().StorageVersions()
 
 	controller := NewStorageVersionGC(ctx, clientset, leaseInformer, storageVersionInformer)
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	// Using this ensure informer caches are fully populated before starting the controller.
 	if !cache.WaitForCacheSync(ctx.Done(), controller.leasesSynced, controller.storageVersionSynced) {
 		panic("timed out waiting for caches to sync")

--- a/pkg/controller/storageversionmigrator/migrationrunner.go
+++ b/pkg/controller/storageversionmigrator/migrationrunner.go
@@ -78,7 +78,10 @@ func NewCustomResourceController(
 		crdClient:  crdClient,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[metav1.GroupResource](),
-			workqueue.TypedRateLimitingQueueConfig[metav1.GroupResource]{Name: ResourceVersionControllerName},
+			workqueue.TypedRateLimitingQueueConfig[metav1.GroupResource]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   ResourceVersionControllerName,
+			},
 		),
 	}
 

--- a/pkg/controller/storageversionmigrator/migrationrunner.go
+++ b/pkg/controller/storageversionmigrator/migrationrunner.go
@@ -137,7 +137,7 @@ func (crc *MigrationRunnerController) enqueue(svm *svmv1.StorageVersionMigration
 }
 
 func (crc *MigrationRunnerController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", MigrationRunnerControllerName)

--- a/pkg/controller/storageversionmigrator/migrationrunner_test.go
+++ b/pkg/controller/storageversionmigrator/migrationrunner_test.go
@@ -348,7 +348,7 @@ func TestCustomResourceController_Sync(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			logger, ctx := ktesting.NewTestContext(t)
 			var initialSVMs []runtime.Object
 			for _, svm := range tc.svms {
 				initialSVMs = append(initialSVMs, svm)
@@ -370,7 +370,7 @@ func TestCustomResourceController_Sync(t *testing.T) {
 
 			crdScheme := runtime.NewScheme()
 			_ = apiextensionsv1.AddToScheme(crdScheme)
-			crdTracker := k8stesting.NewObjectTracker(crdScheme, serializer.NewCodecFactory(crdScheme).UniversalDecoder())
+			crdTracker := k8stesting.NewObjectTrackerWithLogger(logger, crdScheme, serializer.NewCodecFactory(crdScheme).UniversalDecoder())
 
 			for _, obj := range initialCRDs {
 				_ = crdTracker.Add(obj)

--- a/pkg/controller/storageversionmigrator/resourceversion.go
+++ b/pkg/controller/storageversionmigrator/resourceversion.go
@@ -86,7 +86,10 @@ func NewResourceVersionController(
 		mapper:          mapper,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: ResourceVersionControllerName},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   ResourceVersionControllerName,
+			},
 		),
 	}
 

--- a/pkg/controller/storageversionmigrator/resourceversion.go
+++ b/pkg/controller/storageversionmigrator/resourceversion.go
@@ -130,7 +130,7 @@ func (rv *ResourceVersionController) enqueue(svm *svmv1.StorageVersionMigration)
 }
 
 func (rv *ResourceVersionController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", ResourceVersionControllerName)

--- a/pkg/controller/storageversionmigrator/resourceversion_test.go
+++ b/pkg/controller/storageversionmigrator/resourceversion_test.go
@@ -488,6 +488,7 @@ type testRESTMapper struct {
 }
 
 func (m *testRESTMapper) Reset() {
+	//nolint:logcheck // Reset() has a fixed signature from meta.ResettableRESTMapper and cannot accept a context.
 	meta.MaybeResetRESTMapper(m.RESTMapper)
 }
 

--- a/pkg/controller/storageversionmigrator/storageversionmigrator.go
+++ b/pkg/controller/storageversionmigrator/storageversionmigrator.go
@@ -139,7 +139,7 @@ func (svmc *SVMController) enqueue(svm *svmv1.StorageVersionMigration) {
 }
 
 func (svmc *SVMController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", svmc.controllerName)

--- a/pkg/controller/storageversionmigrator/storageversionmigrator.go
+++ b/pkg/controller/storageversionmigrator/storageversionmigrator.go
@@ -90,7 +90,10 @@ func NewSVMController(
 		dependencyGraphBuilder: dependencyGraphBuilder,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			rateLimiter,
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: controllerName},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   controllerName,
+			},
 		),
 		rateLimiter: rateLimiter,
 	}

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -277,7 +277,7 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 
 // Run starts the controller which will run in loop until `stopCh` is closed.
 func (tc *Controller) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting", "controller", tc.name)

--- a/pkg/controller/tainteviction/taint_eviction.go
+++ b/pkg/controller/tainteviction/taint_eviction.go
@@ -222,7 +222,7 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 	}
 	tm.taintEvictionQueue = CreateWorkerQueue(deletePodHandler(c, tm.emitPodDeletionEvent, tm.name))
 
-	_, err := podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*v1.Pod)
 			tm.PodUpdated(nil, pod)
@@ -249,12 +249,12 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 			}
 			tm.PodUpdated(pod, nil)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, fmt.Errorf("unable to add pod event handler: %w", err)
 	}
 
-	_, err = nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: controllerutil.CreateAddNodeHandler(func(node *v1.Node) error {
 			tm.NodeUpdated(nil, node)
 			return nil
@@ -267,7 +267,7 @@ func New(ctx context.Context, c clientset.Interface, podInformer corev1informers
 			tm.NodeUpdated(node, nil)
 			return nil
 		}),
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, fmt.Errorf("unable to add node event handler: %w", err)
 	}

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -128,7 +128,7 @@ var (
 
 // Run begins watching and syncing.
 func (ttlc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting TTL controller")

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -79,15 +79,18 @@ type Controller struct {
 
 // NewTTLController creates a new TTLController
 func NewTTLController(ctx context.Context, nodeInformer informers.NodeInformer, kubeClient clientset.Interface) *Controller {
+	logger := klog.FromContext(ctx)
 	ttlc := &Controller{
 		kubeClient: kubeClient,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "ttlcontroller"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "ttlcontroller",
+			},
 		),
 	}
-	logger := klog.FromContext(ctx)
-	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = nodeInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			ttlc.addNode(logger, obj)
 		},
@@ -97,6 +100,8 @@ func NewTTLController(ctx context.Context, nodeInformer informers.NodeInformer, 
 		DeleteFunc: func(obj interface{}) {
 			ttlc.deleteNode(logger, obj)
 		},
+	}, cache.HandlerOptions{
+		Logger: &logger,
 	})
 
 	ttlc.nodeStore = listers.NewNodeLister(nodeInformer.Informer().GetIndexer())

--- a/pkg/controller/ttl/ttl_controller_test.go
+++ b/pkg/controller/ttl/ttl_controller_test.go
@@ -231,7 +231,7 @@ func TestDesiredTTL(t *testing.T) {
 	for i, testCase := range testCases {
 		logger, _ := ktesting.NewTestContext(t)
 		ttlController := &Controller{
-			queue:             workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()),
+			queue:             workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]()), //nolint:logcheck // Intentionally testing old API here.
 			nodeCount:         testCase.nodeCount,
 			desiredTTLSeconds: testCase.desiredTTL,
 			boundaryStep:      testCase.boundaryStep,

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -76,24 +76,29 @@ func New(ctx context.Context, jobInformer batchinformers.JobInformer, client cli
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: client.CoreV1().Events("")})
 
 	metrics.Register()
+	logger := klog.FromContext(ctx)
 
 	tc := &Controller{
 		client:   client,
 		recorder: eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "ttl-after-finished-controller"}),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "ttl_jobs_to_delete"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "ttl_jobs_to_delete",
+			},
 		),
 	}
 
-	logger := klog.FromContext(ctx)
-	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = jobInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			tc.addJob(logger, obj)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			tc.updateJob(logger, oldObj, newObj)
 		},
+	}, cache.HandlerOptions{
+		Logger: &logger,
 	})
 
 	tc.jLister = jobInformer.Lister()

--- a/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
+++ b/pkg/controller/ttlafterfinished/ttlafterfinished_controller.go
@@ -111,7 +111,7 @@ func New(ctx context.Context, jobInformer batchinformers.JobInformer, client cli
 
 // Run starts the workers to clean up Jobs.
 func (tc *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting TTL after finished controller")

--- a/pkg/controller/validatingadmissionpolicystatus/controller.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -33,6 +33,7 @@ import (
 	admissionregistrationv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
 )
 
 // ControllerName has "Status" in it to differentiate this controller with the other that runs in API server.
@@ -73,24 +74,27 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	<-ctx.Done()
 }
 
-func NewController(policyInformer informerv1.ValidatingAdmissionPolicyInformer, policyClient admissionregistrationv1.ValidatingAdmissionPolicyInterface, typeChecker *validatingadmissionpolicy.TypeChecker) (*Controller, error) {
+func NewController(logger klog.Logger, policyInformer informerv1.ValidatingAdmissionPolicyInformer, policyClient admissionregistrationv1.ValidatingAdmissionPolicyInterface, typeChecker *validatingadmissionpolicy.TypeChecker) (*Controller, error) {
 	c := &Controller{
 		policyInformer: policyInformer,
 		policyQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: ControllerName},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   ControllerName,
+			},
 		),
 		policyClient: policyClient,
 		typeChecker:  typeChecker,
 	}
-	reg, err := policyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := policyInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			c.enqueuePolicy(obj)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			c.enqueuePolicy(newObj)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/validatingadmissionpolicystatus/controller.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller.go
@@ -54,7 +54,7 @@ type Controller struct {
 }
 
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	var wg sync.WaitGroup
 	defer func() {

--- a/pkg/controller/validatingadmissionpolicystatus/controller_test.go
+++ b/pkg/controller/validatingadmissionpolicystatus/controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubernetes/pkg/generated/openapi"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 func TestTypeChecking(t *testing.T) {
@@ -95,8 +96,7 @@ func TestTypeChecking(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			defer cancel()
+			tCtx := ktesting.Init(t).WithTimeout(time.Minute, "test timed out")
 			policy := tc.policy.DeepCopy()
 			policy.ObjectMeta.Generation = 1 // fake storage does not do this automatically
 			client := fake.NewSimpleClientset(policy)
@@ -106,6 +106,7 @@ func TestTypeChecking(t *testing.T) {
 				RestMapper:     testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme),
 			}
 			controller, err := NewController(
+				tCtx.Logger(),
 				informerFactory.Admissionregistration().V1().ValidatingAdmissionPolicies(),
 				client.AdmissionregistrationV1().ValidatingAdmissionPolicies(),
 				typeChecker,
@@ -113,10 +114,10 @@ func TestTypeChecking(t *testing.T) {
 			if err != nil {
 				t.Fatalf("cannot create controller: %v", err)
 			}
-			informerFactory.Start(ctx.Done())
-			informerFactory.WaitForCacheSync(ctx.Done())
-			go controller.Run(ctx, 1)
-			err = wait.PollUntilContextCancel(ctx, time.Second, false, func(ctx context.Context) (done bool, err error) {
+			informerFactory.StartWithContext(tCtx)
+			informerFactory.WaitForCacheSyncWithContext(tCtx)
+			go controller.Run(tCtx, 1)
+			err = wait.PollUntilContextCancel(tCtx, time.Second, false, func(ctx context.Context) (done bool, err error) {
 				name := policy.Name
 				// wait until the typeChecking is set, which means the type checking
 				// is complete.

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -132,7 +132,10 @@ func NewAttachDetachController(
 		nodesSynced: nodeInformer.Informer().HasSynced,
 		pvcQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "pvcs"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "pvcs",
+			},
 		),
 	}
 

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -335,7 +335,7 @@ type attachDetachController struct {
 }
 
 func (adc *attachDetachController) Run(ctx context.Context) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	adc.broadcaster.StartStructuredLogging(3)

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -100,7 +100,7 @@ func Test_AttachDetachControllerStateOfWorldPopulators_Positive(t *testing.T) {
 	adc := createADC(t, tCtx, fakeKubeClient, informerFactory, plugins)
 
 	// Act
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	informerFactory.WaitForCacheSync(tCtx.Done())
 
 	err := adc.populateActualStateOfWorld(logger)
@@ -209,7 +209,7 @@ func BenchmarkPopulateActualStateOfWorld(b *testing.B) {
 	adc := createADC(b, tCtx, fakeKubeClient, informerFactory, nil)
 
 	// Act
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	informerFactory.WaitForCacheSync(tCtx.Done())
 
 	b.ResetTimer()
@@ -229,7 +229,7 @@ func BenchmarkNodeUpdate(b *testing.B) {
 	logger := tCtx.Logger()
 	adc := createADC(b, tCtx, fakeKubeClient, informerFactory, nil)
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	informerFactory.WaitForCacheSync(tCtx.Done())
 
 	err := adc.populateActualStateOfWorld(logger.V(2))
@@ -351,7 +351,7 @@ func attachDetachRecoveryTestCase(t *testing.T, extraPods1 []*v1.Pod, extraPods2
 		_ = csiNodeInformer.GetIndexer().Add(&csiNode)
 	}
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 
 	if !kcache.WaitForNamedCacheSyncWithContext(tCtx,
 		informerFactory.Core().V1().Pods().Informer().HasSynced,
@@ -661,7 +661,7 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 	}
 
 	// Makesure the informer cache is synced
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 
 	if !kcache.WaitForNamedCacheSyncWithContext(tCtx,
 		informerFactory.Core().V1().Pods().Informer().HasSynced,

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -101,7 +101,7 @@ func Test_AttachDetachControllerStateOfWorldPopulators_Positive(t *testing.T) {
 
 	// Act
 	informerFactory.StartWithContext(tCtx)
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	err := adc.populateActualStateOfWorld(logger)
 	if err != nil {
@@ -210,7 +210,7 @@ func BenchmarkPopulateActualStateOfWorld(b *testing.B) {
 
 	// Act
 	informerFactory.StartWithContext(tCtx)
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -230,7 +230,7 @@ func BenchmarkNodeUpdate(b *testing.B) {
 	adc := createADC(b, tCtx, fakeKubeClient, informerFactory, nil)
 
 	informerFactory.StartWithContext(tCtx)
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	err := adc.populateActualStateOfWorld(logger.V(2))
 	if err != nil {

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -91,7 +91,10 @@ func NewController(
 		pvcsSynced: pvcInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "ephemeral_volume"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "ephemeral_volume",
+			},
 		),
 	}
 

--- a/pkg/controller/volume/ephemeral/controller.go
+++ b/pkg/controller/volume/ephemeral/controller.go
@@ -178,7 +178,7 @@ func (ec *ephemeralController) onPVCDelete(obj interface{}) {
 }
 
 func (ec *ephemeralController) Run(ctx context.Context, workers int) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting ephemeral volume controller")

--- a/pkg/controller/volume/ephemeral/controller_test.go
+++ b/pkg/controller/volume/ephemeral/controller_test.go
@@ -153,7 +153,7 @@ func TestSyncHandler(t *testing.T) {
 
 			// Ensure informers are up-to-date.
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			cache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced, pvcInformer.Informer().HasSynced)
 
 			err = ec.syncHandler(context.TODO(), tc.podKey)

--- a/pkg/controller/volume/ephemeral/controller_test.go
+++ b/pkg/controller/volume/ephemeral/controller_test.go
@@ -152,7 +152,7 @@ func TestSyncHandler(t *testing.T) {
 			defer ec.queue.ShutDown()
 
 			// Ensure informers are up-to-date.
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			cache.WaitForCacheSync(ctx.Done(), podInformer.Informer().HasSynced, pvcInformer.Informer().HasSynced)
 

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -329,7 +329,7 @@ func (expc *expandController) expand(logger klog.Logger, pvc *v1.PersistentVolum
 
 // TODO make concurrency configurable (workers argument). previously, nestedpendingoperations spawned unlimited goroutines
 func (expc *expandController) Run(ctx context.Context) {
-	defer runtime.HandleCrash()
+	defer runtime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting expand controller")

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -111,7 +111,10 @@ func NewExpandController(
 		pvcsSynced: pvcInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "volume_expand"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "volume_expand",
+			},
 		),
 		translator:               translator,
 		csiMigratedPluginManager: csiMigratedPluginManager,

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -328,7 +328,7 @@ func (ctrl *PersistentVolumeController) deleteClaim(ctx context.Context, claim *
 
 // Run starts all of this controller's control loops
 func (ctrl *PersistentVolumeController) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	// Start events processing pipeline.
 	ctrl.eventBroadcaster.StartStructuredLogging(3)

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -91,11 +91,17 @@ func NewController(ctx context.Context, p ControllerParameters) (*PersistentVolu
 		createProvisionedPVInterval:   createProvisionedPVInterval,
 		claimQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "claims"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "claims",
+			},
 		),
 		volumeQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "volumes"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "volumes",
+			},
 		),
 		resyncPeriod:        p.SyncPeriod,
 		operationTimestamps: metrics.NewOperationStartTimeCache(),

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -361,7 +361,7 @@ func TestControllerSync(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.TODO())
 		defer cancel()
 
-		informers.Start(ctx.Done())
+		informers.StartWithContext(ctx)
 		informers.WaitForCacheSync(ctx.Done())
 
 		wg.Go(func() {

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -362,7 +362,7 @@ func TestControllerSync(t *testing.T) {
 		defer cancel()
 
 		informers.StartWithContext(ctx)
-		informers.WaitForCacheSync(ctx.Done())
+		informers.WaitForCacheSyncWithContext(ctx)
 
 		wg.Go(func() {
 			ctrl.Run(ctx)

--- a/pkg/controller/volume/persistentvolume/testing/testing.go
+++ b/pkg/controller/volume/persistentvolume/testing/testing.go
@@ -271,11 +271,11 @@ func (r *VolumeReactor) React(ctx context.Context, action core.Action) (handled 
 
 // Watch watches objects from the VolumeReactor. Watch returns a channel which
 // will push added / modified / deleted object.
-func (r *VolumeReactor) Watch(gvr schema.GroupVersionResource, ns string) (watch.Interface, error) {
+func (r *VolumeReactor) Watch(logger klog.Logger, gvr schema.GroupVersionResource, ns string) (watch.Interface, error) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	fakewatcher := watch.NewRaceFreeFake()
+	fakewatcher := watch.NewRaceFreeFakeWithLogger(logger)
 
 	if _, exists := r.watchers[gvr]; !exists {
 		r.watchers[gvr] = make(map[string][]*watch.RaceFreeFakeWatcher)

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -127,7 +127,10 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 		client: cl,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "pvcprotection"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "pvcprotection",
+			},
 		),
 		pvcProcessingStore: NewPVCProcessingStore(),
 	}

--- a/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
+++ b/pkg/controller/volume/pvcprotection/pvc_protection_controller.go
@@ -175,7 +175,7 @@ func NewPVCProtectionController(logger klog.Logger, pvcInformer coreinformers.Pe
 
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PVC protection controller")

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -81,7 +81,7 @@ func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.Pers
 
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting PV protection controller")

--- a/pkg/controller/volume/pvprotection/pv_protection_controller.go
+++ b/pkg/controller/volume/pvprotection/pv_protection_controller.go
@@ -55,7 +55,10 @@ func NewPVProtectionController(logger klog.Logger, pvInformer coreinformers.Pers
 		client: cl,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "pvprotection"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "pvprotection",
+			},
 		),
 	}
 

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
@@ -356,7 +356,7 @@ func (c *Controller) enqueueAllPodsForCSIDriver(csiDriverName string) {
 }
 
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting SELinux warning controller")

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller.go
@@ -117,7 +117,8 @@ func NewController(
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig[cache.ObjectName](
 			workqueue.DefaultTypedControllerRateLimiter[cache.ObjectName](),
 			workqueue.TypedRateLimitingQueueConfig[cache.ObjectName]{
-				Name: "selinux_warning",
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "selinux_warning",
 			},
 		),
 		labelCache: volumecache.NewVolumeLabelCache(seLinuxTranslator),

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller_test.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller_test.go
@@ -535,7 +535,7 @@ func TestSELinuxWarningController_Sync(t *testing.T) {
 
 			// Start the informers
 			fakeInformerFactory.StartWithContext(ctx)
-			fakeInformerFactory.WaitForCacheSync(ctx.Done())
+			fakeInformerFactory.WaitForCacheSyncWithContext(ctx)
 			// Start the controller
 			wg.Go(func() {
 				c.Run(ctx, 1)

--- a/pkg/controller/volume/selinuxwarning/selinux_warning_controller_test.go
+++ b/pkg/controller/volume/selinuxwarning/selinux_warning_controller_test.go
@@ -534,7 +534,7 @@ func TestSELinuxWarningController_Sync(t *testing.T) {
 			c.eventRecorder = fakeRecorder
 
 			// Start the informers
-			fakeInformerFactory.Start(ctx.Done())
+			fakeInformerFactory.StartWithContext(ctx)
 			fakeInformerFactory.WaitForCacheSync(ctx.Done())
 			// Start the controller
 			wg.Go(func() {

--- a/pkg/controller/volume/vacprotection/vac_protection_controller.go
+++ b/pkg/controller/volume/vacprotection/vac_protection_controller.go
@@ -108,7 +108,8 @@ func NewVACProtectionController(logger klog.Logger,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{
-				Name: "vacprotection",
+				Logger: &logger,
+				Name:   "vacprotection",
 			},
 		),
 	}

--- a/pkg/controller/volume/vacprotection/vac_protection_controller.go
+++ b/pkg/controller/volume/vacprotection/vac_protection_controller.go
@@ -210,7 +210,7 @@ func NewVACProtectionController(logger klog.Logger,
 
 // Run runs the controller goroutines.
 func (c *Controller) Run(ctx context.Context, workers int) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting VAC protection controller")

--- a/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	utiltesting "k8s.io/client-go/util/testing"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/test/utils/ktesting"
 
 	"github.com/google/go-cmp/cmp"
@@ -350,7 +351,7 @@ users:
 
 func TestRequestNodeCertificateNoKeyData(t *testing.T) {
 	tCtx := ktesting.Init(t)
-	certData, err := requestNodeCertificate(tCtx, newClientset(fakeClient{}), []byte{}, "fake-node-name")
+	certData, err := requestNodeCertificate(tCtx, newClientset(tCtx.Logger(), fakeClient{}), []byte{}, "fake-node-name")
 	if err == nil {
 		t.Errorf("Got no error, wanted error an error because there was an empty private key passed in.")
 	}
@@ -361,7 +362,7 @@ func TestRequestNodeCertificateNoKeyData(t *testing.T) {
 
 func TestRequestNodeCertificateErrorCreatingCSR(t *testing.T) {
 	tCtx := ktesting.Init(t)
-	client := newClientset(fakeClient{
+	client := newClientset(tCtx.Logger(), fakeClient{
 		failureType: createError,
 	})
 	privateKeyData, err := keyutil.MakeEllipticPrivateKeyPEM()
@@ -385,7 +386,7 @@ func TestRequestNodeCertificate(t *testing.T) {
 		t.Fatalf("Unable to generate a new private key: %v", err)
 	}
 
-	certData, err := requestNodeCertificate(tCtx, newClientset(fakeClient{}), privateKeyData, "fake-node-name")
+	certData, err := requestNodeCertificate(tCtx, newClientset(tCtx.Logger(), fakeClient{}), privateKeyData, "fake-node-name")
 	if err != nil {
 		t.Errorf("Got %v, wanted no error.", err)
 	}
@@ -407,7 +408,7 @@ type fakeClient struct {
 	failureType failureType
 }
 
-func newClientset(opts fakeClient) *fake.Clientset {
+func newClientset(logger klog.Logger, opts fakeClient) *fake.Clientset {
 	f := fake.NewSimpleClientset()
 	switch opts.failureType {
 	case createError:
@@ -439,7 +440,7 @@ func newClientset(opts fakeClient) *fake.Clientset {
 		f.PrependWatchReactor("certificatesigningrequests", func(action clienttesting.Action) (handled bool, ret watch.Interface, err error) {
 			switch action.GetResource().Version {
 			case "v1":
-				w := watch.NewFakeWithChanSize(1, false)
+				w := watch.NewFakeWithOptions(watch.FakeOptions{ChannelSize: 1, Logger: &logger})
 				w.Add(opts.generateCSR())
 				w.Stop()
 				return true, w, nil

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
@@ -452,7 +452,7 @@ func (m *LazyInformerManager) ensureManagerSet(ctx context.Context) error {
 	}
 
 	m.manager = clusterTrustBundleManager
-	kubeInformers.Start(m.contextWithLogger.Done())
+	kubeInformers.StartWithContext(m.contextWithLogger)
 	m.logger.Info("Started ClusterTrustBundle informer", "apiGroup", foundGV)
 
 	// a cache fetch will likely follow right after, wait for the freshly started

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
@@ -461,7 +461,7 @@ func (m *LazyInformerManager) ensureManagerSet(ctx context.Context) error {
 	timeoutContext, cancel := context.WithTimeout(m.contextWithLogger, 10*time.Second)
 	defer cancel()
 	m.logger.Info("Waiting for ClusterTrustBundle informer to sync")
-	for _, ok := range kubeInformers.WaitForCacheSync(timeoutContext.Done()) {
+	for _, ok := range kubeInformers.WaitForCacheSyncWithContext(timeoutContext).Synced {
 		synced = synced && ok
 	}
 	if synced {

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager.go
@@ -165,7 +165,7 @@ func newInformerManager[T clusterTrustBundle](ctx context.Context, handlers clus
 	logger := klog.FromContext(ctx)
 	// Have the informer bust cache entries when it sees updates that could
 	// apply to them.
-	_, err := m.ctbInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err := m.ctbInformer.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
 			ctb, ok := obj.(*T)
 			if !ok {
@@ -197,7 +197,7 @@ func newInformerManager[T clusterTrustBundle](ctx context.Context, handlers clus
 			logger.Info("Dropping cache for ClusterTrustBundle", "signerName", m.ctbHandlers.GetSignerName(ctb))
 			m.dropCacheFor(ctb)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, fmt.Errorf("while registering event handler on informer: %w", err)
 	}

--- a/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
+++ b/pkg/kubelet/clustertrustbundle/clustertrustbundle_manager_test.go
@@ -145,7 +145,7 @@ func testGetTrustAnchorsByName[T clusterTrustBundle](tCtx ktesting.TContext, b t
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	ctbInformer := b.informerGetter(informerFactory)
 	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")
@@ -203,7 +203,7 @@ func testGetTrustAnchorsByNameCaching[T clusterTrustBundle](tCtx ktesting.TConte
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	ctbInformer := b.informerGetter(informerFactory)
 	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")
@@ -288,7 +288,7 @@ func testGetTrustAnchorsBySignerName[T clusterTrustBundle](tCtx ktesting.TContex
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	ctbInformer := b.informerGetter(informerFactory)
 	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")
@@ -416,7 +416,7 @@ func testGetTrustAnchorsBySignerNameCaching[T clusterTrustBundle](tCtx ktesting.
 
 	ctbManager, _ := b.informerManagerConstructor(tCtx, informerFactory, 256, 5*time.Minute)
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	ctbInformer := b.informerGetter(informerFactory)
 	if !cache.WaitForCacheSync(tCtx.Done(), ctbInformer.HasSynced) {
 		t.Fatalf("Timed out waiting for informer to sync")

--- a/pkg/kubelet/config/apiserver.go
+++ b/pkg/kubelet/config/apiserver.go
@@ -17,13 +17,13 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
@@ -49,12 +49,12 @@ func NewSourceApiserver(logger klog.Logger, c clientset.Interface, nodeName type
 			logger.V(4).Info("node sync has not completed yet")
 		}
 		logger.Info("Watching apiserver")
-		newSourceApiserverFromLW(lw, updates)
+		newSourceApiserverFromLW(logger, lw, updates)
 	}()
 }
 
 // newSourceApiserverFromLW holds creates a config source that watches and pulls from the apiserver.
-func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- sourceUpdate) {
+func newSourceApiserverFromLW(logger klog.Logger, lw cache.ListerWatcher, updates chan<- sourceUpdate) {
 	send := func(objs []interface{}) {
 		var pods []*v1.Pod
 		for _, o := range objs {
@@ -62,6 +62,8 @@ func newSourceApiserverFromLW(lw cache.ListerWatcher, updates chan<- sourceUpdat
 		}
 		updates <- sourceUpdate{Pods: pods}
 	}
-	r := cache.NewReflector(lw, &v1.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc), 0)
-	go r.Run(wait.NeverStop)
+	r := cache.NewReflectorWithOptions(lw, &v1.Pod{}, cache.NewUndeltaStore(send, cache.MetaNamespaceKeyFunc), cache.ReflectorOptions{
+		Logger: &logger,
+	})
+	go r.RunWithContext(klog.NewContext(context.Background(), logger))
 }

--- a/pkg/kubelet/config/apiserver_test.go
+++ b/pkg/kubelet/config/apiserver_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 type fakePodLW struct {
@@ -52,6 +53,7 @@ func (lw fakePodLW) IsWatchListSemanticsUnSupported() bool { return true }
 var _ cache.ListerWatcher = fakePodLW{}
 
 func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	pod1v1 := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "p"},
 		Spec:       v1.PodSpec{Containers: []v1.Container{{Image: "image/one"}}}}
@@ -71,7 +73,7 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 
 	ch := make(chan sourceUpdate)
 
-	newSourceApiserverFromLW(lw, ch)
+	newSourceApiserverFromLW(tCtx.Logger(), lw, ch)
 
 	update, ok := <-ch
 	if !ok {
@@ -133,6 +135,7 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 }
 
 func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	pod1 := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "one"},
 		Spec:       v1.PodSpec{Containers: []v1.Container{{Image: "image/one"}}}}
@@ -149,7 +152,7 @@ func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 
 	ch := make(chan sourceUpdate)
 
-	newSourceApiserverFromLW(lw, ch)
+	newSourceApiserverFromLW(tCtx.Logger(), lw, ch)
 
 	update, ok := <-ch
 	if !ok {
@@ -172,6 +175,7 @@ func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 }
 
 func TestNewSourceApiserverInitialEmptySendsEmptyPodUpdate(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	// Setup fake api client.
 	fakeWatch := watch.NewFake()
 	lw := fakePodLW{
@@ -181,7 +185,7 @@ func TestNewSourceApiserverInitialEmptySendsEmptyPodUpdate(t *testing.T) {
 
 	ch := make(chan sourceUpdate)
 
-	newSourceApiserverFromLW(lw, ch)
+	newSourceApiserverFromLW(tCtx.Logger(), lw, ch)
 
 	update, ok := <-ch
 	if !ok {

--- a/pkg/kubelet/config/apiserver_test.go
+++ b/pkg/kubelet/config/apiserver_test.go
@@ -54,6 +54,7 @@ var _ cache.ListerWatcher = fakePodLW{}
 
 func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 	pod1v1 := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "p"},
 		Spec:       v1.PodSpec{Containers: []v1.Container{{Image: "image/one"}}}}
@@ -65,7 +66,7 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 		Spec:       v1.PodSpec{Containers: []v1.Container{{Image: "image/blah"}}}}
 
 	// Setup fake api client.
-	fakeWatch := watch.NewFake()
+	fakeWatch := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	lw := fakePodLW{
 		listResp:  &v1.PodList{Items: []v1.Pod{*pod1v1}},
 		watchResp: fakeWatch,
@@ -136,6 +137,7 @@ func TestNewSourceApiserver_UpdatesAndMultiplePods(t *testing.T) {
 
 func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 	pod1 := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "one"},
 		Spec:       v1.PodSpec{Containers: []v1.Container{{Image: "image/one"}}}}
@@ -144,7 +146,7 @@ func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 		Spec:       v1.PodSpec{Containers: []v1.Container{{Image: "image/blah"}}}}
 
 	// Setup fake api client.
-	fakeWatch := watch.NewFake()
+	fakeWatch := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	lw := fakePodLW{
 		listResp:  &v1.PodList{Items: []v1.Pod{pod1, pod2}},
 		watchResp: fakeWatch,
@@ -176,8 +178,9 @@ func TestNewSourceApiserver_TwoNamespacesSameName(t *testing.T) {
 
 func TestNewSourceApiserverInitialEmptySendsEmptyPodUpdate(t *testing.T) {
 	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 	// Setup fake api client.
-	fakeWatch := watch.NewFake()
+	fakeWatch := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	lw := fakePodLW{
 		listResp:  &v1.PodList{Items: []v1.Pod{}},
 		watchResp: fakeWatch,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -511,7 +511,7 @@ func NewMainKubelet(ctx context.Context,
 		nodeInformer = kubeInformers.Core().V1().Nodes()
 		nodeLister = nodeInformer.Lister()
 		nodeHasSynced = newNodeHasSyncedFunc(nodeLister, nodeName)
-		kubeInformers.Start(wait.NeverStop)
+		kubeInformers.StartWithContext(ctx)
 		logger.Info("Attempting to sync node with API server")
 	} else {
 		// we don't have a client to sync!
@@ -574,7 +574,7 @@ func NewMainKubelet(ctx context.Context,
 		}))
 		serviceLister = kubeInformers.Core().V1().Services().Lister()
 		serviceHasSynced = kubeInformers.Core().V1().Services().Informer().HasSynced
-		kubeInformers.Start(wait.NeverStop)
+		kubeInformers.StartWithContext(ctx)
 	} else {
 		serviceIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		serviceLister = corelisters.NewServiceLister(serviceIndexer)
@@ -1035,7 +1035,7 @@ func NewMainKubelet(ctx context.Context,
 			clock.RealClock{},
 		)
 		klet.podCertificateManager = podCertificateManager
-		kubeInformers.Start(ctx.Done())
+		kubeInformers.StartWithContext(ctx)
 		go podCertificateManager.Run(ctx)
 
 		metrics.RegisterCollectors(collectors.PodCertificateCollectorFor(podCertificateManager))
@@ -1988,7 +1988,7 @@ func (kl *Kubelet) Run(ctx context.Context, updates <-chan kubetypes.PodUpdate) 
 
 	// Start syncing RuntimeClasses if enabled.
 	if kl.runtimeClassManager != nil {
-		kl.runtimeClassManager.Start(wait.NeverStop)
+		kl.runtimeClassManager.StartWithContext(ctx)
 	}
 
 	// Start the pod lifecycle event generator.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -751,6 +751,7 @@ func NewMainKubelet(ctx context.Context,
 
 	// setup containerLogManager for CRI container runtime
 	containerLogManager, err := logs.NewContainerLogManager(
+		logger.WithName("ContainerLogManager"),
 		klet.runtimeService,
 		kubeDeps.OSInterface,
 		kubeCfg.ContainerLogMaxSize,

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -55,7 +55,7 @@ func TestRemoveContainer(t *testing.T) {
 	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 	// Swap in real ContainerLogManager for the stub.
-	logManager, err := logs.NewContainerLogManager(m.runtimeService, m.osInterface, "1", 2, 10, metav1.Duration{Duration: 10 * time.Second})
+	logManager, err := logs.NewContainerLogManager(tCtx.Logger(), m.runtimeService, m.osInterface, "1", 2, 10, metav1.Duration{Duration: 10 * time.Second})
 	require.NoError(t, err)
 	m.logManager = logManager
 
@@ -115,7 +115,7 @@ func TestRemoveContainer_keepLogs(t *testing.T) {
 	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)
 	// Swap in real ContainerLogManager for the stub.
-	logManager, err := logs.NewContainerLogManager(m.runtimeService, m.osInterface, "1", 2, 10, metav1.Duration{Duration: 10 * time.Second})
+	logManager, err := logs.NewContainerLogManager(tCtx.Logger(), m.runtimeService, m.osInterface, "1", 2, 10, metav1.Duration{Duration: 10 * time.Second})
 	require.NoError(t, err)
 	m.logManager = logManager
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -143,7 +143,7 @@ func TestGeneratePodSandboxLinuxConfigSeccomp(t *testing.T) {
 func TestCreatePodSandbox_RuntimeClass(t *testing.T) {
 	tCtx := ktesting.Init(t)
 	rcm := runtimeclass.NewManager(rctest.NewPopulatedClient())
-	defer rctest.StartManagerSync(rcm)()
+	defer rctest.StartManagerSync(tCtx, rcm)()
 
 	fakeRuntime, _, m, err := createTestRuntimeManager(tCtx)
 	require.NoError(t, err)

--- a/pkg/kubelet/logs/container_log_manager.go
+++ b/pkg/kubelet/logs/container_log_manager.go
@@ -109,7 +109,7 @@ type containerLogManager struct {
 }
 
 // NewContainerLogManager creates a new container log manager.
-func NewContainerLogManager(runtimeService internalapi.RuntimeService, osInterface kubecontainer.OSInterface, maxSize string, maxFiles int, maxWorkers int, monitorInterval metav1.Duration) (ContainerLogManager, error) {
+func NewContainerLogManager(logger klog.Logger, runtimeService internalapi.RuntimeService, osInterface kubecontainer.OSInterface, maxSize string, maxFiles int, maxWorkers int, monitorInterval metav1.Duration) (ContainerLogManager, error) {
 	if maxFiles <= 1 {
 		return nil, fmt.Errorf("invalid MaxFiles %d, must be > 1", maxFiles)
 	}
@@ -134,7 +134,10 @@ func NewContainerLogManager(runtimeService internalapi.RuntimeService, osInterfa
 		maxWorkers: maxWorkers,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "kubelet_log_rotate_manager"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "kubelet_log_rotate_manager",
+			},
 		),
 		monitoringPeriod: monitorInterval,
 	}, nil

--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -973,7 +973,7 @@ func (p *podWorkers) UpdatePod(ctx context.Context, options UpdatePodOptions) {
 		go func() {
 			// TODO: this should be a wait.Until with backoff to handle panics, and
 			// accept a context for shutdown
-			defer runtime.HandleCrash()
+			defer runtime.HandleCrashWithContext(ctx)
 			defer logger.V(3).Info("Pod worker has stopped", "podUID", uid)
 			p.podWorkerLoop(ctx, uid, outCh)
 		}()

--- a/pkg/kubelet/podcertificate/podcertificatemanager.go
+++ b/pkg/kubelet/podcertificate/podcertificatemanager.go
@@ -267,12 +267,19 @@ func (c *credStateWaitRefresh) metricsState(now time.Time) string {
 var _ Manager = (*IssuingManager)(nil)
 
 func NewIssuingManager(kc kubernetes.Interface, podManager PodManager, recorder record.EventRecorder, pcrInformer certinformersv1.PodCertificateRequestInformer, nodeInformer coreinformersv1.NodeInformer, nodeName types.NodeName, clock clock.WithTicker) *IssuingManager {
+	logger := klog.Background()
 	m := &IssuingManager{
 		kc: kc,
 
-		podManager:      podManager,
-		recorder:        recorder,
-		projectionQueue: workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[projectionKey]()),
+		podManager: podManager,
+		recorder:   recorder,
+		projectionQueue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[projectionKey](),
+			workqueue.TypedRateLimitingQueueConfig[projectionKey]{
+				Logger: &logger,
+				Name:   "podcertificate_projection",
+			},
+		),
 
 		pcrInformer:  pcrInformer.Informer(),
 		pcrLister:    pcrInformer.Lister(),
@@ -289,7 +296,7 @@ func NewIssuingManager(kc kubernetes.Interface, podManager PodManager, recorder 
 	// This is not needed for correctness, since volumeSourceQueue backoffs will
 	// eventually trigger the volume to be inspected.  However, it's a better UX
 	// for us to notice immediately once the certificate is issued.
-	m.pcrInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = m.pcrInformer.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
 			pcr := obj.(*certificatesv1.PodCertificateRequest)
 			m.queueAllProjectionsForPod(pcr.Spec.PodUID)
@@ -302,6 +309,8 @@ func NewIssuingManager(kc kubernetes.Interface, podManager PodManager, recorder 
 			pcr := obj.(*certificatesv1.PodCertificateRequest)
 			m.queueAllProjectionsForPod(pcr.Spec.PodUID)
 		},
+	}, cache.HandlerOptions{
+		Logger: &logger,
 	})
 
 	return m

--- a/pkg/kubelet/podcertificate/podcertificatemanager_test.go
+++ b/pkg/kubelet/podcertificate/podcertificatemanager_test.go
@@ -395,7 +395,7 @@ func TestFullFlow(t *testing.T) {
 		clock,
 	)
 	// Start informers
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 
 	// wait until the informers' watches are actually registered,
 	const expectedWatches = 4 // Manager: Pods, Nodes, PodCertificateRequests. Signer: PodCertificateRequests.

--- a/pkg/kubelet/runtimeclass/runtimeclass_manager.go
+++ b/pkg/kubelet/runtimeclass/runtimeclass_manager.go
@@ -60,8 +60,16 @@ func (m *Manager) StartWithContext(ctx context.Context) {
 
 // WaitForCacheSync exposes the WaitForCacheSync method on the informer factory for testing
 // purposes.
+//
+//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging.
 func (m *Manager) WaitForCacheSync(stopCh <-chan struct{}) {
-	m.informerFactory.WaitForCacheSync(stopCh)
+	m.WaitForCacheSyncWithContext(wait.ContextForChannel(stopCh))
+}
+
+// WaitForCacheSyncWithContext exposes the WaitForCacheSyncWithContext method on the informer
+// factory for testing purposes.
+func (m *Manager) WaitForCacheSyncWithContext(ctx context.Context) {
+	m.informerFactory.WaitForCacheSyncWithContext(ctx)
 }
 
 // LookupRuntimeHandler returns the RuntimeHandler string associated with the given RuntimeClass

--- a/pkg/kubelet/runtimeclass/runtimeclass_manager.go
+++ b/pkg/kubelet/runtimeclass/runtimeclass_manager.go
@@ -17,9 +17,11 @@ limitations under the License.
 package runtimeclass
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	nodev1 "k8s.io/client-go/listers/node/v1"
@@ -45,8 +47,15 @@ func NewManager(client clientset.Interface) *Manager {
 }
 
 // Start starts syncing the RuntimeClass cache with the apiserver.
+//
+//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 func (m *Manager) Start(stopCh <-chan struct{}) {
-	m.informerFactory.Start(stopCh)
+	m.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+// StartWithContext starts syncing the RuntimeClass cache with the apiserver.
+func (m *Manager) StartWithContext(ctx context.Context) {
+	m.informerFactory.StartWithContext(ctx)
 }
 
 // WaitForCacheSync exposes the WaitForCacheSync method on the informer factory for testing

--- a/pkg/kubelet/runtimeclass/runtimeclass_manager_test.go
+++ b/pkg/kubelet/runtimeclass/runtimeclass_manager_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/kubelet/runtimeclass"
 	rctest "k8s.io/kubernetes/pkg/kubelet/runtimeclass/testing"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -39,8 +40,9 @@ func TestLookupRuntimeHandler(t *testing.T) {
 		{rcn: ptr.To("phantom"), expectError: true},
 	}
 
+	tCtx := ktesting.Init(t)
 	manager := runtimeclass.NewManager(rctest.NewPopulatedClient())
-	defer rctest.StartManagerSync(manager)()
+	defer rctest.StartManagerSync(tCtx, manager)()
 
 	for _, test := range tests {
 		tname := "nil"

--- a/pkg/kubelet/runtimeclass/testing/fake_manager.go
+++ b/pkg/kubelet/runtimeclass/testing/fake_manager.go
@@ -22,6 +22,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/kubelet/runtimeclass"
+	"k8s.io/kubernetes/test/utils/ktesting"
 )
 
 const (
@@ -46,13 +47,13 @@ func NewPopulatedClient() clientset.Interface {
 // StartManagerSync starts the manager, and waits for the informer cache to sync.
 // Returns a function to stop the manager, which should be called with a defer:
 //
-//	defer StartManagerSync(t, m)()
-func StartManagerSync(m *runtimeclass.Manager) func() {
-	stopCh := make(chan struct{})
-	m.Start(stopCh)
-	m.WaitForCacheSync(stopCh)
+//	defer StartManagerSync(tCtx, m)()
+func StartManagerSync(tCtx ktesting.TContext, m *runtimeclass.Manager) func() {
+	tCtx = tCtx.WithCancel()
+	m.StartWithContext(tCtx)
+	m.WaitForCacheSync(tCtx.Done())
 	return func() {
-		close(stopCh)
+		tCtx.Cancel("stopping manager")
 	}
 }
 

--- a/pkg/kubelet/runtimeclass/testing/fake_manager.go
+++ b/pkg/kubelet/runtimeclass/testing/fake_manager.go
@@ -51,7 +51,7 @@ func NewPopulatedClient() clientset.Interface {
 func StartManagerSync(tCtx ktesting.TContext, m *runtimeclass.Manager) func() {
 	tCtx = tCtx.WithCancel()
 	m.StartWithContext(tCtx)
-	m.WaitForCacheSync(tCtx.Done())
+	m.WaitForCacheSyncWithContext(tCtx)
 	return func() {
 		tCtx.Cancel("stopping manager")
 	}

--- a/pkg/kubelet/util/manager/watch_based_manager.go
+++ b/pkg/kubelet/util/manager/watch_based_manager.go
@@ -124,7 +124,7 @@ func (i *objectCacheItem) startReflector() {
 	i.waitGroup.Wait()
 	i.waitGroup.Add(1)
 	defer i.waitGroup.Done()
-	i.reflector.Run(i.stopCh)
+	i.reflector.RunWithContext(wait.ContextForChannel(i.stopCh)) // TODO: use a real context with logger
 }
 
 // cacheStore is in order to rewrite Replace function to mark initialized flag
@@ -219,7 +219,7 @@ func (c *objectCache) newStore() *cacheStore {
 	return &cacheStore{store, sync.Mutex{}, false}
 }
 
-func (c *objectCache) newReflectorLocked(namespace, name string) *objectCacheItem {
+func (c *objectCache) newReflectorLocked(logger klog.Logger, namespace, name string) *objectCacheItem {
 	fieldSelector := fields.Set{"metadata.name": name}.AsSelector().String()
 	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
 		options.FieldSelector = fieldSelector
@@ -235,7 +235,8 @@ func (c *objectCache) newReflectorLocked(namespace, name string) *objectCacheIte
 		c.newObject(),
 		store,
 		cache.ReflectorOptions{
-			Name: fmt.Sprintf("object-%q/%q", namespace, name),
+			Logger: &logger,
+			Name:   fmt.Sprintf("object-%q/%q", namespace, name),
 			// Bump default 5m MinWatchTimeout to avoid recreating
 			// watches too often.
 			MinWatchTimeout: 30 * time.Minute,
@@ -268,7 +269,9 @@ func (c *objectCache) AddReference(namespace, name string, referencedFrom types.
 	defer c.lock.Unlock()
 	item, exists := c.items[key]
 	if !exists {
-		item = c.newReflectorLocked(namespace, name)
+		// TODO needs to be resolved together with replacing Run(i.stopCh)
+		// with RunWithContext - more conceptual work needed...
+		item = c.newReflectorLocked(klog.TODO(), namespace, name)
 		c.items[key] = item
 	}
 	item.refMap[referencedFrom]++

--- a/pkg/kubelet/util/manager/watch_based_manager_test.go
+++ b/pkg/kubelet/util/manager/watch_based_manager_test.go
@@ -87,6 +87,7 @@ func newSecretCache(ctx context.Context, fakeClient clientset.Interface, fakeClo
 
 func TestSecretCache(t *testing.T) {
 	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 	fakeClient := &fake.Clientset{}
 
 	listReactor := func(a core.Action) (bool, runtime.Object, error) {
@@ -98,7 +99,7 @@ func TestSecretCache(t *testing.T) {
 		return true, result, nil
 	}
 	fakeClient.AddReactor("list", "secrets", listReactor)
-	fakeWatch := watch.NewFake()
+	fakeWatch := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 
 	fakeClock := testingclock.NewFakeClock(time.Now())
@@ -161,6 +162,7 @@ func TestSecretCache(t *testing.T) {
 
 func TestSecretCacheMultipleRegistrations(t *testing.T) {
 	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 	fakeClient := &fake.Clientset{}
 
 	listReactor := func(a core.Action) (bool, runtime.Object, error) {
@@ -172,7 +174,7 @@ func TestSecretCacheMultipleRegistrations(t *testing.T) {
 		return true, result, nil
 	}
 	fakeClient.AddReactor("list", "secrets", listReactor)
-	fakeWatch := watch.NewFake()
+	fakeWatch := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 
 	fakeClock := testingclock.NewFakeClock(time.Now())
@@ -266,6 +268,7 @@ func TestImmutableSecretStopsTheReflector(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
+			logger := tCtx.Logger()
 			fakeClient := &fake.Clientset{}
 			listReactor := func(a core.Action) (bool, runtime.Object, error) {
 				result := &v1.SecretList{
@@ -279,7 +282,7 @@ func TestImmutableSecretStopsTheReflector(t *testing.T) {
 				return true, result, nil
 			}
 			fakeClient.AddReactor("list", "secrets", listReactor)
-			fakeWatch := watch.NewFake()
+			fakeWatch := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 
 			fakeClock := testingclock.NewFakeClock(time.Now())
@@ -349,6 +352,7 @@ func TestImmutableSecretStopsTheReflector(t *testing.T) {
 
 func TestMaxIdleTimeStopsTheReflector(t *testing.T) {
 	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "name",
@@ -370,7 +374,7 @@ func TestMaxIdleTimeStopsTheReflector(t *testing.T) {
 	}
 
 	fakeClient.AddReactor("list", "secrets", listReactor)
-	fakeWatch := watch.NewFake()
+	fakeWatch := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	store := newSecretCache(tCtx, fakeClient, fakeClock, time.Minute)
@@ -429,6 +433,7 @@ func TestMaxIdleTimeStopsTheReflector(t *testing.T) {
 
 func TestReflectorNotStoppedOnSlowInitialization(t *testing.T) {
 	tCtx := ktesting.Init(t)
+	logger := tCtx.Logger()
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "name",
@@ -454,7 +459,7 @@ func TestReflectorNotStoppedOnSlowInitialization(t *testing.T) {
 	}
 
 	fakeClient.AddReactor("list", "secrets", listReactor)
-	fakeWatch := watch.NewFake()
+	fakeWatch := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 	store := newSecretCache(tCtx, fakeClient, fakeClock, time.Minute)
 
@@ -601,6 +606,7 @@ func TestRefMapHandlesReferencesCorrectly(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			tCtx := ktesting.Init(t)
+			logger := tCtx.Logger()
 			fakeClient := &fake.Clientset{}
 			listReactor := func(a core.Action) (bool, runtime.Object, error) {
 				result := &v1.SecretList{
@@ -612,7 +618,7 @@ func TestRefMapHandlesReferencesCorrectly(t *testing.T) {
 				return true, result, nil
 			}
 			fakeClient.AddReactor("list", "secrets", listReactor)
-			fakeWatch := watch.NewFake()
+			fakeWatch := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			fakeClient.AddWatchReactor("secrets", core.DefaultWatchReactor(fakeWatch, nil))
 			fakeClock := testingclock.NewFakeClock(time.Now())
 			store := newSecretCache(tCtx, fakeClient, fakeClock, time.Minute)

--- a/pkg/kubelet/util/manager/watch_based_manager_test.go
+++ b/pkg/kubelet/util/manager/watch_based_manager_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/rest"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/clock"
@@ -652,7 +653,7 @@ func TestUnSupportWatchListSemantics(t *testing.T) {
 	defer cancel()
 	target := newSecretCache(context.TODO(), fakeClient, fakeClock, time.Minute)
 
-	ret := target.newReflectorLocked("ns", "obj")
+	ret := target.newReflectorLocked(klog.TODO(), "ns", "obj")
 	defer ret.stop()
 
 	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 3*time.Second, true, func(ctx context.Context) (bool, error) {
@@ -663,6 +664,7 @@ func TestUnSupportWatchListSemantics(t *testing.T) {
 }
 
 func TestWatchListSemanticsSimple(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, true)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -715,11 +717,11 @@ func TestWatchListSemanticsSimple(t *testing.T) {
 	}
 
 	fakeClock := testingclock.NewFakeClock(time.Now())
-	ctx, cancel := context.WithTimeout(context.TODO(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(tCtx, 5*time.Second)
 	defer cancel()
-	target := newSecretCache(context.TODO(), client, fakeClock, time.Second)
+	target := newSecretCache(tCtx, client, fakeClock, time.Second)
 
-	ret := target.newReflectorLocked("ns", "obj")
+	ret := target.newReflectorLocked(tCtx.Logger(), "ns", "obj")
 	defer ret.stop()
 
 	if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 3*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/pkg/quota/v1/evaluator/core/registry.go
+++ b/pkg/quota/v1/evaluator/core/registry.go
@@ -17,7 +17,6 @@ limitations under the License.
 package core
 
 import (
-	"context"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +27,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/features"
@@ -65,9 +65,9 @@ func NewEvaluators(f quota.ListerForResourceFunc, i informers.SharedInformerFact
 		var deviceClassMapping *extendedresourcecache.ExtendedResourceCache
 		if utilfeature.DefaultFeatureGate.Enabled(features.DRAExtendedResource) {
 			podLister = i.Core().V1().Pods().Lister()
-			logger := klog.FromContext(context.Background())
+			logger := klog.Background()
 			deviceClassMapping = extendedresourcecache.NewExtendedResourceCache(logger)
-			if _, err := i.Resource().V1().DeviceClasses().Informer().AddEventHandler(deviceClassMapping); err != nil {
+			if _, err := i.Resource().V1().DeviceClasses().Informer().AddEventHandlerWithOptions(deviceClassMapping, cache.HandlerOptions{Logger: &logger}); err != nil {
 				return nil, fmt.Errorf("failed to add device class informer event handler: %w", err)
 			}
 			var err error

--- a/pkg/quota/v1/evaluator/core/resource_claims_test.go
+++ b/pkg/quota/v1/evaluator/core/resource_claims_test.go
@@ -396,7 +396,7 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 		// Now we can wait for all goroutines to stop.
 		informerFactory.Shutdown()
 	})
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	// wait for informer sync
 	time.Sleep(1 * time.Second)
@@ -657,7 +657,7 @@ func TestResourceClaimEvaluatorMatchingResources(t *testing.T) {
 		// Now we can wait for all goroutines to stop.
 		informerFactory.Shutdown()
 	})
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	// wait for informer sync
 	time.Sleep(1 * time.Second)

--- a/pkg/quota/v1/evaluator/core/resource_claims_test.go
+++ b/pkg/quota/v1/evaluator/core/resource_claims_test.go
@@ -34,6 +34,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache"
 	"k8s.io/klog/v2/ktesting"
@@ -379,7 +380,7 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 	client := fake.NewClientset(deviceClass1, podImplicit, podExplicit, podHybrid, podNilStatus, podInit)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	deviceclassmapping := extendedresourcecache.NewExtendedResourceCache(logger)
-	if _, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(deviceclassmapping); err != nil {
+	if _, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandlerWithOptions(deviceclassmapping, cache.HandlerOptions{Logger: &logger}); err != nil {
 		t.Fatal(err)
 	}
 	var otherOwnedClaims []*resourceapi.ResourceClaim
@@ -644,7 +645,7 @@ func TestResourceClaimEvaluatorMatchingResources(t *testing.T) {
 	client := fake.NewClientset(deviceClass1)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	deviceclassmapping := extendedresourcecache.NewExtendedResourceCache(logger)
-	if _, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(deviceclassmapping); err != nil {
+	if _, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandlerWithOptions(deviceclassmapping, cache.HandlerOptions{Logger: &logger}); err != nil {
 		logger.Error(err, "failed to add device class informer event handler")
 	}
 	evaluator := NewResourceClaimEvaluator(nil, deviceclassmapping, informerFactory.Core().V1().Pods().Lister(), nil)

--- a/pkg/quota/v1/evaluator/core/resource_claims_test.go
+++ b/pkg/quota/v1/evaluator/core/resource_claims_test.go
@@ -389,7 +389,7 @@ func TestResourceClaimEvaluatorUsage(t *testing.T) {
 	}
 	evaluatorWithDeviceMapping := NewResourceClaimEvaluator(nil, deviceclassmapping, informerFactory.Core().V1().Pods().Lister(), claimGetter)
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	t.Cleanup(func() {
 		// Need to cancel before waiting for the shutdown.
 		tCancel()
@@ -650,7 +650,7 @@ func TestResourceClaimEvaluatorMatchingResources(t *testing.T) {
 	}
 	evaluator := NewResourceClaimEvaluator(nil, deviceclassmapping, informerFactory.Core().V1().Pods().Lister(), nil)
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	t.Cleanup(func() {
 		// Need to cancel before waiting for the shutdown.
 		tCancel()

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -2924,7 +2924,7 @@ func TestPriorityQueue_NominatedPodDeleted(t *testing.T) {
 			q := NewPriorityQueue(newDefaultQueueSort(), informerFactory, WithPodLister(podLister))
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			if tt.deletePod {
@@ -3004,7 +3004,7 @@ func TestPriorityQueue_NominatedNodeNameEmptyNodeKey(t *testing.T) {
 			q := NewPriorityQueue(newDefaultQueueSort(), informerFactory, WithPodLister(informerFactory.Core().V1().Pods().Lister()))
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			if tt.initialNominatedNode != "" {

--- a/pkg/scheduler/backend/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue_test.go
@@ -2925,7 +2925,7 @@ func TestPriorityQueue_NominatedPodDeleted(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			if tt.deletePod {
 				// Simulate that the test pod gets deleted physically.
@@ -3005,7 +3005,7 @@ func TestPriorityQueue_NominatedNodeNameEmptyNodeKey(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			if tt.initialNominatedNode != "" {
 				q.AddNominatedPod(logger, podInfo, &fwk.NominatingInfo{

--- a/pkg/scheduler/backend/queue/testing.go
+++ b/pkg/scheduler/backend/queue/testing.go
@@ -59,6 +59,6 @@ func NewTestQueueWithInformerFactory(
 ) *PriorityQueue {
 	pq := NewPriorityQueue(lessFn, informerFactory, opts...)
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	return pq
 }

--- a/pkg/scheduler/backend/queue/testing.go
+++ b/pkg/scheduler/backend/queue/testing.go
@@ -58,7 +58,7 @@ func NewTestQueueWithInformerFactory(
 	opts ...Option,
 ) *PriorityQueue {
 	pq := NewPriorityQueue(lessFn, informerFactory, opts...)
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 	return pq
 }

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -644,43 +644,44 @@ func addAllEventHandlers(
 
 	logger := sched.logger
 
-	if handlerRegistration, err = informerFactory.Core().V1().Pods().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	if handlerRegistration, err = informerFactory.Core().V1().Pods().Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    sched.addPod,
 		UpdateFunc: sched.updatePod,
 		DeleteFunc: sched.deletePod,
-	}); err != nil {
+	}, cache.HandlerOptions{Logger: &logger}); err != nil {
 		return err
 	}
 	handlers = append(handlers, handlerRegistration)
 
-	if handlerRegistration, err = informerFactory.Core().V1().Nodes().Informer().AddEventHandler(
+	if handlerRegistration, err = informerFactory.Core().V1().Nodes().Informer().AddEventHandlerWithOptions(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    sched.addNodeToCache,
 			UpdateFunc: sched.updateNodeInCache,
 			DeleteFunc: sched.deleteNodeFromCache,
 		},
+		cache.HandlerOptions{Logger: &logger},
 	); err != nil {
 		return err
 	}
 	handlers = append(handlers, handlerRegistration)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.GenericWorkload) {
-		if handlerRegistration, err = informerFactory.Scheduling().V1beta1().PodGroups().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		if handlerRegistration, err = informerFactory.Scheduling().V1beta1().PodGroups().Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 			AddFunc:    sched.addPodGroup,
 			UpdateFunc: sched.updatePodGroup,
 			DeleteFunc: sched.deletePodGroup,
-		}); err != nil {
+		}, cache.HandlerOptions{Logger: &logger}); err != nil {
 			return err
 		}
 		handlers = append(handlers, handlerRegistration)
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.CompositePodGroup) {
-		if handlerRegistration, err = informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		if handlerRegistration, err = informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 			AddFunc:    sched.addCompositePodGroup,
 			UpdateFunc: sched.updateCompositePodGroup,
 			DeleteFunc: sched.deleteCompositePodGroup,
-		}); err != nil {
+		}, cache.HandlerOptions{Logger: &logger}); err != nil {
 			return err
 		}
 		handlers = append(handlers, handlerRegistration)
@@ -723,22 +724,25 @@ func addAllEventHandlers(
 			// UnscheduledPod, and TargetPod are logical Pod event resources
 			// emitted from the Pod add/update/delete handlers.
 		case fwk.CSINode:
-			if handlerRegistration, err = informerFactory.Storage().V1().CSINodes().Informer().AddEventHandler(
+			if handlerRegistration, err = informerFactory.Storage().V1().CSINodes().Informer().AddEventHandlerWithOptions(
 				buildEvtResHandler(at, fwk.CSINode),
+				cache.HandlerOptions{Logger: &logger},
 			); err != nil {
 				return err
 			}
 			handlers = append(handlers, handlerRegistration)
 		case fwk.CSIDriver:
-			if handlerRegistration, err = informerFactory.Storage().V1().CSIDrivers().Informer().AddEventHandler(
+			if handlerRegistration, err = informerFactory.Storage().V1().CSIDrivers().Informer().AddEventHandlerWithOptions(
 				buildEvtResHandler(at, fwk.CSIDriver),
+				cache.HandlerOptions{Logger: &logger},
 			); err != nil {
 				return err
 			}
 			handlers = append(handlers, handlerRegistration)
 		case fwk.CSIStorageCapacity:
-			if handlerRegistration, err = informerFactory.Storage().V1().CSIStorageCapacities().Informer().AddEventHandler(
+			if handlerRegistration, err = informerFactory.Storage().V1().CSIStorageCapacities().Informer().AddEventHandlerWithOptions(
 				buildEvtResHandler(at, fwk.CSIStorageCapacity),
+				cache.HandlerOptions{Logger: &logger},
 			); err != nil {
 				return err
 			}
@@ -757,16 +761,18 @@ func addAllEventHandlers(
 			// bindings due to conflicts if PVs are updated by PV controller or other
 			// parties, then scheduler will add pod back to unschedulable queue. We
 			// need to move pods to active queue on PV update for this scenario.
-			if handlerRegistration, err = informerFactory.Core().V1().PersistentVolumes().Informer().AddEventHandler(
+			if handlerRegistration, err = informerFactory.Core().V1().PersistentVolumes().Informer().AddEventHandlerWithOptions(
 				buildEvtResHandler(at, fwk.PersistentVolume),
+				cache.HandlerOptions{Logger: &logger},
 			); err != nil {
 				return err
 			}
 			handlers = append(handlers, handlerRegistration)
 		case fwk.PersistentVolumeClaim:
 			// MaxPDVolumeCountPredicate: add/update PVC will affect counts of PV when it is bound.
-			if handlerRegistration, err = informerFactory.Core().V1().PersistentVolumeClaims().Informer().AddEventHandler(
+			if handlerRegistration, err = informerFactory.Core().V1().PersistentVolumeClaims().Informer().AddEventHandlerWithOptions(
 				buildEvtResHandler(at, fwk.PersistentVolumeClaim),
+				cache.HandlerOptions{Logger: &logger},
 			); err != nil {
 				return err
 			}
@@ -801,23 +807,26 @@ func addAllEventHandlers(
 					erCache.AddEventHandler(handler)
 					handler = erCache
 				}
-				if handlerRegistration, err = informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(
+				if handlerRegistration, err = informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandlerWithOptions(
 					handler,
+					cache.HandlerOptions{Logger: &logger},
 				); err != nil {
 					return err
 				}
 				handlers = append(handlers, handlerRegistration)
 			}
 		case fwk.StorageClass:
-			if handlerRegistration, err = informerFactory.Storage().V1().StorageClasses().Informer().AddEventHandler(
+			if handlerRegistration, err = informerFactory.Storage().V1().StorageClasses().Informer().AddEventHandlerWithOptions(
 				buildEvtResHandler(at, fwk.StorageClass),
+				cache.HandlerOptions{Logger: &logger},
 			); err != nil {
 				return err
 			}
 			handlers = append(handlers, handlerRegistration)
 		case fwk.VolumeAttachment:
-			if handlerRegistration, err = informerFactory.Storage().V1().VolumeAttachments().Informer().AddEventHandler(
+			if handlerRegistration, err = informerFactory.Storage().V1().VolumeAttachments().Informer().AddEventHandlerWithOptions(
 				buildEvtResHandler(at, fwk.VolumeAttachment),
+				cache.HandlerOptions{Logger: &logger},
 			); err != nil {
 				return err
 			}
@@ -844,8 +853,9 @@ func addAllEventHandlers(
 			// Fall back to try dynamic informers.
 			gvr, _ := schema.ParseResourceArg(string(gvk))
 			dynInformer := dynInformerFactory.ForResource(*gvr).Informer()
-			if handlerRegistration, err = dynInformer.AddEventHandler(
+			if handlerRegistration, err = dynInformer.AddEventHandlerWithOptions(
 				buildEvtResHandler(at, gvk),
+				cache.HandlerOptions{Logger: &logger},
 			); err != nil {
 				return err
 			}

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -536,7 +536,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 			}
 
 			informerFactory.Start(testSched.StopEverything)
-			dynInformerFactory.Start(testSched.StopEverything)
+			dynInformerFactory.StartWithContext(ctx)
 			staticInformers := informerFactory.WaitForCacheSync(testSched.StopEverything)
 			dynamicInformers := dynInformerFactory.WaitForCacheSync(testSched.StopEverything)
 
@@ -603,7 +603,7 @@ func TestAddAllEventHandlersPodEventResources(t *testing.T) {
 	}
 
 	informerFactory.Start(testSched.StopEverything)
-	dynInformerFactory.Start(testSched.StopEverything)
+	dynInformerFactory.StartWithContext(ctx)
 	staticInformers := informerFactory.WaitForCacheSync(testSched.StopEverything)
 	dynamicInformers := dynInformerFactory.WaitForCacheSync(testSched.StopEverything)
 

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -535,7 +535,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 				t.Fatalf("Add event handlers failed, error = %v", err)
 			}
 
-			informerFactory.Start(testSched.StopEverything)
+			informerFactory.StartWithContext(ctx)
 			dynInformerFactory.StartWithContext(ctx)
 			staticInformers := informerFactory.WaitForCacheSync(testSched.StopEverything)
 			dynamicInformers := dynInformerFactory.WaitForCacheSync(testSched.StopEverything)
@@ -602,7 +602,7 @@ func TestAddAllEventHandlersPodEventResources(t *testing.T) {
 		}
 	}
 
-	informerFactory.Start(testSched.StopEverything)
+	informerFactory.StartWithContext(ctx)
 	dynInformerFactory.StartWithContext(ctx)
 	staticInformers := informerFactory.WaitForCacheSync(testSched.StopEverything)
 	dynamicInformers := dynInformerFactory.WaitForCacheSync(testSched.StopEverything)

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -537,7 +537,7 @@ func TestAddAllEventHandlers(t *testing.T) {
 
 			informerFactory.StartWithContext(ctx)
 			dynInformerFactory.StartWithContext(ctx)
-			staticInformers := informerFactory.WaitForCacheSync(testSched.StopEverything)
+			staticInformers := informerFactory.WaitForCacheSyncWithContext(ctx).Synced
 			dynamicInformers := dynInformerFactory.WaitForCacheSync(testSched.StopEverything)
 
 			expectedStaticInformers := make(map[reflect.Type]bool)
@@ -604,7 +604,7 @@ func TestAddAllEventHandlersPodEventResources(t *testing.T) {
 
 	informerFactory.StartWithContext(ctx)
 	dynInformerFactory.StartWithContext(ctx)
-	staticInformers := informerFactory.WaitForCacheSync(testSched.StopEverything)
+	staticInformers := informerFactory.WaitForCacheSyncWithContext(ctx).Synced
 	dynamicInformers := dynInformerFactory.WaitForCacheSync(testSched.StopEverything)
 
 	expectStaticInformers := map[reflect.Type]bool{

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -2025,7 +2025,7 @@ func TestCustomSelection(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
 			for _, pg := range tt.podGroups {
 				cache.AddGenericPodGroup(framework.NewGenericPodGroup(pg))
@@ -2346,7 +2346,7 @@ func TestCustomOrdering(t *testing.T) {
 			_ = informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
 			_ = informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(tt.pods, nodes, tt.podGroups, tt.compositePodGroups)
 
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
@@ -2574,7 +2574,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 			_ = informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
 			_ = informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			registeredPlugins := []tf.RegisterPluginFunc{
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				tf.RegisterBindPlugin(defaultbinder.Name, defaultbinder.New),
@@ -3477,7 +3477,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 			}
 
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			mainNodeInfo, err := snapshot.NodeInfos().Get(tt.mainNode)
 			if err != nil {

--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -2024,7 +2024,7 @@ func TestCustomSelection(t *testing.T) {
 			logger, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			cache := internalcache.New(ctx, nil, tt.features.EnableGenericWorkload, tt.features.EnableCompositePodGroup)
 			for _, pg := range tt.podGroups {
@@ -2345,7 +2345,7 @@ func TestCustomOrdering(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(cs, 0)
 			_ = informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
 			_ = informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			snapshot := internalcache.NewTestSnapshotWithCompositePodGroups(tt.pods, nodes, tt.podGroups, tt.compositePodGroups)
 
@@ -2573,7 +2573,7 @@ func TestPodEligibleToPreemptOthers(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(cs, 0)
 			_ = informerFactory.Scheduling().V1alpha3().PodGroups().Informer()
 			_ = informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			registeredPlugins := []tf.RegisterPluginFunc{
 				tf.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
@@ -3476,7 +3476,7 @@ func TestSelectVictimsOnNode(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			mainNodeInfo, err := snapshot.NodeInfos().Get(tt.mainNode)

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4629,8 +4629,10 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 
 	tc.draManager = NewDRAManager(tCtx, claimsCache, resourceSliceTracker, tc.informerFactory)
 	if features.EnableDRAExtendedResource {
-		cache := tc.draManager.DeviceClassResolver().(*extendedresourcecache.ExtendedResourceCache)
-		deviceClassHandlerRegistration, err := tc.informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(cache)
+		logger := tCtx.Logger()
+		handlerOptions := cache.HandlerOptions{Logger: &logger}
+		deviceClassCache := tc.draManager.DeviceClassResolver().(*extendedresourcecache.ExtendedResourceCache)
+		deviceClassHandlerRegistration, err := tc.informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandlerWithOptions(deviceClassCache, handlerOptions)
 		require.NoError(tCtx, err, "failed to add device class informer event handler")
 		doneCheckers = append(doneCheckers, deviceClassHandlerRegistration.HasSyncedChecker())
 	}

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4693,7 +4693,7 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 		tc.informerFactory.Shutdown()
 	})
 
-	tc.informerFactory.WaitForCacheSync(tCtx.Done())
+	tc.informerFactory.WaitForCacheSyncWithContext(tCtx)
 	// The above does not tell us if the registered handlers (e.g. from NewAssumeCache)
 	// are synced, we need to wait until the event handlers confirm that they are synced.
 	// This ensures that the assume cache is in sync with the informer's

--- a/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
+++ b/pkg/scheduler/framework/plugins/dynamicresources/dynamicresources_test.go
@@ -4685,7 +4685,7 @@ func setup(tCtx ktesting.TContext, args *config.DynamicResourcesArgs, nodes []*v
 		tCtx.ExpectNoError(err, "create pod group")
 	}
 
-	tc.informerFactory.Start(tCtx.Done())
+	tc.informerFactory.StartWithContext(tCtx)
 	tCtx.Cleanup(func() {
 		// Need to cancel before waiting for the shutdown.
 		tCtx.Cancel("test is done")

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
@@ -625,7 +625,7 @@ func newTestDRAManager(tCtx ktesting.TContext, objects ...apiruntime.Object) *dy
 		// Now we can wait for all goroutines to stop.
 		informerFactory.Shutdown()
 	})
-	informerFactory.WaitForCacheSync(tCtx.Done())
+	informerFactory.WaitForCacheSyncWithContext(tCtx)
 
 	// Wait for full initialization of manager, including
 	// processing of all informer events.

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
@@ -619,7 +619,7 @@ func newTestDRAManager(tCtx ktesting.TContext, objects ...apiruntime.Object) *dy
 		_ = informerFactory.Resource().V1().DeviceClasses().Informer().RemoveEventHandler(handle)
 	})
 
-	informerFactory.Start(tCtx.Done())
+	informerFactory.StartWithContext(tCtx)
 	tCtx.Cleanup(func() {
 		tCtx.Cancel("test has completed")
 		// Now we can wait for all goroutines to stop.

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation_test.go
@@ -31,6 +31,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/dynamic-resource-allocation/cel"
 	"k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache"
@@ -610,8 +611,9 @@ func newTestDRAManager(tCtx ktesting.TContext, objects ...apiruntime.Object) *dy
 		resourceSliceTracker,
 		informerFactory)
 
-	cache := draManager.DeviceClassResolver().(*extendedresourcecache.ExtendedResourceCache)
-	handle, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(cache)
+	deviceClassCache := draManager.DeviceClassResolver().(*extendedresourcecache.ExtendedResourceCache)
+	logger := tCtx.Logger()
+	handle, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandlerWithOptions(deviceClassCache, cache.HandlerOptions{Logger: &logger})
 	tCtx.ExpectNoError(err, "add device class informer event handler")
 	tCtx.Cleanup(func() {
 		_ = informerFactory.Resource().V1().DeviceClasses().Informer().RemoveEventHandler(handle)

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -652,7 +652,7 @@ func TestCSILimits(t *testing.T) {
 				t.Error(err)
 			}
 			_, ctx := ktesting.NewTestContext(t)
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			p := &CSILimits{
 				csiManager:           NewCSIManager(getFakeCSINodeLister(csiNode)),
@@ -1371,7 +1371,7 @@ func TestVolumeLimitScalingGate(t *testing.T) {
 				t.Error(err)
 			}
 			_, ctx := ktesting.NewTestContext(t)
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			csiTranslator := csitrans.New()

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -653,7 +653,7 @@ func TestCSILimits(t *testing.T) {
 			}
 			_, ctx := ktesting.NewTestContext(t)
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			p := &CSILimits{
 				csiManager:           NewCSIManager(getFakeCSINodeLister(csiNode)),
 				pvLister:             getFakeCSIPVLister(test.filterName, test.driverNames...),
@@ -1372,7 +1372,7 @@ func TestVolumeLimitScalingGate(t *testing.T) {
 			}
 			_, ctx := ktesting.NewTestContext(t)
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			csiTranslator := csitrans.New()
 			p := &CSILimits{

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
@@ -103,7 +103,7 @@ func TestPreScoreSkip(t *testing.T) {
 				t.Fatalf("Failed creating plugin: %v", err)
 			}
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			p := pl.(*PodTopologySpread)
 			cs := framework.NewCycleState()
 			if s := p.PreScore(ctx, cs, tt.pod, tf.BuildNodeInfos(tt.nodes)); !s.IsSkip() {
@@ -602,7 +602,7 @@ func TestPreScoreStateEmptyNodes(t *testing.T) {
 				t.Fatalf("Failed creating plugin: %v", err)
 			}
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			p := pl.(*PodTopologySpread)
 			cs := framework.NewCycleState()
 			if s := p.PreScore(ctx, cs, tt.pod, tf.BuildNodeInfos(tt.nodes)); !s.IsSuccess() {

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
@@ -102,7 +102,7 @@ func TestPreScoreSkip(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed creating plugin: %v", err)
 			}
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			p := pl.(*PodTopologySpread)
 			cs := framework.NewCycleState()
@@ -601,7 +601,7 @@ func TestPreScoreStateEmptyNodes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed creating plugin: %v", err)
 			}
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			p := pl.(*PodTopologySpread)
 			cs := framework.NewCycleState()

--- a/pkg/scheduler/framework/plugins/testing/testing.go
+++ b/pkg/scheduler/framework/plugins/testing/testing.go
@@ -54,7 +54,7 @@ func SetupPluginWithInformers(
 		tb.Fatal(err)
 	}
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	return p
 }
 

--- a/pkg/scheduler/framework/plugins/testing/testing.go
+++ b/pkg/scheduler/framework/plugins/testing/testing.go
@@ -53,7 +53,7 @@ func SetupPluginWithInformers(
 	if err != nil {
 		tb.Fatal(err)
 	}
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 	return p
 }

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -153,7 +153,7 @@ func newTestBinder(t *testing.T, ctx context.Context) *testEnv {
 	client.AddWatchReactor("*", func(action k8stesting.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
 		ns := action.GetNamespace()
-		watch, err := reactor.Watch(gvr, ns)
+		watch, err := reactor.Watch(logger, gvr, ns)
 		if err != nil {
 			return false, nil, err
 		}

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -189,7 +189,7 @@ func newTestBinder(t *testing.T, ctx context.Context) *testEnv {
 	}
 
 	// Wait for informers cache sync
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	for v, synced := range informerFactory.WaitForCacheSync(ctx.Done()) {
 		if !synced {
 			logger.Error(nil, "Error syncing informer", "informer", v)

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -190,7 +190,7 @@ func newTestBinder(t *testing.T, ctx context.Context) *testEnv {
 
 	// Wait for informers cache sync
 	informerFactory.StartWithContext(ctx)
-	for v, synced := range informerFactory.WaitForCacheSync(ctx.Done()) {
+	for v, synced := range informerFactory.WaitForCacheSyncWithContext(ctx).Synced {
 		if !synced {
 			logger.Error(nil, "Error syncing informer", "informer", v)
 			os.Exit(1)

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -1246,7 +1246,7 @@ func TestVolumeBinding(t *testing.T) {
 			}
 
 			t.Log("Start informer factory after initialization")
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 
 			t.Log("Wait for all started informers' cache were synced")
 			informerFactory.WaitForCacheSync(ctx.Done())

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding_test.go
@@ -1249,7 +1249,7 @@ func TestVolumeBinding(t *testing.T) {
 			informerFactory.StartWithContext(ctx)
 
 			t.Log("Wait for all started informers' cache were synced")
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			t.Log("Verify")
 

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -754,7 +754,7 @@ func TestPrepareCandidate(t *testing.T) {
 						t.Fatal(err)
 					}
 					informerFactory.StartWithContext(ctx)
-					informerFactory.WaitForCacheSync(ctx.Done())
+					informerFactory.WaitForCacheSyncWithContext(ctx)
 					if asyncAPICallsEnabled {
 						cache := internalcache.New(ctx, apiDispatcher, false, false)
 						framework.SetAPICacher(apicache.New(nil, cache))
@@ -1281,7 +1281,7 @@ func TestAsyncPreemptionFailure(t *testing.T) {
 				t.Fatal(err)
 			}
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			executor := NewExecutor(fwk, feature.Features{EnableAsyncPreemption: true})
 

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -753,7 +753,7 @@ func TestPrepareCandidate(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					informerFactory.Start(ctx.Done())
+					informerFactory.StartWithContext(ctx)
 					informerFactory.WaitForCacheSync(ctx.Done())
 					if asyncAPICallsEnabled {
 						cache := internalcache.New(ctx, apiDispatcher, false, false)
@@ -1000,7 +1000,7 @@ func TestPrepareCandidateAsyncSetsPreemptingSets(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					informerFactory.Start(ctx.Done())
+					informerFactory.StartWithContext(ctx)
 					if asyncAPICallsEnabled {
 						cache := internalcache.New(ctx, apiDispatcher, false, false)
 						fwk.SetAPICacher(apicache.New(nil, cache))
@@ -1280,7 +1280,7 @@ func TestAsyncPreemptionFailure(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			executor := NewExecutor(fwk, feature.Features{EnableAsyncPreemption: true})
@@ -2083,7 +2083,7 @@ func TestPreemptionExecutionDurationMetric(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				informerFactory.Start(ctx.Done())
+				informerFactory.StartWithContext(ctx)
 
 				executor := NewExecutor(fwk, feature.Features{EnableAsyncPreemption: async})
 				podPreemptor := &podExecutorPreemptor{Pod: preemptor}

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -1228,7 +1228,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			// mockSchedulingFunc is used to simulate the scheduling of the preemptor pod group.
@@ -1383,7 +1383,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain_NominatedNodes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	pgLister := &mockPodGroupLister{podGroups: make(map[string]*schedulingv1beta1.PodGroup)}
@@ -1582,7 +1582,7 @@ func TestPodGroupEvaluator_Preempt(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			podGroups := make(map[string]*schedulingv1beta1.PodGroup)
@@ -1701,7 +1701,7 @@ func TestPodGroupPreemptionEvaluationDurationMetric(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			pgLister := &mockPodGroupLister{podGroups: make(map[string]*schedulingv1beta1.PodGroup)}

--- a/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
+++ b/pkg/scheduler/framework/preemption/podgrouppreemption_test.go
@@ -1229,7 +1229,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain(t *testing.T) {
 			}
 
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			// mockSchedulingFunc is used to simulate the scheduling of the preemptor pod group.
 			// For each of the Pod it goes through each node and if there is enough capacity it assigns the pod to the node.
@@ -1384,7 +1384,7 @@ func TestPodGroupEvaluator_SelectVictimsOnDomain_NominatedNodes(t *testing.T) {
 	}
 
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	pgLister := &mockPodGroupLister{podGroups: make(map[string]*schedulingv1beta1.PodGroup)}
 	domain, err := newDomainForWorkloadPreemption(logger, snapshot, pgLister, &mockCompositePodGroupLister{}, "test-domain")
@@ -1583,7 +1583,7 @@ func TestPodGroupEvaluator_Preempt(t *testing.T) {
 			}
 
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			podGroups := make(map[string]*schedulingv1beta1.PodGroup)
 			for _, pg := range tt.initPodGroups {
@@ -1702,7 +1702,7 @@ func TestPodGroupPreemptionEvaluationDurationMetric(t *testing.T) {
 				t.Fatal(err)
 			}
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			pgLister := &mockPodGroupLister{podGroups: make(map[string]*schedulingv1beta1.PodGroup)}
 

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -248,7 +248,7 @@ func TestDryRunPreemption(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			nodeInfos, err := snapshot.NodeInfos().List()
 			if err != nil {
@@ -619,7 +619,7 @@ func TestCallExtenders(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			cache := internalcache.New(ctx, apiDispatcher, false, false)
 			fwk.SetAPICacher(apicache.New(nil, cache))
@@ -1023,7 +1023,7 @@ func TestGetVictimsOnNode(t *testing.T) {
 			_ = informerFactory.Scheduling().V1beta1().PodGroups().Informer()
 			_ = informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
 
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			nodeInfo, err := snapshot.NodeInfos().Get(tt.targetNode)
@@ -1137,7 +1137,7 @@ func TestPreemptionEvaluationDurationMetric(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			fakePostPlugin := &FakePostFilterPlugin{numViolatingVictim: 0}

--- a/pkg/scheduler/framework/preemption/preemption_test.go
+++ b/pkg/scheduler/framework/preemption/preemption_test.go
@@ -249,7 +249,7 @@ func TestDryRunPreemption(t *testing.T) {
 			}
 
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			nodeInfos, err := snapshot.NodeInfos().List()
 			if err != nil {
 				t.Fatal(err)
@@ -620,7 +620,7 @@ func TestCallExtenders(t *testing.T) {
 				t.Fatal(err)
 			}
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			cache := internalcache.New(ctx, apiDispatcher, false, false)
 			fwk.SetAPICacher(apicache.New(nil, cache))
 
@@ -1024,7 +1024,7 @@ func TestGetVictimsOnNode(t *testing.T) {
 			_ = informerFactory.Scheduling().V1alpha3().CompositePodGroups().Informer()
 
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			nodeInfo, err := snapshot.NodeInfos().Get(tt.targetNode)
 			if err != nil {
@@ -1138,7 +1138,7 @@ func TestPreemptionEvaluationDurationMetric(t *testing.T) {
 				t.Fatal(err)
 			}
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			fakePostPlugin := &FakePostFilterPlugin{numViolatingVictim: 0}
 			customInterface := &customEvaluationInterface{

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -846,7 +846,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 	client := clientsetfake.NewClientset(testPodGroup)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	var failureHandlerCalled bool
 	sched := &Scheduler{
@@ -919,7 +919,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 	snapshot := internalcache.NewEmptySnapshot()
 
@@ -1105,7 +1105,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 			snapshot := internalcache.NewEmptySnapshot()
 
@@ -1896,7 +1896,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			fakeClock := testingclock.NewFakeClock(time.Now())
 			schedulingQueue := internalqueue.NewTestQueue(ctx, schedFwk.QueueSortFunc(), internalqueue.WithClock(fakeClock))
@@ -2340,7 +2340,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 			sched := &Scheduler{client: client, Cache: cache}
 
 			var existingLTT metav1.Time
@@ -4391,7 +4391,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 	client := clientsetfake.NewSimpleClientset(testPodGroup)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
 		frameworkruntime.WithInformerFactory(informerFactory),
@@ -4506,7 +4506,7 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	sched := &Scheduler{
 		Profiles:               profile.Map{"test-scheduler": schedFwk},
@@ -4585,7 +4585,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	sched := &Scheduler{
 		Profiles:        profile.Map{"sched1": schedFwk1, "sched2": schedFwk2},
 		SchedulingQueue: internalqueue.NewTestQueue(ctx, nil),
@@ -4785,7 +4785,7 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 			client := clientsetfake.NewClientset(testPodGroup)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			cache := internalcache.New(ctx, nil, true, false /* CompositePodGroup */)
 			cache.AddGenericPodGroup(framework.NewGenericPodGroup(testPodGroup))
@@ -4970,7 +4970,7 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 	client := clientsetfake.NewSimpleClientset(cpgRoot, pg1, pg2, pg3)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
 		frameworkruntime.WithInformerFactory(informerFactory),
@@ -5238,7 +5238,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 	snapshot := internalcache.NewEmptySnapshot()
 
@@ -5254,7 +5254,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 		frameworkruntime.WithPodGroupManager(cache),
 	)
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	if err != nil {
 		t.Fatalf("Failed to create new framework: %v", err)
 	}
@@ -5479,7 +5479,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 		frameworkruntime.WithPodGroupManager(cache),
 	)
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	if err != nil {
 		t.Fatalf("Failed to create new framework: %v", err)
 	}
@@ -5699,7 +5699,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 		frameworkruntime.WithPodGroupManager(cache),
 	)
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	if err != nil {
 		t.Fatalf("Failed to create new framework: %v", err)
 	}
@@ -7352,7 +7352,7 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 					})
 
 					informerFactory.StartWithContext(ctx)
-					informerFactory.WaitForCacheSync(ctx.Done())
+					informerFactory.WaitForCacheSyncWithContext(ctx)
 
 					if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {
 						t.Fatalf("Failed to update snapshot: %v", err)

--- a/pkg/scheduler/schedule_one_podgroup_test.go
+++ b/pkg/scheduler/schedule_one_podgroup_test.go
@@ -845,7 +845,7 @@ func TestPodGroupCycle_UpdateSnapshotError(t *testing.T) {
 
 	client := clientsetfake.NewClientset(testPodGroup)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	var failureHandlerCalled bool
@@ -918,7 +918,7 @@ func TestPodGroupCycle_FillsPodResultsOnFewerResults(t *testing.T) {
 	client := clientsetfake.NewSimpleClientset(testPodGroup, testNode)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 	snapshot := internalcache.NewEmptySnapshot()
@@ -1104,7 +1104,7 @@ func TestPodGroupCycle_PodGroupPostFilter(t *testing.T) {
 			client := clientsetfake.NewSimpleClientset(testPodGroup, testNode)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
 
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 			snapshot := internalcache.NewEmptySnapshot()
@@ -1895,7 +1895,7 @@ func TestSubmitPodGroupAlgorithmResult(t *testing.T) {
 			cache.AddGenericPodGroup(apg)
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			fakeClock := testingclock.NewFakeClock(time.Now())
@@ -2339,7 +2339,7 @@ func TestUpdatePodGroupCondition(t *testing.T) {
 			cache.AddGenericPodGroup(apg)
 
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 			sched := &Scheduler{client: client, Cache: cache}
 
@@ -4390,7 +4390,7 @@ func TestPodGroupCycle_NominatedNodes(t *testing.T) {
 
 	client := clientsetfake.NewSimpleClientset(testPodGroup)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
@@ -4505,7 +4505,7 @@ func TestScheduleOnePodGroup_PodGroupNotFound(t *testing.T) {
 	cache := internalcache.New(ctx, nil, true, false /* CompositePodGroup */)
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	sched := &Scheduler{
@@ -4584,7 +4584,7 @@ func TestScheduleOnePodGroup_SchedulerNameMismatchUpdatesStatus(t *testing.T) {
 	cache.AddGenericPodGroup(apg)
 
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 	sched := &Scheduler{
 		Profiles:        profile.Map{"sched1": schedFwk1, "sched2": schedFwk2},
@@ -4784,7 +4784,7 @@ func TestScheduleOnePodGroup_PodGroupStateAvailability(t *testing.T) {
 			snapshot := internalcache.NewEmptySnapshot()
 			client := clientsetfake.NewClientset(testPodGroup)
 			informerFactory := informers.NewSharedInformerFactory(client, 0)
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			cache := internalcache.New(ctx, nil, true, false /* CompositePodGroup */)
@@ -4969,7 +4969,7 @@ func TestCPGHierarchicalScheduling_ScheduleOnePodGroup(t *testing.T) {
 
 	client := clientsetfake.NewSimpleClientset(cpgRoot, pg1, pg2, pg3)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	schedFwk, err := frameworkruntime.NewFramework(ctx, registry, &profileCfg,
@@ -5237,7 +5237,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 	client := clientsetfake.NewSimpleClientset(clientObjs...)
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 	queue := internalqueue.NewSchedulingQueue(nil, informerFactory)
 	snapshot := internalcache.NewEmptySnapshot()
@@ -5253,7 +5253,7 @@ func TestCPGHierarchicalScheduling_Internal(t *testing.T) {
 		frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
 		frameworkruntime.WithPodGroupManager(cache),
 	)
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 	if err != nil {
 		t.Fatalf("Failed to create new framework: %v", err)
@@ -5478,7 +5478,7 @@ func TestCPGMinGroupCount_Internal(t *testing.T) {
 		frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
 		frameworkruntime.WithPodGroupManager(cache),
 	)
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 	if err != nil {
 		t.Fatalf("Failed to create new framework: %v", err)
@@ -5698,7 +5698,7 @@ func TestCPGBasicWithGangChildren_Internal(t *testing.T) {
 		frameworkruntime.WithPodsInPreBind(frameworkruntime.NewPodsInPreBindMap()),
 		frameworkruntime.WithPodGroupManager(cache),
 	)
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 	if err != nil {
 		t.Fatalf("Failed to create new framework: %v", err)
@@ -7351,7 +7351,7 @@ func TestPodGroupCycle_PodStatusConditions(t *testing.T) {
 						return true, binding, nil
 					})
 
-					informerFactory.Start(ctx.Done())
+					informerFactory.StartWithContext(ctx)
 					informerFactory.WaitForCacheSync(ctx.Done())
 
 					if err := sched.Cache.UpdateSnapshot(logger, sched.nodeInfoSnapshot); err != nil {

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -541,7 +541,7 @@ func TestSchedulerMultipleProfilesScheduling(t *testing.T) {
 	defer stopFn()
 
 	// Run scheduler.
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 	if err = sched.WaitForHandlersSync(ctx); err != nil {
 		t.Fatalf("Handlers failed to sync: %v: ", err)
@@ -633,7 +633,7 @@ func TestSchedulerGuaranteeNonNilNodeInSchedulingCycle(t *testing.T) {
 	}
 
 	// Run scheduler.
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 	go sched.Run(ctx)
 
@@ -1163,7 +1163,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			APIDispatcher:                          apiDispatcher,
 			nominatedNodeNameForExpectationEnabled: features.nominatedNodeNameForExpectationEnabled,
 		}
-		informerFactory.Start(ctx.Done())
+		informerFactory.StartWithContext(ctx)
 		informerFactory.WaitForCacheSync(ctx.Done())
 
 		if scheduleAsPodGroup {
@@ -1360,7 +1360,7 @@ func TestHandleSchedulingFailureSkipsRecreatedPod(t *testing.T) {
 		SchedulingQueue: queue,
 	}
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	queue.Add(ctx, oldPod)
@@ -1451,7 +1451,7 @@ func TestHandleSchedulingFailureForDeferredResizePod(t *testing.T) {
 		inPlacePodVerticalScalingSchedulerPreemptionEnabled: true,
 	}
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	queue.Add(ctx, pod)
@@ -1528,7 +1528,7 @@ func TestHandleSchedulingFailure_PodGroupFitErrorCloned(t *testing.T) {
 		SchedulingQueue: queue,
 	}
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
@@ -3971,7 +3971,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 			}
 			sched.applyDefaultHandlers()
 
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			podInfo := queuedPodInfoForPod(test.pod)
@@ -5288,7 +5288,7 @@ func TestScheduler_DeferredResizePluginSkipping(t *testing.T) {
 		nodeInfoSnapshot: snapshot,
 	}
 
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	state := framework.NewCycleState()
@@ -5413,7 +5413,7 @@ func TestScheduler_DeferredResizePostFilterPluginSkipping(t *testing.T) {
 				t.Fatalf("NewFramework failed: %v", err)
 			}
 
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			state := framework.NewCycleState()
@@ -5500,7 +5500,7 @@ func TestSchedulePodWithOpportunisticBatching(t *testing.T) {
 			}
 			sched.applyDefaultHandlers()
 
-			informerFactory.Start(ctx.Done())
+			informerFactory.StartWithContext(ctx)
 			informerFactory.WaitForCacheSync(ctx.Done())
 
 			// Schedule first pod.

--- a/pkg/scheduler/schedule_one_test.go
+++ b/pkg/scheduler/schedule_one_test.go
@@ -542,7 +542,7 @@ func TestSchedulerMultipleProfilesScheduling(t *testing.T) {
 
 	// Run scheduler.
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	if err = sched.WaitForHandlersSync(ctx); err != nil {
 		t.Fatalf("Handlers failed to sync: %v: ", err)
 	}
@@ -634,7 +634,7 @@ func TestSchedulerGuaranteeNonNilNodeInSchedulingCycle(t *testing.T) {
 
 	// Run scheduler.
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	go sched.Run(ctx)
 
 	var deleteNodeIndex int
@@ -1164,7 +1164,7 @@ func TestSchedulerScheduleOne(t *testing.T) {
 			nominatedNodeNameForExpectationEnabled: features.nominatedNodeNameForExpectationEnabled,
 		}
 		informerFactory.StartWithContext(ctx)
-		informerFactory.WaitForCacheSync(ctx.Done())
+		informerFactory.WaitForCacheSyncWithContext(ctx)
 
 		if scheduleAsPodGroup {
 			queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(podGroup))
@@ -1361,7 +1361,7 @@ func TestHandleSchedulingFailureSkipsRecreatedPod(t *testing.T) {
 	}
 
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	queue.Add(ctx, oldPod)
 	popped, err := queue.Pop(logger)
@@ -1452,7 +1452,7 @@ func TestHandleSchedulingFailureForDeferredResizePod(t *testing.T) {
 	}
 
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	queue.Add(ctx, pod)
 	popped, err := queue.Pop(logger)
@@ -1529,7 +1529,7 @@ func TestHandleSchedulingFailure_PodGroupFitErrorCloned(t *testing.T) {
 	}
 
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	queue.AddGenericPodGroup(logger, framework.NewGenericPodGroup(pg))
 	queue.Add(ctx, pod1)
@@ -3972,7 +3972,7 @@ func TestSchedulerSchedulePod(t *testing.T) {
 			sched.applyDefaultHandlers()
 
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			podInfo := queuedPodInfoForPod(test.pod)
 			result, err := sched.SchedulePod(ctx, schedFramework, framework.NewCycleState(), podInfo)
@@ -5289,7 +5289,7 @@ func TestScheduler_DeferredResizePluginSkipping(t *testing.T) {
 	}
 
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	state := framework.NewCycleState()
 	podInfo := queuedPodInfoForPod(pod)
@@ -5414,7 +5414,7 @@ func TestScheduler_DeferredResizePostFilterPluginSkipping(t *testing.T) {
 			}
 
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			state := framework.NewCycleState()
 
@@ -5501,7 +5501,7 @@ func TestSchedulePodWithOpportunisticBatching(t *testing.T) {
 			sched.applyDefaultHandlers()
 
 			informerFactory.StartWithContext(ctx)
-			informerFactory.WaitForCacheSync(ctx.Done())
+			informerFactory.WaitForCacheSyncWithContext(ctx)
 
 			// Schedule first pod.
 			pod1 := st.MakePod().Name("pod1").UID("pod1").Namespace(v1.NamespaceDefault).Req(map[v1.ResourceName]string{v1.ResourceCPU: "1"}).Obj()

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1299,7 +1299,7 @@ func TestFrameworkHandler_IterateOverWaitingPods(t *testing.T) {
 			defer stopFn()
 
 			// Run scheduler.
-			informerFactory.Start(tCtx.Done())
+			informerFactory.StartWithContext(tCtx)
 			informerFactory.WaitForCacheSync(tCtx.Done())
 			go scheduler.Run(tCtx)
 
@@ -1518,7 +1518,7 @@ func TestNewInformerFactoryTrim(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	p, err := lister.Pods("default").Get("test")
@@ -1543,7 +1543,7 @@ func TestNewInformerFactoryMetrics(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	informerFactory.WaitForCacheSync(ctx.Done())
 
 	want := `

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1300,7 +1300,7 @@ func TestFrameworkHandler_IterateOverWaitingPods(t *testing.T) {
 
 			// Run scheduler.
 			informerFactory.StartWithContext(tCtx)
-			informerFactory.WaitForCacheSync(tCtx.Done())
+			informerFactory.WaitForCacheSyncWithContext(tCtx)
 			go scheduler.Run(tCtx)
 
 			// Send pods to be scheduled.
@@ -1519,7 +1519,7 @@ func TestNewInformerFactoryTrim(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	p, err := lister.Pods("default").Get("test")
 	require.NoError(t, err)
@@ -1544,7 +1544,7 @@ func TestNewInformerFactoryMetrics(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	informerFactory.StartWithContext(ctx)
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 
 	want := `
 # HELP informer_queued_items [ALPHA] Number of items currently queued in the FIFO.

--- a/pkg/scheduler/util/assumecache/assume_cache.go
+++ b/pkg/scheduler/util/assumecache/assume_cache.go
@@ -557,7 +557,7 @@ func (c *AssumeCache) emitEvents() {
 			return
 		}
 		func() {
-			defer utilruntime.HandleCrash()
+			defer utilruntime.HandleCrashWithLogger(c.logger)
 			deliver()
 		}()
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
@@ -311,7 +311,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/informers/externalversions/factory.go
@@ -288,7 +288,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -311,7 +311,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -288,7 +288,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/apiapproval/apiapproval_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/apiapproval/apiapproval_controller.go
@@ -182,13 +182,13 @@ func (c *KubernetesAPIApprovalPolicyConformantConditionController) sync(ctx cont
 }
 
 // Run starts the controller.
+//
+//logcheck:context // RunWithContext should be used instead of Run in code which supports contextual logging.
 func (c *KubernetesAPIApprovalPolicyConformantConditionController) Run(workers int, stopCh <-chan struct{}) {
 	c.RunWithContext(workers, wait.ContextForChannel(stopCh))
 }
 
 // RunWithContext starts the controller with a context.
-//
-//logcheck:context // RunWithContext should be used instead of Run in code which supports contextual logging.
 func (c *KubernetesAPIApprovalPolicyConformantConditionController) RunWithContext(workers int, ctx context.Context) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/interfaces.go
@@ -113,7 +113,7 @@ type RESTMapping struct {
 //
 // RESTMapperWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use RESTMapperWithContext instead.
+//logcheck:context // Use RESTMapperWithContext instead of RESTMapper in code which supports contextual logging.
 type RESTMapper interface {
 	// KindFor takes a partial resource and returns the single match.  Returns an error if there are multiple matches
 	KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error)
@@ -212,7 +212,7 @@ func (m *restMapperWrapper) ResourceSingularizerWithContext(ctx context.Context,
 //
 // ResettableRESTMapperWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ResettableRESTMapperWithContext instead.
+//logcheck:context // Use ResettableRESTMapperWithContext instead of ResettableRESTMapper in code which supports contextual logging.
 type ResettableRESTMapper interface {
 	RESTMapper
 	Reset()

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/multirestmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/multirestmapper.go
@@ -36,7 +36,7 @@ var (
 //
 // MultiRESTMapperWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use MultiRESTMapperWithContext instead.
+//logcheck:context // Use MultiRESTMapperWithContext instead of MultiRESTMapper in code which supports contextual logging.
 type MultiRESTMapper []RESTMapper
 
 // MultiRESTMapperWithContext is a wrapper for multiple RESTMapperWithContext instances.
@@ -77,35 +77,35 @@ func ToMultiRESTMapperWithContext(m MultiRESTMapper) MultiRESTMapperWithContext 
 //
 // MultiRESTMapperWithContext.ResourceSingularizerWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use MultiRESTMapperWithContext.ResourceSingularizerWithContext instead.
+//logcheck:context // Use MultiRESTMapperWithContext.ResourceSingularizerWithContext instead of ResourceSingularizer in code which supports contextual logging.
 func (m MultiRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
 	return ToMultiRESTMapperWithContext(m).ResourceSingularizerWithContext(context.Background(), resource)
 }
 
 // MultiRESTMapperWithContext.ResourcesForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use MultiRESTMapperWithContext.ResourcesForWithContext instead.
+//logcheck:context // Use MultiRESTMapperWithContext.ResourcesForWithContext instead of ResourcesFor in code which supports contextual logging.
 func (m MultiRESTMapper) ResourcesFor(resource schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
 	return ToMultiRESTMapperWithContext(m).ResourcesForWithContext(context.Background(), resource)
 }
 
 // MultiRESTMapperWithContext.KindsForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use MultiRESTMapperWithContext.KindsForWithContext instead.
+//logcheck:context // Use MultiRESTMapperWithContext.KindsForWithContext instead of KindsFor in code which supports contextual logging.
 func (m MultiRESTMapper) KindsFor(resource schema.GroupVersionResource) (gvk []schema.GroupVersionKind, err error) {
 	return ToMultiRESTMapperWithContext(m).KindsForWithContext(context.Background(), resource)
 }
 
 // MultiRESTMapperWithContext.ResourceForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use MultiRESTMapperWithContext.ResourceForWithContext instead.
+//logcheck:context // Use MultiRESTMapperWithContext.ResourceForWithContext instead of ResourceFor in code which supports contextual logging.
 func (m MultiRESTMapper) ResourceFor(resource schema.GroupVersionResource) (schema.GroupVersionResource, error) {
 	return ToMultiRESTMapperWithContext(m).ResourceForWithContext(context.Background(), resource)
 }
 
 // MultiRESTMapperWithContext.KindForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use MultiRESTMapperWithContext.KindForWithContext instead.
+//logcheck:context // Use MultiRESTMapperWithContext.KindForWithContext instead of KindFor in code which supports contextual logging.
 func (m MultiRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
 	return ToMultiRESTMapperWithContext(m).KindForWithContext(context.Background(), resource)
 }
@@ -116,7 +116,7 @@ func (m MultiRESTMapper) KindFor(resource schema.GroupVersionResource) (schema.G
 //
 // MultiRESTMapperWithContext.RESTMappingWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use MultiRESTMapperWithContext.RESTMappingWithContext instead.
+//logcheck:context // Use MultiRESTMapperWithContext.RESTMappingWithContext instead of RESTMapping in code which supports contextual logging.
 func (m MultiRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*RESTMapping, error) {
 	return ToMultiRESTMapperWithContext(m).RESTMappingWithContext(context.Background(), gk, versions...)
 }
@@ -126,14 +126,14 @@ func (m MultiRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*
 //
 // MultiRESTMapperWithContext.RESTMappingsWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use MultiRESTMapperWithContext.RESTMappingsWithContext instead.
+//logcheck:context // Use MultiRESTMapperWithContext.RESTMappingsWithContext instead of RESTMappings in code which supports contextual logging.
 func (m MultiRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*RESTMapping, error) {
 	return ToMultiRESTMapperWithContext(m).RESTMappingsWithContext(context.Background(), gk, versions...)
 }
 
-// MultiRESTMapperWithContext.Reset is a better alternative because it supports contextual logging and cancellation.
+// MultiRESTMapperWithContext.ResetWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use MultiRESTMapperWithContext.Reset instead.
+//logcheck:context // Use MultiRESTMapperWithContext.ResetWithContext instead of Reset in code which supports contextual logging.
 func (m MultiRESTMapper) Reset() {
 	for _, t := range m {
 		MaybeResetRESTMapper(t)

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/multirestmapper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/multirestmapper_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestMultiRESTMapperResourceFor(t *testing.T) {
@@ -56,8 +57,9 @@ func TestMultiRESTMapperResourceFor(t *testing.T) {
 		},
 	}
 
+	_, ctx := ktesting.NewTestContext(t)
 	for _, tc := range tcs {
-		actualResult, actualErr := tc.mapper.ResourceFor(tc.input)
+		actualResult, actualErr := ToMultiRESTMapperWithContext(tc.mapper).ResourceForWithContext(ctx, tc.input)
 		if e, a := tc.result, actualResult; e != a {
 			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
 		}
@@ -123,8 +125,9 @@ func TestMultiRESTMapperResourcesFor(t *testing.T) {
 		},
 	}
 
+	_, ctx := ktesting.NewTestContext(t)
 	for _, tc := range tcs {
-		actualResult, actualErr := tc.mapper.ResourcesFor(tc.input)
+		actualResult, actualErr := ToMultiRESTMapperWithContext(tc.mapper).ResourcesForWithContext(ctx, tc.input)
 		if e, a := tc.result, actualResult; !reflect.DeepEqual(e, a) {
 			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
 		}
@@ -190,8 +193,9 @@ func TestMultiRESTMapperKindsFor(t *testing.T) {
 		},
 	}
 
+	_, ctx := ktesting.NewTestContext(t)
 	for _, tc := range tcs {
-		actualResult, actualErr := tc.mapper.KindsFor(tc.input)
+		actualResult, actualErr := ToMultiRESTMapperWithContext(tc.mapper).KindsForWithContext(ctx, tc.input)
 		if e, a := tc.result, actualResult; !reflect.DeepEqual(e, a) {
 			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
 		}
@@ -239,8 +243,9 @@ func TestMultiRESTMapperKindFor(t *testing.T) {
 		},
 	}
 
+	_, ctx := ktesting.NewTestContext(t)
 	for _, tc := range tcs {
-		actualResult, actualErr := tc.mapper.KindFor(tc.input)
+		actualResult, actualErr := ToMultiRESTMapperWithContext(tc.mapper).KindForWithContext(ctx, tc.input)
 		if e, a := tc.result, actualResult; e != a {
 			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
 		}
@@ -331,8 +336,9 @@ func TestMultiRESTMapperRESTMappings(t *testing.T) {
 		},
 	}
 
+	_, ctx := ktesting.NewTestContext(t)
 	for _, tc := range tcs {
-		actualResult, actualErr := tc.mapper.RESTMappings(tc.groupKind, tc.versions...)
+		actualResult, actualErr := ToMultiRESTMapperWithContext(tc.mapper).RESTMappingsWithContext(ctx, tc.groupKind, tc.versions...)
 		if e, a := tc.result, actualResult; !reflect.DeepEqual(e, a) {
 			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/priority.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/priority.go
@@ -41,7 +41,7 @@ var (
 //
 // PriorityRESTMapperWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use PriorityRESTMapperWithContext instead.
+//logcheck:context // Use PriorityRESTMapperWithContext instead of PriorityRESTMapper in code which supports contextual logging.
 type PriorityRESTMapper struct {
 	// Delegate is the RESTMapper to use to locate all the Kind and Resource matches
 	Delegate RESTMapper
@@ -98,7 +98,7 @@ func ToPriorityRESTMapperWithContext(m PriorityRESTMapper) PriorityRESTMapperWit
 //
 // PriorityRESTMapperWithContext.ResourceForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use PriorityRESTMapperWithContext.ResourceForWithContext instead.
+//logcheck:context // Use PriorityRESTMapperWithContext.ResourceForWithContext instead of ResourceFor in code which supports contextual logging.
 func (m PriorityRESTMapper) ResourceFor(partiallySpecifiedResource schema.GroupVersionResource) (schema.GroupVersionResource, error) {
 	return ToPriorityRESTMapperWithContext(m).ResourceForWithContext(context.Background(), partiallySpecifiedResource)
 }
@@ -107,49 +107,49 @@ func (m PriorityRESTMapper) ResourceFor(partiallySpecifiedResource schema.GroupV
 //
 // PriorityRESTMapperWithContext.KindForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use PriorityRESTMapperWithContext.KindForWithContext instead.
+//logcheck:context // Use PriorityRESTMapperWithContext.KindForWithContext instead of KindFor in code which supports contextual logging.
 func (m PriorityRESTMapper) KindFor(partiallySpecifiedResource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
 	return ToPriorityRESTMapperWithContext(m).KindForWithContext(context.Background(), partiallySpecifiedResource)
 }
 
 // PriorityRESTMapperWithContext.RESTMappingWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use PriorityRESTMapperWithContext.RESTMappingWithContext instead.
+//logcheck:context // Use PriorityRESTMapperWithContext.RESTMappingWithContext instead of RESTMapping in code which supports contextual logging.
 func (m PriorityRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (mapping *RESTMapping, err error) {
 	return ToPriorityRESTMapperWithContext(m).RESTMappingWithContext(context.Background(), gk, versions...)
 }
 
 // PriorityRESTMapperWithContext.RESTMappingsWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use PriorityRESTMapperWithContext.RESTMappingsWithContext instead.
+//logcheck:context // Use PriorityRESTMapperWithContext.RESTMappingsWithContext instead of RESTMappings in code which supports contextual logging.
 func (m PriorityRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*RESTMapping, error) {
 	return m.Delegate.RESTMappings(gk, versions...)
 }
 
 // PriorityRESTMapperWithContext.ResourceSingularizerWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use PriorityRESTMapperWithContext.ResourceSingularizerWithContext instead.
+//logcheck:context // Use PriorityRESTMapperWithContext.ResourceSingularizerWithContext instead of ResourceSingularizer in code which supports contextual logging.
 func (m PriorityRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
 	return m.Delegate.ResourceSingularizer(resource)
 }
 
 // PriorityRESTMapperWithContext.ResourcesForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use PriorityRESTMapperWithContext.ResourcesForWithContext instead.
+//logcheck:context // Use PriorityRESTMapperWithContext.ResourcesForWithContext instead of ResourcesFor in code which supports contextual logging.
 func (m PriorityRESTMapper) ResourcesFor(partiallySpecifiedResource schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
 	return m.Delegate.ResourcesFor(partiallySpecifiedResource)
 }
 
 // PriorityRESTMapperWithContext.KindsForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use PriorityRESTMapperWithContext.KindsForWithContext instead.
+//logcheck:context // Use PriorityRESTMapperWithContext.KindsForWithContext instead of KindsFor in code which supports contextual logging.
 func (m PriorityRESTMapper) KindsFor(partiallySpecifiedResource schema.GroupVersionResource) (gvk []schema.GroupVersionKind, err error) {
 	return m.Delegate.KindsFor(partiallySpecifiedResource)
 }
 
 // PriorityRESTMapperWithContext.ResetWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use PriorityRESTMapperWithContext.ResetWithContext instead.
+//logcheck:context // Use PriorityRESTMapperWithContext.ResetWithContext instead of Reset in code which supports contextual logging.
 func (m PriorityRESTMapper) Reset() {
 	MaybeResetRESTMapper(m.Delegate)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/priority_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/priority_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestPriorityRESTMapperResourceForErrorHandling(t *testing.T) {
@@ -120,10 +121,11 @@ func TestPriorityRESTMapperResourceForErrorHandling(t *testing.T) {
 		},
 	}
 
+	_, ctx := ktesting.NewTestContext(t)
 	for _, tc := range tcs {
-		mapper := PriorityRESTMapper{Delegate: tc.delegate, ResourcePriority: tc.resourcePatterns}
+		mapper := ToPriorityRESTMapperWithContext(PriorityRESTMapper{Delegate: tc.delegate, ResourcePriority: tc.resourcePatterns})
 
-		actualResult, actualErr := mapper.ResourceFor(schema.GroupVersionResource{})
+		actualResult, actualErr := mapper.ResourceForWithContext(ctx, schema.GroupVersionResource{})
 		if e, a := tc.result, actualResult; e != a {
 			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
 		}
@@ -239,10 +241,11 @@ func TestPriorityRESTMapperKindForErrorHandling(t *testing.T) {
 		},
 	}
 
+	_, ctx := ktesting.NewTestContext(t)
 	for _, tc := range tcs {
-		mapper := PriorityRESTMapper{Delegate: tc.delegate, KindPriority: tc.kindPatterns}
+		mapper := ToPriorityRESTMapperWithContext(PriorityRESTMapper{Delegate: tc.delegate, KindPriority: tc.kindPatterns})
 
-		actualResult, actualErr := mapper.KindFor(schema.GroupVersionResource{})
+		actualResult, actualErr := mapper.KindForWithContext(ctx, schema.GroupVersionResource{})
 		if e, a := tc.result, actualResult; e != a {
 			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
 		}
@@ -354,8 +357,9 @@ func TestPriorityRESTMapperRESTMapping(t *testing.T) {
 		},
 	}
 
+	_, ctx := ktesting.NewTestContext(t)
 	for _, tc := range tcs {
-		actualResult, actualErr := tc.mapper.RESTMapping(tc.input)
+		actualResult, actualErr := ToPriorityRESTMapperWithContext(tc.mapper).RESTMappingWithContext(ctx, tc.input)
 		if e, a := tc.result, actualResult; !reflect.DeepEqual(e, a) {
 			t.Errorf("%s: expected %v, got %v", tc.name, e, a)
 		}
@@ -384,12 +388,13 @@ func TestPriorityRESTMapperRESTMappingHonorsUserVersion(t *testing.T) {
 		fixedRESTMapper{mappings: []*RESTMapping{mappingV1}},
 	}
 
-	mapper := PriorityRESTMapper{
+	mapper := ToPriorityRESTMapperWithContext(PriorityRESTMapper{
 		Delegate:     allMappers,
 		KindPriority: []schema.GroupVersionKind{{Group: "Bar", Version: "v2alpha1", Kind: AnyKind}, {Group: "Bar", Version: AnyVersion, Kind: AnyKind}},
-	}
+	})
+	_, ctx := ktesting.NewTestContext(t)
 
-	outMapping1, err := mapper.RESTMapping(schema.GroupKind{Group: "Bar", Kind: "Foo"}, "v1")
+	outMapping1, err := mapper.RESTMappingWithContext(ctx, schema.GroupKind{Group: "Bar", Kind: "Foo"}, "v1")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -398,7 +403,7 @@ func TestPriorityRESTMapperRESTMappingHonorsUserVersion(t *testing.T) {
 		t.Errorf("asked for version %v, expected mapping for %v, got mapping for %v", "v1", mappingV1.GroupVersionKind, outMapping1.GroupVersionKind)
 	}
 
-	outMapping2, err := mapper.RESTMapping(schema.GroupKind{Group: "Bar", Kind: "Foo"}, "v2alpha1")
+	outMapping2, err := mapper.RESTMappingWithContext(ctx, schema.GroupKind{Group: "Bar", Kind: "Foo"}, "v2alpha1")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -556,7 +556,7 @@ func (m *DefaultRESTMapper) RESTMappingsWithContext(_ context.Context, gk schema
 //
 // MaybeResetRESTMapperWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use MaybeResetRESTMapperWithContext instead.
+//logcheck:context // Use MaybeResetRESTMapperWithContext instead of MaybeResetRESTMapper in code which supports contextual logging.
 func MaybeResetRESTMapper(mapper RESTMapper) {
 	maybeReset(context.Background(), mapper)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/wsstream.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/wsstream.go
@@ -54,8 +54,9 @@ func IsWebSocketRequestWithTunnelingProtocol(req *http.Request) bool {
 	return streamws.IsWebSocketRequestWithTunnelingProtocol(req)
 }
 
+//logcheck:context // IgnoreReceivesWithLogger should be used instead of IgnoreReceives in code which uses contextual logging.
 func IgnoreReceives(ws *websocket.Conn, timeout time.Duration) {
-	streamws.IgnoreReceives(ws, timeout)
+	streamws.IgnoreReceivesWithLogger(klog.Background(), ws, timeout)
 }
 
 func IgnoreReceivesWithLogger(logger klog.Logger, ws *websocket.Conn, timeout time.Duration) {

--- a/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go
@@ -53,7 +53,7 @@ var PanicHandlers = []func(context.Context, interface{}){logPanic}
 //
 // E.g., you can provide one or more additional handlers for something like shutting down go routines gracefully.
 //
-// Contextual logging: HandleCrashWithContext or HandleCrashWithLogger should be used instead of HandleCrash in code which supports contextual logging.
+//logcheck:context // HandleCrashWithContext or HandleCrashWithLogger should be used instead of HandleCrash in code which supports contextual logging.
 func HandleCrash(additionalHandlers ...func(interface{})) {
 	if r := recover(); r != nil {
 		additionalHandlersWithContext := make([]func(context.Context, interface{}), len(additionalHandlers))

--- a/staging/src/k8s.io/apimachinery/pkg/watch/filter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/filter_test.go
@@ -21,9 +21,11 @@ import (
 	"testing"
 
 	. "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestFilter(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	table := []Event{
 		{Type: Added, Object: testType("foo")},
 		{Type: Added, Object: testType("bar")},
@@ -32,7 +34,7 @@ func TestFilter(t *testing.T) {
 		{Type: Added, Object: testType("zoo")},
 	}
 
-	source := NewFake()
+	source := NewFakeWithOptions(FakeOptions{Logger: &logger})
 	filtered := Filter(source, func(e Event) (Event, bool) {
 		return e, e.Object.(testType)[0] != 'b'
 	})
@@ -59,7 +61,8 @@ func TestFilter(t *testing.T) {
 }
 
 func TestFilterStop(t *testing.T) {
-	source := NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	source := NewFakeWithOptions(FakeOptions{Logger: &logger})
 	filtered := Filter(source, func(e Event) (Event, bool) {
 		return e, e.Object.(testType)[0] != 'b'
 	})
@@ -84,6 +87,7 @@ func TestFilterStop(t *testing.T) {
 }
 
 func TestRecorder(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	events := []Event{
 		{Type: Added, Object: testType("foo")},
 		{Type: Added, Object: testType("bar")},
@@ -92,7 +96,7 @@ func TestRecorder(t *testing.T) {
 		{Type: Added, Object: testType("zoo")},
 	}
 
-	source := NewFake()
+	source := NewFakeWithOptions(FakeOptions{Logger: &logger})
 	go func() {
 		for _, item := range events {
 			source.Action(item.Type, item.Object)

--- a/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/streamwatcher.go
@@ -61,7 +61,7 @@ type StreamWatcher struct {
 
 // NewStreamWatcher creates a StreamWatcher from the given decoder.
 //
-// Contextual logging: NewStreamWatcherWithLogger should be used instead of NewStreamWatcher in code which supports contextual logging.
+//logcheck:context // NewStreamWatcherWithLogger should be used instead of NewStreamWatcher in code which supports contextual logging.
 func NewStreamWatcher(d Decoder, r Reporter) *StreamWatcher {
 	return NewStreamWatcherWithLogger(klog.Background(), d, r)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
@@ -112,12 +112,12 @@ type FakeWatcher struct {
 
 var _ Interface = &FakeWatcher{}
 
-// Contextual logging: NewFakeWithOptions and a logger in the FakeOptions should be used instead in code which supports contextual logging.
+//logcheck:context // NewFakeWithOptions and a logger in the FakeOptions should be used instead in code which supports contextual logging.
 func NewFake() *FakeWatcher {
 	return NewFakeWithOptions(FakeOptions{}) //nolint:logcheck // Intentionally not providing Logger here.
 }
 
-// Contextual logging: NewFakeWithOptions and a logger in the FakeOptions should be used instead in code which supports contextual logging.
+//logcheck:context // NewFakeWithOptions and a logger in the FakeOptions should be used instead in code which supports contextual logging.
 func NewFakeWithChanSize(size int, blocking bool) *FakeWatcher {
 	return NewFakeWithOptions(FakeOptions{ChannelSize: size}) //nolint:logcheck // Intentionally not providing Logger here.
 }
@@ -198,7 +198,7 @@ type RaceFreeFakeWatcher struct {
 
 var _ Interface = &RaceFreeFakeWatcher{}
 
-// Contextual logging: RaceFreeFakeWatcherWithLogger should be used instead of NewRaceFreeFake in code which supports contextual logging.
+//logcheck:context // RaceFreeFakeWatcherWithLogger should be used instead of NewRaceFreeFake in code which supports contextual logging.
 func NewRaceFreeFake() *RaceFreeFakeWatcher {
 	return NewRaceFreeFakeWithLogger(klog.Background())
 }

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch.go
@@ -114,12 +114,12 @@ var _ Interface = &FakeWatcher{}
 
 // Contextual logging: NewFakeWithOptions and a logger in the FakeOptions should be used instead in code which supports contextual logging.
 func NewFake() *FakeWatcher {
-	return NewFakeWithOptions(FakeOptions{})
+	return NewFakeWithOptions(FakeOptions{}) //nolint:logcheck // Intentionally not providing Logger here.
 }
 
 // Contextual logging: NewFakeWithOptions and a logger in the FakeOptions should be used instead in code which supports contextual logging.
 func NewFakeWithChanSize(size int, blocking bool) *FakeWatcher {
-	return NewFakeWithOptions(FakeOptions{ChannelSize: size})
+	return NewFakeWithOptions(FakeOptions{ChannelSize: size}) //nolint:logcheck // Intentionally not providing Logger here.
 }
 
 func NewFakeWithOptions(options FakeOptions) *FakeWatcher {

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	. "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2/ktesting"
 )
 
 type testType string
@@ -78,7 +79,8 @@ func TestFake(t *testing.T) {
 }
 
 func TestRaceFreeFake(t *testing.T) {
-	f := NewRaceFreeFake()
+	logger, _ := ktesting.NewTestContext(t)
+	f := NewRaceFreeFakeWithLogger(logger)
 
 	table := []struct {
 		t EventType

--- a/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/watch_test.go
@@ -32,7 +32,8 @@ func (obj testType) GetObjectKind() schema.ObjectKind { return schema.EmptyObjec
 func (obj testType) DeepCopyObject() runtime.Object   { return obj }
 
 func TestFake(t *testing.T) {
-	f := NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	f := NewFakeWithOptions(FakeOptions{Logger: &logger})
 
 	table := []struct {
 		t EventType

--- a/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/unstructured.go
+++ b/staging/src/k8s.io/client-go/applyconfigurations/meta/v1/unstructured.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -56,7 +57,7 @@ type gvkParserCache struct {
 
 // regenerateGVKParser builds the parser from the raw OpenAPI schema.
 func regenerateGVKParser(dc discovery.DiscoveryInterface) (*managedfields.GvkParser, error) {
-	doc, err := dc.OpenAPISchema()
+	doc, err := discovery.ToDiscoveryInterfaceWithContext(dc).OpenAPISchemaWithContext(context.TODO())
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -75,7 +75,7 @@ var (
 //
 // ServerResourcesForGroupVersionWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerResourcesForGroupVersionWithContext instead.
+//logcheck:context // Use ServerResourcesForGroupVersionWithContext instead of ServerResourcesForGroupVersion in code which supports contextual logging.
 func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
 	return d.ServerResourcesForGroupVersionWithContext(context.Background(), groupVersion)
 }
@@ -114,7 +114,7 @@ func (d *CachedDiscoveryClient) ServerResourcesForGroupVersionWithContext(ctx co
 //
 // ServerGroupsAndResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerGroupsAndResourcesWithContext instead.
+//logcheck:context // Use ServerGroupsAndResourcesWithContext instead of ServerGroupsAndResources in code which supports contextual logging.
 func (d *CachedDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return d.ServerGroupsAndResourcesWithContext(context.Background())
 }
@@ -129,7 +129,7 @@ func (d *CachedDiscoveryClient) ServerGroupsAndResourcesWithContext(ctx context.
 //
 // ServerGroupsWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerGroupsWithContext instead.
+//logcheck:context // Use ServerGroupsWithContext instead of ServerGroups in code which supports contextual logging.
 func (d *CachedDiscoveryClient) ServerGroups() (*metav1.APIGroupList, error) {
 	return d.ServerGroupsWithContext(context.Background())
 }
@@ -255,7 +255,7 @@ func (d *CachedDiscoveryClient) RESTClient() restclient.Interface {
 //
 // ServerPreferredResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerPreferredResourcesWithContext instead.
+//logcheck:context // Use ServerPreferredResourcesWithContext instead of ServerPreferredResources in code which supports contextual logging.
 func (d *CachedDiscoveryClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
 	return d.ServerPreferredResourcesWithContext(context.Background())
 }
@@ -271,7 +271,7 @@ func (d *CachedDiscoveryClient) ServerPreferredResourcesWithContext(ctx context.
 //
 // ServerPreferredNamespacedResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerPreferredNamespacedResourcesWithContext instead.
+//logcheck:context // Use ServerPreferredNamespacedResourcesWithContext instead of ServerPreferredNamespacedResources in code which supports contextual logging.
 func (d *CachedDiscoveryClient) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
 	return d.ServerPreferredNamespacedResourcesWithContext(context.Background())
 }
@@ -286,7 +286,7 @@ func (d *CachedDiscoveryClient) ServerPreferredNamespacedResourcesWithContext(ct
 //
 // ServerVersionWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerVersionWithContext instead.
+//logcheck:context // Use ServerVersionWithContext instead of ServerVersion in code which supports contextual logging.
 func (d *CachedDiscoveryClient) ServerVersion() (*version.Info, error) {
 	return d.ServerVersionWithContext(context.Background())
 }
@@ -300,7 +300,7 @@ func (d *CachedDiscoveryClient) ServerVersionWithContext(ctx context.Context) (*
 //
 // OpenAPISchemaWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use OpenAPISchemaWithContext instead.
+//logcheck:context // Use OpenAPISchemaWithContext instead of OpenAPISchema in code which supports contextual logging.
 func (d *CachedDiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
 	return d.OpenAPISchemaWithContext(context.Background())
 }
@@ -339,7 +339,7 @@ func (d *CachedDiscoveryClient) openAPIV3(ctx context.Context) *cachedopenapi.Cl
 //
 // FreshWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use FreshWithContext instead.
+//logcheck:context // Use FreshWithContext instead of Fresh in code which supports contextual logging.
 func (d *CachedDiscoveryClient) Fresh() bool {
 	return d.FreshWithContext(context.Background())
 }
@@ -357,7 +357,7 @@ func (d *CachedDiscoveryClient) FreshWithContext(ctx context.Context) bool {
 //
 // InvalidateWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use InvalidateWithContext instead.
+//logcheck:context // Use InvalidateWithContext instead of Invalidate in code which supports contextual logging.
 func (d *CachedDiscoveryClient) Invalidate() {
 	d.InvalidateWithContext(context.Background())
 }

--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery_test.go
@@ -42,9 +42,11 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	testutil "k8s.io/client-go/util/testing"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestCachedDiscoveryClient_Fresh(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	assert := assert.New(t)
 
 	d, err := os.MkdirTemp("", "")
@@ -53,42 +55,43 @@ func TestCachedDiscoveryClient_Fresh(t *testing.T) {
 
 	c := fakeDiscoveryClient{}
 	cdc := newCachedDiscoveryClient(discovery.ToDiscoveryInterfaceWithContext(&c), d, 60*time.Second)
-	assert.True(cdc.Fresh(), "should be fresh after creation")
+	assert.True(cdc.FreshWithContext(ctx), "should be fresh after creation")
 
-	cdc.ServerGroups()
-	assert.True(cdc.Fresh(), "should be fresh after groups call without cache")
+	_, _ = cdc.ServerGroupsWithContext(ctx)
+	assert.True(cdc.FreshWithContext(ctx), "should be fresh after groups call without cache")
 	assert.Equal(1, c.groupCalls)
 
-	cdc.ServerGroups()
-	assert.True(cdc.Fresh(), "should be fresh after another groups call")
+	_, _ = cdc.ServerGroupsWithContext(ctx)
+	assert.True(cdc.FreshWithContext(ctx), "should be fresh after another groups call")
 	assert.Equal(1, c.groupCalls)
 
-	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should be fresh after resources call")
+	_, _, _ = cdc.ServerGroupsAndResourcesWithContext(ctx)
+	assert.True(cdc.FreshWithContext(ctx), "should be fresh after resources call")
 	assert.Equal(1, c.resourceCalls)
 
-	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should be fresh after another resources call")
+	_, _, _ = cdc.ServerGroupsAndResourcesWithContext(ctx)
+	assert.True(cdc.FreshWithContext(ctx), "should be fresh after another resources call")
 	assert.Equal(1, c.resourceCalls)
 
 	cdc = newCachedDiscoveryClient(discovery.ToDiscoveryInterfaceWithContext(&c), d, 60*time.Second)
-	cdc.ServerGroups()
-	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing groups cache")
+	_, _ = cdc.ServerGroupsWithContext(ctx)
+	assert.False(cdc.FreshWithContext(ctx), "should NOT be fresh after recreation with existing groups cache")
 	assert.Equal(1, c.groupCalls)
 
-	cdc.ServerGroupsAndResources()
-	assert.False(cdc.Fresh(), "should NOT be fresh after recreation with existing resources cache")
+	_, _, _ = cdc.ServerGroupsAndResourcesWithContext(ctx)
+	assert.False(cdc.FreshWithContext(ctx), "should NOT be fresh after recreation with existing resources cache")
 	assert.Equal(1, c.resourceCalls)
 
-	cdc.Invalidate()
-	assert.True(cdc.Fresh(), "should be fresh after cache invalidation")
+	cdc.InvalidateWithContext(ctx)
+	assert.True(cdc.FreshWithContext(ctx), "should be fresh after cache invalidation")
 
-	cdc.ServerGroupsAndResources()
-	assert.True(cdc.Fresh(), "should ignore existing resources cache after invalidation")
+	_, _, _ = cdc.ServerGroupsAndResourcesWithContext(ctx)
+	assert.True(cdc.FreshWithContext(ctx), "should ignore existing resources cache after invalidation")
 	assert.Equal(2, c.resourceCalls)
 }
 
 func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	assert := assert.New(t)
 
 	d, err := os.MkdirTemp("", "")
@@ -97,16 +100,17 @@ func TestNewCachedDiscoveryClient_TTL(t *testing.T) {
 
 	c := fakeDiscoveryClient{}
 	cdc := newCachedDiscoveryClient(discovery.ToDiscoveryInterfaceWithContext(&c), d, 1*time.Nanosecond)
-	cdc.ServerGroups()
+	_, _ = cdc.ServerGroupsWithContext(ctx)
 	assert.Equal(1, c.groupCalls)
 
 	time.Sleep(1 * time.Second)
 
-	cdc.ServerGroups()
+	_, _ = cdc.ServerGroupsWithContext(ctx)
 	assert.Equal(2, c.groupCalls)
 }
 
 func TestNewCachedDiscoveryClient_PathPerm(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	assert := assert.New(t)
 
 	d, err := os.MkdirTemp("", "")
@@ -116,7 +120,7 @@ func TestNewCachedDiscoveryClient_PathPerm(t *testing.T) {
 
 	c := fakeDiscoveryClient{}
 	cdc := newCachedDiscoveryClient(discovery.ToDiscoveryInterfaceWithContext(&c), d, 1*time.Nanosecond)
-	cdc.ServerGroups()
+	_, _ = cdc.ServerGroupsWithContext(ctx)
 
 	err = filepath.Walk(d, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -135,6 +139,7 @@ func TestNewCachedDiscoveryClient_PathPerm(t *testing.T) {
 // Tests that schema instances returned by openapi cached and returned after
 // successive calls
 func TestOpenAPIDiskCache(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	// Create discovery cache dir (unused)
 	discoCache, err := os.MkdirTemp("", "test-cached-discovery-client-disco-*")
 	require.NoError(t, err)
@@ -203,7 +208,7 @@ func TestOpenAPIDiskCache(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, 1, fakeServer.RequestCounters[path])
 
-				client.Invalidate()
+				client.InvalidateWithContext(ctx)
 
 				// Refetch the schema from a new openapi client to try to force a new
 				// http request
@@ -224,6 +229,7 @@ func TestOpenAPIDiskCache(t *testing.T) {
 
 // Tests function "ServerGroups" when the "unaggregated" discovery is returned.
 func TestCachedDiscoveryClientUnaggregatedServerGroups(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := []struct {
 		name                  string
 		corev1                *metav1.APIVersions
@@ -367,7 +373,7 @@ func TestCachedDiscoveryClientUnaggregatedServerGroups(t *testing.T) {
 			1*time.Nanosecond,
 		)
 		require.NoError(t, err)
-		apiGroupList, err := client.ServerGroups()
+		apiGroupList, err := client.ServerGroupsWithContext(ctx)
 		require.NoError(t, err)
 		// Discovery groups cached in servergroups.json file.
 		numFound, err := numFilesFound(discoCache, "servergroups.json")
@@ -389,6 +395,7 @@ func TestCachedDiscoveryClientUnaggregatedServerGroups(t *testing.T) {
 
 // Aggregated discovery format returned
 func TestCachedDiscoveryClientAggregatedServerGroups(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := []struct {
 		name                      string
 		corev1                    *apidiscovery.APIGroupDiscoveryList
@@ -658,7 +665,7 @@ func TestCachedDiscoveryClientAggregatedServerGroups(t *testing.T) {
 			1*time.Nanosecond,
 		)
 		require.NoError(t, err)
-		apiGroupList, err := client.ServerGroups()
+		apiGroupList, err := client.ServerGroupsWithContext(ctx)
 		require.NoError(t, err)
 		// Discovery groups cached in servergroups.json file.
 		numFound, err := numFilesFound(discoCache, "servergroups.json")

--- a/staging/src/k8s.io/client-go/discovery/cached/legacy.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/legacy.go
@@ -21,9 +21,11 @@ import (
 	"k8s.io/client-go/discovery/cached/memory"
 )
 
-// NewMemCacheClient is DEPRECATED. Use memory.NewMemCacheClient directly.
+// NewMemCacheClient is DEPRECATED. Use memory.NewMemCacheClientWithContext directly.
+//
+//logcheck:context // Use memory.NewMemCacheClientWithContext instead of NewMemCacheClient in code which supports contextual logging.
 func NewMemCacheClient(delegate discovery.DiscoveryInterface) discovery.CachedDiscoveryInterface {
-	return memory.NewMemCacheClient(delegate)
+	return memory.NewMemCacheClient(delegate) //nolint:logcheck // This whole package is deprecated in favor of the memory package.
 }
 
 // ErrCacheNotFound is DEPRECATED. Use memory.ErrCacheNotFound directly.

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
@@ -144,7 +144,7 @@ func (d *memCacheClient) ServerResourcesForGroupVersionWithContext(ctx context.C
 //
 // ServerGroupsAndResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerGroupsAndResourcesWithContext instead.
+//logcheck:context // Use ServerGroupsAndResourcesWithContext instead of ServerGroupsAndResources in code which supports contextual logging.
 func (d *memCacheClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return d.ServerGroupsAndResourcesWithContext(context.Background())
 }
@@ -160,7 +160,7 @@ func (d *memCacheClient) ServerGroupsAndResourcesWithContext(ctx context.Context
 //
 // GroupsAndMaybeResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use GroupsAndMaybeResourcesWithContext instead.
+//logcheck:context // Use GroupsAndMaybeResourcesWithContext instead of GroupsAndMaybeResources in code which supports contextual logging.
 func (d *memCacheClient) GroupsAndMaybeResources() (*metav1.APIGroupList, map[schema.GroupVersion]*metav1.APIResourceList, map[schema.GroupVersion]error, error) {
 	return d.GroupsAndMaybeResourcesWithContext(context.Background())
 }
@@ -204,7 +204,7 @@ func (d *memCacheClient) GroupsAndMaybeResourcesWithContext(ctx context.Context)
 
 // ServerGroupsWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerGroupsWithContext instead.
+//logcheck:context // Use ServerGroupsWithContext instead of ServerGroups in code which supports contextual logging.
 func (d *memCacheClient) ServerGroups() (*metav1.APIGroupList, error) {
 	return d.ServerGroupsWithContext(context.Background())
 }
@@ -223,7 +223,7 @@ func (d *memCacheClient) RESTClient() restclient.Interface {
 
 // ServerPreferredResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerPreferredResourcesWithContext instead.
+//logcheck:context // Use ServerPreferredResourcesWithContext instead of ServerPreferredResources in code which supports contextual logging.
 func (d *memCacheClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
 	return d.ServerPreferredResourcesWithContext(context.Background())
 }
@@ -234,7 +234,7 @@ func (d *memCacheClient) ServerPreferredResourcesWithContext(ctx context.Context
 
 // ServerPreferredNamespacedResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerPreferredNamespacedResourcesWithContext instead.
+//logcheck:context // Use ServerPreferredNamespacedResourcesWithContext instead of ServerPreferredNamespacedResources in code which supports contextual logging.
 func (d *memCacheClient) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
 	return d.ServerPreferredNamespacedResourcesWithContext(context.Background())
 }
@@ -245,7 +245,7 @@ func (d *memCacheClient) ServerPreferredNamespacedResourcesWithContext(ctx conte
 
 // ServerVersionWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerVersionWithContext instead.
+//logcheck:context // Use ServerVersionWithContext instead of ServerVersion in code which supports contextual logging.
 func (d *memCacheClient) ServerVersion() (*version.Info, error) {
 	return d.ServerVersionWithContext(context.Background())
 }
@@ -256,7 +256,7 @@ func (d *memCacheClient) ServerVersionWithContext(ctx context.Context) (*version
 
 // OpenAPISchemaWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use OpenAPISchemaWithContext instead.
+//logcheck:context // Use OpenAPISchemaWithContext instead of OpenAPISchema in code which supports contextual logging.
 func (d *memCacheClient) OpenAPISchema() (*openapi_v2.Document, error) {
 	return d.OpenAPISchemaWithContext(context.Background())
 }
@@ -267,7 +267,7 @@ func (d *memCacheClient) OpenAPISchemaWithContext(ctx context.Context) (*openapi
 
 // OpenAPIV3WithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use OpenAPIV3WithContext instead.
+//logcheck:context // Use OpenAPIV3WithContext instead of OpenAPIV3 in code which supports contextual logging.
 func (d *memCacheClient) OpenAPIV3() openapi.Client {
 	return d.openAPIV3(context.Background())
 }
@@ -290,7 +290,7 @@ func (d *memCacheClient) openAPIV3(ctx context.Context) *cachedopenapi.Client {
 
 // FreshWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use FreshWithContext instead.
+//logcheck:context // Use FreshWithContext instead of Fresh in code which supports contextual logging.
 func (d *memCacheClient) Fresh() bool {
 	return d.FreshWithContext(context.Background())
 }
@@ -309,7 +309,7 @@ func (d *memCacheClient) FreshWithContext(ctx context.Context) bool {
 //
 // InvalidateWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use InvalidateWithContext instead.
+//logcheck:context // Use InvalidateWithContext instead of Invalidate in code which supports contextual logging.
 func (d *memCacheClient) Invalidate() {
 	d.InvalidateWithContext(context.Background())
 }
@@ -433,7 +433,7 @@ func (d *memCacheClient) serverResourcesForGroupVersion(ctx context.Context, gro
 //
 // WithLegacyWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use WithLegacyWithContext instead.
+//logcheck:context // Use WithLegacyWithContext instead of WithLegacy in code which supports contextual logging.
 func (d *memCacheClient) WithLegacy() discovery.DiscoveryInterface {
 	return d
 }
@@ -452,7 +452,7 @@ func (d *memCacheClient) WithLegacyWithContext(ctx context.Context) discovery.Di
 //
 // NewMemCacheClientWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use NewMemCacheClientWithContext instead.
+//logcheck:context // Use NewMemCacheClientWithContext instead of NewMemCacheClient in code which supports contextual logging.
 func NewMemCacheClient(delegate discovery.DiscoveryInterface) discovery.CachedDiscoveryInterface {
 	return newMemCacheClient(discovery.ToDiscoveryInterfaceWithContext(delegate))
 }

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -147,36 +147,37 @@ func TestClient(t *testing.T) {
 }
 
 func testClient(t *testing.T, fake *fakeDiscovery, delegate discovery.DiscoveryInterface) {
-	c := NewMemCacheClient(delegate)
-	if c.Fresh() {
+	_, ctx := ktesting.NewTestContext(t)
+	c := NewMemCacheClientWithContext(discovery.ToDiscoveryInterfaceWithContext(delegate))
+	if c.FreshWithContext(ctx) {
 		t.Errorf("Expected not fresh.")
 	}
-	g, err := c.ServerGroups()
+	g, err := c.ServerGroupsWithContext(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if e, a := fake.groupList, g; !reflect.DeepEqual(e, a) {
 		t.Errorf("Expected %#v, got %#v", e, a)
 	}
-	if !c.Fresh() {
+	if !c.FreshWithContext(ctx) {
 		t.Errorf("Expected fresh.")
 	}
-	c.Invalidate()
-	if c.Fresh() {
+	c.InvalidateWithContext(ctx)
+	if c.FreshWithContext(ctx) {
 		t.Errorf("Expected not fresh.")
 	}
 
-	g, err = c.ServerGroups()
+	g, err = c.ServerGroupsWithContext(ctx)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if e, a := fake.groupList, g; !reflect.DeepEqual(e, a) {
 		t.Errorf("Expected %#v, got %#v", e, a)
 	}
-	if !c.Fresh() {
+	if !c.FreshWithContext(ctx) {
 		t.Errorf("Expected fresh.")
 	}
-	r, err := c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	r, err := c.ServerResourcesForGroupVersionWithContext(ctx, "astronomy/v8beta1")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -201,8 +202,8 @@ func testClient(t *testing.T, fake *fakeDiscovery, delegate discovery.DiscoveryI
 	}
 	fake.lock.Unlock()
 
-	c.Invalidate()
-	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	c.InvalidateWithContext(ctx)
+	r, err = c.ServerResourcesForGroupVersionWithContext(ctx, "astronomy/v8beta1")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -295,28 +296,29 @@ func TestServerGroupsFails(t *testing.T) {
 		},
 	}
 
-	c := NewMemCacheClient(fake)
-	if c.Fresh() {
+	c := NewMemCacheClientWithContext(discovery.ToDiscoveryInterfaceWithContext(fake))
+	_, ctx := ktesting.NewTestContext(t)
+	if c.FreshWithContext(ctx) {
 		t.Errorf("Expected not fresh.")
 	}
-	_, err := c.ServerGroups()
+	_, err := c.ServerGroupsWithContext(ctx)
 	if err == nil {
 		t.Errorf("Expected error")
 	}
-	if c.Fresh() {
+	if c.FreshWithContext(ctx) {
 		t.Errorf("Expected not fresh.")
 	}
 	fake.lock.Lock()
 	fake.groupListErr = nil
 	fake.lock.Unlock()
-	r, err := c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	r, err := c.ServerResourcesForGroupVersionWithContext(ctx, "astronomy/v8beta1")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
 		t.Errorf("Expected %#v, got %#v", e, a)
 	}
-	if !c.Fresh() {
+	if !c.FreshWithContext(ctx) {
 		t.Errorf("Expected not fresh.")
 	}
 }
@@ -360,18 +362,19 @@ func TestPartialPermanentFailure(t *testing.T) {
 		},
 	}
 
-	c := NewMemCacheClient(fake)
-	if c.Fresh() {
+	c := NewMemCacheClientWithContext(discovery.ToDiscoveryInterfaceWithContext(fake))
+	_, ctx := ktesting.NewTestContext(t)
+	if c.FreshWithContext(ctx) {
 		t.Errorf("Expected not fresh.")
 	}
-	r, err := c.ServerResourcesForGroupVersion("astronomy2/v8beta1")
+	r, err := c.ServerResourcesForGroupVersionWithContext(ctx, "astronomy2/v8beta1")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if e, a := fake.resourceMap["astronomy2/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
 		t.Errorf("Expected %#v, got %#v", e, a)
 	}
-	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	_, err = c.ServerResourcesForGroupVersionWithContext(ctx, "astronomy/v8beta1")
 	if err == nil {
 		t.Errorf("Expected error, got nil")
 	}
@@ -392,14 +395,14 @@ func TestPartialPermanentFailure(t *testing.T) {
 	}
 	fake.lock.Unlock()
 	// We don't retry permanent errors, so it should fail.
-	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	_, err = c.ServerResourcesForGroupVersionWithContext(ctx, "astronomy/v8beta1")
 	if err == nil {
 		t.Errorf("Expected error, got nil")
 	}
-	c.Invalidate()
+	c.InvalidateWithContext(ctx)
 
 	// After Invalidate, we should retry.
-	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	r, err = c.ServerResourcesForGroupVersionWithContext(ctx, "astronomy/v8beta1")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -453,18 +456,19 @@ func TestPartialRetryableFailure(t *testing.T) {
 		},
 	}
 
-	c := NewMemCacheClient(fake)
-	if c.Fresh() {
+	c := NewMemCacheClientWithContext(discovery.ToDiscoveryInterfaceWithContext(fake))
+	_, ctx := ktesting.NewTestContext(t)
+	if c.FreshWithContext(ctx) {
 		t.Errorf("Expected not fresh.")
 	}
-	r, err := c.ServerResourcesForGroupVersion("astronomy2/v8beta1")
+	r, err := c.ServerResourcesForGroupVersionWithContext(ctx, "astronomy2/v8beta1")
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 	if e, a := fake.resourceMap["astronomy2/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
 		t.Errorf("Expected %#v, got %#v", e, a)
 	}
-	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	_, err = c.ServerResourcesForGroupVersionWithContext(ctx, "astronomy/v8beta1")
 	if err == nil {
 		t.Errorf("Expected error, got nil")
 	}
@@ -486,7 +490,7 @@ func TestPartialRetryableFailure(t *testing.T) {
 	fake.lock.Unlock()
 	// We should retry retryable error even without Invalidate() being called,
 	// so no error is expected.
-	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	r, err = c.ServerResourcesForGroupVersionWithContext(ctx, "astronomy/v8beta1")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -498,7 +502,7 @@ func TestPartialRetryableFailure(t *testing.T) {
 	fake.lock.Lock()
 	fake.resourceMap["astronomy/v8beta1"].err = errors.New("some permanent error")
 	fake.lock.Unlock()
-	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	r, err = c.ServerResourcesForGroupVersionWithContext(ctx, "astronomy/v8beta1")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -510,20 +514,23 @@ func TestPartialRetryableFailure(t *testing.T) {
 // Tests that schema instances returned by openapi cached and returned after
 // successive calls
 func TestOpenAPIMemCache(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	fakeServer, err := testutil.NewFakeOpenAPIV3Server("../../testdata")
 	require.NoError(t, err)
 	defer fakeServer.HttpServer.Close()
 
 	require.NotEmpty(t, fakeServer.ServedDocuments)
 
-	client := NewMemCacheClient(
-		discovery.NewDiscoveryClientForConfigOrDie(
-			&rest.Config{Host: fakeServer.HttpServer.URL},
+	client := NewMemCacheClientWithContext(
+		discovery.ToDiscoveryInterfaceWithContext(
+			discovery.NewDiscoveryClientForConfigOrDie(
+				&rest.Config{Host: fakeServer.HttpServer.URL},
+			),
 		),
 	)
-	openapiClient := client.OpenAPIV3()
+	openapiClient := client.OpenAPIV3WithContext(ctx)
 
-	paths, err := openapiClient.Paths()
+	paths, err := openapiClient.PathsWithContext(ctx)
 	require.NoError(t, err)
 
 	contentTypes := []string{
@@ -533,19 +540,19 @@ func TestOpenAPIMemCache(t *testing.T) {
 	for _, contentType := range contentTypes {
 		t.Run(contentType, func(t *testing.T) {
 			for k, v := range paths {
-				original, err := v.Schema(contentType)
+				original, err := v.SchemaWithContext(ctx, contentType)
 				if !assert.NoError(t, err) {
 					continue
 				}
 
 				// This is the original OpenAPI client. It is not affected
 				// by client.Invalidate() below.
-				pathsAgain, err := openapiClient.Paths()
+				pathsAgain, err := openapiClient.PathsWithContext(ctx)
 				if !assert.NoError(t, err) {
 					continue
 				}
 
-				schemaAgain, err := pathsAgain[k].Schema(contentType)
+				schemaAgain, err := pathsAgain[k].SchemaWithContext(ctx, contentType)
 				if !assert.NoError(t, err) {
 					continue
 				}
@@ -555,14 +562,14 @@ func TestOpenAPIMemCache(t *testing.T) {
 				assert.Equal(t, reflect.ValueOf(original).Pointer(), reflect.ValueOf(schemaAgain).Pointer())
 
 				// Invalidate and try again. This time pointers should not be equal
-				client.Invalidate()
+				client.InvalidateWithContext(ctx)
 
-				pathsAgain, err = client.OpenAPIV3().Paths()
+				pathsAgain, err = client.OpenAPIV3WithContext(ctx).PathsWithContext(ctx)
 				if !assert.NoError(t, err) {
 					continue
 				}
 
-				schemaAgain, err = pathsAgain[k].Schema(contentType)
+				schemaAgain, err = pathsAgain[k].SchemaWithContext(ctx, contentType)
 				if !assert.NoError(t, err) {
 					continue
 				}
@@ -647,6 +654,7 @@ func TestOpenAPIMemCacheWithContext(t *testing.T) {
 
 // Tests function "GroupsAndMaybeResources" when the "unaggregated" discovery is returned.
 func TestMemCacheGroupsAndMaybeResources(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := []struct {
 		name                  string
 		corev1                *metav1.APIVersions
@@ -778,14 +786,14 @@ func TestMemCacheGroupsAndMaybeResources(t *testing.T) {
 			delegate:               client,
 			groupToServerResources: map[string]*cacheEntry{},
 		}
-		assert.False(t, memClient.Fresh())
-		apiGroupList, resourcesMap, failedGVs, err := memClient.GroupsAndMaybeResources()
+		assert.False(t, memClient.FreshWithContext(ctx))
+		apiGroupList, resourcesMap, failedGVs, err := memClient.GroupsAndMaybeResourcesWithContext(ctx)
 		require.NoError(t, err)
 		// "Unaggregated" discovery always returns nil for resources.
 		assert.Nil(t, resourcesMap)
 		assert.Emptyf(t, failedGVs, "expected empty failed GroupVersions, got (%d)", len(failedGVs))
 		assert.False(t, memClient.receivedAggregatedDiscovery)
-		assert.True(t, memClient.Fresh())
+		assert.True(t, memClient.FreshWithContext(ctx))
 		// Test the expected groups are returned for the aggregated format.
 		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
 		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
@@ -797,9 +805,9 @@ func TestMemCacheGroupsAndMaybeResources(t *testing.T) {
 		assert.True(t, expectedGroupVersions.Equal(actualGroupVersions),
 			"%s: Expected group/versions (%s), got (%s)", test.name, expectedGroupVersions.List(), actualGroupVersions.List())
 		// Invalidate the cache and retrieve the server groups and resources again.
-		memClient.Invalidate()
-		assert.False(t, memClient.Fresh())
-		apiGroupList, resourcesMap, _, err = memClient.GroupsAndMaybeResources()
+		memClient.InvalidateWithContext(ctx)
+		assert.False(t, memClient.FreshWithContext(ctx))
+		apiGroupList, resourcesMap, _, err = memClient.GroupsAndMaybeResourcesWithContext(ctx)
 		require.NoError(t, err)
 		assert.Nil(t, resourcesMap)
 		assert.False(t, memClient.receivedAggregatedDiscovery)
@@ -812,6 +820,7 @@ func TestMemCacheGroupsAndMaybeResources(t *testing.T) {
 
 // Tests function "GroupsAndMaybeResources" when the "aggregated" discovery is returned.
 func TestAggregatedMemCacheGroupsAndMaybeResources(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := []struct {
 		name                  string
 		corev1                *apidiscovery.APIGroupDiscoveryList
@@ -1310,11 +1319,11 @@ func TestAggregatedMemCacheGroupsAndMaybeResources(t *testing.T) {
 			delegate:               client,
 			groupToServerResources: map[string]*cacheEntry{},
 		}
-		assert.False(t, memClient.Fresh())
-		apiGroupList, resourcesMap, failedGVs, err := memClient.GroupsAndMaybeResources()
+		assert.False(t, memClient.FreshWithContext(ctx))
+		apiGroupList, resourcesMap, failedGVs, err := memClient.GroupsAndMaybeResourcesWithContext(ctx)
 		require.NoError(t, err)
 		assert.True(t, memClient.receivedAggregatedDiscovery)
-		assert.True(t, memClient.Fresh())
+		assert.True(t, memClient.FreshWithContext(ctx))
 		// Test the expected groups are returned for the aggregated format.
 		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
 		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
@@ -1340,9 +1349,9 @@ func TestAggregatedMemCacheGroupsAndMaybeResources(t *testing.T) {
 		assert.True(t, expectedFailedGVs.Equal(actualFailedGVs),
 			"%s: Expected Failed GroupVersions (%s), got (%s)", test.name, expectedFailedGVs.List(), actualFailedGVs.List())
 		// Invalidate the cache and retrieve the server groups again.
-		memClient.Invalidate()
-		assert.False(t, memClient.Fresh())
-		apiGroupList, _, _, err = memClient.GroupsAndMaybeResources()
+		memClient.InvalidateWithContext(ctx)
+		assert.False(t, memClient.FreshWithContext(ctx))
+		apiGroupList, _, _, err = memClient.GroupsAndMaybeResourcesWithContext(ctx)
 
 		require.NoError(t, err)
 		// Test the expected groups are returned for the aggregated format.
@@ -1354,6 +1363,7 @@ func TestAggregatedMemCacheGroupsAndMaybeResources(t *testing.T) {
 
 // Tests function "ServerGroups" when the "aggregated" discovery is returned.
 func TestMemCacheAggregatedServerGroups(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := []struct {
 		name                      string
 		corev1                    *apidiscovery.APIGroupDiscoveryList
@@ -1607,11 +1617,11 @@ func TestMemCacheAggregatedServerGroups(t *testing.T) {
 		}))
 		defer server.Close()
 		client := discovery.NewDiscoveryClientForConfigOrDie(&rest.Config{Host: server.URL})
-		memCacheClient := NewMemCacheClient(client)
-		assert.False(t, memCacheClient.Fresh())
-		apiGroupList, err := memCacheClient.ServerGroups()
+		memCacheClient := NewMemCacheClientWithContext(discovery.ToDiscoveryInterfaceWithContext(client))
+		assert.False(t, memCacheClient.FreshWithContext(ctx))
+		apiGroupList, err := memCacheClient.ServerGroupsWithContext(ctx)
 		require.NoError(t, err)
-		assert.True(t, memCacheClient.Fresh())
+		assert.True(t, memCacheClient.FreshWithContext(ctx))
 		// Test the expected groups are returned for the aggregated format.
 		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
 		actualGroupNames := sets.NewString(groupNamesFromList(apiGroupList)...)
@@ -1628,9 +1638,9 @@ func TestMemCacheAggregatedServerGroups(t *testing.T) {
 		assert.True(t, expectedPreferredVersions.Equal(actualPreferredVersions),
 			"%s: Expected preferred group/version (%s), got (%s)", test.name, expectedPreferredVersions.List(), actualPreferredVersions.List())
 		// Invalidate the cache and retrieve the server groups again.
-		memCacheClient.Invalidate()
-		assert.False(t, memCacheClient.Fresh())
-		apiGroupList, err = memCacheClient.ServerGroups()
+		memCacheClient.InvalidateWithContext(ctx)
+		assert.False(t, memCacheClient.FreshWithContext(ctx))
+		apiGroupList, err = memCacheClient.ServerGroupsWithContext(ctx)
 		require.NoError(t, err)
 		// Test the expected groups are returned for the aggregated format.
 		actualGroupNames = sets.NewString(groupNamesFromList(apiGroupList)...)

--- a/staging/src/k8s.io/client-go/discovery/discovery_client.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client.go
@@ -76,7 +76,7 @@ var v2GVK = schema.GroupVersionKind{Group: "apidiscovery.k8s.io", Version: "v2",
 //
 // DiscoveryInterfaceWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use DiscoveryInterfaceWithContext instead.
+//logcheck:context // Use DiscoveryInterfaceWithContext instead of DiscoveryInterface in code which supports contextual logging.
 type DiscoveryInterface interface {
 	RESTClient() restclient.Interface
 	ServerGroupsInterface
@@ -90,7 +90,7 @@ type DiscoveryInterface interface {
 	//
 	// DiscoveryInterfaceWithContext.WithLegacyWithContext is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use DiscoveryInterfaceWithContext.WithLegacyWithContext instead.
+	//logcheck:context // Use DiscoveryInterfaceWithContext.WithLegacyWithContext instead of WithLegacy in code which supports contextual logging.
 	WithLegacy() DiscoveryInterface
 }
 
@@ -146,7 +146,7 @@ func (i *discoveryInterfaceWrapper) RESTClient() restclient.Interface {
 }
 
 func (i *discoveryInterfaceWrapper) WithLegacyWithContext(ctx context.Context) DiscoveryInterfaceWithContext {
-	return ToDiscoveryInterfaceWithContext(i.delegate.WithLegacy())
+	return ToDiscoveryInterfaceWithContext(i.delegate.WithLegacy()) //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 // AggregatedDiscoveryInterface extends DiscoveryInterface to include a method to possibly
@@ -155,13 +155,13 @@ func (i *discoveryInterfaceWrapper) WithLegacyWithContext(ctx context.Context) D
 //
 // AggregatedDiscoveryInterfaceWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use AggregatedDiscoveryInterfaceWithContext instead.
+//logcheck:context // Use AggregatedDiscoveryInterfaceWithContext instead of AggregatedDiscoveryInterface in code which supports contextual logging.
 type AggregatedDiscoveryInterface interface {
 	DiscoveryInterface
 
 	// AggregatedDiscoveryInterfaceWithContext.GroupsAndMaybeResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use AggregatedDiscoveryInterfaceWithContext.GroupsAndMaybeResourcesWithContext instead.
+	//logcheck:context // Use AggregatedDiscoveryInterfaceWithContext.GroupsAndMaybeResourcesWithContext instead of GroupsAndMaybeResources in code which supports contextual logging.
 	GroupsAndMaybeResources() (*metav1.APIGroupList, map[schema.GroupVersion]*metav1.APIResourceList, map[schema.GroupVersion]error, error)
 }
 
@@ -193,7 +193,7 @@ type aggregatedDiscoveryInterfaceWrapper struct {
 }
 
 func (i *aggregatedDiscoveryInterfaceWrapper) GroupsAndMaybeResourcesWithContext(ctx context.Context) (*metav1.APIGroupList, map[schema.GroupVersion]*metav1.APIResourceList, map[schema.GroupVersion]error, error) {
-	return i.delegate.GroupsAndMaybeResources()
+	return i.delegate.GroupsAndMaybeResources() //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 // CachedDiscoveryInterface is a DiscoveryInterface with cache invalidation and freshness.
@@ -203,7 +203,7 @@ func (i *aggregatedDiscoveryInterfaceWrapper) GroupsAndMaybeResourcesWithContext
 //
 // CachedDiscoveryInterfaceWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use CachedDiscoveryInterfaceWithContext instead.
+//logcheck:context // Use CachedDiscoveryInterfaceWithContext instead of CachedDiscoveryInterface in code which supports contextual logging.
 type CachedDiscoveryInterface interface {
 	DiscoveryInterface
 	// Fresh is supposed to tell the caller whether or not to retry if the cache
@@ -214,14 +214,14 @@ type CachedDiscoveryInterface interface {
 	//
 	// CachedDiscoveryInterfaceWithContext.FreshWithContext is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use CachedDiscoveryInterfaceWithContext.FreshWithContext instead.
+	//logcheck:context // Use CachedDiscoveryInterfaceWithContext.FreshWithContext instead of Fresh in code which supports contextual logging.
 	Fresh() bool
 	// Invalidate enforces that no cached data that is older than the current time
 	// is used.
 	//
 	// CachedDiscoveryInterfaceWithContext.InvalidateWithContext is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use CachedDiscoveryInterfaceWithContext.InvalidateWithContext instead.
+	//logcheck:context // Use CachedDiscoveryInterfaceWithContext.InvalidateWithContext instead of Invalidate in code which supports contextual logging.
 	Invalidate()
 }
 
@@ -261,25 +261,25 @@ type cachedDiscoveryInterfaceWrapper struct {
 }
 
 func (i *cachedDiscoveryInterfaceWrapper) FreshWithContext(ctx context.Context) bool {
-	return i.delegate.Fresh()
+	return i.delegate.Fresh() //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 func (i *cachedDiscoveryInterfaceWrapper) InvalidateWithContext(ctx context.Context) {
-	i.delegate.Invalidate()
+	i.delegate.Invalidate() //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 // ServerGroupsInterface has methods for obtaining supported groups on the API server
 //
 // ServerGroupsInterfaceWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerGroupsInterfaceWithContext instead.
+//logcheck:context // Use ServerGroupsInterfaceWithContext instead of ServerGroupsInterface in code which supports contextual logging.
 type ServerGroupsInterface interface {
 	// ServerGroups returns the supported groups, with information like supported versions and the
 	// preferred version.
 	//
 	// ServerGroupsInterfaceWithContext.ServerGroups is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use ServerGroupsInterfaceWithContext.ServerGroups instead.
+	//logcheck:context // Use ServerGroupsInterfaceWithContext.ServerGroupsWithContext instead of ServerGroups in code which supports contextual logging.
 	ServerGroups() (*metav1.APIGroupList, error)
 }
 
@@ -307,29 +307,29 @@ type serverGroupsInterfaceWrapper struct {
 }
 
 func (i *serverGroupsInterfaceWrapper) ServerGroupsWithContext(ctx context.Context) (*metav1.APIGroupList, error) {
-	return i.delegate.ServerGroups()
+	return i.delegate.ServerGroups() //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 // ServerResourcesInterface has methods for obtaining supported resources on the API server
 //
 // ServerGroupsAndResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerGroupsAndResourcesWithContext instead.
+//logcheck:context // Use ServerResourcesInterfaceWithContext instead of ServerResourcesInterface in code which supports contextual logging.
 type ServerResourcesInterface interface {
 	// ServerResourcesForGroupVersion returns the supported resources for a group and version.
 	//
-	// ServerGroupsAndResourcesWithContext.ServerResourcesForGroupVersionWithContext is a better alternative because it supports contextual logging and cancellation.
+	// ServerResourcesInterfaceWithContext.ServerResourcesForGroupVersionWithContext is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use ServerGroupsAndResourcesWithContext.ServerResourcesForGroupVersionWithContext instead.
+	//logcheck:context // Use ServerResourcesInterfaceWithContext.ServerResourcesForGroupVersionWithContext instead of ServerResourcesForGroupVersion in code which supports contextual logging.
 	ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error)
 	// ServerGroupsAndResources returns the supported groups and resources for all groups and versions.
 	//
 	// The returned group and resource lists might be non-nil with partial results even in the
 	// case of non-nil error.
 	//
-	// ServerGroupsAndResourcesWithContext.ServerGroupsAndResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
+	// ServerResourcesInterfaceWithContext.ServerGroupsAndResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use ServerGroupsAndResourcesWithContext.ServerGroupsAndResourcesWithContext instead.
+	//logcheck:context // Use ServerResourcesInterfaceWithContext.ServerGroupsAndResourcesWithContext instead of ServerGroupsAndResources in code which supports contextual logging.
 	ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error)
 	// ServerPreferredResources returns the supported resources with the version preferred by the
 	// server.
@@ -339,7 +339,7 @@ type ServerResourcesInterface interface {
 	//
 	// ServerResourcesInterfaceWithContext.ServerPreferredResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use ServerResourcesInterfaceWithContext.ServerPreferredResourcesWithContext instead.
+	//logcheck:context // Use ServerResourcesInterfaceWithContext.ServerPreferredResourcesWithContext instead of ServerPreferredResources in code which supports contextual logging.
 	ServerPreferredResources() ([]*metav1.APIResourceList, error)
 	// ServerPreferredNamespacedResources returns the supported namespaced resources with the
 	// version preferred by the server.
@@ -349,7 +349,7 @@ type ServerResourcesInterface interface {
 	//
 	// ServerResourcesInterfaceWithContext.ServerPreferredNamespacedResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use ServerResourcesInterfaceWithContext.ServerPreferredNamespacedResourcesWithContext instead.
+	//logcheck:context // Use ServerResourcesInterfaceWithContext.ServerPreferredNamespacedResourcesWithContext instead of ServerPreferredNamespacedResources in code which supports contextual logging.
 	ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error)
 }
 
@@ -393,32 +393,32 @@ type serverResourcesInterfaceWrapper struct {
 }
 
 func (i *serverResourcesInterfaceWrapper) ServerResourcesForGroupVersionWithContext(ctx context.Context, groupVersion string) (*metav1.APIResourceList, error) {
-	return i.delegate.ServerResourcesForGroupVersion(groupVersion)
+	return i.delegate.ServerResourcesForGroupVersion(groupVersion) //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 func (i *serverResourcesInterfaceWrapper) ServerGroupsAndResourcesWithContext(ctx context.Context) ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
-	return i.delegate.ServerGroupsAndResources()
+	return i.delegate.ServerGroupsAndResources() //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 func (i *serverResourcesInterfaceWrapper) ServerPreferredResourcesWithContext(ctx context.Context) ([]*metav1.APIResourceList, error) {
-	return i.delegate.ServerPreferredResources()
+	return i.delegate.ServerPreferredResources() //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 func (i *serverResourcesInterfaceWrapper) ServerPreferredNamespacedResourcesWithContext(ctx context.Context) ([]*metav1.APIResourceList, error) {
-	return i.delegate.ServerPreferredNamespacedResources()
+	return i.delegate.ServerPreferredNamespacedResources() //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 // ServerVersionInterface has a method for retrieving the server's version.
 //
 // ServerVersionInterfaceWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerVersionInterfaceWithContext instead.
+//logcheck:context // Use ServerVersionInterfaceWithContext instead of ServerVersionInterface in code which supports contextual logging.
 type ServerVersionInterface interface {
 	// ServerVersion retrieves and parses the server's version (git version).
 	//
 	// ServerVersionInterfaceWithContext.ServerVersionWithContext is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use ServerVersionInterfaceWithContext.ServerVersionWithContext instead.
+	//logcheck:context // Use ServerVersionInterfaceWithContext.ServerVersionWithContext instead of ServerVersion in code which supports contextual logging.
 	ServerVersion() (*version.Info, error)
 }
 
@@ -445,20 +445,20 @@ type serverVersionInterfaceWrapper struct {
 }
 
 func (i *serverVersionInterfaceWrapper) ServerVersionWithContext(ctx context.Context) (*version.Info, error) {
-	return i.delegate.ServerVersion()
+	return i.delegate.ServerVersion() //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 // OpenAPISchemaInterface has a method to retrieve the open API schema.
 //
 // OpenAPISchemaInterfaceWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use OpenAPISchemaInterfaceWithContext instead.
+//logcheck:context // Use OpenAPISchemaInterfaceWithContext instead of OpenAPISchemaInterface in code which supports contextual logging.
 type OpenAPISchemaInterface interface {
 	// OpenAPISchema retrieves and parses the swagger API schema the server supports.
 	//
 	// OpenAPISchemaInterfaceWithContext.OpenAPISchemaWithContext is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use OpenAPISchemaInterfaceWithContext.OpenAPISchemaWithContext instead.
+	//logcheck:context // Use OpenAPISchemaInterfaceWithContext.OpenAPISchemaWithContext instead of OpenAPISchema in code which supports contextual logging.
 	OpenAPISchema() (*openapi_v2.Document, error)
 }
 
@@ -485,16 +485,16 @@ type openAPISchemaInterfaceWrapper struct {
 }
 
 func (i *openAPISchemaInterfaceWrapper) OpenAPISchemaWithContext(ctx context.Context) (*openapi_v2.Document, error) {
-	return i.delegate.OpenAPISchema()
+	return i.delegate.OpenAPISchema() //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 // OpenAPIV3SchemaInterfaceWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use OpenAPIV3SchemaInterfaceWithContext instead.
+//logcheck:context // Use OpenAPIV3SchemaInterfaceWithContext instead of OpenAPIV3SchemaInterface in code which supports contextual logging.
 type OpenAPIV3SchemaInterface interface {
 	// OpenAPIV3SchemaInterfaceWithContext.OpenAPIV3WithContext is a better alternative because it supports contextual logging and cancellation.
 	//
-	// Contextual logging: Use OpenAPIV3SchemaInterfaceWithContext.OpenAPIV3WithContext instead.
+	//logcheck:context // Use OpenAPIV3SchemaInterfaceWithContext.OpenAPIV3WithContext instead of OpenAPIV3 in code which supports contextual logging.
 	OpenAPIV3() openapi.Client
 }
 
@@ -519,7 +519,7 @@ type openAPIV3SchemaInterfaceWrapper struct {
 }
 
 func (i *openAPIV3SchemaInterfaceWrapper) OpenAPIV3WithContext(ctx context.Context) openapi.ClientWithContext {
-	return ToOpenAPIClientWithContext(i.delegate.OpenAPIV3())
+	return ToOpenAPIClientWithContext(i.delegate.OpenAPIV3()) //nolint:logcheck // Bridging from the old interface without context support; cannot provide a logger here.
 }
 
 func ToOpenAPIClientWithContext(i openapi.Client) openapi.ClientWithContext { //nolint:staticcheck // Intentionally using the old interface here.
@@ -592,7 +592,7 @@ func apiVersionsToAPIGroup(apiVersions *metav1.APIVersions) (apiGroup metav1.API
 //
 // GroupsAndMaybeResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use GroupsAndMaybeResourcesWithContext instead.
+//logcheck:context // Use GroupsAndMaybeResourcesWithContext instead of GroupsAndMaybeResources in code which supports contextual logging.
 func (d *DiscoveryClient) GroupsAndMaybeResources() (
 	*metav1.APIGroupList,
 	map[schema.GroupVersion]*metav1.APIResourceList,
@@ -787,7 +787,7 @@ func ContentTypeIsGVK(contentType string, gvk schema.GroupVersionKind) (bool, er
 //
 // ServerGroupsWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerGroupsWithContext instead.
+//logcheck:context // Use ServerGroupsWithContext instead of ServerGroups in code which supports contextual logging.
 func (d *DiscoveryClient) ServerGroups() (*metav1.APIGroupList, error) {
 	return d.ServerGroupsWithContext(context.Background())
 }
@@ -806,7 +806,7 @@ func (d *DiscoveryClient) ServerGroupsWithContext(ctx context.Context) (*metav1.
 //
 // ServerResourcesForGroupVersionWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerResourcesForGroupVersionWithContext instead.
+//logcheck:context // Use ServerResourcesForGroupVersionWithContext instead of ServerResourcesForGroupVersion in code which supports contextual logging.
 func (d *DiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (resources *metav1.APIResourceList, err error) {
 	return d.ServerResourcesForGroupVersionWithContext(context.Background(), groupVersion)
 }
@@ -891,7 +891,7 @@ func GroupDiscoveryFailedErrorGroups(err error) (map[schema.GroupVersion]error, 
 
 // ServerGroupsAndResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerGroupsAndResourcesWithContext instead.
+//logcheck:context // Use ServerGroupsAndResourcesWithContext instead of ServerGroupsAndResources in code which supports contextual logging.
 func ServerGroupsAndResources(d DiscoveryInterface) ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return ServerGroupsAndResourcesWithContext(context.Background(), ToDiscoveryInterfaceWithContext(d))
 }
@@ -967,7 +967,7 @@ func ServerGroupsAndResourcesWithContext(ctx context.Context, d DiscoveryInterfa
 //
 // ServerPreferredResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerPreferredResourcesWithContext instead.
+//logcheck:context // Use ServerPreferredResourcesWithContext instead of ServerPreferredResources in code which supports contextual logging.
 func ServerPreferredResources(d DiscoveryInterface) ([]*metav1.APIResourceList, error) {
 	return ServerPreferredResourcesWithContext(context.Background(), ToDiscoveryInterfaceWithContext(d))
 }
@@ -1100,10 +1100,11 @@ func fetchGroupVersionResources(ctx context.Context, d DiscoveryInterfaceWithCon
 //
 // ServerPreferredResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerPreferredResourcesWithContext instead.
+//logcheck:context // Use ServerPreferredResourcesWithContext instead of ServerPreferredResources in code which supports contextual logging.
 func (d *DiscoveryClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
-	_, rs, err := withRetries(context.Background(), defaultRetries, func() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
-		rs, err := ServerPreferredResources(d)
+	ctx := context.Background()
+	_, rs, err := withRetries(ctx, defaultRetries, func() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+		rs, err := ServerPreferredResourcesWithContext(ctx, ToDiscoveryInterfaceWithContext(d))
 		return nil, rs, err
 	})
 	return rs, err
@@ -1124,7 +1125,7 @@ func (d *DiscoveryClient) ServerPreferredResourcesWithContext(ctx context.Contex
 //
 // ServerPreferredNamespacedResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerPreferredNamespacedResourcesWithContext instead.
+//logcheck:context // Use ServerPreferredNamespacedResourcesWithContext instead of ServerPreferredNamespacedResources in code which supports contextual logging.
 func (d *DiscoveryClient) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
 	return ServerPreferredNamespacedResources(d)
 }
@@ -1139,7 +1140,7 @@ func (d *DiscoveryClient) ServerPreferredNamespacedResourcesWithContext(ctx cont
 //
 // ServerPreferredNamespacedResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerPreferredNamespacedResourcesWithContext instead.
+//logcheck:context // Use ServerPreferredNamespacedResourcesWithContext instead of ServerPreferredNamespacedResources in code which supports contextual logging.
 func ServerPreferredNamespacedResources(d DiscoveryInterface) ([]*metav1.APIResourceList, error) {
 	return ServerPreferredNamespacedResourcesWithContext(context.Background(), ToDiscoveryInterfaceWithContext(d))
 }
@@ -1192,9 +1193,9 @@ func (d *DiscoveryClient) OpenAPISchemaWithContext(ctx context.Context) (*openap
 
 // OpenAPIV3WithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use OpenAPIV3WithContext instead.
+//logcheck:context // Use OpenAPIV3WithContext instead of OpenAPIV3 in code which supports contextual logging.
 func (d *DiscoveryClient) OpenAPIV3() openapi.Client {
-	return openapi.NewClient(d.restClient)
+	return openapi.NewClient(d.restClient) //nolint:logcheck // This method itself is deprecated in favor of OpenAPIV3WithContext.
 }
 
 func (d *DiscoveryClient) OpenAPIV3WithContext(ctx context.Context) openapi.ClientWithContext {
@@ -1206,7 +1207,7 @@ func (d *DiscoveryClient) OpenAPIV3WithContext(ctx context.Context) openapi.Clie
 //
 // WithLegacyWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use WithLegacyWithContext instead.
+//logcheck:context // Use WithLegacyWithContext instead of WithLegacy in code which supports contextual logging.
 func (d *DiscoveryClient) WithLegacy() DiscoveryInterface {
 	client := *d
 	client.UseLegacyDiscovery = true

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/openapi"
 	restclient "k8s.io/client-go/rest"
 	testutil "k8s.io/client-go/util/testing"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/kube-openapi/pkg/spec3"
 )
 
@@ -76,6 +77,7 @@ func TestGetServerVersion(t *testing.T) {
 }
 
 func TestGetServerGroupsWithV1Server(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		var obj interface{}
 		switch req.URL.Path {
@@ -114,7 +116,7 @@ func TestGetServerGroupsWithV1Server(t *testing.T) {
 	}))
 	defer server.Close()
 	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
-	apiGroupList, err := client.ServerGroups()
+	apiGroupList, err := client.ServerGroupsWithContext(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -125,6 +127,7 @@ func TestGetServerGroupsWithV1Server(t *testing.T) {
 }
 
 func TestDiscoveryToleratesMissingCoreGroup(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	// Discovery tolerates 404 from /api. Aggregated api servers can do this.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		var obj interface{}
@@ -158,7 +161,7 @@ func TestDiscoveryToleratesMissingCoreGroup(t *testing.T) {
 	defer server.Close()
 	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
 	// ServerGroups should not return an error even if server returns 404 at /api.
-	apiGroupList, err := client.ServerGroups()
+	apiGroupList, err := client.ServerGroupsWithContext(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -169,6 +172,7 @@ func TestDiscoveryToleratesMissingCoreGroup(t *testing.T) {
 }
 
 func TestDiscoveryFailsWhenNonCoreGroupsMissing(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	// Discovery fails when /apis returns 404.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		var obj interface{}
@@ -196,13 +200,14 @@ func TestDiscoveryFailsWhenNonCoreGroupsMissing(t *testing.T) {
 	}))
 	defer server.Close()
 	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
-	_, err := client.ServerGroups()
+	_, err := client.ServerGroupsWithContext(ctx)
 	if err == nil {
 		t.Fatal("expected error, received none")
 	}
 }
 
 func TestGetServerGroupsWithBrokenServer(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	// 404 Not Found errors because discovery at /apis returns an error.
 	// 403 Forbidden errors because discovery at both /api and /apis returns error.
 	for _, statusCode := range []int{http.StatusNotFound, http.StatusForbidden} {
@@ -211,7 +216,7 @@ func TestGetServerGroupsWithBrokenServer(t *testing.T) {
 		}))
 		defer server.Close()
 		client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
-		_, err := client.ServerGroups()
+		_, err := client.ServerGroupsWithContext(ctx)
 		if err == nil {
 			t.Fatal("expected error, received none")
 		}
@@ -225,6 +230,7 @@ func TestTimeoutIsSet(t *testing.T) {
 }
 
 func TestGetServerResourcesForGroupVersion(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	stable := metav1.APIResourceList{
 		GroupVersion: "v1",
 		APIResources: []metav1.APIResource{
@@ -400,7 +406,7 @@ func TestGetServerResourcesForGroupVersion(t *testing.T) {
 	defer server.Close()
 	for _, test := range tests {
 		client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
-		got, err := client.ServerResourcesForGroupVersion(test.request)
+		got, err := client.ServerResourcesForGroupVersionWithContext(ctx, test.request)
 		if test.expectErr {
 			if err == nil {
 				t.Error("unexpected non-error")
@@ -573,6 +579,7 @@ func TestGetOpenAPISchema(t *testing.T) {
 }
 
 func TestGetOpenAPISchemaV3(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	server, testV3Specs, err := openapiV3SchemaFakeServer(t)
 	if err != nil {
 		t.Errorf("unexpected error starting fake server: %v", err)
@@ -580,8 +587,8 @@ func TestGetOpenAPISchemaV3(t *testing.T) {
 	defer server.Close()
 
 	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
-	openapiClient := client.OpenAPIV3()
-	paths, err := openapiClient.Paths()
+	openapiClient := client.OpenAPIV3WithContext(ctx)
+	paths, err := openapiClient.PathsWithContext(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error getting openapi: %v", err)
 	}
@@ -593,7 +600,7 @@ func TestGetOpenAPISchemaV3(t *testing.T) {
 	for _, contentType := range contentTypes {
 		t.Run(contentType, func(t *testing.T) {
 			for k, v := range paths {
-				actual, err := v.Schema(contentType)
+				actual, err := v.SchemaWithContext(ctx, contentType)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -637,7 +644,7 @@ func TestGetOpenAPISchemaV3(t *testing.T) {
 				}
 
 				// Ensure that fetching schema once again does not return same instance
-				actualAgain, err := v.Schema(contentType)
+				actualAgain, err := v.SchemaWithContext(ctx, contentType)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -652,6 +659,7 @@ func TestGetOpenAPISchemaV3(t *testing.T) {
 }
 
 func TestServerPreferredResources(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	stable := metav1.APIResourceList{
 		GroupVersion: "v1",
 		APIResources: []metav1.APIResource{
@@ -755,7 +763,7 @@ func TestServerPreferredResources(t *testing.T) {
 		defer server.Close()
 
 		client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
-		resources, err := client.ServerPreferredResources()
+		resources, err := client.ServerPreferredResourcesWithContext(ctx)
 		if test.expectErr != nil {
 			if err == nil {
 				t.Error("unexpected non-error")
@@ -781,6 +789,7 @@ func TestServerPreferredResources(t *testing.T) {
 }
 
 func TestServerPreferredResourcesRetries(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	stable := metav1.APIResourceList{
 		GroupVersion: "v1",
 		APIResources: []metav1.APIResource{
@@ -868,7 +877,7 @@ func TestServerPreferredResourcesRetries(t *testing.T) {
 		defer server.Close()
 
 		client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
-		resources, err := client.ServerPreferredResources()
+		resources, err := client.ServerPreferredResourcesWithContext(ctx)
 		if !tc.expectedError(err) {
 			t.Errorf("case %d: unexpected error: %v", i, err)
 		}
@@ -884,6 +893,7 @@ func TestServerPreferredResourcesRetries(t *testing.T) {
 }
 
 func TestServerPreferredNamespacedResources(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	stable := metav1.APIResourceList{
 		GroupVersion: "v1",
 		APIResources: []metav1.APIResource{
@@ -1058,7 +1068,7 @@ func TestServerPreferredNamespacedResources(t *testing.T) {
 		defer server.Close()
 
 		client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
-		resources, err := client.ServerPreferredNamespacedResources()
+		resources, err := client.ServerPreferredNamespacedResourcesWithContext(ctx)
 		if err != nil {
 			t.Errorf("[%d] unexpected error: %v", i, err)
 			continue
@@ -1078,6 +1088,7 @@ func TestServerPreferredNamespacedResources(t *testing.T) {
 
 // Tests of the aggregated discovery format.
 func TestAggregatedServerGroups(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := []struct {
 		name                      string
 		corev1                    *apidiscovery.APIGroupDiscoveryList
@@ -1338,7 +1349,7 @@ func TestAggregatedServerGroups(t *testing.T) {
 		}))
 		defer server.Close()
 		client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
-		apiGroupList, err := client.ServerGroups()
+		apiGroupList, err := client.ServerGroupsWithContext(ctx)
 		require.NoError(t, err)
 		// Test the expected groups are returned for the aggregated format.
 		expectedGroupNames := sets.NewString(test.expectedGroupNames...)
@@ -2108,6 +2119,7 @@ func TestAggregatedServerGroupsAndResourcesWithErrors(t *testing.T) {
 }
 
 func TestAggregatedServerPreferredResources(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := []struct {
 		name              string
 		corev1            *apidiscovery.APIGroupDiscoveryList
@@ -2703,7 +2715,7 @@ func TestAggregatedServerPreferredResources(t *testing.T) {
 		}))
 		defer server.Close()
 		client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
-		resources, err := client.ServerPreferredResources()
+		resources, err := client.ServerPreferredResourcesWithContext(ctx)
 		if len(test.expectedFailedGVs) > 0 {
 			require.Error(t, err)
 			expectedFailedGVs := sets.NewString(test.expectedFailedGVs...)
@@ -2796,6 +2808,7 @@ func TestDiscoveryContentTypeVersion(t *testing.T) {
 }
 
 func TestUseLegacyDiscovery(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	// Default client sends aggregated discovery accept format (first) as well as legacy format.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		acceptHeader := req.Header.Get("Accept")
@@ -2803,7 +2816,7 @@ func TestUseLegacyDiscovery(t *testing.T) {
 	}))
 	defer server.Close()
 	client := NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
-	client.ServerGroups()
+	_, _ = client.ServerGroupsWithContext(ctx)
 	// When "UseLegacyDiscovery" field is set, only the legacy discovery format is requested.
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		acceptHeader := req.Header.Get("Accept")
@@ -2812,7 +2825,7 @@ func TestUseLegacyDiscovery(t *testing.T) {
 	defer server.Close()
 	client = NewDiscoveryClientForConfigOrDie(&restclient.Config{Host: server.URL})
 	client.UseLegacyDiscovery = true
-	client.ServerGroups()
+	_, _ = client.ServerGroupsWithContext(ctx)
 }
 
 func groupNames(groups []*metav1.APIGroup) []string {

--- a/staging/src/k8s.io/client-go/discovery/fake/discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/fake/discovery.go
@@ -53,7 +53,7 @@ var (
 //
 // ServerResourcesForGroupVersionWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerResourcesForGroupVersionWithContext instead.
+//logcheck:context // Use ServerResourcesForGroupVersionWithContext instead of ServerResourcesForGroupVersion in code which supports contextual logging.
 func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
 	return c.ServerResourcesForGroupVersionWithContext(context.Background(), groupVersion)
 }
@@ -86,7 +86,7 @@ func (c *FakeDiscovery) ServerResourcesForGroupVersionWithContext(ctx context.Co
 //
 // ServerGroupsAndResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerGroupsAndResourcesWithContext instead.
+//logcheck:context // Use ServerGroupsAndResourcesWithContext instead of ServerGroupsAndResources in code which supports contextual logging.
 func (c *FakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return c.ServerGroupsAndResourcesWithContext(context.Background())
 }
@@ -117,7 +117,7 @@ func (c *FakeDiscovery) ServerGroupsAndResourcesWithContext(ctx context.Context)
 //
 // ServerPreferredResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerPreferredResourcesWithContext instead.
+//logcheck:context // Use ServerPreferredResourcesWithContext instead of ServerPreferredResources in code which supports contextual logging.
 func (c *FakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
 	return c.ServerPreferredResourcesWithContext(context.Background())
 }
@@ -133,7 +133,7 @@ func (c *FakeDiscovery) ServerPreferredResourcesWithContext(ctx context.Context)
 //
 // ServerPreferredNamespacedResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerPreferredNamespacedResourcesWithContext instead.
+//logcheck:context // Use ServerPreferredNamespacedResourcesWithContext instead of ServerPreferredNamespacedResources in code which supports contextual logging.
 func (c *FakeDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
 	return c.ServerPreferredNamespacedResourcesWithContext(context.Background())
 }
@@ -149,7 +149,7 @@ func (c *FakeDiscovery) ServerPreferredNamespacedResourcesWithContext(ctx contex
 //
 // ServerGroupsWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerGroupsWithContext instead.
+//logcheck:context // Use ServerGroupsWithContext instead of ServerGroups in code which supports contextual logging.
 func (c *FakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
 	return c.ServerGroupsWithContext(context.Background())
 }
@@ -203,7 +203,7 @@ func (c *FakeDiscovery) ServerGroupsWithContext(ctx context.Context) (*metav1.AP
 //
 // ServerVersionWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ServerVersionWithContext instead.
+//logcheck:context // Use ServerVersionWithContext instead of ServerVersion in code which supports contextual logging.
 func (c *FakeDiscovery) ServerVersion() (*version.Info, error) {
 	return c.ServerVersionWithContext(context.Background())
 }
@@ -230,7 +230,7 @@ func (c *FakeDiscovery) ServerVersionWithContext(ctx context.Context) (*version.
 //
 // OpenAPISchemaWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use OpenAPISchemaWithContext instead.
+//logcheck:context // Use OpenAPISchemaWithContext instead of OpenAPISchema in code which supports contextual logging.
 func (c *FakeDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
 	return c.OpenAPISchemaWithContext(context.Background())
 }
@@ -242,7 +242,7 @@ func (c *FakeDiscovery) OpenAPISchemaWithContext(ctx context.Context) (*openapi_
 
 // OpenAPIV3WithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use OpenAPIV3WithContext instead.
+//logcheck:context // Use OpenAPIV3WithContext instead of OpenAPIV3 in code which supports contextual logging.
 func (c *FakeDiscovery) OpenAPIV3() openapi.Client {
 	panic("unimplemented")
 }
@@ -259,7 +259,7 @@ func (c *FakeDiscovery) RESTClient() restclient.Interface {
 
 // WithLegacyWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use WithLegacyWithContext instead.
+//logcheck:context // Use WithLegacyWithContext instead of WithLegacy in code which supports contextual logging.
 func (c *FakeDiscovery) WithLegacy() discovery.DiscoveryInterface {
 	panic("unimplemented")
 }

--- a/staging/src/k8s.io/client-go/discovery/fake/discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/fake/discovery_test.go
@@ -25,9 +25,11 @@ import (
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestFakingServerVersion(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	client := fakeclientset.NewSimpleClientset()
 	fakeDiscovery, ok := client.Discovery().(*fakediscovery.FakeDiscovery)
 	if !ok {
@@ -39,7 +41,7 @@ func TestFakingServerVersion(t *testing.T) {
 		GitCommit: testGitCommit,
 	}
 
-	sv, err := client.Discovery().ServerVersion()
+	sv, err := client.Discovery().(*fakediscovery.FakeDiscovery).ServerVersionWithContext(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -49,13 +51,14 @@ func TestFakingServerVersion(t *testing.T) {
 }
 
 func TestFakingServerVersionWithError(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	expectedError := errors.New("an error occurred")
 	fakeClient := fakeclientset.NewSimpleClientset()
 	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).PrependReactor("*", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, nil, expectedError
 	})
 
-	_, err := fakeClient.Discovery().ServerVersion()
+	_, err := fakeClient.Discovery().(*fakediscovery.FakeDiscovery).ServerVersionWithContext(ctx)
 	if err == nil {
 		t.Fatal("ServerVersion should return error, returned nil instead")
 	}
@@ -65,13 +68,14 @@ func TestFakingServerVersionWithError(t *testing.T) {
 }
 
 func TestFakingServerResourcesForGroupVersionWithError(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	expectedError := errors.New("an error occurred")
 	fakeClient := fakeclientset.NewClientset()
 	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).PrependReactor("*", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, nil, expectedError
 	})
 
-	result, err := fakeClient.Discovery().ServerResourcesForGroupVersion("dummy.group.io/v1beta2")
+	result, err := fakeClient.Discovery().(*fakediscovery.FakeDiscovery).ServerResourcesForGroupVersionWithContext(ctx, "dummy.group.io/v1beta2")
 	if result != nil {
 		t.Errorf(`expect result to be nil but got "%v" instead`, result)
 	}
@@ -81,13 +85,14 @@ func TestFakingServerResourcesForGroupVersionWithError(t *testing.T) {
 }
 
 func TestFakingServerGroupsWithError(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	expectedError := errors.New("an error occurred")
 	fakeClient := fakeclientset.NewClientset()
 	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).PrependReactor("*", "*", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, nil, expectedError
 	})
 
-	result, err := fakeClient.Discovery().ServerGroups()
+	result, err := fakeClient.Discovery().(*fakediscovery.FakeDiscovery).ServerGroupsWithContext(ctx)
 	if result != nil {
 		t.Errorf(`expect result to be nil but got "%v" instead`, result)
 	}
@@ -97,13 +102,14 @@ func TestFakingServerGroupsWithError(t *testing.T) {
 }
 
 func TestFakingServerGroupsAndResourcesWithError(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	expectedError := errors.New("an error occurred")
 	fakeClient := fakeclientset.NewClientset()
 	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).PrependReactor("get", "resource", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, nil, expectedError
 	})
 
-	_, _, err := fakeClient.Discovery().ServerGroupsAndResources()
+	_, _, err := fakeClient.Discovery().(*fakediscovery.FakeDiscovery).ServerGroupsAndResourcesWithContext(ctx)
 	if !errors.Is(err, expectedError) {
 		t.Errorf(`expect error to be "%v" but got "%v" instead`, expectedError, err)
 	}

--- a/staging/src/k8s.io/client-go/discovery/helper.go
+++ b/staging/src/k8s.io/client-go/discovery/helper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package discovery
 
 import (
+	"context"
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,9 +29,19 @@ import (
 
 // IsResourceEnabled queries the server to determine if the resource specified is present on the server.
 // This is particularly helpful when writing a controller or an e2e test that requires a particular resource to function.
+//
+// IsResourceEnabledWithContext is a better alternative because it supports contextual logging and cancellation.
+//
+//logcheck:context // Use IsResourceEnabledWithContext instead of IsResourceEnabled in code which supports contextual logging.
 func IsResourceEnabled(client DiscoveryInterface, resourceToCheck schema.GroupVersionResource) (bool, error) {
+	return IsResourceEnabledWithContext(context.Background(), ToDiscoveryInterfaceWithContext(client), resourceToCheck)
+}
+
+// IsResourceEnabledWithContext queries the server to determine if the resource specified is present on the server.
+// This is particularly helpful when writing a controller or an e2e test that requires a particular resource to function.
+func IsResourceEnabledWithContext(ctx context.Context, client DiscoveryInterfaceWithContext, resourceToCheck schema.GroupVersionResource) (bool, error) {
 	// this is a single request.  The ServerResourcesForGroupVersion handles the core v1 group as legacy.
-	resourceList, err := client.ServerResourcesForGroupVersion(resourceToCheck.GroupVersion().String())
+	resourceList, err := client.ServerResourcesForGroupVersionWithContext(ctx, resourceToCheck.GroupVersion().String())
 	if apierrors.IsNotFound(err) { // if the discovery endpoint isn't present, then the resource isn't present.
 		return false, nil
 	}
@@ -49,8 +60,19 @@ func IsResourceEnabled(client DiscoveryInterface, resourceToCheck schema.GroupVe
 // MatchesServerVersion queries the server to compares the build version
 // (git hash) of the client with the server's build version. It returns an error
 // if it failed to contact the server or if the versions are not an exact match.
+//
+// MatchesServerVersionWithContext is a better alternative because it supports contextual logging and cancellation.
+//
+//logcheck:context // Use MatchesServerVersionWithContext instead of MatchesServerVersion in code which supports contextual logging.
 func MatchesServerVersion(clientVersion apimachineryversion.Info, client DiscoveryInterface) error {
-	sVer, err := client.ServerVersion()
+	return MatchesServerVersionWithContext(context.Background(), clientVersion, ToDiscoveryInterfaceWithContext(client))
+}
+
+// MatchesServerVersionWithContext queries the server to compares the build version
+// (git hash) of the client with the server's build version. It returns an error
+// if it failed to contact the server or if the versions are not an exact match.
+func MatchesServerVersionWithContext(ctx context.Context, clientVersion apimachineryversion.Info, client DiscoveryInterfaceWithContext) error {
+	sVer, err := client.ServerVersionWithContext(ctx)
 	if err != nil {
 		return fmt.Errorf("couldn't read version from server: %v", err)
 	}
@@ -63,8 +85,17 @@ func MatchesServerVersion(clientVersion apimachineryversion.Info, client Discove
 }
 
 // ServerSupportsVersion returns an error if the server doesn't have the required version
+//
+// ServerSupportsVersionWithContext is a better alternative because it supports contextual logging and cancellation.
+//
+//logcheck:context // Use ServerSupportsVersionWithContext instead of ServerSupportsVersion in code which supports contextual logging.
 func ServerSupportsVersion(client DiscoveryInterface, requiredGV schema.GroupVersion) error {
-	groups, err := client.ServerGroups()
+	return ServerSupportsVersionWithContext(context.Background(), ToDiscoveryInterfaceWithContext(client), requiredGV)
+}
+
+// ServerSupportsVersionWithContext returns an error if the server doesn't have the required version
+func ServerSupportsVersionWithContext(ctx context.Context, client DiscoveryInterfaceWithContext, requiredGV schema.GroupVersion) error {
+	groups, err := client.ServerGroupsWithContext(ctx)
 	if err != nil {
 		// This is almost always a connection error, and higher level code should treat this as a generic error,
 		// not a negotiation specific error.

--- a/staging/src/k8s.io/client-go/discovery/helper_blackbox_test.go
+++ b/staging/src/k8s.io/client-go/discovery/helper_blackbox_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func objBody(object interface{}) io.ReadCloser {
@@ -44,6 +45,7 @@ func objBody(object interface{}) io.ReadCloser {
 }
 
 func TestServerSupportsVersion(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
 	tests := []struct {
 		name            string
 		requiredVersion schema.GroupVersion
@@ -101,7 +103,7 @@ func TestServerSupportsVersion(t *testing.T) {
 		})
 		c := discovery.NewDiscoveryClientForConfigOrDie(&restclient.Config{})
 		c.RESTClient().(*restclient.RESTClient).Client = fakeClient
-		err := discovery.ServerSupportsVersion(c, test.requiredVersion)
+		err := discovery.ServerSupportsVersionWithContext(ctx, discovery.ToDiscoveryInterfaceWithContext(c), test.requiredVersion)
 		if err == nil && test.expectErr != nil {
 			t.Errorf("expected error, got nil for [%s].", test.name)
 		}

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamiclister"
@@ -88,7 +89,14 @@ func (f *dynamicSharedInformerFactory) ForResource(gvr schema.GroupVersionResour
 }
 
 // Start initializes all requested informers.
+//
+//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
+	f.StartWithContext(wait.ContextForChannel(stopCh))
+}
+
+// StartWithContext initializes all requested informers.
+func (f *dynamicSharedInformerFactory) StartWithContext(ctx context.Context) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -105,7 +113,7 @@ func (f *dynamicSharedInformerFactory) Start(stopCh <-chan struct{}) {
 			informer := informer.Informer()
 			go func() {
 				defer f.wg.Done()
-				informer.Run(stopCh)
+				informer.RunWithContext(ctx)
 			}()
 			f.startedInformers[informerType] = true
 		}

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
@@ -123,7 +123,7 @@ func TestWatchListSemanticsSimple(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	factory.Start(ctx.Done())
+	factory.StartWithContext(ctx)
 
 	if !cache.WaitForCacheSync(ctx.Done(), target.Informer().HasSynced) {
 		t.Fatalf("failed to wait for caches to sync")
@@ -144,7 +144,7 @@ func TestUnSupportWatchListSemantics(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	factory.Start(ctx.Done())
+	factory.StartWithContext(ctx)
 
 	if !cache.WaitForCacheSync(ctx.Done(), target.Informer().HasSynced) {
 		t.Fatalf("failed to wait for caches to sync")
@@ -250,7 +250,7 @@ func TestFilteredDynamicSharedInformerFactory(t *testing.T) {
 			informerListerForGvr := target.ForResource(ts.gvr)
 			logger := klog.FromContext(ctx)
 			_, _ = informerListerForGvr.Informer().AddEventHandlerWithOptions(ts.handler(informerReciveObjectCh), cache.HandlerOptions{Logger: &logger})
-			target.Start(ctx.Done())
+			target.StartWithContext(ctx)
 			if synced := target.WaitForCacheSync(ctx.Done()); !synced[ts.gvr] {
 				t.Errorf("informer for %s hasn't synced", ts.gvr)
 			}
@@ -375,7 +375,7 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 			informerListerForGvr := target.ForResource(ts.gvr)
 			logger := klog.FromContext(ctx)
 			_, _ = informerListerForGvr.Informer().AddEventHandlerWithOptions(ts.handler(informerReciveObjectCh), cache.HandlerOptions{Logger: &logger})
-			target.Start(ctx.Done())
+			target.StartWithContext(ctx)
 			if synced := target.WaitForCacheSync(ctx.Done()); !synced[ts.gvr] {
 				t.Errorf("informer for %s hasn't synced", ts.gvr)
 			}

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
@@ -39,6 +39,7 @@ import (
 	clientfeaturestesting "k8s.io/client-go/features/testing"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 	"net/http"
 	"net/http/httptest"
 )
@@ -247,7 +248,8 @@ func TestFilteredDynamicSharedInformerFactory(t *testing.T) {
 
 			// act
 			informerListerForGvr := target.ForResource(ts.gvr)
-			informerListerForGvr.Informer().AddEventHandler(ts.handler(informerReciveObjectCh))
+			logger := klog.FromContext(ctx)
+			_, _ = informerListerForGvr.Informer().AddEventHandlerWithOptions(ts.handler(informerReciveObjectCh), cache.HandlerOptions{Logger: &logger})
 			target.Start(ctx.Done())
 			if synced := target.WaitForCacheSync(ctx.Done()); !synced[ts.gvr] {
 				t.Errorf("informer for %s hasn't synced", ts.gvr)
@@ -371,7 +373,8 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 
 			// act
 			informerListerForGvr := target.ForResource(ts.gvr)
-			informerListerForGvr.Informer().AddEventHandler(ts.handler(informerReciveObjectCh))
+			logger := klog.FromContext(ctx)
+			_, _ = informerListerForGvr.Informer().AddEventHandlerWithOptions(ts.handler(informerReciveObjectCh), cache.HandlerOptions{Logger: &logger})
 			target.Start(ctx.Done())
 			if synced := target.WaitForCacheSync(ctx.Done()); !synced[ts.gvr] {
 				t.Errorf("informer for %s hasn't synced", ts.gvr)

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
@@ -17,6 +17,8 @@ limitations under the License.
 package dynamicinformer
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/informers"
@@ -26,7 +28,13 @@ import (
 type DynamicSharedInformerFactory interface {
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
+	//
+	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
+
+	// StartWithContext initializes all requested informers. They are handled in goroutines
+	// which run until the context gets canceled.
+	StartWithContext(ctx context.Context)
 
 	// ForResource gives generic access to a shared informer of the matching type.
 	ForResource(gvr schema.GroupVersionResource) informers.GenericInformer

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/interface.go
@@ -29,7 +29,7 @@ type DynamicSharedInformerFactory interface {
 	// Start initializes all requested informers. They are handled in goroutines
 	// which run until the stop channel gets closed.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
 )
 
 func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
@@ -104,7 +105,7 @@ func NewSimpleDynamicClientWithCustomListKinds(scheme *runtime.Scheme, gvrToList
 	}
 
 	codecs := serializer.NewCodecFactory(scheme)
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := testing.NewObjectTrackerWithLogger(klog.TODO() /* We need some way for the caller to pass a logger - see also NewSimpleMetadataClient. */, scheme, codecs.UniversalDecoder())
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)

--- a/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
+++ b/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
 )
 
 // TestFakeClient demonstrates how to use a fake client with SharedInformerFactory in tests.
@@ -59,13 +60,14 @@ func TestFakeClient(t *testing.T) {
 	pods := make(chan *v1.Pod, 1)
 	informers := informers.NewSharedInformerFactory(client, 0)
 	podInformer := informers.Core().V1().Pods().Informer()
-	podInformer.AddEventHandler(&cache.ResourceEventHandlerFuncs{
+	logger := klog.FromContext(ctx)
+	_, _ = podInformer.AddEventHandlerWithOptions(&cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pod := obj.(*v1.Pod)
 			t.Logf("pod added: %s/%s", pod.Namespace, pod.Name)
 			pods <- pod
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	// Make sure informers are running.
 	informers.Start(ctx.Done())

--- a/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
+++ b/staging/src/k8s.io/client-go/examples/fake-client/main_test.go
@@ -70,7 +70,7 @@ func TestFakeClient(t *testing.T) {
 	}, cache.HandlerOptions{Logger: &logger})
 
 	// Make sure informers are running.
-	informers.Start(ctx.Done())
+	informers.StartWithContext(ctx)
 
 	// This is not required in tests, but it serves as a proof-of-concept by
 	// ensuring that the informer goroutine have warmed up and called List before

--- a/staging/src/k8s.io/client-go/examples/workqueue/main.go
+++ b/staging/src/k8s.io/client-go/examples/workqueue/main.go
@@ -178,34 +178,43 @@ func main() {
 	podListWatcher := cache.NewListWatchFromClient(clientset.CoreV1().RESTClient(), "pods", v1.NamespaceDefault, fields.Everything())
 
 	// create the workqueue
-	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{
+		Logger: &logger,
+	})
 
 	// Bind the workqueue to a cache with the help of an informer. This way we make sure that
 	// whenever the cache is updated, the pod key is added to the workqueue.
 	// Note that when we finally process the item from the workqueue, we might see a newer version
 	// of the Pod than the version which was responsible for triggering the update.
-	indexer, informer := cache.NewIndexerInformer(podListWatcher, &v1.Pod{}, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			key, err := cache.MetaNamespaceKeyFunc(obj)
-			if err == nil {
-				queue.Add(key)
-			}
+	store, informer := cache.NewInformerWithOptions(cache.InformerOptions{
+		Logger:        &logger,
+		ListerWatcher: podListWatcher,
+		ObjectType:    &v1.Pod{},
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				key, err := cache.MetaNamespaceKeyFunc(obj)
+				if err == nil {
+					queue.Add(key)
+				}
+			},
+			UpdateFunc: func(old interface{}, new interface{}) {
+				key, err := cache.MetaNamespaceKeyFunc(new)
+				if err == nil {
+					queue.Add(key)
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				// IndexerInformer uses a delta queue, therefore for deletes we have to use this
+				// key function.
+				key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+				if err == nil {
+					queue.Add(key)
+				}
+			},
 		},
-		UpdateFunc: func(old interface{}, new interface{}) {
-			key, err := cache.MetaNamespaceKeyFunc(new)
-			if err == nil {
-				queue.Add(key)
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			// IndexerInformer uses a delta queue, therefore for deletes we have to use this
-			// key function.
-			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-			if err == nil {
-				queue.Add(key)
-			}
-		},
-	}, cache.Indexers{})
+		Indexers: cache.Indexers{},
+	})
+	indexer := store.(cache.Indexer)
 
 	controller := NewController(queue, indexer, informer)
 

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -308,7 +308,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -331,7 +331,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/client-go/kubernetes_test/clientset_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes_test/clientset_test.go
@@ -108,7 +108,7 @@ func TestWatchListSemanticsSimple(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	factory.Start(ctx.Done())
+	factory.StartWithContext(ctx)
 
 	if !cache.WaitForCacheSync(ctx.Done(), target.HasSynced) {
 		t.Fatalf("failed to wait for caches to sync")
@@ -127,7 +127,7 @@ func TestUnSupportWatchListSemantics(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	factory.Start(ctx.Done())
+	factory.StartWithContext(ctx)
 
 	if !cache.WaitForCacheSync(ctx.Done(), target.HasSynced) {
 		t.Fatalf("failed to wait for caches to sync")

--- a/staging/src/k8s.io/client-go/metadata/fake/simple.go
+++ b/staging/src/k8s.io/client-go/metadata/fake/simple.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
 )
 
 // MetadataClient assists in creating fake objects for use when testing, since metadata.Getter
@@ -58,7 +59,7 @@ func NewSimpleMetadataClient(scheme *runtime.Scheme, objects ...runtime.Object) 
 	}
 
 	codecs := serializer.NewCodecFactory(scheme)
-	o := testing.NewObjectTracker(scheme, codecs.UniversalDeserializer())
+	o := testing.NewObjectTrackerWithLogger(klog.TODO() /* We need some way for the caller to pass a logger - see also NewSimpleDynamicClientWithCustomListKinds. */, scheme, codecs.UniversalDeserializer())
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)

--- a/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/metadata/metadatainformer/informer_test.go
@@ -232,7 +232,8 @@ func TestMetadataSharedInformerFactory(t *testing.T) {
 
 			// act
 			informerListerForGvr := target.ForResource(ts.gvr)
-			informerListerForGvr.Informer().AddEventHandler(ts.handler(informerReciveObjectCh))
+			logger := klog.FromContext(ctx)
+			_, _ = informerListerForGvr.Informer().AddEventHandlerWithOptions(ts.handler(informerReciveObjectCh), cache.HandlerOptions{Logger: &logger})
 			target.Start(ctx.Done())
 			if synced := target.WaitForCacheSync(ctx.Done()); !synced[ts.gvr] {
 				t.Fatalf("informer for %s hasn't synced", ts.gvr)

--- a/staging/src/k8s.io/client-go/openapi/cached/client.go
+++ b/staging/src/k8s.io/client-go/openapi/cached/client.go
@@ -39,7 +39,7 @@ var (
 
 // NewClientWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use NewClientWithContext instead.
+//logcheck:context // Use NewClientWithContext instead of NewClient in code which supports contextual logging.
 func NewClient(other openapi.Client) openapi.Client {
 	return newClient(openapi.ToClientWithContext(other))
 }
@@ -56,7 +56,7 @@ func newClient(other openapi.ClientWithContext) *Client {
 
 // PathsWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use PathsWithContext instead.
+//logcheck:context // Use PathsWithContext instead of Paths in code which supports contextual logging.
 func (c *Client) Paths() (map[string]openapi.GroupVersion, error) {
 	// For efficiency reasons in the *WithContext case this is a map to
 	// openapi.GroupVersionWithContext. But we know that all entries

--- a/staging/src/k8s.io/client-go/openapi/cached/groupversion.go
+++ b/staging/src/k8s.io/client-go/openapi/cached/groupversion.go
@@ -49,7 +49,7 @@ func newGroupVersion(delegate openapi.GroupVersionWithContext) *groupversion {
 
 // SchemaWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use SchemaWithContext instead.
+//logcheck:context // Use SchemaWithContext instead of Schema in code which supports contextual logging.
 func (g *groupversion) Schema(contentType string) ([]byte, error) {
 	return g.SchemaWithContext(context.Background(), contentType)
 }

--- a/staging/src/k8s.io/client-go/openapi/client.go
+++ b/staging/src/k8s.io/client-go/openapi/client.go
@@ -27,7 +27,7 @@ import (
 
 // ClientWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ClientWithContext instead.
+//logcheck:context // Use ClientWithContext instead of Client in code which supports contextual logging.
 type Client interface {
 	Paths() (map[string]GroupVersion, error)
 }
@@ -68,7 +68,7 @@ type client struct {
 
 // NewClientWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use NewClientWithContext instead.
+//logcheck:context // Use NewClientWithContext instead of NewClient in code which supports contextual logging.
 func NewClient(restClient rest.Interface) Client {
 	return newClient(restClient)
 }
@@ -85,7 +85,7 @@ func newClient(restClient rest.Interface) *client {
 
 // PathsWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use PathsWithContext instead.
+//logcheck:context // Use PathsWithContext instead of Paths in code which supports contextual logging.
 func (c *client) Paths() (map[string]GroupVersion, error) {
 	resultWithContext, err := c.PathsWithContext(context.Background())
 	result := make(map[string]GroupVersion, len(resultWithContext))

--- a/staging/src/k8s.io/client-go/openapi/groupversion.go
+++ b/staging/src/k8s.io/client-go/openapi/groupversion.go
@@ -27,7 +27,7 @@ const ContentTypeOpenAPIV3PB = "application/com.github.proto-openapi.spec.v3@v1.
 
 // GroupVersionWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use GroupVersionWithContext instead.
+//logcheck:context // Use GroupVersionWithContext instead of GroupVersion in code which supports contextual logging.
 type GroupVersion interface {
 	Schema(contentType string) ([]byte, error)
 

--- a/staging/src/k8s.io/client-go/openapi/groupversion_test.go
+++ b/staging/src/k8s.io/client-go/openapi/groupversion_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestGroupVersion(t *testing.T) {
@@ -88,12 +89,13 @@ func TestGroupVersion(t *testing.T) {
 				t.Fatalf("unexpected error occurred: %v", err)
 			}
 
-			openapiClient := NewClient(c)
-			paths, err := openapiClient.Paths()
+			_, ctx := ktesting.NewTestContext(t)
+			openapiClient := NewClientWithContext(c)
+			paths, err := openapiClient.PathsWithContext(ctx)
 			if err != nil {
 				t.Fatalf("unexpected error occurred: %v", err)
 			}
-			schema, err := paths["apis/apps/v1"].Schema(runtime.ContentTypeJSON)
+			schema, err := paths["apis/apps/v1"].SchemaWithContext(ctx, runtime.ContentTypeJSON)
 			if err != nil {
 				t.Fatalf("unexpected error occurred: %v", err)
 			}

--- a/staging/src/k8s.io/client-go/restmapper/category_expansion.go
+++ b/staging/src/k8s.io/client-go/restmapper/category_expansion.go
@@ -30,7 +30,7 @@ import (
 //
 // CategoryExpanderWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use CategoryExpanderWithContext instead.
+//logcheck:context // Use CategoryExpanderWithContext instead of CategoryExpander in code which supports contextual logging.
 type CategoryExpander interface {
 	Expand(category string) ([]schema.GroupResource, bool)
 }
@@ -95,7 +95,7 @@ type discoveryCategoryExpander struct {
 //
 // NewDiscoveryCategoryExpanderWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use NewDiscoveryCategoryExpanderWithContext instead.
+//logcheck:context // Use NewDiscoveryCategoryExpanderWithContext instead of NewDiscoveryCategoryExpander in code which supports contextual logging.
 func NewDiscoveryCategoryExpander(client discovery.DiscoveryInterface) CategoryExpander {
 	return newDiscoveryCategoryExpander(discovery.ToDiscoveryInterfaceWithContext(client))
 }
@@ -118,7 +118,7 @@ func newDiscoveryCategoryExpander(client discovery.DiscoveryInterfaceWithContext
 //
 // ExpandWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ExpandWithContext instead.
+//logcheck:context // Use ExpandWithContext instead of Expand in code which supports contextual logging.
 func (e discoveryCategoryExpander) Expand(category string) ([]schema.GroupResource, bool) {
 	return e.ExpandWithContext(context.Background(), category)
 }
@@ -160,7 +160,7 @@ func (e discoveryCategoryExpander) ExpandWithContext(ctx context.Context, catego
 //
 // UnionCategoryExpanderWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use UnionCategoryExpanderWithContext instead.
+//logcheck:context // Use UnionCategoryExpanderWithContext instead of UnionCategoryExpander in code which supports contextual logging.
 type UnionCategoryExpander []CategoryExpander
 
 var _ CategoryExpander = UnionCategoryExpander{}

--- a/staging/src/k8s.io/client-go/restmapper/category_expansion_test.go
+++ b/staging/src/k8s.io/client-go/restmapper/category_expansion_test.go
@@ -22,6 +22,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestCategoryExpansion(t *testing.T) {
@@ -131,12 +133,13 @@ func TestDiscoveryCategoryExpander(t *testing.T) {
 	}
 
 	dc := &fakeDiscoveryClient{}
+	_, ctx := ktesting.NewTestContext(t)
 	for _, test := range tests {
 		dc.serverResourcesHandler = func() ([]*metav1.APIResourceList, error) {
 			return test.serverResponse, nil
 		}
-		expander := NewDiscoveryCategoryExpander(dc)
-		expanded, _ := expander.Expand(test.category)
+		expander := NewDiscoveryCategoryExpanderWithContext(discovery.ToDiscoveryInterfaceWithContext(dc))
+		expanded, _ := expander.ExpandWithContext(ctx, test.category)
 		if !reflect.DeepEqual(expanded, test.expected) {
 			t.Errorf("expected %v, got %v", test.expected, expanded)
 		}

--- a/staging/src/k8s.io/client-go/restmapper/discovery.go
+++ b/staging/src/k8s.io/client-go/restmapper/discovery.go
@@ -44,7 +44,7 @@ type APIGroupResources struct {
 //
 // NewDiscoveryRESTMapperWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use NewDiscoveryRESTMapperWithContext instead.
+//logcheck:context // Use NewDiscoveryRESTMapperWithContext instead of NewDiscoveryRESTMapper in code which supports contextual logging.
 func NewDiscoveryRESTMapper(groupResources []*APIGroupResources) meta.RESTMapper {
 	mappers, resourcePriority, kindPriority := newDiscoveryRESTMapper(groupResources)
 	multiMapper := make(meta.MultiRESTMapper, len(mappers))
@@ -176,7 +176,7 @@ func newDiscoveryRESTMapper(groupResources []*APIGroupResources) ([]*meta.Defaul
 //
 // GetAPIGroupResourcesWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use GetAPIGroupResourcesWithContext instead.
+//logcheck:context // Use GetAPIGroupResourcesWithContext instead of GetAPIGroupResources in code which supports contextual logging.
 func GetAPIGroupResources(cl discovery.DiscoveryInterface) ([]*APIGroupResources, error) {
 	return GetAPIGroupResourcesWithContext(context.Background(), discovery.ToDiscoveryInterfaceWithContext(cl))
 }
@@ -234,7 +234,7 @@ var (
 //
 // NewDeferredDiscoveryRESTMapperWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use NewDeferredDiscoveryRESTMapperWithContext instead. NewDeferredDiscoveryRESTMapper will try to convert cl to discovery.CachedDiscoveryInterfaceWithContext and use a wrapper if that is not possible, but NewDeferredDiscoveryRESTMapperWithContext ensures that no such conversion is necessary.
+//logcheck:context // Use NewDeferredDiscoveryRESTMapperWithContext instead of NewDeferredDiscoveryRESTMapper in code which supports contextual logging. NewDeferredDiscoveryRESTMapper will try to convert cl to discovery.CachedDiscoveryInterfaceWithContext and use a wrapper if that is not possible, but NewDeferredDiscoveryRESTMapperWithContext ensures that no such conversion is necessary.
 func NewDeferredDiscoveryRESTMapper(cl discovery.CachedDiscoveryInterface) *DeferredDiscoveryRESTMapper {
 	return &DeferredDiscoveryRESTMapper{
 		cl: discovery.ToCachedDiscoveryInterfaceWithContext(cl),
@@ -290,7 +290,7 @@ func (d *DeferredDiscoveryRESTMapper) ResetWithContext(ctx context.Context) {
 //
 // KindForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use KindForWithContext instead.
+//logcheck:context // Use KindForWithContext instead of KindFor in code which supports contextual logging.
 func (d *DeferredDiscoveryRESTMapper) KindFor(resource schema.GroupVersionResource) (gvk schema.GroupVersionKind, err error) {
 	return d.KindForWithContext(context.Background(), resource)
 }
@@ -315,7 +315,7 @@ func (d *DeferredDiscoveryRESTMapper) KindForWithContext(ctx context.Context, re
 //
 // KindsForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use KindsForWithContext instead.
+//logcheck:context // Use KindsForWithContext instead of KindsFor in code which supports contextual logging.
 func (d *DeferredDiscoveryRESTMapper) KindsFor(resource schema.GroupVersionResource) (gvks []schema.GroupVersionKind, err error) {
 	return d.KindsForWithContext(context.Background(), resource)
 }
@@ -340,7 +340,7 @@ func (d *DeferredDiscoveryRESTMapper) KindsForWithContext(ctx context.Context, r
 //
 // ResourceForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ResourceForWithContext instead.
+//logcheck:context // Use ResourceForWithContext instead of ResourceFor in code which supports contextual logging.
 func (d *DeferredDiscoveryRESTMapper) ResourceFor(input schema.GroupVersionResource) (gvr schema.GroupVersionResource, err error) {
 	return d.ResourceForWithContext(context.Background(), input)
 }
@@ -365,7 +365,7 @@ func (d *DeferredDiscoveryRESTMapper) ResourceForWithContext(ctx context.Context
 //
 // ResourcesForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ResourcesForWithContext instead.
+//logcheck:context // Use ResourcesForWithContext instead of ResourcesFor in code which supports contextual logging.
 func (d *DeferredDiscoveryRESTMapper) ResourcesFor(input schema.GroupVersionResource) (gvrs []schema.GroupVersionResource, err error) {
 	return d.ResourcesForWithContext(context.Background(), input)
 }
@@ -390,7 +390,7 @@ func (d *DeferredDiscoveryRESTMapper) ResourcesForWithContext(ctx context.Contex
 //
 // RESTMappingWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use RESTMappingWithContext instead.
+//logcheck:context // Use RESTMappingWithContext instead of RESTMapping in code which supports contextual logging.
 func (d *DeferredDiscoveryRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (m *meta.RESTMapping, err error) {
 	return d.RESTMappingWithContext(context.Background(), gk, versions...)
 }
@@ -416,7 +416,7 @@ func (d *DeferredDiscoveryRESTMapper) RESTMappingWithContext(ctx context.Context
 //
 // RESTMappingsWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use RESTMappingsWithContext instead.
+//logcheck:context // Use RESTMappingsWithContext instead of RESTMappings in code which supports contextual logging.
 func (d *DeferredDiscoveryRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) (ms []*meta.RESTMapping, err error) {
 	return d.RESTMappingsWithContext(context.Background(), gk, versions...)
 }
@@ -442,7 +442,7 @@ func (d *DeferredDiscoveryRESTMapper) RESTMappingsWithContext(ctx context.Contex
 //
 // ResourceSingularizerWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ResourceSingularizerWithContext instead.
+//logcheck:context // Use ResourceSingularizerWithContext instead of ResourceSingularizer in code which supports contextual logging.
 func (d *DeferredDiscoveryRESTMapper) ResourceSingularizer(resource string) (singular string, err error) {
 	return d.ResourceSingularizerWithContext(context.Background(), resource)
 }

--- a/staging/src/k8s.io/client-go/restmapper/discovery_test.go
+++ b/staging/src/k8s.io/client-go/restmapper/discovery_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/openapi"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/dump"
 
 	openapi_v2 "github.com/google/gnostic-models/openapiv2"
@@ -97,7 +98,8 @@ func TestRESTMapper(t *testing.T) {
 		},
 	}
 
-	restMapper := NewDiscoveryRESTMapper(resources)
+	_, ctx := ktesting.NewTestContext(t)
+	restMapper := NewDiscoveryRESTMapperWithContext(resources)
 
 	kindTCs := []struct {
 		input schema.GroupVersionResource
@@ -164,7 +166,7 @@ func TestRESTMapper(t *testing.T) {
 	}
 
 	for _, tc := range kindTCs {
-		got, err := restMapper.KindFor(tc.input)
+		got, err := restMapper.KindForWithContext(ctx, tc.input)
 		if err != nil {
 			t.Errorf("KindFor(%#v) unexpected error: %v", tc.input, err)
 			continue
@@ -230,7 +232,7 @@ func TestRESTMapper(t *testing.T) {
 	}
 
 	for _, tc := range resourceTCs {
-		got, err := restMapper.ResourceFor(tc.input)
+		got, err := restMapper.ResourceForWithContext(ctx, tc.input)
 		if err != nil {
 			t.Errorf("ResourceFor(%#v) unexpected error: %v", tc.input, err)
 			continue
@@ -245,12 +247,13 @@ func TestRESTMapper(t *testing.T) {
 func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 	assert := assert.New(t)
 
+	_, ctx := ktesting.NewTestContext(t)
 	cdc := fakeCachedDiscoveryInterface{fresh: false}
-	m := NewDeferredDiscoveryRESTMapper(&cdc)
+	m := NewDeferredDiscoveryRESTMapperWithContext(ToCachedDiscoveryInterfaceWithContext(&cdc))
 	assert.False(cdc.fresh, "should NOT be fresh after instantiation")
 	assert.Zero(cdc.invalidateCalls, "should not have called Invalidate()")
 
-	gvk, err := m.KindFor(schema.GroupVersionResource{
+	gvk, err := m.KindForWithContext(ctx, schema.GroupVersionResource{
 		Group:    "a",
 		Version:  "v1",
 		Resource: "foo",
@@ -260,7 +263,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 	assert.Equal(1, cdc.invalidateCalls, "should have called Invalidate() once")
 	assert.Equal("Foo", gvk.Kind)
 
-	gvk, err = m.KindFor(schema.GroupVersionResource{
+	gvk, err = m.KindForWithContext(ctx, schema.GroupVersionResource{
 		Group:    "a",
 		Version:  "v1",
 		Resource: "foo",
@@ -268,7 +271,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(1, cdc.invalidateCalls, "should NOT have called Invalidate() again")
 
-	gvk, err = m.KindFor(schema.GroupVersionResource{
+	gvk, err = m.KindForWithContext(ctx, schema.GroupVersionResource{
 		Group:    "a",
 		Version:  "v1",
 		Resource: "bar",
@@ -277,7 +280,7 @@ func TestDeferredDiscoveryRESTMapper_CacheMiss(t *testing.T) {
 	assert.Equal(1, cdc.invalidateCalls, "should NOT have called Invalidate() again after another cache-miss, but with fresh==true")
 
 	cdc.fresh = false
-	gvk, err = m.KindFor(schema.GroupVersionResource{
+	gvk, err = m.KindForWithContext(ctx, schema.GroupVersionResource{
 		Group:    "a",
 		Version:  "v1",
 		Resource: "bar",
@@ -357,7 +360,8 @@ func TestGetAPIGroupResources(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := GetAPIGroupResources(test.discovery)
+			_, ctx := ktesting.NewTestContext(t)
+			got, err := GetAPIGroupResourcesWithContext(ctx, ToDiscoveryInterfaceWithContext(test.discovery))
 			if err == nil && test.expectedError != nil {
 				t.Fatalf("expected error %q, but got none", test.expectedError)
 			} else if err != nil && test.expectedError == nil {
@@ -393,6 +397,7 @@ func (d *fakeFailingDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
 }
 
 func (d *fakeFailingDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	//nolint:logcheck // Implementing the old, non-contextual DiscoveryInterface method leaves no context to pass through.
 	return ServerGroupsAndResources(d)
 }
 func (d *fakeFailingDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
@@ -403,10 +408,12 @@ func (d *fakeFailingDiscovery) ServerResourcesForGroupVersion(groupVersion strin
 }
 
 func (d *fakeFailingDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	//nolint:logcheck // Implementing the old, non-contextual DiscoveryInterface method leaves no context to pass through.
 	return ServerPreferredResources(d)
 }
 
 func (d *fakeFailingDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	//nolint:logcheck // Implementing the old, non-contextual DiscoveryInterface method leaves no context to pass through.
 	return ServerPreferredNamespacedResources(d)
 }
 
@@ -458,6 +465,7 @@ func (c *fakeCachedDiscoveryInterface) ServerGroups() (*metav1.APIGroupList, err
 }
 
 func (c *fakeCachedDiscoveryInterface) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	//nolint:logcheck // Implementing the old, non-contextual DiscoveryInterface method leaves no context to pass through.
 	return ServerGroupsAndResources(c)
 }
 

--- a/staging/src/k8s.io/client-go/restmapper/shortcut.go
+++ b/staging/src/k8s.io/client-go/restmapper/shortcut.go
@@ -45,7 +45,7 @@ var _ meta.ResettableRESTMapperWithContext = shortcutExpander{}
 //
 // NewShortcutExpanderWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use NewShortcutExpanderWithContext instead.
+//logcheck:context // Use NewShortcutExpanderWithContext instead of NewShortcutExpander in code which supports contextual logging.
 func NewShortcutExpander(delegate meta.RESTMapper, client discovery.DiscoveryInterface, warningHandler func(string)) meta.RESTMapper {
 	return newShortcutExpander(meta.ToRESTMapperWithContext(delegate), discovery.ToDiscoveryInterfaceWithContext(client), warningHandler)
 }
@@ -84,7 +84,7 @@ func (e shortcutExpander) KindForWithContext(ctx context.Context, resource schem
 //
 // KindsForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use KindsForWithContext instead.
+//logcheck:context // Use KindsForWithContext instead of KindsFor in code which supports contextual logging.
 func (e shortcutExpander) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
 	return e.KindsForWithContext(context.Background(), resource)
 }
@@ -98,7 +98,7 @@ func (e shortcutExpander) KindsForWithContext(ctx context.Context, resource sche
 //
 // ResourcesForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ResourcesForWithContext instead.
+//logcheck:context // Use ResourcesForWithContext instead of ResourcesFor in code which supports contextual logging.
 func (e shortcutExpander) ResourcesFor(resource schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
 	return e.ResourcesForWithContext(context.Background(), resource)
 }
@@ -112,7 +112,7 @@ func (e shortcutExpander) ResourcesForWithContext(ctx context.Context, resource 
 //
 // ResourceForWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ResourceForWithContext instead.
+//logcheck:context // Use ResourceForWithContext instead of ResourceFor in code which supports contextual logging.
 func (e shortcutExpander) ResourceFor(resource schema.GroupVersionResource) (schema.GroupVersionResource, error) {
 	return e.ResourceForWithContext(context.Background(), resource)
 }
@@ -126,7 +126,7 @@ func (e shortcutExpander) ResourceForWithContext(ctx context.Context, resource s
 //
 // ResourceSingularizerWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ResourceSingularizerWithContext instead.
+//logcheck:context // Use ResourceSingularizerWithContext instead of ResourceSingularizer in code which supports contextual logging.
 func (e shortcutExpander) ResourceSingularizer(resource string) (string, error) {
 	return e.ResourceSingularizerWithContext(context.Background(), resource)
 }
@@ -140,7 +140,7 @@ func (e shortcutExpander) ResourceSingularizerWithContext(ctx context.Context, r
 //
 // RESTMappingWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use RESTMappingWithContext instead.
+//logcheck:context // Use RESTMappingWithContext instead of RESTMapping in code which supports contextual logging.
 func (e shortcutExpander) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
 	return e.RESTMappingWithContext(context.Background(), gk, versions...)
 }
@@ -154,7 +154,7 @@ func (e shortcutExpander) RESTMappingWithContext(ctx context.Context, gk schema.
 //
 // RESTMappingsWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use RESTMappingsWithContext instead.
+//logcheck:context // Use RESTMappingsWithContext instead of RESTMappings in code which supports contextual logging.
 func (e shortcutExpander) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
 	return e.RESTMappingsWithContext(context.Background(), gk, versions...)
 }
@@ -275,7 +275,7 @@ func (e shortcutExpander) expandResourceShortcut(ctx context.Context, resource s
 
 // ResetWithContext is a better alternative because it supports contextual logging and cancellation.
 //
-// Contextual logging: Use ResetWithContext instead.
+//logcheck:context // Use ResetWithContext instead of Reset in code which supports contextual logging.
 func (e shortcutExpander) Reset() {
 	e.ResetWithContext(context.Background())
 }

--- a/staging/src/k8s.io/client-go/restmapper/shortcut_test.go
+++ b/staging/src/k8s.io/client-go/restmapper/shortcut_test.go
@@ -136,7 +136,7 @@ func TestReplaceAliases(t *testing.T) {
 		ds.serverResourcesHandler = func() ([]*metav1.APIResourceList, error) {
 			return test.srvRes, nil
 		}
-		mapper := NewShortcutExpander(&fakeRESTMapper{}, ds, nil).(shortcutExpander)
+		mapper := NewShortcutExpanderWithContext(meta.ToRESTMapperWithContext(&fakeRESTMapper{}), discovery.ToDiscoveryInterfaceWithContext(ds), nil).(shortcutExpander)
 
 		actual := mapper.expandResourceShortcut(ctx, schema.GroupVersionResource{Resource: test.arg})
 		if actual != test.expected {
@@ -183,6 +183,7 @@ func TestKindFor(t *testing.T) {
 		},
 	}
 
+	_, ctx := ktesting.NewTestContext(t)
 	for i, test := range tests {
 		ds := &fakeDiscoveryClient{}
 		ds.serverResourcesHandler = func() ([]*metav1.APIResourceList, error) {
@@ -190,11 +191,11 @@ func TestKindFor(t *testing.T) {
 		}
 
 		delegate := &fakeRESTMapper{}
-		mapper := NewShortcutExpander(delegate, ds, func(a string) {
+		mapper := NewShortcutExpanderWithContext(meta.ToRESTMapperWithContext(delegate), discovery.ToDiscoveryInterfaceWithContext(ds), func(a string) {
 			t.Fatalf("unexpected warning message %s", a)
 		})
 
-		mapper.KindFor(test.in)
+		_, _ = mapper.KindForWithContext(ctx, test.in)
 		if delegate.kindForInput != test.expected {
 			t.Errorf("%d: unexpected data returned %#v, expected %#v", i, delegate.kindForInput, test.expected)
 		}
@@ -246,12 +247,14 @@ func TestKindForWithNewCRDs(t *testing.T) {
 			// in real world the discovery client is fronted with a cache which
 			// will answer the initial request, only failure to match will trigger
 			// the cache invalidation and live discovery call
-			delegate := NewDeferredDiscoveryRESTMapper(fakeCachedDiscovery)
-			mapper := NewShortcutExpander(delegate, fakeCachedDiscovery, func(a string) {
+			cachedDiscoveryWithContext := discovery.ToCachedDiscoveryInterfaceWithContext(fakeCachedDiscovery)
+			delegate := NewDeferredDiscoveryRESTMapperWithContext(cachedDiscoveryWithContext)
+			mapper := NewShortcutExpanderWithContext(delegate, cachedDiscoveryWithContext, func(a string) {
 				t.Fatalf("unexpected warning message %s", a)
 			})
 
-			gvk, err := mapper.KindFor(test.in)
+			_, ctx := ktesting.NewTestContext(t)
+			gvk, err := mapper.KindForWithContext(ctx, test.in)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -440,7 +443,7 @@ func TestWarnAmbigious(t *testing.T) {
 		}
 
 		var actualWarnings []string
-		mapper := NewShortcutExpander(&fakeRESTMapper{}, ds, func(a string) {
+		mapper := NewShortcutExpanderWithContext(meta.ToRESTMapperWithContext(&fakeRESTMapper{}), discovery.ToDiscoveryInterfaceWithContext(ds), func(a string) {
 			actualWarnings = append(actualWarnings, a)
 		}).(shortcutExpander)
 

--- a/staging/src/k8s.io/client-go/scale/client_test.go
+++ b/staging/src/k8s.io/client-go/scale/client_test.go
@@ -97,10 +97,12 @@ func fakeScaleClient(t *testing.T) (ScalesGetter, []schema.GroupResource) {
 		},
 	}
 
+	//nolint:logcheck // scale.New below requires a PreferredResourceMapper, which is the older, non-contextual interface, so building it from discovery has no context to thread through here.
 	restMapperRes, err := restmapper.GetAPIGroupResources(fakeDiscoveryClient)
 	if err != nil {
 		t.Fatalf("unexpected error while constructing resource list from fake discovery client: %v", err)
 	}
+	//nolint:logcheck // scale.New below requires a PreferredResourceMapper, which is the older, non-contextual interface, so building it from discovery has no context to thread through here.
 	restMapper := restmapper.NewDiscoveryRESTMapper(restMapperRes)
 
 	autoscalingScale := &autoscalingv1.Scale{

--- a/staging/src/k8s.io/client-go/scale/util.go
+++ b/staging/src/k8s.io/client-go/scale/util.go
@@ -61,6 +61,7 @@ type discoveryScaleResolver struct {
 }
 
 func (r *discoveryScaleResolver) ScaleForResource(inputRes schema.GroupVersionResource) (scaleVersion schema.GroupVersionKind, err error) {
+	//nolint:logcheck // ScaleForResource implements the old, non-contextual ScaleKindResolver interface method, leaving no context to pass through.
 	groupVerResources, err := r.discoveryClient.ServerResourcesForGroupVersion(inputRes.GroupVersion().String())
 	if err != nil {
 		return schema.GroupVersionKind{}, fmt.Errorf("unable to fetch discovery information for %s: %v", inputRes.String(), err)

--- a/staging/src/k8s.io/client-go/testing/fixture.go
+++ b/staging/src/k8s.io/client-go/testing/fixture.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/watch"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 )
 
 // ObjectTracker keeps track of objects. It is intended to be used to
@@ -288,6 +289,7 @@ func (o objectTrackerReact) Patch(action PatchActionImpl) (runtime.Object, error
 type tracker struct {
 	scheme  ObjectScheme
 	decoder runtime.Decoder
+	logger  klog.Logger
 	lock    sync.RWMutex
 	objects map[schema.GroupVersionResource]map[types.NamespacedName]versionedObject
 	// The value type of watchers is a map of which the key is either a namespace or
@@ -335,10 +337,19 @@ var _ ObjectTracker = &tracker{}
 
 // NewObjectTracker returns an ObjectTracker that can be used to keep track
 // of objects for the fake clientset. Mostly useful for unit tests.
+//
+//logcheck:context // NewObjectTrackerWithLogger should be used instead of NewObjectTracker in code which supports contextual logging.
 func NewObjectTracker(scheme ObjectScheme, decoder runtime.Decoder) ObjectTracker {
+	return NewObjectTrackerWithLogger(klog.Background(), scheme, decoder)
+}
+
+// NewObjectTrackerWithLogger is like NewObjectTracker, but supports passing
+// a logger for contextual logging instead of falling back to klog.Background.
+func NewObjectTrackerWithLogger(logger klog.Logger, scheme ObjectScheme, decoder runtime.Decoder) ObjectTracker {
 	return &tracker{
 		scheme:           scheme,
 		decoder:          decoder,
+		logger:           logger,
 		objects:          make(map[schema.GroupVersionResource]map[types.NamespacedName]versionedObject),
 		watchers:         make(map[schema.GroupVersionResource]map[string][]*watch.RaceFreeFakeWatcher),
 		resourceVersions: make(map[schema.GroupVersionResource]int64),
@@ -430,7 +441,7 @@ func (t *tracker) Watch(gvr schema.GroupVersionResource, ns string, opts ...meta
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	fakewatcher := watch.NewRaceFreeFake()
+	fakewatcher := watch.NewRaceFreeFakeWithLogger(t.logger)
 
 	if _, exists := t.watchers[gvr]; !exists {
 		t.watchers[gvr] = make(map[string][]*watch.RaceFreeFakeWatcher)
@@ -745,9 +756,17 @@ var _ ObjectTracker = &managedFieldObjectTracker{}
 
 // NewFieldManagedObjectTracker returns an ObjectTracker that can be used to keep track
 // of objects and managed fields for the fake clientset. Mostly useful for unit tests.
+//
+//logcheck:context // NewFieldManagedObjectTrackerWithLogger should be used instead of NewFieldManagedObjectTracker in code which supports contextual logging.
 func NewFieldManagedObjectTracker(scheme *runtime.Scheme, decoder runtime.Decoder, typeConverter managedfields.TypeConverter) ObjectTracker {
+	return NewFieldManagedObjectTrackerWithLogger(klog.Background(), scheme, decoder, typeConverter)
+}
+
+// NewFieldManagedObjectTrackerWithLogger is like NewFieldManagedObjectTracker, but supports passing
+// a logger for contextual logging instead of falling back to klog.Background.
+func NewFieldManagedObjectTrackerWithLogger(logger klog.Logger, scheme *runtime.Scheme, decoder runtime.Decoder, typeConverter managedfields.TypeConverter) ObjectTracker {
 	return &managedFieldObjectTracker{
-		ObjectTracker:   NewObjectTracker(scheme, decoder),
+		ObjectTracker:   NewObjectTrackerWithLogger(logger, scheme, decoder),
 		scheme:          scheme,
 		objectConverter: scheme,
 		mapper: func() meta.RESTMapper {

--- a/staging/src/k8s.io/client-go/testing/fixture_test.go
+++ b/staging/src/k8s.io/client-go/testing/fixture_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/managedfields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/util/watchlist"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -61,6 +62,7 @@ func getArbitraryResource(s schema.GroupVersionResource, name, namespace string)
 }
 
 func TestWatchCallNonNamespace(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testResource := schema.GroupVersionResource{Group: "", Version: "test_version", Resource: "test_kind"}
 	testObj := getArbitraryResource(testResource, "test_name", "test_namespace")
 	accessor, err := meta.Accessor(testObj)
@@ -70,7 +72,7 @@ func TestWatchCallNonNamespace(t *testing.T) {
 	ns := accessor.GetNamespace()
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	watch, err := o.Watch(testResource, ns)
 	if err != nil {
 		t.Fatalf("test resource watch failed in %s: %v ", ns, err)
@@ -86,6 +88,7 @@ func TestWatchCallNonNamespace(t *testing.T) {
 }
 
 func TestWatchCallAllNamespace(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testResource := schema.GroupVersionResource{Group: "", Version: "test_version", Resource: "test_kind"}
 	testObj := getArbitraryResource(testResource, "test_name", "test_namespace")
 	accessor, err := meta.Accessor(testObj)
@@ -95,7 +98,7 @@ func TestWatchCallAllNamespace(t *testing.T) {
 	ns := accessor.GetNamespace()
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	w, err := o.Watch(testResource, "test_namespace")
 	if err != nil {
 		t.Fatalf("test resource watch failed in test_namespace: %v", err)
@@ -137,6 +140,7 @@ func TestWatchCallAllNamespace(t *testing.T) {
 }
 
 func TestWatchCallMultipleInvocation(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cases := []struct {
 		name string
 		op   watch.EventType
@@ -188,7 +192,7 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 	codecs := serializer.NewCodecFactory(scheme)
 	testResource := schema.GroupVersionResource{Group: "", Version: "test_version", Resource: "test_kind"}
 
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	watchNamespaces := []string{
 		"",
 		"",
@@ -239,6 +243,7 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 }
 
 func TestWatchAddAfterStop(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	testResource := schema.GroupVersionResource{Group: "", Version: "test_version", Resource: "test_kind"}
 	testObj := getArbitraryResource(testResource, "test_name", "test_namespace")
 	accessor, err := meta.Accessor(testObj)
@@ -249,7 +254,7 @@ func TestWatchAddAfterStop(t *testing.T) {
 	ns := accessor.GetNamespace()
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	watch, err := o.Watch(testResource, ns)
 	if err != nil {
 		t.Errorf("watch creation failed: %v", err)
@@ -270,11 +275,12 @@ func TestWatchAddAfterStop(t *testing.T) {
 }
 
 func TestPatchWithMissingObject(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	nodesResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}
 
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	reaction := ObjectReaction(o)
 	action := NewRootPatchSubresourceAction(nodesResource, "node-1", types.StrategicMergePatchType, []byte(`{}`))
 	handled, node, err := reaction(action)
@@ -284,11 +290,12 @@ func TestPatchWithMissingObject(t *testing.T) {
 }
 
 func TestApplyCreate(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cmResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configMaps"}
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypes(cmResource.GroupVersion(), &v1.ConfigMap{})
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewFieldManagedObjectTracker(scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
+	o := NewFieldManagedObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
 
 	reaction := ObjectReaction(o)
 	patch := []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "cm-1"}, "data": {"k": "v"}}`)
@@ -304,11 +311,12 @@ func TestApplyCreate(t *testing.T) {
 }
 
 func TestApplyNoMeta(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cmResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configMaps"}
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypes(cmResource.GroupVersion(), &v1.ConfigMap{})
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewFieldManagedObjectTracker(scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
+	o := NewFieldManagedObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
 
 	reaction := ObjectReaction(o)
 	patch := []byte(`{"apiVersion": "v1", "kind": "ConfigMap", "data": {"k": "v"}}`)
@@ -325,11 +333,12 @@ func TestApplyNoMeta(t *testing.T) {
 }
 
 func TestApplyUpdateMultipleFieldManagers(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cmResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configMaps"}
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypes(cmResource.GroupVersion(), &v1.ConfigMap{})
 	codecs := serializer.NewCodecFactory(scheme)
-	o := NewFieldManagedObjectTracker(scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
+	o := NewFieldManagedObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
 
 	reaction := ObjectReaction(o)
 	action := NewCreateAction(cmResource, "default", &v1.ConfigMap{
@@ -436,6 +445,7 @@ func TestApplyUpdateMultipleFieldManagers(t *testing.T) {
 }
 
 func TestGetWithExactMatch(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 
@@ -449,7 +459,7 @@ func TestGetWithExactMatch(t *testing.T) {
 
 	var err error
 	// Object with empty namespace
-	o := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	nodeResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "node"}
 	node, gvr := constructObject(nodeResource, "node", "")
 
@@ -466,7 +476,7 @@ func TestGetWithExactMatch(t *testing.T) {
 	assert.EqualError(t, err, errNotFound.Error())
 
 	// Object with non-empty namespace
-	o = NewObjectTracker(scheme, codecs.UniversalDecoder())
+	o = NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 	podResource := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pod"}
 	pod, gvr := constructObject(podResource, "pod", "default")
 	assert.NoError(t, o.Add(pod))
@@ -666,12 +676,13 @@ var configMapTypedSchema = typed.YAMLObject(`types:
 `)
 
 func TestManagedFieldsObjectTrackerReloadsScheme(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cmResource := schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 
 	// Create tracker without registered ConfigMap type
-	tracker := NewFieldManagedObjectTracker(scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
+	tracker := NewFieldManagedObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder(), configMapTypeConverter(scheme))
 
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -688,13 +699,14 @@ func TestManagedFieldsObjectTrackerReloadsScheme(t *testing.T) {
 }
 
 func TestManagedFielsdObjectTrackerWithUnstructured(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	cmResource := schema.GroupVersionResource{Version: "v1", Resource: "configmaps"}
 	cmGVK := schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypeWithName(cmGVK, &unstructured.Unstructured{})
 	codecs := serializer.NewCodecFactory(scheme)
 
-	tracker := NewFieldManagedObjectTracker(scheme, codecs.UniversalDecoder(), managedfields.NewDeducedTypeConverter())
+	tracker := NewFieldManagedObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder(), managedfields.NewDeducedTypeConverter())
 
 	cm := &unstructured.Unstructured{}
 	cm.SetAPIVersion("v1")
@@ -743,10 +755,11 @@ func TestManagedFielsdObjectTrackerWithUnstructured(t *testing.T) {
 }
 
 func TestDoesClientSupportWatchListSemantics(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 
-	target := NewObjectTracker(scheme, codecs.UniversalDecoder())
+	target := NewObjectTrackerWithLogger(logger, scheme, codecs.UniversalDecoder())
 
 	if !watchlist.DoesClientNotSupportWatchListSemantics(target) {
 		t.Fatalf("ObjectTracker should NOT support WatchList semantics")

--- a/staging/src/k8s.io/client-go/testing/internal/listandwatch_test.go
+++ b/staging/src/k8s.io/client-go/testing/internal/listandwatch_test.go
@@ -47,6 +47,8 @@ import (
 func TestListAndWatch(t *testing.T) { synctest.Test(t, testListAndWatch) }
 func testListAndWatch(t *testing.T) {
 	logger, ctx := ktesting.NewTestContext(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	cm := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "cm1",
@@ -54,8 +56,6 @@ func testListAndWatch(t *testing.T) {
 		},
 	}
 	client := fake.NewClientset(cm)
-	stopCh := make(chan struct{})
-	defer close(stopCh)
 	createDone := make(chan struct{})
 
 	f := informers.NewSharedInformerFactory(client, 0)
@@ -96,7 +96,7 @@ func testListAndWatch(t *testing.T) {
 	defer configMapInformer.RemoveEventHandler(handle)
 
 	configMapStore := configMapInformer.GetStore()
-	f.Start(stopCh)
+	f.StartWithContext(ctx)
 	f.WaitForCacheSync(stopCh)
 	logger.Info("Caches synced")
 

--- a/staging/src/k8s.io/client-go/testing/internal/listandwatch_test.go
+++ b/staging/src/k8s.io/client-go/testing/internal/listandwatch_test.go
@@ -85,11 +85,11 @@ func testListAndWatch(t *testing.T) {
 	})
 
 	var adds, updates, deletes int
-	handle, err := configMapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	handle, err := configMapInformer.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    func(_ any) { adds++ },
 		UpdateFunc: func(_, _ any) { updates++ },
 		DeleteFunc: func(_ any) { deletes++ },
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		t.Fatalf("Unexpected error adding event handler: %v", err)
 	}

--- a/staging/src/k8s.io/client-go/testing/internal/listandwatch_test.go
+++ b/staging/src/k8s.io/client-go/testing/internal/listandwatch_test.go
@@ -97,7 +97,7 @@ func testListAndWatch(t *testing.T) {
 
 	configMapStore := configMapInformer.GetStore()
 	f.StartWithContext(ctx)
-	f.WaitForCacheSync(stopCh)
+	f.WaitForCacheSyncWithContext(ctx)
 	logger.Info("Caches synced")
 
 	objs := configMapStore.List()

--- a/staging/src/k8s.io/client-go/tools/cache/controller.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller.go
@@ -90,7 +90,7 @@ type Config struct {
 
 	// Called whenever the ListAndWatch drops the connection with an error.
 	//
-	// Contextual logging: WatchErrorHandlerWithContext should be used instead of WatchErrorHandler in code which supports contextual logging.
+	//logcheck:context // WatchErrorHandlerWithContext should be used instead of WatchErrorHandler in code which supports contextual logging.
 	WatchErrorHandler WatchErrorHandler
 
 	// Called whenever the ListAndWatch drops the connection with an error
@@ -138,7 +138,7 @@ type Controller interface {
 	// Run does the same as RunWithContext with a stop channel instead of
 	// a context.
 	//
-	// Contextual logging: RunWithcontext should be used instead of Run in code which supports contextual logging.
+	//logcheck:context // RunWithcontext should be used instead of Run in code which supports contextual logging.
 	Run(stopCh <-chan struct{})
 
 	// HasSynced delegates to the Config's Queue
@@ -703,6 +703,8 @@ func NewInformerWithOptions(options InformerOptions) (Store, Controller) {
 //   - h is the object you want notifications sent to.
 //
 // Deprecated: Use NewInformerWithOptions instead.
+//
+//logcheck:context // NewInformerWithOptions and logger should be used instead of NewInformer in code which supports contextual logging.
 func NewInformer(
 	lw ListerWatcher,
 	objType runtime.Object,
@@ -718,6 +720,7 @@ func NewInformer(
 		Handler:       h,
 		ResyncPeriod:  resyncPeriod,
 	}
+	//nolint:logcheck // Cannot provide Logger here, use NewInformerWithOptions.
 	return clientState, newInformer(clientState, options, DeletionHandlingMetaNamespaceKeyFunc)
 }
 
@@ -738,6 +741,8 @@ func NewInformer(
 //   - indexers is the indexer for the received object type.
 //
 // Deprecated: Use NewInformerWithOptions instead.
+//
+//logcheck:context // NewInformerWithOptions and logger should be used instead of NewIndexerInformer in code which supports contextual logging.
 func NewIndexerInformer(
 	lw ListerWatcher,
 	objType runtime.Object,
@@ -755,6 +760,7 @@ func NewIndexerInformer(
 		ResyncPeriod:  resyncPeriod,
 		Indexers:      indexers,
 	}
+	//nolint:logcheck // Cannot provide Logger here.
 	return clientState, newInformer(clientState, options, DeletionHandlingMetaNamespaceKeyFunc)
 }
 
@@ -767,6 +773,8 @@ func NewIndexerInformer(
 // be invoked for them.
 //
 // Deprecated: Use NewInformerWithOptions instead.
+//
+//logcheck:context // NewInformerWithOptions and logger should be used instead of NewTransformingInformer in code which supports contextual logging.
 func NewTransformingInformer(
 	lw ListerWatcher,
 	objType runtime.Object,
@@ -784,6 +792,7 @@ func NewTransformingInformer(
 		ResyncPeriod:  resyncPeriod,
 		Transform:     transformer,
 	}
+	//nolint:logcheck // Cannot provide Logger here.
 	return clientState, newInformer(clientState, options, DeletionHandlingMetaNamespaceKeyFunc)
 }
 
@@ -796,6 +805,8 @@ func NewTransformingInformer(
 // be invoked for them.
 //
 // Deprecated: Use NewInformerWithOptions instead.
+//
+//logcheck:context // NewInformerWithOptions and logger should be used instead of NewTransformingIndexerInformer in code which supports contextual logging.
 func NewTransformingIndexerInformer(
 	lw ListerWatcher,
 	objType runtime.Object,
@@ -815,6 +826,7 @@ func NewTransformingIndexerInformer(
 		Indexers:      indexers,
 		Transform:     transformer,
 	}
+	//nolint:logcheck // Cannot provide Logger here.
 	return clientState, newInformer(clientState, options, DeletionHandlingMetaNamespaceKeyFunc)
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/controller_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/controller_test.go
@@ -56,7 +56,7 @@ func Example() {
 	// This will hold incoming changes. Note how we pass downstream in as a
 	// KeyLister, that way resync operations will result in the correct set
 	// of update/delete deltas.
-	fifo := NewRealFIFO(MetaNamespaceKeyFunc, downstream, nil)
+	fifo := NewRealFIFO(MetaNamespaceKeyFunc, downstream, nil) //nolint:logcheck // Intentionally testing old API here.
 
 	// Let's do threadsafe output to get predictable test results.
 	deletionCounter := make(chan string, 1000)
@@ -141,7 +141,7 @@ func ExampleNewInformer() {
 
 	// Make a controller that immediately deletes anything added to it, and
 	// logs anything deleted.
-	_, controller := NewInformer(
+	_, controller := NewInformer( //nolint:logcheck // Intentionally testing old API here.
 		source,
 		&v1.Pod{},
 		time.Millisecond*100,
@@ -217,7 +217,7 @@ func TestHammerController(t *testing.T) {
 	}
 
 	// Make a controller which just logs all the changes it gets.
-	_, controller := NewInformer(
+	_, controller := NewInformer( //nolint:logcheck // Intentionally testing old API here.
 		source,
 		&v1.Pod{},
 		time.Millisecond*100,
@@ -369,7 +369,7 @@ func TestUpdate(t *testing.T) {
 	// It calls Done() on the wait group on deletions so we can tell when
 	// everything we've added has been deleted.
 	watchCh := make(chan struct{})
-	_, controller := NewInformer(
+	_, controller := NewInformer( //nolint:logcheck // Intentionally testing old API here.
 		toListWatcherWithUnSupportedWatchListSemantics(&ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				watch, err := source.Watch(options)
@@ -430,7 +430,7 @@ func TestPanicPropagated(t *testing.T) {
 	source := newFakeControllerSource(t)
 
 	// Make a controller that just panic if the AddFunc is called.
-	_, controller := NewInformer(
+	_, controller := NewInformer( //nolint:logcheck // Intentionally testing old API here.
 		source,
 		&v1.Pod{},
 		time.Millisecond*100,
@@ -541,7 +541,7 @@ func TestTransformingInformer(t *testing.T) {
 		return pod, nil
 	}
 
-	store, controller := NewTransformingInformer(
+	store, controller := NewTransformingInformer( //nolint:logcheck // Intentionally testing old API here.
 		source,
 		&v1.Pod{},
 		0,
@@ -653,7 +653,7 @@ func TestTransformingInformerRace(t *testing.T) {
 			<-events
 		}
 	}
-	store, controller := NewTransformingInformer(
+	store, controller := NewTransformingInformer( //nolint:logcheck // Intentionally testing old API here.
 		source,
 		&v1.Pod{},
 		5*time.Millisecond,

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -263,7 +263,10 @@ type Deltas []Delta
 // instead to receive a `Replaced` event depending on the type.
 //
 // Deprecated: Equivalent to NewDeltaFIFOWithOptions(DeltaFIFOOptions{KeyFunction: keyFunc, KnownObjects: knownObjects})
+//
+//logcheck:context // NewDeltaFIFOWithOptions and logger should be used instead of NewDeltaFIFO in code which supports contextual logging.
 func NewDeltaFIFO(keyFunc KeyFunc, knownObjects KeyListerGetter) *DeltaFIFO {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewDeltaFIFOWithOptions(DeltaFIFOOptions{
 		KeyFunction:  keyFunc,
 		KnownObjects: knownObjects,

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_detector_test.go
@@ -25,10 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestMutationDetector(t *testing.T) {
-	fakeWatch := watch.NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	fakeWatch := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	lw := toListWatcherWithUnSupportedWatchListSemantics(&ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			return fakeWatch, nil

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -238,13 +238,19 @@ func NewNamespaceKeyedIndexerAndReflector(lw ListerWatcher, expectedType interfa
 
 // NewReflector creates a new Reflector with its name defaulted to the closest source_file.go:line in the call stack
 // that is outside this package. See NewReflectorWithOptions for further information.
+//
+//logcheck:context // NewReflectorWithOptions and logger should be used instead of NewReflector in code which supports contextual logging.
 func NewReflector(lw ListerWatcher, expectedType interface{}, store ReflectorStore, resyncPeriod time.Duration) *Reflector {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewReflectorWithOptions(lw, expectedType, store, ReflectorOptions{ResyncPeriod: resyncPeriod})
 }
 
 // NewNamedReflector creates a new Reflector with the specified name. See NewReflectorWithOptions for further
 // information.
+//
+//logcheck:context // NewNamedReflector and logger should be used instead of NewNamedReflector in code which supports contextual logging.
 func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, store ReflectorStore, resyncPeriod time.Duration) *Reflector {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewReflectorWithOptions(lw, expectedType, store, ReflectorOptions{Name: name, ResyncPeriod: resyncPeriod})
 }
 
@@ -412,7 +418,7 @@ var internalPackages = []string{"client-go/tools/cache/"}
 // objects and subsequent deltas.
 // Run will exit when stopCh is closed.
 //
-// Contextual logging: RunWithContext should be used instead of Run in code which supports contextual logging.
+//logcheck:context // RunWithContext should be used instead of Run in code which supports contextual logging.
 func (r *Reflector) Run(stopCh <-chan struct{}) {
 	r.RunWithContext(wait.ContextForChannel(stopCh))
 }
@@ -459,7 +465,7 @@ func (r *Reflector) resyncChan() (<-chan time.Time, func() bool) {
 // and then use the resource version to watch.
 // It returns error if ListAndWatch didn't even try to initialize watch.
 //
-// Contextual logging: ListAndWatchWithContext should be used instead of ListAndWatch in code which supports contextual logging.
+//logcheck:context // ListAndWatchWithContext should be used instead of ListAndWatch in code which supports contextual logging.
 func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 	return r.ListAndWatchWithContext(wait.ContextForChannel(stopCh))
 }

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
@@ -85,7 +85,7 @@ func runTestReflectorDataConsistencyDetector(t *testing.T, transformer Transform
 			}, nil
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			w := watch.NewFake()
+			w := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			go func() {
 				w.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod-1", ResourceVersion: "1"}})
 				w.Action(watch.Bookmark, &v1.Pod{ObjectMeta: metav1.ObjectMeta{

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_data_consistency_detector_test.go
@@ -98,7 +98,7 @@ func runTestReflectorDataConsistencyDetector(t *testing.T, transformer Transform
 		},
 	}
 
-	r := NewReflector(lw, &v1.Pod{}, fifo, 0)
+	r := NewReflector(lw, &v1.Pod{}, fifo, 0) //nolint:logcheck // Intentionally testing old API here.
 
 	go func() {
 		_ = wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -912,7 +912,7 @@ func TestBackoffOnTooManyRequests(t *testing.T) {
 			case 0:
 				return nil, err
 			case 1:
-				w := watch.NewFakeWithChanSize(1, false)
+				w := watch.NewFakeWithOptions(watch.FakeOptions{ChannelSize: 1, Logger: &logger})
 				status := err.Status()
 				w.Error(&status)
 				return w, nil
@@ -1014,6 +1014,7 @@ func TestRetryInternalError(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		logger, _ := ktesting.NewTestContext(t)
 		err := apierrors.NewInternalError(fmt.Errorf("etcdserver: no leader"))
 		fakeClock := testingclock.NewFakeClock(time.Now())
 		fd := &fakeDelayFunc{}
@@ -1033,7 +1034,7 @@ func TestRetryInternalError(t *testing.T) {
 				}
 
 				fakeClock.Step(time.Second)
-				w := watch.NewFakeWithChanSize(1, false)
+				w := watch.NewFakeWithOptions(watch.FakeOptions{ChannelSize: 1, Logger: &logger})
 				status := err.Status()
 				w.Error(&status)
 				return w, nil

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -60,10 +60,10 @@ import (
 var nevererrc chan error
 
 func TestCloseWatchChannelOnError(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	r := NewReflector(&ListWatch{}, &v1.Pod{}, NewStore(MetaNamespaceKeyFunc), 0) //nolint:logcheck // Intentionally testing old API here.
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}
-	fw := watch.NewFake()
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	r.listerWatcher = &ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			return fw, nil
@@ -86,11 +86,11 @@ func TestCloseWatchChannelOnError(t *testing.T) {
 }
 
 func TestRunUntil(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)
 	store := NewStore(MetaNamespaceKeyFunc)
 	r := NewReflector(&ListWatch{}, &v1.Pod{}, store, 0) //nolint:logcheck // Intentionally testing old API here.
-	fw := watch.NewFake()
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	r.listerWatcher = &ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			return fw, nil
@@ -171,7 +171,7 @@ func TestReflectorWatchStoppedBefore(t *testing.T) {
 // TestReflectorWatchStoppedAfter ensures that Reflector.watch always stops
 // the watcher when the stop channel is closed.
 func TestReflectorWatchStoppedAfter(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)
 
 	var watchers []*watch.FakeWatcher
@@ -188,7 +188,7 @@ func TestReflectorWatchStoppedAfter(t *testing.T) {
 				cancel(errors.New("10ms timeout reached"))
 			}()
 			// Use a fake watcher that never sends events
-			w := watch.NewFake()
+			w := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			watchers = append(watchers, w)
 			return w, nil
 		},
@@ -336,7 +336,7 @@ func TestReflectorWatchHandler(t *testing.T) {
 	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 	// Wrap setLastSyncResourceVersion so we can tell the watchHandler to stop
 	// watching after all the events have been consumed.
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)
 	setLastSyncResourceVersion := func(rv string, _ bool) {
 		g.setLastSyncResourceVersion(rv)
@@ -344,7 +344,7 @@ func TestReflectorWatchHandler(t *testing.T) {
 			cancel(errors.New("LastSyncResourceVersion is 32"))
 		}
 	}
-	fw := watch.NewFake()
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	s.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}})
 	s.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}})
 	go func() {
@@ -394,8 +394,8 @@ func TestReflectorWatchHandler(t *testing.T) {
 func TestReflectorStopWatch(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
 	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
-	fw := watch.NewFake()
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	ctx, cancel := context.WithCancelCause(ctx)
 	cancel(errors.New("don't run"))
 	err := handleWatch(ctx, time.Now(), fw, s, g.expectedType, g.expectedGVK, g.name, g.typeDescription, func(rv string, _ bool) { g.setLastSyncResourceVersion(rv) }, g.clock, nevererrc)
@@ -541,6 +541,8 @@ func TestReflectorListAndWatch(t *testing.T) {
 			watcherCh := make(chan *watch.FakeWatcher)
 			var listOpts, watchOpts []metav1.ListOptions
 
+			logger, ctx := ktesting.NewTestContext(t)
+
 			// The ListFunc will never be called. So we expect Watch to only be called
 			// with options.ResourceVersion="" to start the WatchList.
 			lw := &ListWatch{
@@ -550,7 +552,7 @@ func TestReflectorListAndWatch(t *testing.T) {
 						return nil, fmt.Errorf("Expected ListerWatcher.Watch to only be called %d times",
 							len(tc.expectedWatchOptions))
 					}
-					w := watch.NewFake()
+					w := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 					// Enqueue for event producer to use
 					go func() { watcherCh <- w }()
 					t.Log("Watcher Started")
@@ -572,7 +574,6 @@ func TestReflectorListAndWatch(t *testing.T) {
 			// Start ListAndWatch in the background.
 			// When it returns, it will send an error or nil on the error
 			// channel and close the error channel.
-			_, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			errCh := make(chan error)
@@ -686,7 +687,7 @@ func TestReflectorListAndWatchWithErrors(t *testing.T) {
 			}
 		}
 		watchRet, watchErr := item.events, item.watchErr
-		_, ctx := ktesting.NewTestContext(t)
+		logger, ctx := ktesting.NewTestContext(t)
 		ctx, cancel := context.WithCancelCause(ctx)
 		lw := toListWatcherWithUnSupportedWatchListSemantics(&ListWatch{
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
@@ -694,7 +695,7 @@ func TestReflectorListAndWatchWithErrors(t *testing.T) {
 					return nil, watchErr
 				}
 				watchErr = fmt.Errorf("second watch")
-				fw := watch.NewFake()
+				fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 				go func() {
 					for _, e := range watchRet {
 						fw.Action(e.Type, e.Object)
@@ -741,7 +742,7 @@ func TestReflectorListAndWatchInitConnBackoff(t *testing.T) {
 	for _, test := range table {
 		t.Run(fmt.Sprintf("%d connection failures takes at least %d ms", test.numConnFails, 1<<test.numConnFails),
 			func(t *testing.T) {
-				_, ctx := ktesting.NewTestContext(t)
+				logger, ctx := ktesting.NewTestContext(t)
 				ctx, cancel := context.WithCancelCause(ctx)
 				connFails := test.numConnFails
 				fakeClock := testingclock.NewFakeClock(time.Unix(0, 0))
@@ -781,7 +782,7 @@ func TestReflectorListAndWatchInitConnBackoff(t *testing.T) {
 							return nil, syscall.ECONNREFUSED
 						}
 						cancel(errors.New("done"))
-						return watch.NewFake(), nil
+						return watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger}), nil
 					},
 					ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 						return &v1.PodList{ListMeta: metav1.ListMeta{ResourceVersion: "1"}}, nil
@@ -847,7 +848,7 @@ func TestNewReflectorWithCustomBackoff(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			logger, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancelCause(ctx)
 			connFails := tc.numConnFails
 
@@ -861,7 +862,7 @@ func TestNewReflectorWithCustomBackoff(t *testing.T) {
 						return nil, syscall.ECONNREFUSED
 					}
 					cancel(errors.New("done"))
-					return watch.NewFake(), nil
+					return watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger}), nil
 				},
 			}
 
@@ -897,7 +898,7 @@ func (f *fakeDelayFunc) delayFunc() time.Duration {
 }
 
 func TestBackoffOnTooManyRequests(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	err := apierrors.NewTooManyRequests("too many requests", 1)
 	clock := &clock.RealClock{}
 	fd := &fakeDelayFunc{}
@@ -916,7 +917,7 @@ func TestBackoffOnTooManyRequests(t *testing.T) {
 				w.Error(&status)
 				return w, nil
 			default:
-				w := watch.NewFake()
+				w := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 				w.Stop()
 				return w, nil
 			}
@@ -943,6 +944,7 @@ func TestBackoffOnTooManyRequests(t *testing.T) {
 }
 
 func TestNoRelistOnTooManyRequests(t *testing.T) {
+	logger, ctx := ktesting.NewTestContext(t)
 	err := apierrors.NewTooManyRequests("too many requests", 1)
 	clock := &clock.RealClock{}
 	fd := &fakeDelayFunc{}
@@ -958,7 +960,7 @@ func TestNoRelistOnTooManyRequests(t *testing.T) {
 			if watchCalls < 5 {
 				return nil, err
 			}
-			w := watch.NewFake()
+			w := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			w.Stop()
 			return w, nil
 		},
@@ -973,7 +975,6 @@ func TestNoRelistOnTooManyRequests(t *testing.T) {
 		watchErrorHandler: WatchErrorHandlerWithContext(DefaultWatchErrorHandler),
 	}
 
-	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)
 	if err := r.ListAndWatchWithContext(ctx); err != nil {
 		t.Fatal(err)
@@ -1063,7 +1064,7 @@ func TestRetryInternalError(t *testing.T) {
 
 func TestReflectorResync(t *testing.T) {
 	iteration := 0
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	rerr := errors.New("expected resync reached")
 	s := &FakeCustomStore{
 		ResyncFunc: func() error {
@@ -1077,7 +1078,7 @@ func TestReflectorResync(t *testing.T) {
 
 	lw := toListWatcherWithUnSupportedWatchListSemantics(&ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			fw := watch.NewFake()
+			fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			return fw, nil
 		},
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1096,7 +1097,7 @@ func TestReflectorResync(t *testing.T) {
 }
 
 func TestReflectorWatchListPageSize(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)
 	s := NewStore(MetaNamespaceKeyFunc)
 
@@ -1104,7 +1105,7 @@ func TestReflectorWatchListPageSize(t *testing.T) {
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			// Stop once the reflector begins watching since we're only interested in the list.
 			cancel(errors.New("done"))
-			fw := watch.NewFake()
+			fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			return fw, nil
 		},
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1142,7 +1143,7 @@ func TestReflectorWatchListPageSize(t *testing.T) {
 }
 
 func TestReflectorNotPaginatingNotConsistentReads(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)
 	s := NewStore(MetaNamespaceKeyFunc)
 
@@ -1150,7 +1151,7 @@ func TestReflectorNotPaginatingNotConsistentReads(t *testing.T) {
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			// Stop once the reflector begins watching since we're only interested in the list.
 			cancel(errors.New("done"))
-			fw := watch.NewFake()
+			fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			return fw, nil
 		},
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1178,7 +1179,7 @@ func TestReflectorNotPaginatingNotConsistentReads(t *testing.T) {
 }
 
 func TestReflectorPaginatingNonConsistentReadsIfWatchCacheDisabled(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	var cancel func(error)
 	s := NewStore(MetaNamespaceKeyFunc)
 
@@ -1186,7 +1187,7 @@ func TestReflectorPaginatingNonConsistentReadsIfWatchCacheDisabled(t *testing.T)
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			// Stop once the reflector begins watching since we're only interested in the list.
 			cancel(errors.New("done"))
-			fw := watch.NewFake()
+			fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			return fw, nil
 		},
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1234,7 +1235,7 @@ func TestReflectorPaginatingNonConsistentReadsIfWatchCacheDisabled(t *testing.T)
 // it in relist requests to prevent the reflector from traveling back in time if the relist is to a api-server or
 // etcd that is partitioned and serving older data than the reflector has already processed.
 func TestReflectorResyncWithResourceVersion(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	cancelCtx, cancel := context.WithCancelCause(ctx)
 	s := NewStore(MetaNamespaceKeyFunc)
 	listCallRVs := []string{}
@@ -1243,7 +1244,7 @@ func TestReflectorResyncWithResourceVersion(t *testing.T) {
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			// Stop once the reflector begins watching since we're only interested in the list.
 			cancel(errors.New("done"))
-			fw := watch.NewFake()
+			fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			return fw, nil
 		},
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1294,7 +1295,7 @@ func TestReflectorResyncWithResourceVersion(t *testing.T) {
 // (In kubernetes 1.17, or when the watch cache is enabled, the List will instead return the list that is no older than
 // the requested ResourceVersion).
 func TestReflectorExpiredExactResourceVersion(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	var cancelCtx context.Context
 	var cancel func(error)
 	s := NewStore(MetaNamespaceKeyFunc)
@@ -1304,7 +1305,7 @@ func TestReflectorExpiredExactResourceVersion(t *testing.T) {
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			// Stop once the reflector begins watching since we're only interested in the list.
 			cancel(errors.New("done"))
-			fw := watch.NewFake()
+			fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			return fw, nil
 		},
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1354,7 +1355,7 @@ func TestReflectorExpiredExactResourceVersion(t *testing.T) {
 }
 
 func TestReflectorFullListIfExpired(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	var cancelCtx context.Context
 	var cancel func(error)
 	s := NewStore(MetaNamespaceKeyFunc)
@@ -1364,7 +1365,7 @@ func TestReflectorFullListIfExpired(t *testing.T) {
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			// Stop once the reflector begins watching since we're only interested in the list.
 			cancel(errors.New("done"))
-			fw := watch.NewFake()
+			fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			return fw, nil
 		},
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1428,7 +1429,7 @@ func TestReflectorFullListIfExpired(t *testing.T) {
 }
 
 func TestReflectorFullListIfTooLarge(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	var cancelCtx context.Context
 	var cancel func(error)
 	s := NewStore(MetaNamespaceKeyFunc)
@@ -1439,7 +1440,7 @@ func TestReflectorFullListIfTooLarge(t *testing.T) {
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			// Stop once the reflector begins watching since we're only interested in the list.
 			cancel(errors.New("done"))
-			fw := watch.NewFake()
+			fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			return fw, nil
 		},
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -1604,7 +1605,7 @@ func TestWatchTimeout(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, ctx := ktesting.NewTestContext(t)
+			logger, ctx := ktesting.NewTestContext(t)
 			ctx, cancel := context.WithCancelCause(ctx)
 			s := NewStore(MetaNamespaceKeyFunc)
 			var gotTimeoutSeconds int64
@@ -1620,7 +1621,7 @@ func TestWatchTimeout(t *testing.T) {
 
 					// Stop once the reflector begins watching since we're only interested in the list.
 					cancel(errors.New("done"))
-					return watch.NewFake(), nil
+					return watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger}), nil
 				},
 			}
 
@@ -1661,9 +1662,9 @@ func newStoreWithRV() *storeWithRV {
 func TestReflectorResourceVersionUpdate(t *testing.T) {
 	s := newStoreWithRV()
 
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)
-	fw := watch.NewFake()
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 
 	lw := toListWatcherWithUnSupportedWatchListSemantics(&ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
@@ -2007,6 +2008,7 @@ func TestReflectorListExtract(t *testing.T) {
 }
 
 func TestReflectorReplacesStoreOnUnsafeDelete(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	mkPod := func(id string, rv string) *v1.Pod {
 		return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: id, ResourceVersion: rv}}
 	}
@@ -2083,7 +2085,7 @@ func TestReflectorReplacesStoreOnUnsafeDelete(t *testing.T) {
 	var once sync.Once
 	lw := toListWatcherWithUnSupportedWatchListSemantics(&ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			fw := watch.NewFake()
+			fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 			go func() {
 				once.Do(func() {
 					for _, e := range events {
@@ -2186,6 +2188,7 @@ func TestReflectorRespectStoreTransformer(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			logger, _ := ktesting.NewTestContext(t)
 			mkPod := func(id string, rv string) *v1.Pod {
 				return &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: id, ResourceVersion: rv},
@@ -2220,7 +2223,7 @@ func TestReflectorRespectStoreTransformer(t *testing.T) {
 			var once sync.Once
 			lw := &ListWatch{
 				WatchFunc: func(metav1.ListOptions) (watch.Interface, error) {
-					fw := watch.NewFake()
+					fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 					go func() {
 						once.Do(func() {
 							for _, e := range events {

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -61,7 +61,7 @@ var nevererrc chan error
 
 func TestCloseWatchChannelOnError(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
-	r := NewReflector(&ListWatch{}, &v1.Pod{}, NewStore(MetaNamespaceKeyFunc), 0)
+	r := NewReflector(&ListWatch{}, &v1.Pod{}, NewStore(MetaNamespaceKeyFunc), 0) //nolint:logcheck // Intentionally testing old API here.
 	pod := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "bar"}}
 	fw := watch.NewFake()
 	r.listerWatcher = &ListWatch{
@@ -89,7 +89,7 @@ func TestRunUntil(t *testing.T) {
 	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)
 	store := NewStore(MetaNamespaceKeyFunc)
-	r := NewReflector(&ListWatch{}, &v1.Pod{}, store, 0)
+	r := NewReflector(&ListWatch{}, &v1.Pod{}, store, 0) //nolint:logcheck // Intentionally testing old API here.
 	fw := watch.NewFake()
 	r.listerWatcher = &ListWatch{
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
@@ -133,7 +133,7 @@ func TestRunUntil(t *testing.T) {
 
 func TestReflectorResyncChan(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
-	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, time.Millisecond)
+	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, time.Millisecond) //nolint:logcheck // Intentionally testing old API here.
 	a, _ := g.resyncChan()
 	b := time.After(wait.ForeverTestTimeout)
 	select {
@@ -162,7 +162,7 @@ func TestReflectorWatchStoppedBefore(t *testing.T) {
 			return nil, nil
 		},
 	}
-	target := NewReflector(lw, &v1.Pod{}, nil, 0)
+	target := NewReflector(lw, &v1.Pod{}, nil, 0) //nolint:logcheck // Intentionally testing old API here.
 
 	err := target.watch(ctx, nil, nil)
 	require.NoError(t, err)
@@ -193,7 +193,7 @@ func TestReflectorWatchStoppedAfter(t *testing.T) {
 			return w, nil
 		},
 	}
-	target := NewReflector(lw, &v1.Pod{}, nil, 0)
+	target := NewReflector(lw, &v1.Pod{}, nil, 0) //nolint:logcheck // Intentionally testing old API here.
 
 	err := target.watch(ctx, nil, nil)
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestReflectorWatchStoppedAfter(t *testing.T) {
 
 func BenchmarkReflectorResyncChanMany(b *testing.B) {
 	s := NewStore(MetaNamespaceKeyFunc)
-	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 25*time.Millisecond)
+	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 25*time.Millisecond) //nolint:logcheck // Intentionally testing old API here.
 	// The improvement to this (calling the timer's Stop() method) makes
 	// this benchmark about 40% faster.
 	for i := 0; i < b.N; i++ {
@@ -218,7 +218,7 @@ func BenchmarkReflectorResyncChanMany(b *testing.B) {
 // ResultChan and Stop are both called once.
 func TestReflectorHandleWatchStoppedBefore(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
-	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0)
+	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)
 	// Simulate the context being canceled before the watchHandler is called
@@ -246,7 +246,7 @@ func TestReflectorHandleWatchStoppedBefore(t *testing.T) {
 // ResultChan and Stop are both called once.
 func TestReflectorHandleWatchStoppedAfter(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
-	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0)
+	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 	var calls []string
 	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)
@@ -279,7 +279,7 @@ func TestReflectorHandleWatchStoppedAfter(t *testing.T) {
 // It also ensures that ResultChan and Stop are both called once.
 func TestReflectorHandleWatchResultChanClosedBefore(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
-	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0)
+	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 	_, ctx := ktesting.NewTestContext(t)
 	var calls []string
 	resultCh := make(chan watch.Event)
@@ -305,7 +305,7 @@ func TestReflectorHandleWatchResultChanClosedBefore(t *testing.T) {
 // watching. It also ensures that ResultChan and Stop are both called once.
 func TestReflectorHandleWatchResultChanClosedAfter(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
-	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0)
+	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 	_, ctx := ktesting.NewTestContext(t)
 	var calls []string
 	resultCh := make(chan watch.Event)
@@ -333,7 +333,7 @@ func TestReflectorHandleWatchResultChanClosedAfter(t *testing.T) {
 
 func TestReflectorWatchHandler(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
-	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0)
+	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 	// Wrap setLastSyncResourceVersion so we can tell the watchHandler to stop
 	// watching after all the events have been consumed.
 	_, ctx := ktesting.NewTestContext(t)
@@ -393,7 +393,7 @@ func TestReflectorWatchHandler(t *testing.T) {
 
 func TestReflectorStopWatch(t *testing.T) {
 	s := NewStore(MetaNamespaceKeyFunc)
-	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0)
+	g := NewReflector(&ListWatch{}, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 	fw := watch.NewFake()
 	_, ctx := ktesting.NewTestContext(t)
 	ctx, cancel := context.WithCancelCause(ctx)
@@ -567,7 +567,7 @@ func TestReflectorListAndWatch(t *testing.T) {
 				},
 			}
 			s := NewFIFO(MetaNamespaceKeyFunc)
-			r := NewReflector(lw, &v1.Pod{}, s, 0)
+			r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 
 			// Start ListAndWatch in the background.
 			// When it returns, it will send an error or nil on the error
@@ -713,7 +713,7 @@ func TestReflectorListAndWatchWithErrors(t *testing.T) {
 				return item.list, item.listErr
 			},
 		})
-		r := NewReflector(lw, &v1.Pod{}, s, 0)
+		r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 		err := r.ListAndWatchWithContext(ctx)
 		if item.listErr != nil && !errors.Is(err, item.listErr) {
 			t.Errorf("unexpected ListAndWatch error: %v", err)
@@ -1085,7 +1085,7 @@ func TestReflectorResync(t *testing.T) {
 		},
 	})
 	resyncPeriod := 1 * time.Millisecond
-	r := NewReflector(lw, &v1.Pod{}, s, resyncPeriod)
+	r := NewReflector(lw, &v1.Pod{}, s, resyncPeriod) //nolint:logcheck // Intentionally testing old API here.
 	if err := r.ListAndWatchWithContext(ctx); err != nil {
 		// error from Resync is not propaged up to here.
 		t.Errorf("expected error %v", err)
@@ -1128,7 +1128,7 @@ func TestReflectorWatchListPageSize(t *testing.T) {
 			return nil, nil
 		},
 	})
-	r := NewReflector(lw, &v1.Pod{}, s, 0)
+	r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 	// Set resource version to test pagination also for not consistent reads.
 	r.setLastSyncResourceVersion("10")
 	// Set the reflector to paginate the list request in 4 item chunks.
@@ -1167,7 +1167,7 @@ func TestReflectorNotPaginatingNotConsistentReads(t *testing.T) {
 			return &v1.PodList{ListMeta: metav1.ListMeta{ResourceVersion: "10"}, Items: pods}, nil
 		},
 	})
-	r := NewReflector(lw, &v1.Pod{}, s, 0)
+	r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 	r.setLastSyncResourceVersion("10")
 	require.NoError(t, r.ListAndWatchWithContext(ctx))
 
@@ -1211,7 +1211,7 @@ func TestReflectorPaginatingNonConsistentReadsIfWatchCacheDisabled(t *testing.T)
 			return nil, nil
 		},
 	})
-	r := NewReflector(lw, &v1.Pod{}, s, 0)
+	r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 
 	// Initial list should initialize paginatedResult in the reflector.
 	var cancelCtx context.Context
@@ -1263,7 +1263,7 @@ func TestReflectorResyncWithResourceVersion(t *testing.T) {
 			return nil, nil
 		},
 	})
-	r := NewReflector(lw, &v1.Pod{}, s, 0)
+	r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 
 	// Initial list should use RV=0
 	require.NoError(t, r.ListAndWatchWithContext(cancelCtx))
@@ -1327,7 +1327,7 @@ func TestReflectorExpiredExactResourceVersion(t *testing.T) {
 			return nil, nil
 		},
 	})
-	r := NewReflector(lw, &v1.Pod{}, s, 0)
+	r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 
 	// Initial list should use RV=0
 	cancelCtx, cancel = context.WithCancelCause(ctx)
@@ -1396,7 +1396,7 @@ func TestReflectorFullListIfExpired(t *testing.T) {
 			}
 		},
 	})
-	r := NewReflector(lw, &v1.Pod{}, s, 0)
+	r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 	r.WatchListPageSize = 4
 
 	// Initial list should use RV=0
@@ -1473,7 +1473,7 @@ func TestReflectorFullListIfTooLarge(t *testing.T) {
 			}
 		},
 	})
-	r := NewReflector(lw, &v1.Pod{}, s, 0)
+	r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 
 	// Initial list should use RV=0
 	cancelCtx, cancel = context.WithCancelCause(ctx)
@@ -1673,7 +1673,7 @@ func TestReflectorResourceVersionUpdate(t *testing.T) {
 			return &v1.PodList{ListMeta: metav1.ListMeta{ResourceVersion: "10"}}, nil
 		},
 	})
-	r := NewReflector(lw, &v1.Pod{}, s, 0)
+	r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 
 	makePod := func(rv string) *v1.Pod {
 		return &v1.Pod{ObjectMeta: metav1.ObjectMeta{ResourceVersion: rv}}
@@ -1940,7 +1940,7 @@ func TestReflectorListExtract(t *testing.T) {
 	})
 
 	lw := newPageTestLW(5)
-	reflector := NewReflector(lw, &v1.Pod{}, store, 0)
+	reflector := NewReflector(lw, &v1.Pod{}, store, 0) //nolint:logcheck // Intentionally testing old API here.
 	reflector.WatchListPageSize = fakeItemsNum
 
 	// execute list to fill store
@@ -2103,7 +2103,7 @@ func TestReflectorReplacesStoreOnUnsafeDelete(t *testing.T) {
 		},
 	})
 
-	r := NewReflector(lw, &v1.Pod{}, store, 0)
+	r := NewReflector(lw, &v1.Pod{}, store, 0) //nolint:logcheck // Intentionally testing old API here.
 	doneCh, stopCh := make(chan struct{}), make(chan struct{})
 	go func() {
 		defer close(doneCh)
@@ -2147,7 +2147,7 @@ func TestReflectorRespectStoreTransformer(t *testing.T) {
 	}{
 		"real-fifo": {
 			storeBuilder: func(counter *atomic.Int32) ReflectorStore {
-				return NewRealFIFO(MetaNamespaceKeyFunc, NewStore(MetaNamespaceKeyFunc), func(i interface{}) (interface{}, error) {
+				return NewRealFIFO(MetaNamespaceKeyFunc, NewStore(MetaNamespaceKeyFunc), func(i interface{}) (interface{}, error) { //nolint:logcheck // Intentionally testing old API here.
 					counter.Add(1)
 					cast := i.(*v1.Pod)
 					cast.Spec.Hostname = "transformed"
@@ -2237,7 +2237,7 @@ func TestReflectorRespectStoreTransformer(t *testing.T) {
 			}
 
 			clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, true)
-			r := NewReflector(lw, &v1.Pod{}, s, 0)
+			r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 			ctx, cancel := context.WithCancel(context.Background())
 			doneCh := make(chan struct{})
 			go func() {
@@ -2465,7 +2465,7 @@ func BenchmarkReflectorList(b *testing.B) {
 			_, ctx := ktesting.NewTestContext(b)
 
 			sample := tc.sample()
-			reflector := NewReflector(newPageTestLW(pageNum), &sample, store, 0)
+			reflector := NewReflector(newPageTestLW(pageNum), &sample, store, 0) //nolint:logcheck // Intentionally testing old API here.
 			reflector.WatchListPageSize = fakeItemsNum
 
 			b.ResetTimer()

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_watchlist_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_watchlist_test.go
@@ -698,7 +698,7 @@ func testData(ctx context.Context) (*fakeListWatcher, Store, *Reflector, context
 			cancel(errors.New("time to stop"))
 		},
 	}
-	r := NewReflector(lw, &v1.Pod{}, s, 0)
+	r := NewReflector(lw, &v1.Pod{}, s, 0) //nolint:logcheck // Intentionally testing old API here.
 
 	return lw, s, r, ctx, cancel
 }

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_watchlist_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_watchlist_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	clientfeatures "k8s.io/client-go/features"
 	clientfeaturestesting "k8s.io/client-go/features/testing"
+	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -592,14 +593,14 @@ func TestWatchList(t *testing.T) {
 	for _, s := range scenarios {
 		t.Run(s.name, func(t *testing.T) {
 			scenario := s // capture as local variable
-			_, ctx := ktesting.NewTestContext(t)
+			logger, ctx := ktesting.NewTestContext(t)
 			clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, !scenario.disableUseWatchList)
 			listWatcher, store, reflector, ctx, cancel := testData(ctx)
 			go func() {
 				for i, e := range scenario.watchEvents {
 					listWatcher.fakeWatcher.Action(e.Type, e.Object)
 					if i+1 == scenario.stopAfterWatchEvents {
-						listWatcher.StopAndRecreateWatch()
+						listWatcher.StopAndRecreateWatch(logger)
 						continue
 					}
 					if i+1 == scenario.closeAfterWatchEvents {
@@ -691,9 +692,10 @@ func makePod(name, rv string) *v1.Pod {
 
 func testData(ctx context.Context) (*fakeListWatcher, Store, *Reflector, context.Context, func(error)) {
 	ctx, cancel := context.WithCancelCause(ctx)
+	logger := klog.FromContext(ctx)
 	s := NewStore(MetaNamespaceKeyFunc)
 	lw := &fakeListWatcher{
-		fakeWatcher: watch.NewFake(),
+		fakeWatcher: watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger}),
 		stopFunc: func() {
 			cancel(errors.New("time to stop"))
 		},
@@ -746,11 +748,11 @@ func (lw *fakeListWatcher) Watch(options metav1.ListOptions) (watch.Interface, e
 	return lw.fakeWatcher, nil
 }
 
-func (lw *fakeListWatcher) StopAndRecreateWatch() {
+func (lw *fakeListWatcher) StopAndRecreateWatch(logger klog.Logger) {
 	lw.lock.Lock()
 	defer lw.lock.Unlock()
 	lw.fakeWatcher.Stop()
-	lw.fakeWatcher = watch.NewFake()
+	lw.fakeWatcher = watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 }
 
 func (lw *fakeListWatcher) Stop() {

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -151,7 +151,7 @@ type SharedInformer interface {
 	// remove the handler again, or to tell if the handler is synced (has
 	// seen every item in the initial list).
 	//
-	// Contextual logging: AddEventHandlerWithOptions together with a logger in the options should be used instead of AddEventHandler in code which supports contextual logging.
+	//logcheck:context // AddEventHandlerWithOptions together with a logger in the options should be used instead of AddEventHandler in code which supports contextual logging.
 	AddEventHandler(handler ResourceEventHandler) (ResourceEventHandlerRegistration, error)
 	// AddEventHandlerWithResyncPeriod adds an event handler to the
 	// shared informer with the requested resync period; zero means
@@ -170,7 +170,7 @@ type SharedInformer interface {
 	// It returns a registration handle for the handler that can be used to remove
 	// the handler again and an error if the handler cannot be added.
 	//
-	// Contextual logging: AddEventHandlerWithOptions together with a logger in the options should be used instead of AddEventHandlerWithResyncPeriod in code which supports contextual logging.
+	//logcheck:context // AddEventHandlerWithOptions together with a logger in the options should be used instead of AddEventHandlerWithResyncPeriod in code which supports contextual logging.
 	AddEventHandlerWithResyncPeriod(handler ResourceEventHandler, resyncPeriod time.Duration) (ResourceEventHandlerRegistration, error)
 	// AddEventHandlerWithOptions is a variant of AddEventHandlerWithResyncPeriod where
 	// all optional parameters are passed in a struct.
@@ -195,7 +195,7 @@ type SharedInformer interface {
 	// Run starts and runs the shared informer, returning after it stops.
 	// The informer will be stopped when stopCh is closed.
 	//
-	// Contextual logging: RunWithContext should be used instead of Run in code which uses contextual logging.
+	//logcheck:context // RunWithContext should be used instead of Run in code which uses contextual logging.
 	Run(stopCh <-chan struct{})
 	// RunWithContext starts and runs the shared informer, returning after it stops.
 	// The informer will be stopped when the context is canceled.
@@ -235,7 +235,7 @@ type SharedInformer interface {
 	// The handler should return quickly - any expensive processing should be
 	// offloaded.
 	//
-	// Contextual logging: SetWatchErrorHandlerWithContext should be used instead of SetWatchErrorHandler in code which supports contextual logging.
+	//logcheck:context // SetWatchErrorHandlerWithContext should be used instead of SetWatchErrorHandler in code which supports contextual logging.
 	SetWatchErrorHandler(handler WatchErrorHandler) error
 
 	// SetWatchErrorHandlerWithContext is a variant of SetWatchErrorHandler where
@@ -498,7 +498,7 @@ const (
 // indicating that the caller identified by name is waiting for syncs, followed by
 // either a successful or failed sync.
 //
-// Contextual logging: WaitForNamedCacheSyncWithContext should be used instead of WaitForNamedCacheSync in code which supports contextual logging.
+//logcheck:context // WaitForNamedCacheSyncWithContext should be used instead of WaitForNamedCacheSync in code which supports contextual logging.
 func WaitForNamedCacheSync(controllerName string, stopCh <-chan struct{}, cacheSyncs ...InformerSynced) bool {
 	klog.Background().Info("Waiting for caches to sync", "controller", controllerName)
 
@@ -972,6 +972,7 @@ func (s *sharedIndexInformer) GetController() Controller {
 }
 
 func (s *sharedIndexInformer) AddEventHandler(handler ResourceEventHandler) (ResourceEventHandlerRegistration, error) {
+	//nolint:logcheck // Cannot provide Logger here.
 	return s.AddEventHandlerWithOptions(handler, HandlerOptions{})
 }
 
@@ -993,6 +994,7 @@ func determineResyncPeriod(logger klog.Logger, desired, check time.Duration) tim
 const minimumResyncPeriod = 1 * time.Second
 
 func (s *sharedIndexInformer) AddEventHandlerWithResyncPeriod(handler ResourceEventHandler, resyncPeriod time.Duration) (ResourceEventHandlerRegistration, error) {
+	//nolint:logcheck // Cannot provide Logger here.
 	return s.AddEventHandlerWithOptions(handler, HandlerOptions{ResyncPeriod: &resyncPeriod})
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_bench_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_bench_test.go
@@ -41,7 +41,8 @@ func BenchmarkSharedIndexInformer(b *testing.B) {
 			pods := createPods(podCount, benchmarkNamespace)
 			for _, readers := range []int{0, 1, 10, 20, 40, 80} {
 				b.Run(fmt.Sprintf("readers=%d", readers), func(b *testing.B) {
-					watcher := watch.NewFakeWithChanSize(1, false)
+					logger, _ := ktesting.NewTestContext(b)
+					watcher := watch.NewFakeWithOptions(watch.FakeOptions{ChannelSize: 1, Logger: &logger})
 					informer, stop := setupSharedIndexInformer(watcher, pods)
 					defer stop()
 					queuedEvents := 10

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_bench_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_bench_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2/ktesting"
 )
 
 var benchmarkNamespace = "default"
@@ -89,7 +90,7 @@ func setupSharedIndexInformer(watcher watch.Interface, pods []corev1.Pod) (Share
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		podInformer.Run(stop)
+		podInformer.Run(stop) //nolint:logcheck // Intentionally testing old API here.
 	}()
 	for !podInformer.HasSynced() {
 		time.Sleep(time.Millisecond)
@@ -101,10 +102,11 @@ func setupSharedIndexInformer(watcher watch.Interface, pods []corev1.Pod) (Share
 }
 
 func benchmarkSharedIndexInformer(b *testing.B, readers int, watcher *watch.FakeWatcher, podInformer SharedIndexInformer, pods []corev1.Pod, queuedEvents int) {
+	logger, _ := ktesting.NewTestContext(b)
 	var writes atomic.Int64
 	got := make(chan struct{}, queuedEvents)
 
-	_, err := podInformer.AddEventHandler(ResourceEventHandlerDetailedFuncs{
+	_, err := podInformer.AddEventHandlerWithOptions(ResourceEventHandlerDetailedFuncs{
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			writes.Add(1)
 			select {
@@ -112,7 +114,7 @@ func benchmarkSharedIndexInformer(b *testing.B, readers int, watcher *watch.Fake
 			default:
 			}
 		},
-	})
+	}, HandlerOptions{Logger: &logger})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -614,19 +614,20 @@ func TestSharedInformerTransformer(t *testing.T) {
 }
 
 func TestSharedInformerRemoveHandler(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	source := newFakeControllerSource(t)
 	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}})
 
 	informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second)
 
 	handler1 := &ResourceEventHandlerFuncs{}
-	handle1, err := informer.AddEventHandler(handler1)
+	handle1, err := informer.AddEventHandlerWithOptions(handler1, HandlerOptions{Logger: &logger})
 	if err != nil {
 		t.Errorf("informer did not add handler1: %s", err)
 		return
 	}
 	handler2 := &ResourceEventHandlerFuncs{}
-	handle2, err := informer.AddEventHandler(handler2)
+	handle2, err := informer.AddEventHandlerWithOptions(handler2, HandlerOptions{Logger: &logger})
 	if err != nil {
 		t.Errorf("informer did not add handler2: %s", err)
 		return
@@ -1181,12 +1182,13 @@ func TestAddWhileActive(t *testing.T) {
 // all goroutines really have stopped in the different scenarios.
 func TestShutdown(t *testing.T) {
 	t.Run("no-context", func(t *testing.T) {
+		logger, _ := ktesting.NewTestContext(t)
 		source := newFakeControllerSource(t)
 
 		informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second)
-		handler, err := informer.AddEventHandler(ResourceEventHandlerFuncs{
+		handler, err := informer.AddEventHandlerWithOptions(ResourceEventHandlerFuncs{
 			AddFunc: func(_ any) {},
-		})
+		}, HandlerOptions{Logger: &logger})
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, informer.RemoveEventHandler(handler))
@@ -1204,6 +1206,7 @@ func TestShutdown(t *testing.T) {
 	})
 
 	t.Run("no-context-later", func(t *testing.T) {
+		logger, _ := ktesting.NewTestContext(t)
 		source := newFakeControllerSource(t)
 		informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second)
 
@@ -1217,19 +1220,20 @@ func TestShutdown(t *testing.T) {
 
 		require.Eventually(t, informer.HasSynced, time.Minute, time.Millisecond, "informer has synced")
 
-		handler, err := informer.AddEventHandler(ResourceEventHandlerFuncs{
+		handler, err := informer.AddEventHandlerWithOptions(ResourceEventHandlerFuncs{
 			AddFunc: func(_ any) {},
-		})
+		}, HandlerOptions{Logger: &logger})
 		require.NoError(t, err)
 		assert.NoError(t, informer.RemoveEventHandler(handler))
 	})
 
 	t.Run("no-run", func(t *testing.T) {
+		logger, _ := ktesting.NewTestContext(t)
 		source := newFakeControllerSource(t)
 		informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second)
-		_, err := informer.AddEventHandler(ResourceEventHandlerFuncs{
+		_, err := informer.AddEventHandlerWithOptions(ResourceEventHandlerFuncs{
 			AddFunc: func(_ any) {},
-		})
+		}, HandlerOptions{Logger: &logger})
 		require.NoError(t, err)
 
 		// At this point, neither informer nor handler have any goroutines running
@@ -1290,7 +1294,7 @@ func TestEventPanics(t *testing.T) {
 		klog.SetLogger(logger)
 		stop := make(chan struct{})
 		informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second)
-		handle, err := informer.AddEventHandler(handler)
+		handle, err := informer.AddEventHandlerWithOptions(handler, HandlerOptions{Logger: &logger})
 		require.NoError(t, err)
 		defer func() {
 			assert.NoError(t, informer.RemoveEventHandler(handle))

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo.go
@@ -795,7 +795,10 @@ func (f *RealFIFO) Transformer() TransformFunc {
 // process.
 //
 // Deprecated: Use NewRealFIFOWithOptions instead.
+//
+//logcheck:context // NewRealFIFOWithOptions and logger should be used instead of NewRealFIFO in code which supports contextual logging.
 func NewRealFIFO(keyFunc KeyFunc, knownObjects KeyListerGetter, transformer TransformFunc) *RealFIFO {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewRealFIFOWithOptions(RealFIFOOptions{
 		KeyFunction:  keyFunc,
 		KnownObjects: knownObjects,

--- a/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/the_real_fifo_test.go
@@ -82,7 +82,7 @@ func emptyKnownObjects() KeyListerGetter {
 }
 
 func TestRealFIFO_basic(t *testing.T) {
-	f := NewRealFIFO(testFifoObjectKeyFunc, emptyKnownObjects(), nil)
+	f := NewRealFIFO(testFifoObjectKeyFunc, emptyKnownObjects(), nil) //nolint:logcheck // Intentionally testing old API here.
 	const amount = 500
 	go func() {
 		for i := 0; i < amount; i++ {
@@ -126,7 +126,7 @@ func TestRealFIFO_replaceWithDeleteDeltaIn(t *testing.T) {
 	oldObj := mkFifoObj("foo", 1)
 	newObj := mkFifoObj("foo", 2)
 
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{oldObj}
@@ -248,7 +248,7 @@ func TestRealFIFOW_ReplaceMakesDeletionsForObjectsOnlyInQueue(t *testing.T) {
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test with a RealFIFO with a backing KnownObjects
-			fWithKnownObjects := NewRealFIFO(
+			fWithKnownObjects := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 				testFifoObjectKeyFunc,
 				literalListerGetter(func() []testFifoObject {
 					return []testFifoObject{}
@@ -284,7 +284,7 @@ func collapseDeltas(ins []interface{}) Deltas {
 // func TestDeltaFIFO_requeueOnPop(t *testing.T) {
 
 func TestRealFIFO_addUpdate(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		emptyKnownObjects(),
 		nil,
@@ -381,7 +381,7 @@ func TestRealFIFO_transformer(t *testing.T) {
 		return ret
 	}
 
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		emptyKnownObjects(),
 		xfrm,
@@ -442,7 +442,7 @@ func TestRealFIFO_transformer(t *testing.T) {
 }
 
 func TestRealFIFO_enqueueingNoLister(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		emptyKnownObjects(),
 		nil,
@@ -468,7 +468,7 @@ func TestRealFIFO_enqueueingNoLister(t *testing.T) {
 }
 
 func TestRealFIFO_enqueueingWithLister(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{mkFifoObj("foo", 5), mkFifoObj("bar", 6), mkFifoObj("baz", 7)}
@@ -493,7 +493,7 @@ func TestRealFIFO_enqueueingWithLister(t *testing.T) {
 }
 
 func TestRealFIFO_addReplace(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		emptyKnownObjects(),
 		nil,
@@ -537,7 +537,7 @@ func TestRealFIFO_addReplace(t *testing.T) {
 }
 
 func TestRealFIFO_ResyncNonExisting(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{mkFifoObj("foo", 5)}
@@ -557,7 +557,7 @@ func TestRealFIFO_ResyncNonExisting(t *testing.T) {
 }
 
 func TestRealFIFO_Resync(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{mkFifoObj("foo", 5)}
@@ -577,7 +577,7 @@ func TestRealFIFO_Resync(t *testing.T) {
 
 func TestRealFIFO_ResyncPropagatesQueueError(t *testing.T) {
 	sentinel := errors.New("computing key failed")
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		func(obj interface{}) (string, error) {
 			if fifoObj, ok := obj.(testFifoObject); ok && fifoObj.name == "broken" {
 				return "", sentinel
@@ -599,7 +599,7 @@ func TestRealFIFO_ResyncPropagatesQueueError(t *testing.T) {
 }
 
 func TestRealFIFO_DeleteExistingNonPropagated(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		emptyKnownObjects(),
 		nil,
@@ -621,7 +621,7 @@ func TestRealFIFO_ReplaceMakesDeletions(t *testing.T) {
 	// promise about how their deletes are ordered.
 
 	// Try it with a pre-existing Delete
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{mkFifoObj("foo", 5), mkFifoObj("bar", 6), mkFifoObj("baz", 7)}
@@ -648,7 +648,7 @@ func TestRealFIFO_ReplaceMakesDeletions(t *testing.T) {
 	}
 
 	// Now try starting with an Add instead of a Delete
-	f = NewRealFIFO(
+	f = NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{mkFifoObj("foo", 5), mkFifoObj("bar", 6), mkFifoObj("baz", 7)}
@@ -677,7 +677,7 @@ func TestRealFIFO_ReplaceMakesDeletions(t *testing.T) {
 	}
 
 	// Now try deleting and recreating the object in the queue, then delete it by a Replace call
-	f = NewRealFIFO(
+	f = NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{mkFifoObj("foo", 5), mkFifoObj("bar", 6), mkFifoObj("baz", 7)}
@@ -708,7 +708,7 @@ func TestRealFIFO_ReplaceMakesDeletions(t *testing.T) {
 	}
 
 	// Now try syncing it first to ensure the delete use the latest version
-	f = NewRealFIFO(
+	f = NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{mkFifoObj("foo", 5), mkFifoObj("bar", 6), mkFifoObj("baz", 7)}
@@ -740,7 +740,7 @@ func TestRealFIFO_ReplaceMakesDeletions(t *testing.T) {
 	}
 
 	// Now try starting without an explicit KeyListerGetter
-	f = NewRealFIFO(
+	f = NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		emptyKnownObjects(),
 		nil,
@@ -765,7 +765,7 @@ func TestRealFIFO_ReplaceMakesDeletions(t *testing.T) {
 // TestRealFIFO_ReplaceMakesDeletionsReplaced is the same as the above test, but
 // ensures that a Replaced DeltaType is emitted.
 func TestRealFIFO_ReplaceMakesDeletionsReplaced(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{mkFifoObj("foo", 5), mkFifoObj("bar", 6), mkFifoObj("baz", 7)}
@@ -797,7 +797,7 @@ func TestRealFIFO_ReplaceMakesDeletionsReplaced(t *testing.T) {
 //func TestRealFIFO_ReplaceDeltaType(t *testing.T) {
 
 func TestRealFIFO_UpdateResyncRace(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{mkFifoObj("foo", 5)}
@@ -820,7 +820,7 @@ func TestRealFIFO_UpdateResyncRace(t *testing.T) {
 }
 
 func TestRealFIFO_HasSyncedCorrectOnDeletion(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{mkFifoObj("foo", 5), mkFifoObj("bar", 6), mkFifoObj("baz", 7)}
@@ -856,7 +856,7 @@ func TestRealFIFO_HasSyncedCorrectOnDeletion(t *testing.T) {
 }
 
 func TestRealFIFO_detectLineJumpers(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		emptyKnownObjects(),
 		nil,
@@ -974,7 +974,7 @@ func TestRealFIFO_HasSynced(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		f := NewRealFIFO(
+		f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 			testFifoObjectKeyFunc,
 			emptyKnownObjects(),
 			nil,
@@ -992,7 +992,7 @@ func TestRealFIFO_HasSynced(t *testing.T) {
 // TestRealFIFO_PopShouldUnblockWhenClosed checks that any blocking Pop on an empty queue
 // should unblock and return after Close is called.
 func TestRealFIFO_PopShouldUnblockWhenClosed(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		literalListerGetter(func() []testFifoObject {
 			return []testFifoObject{mkFifoObj("foo", 5)}
@@ -1153,7 +1153,7 @@ func TestRealFIFO_PopMultipleDeltaInBatch(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			f := NewRealFIFO(
+			f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 				testFifoObjectKeyFunc,
 				literalListerGetter(func() []testFifoObject {
 					return tc.initialItems
@@ -1293,7 +1293,7 @@ func TestRealFIFO_PopBrokenItemsInBatch(t *testing.T) {
 				// otherwise success
 				return testFifoObjectKeyFunc(obj)
 			}
-			f := NewRealFIFO(
+			f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 				testBrokenItemKeyFunc,
 				literalListerGetter(func() []testFifoObject {
 					return nil
@@ -1417,7 +1417,7 @@ func TestRealFIFO_ReplaceAtomic(t *testing.T) {
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test with a RealFIFO with a backing KnownObjects
-			f := NewRealFIFO(
+			f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 				testFifoObjectKeyFunc,
 				literalListerGetter(func() []testFifoObject {
 					return []testFifoObject{}
@@ -1441,7 +1441,7 @@ func TestRealFIFO_ReplaceAtomic(t *testing.T) {
 }
 
 func TestRealFIFO_ReplaceAtomicPop(t *testing.T) {
-	f := NewRealFIFO(
+	f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 		testFifoObjectKeyFunc,
 		emptyKnownObjects(),
 		nil,
@@ -1516,7 +1516,7 @@ func TestRealFIFO_ResyncAtomic(t *testing.T) {
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test with a RealFIFO with a backing KnownObjects
-			f := NewRealFIFO(
+			f := NewRealFIFO( //nolint:logcheck // Intentionally testing old API here.
 				testFifoObjectKeyFunc,
 				literalListerGetter(func() []testFifoObject {
 					return []testFifoObject{}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
@@ -67,18 +67,57 @@ type LeaseCandidate struct {
 	strategy                        v1.CoordinatedLeaseStrategy
 }
 
+// CandidateConfig specifies optional configuration for NewCandidateWithConfig.
+type CandidateConfig struct {
+	// Logger is used for contextual logging. If unset, klog.Background() is used.
+	Logger *klog.Logger
+}
+
 // NewCandidate creates new LeaseCandidate controller that creates a
 // LeaseCandidate object if it does not exist and watches changes
 // to the corresponding object and renews if PingTime is set.
 // WARNING: This is an ALPHA feature. Ensure that the CoordinatedLeaderElection
 // feature gate is on.
-func NewCandidate(clientset kubernetes.Interface,
+//
+//logcheck:context // NewCandidateWithConfig and logger should be used instead of NewCandidate in code which supports contextual logging.
+func NewCandidate(
+	clientset kubernetes.Interface,
 	candidateNamespace string,
 	candidateName string,
 	targetLease string,
 	binaryVersion, emulationVersion string,
 	strategy v1.CoordinatedLeaseStrategy,
 ) (*LeaseCandidate, CacheSyncWaiter, error) {
+	//nolint:logcheck // Cannot provide Logger here, use NewCandidateWithConfig.
+	return NewCandidateWithConfig(
+		clientset,
+		candidateNamespace,
+		candidateName,
+		targetLease,
+		binaryVersion, emulationVersion,
+		strategy,
+		CandidateConfig{},
+	)
+}
+
+// NewCandidateWithConfig creates new LeaseCandidate controller that creates a
+// LeaseCandidate object if it does not exist and watches changes
+// to the corresponding object and renews if PingTime is set.
+// WARNING: This is an ALPHA feature. Ensure that the CoordinatedLeaderElection
+// feature gate is on.
+func NewCandidateWithConfig(
+	clientset kubernetes.Interface,
+	candidateNamespace string,
+	candidateName string,
+	targetLease string,
+	binaryVersion, emulationVersion string,
+	strategy v1.CoordinatedLeaseStrategy,
+	config CandidateConfig,
+) (*LeaseCandidate, CacheSyncWaiter, error) {
+	logger := klog.Background()
+	if config.Logger != nil {
+		logger = *config.Logger
+	}
 	fieldSelector := fields.OneTermEqualSelector("metadata.name", candidateName).String()
 	// A separate informer factory is required because this must start before informerFactories
 	// are started for leader elected components
@@ -105,9 +144,12 @@ func NewCandidate(clientset kubernetes.Interface,
 		emulationVersion:       emulationVersion,
 		strategy:               strategy,
 	}
-	lc.queue = workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[int](), workqueue.TypedRateLimitingQueueConfig[int]{Name: "leasecandidate"})
+	lc.queue = workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[int](), workqueue.TypedRateLimitingQueueConfig[int]{
+		Logger: &logger,
+		Name:   "leasecandidate",
+	})
 
-	h, err := leaseCandidateInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	h, err := leaseCandidateInformer.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldObj, newObj interface{}) {
 			if leasecandidate, ok := newObj.(*v1beta1.LeaseCandidate); ok {
 				if leasecandidate.Spec.PingTime != nil && leasecandidate.Spec.PingTime.After(leasecandidate.Spec.RenewTime.Time) {
@@ -115,7 +157,7 @@ func NewCandidate(clientset kubernetes.Interface,
 				}
 			}
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate.go
@@ -177,7 +177,7 @@ func (c *LeaseCandidate) Run(ctx context.Context) {
 		wg.Wait()
 	}()
 
-	c.informerFactory.Start(ctx.Done())
+	c.informerFactory.StartWithContext(ctx)
 	if !cache.WaitForNamedCacheSyncWithContext(ctx, c.hasSynced) {
 		return
 	}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leasecandidate_test.go
@@ -35,7 +35,7 @@ type testcase struct {
 }
 
 func TestLeaseCandidateCreation(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 	tc := testcase{
 		candidateName:      "foo",
 		candidateNamespace: "default",
@@ -48,7 +48,7 @@ func TestLeaseCandidateCreation(t *testing.T) {
 	defer cancel()
 
 	client := fake.NewSimpleClientset()
-	candidate, _, err := NewCandidate(
+	candidate, _, err := NewCandidateWithConfig(
 		client,
 		tc.candidateNamespace,
 		tc.candidateName,
@@ -56,6 +56,7 @@ func TestLeaseCandidateCreation(t *testing.T) {
 		tc.binaryVersion,
 		tc.emulationVersion,
 		v1.OldestEmulationVersion,
+		CandidateConfig{Logger: new(logger)},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -69,7 +70,7 @@ func TestLeaseCandidateCreation(t *testing.T) {
 }
 
 func TestLeaseCandidateAck(t *testing.T) {
-	_, ctx := ktesting.NewTestContext(t)
+	logger, ctx := ktesting.NewTestContext(t)
 
 	tc := testcase{
 		candidateName:      "foo",
@@ -84,7 +85,7 @@ func TestLeaseCandidateAck(t *testing.T) {
 
 	client := fake.NewSimpleClientset()
 
-	candidate, _, err := NewCandidate(
+	candidate, _, err := NewCandidateWithConfig(
 		client,
 		tc.candidateNamespace,
 		tc.candidateName,
@@ -92,6 +93,7 @@ func TestLeaseCandidateAck(t *testing.T) {
 		tc.binaryVersion,
 		tc.emulationVersion,
 		v1.OldestEmulationVersion,
+		CandidateConfig{Logger: new(logger)},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -106,7 +106,7 @@ func (e *eventProcessor) stop() {
 // so you can use it anywhere where you'd have used a regular Watcher returned from Watch method.
 // it also returns a channel you can use to wait for the informers to fully shutdown.
 //
-// Contextual logging: NewIndexerInformerWatcherWithLogger should be used instead of NewIndexerInformerWatcher in code which supports contextual logging.
+//logcheck:context // NewIndexerInformerWatcherWithLogger should be used instead of NewIndexerInformerWatcher in code which supports contextual logging.
 func NewIndexerInformerWatcher(lw cache.ListerWatcher, objType runtime.Object) (cache.Indexer, cache.Controller, watch.Interface, <-chan struct{}) {
 	return NewIndexerInformerWatcherWithLogger(klog.Background(), lw, objType)
 }

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher.go
@@ -119,34 +119,40 @@ func NewIndexerInformerWatcherWithLogger(logger klog.Logger, lw cache.ListerWatc
 	w := watch.NewProxyWatcher(ch)
 	e := newEventProcessor(ch)
 
-	indexer, informer := cache.NewIndexerInformer(lw, objType, 0, cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			e.push(watch.Event{
-				Type:   watch.Added,
-				Object: obj.(runtime.Object),
-			})
-		},
-		UpdateFunc: func(old, new interface{}) {
-			e.push(watch.Event{
-				Type:   watch.Modified,
-				Object: new.(runtime.Object),
-			})
-		},
-		DeleteFunc: func(obj interface{}) {
-			staleObj, stale := obj.(cache.DeletedFinalStateUnknown)
-			if stale {
-				// We have no means of passing the additional information down using
-				// watch API based on watch.Event but the caller can filter such
-				// objects by checking if metadata.deletionTimestamp is set
-				obj = staleObj.Obj
-			}
+	store, informer := cache.NewInformerWithOptions(cache.InformerOptions{
+		Logger:        &logger,
+		ListerWatcher: lw,
+		ObjectType:    objType,
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				e.push(watch.Event{
+					Type:   watch.Added,
+					Object: obj.(runtime.Object),
+				})
+			},
+			UpdateFunc: func(old, new interface{}) {
+				e.push(watch.Event{
+					Type:   watch.Modified,
+					Object: new.(runtime.Object),
+				})
+			},
+			DeleteFunc: func(obj interface{}) {
+				staleObj, stale := obj.(cache.DeletedFinalStateUnknown)
+				if stale {
+					// We have no means of passing the additional information down using
+					// watch API based on watch.Event but the caller can filter such
+					// objects by checking if metadata.deletionTimestamp is set
+					obj = staleObj.Obj
+				}
 
-			e.push(watch.Event{
-				Type:   watch.Deleted,
-				Object: obj.(runtime.Object),
-			})
+				e.push(watch.Event{
+					Type:   watch.Deleted,
+					Object: obj.(runtime.Object),
+				})
+			},
 		},
-	}, cache.Indexers{})
+		Indexers: cache.Indexers{},
+	})
 
 	// This will get stopped, but without waiting for it.
 	go e.run()
@@ -161,6 +167,9 @@ func NewIndexerInformerWatcherWithLogger(logger klog.Logger, lw cache.ListerWatc
 		ctx = klog.NewContext(ctx, logger)
 		informer.RunWithContext(ctx)
 	}()
+
+	// Since Indexers were set, the returned Store is guaranteed to also implement Indexer.
+	indexer := store.(cache.Indexer)
 
 	return indexer, informer, w, doneCh
 }

--- a/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/informerwatcher_test.go
@@ -38,6 +38,7 @@ import (
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	testcore "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/dump"
 )
 
@@ -385,6 +386,7 @@ func TestNewInformerWatcher(t *testing.T) {
 //
 // Code from @liggitt
 func TestInformerWatcherDeletedFinalStateUnknown(t *testing.T) {
+	logger, _ := ktesting.NewTestContext(t)
 	listCalls := 0
 	watchCalls := 0
 	lw := toListWatcherWithUnSupportedWatchListSemantics(&cache.ListWatch{
@@ -402,7 +404,7 @@ func TestInformerWatcherDeletedFinalStateUnknown(t *testing.T) {
 			return retval, nil
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			w := watch.NewRaceFreeFake()
+			w := watch.NewRaceFreeFakeWithLogger(logger)
 			if options.ResourceVersion == "1" {
 				go func() {
 					// Close with a "Gone" error when trying to start a watch from the first list

--- a/staging/src/k8s.io/client-go/tools/watch/until_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	fakeclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2/ktesting"
 )
 
 type fakePod struct {
@@ -42,7 +43,8 @@ func (obj *fakePod) GetObjectKind() schema.ObjectKind { return schema.EmptyObjec
 func (obj *fakePod) DeepCopyObject() runtime.Object   { panic("DeepCopyObject not supported by fakePod") }
 
 func TestUntil(t *testing.T) {
-	fw := watch.NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)
@@ -72,7 +74,8 @@ func TestUntil(t *testing.T) {
 }
 
 func TestUntilMultipleConditions(t *testing.T) {
-	fw := watch.NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)
@@ -101,7 +104,8 @@ func TestUntilMultipleConditions(t *testing.T) {
 }
 
 func TestUntilMultipleConditionsFail(t *testing.T) {
-	fw := watch.NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)
@@ -131,7 +135,8 @@ func TestUntilMultipleConditionsFail(t *testing.T) {
 }
 
 func TestUntilTimeout(t *testing.T) {
-	fw := watch.NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)
@@ -162,7 +167,8 @@ func TestUntilTimeout(t *testing.T) {
 }
 
 func TestUntilErrorCondition(t *testing.T) {
-	fw := watch.NewFake()
+	logger, _ := ktesting.NewTestContext(t)
+	fw := watch.NewFakeWithOptions(watch.FakeOptions{Logger: &logger})
 	go func() {
 		var obj *fakePod
 		fw.Add(obj)

--- a/staging/src/k8s.io/client-go/transport/cert_rotation.go
+++ b/staging/src/k8s.io/client-go/transport/cert_rotation.go
@@ -57,7 +57,10 @@ func certRotatingDialer(logger klog.Logger, reload reloadFunc, dial utilnet.Dial
 		connDialer: connrotation.NewDialer(connrotation.DialFunc(dial)),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "DynamicClientCertificate"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: &logger,
+				Name:   "DynamicClientCertificate",
+			},
 		),
 	}
 

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_store.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_store.go
@@ -69,7 +69,7 @@ type FileStore interface {
 // ${certDirectory}/${pairNamePrefix}-current.pem will be created as a soft
 // link to the currently selected cert/key pair.
 //
-// Contextual logging: NewFileStoreWithLogger should be used instead of NewFileStore in code which supports contextual logging.
+//logcheck:context // NewFileStoreWithLogger should be used instead of NewFileStore in code which supports contextual logging.
 func NewFileStore(
 	pairNamePrefix string,
 	certDirectory string,

--- a/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/delaying_queue.go
@@ -70,14 +70,20 @@ type TypedDelayingQueueConfig[T comparable] struct {
 // NewDelayingQueueWithConfig instead and specify a name.
 //
 // Deprecated: use NewTypedDelayingQueue instead.
+//
+//logcheck:context // NewDelayingQueueWithConfig and logger should be used instead of NewDelayingQueue in code which supports contextual logging.
 func NewDelayingQueue() DelayingInterface {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewDelayingQueueWithConfig(DelayingQueueConfig{})
 }
 
 // NewTypedDelayingQueue constructs a new workqueue with delayed queuing ability.
 // NewTypedDelayingQueue does not emit metrics. For use with a MetricsProvider, please use
 // NewTypedDelayingQueueWithConfig instead and specify a name.
+//
+//logcheck:context // NewTypedDelayingQueueWithConfig and logger should be used instead of NewTypedDelayingQueue in code which supports contextual logging.
 func NewTypedDelayingQueue[T comparable]() TypedDelayingInterface[T] {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewTypedDelayingQueueWithConfig(TypedDelayingQueueConfig[T]{})
 }
 
@@ -120,8 +126,12 @@ func NewTypedDelayingQueueWithConfig[T comparable](config TypedDelayingQueueConf
 
 // NewDelayingQueueWithCustomQueue constructs a new workqueue with ability to
 // inject custom queue Interface instead of the default one
+//
 // Deprecated: Use NewDelayingQueueWithConfig instead.
+//
+//logcheck:context // NewDelayingQueueWithConfig and logger should be used instead of NewDelayingQueueWithCustomQueue in code which supports contextual logging.
 func NewDelayingQueueWithCustomQueue(q Interface, name string) DelayingInterface {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewDelayingQueueWithConfig(DelayingQueueConfig{
 		Name:  name,
 		Queue: q,
@@ -129,15 +139,23 @@ func NewDelayingQueueWithCustomQueue(q Interface, name string) DelayingInterface
 }
 
 // NewNamedDelayingQueue constructs a new named workqueue with delayed queuing ability.
+//
 // Deprecated: Use NewDelayingQueueWithConfig instead.
+//
+//logcheck:context // NewDelayingQueueWithConfig and logger should be used instead of NewNamedDelayingQueue in code which supports contextual logging.
 func NewNamedDelayingQueue(name string) DelayingInterface {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewDelayingQueueWithConfig(DelayingQueueConfig{Name: name})
 }
 
 // NewDelayingQueueWithCustomClock constructs a new named workqueue
 // with ability to inject real or fake clock for testing purposes.
+//
 // Deprecated: Use NewDelayingQueueWithConfig instead.
+//
+//logcheck:context // NewDelayingQueueWithConfig and logger should be used instead of NewDelayingQueueWithCustomClock in code which supports contextual logging.
 func NewDelayingQueueWithCustomClock(clock clock.WithTicker, name string) DelayingInterface {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewDelayingQueueWithConfig(DelayingQueueConfig{
 		Name:  name,
 		Clock: clock,

--- a/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package workqueue
 
-import "k8s.io/utils/clock"
+import (
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
 
 // RateLimitingInterface is an interface that rate limits items being added to the queue.
 //
@@ -46,6 +49,10 @@ type RateLimitingQueueConfig = TypedRateLimitingQueueConfig[any]
 
 // TypedRateLimitingQueueConfig specifies optional configurations to customize a TypedRateLimitingInterface.
 type TypedRateLimitingQueueConfig[T comparable] struct {
+	// An optional logger. The name of the queue does *not* get added to it, this should
+	// be done by the caller if desired.
+	Logger *klog.Logger
+
 	// Name for the queue. If unnamed, the metrics will not be registered.
 	Name string
 
@@ -66,7 +73,10 @@ type TypedRateLimitingQueueConfig[T comparable] struct {
 // NewRateLimitingQueueWithConfig instead and specify a name.
 //
 // Deprecated: Use NewTypedRateLimitingQueue instead.
+//
+//logcheck:context // NewRateLimitingQueueWithConfig and logger should be used instead of NewRateLimitingQueue in code which supports contextual logging.
 func NewRateLimitingQueue(rateLimiter RateLimiter) RateLimitingInterface {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewRateLimitingQueueWithConfig(rateLimiter, RateLimitingQueueConfig{})
 }
 
@@ -74,7 +84,10 @@ func NewRateLimitingQueue(rateLimiter RateLimiter) RateLimitingInterface {
 // Remember to call Forget!  If you don't, you may end up tracking failures forever.
 // NewTypedRateLimitingQueue does not emit metrics. For use with a MetricsProvider, please use
 // NewTypedRateLimitingQueueWithConfig instead and specify a name.
+//
+//logcheck:context // NewTypedRateLimitingQueueWithConfig and logger should be used instead of NewTypedRateLimitingQueue in code which supports contextual logging.
 func NewTypedRateLimitingQueue[T comparable](rateLimiter TypedRateLimiter[T]) TypedRateLimitingInterface[T] {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewTypedRateLimitingQueueWithConfig(rateLimiter, TypedRateLimitingQueueConfig[T]{})
 }
 
@@ -97,6 +110,7 @@ func NewTypedRateLimitingQueueWithConfig[T comparable](rateLimiter TypedRateLimi
 
 	if config.DelayingQueue == nil {
 		config.DelayingQueue = NewTypedDelayingQueueWithConfig(TypedDelayingQueueConfig[T]{
+			Logger:          config.Logger,
 			Name:            config.Name,
 			MetricsProvider: config.MetricsProvider,
 			Clock:           config.Clock,
@@ -110,8 +124,12 @@ func NewTypedRateLimitingQueueWithConfig[T comparable](rateLimiter TypedRateLimi
 }
 
 // NewNamedRateLimitingQueue constructs a new named workqueue with rateLimited queuing ability.
+//
 // Deprecated: Use NewRateLimitingQueueWithConfig instead.
+//
+//logcheck:context // NewRateLimitingQueueWithConfig and logger should be used instead of NewNamedRateLimitingQueue in code which supports contextual logging.
 func NewNamedRateLimitingQueue(rateLimiter RateLimiter, name string) RateLimitingInterface {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewRateLimitingQueueWithConfig(rateLimiter, RateLimitingQueueConfig{
 		Name: name,
 	})
@@ -119,8 +137,12 @@ func NewNamedRateLimitingQueue(rateLimiter RateLimiter, name string) RateLimitin
 
 // NewRateLimitingQueueWithDelayingInterface constructs a new named workqueue with rateLimited queuing ability
 // with the option to inject a custom delaying queue instead of the default one.
+//
 // Deprecated: Use NewRateLimitingQueueWithConfig instead.
+//
+//logcheck:context // NewRateLimitingQueueWithDelayingInterface and logger should be used instead of NewRateLimitingQueueWithConfig in code which supports contextual logging.
 func NewRateLimitingQueueWithDelayingInterface(di DelayingInterface, rateLimiter RateLimiter) RateLimitingInterface {
+	//nolint:logcheck // Cannot provide Logger here.
 	return NewRateLimitingQueueWithConfig(rateLimiter, RateLimitingQueueConfig{
 		DelayingQueue: di,
 	})

--- a/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/rate_limiting_queue_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestRateLimitingQueue(t *testing.T) {
 	limiter := NewItemExponentialFailureRateLimiter(1*time.Millisecond, 1*time.Second)
-	queue := NewRateLimitingQueue(limiter).(*rateLimitingType[any])
+	queue := NewRateLimitingQueue(limiter).(*rateLimitingType[any]) //nolint:logcheck // Intentionally testing old API here.
 	fakeClock := testingclock.NewFakeClock(time.Now())
 	delayingQueue := &delayingType[any]{
 		TypedInterface:  New(),

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
@@ -366,7 +366,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factory.go
@@ -389,7 +389,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[{{.reflectType|raw}}]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
@@ -311,7 +311,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/HyphenGroup/informers/externalversions/factory.go
@@ -288,7 +288,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
@@ -311,7 +311,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/MixedCase/informers/externalversions/factory.go
@@ -288,7 +288,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
@@ -314,7 +314,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/apiserver/informers/externalversions/factory.go
@@ -291,7 +291,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
@@ -314,7 +314,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/crd/informers/externalversions/factory.go
@@ -291,7 +291,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
@@ -311,7 +311,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/examples/single/informers/externalversions/factory.go
@@ -288,7 +288,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/client/generic.go
@@ -204,11 +204,11 @@ func (t *convertingClient[NP, N, NL, NAC, OP, O, OL, OAC, O2P, O2, O2L, O2AC]) W
 	apis := newCall(t.c, func(currentAPI int32) (watch.Interface, error) {
 		switch currentAPI {
 		case useV1beta1API:
-			return watchWithConversion[NP, N, OP](func() (watch.Interface, error) {
+			return watchWithConversion[NP, N, OP](klog.FromContext(ctx), func() (watch.Interface, error) {
 				return t.v1beta1.Watch(ctx, opts)
 			})
 		case useV1beta2API:
-			return watchWithConversion[NP, N, O2P](func() (watch.Interface, error) {
+			return watchWithConversion[NP, N, O2P](klog.FromContext(ctx), func() (watch.Interface, error) {
 				return t.v1beta2.Watch(ctx, opts)
 			})
 		default:
@@ -295,7 +295,7 @@ func getWithConversion[N, O any](call func() (*O, error)) (*N, error) {
 	return value, nil
 }
 
-func watchWithConversion[NP objectPtr[N], N any, OP runtime.Object](call func() (watch.Interface, error)) (watch.Interface, error) {
+func watchWithConversion[NP objectPtr[N], N any, OP runtime.Object](logger klog.Logger, call func() (watch.Interface, error)) (watch.Interface, error) {
 	in, err := call()
 	if err != nil {
 		return nil, err
@@ -305,7 +305,7 @@ func watchWithConversion[NP objectPtr[N], N any, OP runtime.Object](call func() 
 		resultChan: make(chan watch.Event),
 		stopChan:   make(chan struct{}),
 	}
-	go out.run() // TODO: ctx
+	go out.run(logger)
 	return out, nil
 }
 
@@ -334,8 +334,8 @@ func (w *watchSomething[NP, N, OP]) ResultChan() <-chan watch.Event {
 	return w.resultChan
 }
 
-func (w *watchSomething[NP, N, OP]) run() {
-	defer utilruntime.HandleCrash()
+func (w *watchSomething[NP, N, OP]) run(logger klog.Logger) {
+	defer utilruntime.HandleCrashWithLogger(logger)
 	defer close(w.resultChan)
 	resultChan := w.upstream.ResultChan()
 	for {
@@ -347,8 +347,7 @@ func (w *watchSomething[NP, N, OP]) run() {
 		if in, ok := e.Object.(OP); ok {
 			out := new(N)
 			if err := scheme.Convert(in, out, nil); err != nil {
-				//nolint:logcheck // Shouldn't happen.
-				klog.Error(err, "convert ResourceSlice")
+				logger.Error(err, "convert ResourceSlice")
 			}
 			e = watch.Event{
 				Type:   e.Type,

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
@@ -736,7 +736,7 @@ func setup(t *testing.T) (context.Context, *fake.Clientset, *ExtendedResourceCac
 		// Now we can wait for all goroutines to stop.
 		informerFactory.Shutdown()
 	})
-	informerFactory.WaitForCacheSync(ctx.Done())
+	informerFactory.WaitForCacheSyncWithContext(ctx)
 	clientcache.WaitForNamedCacheSyncWithContext(ctx, handle.HasSynced)
 
 	// fake.Clientset suffers from a race condition related to informers:

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
@@ -725,7 +725,7 @@ func setup(t *testing.T) (context.Context, *fake.Clientset, *ExtendedResourceCac
 	client := fake.NewClientset()
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	ec := NewExtendedResourceCache(logger)
-	handle, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandler(ec)
+	handle, err := informerFactory.Resource().V1().DeviceClasses().Informer().AddEventHandlerWithOptions(ec, clientcache.HandlerOptions{Logger: &logger})
 	if err != nil {
 		t.Fatalf("failed to add device class informer event handler: %v", err)
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/deviceclass/extendedresourcecache/extendedresourcecache_test.go
@@ -729,7 +729,7 @@ func setup(t *testing.T) (context.Context, *fake.Clientset, *ExtendedResourceCac
 	if err != nil {
 		t.Fatalf("failed to add device class informer event handler: %v", err)
 	}
-	informerFactory.Start(ctx.Done())
+	informerFactory.StartWithContext(ctx)
 	t.Cleanup(func() {
 		// Need to cancel before waiting for the shutdown.
 		cancel()

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/resourceslicecontroller.go
@@ -521,7 +521,10 @@ func newController(ctx context.Context, options Options) (*Controller, error) {
 	if c.queue == nil {
 		c.queue = workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "node_resource_slices"},
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Logger: new(klog.FromContext(ctx)),
+				Name:   "node_resource_slices",
+			},
 		)
 	}
 	if c.errorHandler == nil {

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -329,7 +329,7 @@ func (t *Tracker) emitEvents() {
 			return
 		}
 		func() {
-			defer utilruntime.HandleCrash()
+			defer utilruntime.HandleCrashWithLogger(t.logger)
 			deliver()
 		}()
 	}

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -54,6 +54,7 @@ const (
 // potential changes to resolved ResourceSlices asynchronously.
 type Tracker struct {
 	enableDeviceTaintRules bool
+	logger                 klog.Logger
 
 	resourceSliceLister   resourcelisters.ResourceSliceLister
 	resourceSlices        resourceinformers.ResourceSliceIndexInformer
@@ -127,6 +128,7 @@ func StartTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr 
 	if !opts.EnableDeviceTaintRules {
 		// Minimal wrapper. All public methods shortcut by calling the underlying informer.
 		return &Tracker{
+			logger:              klog.FromContext(ctx),
 			resourceSliceLister: opts.SliceInformer.Lister(),
 			resourceSlices:      opts.SliceInformer.TypedInformer(),
 		}, nil
@@ -152,6 +154,7 @@ func StartTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr 
 func newTracker(ctx context.Context, opts Options) (finalT *Tracker, finalErr error) {
 	t := &Tracker{
 		enableDeviceTaintRules: opts.EnableDeviceTaintRules,
+		logger:                 klog.FromContext(ctx),
 		resourceSliceLister:    opts.SliceInformer.Lister(),
 		resourceSlices:         opts.SliceInformer.TypedInformer(),
 		deviceTaints:           opts.TaintInformer.TypedInformer(),
@@ -293,7 +296,7 @@ func (t *Tracker) ListPatchedResourceSlices() ([]*resourceapi.ResourceSlice, err
 // before this method returns.
 func (t *Tracker) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
 	if !t.enableDeviceTaintRules {
-		return t.resourceSlices.AddEventHandler(handler)
+		return t.resourceSlices.AddEventHandlerWithOptions(handler, cache.HandlerOptions{Logger: &t.logger})
 	}
 
 	defer t.emitEvents()

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -311,7 +311,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -288,7 +288,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission_test.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
 	clienttesting "k8s.io/client-go/testing"
 	"k8s.io/sample-apiserver/pkg/admission/plugin/banflunder"
@@ -124,7 +125,7 @@ func TestBanflunderAdmissionPlugin(t *testing.T) {
 
 			stop := make(chan struct{})
 			defer close(stop)
-			informersFactory.Start(stop)
+			informersFactory.StartWithContext(wait.ContextForChannel(stop))
 			informersFactory.WaitForCacheSync(stop)
 
 			// act

--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission_test.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission_test.go
@@ -125,8 +125,9 @@ func TestBanflunderAdmissionPlugin(t *testing.T) {
 
 			stop := make(chan struct{})
 			defer close(stop)
-			informersFactory.StartWithContext(wait.ContextForChannel(stop))
-			informersFactory.WaitForCacheSync(stop)
+			ctx := wait.ContextForChannel(stop)
+			informersFactory.StartWithContext(ctx)
+			informersFactory.WaitForCacheSyncWithContext(ctx)
 
 			// act
 			err = target.Admit(context.TODO(), admission.NewAttributesRecord(

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -241,8 +241,8 @@ func (o WardleServerOptions) RunWardleServer(ctx context.Context) error {
 	}
 
 	server.GenericAPIServer.AddPostStartHookOrDie("start-sample-server-informers", func(context genericapiserver.PostStartHookContext) error {
-		config.GenericConfig.SharedInformerFactory.Start(context.Done())
-		o.SharedInformerFactory.Start(context.Done())
+		config.GenericConfig.SharedInformerFactory.StartWithContext(context)
+		o.SharedInformerFactory.StartWithContext(context)
 		return nil
 	})
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
@@ -311,7 +311,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/factory.go
@@ -288,7 +288,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/sample-controller/controller.go
+++ b/staging/src/k8s.io/sample-controller/controller.go
@@ -119,25 +119,27 @@ func NewController(
 		deploymentsSynced: deploymentInformer.Informer().HasSynced,
 		foosLister:        fooInformer.Lister(),
 		foosSynced:        fooInformer.Informer().HasSynced,
-		workqueue:         workqueue.NewTypedRateLimitingQueue(ratelimiter),
-		recorder:          recorder,
+		workqueue: workqueue.NewTypedRateLimitingQueueWithConfig(ratelimiter, workqueue.TypedRateLimitingQueueConfig[cache.ObjectName]{
+			Logger: &logger,
+		}),
+		recorder: recorder,
 	}
 
 	logger.Info("Setting up event handlers")
 	// Set up an event handler for when Foo resources change
-	fooInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = fooInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.enqueueFoo,
 		UpdateFunc: func(old, new interface{}) {
 			controller.enqueueFoo(new)
 		},
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 	// Set up an event handler for when Deployment resources change. This
 	// handler will lookup the owner of the given Deployment, and if it is
 	// owned by a Foo resource then the handler will enqueue that Foo resource for
 	// processing. This way, we don't need to implement custom logic for
 	// handling Deployment resources. More info on this pattern:
 	// https://github.com/kubernetes/community/blob/8cafef897a22026d42f5e5bb3f104febe7e29830/contributors/devel/controllers.md
-	deploymentInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, _ = deploymentInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: controller.handleObject,
 		UpdateFunc: func(old, new interface{}) {
 			newDepl := new.(*appsv1.Deployment)
@@ -150,7 +152,7 @@ func NewController(
 			controller.handleObject(new)
 		},
 		DeleteFunc: controller.handleObject,
-	})
+	}, cache.HandlerOptions{Logger: &logger})
 
 	return controller
 }

--- a/staging/src/k8s.io/sample-controller/controller.go
+++ b/staging/src/k8s.io/sample-controller/controller.go
@@ -162,7 +162,7 @@ func NewController(
 // is closed, at which point it will shutdown the workqueue and wait for
 // workers to finish processing their current work items.
 func (c *Controller) Run(ctx context.Context, workers int) error {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 	defer c.workqueue.ShutDown()
 	logger := klog.FromContext(ctx)
 

--- a/staging/src/k8s.io/sample-controller/controller_test.go
+++ b/staging/src/k8s.io/sample-controller/controller_test.go
@@ -120,8 +120,8 @@ func (f *fixture) runExpectError(ctx context.Context, fooRef cache.ObjectName) {
 func (f *fixture) runController(ctx context.Context, fooRef cache.ObjectName, startInformers bool, expectError bool) {
 	c, i, k8sI := f.newController(ctx)
 	if startInformers {
-		i.Start(ctx.Done())
-		k8sI.Start(ctx.Done())
+		i.StartWithContext(ctx)
+		k8sI.StartWithContext(ctx)
 	}
 
 	err := c.syncHandler(ctx, fooRef)

--- a/staging/src/k8s.io/sample-controller/main.go
+++ b/staging/src/k8s.io/sample-controller/main.go
@@ -72,8 +72,8 @@ func main() {
 
 	// notice that there is no need to run Start methods in a separate goroutine. (i.e. go kubeInformerFactory.Start(ctx.done())
 	// Start method is non-blocking and runs all registered informers in a dedicated goroutine.
-	kubeInformerFactory.Start(ctx.Done())
-	exampleInformerFactory.Start(ctx.Done())
+	kubeInformerFactory.StartWithContext(ctx)
+	exampleInformerFactory.StartWithContext(ctx)
 
 	if err = controller.Run(ctx, 2); err != nil {
 		logger.Error(err, "Error running controller")

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
@@ -311,7 +311,7 @@ type SharedInformerFactory interface {
 	// WaitForCacheSync blocks until all started informers' caches were synced
 	// or the stop channel gets closed.
 	//
-	// Contextual logging: WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
+	//logcheck:context // WaitForCacheSyncWithContext should be used instead of WaitForCacheSync in code which supports contextual logging. It also returns a more useful result.
 	WaitForCacheSync(stopCh <-chan struct{}) map[reflect.Type]bool
 
 	// WaitForCacheSyncWithContext blocks until all started informers' caches were synced

--- a/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/informers/externalversions/factory.go
@@ -288,7 +288,7 @@ type SharedInformerFactory interface {
 	// which run until the stop channel gets closed.
 	// Warning: Start does not block. When run in a go-routine, it will race with a later WaitForCacheSync.
 	//
-	// Contextual logging: StartWithContext should be used instead of Start in code which supports contextual logging.
+	//logcheck:context // StartWithContext should be used instead of Start in code which supports contextual logging.
 	Start(stopCh <-chan struct{})
 
 	// StartWithContext initializes all requested informers. They are handled in goroutines

--- a/staging/src/k8s.io/streaming/pkg/httpstream/wsstream/conn.go
+++ b/staging/src/k8s.io/streaming/pkg/httpstream/wsstream/conn.go
@@ -127,7 +127,7 @@ func IsWebSocketRequestWithTunnelingProtocol(req *http.Request) bool {
 // IgnoreReceives reads from a WebSocket until it is closed, then returns. If timeout is set, the
 // read and write deadlines are pushed every time a new message is received.
 //
-// Contextual logging: IgnoreReceivesWithLogger should be used instead of IgnoreReceives in code which uses contextual logging.
+//logcheck:context // IgnoreReceivesWithLogger should be used instead of IgnoreReceives in code which uses contextual logging.
 func IgnoreReceives(ws *websocket.Conn, timeout time.Duration) {
 	IgnoreReceivesWithLogger(klog.Background(), ws, timeout)
 }

--- a/test/e2e/apimachinery/coordinatedleaderelection.go
+++ b/test/e2e/apimachinery/coordinatedleaderelection.go
@@ -212,7 +212,7 @@ func (t *cleTest) createAndRunFakeLegacyController(name string, namespace string
 
 }
 func (t *cleTest) createAndRunFakeController(name string, namespace string, targetLease string, binaryVersion string, compatibilityVersion string, preferredStrategy coordinationv1.CoordinatedLeaseStrategy) {
-	identityLease, _, err := leaderelection.NewCandidate(
+	identityLease, _, err := leaderelection.NewCandidateWithConfig(
 		t.clientset,
 		namespace,
 		name,
@@ -220,6 +220,12 @@ func (t *cleTest) createAndRunFakeController(name string, namespace string, targ
 		binaryVersion,
 		compatibilityVersion,
 		preferredStrategy,
+		leaderelection.CandidateConfig{
+			// In E2E tests we don't need contextual logging.
+			// Including the name in the logger is useful
+			// because some tests run more than one controller.
+			Logger: new(klog.LoggerWithName(klog.Background(), name)),
+		},
 	)
 	framework.ExpectNoError(err)
 	ctx, cancel := context.WithCancel(t.ctx)

--- a/test/e2e/dra/utils/deploy.go
+++ b/test/e2e/dra/utils/deploy.go
@@ -191,7 +191,7 @@ func (nodes *Nodes) init(tCtx ktesting.TContext, minNodes, maxNodes int) {
 		cancel(errors.New("test has completed"))
 		wg.Wait()
 	})
-	_, err = claimInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	_, err = claimInformer.AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
 			claim := obj.(*resourceapi.ResourceClaim)
 			resourceClaimLogger.Info("New claim", "claim", format.Object(claim, 0))
@@ -210,7 +210,7 @@ func (nodes *Nodes) init(tCtx ktesting.TContext, minNodes, maxNodes int) {
 			claim := obj.(*resourceapi.ResourceClaim)
 			resourceClaimLogger.Info("Deleted claim", "claim", format.Object(claim, 0))
 		},
-	})
+	}, cache.HandlerOptions{Logger: &resourceClaimLogger})
 	tCtx.ExpectNoError(err, "AddEventHandler")
 	wg.Add(1)
 	go func() {

--- a/test/integration/apiserver/coordinatedleaderelection/cle_managed_lease_test.go
+++ b/test/integration/apiserver/coordinatedleaderelection/cle_managed_lease_test.go
@@ -39,6 +39,7 @@ import (
 	apiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
 	"k8s.io/kubernetes/pkg/controlplane/apiserver"
 	"k8s.io/kubernetes/test/integration/framework"
+	"k8s.io/kubernetes/test/utils/ktesting"
 	"k8s.io/utils/ptr"
 )
 
@@ -66,13 +67,12 @@ func TestSingleLeaseCandidate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			tCtx := ktesting.Init(t)
 
-			cletest := setupCLE(config, ctx, t)
+			cletest := setupCLE(config, tCtx, t)
 			defer cletest.cleanup()
-			go cletest.createAndRunFakeController("foo1", "default", "foo", "1.20.0", "1.20.0", tc.preferredStrategy)
-			cletest.pollForLease(ctx, "foo", "default", tc.expectedHolderIdentity)
+			go cletest.createAndRunFakeController(tCtx.Logger(), "foo1", "default", "foo", "1.20.0", "1.20.0", tc.preferredStrategy)
+			cletest.pollForLease(tCtx, "foo", "default", tc.expectedHolderIdentity)
 		})
 	}
 }
@@ -105,13 +105,12 @@ func TestSingleLeaseCandidateUsingThirdPartyStrategy(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			tCtx := ktesting.Init(t)
 
-			cletest := setupCLE(config, ctx, t)
+			cletest := setupCLE(config, tCtx, t)
 			defer cletest.cleanup()
-			go cletest.createAndRunFakeController("foo1", "default", "foo", "1.20.0", "1.20.0", tc.preferredStrategy)
-			cletest.pollForLease(ctx, "foo", "default", tc.expectedHolderIdentity)
+			go cletest.createAndRunFakeController(tCtx.Logger(), "foo1", "default", "foo", "1.20.0", "1.20.0", tc.preferredStrategy)
+			cletest.pollForLease(tCtx, "foo", "default", tc.expectedHolderIdentity)
 		})
 	}
 }
@@ -143,16 +142,15 @@ func TestMultipleLeaseCandidate(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			tCtx := ktesting.Init(t)
 
-			cletest := setupCLE(config, ctx, t)
+			cletest := setupCLE(config, tCtx, t)
 			defer cletest.cleanup()
-			go cletest.createAndRunFakeController("baz1", "default", "baz", "1.20.0", "1.20.0", tc.preferredStrategy)
-			go cletest.createAndRunFakeController("baz2", "default", "baz", "1.20.0", "1.19.0", tc.preferredStrategy)
-			go cletest.createAndRunFakeController("baz3", "default", "baz", "1.19.0", "1.19.0", tc.preferredStrategy)
-			go cletest.createAndRunFakeController("baz4", "default", "baz", "1.20.0", "1.19.0", tc.preferredStrategy)
-			cletest.pollForLease(ctx, "baz", "default", tc.expectedHolderIdentity)
+			go cletest.createAndRunFakeController(tCtx.Logger().WithName("baz1"), "baz1", "default", "baz", "1.20.0", "1.20.0", tc.preferredStrategy)
+			go cletest.createAndRunFakeController(tCtx.Logger().WithName("baz2"), "baz2", "default", "baz", "1.20.0", "1.19.0", tc.preferredStrategy)
+			go cletest.createAndRunFakeController(tCtx.Logger().WithName("baz3"), "baz3", "default", "baz", "1.19.0", "1.19.0", tc.preferredStrategy)
+			go cletest.createAndRunFakeController(tCtx.Logger().WithName("baz4"), "baz4", "default", "baz", "1.20.0", "1.19.0", tc.preferredStrategy)
+			cletest.pollForLease(tCtx, "baz", "default", tc.expectedHolderIdentity)
 		})
 	}
 }
@@ -186,22 +184,22 @@ func TestMultipleLeaseCandidateUsingThirdPartyStrategy(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			tCtx := ktesting.Init(t)
 
-			cletest := setupCLE(config, ctx, t)
+			cletest := setupCLE(config, tCtx, t)
 			defer cletest.cleanup()
-			go cletest.createAndRunFakeController("baz1", "default", "baz", "1.20.0", "1.20.0", tc.preferredStrategy)
-			go cletest.createAndRunFakeController("baz2", "default", "baz", "1.20.0", "1.19.0", tc.preferredStrategy)
-			go cletest.createAndRunFakeController("baz3", "default", "baz", "1.19.0", "1.19.0", tc.preferredStrategy)
-			go cletest.createAndRunFakeController("baz4", "default", "baz", "1.2.0", "1.19.0", tc.preferredStrategy)
-			go cletest.createAndRunFakeController("baz5", "default", "baz", "1.20.0", "1.19.0", tc.preferredStrategy)
-			cletest.pollForLease(ctx, "baz", "default", tc.expectedHolderIdentity)
+			go cletest.createAndRunFakeController(tCtx.Logger().WithName("baz1"), "baz1", "default", "baz", "1.20.0", "1.20.0", tc.preferredStrategy)
+			go cletest.createAndRunFakeController(tCtx.Logger().WithName("baz2"), "baz2", "default", "baz", "1.20.0", "1.19.0", tc.preferredStrategy)
+			go cletest.createAndRunFakeController(tCtx.Logger().WithName("baz3"), "baz3", "default", "baz", "1.19.0", "1.19.0", tc.preferredStrategy)
+			go cletest.createAndRunFakeController(tCtx.Logger().WithName("baz4"), "baz4", "default", "baz", "1.2.0", "1.19.0", tc.preferredStrategy)
+			go cletest.createAndRunFakeController(tCtx.Logger().WithName("baz5"), "baz5", "default", "baz", "1.20.0", "1.19.0", tc.preferredStrategy)
+			cletest.pollForLease(tCtx, "baz", "default", tc.expectedHolderIdentity)
 		})
 	}
 }
 
 func TestLeaseSwapIfBetterAvailable(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.CoordinatedLeaderElection, true)
 
 	flags := []string{fmt.Sprintf("--runtime-config=%s=true", v1beta1.SchemeGroupVersion)}
@@ -212,19 +210,18 @@ func TestLeaseSwapIfBetterAvailable(t *testing.T) {
 	defer server.TearDownFn()
 	config := server.ClientConfig
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	cletest := setupCLE(config, ctx, t)
+	cletest := setupCLE(config, tCtx, t)
 	defer cletest.cleanup()
 
-	go cletest.createAndRunFakeController("bar1", "default", "bar", "1.20.0", "1.20.0", v1.OldestEmulationVersion)
-	cletest.pollForLease(ctx, "bar", "default", ptr.To("bar1"))
-	go cletest.createAndRunFakeController("bar2", "default", "bar", "1.19.0", "1.19.0", v1.OldestEmulationVersion)
-	cletest.pollForLease(ctx, "bar", "default", ptr.To("bar2"))
+	go cletest.createAndRunFakeController(tCtx.Logger().WithName("bar1"), "bar1", "default", "bar", "1.20.0", "1.20.0", v1.OldestEmulationVersion)
+	cletest.pollForLease(tCtx, "bar", "default", new("bar1"))
+	go cletest.createAndRunFakeController(tCtx.Logger().WithName("bar2"), "bar2", "default", "bar", "1.19.0", "1.19.0", v1.OldestEmulationVersion)
+	cletest.pollForLease(tCtx, "bar", "default", new("bar2"))
 }
 
 // TestUpgradeSkew tests that a legacy client and a CLE aware client operating on the same lease do not cause errors
 func TestUpgradeSkew(t *testing.T) {
+	tCtx := ktesting.Init(t)
 	featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, genericfeatures.CoordinatedLeaderElection, true)
 
 	flags := []string{fmt.Sprintf("--runtime-config=%s=true", v1beta1.SchemeGroupVersion)}
@@ -235,18 +232,16 @@ func TestUpgradeSkew(t *testing.T) {
 	defer server.TearDownFn()
 	config := server.ClientConfig
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	cletest := setupCLE(config, ctx, t)
+	cletest := setupCLE(config, tCtx, t)
 	defer cletest.cleanup()
 
 	go cletest.createAndRunFakeLegacyController("foo1-130", "default", "foobar")
-	cletest.pollForLease(ctx, "foobar", "default", ptr.To("foo1-130"))
-	go cletest.createAndRunFakeController("foo1-131", "default", "foobar", "1.31.0", "1.31.0", v1.OldestEmulationVersion)
+	cletest.pollForLease(tCtx, "foobar", "default", new("foo1-130"))
+	go cletest.createAndRunFakeController(tCtx.Logger().WithName("foo1-131"), "foo1-131", "default", "foobar", "1.31.0", "1.31.0", v1.OldestEmulationVersion)
 	// running a new controller should not kick off old leader
-	cletest.pollForLease(ctx, "foobar", "default", ptr.To("foo1-130"))
+	cletest.pollForLease(tCtx, "foobar", "default", new("foo1-130"))
 	cletest.cancelController("foo1-130", "default")
-	cletest.pollForLease(ctx, "foobar", "default", ptr.To("foo1-131"))
+	cletest.pollForLease(tCtx, "foobar", "default", new("foo1-131"))
 }
 
 func TestLeaseCandidateCleanup(t *testing.T) {
@@ -335,8 +330,8 @@ func (t *cleTest) createAndRunFakeLegacyController(name string, namespace string
 		})
 
 }
-func (t *cleTest) createAndRunFakeController(name string, namespace string, targetLease string, binaryVersion string, compatibilityVersion string, preferredStrategy v1.CoordinatedLeaseStrategy) {
-	identityLease, _, err := leaderelection.NewCandidate(
+func (t *cleTest) createAndRunFakeController(logger klog.Logger, name string, namespace string, targetLease string, binaryVersion string, compatibilityVersion string, preferredStrategy v1.CoordinatedLeaseStrategy) {
+	identityLease, _, err := leaderelection.NewCandidateWithConfig(
 		t.clientset,
 		namespace,
 		name,
@@ -344,12 +339,14 @@ func (t *cleTest) createAndRunFakeController(name string, namespace string, targ
 		binaryVersion,
 		compatibilityVersion,
 		preferredStrategy,
+		leaderelection.CandidateConfig{Logger: new(logger)},
 	)
 	if err != nil {
 		t.t.Error(err)
 	}
 
 	ctx, cancel := context.WithCancel(t.ctx)
+	ctx = klog.NewContext(ctx, logger)
 	t.mu.Lock()
 	t.ctxList[name+"/"+namespace] = ctxCancelPair{ctx, cancel}
 	t.mu.Unlock()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Kubernetes 1.37 (mostly) finished adding context-aware alternatives to APIs. What is left is actually using the new APIs in those part of the code base (scheduler, controller manager, kubelet) which want to support contextual logging.

#### Which issue(s) this PR is related to:

https://github.com/kubernetes/kubernetes/issues/126379

#### Special notes for your reviewer:

Large PR, I'll try to split up...

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
