### PR TITLE
kubelet/stats: verify Windows container rootfs usage is surfaced in summary

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider_windows_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows_test.go
@@ -463,6 +463,14 @@ func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
 	memoryUsagePageFaults := uint64(200)
 	logStatsUsed := uint64(5000)
 	logStatsInodesUsed := uint64(5050)
+	// CRI reports the writable layer usage of the Windows container rootfs.
+	writableLayerUsedBytes := uint64(0x77778888)
+	// The node-level filesystem stats that back the container rootfs capacity
+	// and available bytes (matched by the writable layer's FS mountpoint).
+	rootFsMountpoint := "C:"
+	rootFsAvailableBytes := uint64(0x11112222)
+	rootFsCapacityBytes := uint64(0xAAAA0000)
+	rootFsUsageBytes := writableLayerUsedBytes
 
 	// getPodContainerLogStats is called during makeWindowsContainerStats to populate ContainerStats.Logs
 	c0LogStats := &volume.Metrics{
@@ -510,6 +518,18 @@ func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
 				Value: memoryUsagePageFaults,
 			},
 		},
+		// The writable layer is what the Windows runtime charges against the
+		// per-container rootfs cap. Verify it is surfaced as container rootfs
+		// usage in the summary API.
+		WritableLayer: &runtimeapi.WindowsFilesystemUsage{
+			Timestamp: int64(777777),
+			FsId: &runtimeapi.FilesystemIdentifier{
+				Mountpoint: rootFsMountpoint,
+			},
+			UsedBytes: &runtimeapi.UInt64Value{
+				Value: writableLayerUsedBytes,
+			},
+		},
 	}
 
 	inputContainer := &runtimeapi.Container{
@@ -528,8 +548,17 @@ func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
 		Uid:       "sb0-uid",
 	}
 
+	fsIDtoInfo := map[string]*cadvisorapi.FsInfo{
+		rootFsMountpoint: {
+			Mountpoint: rootFsMountpoint,
+			Available:  rootFsAvailableBytes,
+			Capacity:   rootFsCapacityBytes,
+			Usage:      rootFsUsageBytes,
+		},
+	}
+
 	logger, _ := ktesting.NewTestContext(t)
-	got, err := p.makeWinContainerStats(logger, inputStats, inputContainer, inputRootFsInfo, make(map[string]*cadvisorapi.FsInfo), inputPodSandboxMetadata)
+	got, err := p.makeWinContainerStats(logger, inputStats, inputContainer, inputRootFsInfo, fsIDtoInfo, inputPodSandboxMetadata)
 
 	expected := &statsapi.ContainerStats{
 		Name:      "c0",
@@ -546,7 +575,12 @@ func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
 			WorkingSetBytes: ptr.To[uint64](memoryUsageWorkingSetBytes),
 			PageFaults:      ptr.To[uint64](memoryUsagePageFaults),
 		},
-		Rootfs: &statsapi.FsStats{},
+		Rootfs: &statsapi.FsStats{
+			Time:           v1.NewTime(time.Unix(0, int64(777777))),
+			UsedBytes:      ptr.To[uint64](writableLayerUsedBytes),
+			AvailableBytes: ptr.To[uint64](rootFsAvailableBytes),
+			CapacityBytes:  ptr.To[uint64](rootFsCapacityBytes),
+		},
 		Logs: &statsapi.FsStats{
 			Time:       c0LogStats.Time,
 			UsedBytes:  ptr.To[uint64](logStatsUsed),


### PR DESCRIPTION
**What this PR does / why we need it**

Closes the request in https://github.com/kubernetes/kubernetes/issues/112743 (Windows node should provide metrics for rootfs / ephemeral-storage space usage).

The CRI path already surfaces the Windows container rootfs usage: cri_stats_provider_windows.makeWinContainerStats reads the writable-layer UsedBytes reported by the Windows runtime (WindowsContainerStats.WritableLayer) and populates ContainerStats.Rootfs.UsedBytes, which is aggregated into the pod EphemeralStorage and appears in /stats/summary. That mirrors the Linux semantics, where the CRI writable-layer usage is charged against the per-container rootfs cap.

However, the existing unit test Test_criStatsProvider_makeWinContainerStats did not exercise the WritableLayer/rootfs path at all, so there was no regression coverage proving that Windows container rootfs (and thus ephemeral-storage) usage is actually surfaced.

This PR adds that coverage: it feeds a WritableLayer with UsedBytes and an FS id into makeWinContainerStats and asserts the container Rootfs (used/available/capacity bytes) is populated. It confirms parity with the Linux reporting path and guards the behavior going forward.

**Scope / limitation**

Reporting "how close a Windows container is to its fixed per-container rootfs cap" (i.e. the sandbox rootfs capacity/available) is not possible in a kubelet-only change: the CRI WindowsFilesystemUsage exposed via WritableLayer only carries used_bytes, not capacity or available. Surfacing the container writable-layer capacity would require adding that field to the CRI API and having the Windows container runtime populate it. This PR locks in the usage that the kubelet can already report.


```release-note
kubelet: container rootfs usage on Windows (from the CRI writable-layer stats) is verified to be surfaced in /stats/summary and aggregated into pod ephemeral-storage usage, matching the Linux reporting path.
```

Links: [issue #112743](https://github.com/kubernetes/kubernetes/issues/112743)

---

**AI-assistance disclosure:**

This pull request was created with AI assistance. The code change (unit test coverage) was authored and verified with iterative AI support: the AI located the relevant stats code path, generated the test additions, and ran the Windows-targeted build/tests (go test, go vet, gofmt). The human author reviewed the diff before submission and is responsible for this change. See CONTRIBUTING.md.