### PR TITLE
fix: make nil DeviceTaintSelector match no devices (tracker)

### DIFF
--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go
@@ -380,7 +380,11 @@ func sliceDriverPoolDeviceIndexFunc(slice *resourceapi.ResourceSlice) ([]string,
 }
 
 func driverPoolDeviceIndexPatchKey(patch *resourceapi.DeviceTaintRule) string {
-	deviceSelector := ptr.Deref(patch.Spec.DeviceSelector, resourceapi.DeviceTaintSelector{})
+	deviceSelector := patch.Spec.DeviceSelector
+	if deviceSelector == nil {
+		// No selector matches no devices, so it matches no slices.
+		return ""
+	}
 	driverKey := ptr.Deref(deviceSelector.Driver, anyDriver)
 	poolKey := ptr.Deref(deviceSelector.Pool, anyPool)
 	deviceKey := ptr.Deref(deviceSelector.Device, anyDevice)
@@ -578,18 +582,20 @@ func (t *Tracker) applyPatches(ctx context.Context, slice *resourceapi.ResourceS
 		logger.V(6).Info("processing DeviceTaintRule")
 
 		deviceSelector := taintRule.Spec.DeviceSelector
-		var deviceName *string
-		if deviceSelector != nil {
-			if deviceSelector.Driver != nil && *deviceSelector.Driver != slice.Spec.Driver {
-				logger.V(7).Info("DeviceTaintRule does not apply, mismatched driver", "sliceDriver", slice.Spec.Driver, "taintDriver", *deviceSelector.Driver)
-				continue
-			}
-			if deviceSelector.Pool != nil && *deviceSelector.Pool != slice.Spec.Pool.Name {
-				logger.V(7).Info("DeviceTaintRule does not apply, mismatched pool", "slicePool", slice.Spec.Pool.Name, "taintPool", *deviceSelector.Pool)
-				continue
-			}
-			deviceName = deviceSelector.Device
+		if deviceSelector == nil {
+			// No selector matches no devices.
+			logger.V(7).Info("DeviceTaintRule does not apply, no selector")
+			continue
 		}
+		if deviceSelector.Driver != nil && *deviceSelector.Driver != slice.Spec.Driver {
+			logger.V(7).Info("DeviceTaintRule does not apply, mismatched driver", "sliceDriver", slice.Spec.Driver, "taintDriver", *deviceSelector.Driver)
+			continue
+		}
+		if deviceSelector.Pool != nil && *deviceSelector.Pool != slice.Spec.Pool.Name {
+			logger.V(7).Info("DeviceTaintRule does not apply, mismatched pool", "slicePool", slice.Spec.Pool.Name, "taintPool", *deviceSelector.Pool)
+			continue
+		}
+		deviceName := deviceSelector.Device
 		for dIndex, device := range slice.Spec.Devices {
 			deviceID := deviceID(slice.Spec.Driver, slice.Spec.Pool.Name, device.Name)
 			logger := logger.WithValues("device", deviceID)

--- a/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker_test.go
@@ -278,6 +278,15 @@ var (
 			Name: "rule",
 		},
 		Spec: resourceapi.DeviceTaintRuleSpec{
+			DeviceSelector: &resourceapi.DeviceTaintSelector{},
+			Taint:          deviceTaint(deviceTaint1),
+		},
+	}
+	taintNoSelectorRule = &resourceapi.DeviceTaintRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "rule-no-selector",
+		},
+		Spec: resourceapi.DeviceTaintRuleSpec{
 			Taint: deviceTaint(deviceTaint1),
 		},
 	}
@@ -560,6 +569,21 @@ func TestListPatchedResourceSlices(t *testing.T) {
 				{event: handlerEventUpdate, oldObj: sliceWithDevices(slice2, threeDevicesOneTainted), newObj: sliceWithDevices(slice2, taintedDevices)},
 			},
 		},
+		"nil-selector-matches-none": {
+			events: []any{
+				add(slice1),
+				add(slice2),
+				add(taintNoSelectorRule),
+			},
+			expectedPatchedSlices: []*resourceapi.ResourceSlice{
+				slice1,
+				slice2,
+			},
+			expectedHandlerEvents: []handlerEvent{
+				{event: handlerEventAdd, newObj: slice1},
+				{event: handlerEventAdd, newObj: slice2},
+			},
+		},
 	}
 
 	setup := func(t *testing.T) *testContext {
@@ -780,7 +804,7 @@ func BenchmarkEventHandlers(b *testing.B) {
 						Name: "taintRule",
 					},
 					Spec: resourceapi.DeviceTaintRuleSpec{
-						DeviceSelector: nil, // all slices
+						DeviceSelector: &resourceapi.DeviceTaintSelector{}, // all slices
 						Taint: resourceapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",
@@ -815,7 +839,7 @@ func BenchmarkEventHandlers(b *testing.B) {
 						Name: "taintRule",
 					},
 					Spec: resourceapi.DeviceTaintRuleSpec{
-						DeviceSelector: nil, // all slices
+						DeviceSelector: &resourceapi.DeviceTaintSelector{}, // all slices
 						Taint: resourceapi.DeviceTaint{
 							Key:       "example.com/taint",
 							Value:     "tainted",


### PR DESCRIPTION
### Which issue is this PR fixing?

Closes #141620

### What this PR does

Fixes the `NoSchedule` enforcement path for `DeviceTaintRule` when `spec.deviceSelector` is omitted (nil).

**Root cause:** `staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker/tracker.go` treated a nil selector as matching every device:

- `driverPoolDeviceIndexPatchKey()` used `ptr.Deref(patch.Spec.DeviceSelector, DeviceTaintSelector{})` which defaults nil to empty struct and keys `*`/`*`/`*` (matches all slices via index).
- `applyPatches()` skipped driver/pool checks when selector was nil and never filtered by device name, so every device in every matching slice got tainted.

This contradicts the API doc ("The empty selector matches all devices. Without a selector, no devices are matches.") and made a single rule with an omitted field block all DRA scheduling cluster-wide, including `adminAccess: true` claims. The separate `NoExecute` path (`pkg/controller/devicetainteviction/device_taint_eviction.go:ruleMatchesDevice`) already correctly returned false for nil, so only `NoSchedule` was affected (as noted in the issue).

**Fix:**

- `driverPoolDeviceIndexPatchKey`: return `""` (matches no index) when selector is nil.
- `applyPatches`: early-continue with log when selector is nil, matching the `ruleMatchesDevice` semantics.

**Tests:**

- Update `tracker_test.go`: `taintAllDevicesRule` now uses an explicit empty selector `&DeviceTaintSelector{}` to represent "match all" per API spec (previously relied on the buggy nil to all behavior). Update benchmarks accordingly.
- Add regression case `nil-selector-matches-none`: a rule with nil selector plus two slices should produce zero patches and no handler events.

### Why the test was updated

The existing `taintAllDevicesRule` fixture left `deviceSelector` unset and asserted it tainted slices. That tested the buggy ship behavior opposite to the doc (see https://github.com/kubernetes/kubernetes/issues/141620#issuecomment-5437624477). Switching it to an empty selector preserves coverage for "taint all devices" while fixing the nil semantics. The new test guards the documented nil to none behavior.

### Validation

`go test ./staging/src/k8s.io/dynamic-resource-allocation/resourceslice/tracker ./pkg/controller/devicetainteviction ./pkg/apis/resource/validation` all pass locally.

Distinct from #141422 / #141425: that PR validates and rejects an *empty but present* `deviceSelector: {}` (all fields nil). This PR fixes the *absent* (`nil`) selector path, which #141425 explicitly does not cover (it returns immediately with no error when selector is nil).

### Special notes for your reviewer

AI assistance disclosure: Muse Spark was used for issue analysis, codebase research, and drafting the fix/tests. The author has reviewed all changes and is responsible per `CONTRIBUTING.md`.

```release-note
Fixed a bug where a DeviceTaintRule with no `spec.deviceSelector` incorrectly matched every device cluster-wide and made all DRA devices unschedulable for `NoSchedule` or `NoExecute` taints. The rule now correctly matches no devices as documented. Use an explicit empty selector (`deviceSelector: {}`) to target all devices.
```
