### PR TITLE
kubelet-report-device-plugin-devices-in-podresources-GetAllocatableResources-on-Windows

### DIFF
--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -320,8 +320,8 @@ func (cm *containerManagerImpl) GetDevices(podUID, containerName string) []*podr
 	return containerDevicesFromResourceDeviceInstances(cm.deviceManager.GetDevices(podUID, containerName))
 }
 
-func (cm *containerManagerImpl) GetAllocatableDevices(_ klog.Logger) []*podresourcesapi.ContainerDevices {
-	return nil
+func (cm *containerManagerImpl) GetAllocatableDevices(logger klog.Logger) []*podresourcesapi.ContainerDevices {
+	return containerDevicesFromResourceDeviceInstances(cm.deviceManager.GetAllocatableDevices(logger))
 }
 
 func (cm *containerManagerImpl) ShouldResetExtendedResourceCapacity() bool {

--- a/pkg/kubelet/cm/container_manager_windows_test.go
+++ b/pkg/kubelet/cm/container_manager_windows_test.go
@@ -1,0 +1,81 @@
+//go:build windows
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"testing"
+
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/ktesting"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+	"k8s.io/kubernetes/pkg/kubelet/cm/devicemanager"
+)
+
+// fakeDeviceManager is a minimal devicemanager.Manager stub. It embeds the
+// interface so methods not built by the test default to nil; only
+// GetAllocatableDevices is overridden.
+type fakeDeviceManager struct {
+	devicemanager.Manager
+	allocatableDevices devicemanager.ResourceDeviceInstances
+}
+
+func (f *fakeDeviceManager) GetAllocatableDevices(_ klog.Logger) devicemanager.ResourceDeviceInstances {
+	return f.allocatableDevices
+}
+
+func TestGetAllocatableDevices(t *testing.T) {
+	resourceName := "example.com/res1"
+	allocatable := devicemanager.NewResourceDeviceInstances()
+	// Devices without topology information are still reported, mirroring
+	// device plugins that do not provide NUMA topology.
+	allocatable[resourceName] = devicemanager.DeviceInstances{
+		"dev-1": &pluginapi.Device{ID: "dev-1"},
+		"dev-2": &pluginapi.Device{ID: "dev-2"},
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+	cm := &containerManagerImpl{
+		deviceManager: &fakeDeviceManager{allocatableDevices: allocatable},
+	}
+
+	got := cm.GetAllocatableDevices(logger)
+
+	// containerDevicesFromResourceDeviceInstances emits one ContainerDevices
+	// entry per device, each carrying the resource name and a single device id.
+	if len(got) != 2 {
+		t.Fatalf("expected 2 allocatable device entries, got %d: %v", len(got), got)
+	}
+	expected := map[string]struct{}{
+		"dev-1": {},
+		"dev-2": {},
+	}
+	for _, cd := range got {
+		if cd.ResourceName != resourceName {
+			t.Errorf("expected resource %q, got %q", resourceName, cd.ResourceName)
+		}
+		if len(cd.DeviceIds) != 1 {
+			t.Errorf("expected a single device id for %q, got %v", cd.ResourceName, cd.DeviceIds)
+			continue
+		}
+		id := cd.DeviceIds[0]
+		if _, ok := expected[id]; !ok {
+			t.Errorf("unexpected device id %q", id)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

On Windows, `containerManagerImpl.GetAllocatableDevices` in `pkg/kubelet/cm/container_manager_windows.go` always returned `nil`. As a result, the podresources `GetAllocatableResources` endpoint reported no device plugin devices for Windows nodes even when device plugins were healthy and had allocatable devices.

This PR mirrors the Linux implementation (`container_manager_linux.go`) so that device plugin devices are correctly reported on Windows:

```go
func (cm *containerManagerImpl) GetAllocatableDevices(logger klog.Logger) []*podresourcesapi.ContainerDevices {
	return containerDevicesFromResourceDeviceInstances(cm.deviceManager.GetAllocatableDevices(logger))
}
```

The `containerDevicesFromResourceDeviceInstances` helper already exists in `pkg/kubelet/cm/container_manager.go`, and the sibling Windows `GetDevices` already uses this identical pattern, so no new imports are required.

**Which issue(s) this PR fixes:**

None currently linked.

**Special notes for your reviewer:**

This is a small, focused parity fix (2 lines). The passed `logger` parameter is now used instead of being discarded.

**Release note:**

```release-note
kubelet: the podresources GetAllocatableResources endpoint now correctly reports device plugin devices on Windows.
```

**AI assistance disclosure:**

This PR was generated with assistance from an AI coding agent. The AI agent identified the parity gap by comparing the Windows and Linux implementations, applied the change, built and ran the `pkg/kubelet/cm` unit tests and `go vet`, and prepared this PR. The human author (MartinForReal) is responsible for reviewing and validating the change before merge. See `CONTRIBUTING.md` for contribution guidelines.
