### PR TITLE
client-go: avoid holding the event broadcaster lock during EventSeries updates

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -72,6 +72,11 @@ type eventBroadcasterImpl struct {
 	sleepDuration time.Duration
 	sink          EventSink
 
+	// seriesSyncMu serializes refreshExistingEventSeries and finishSeries
+	// so their API calls for the same event cannot interleave.
+	// It must be acquired before mu and is not used by recordToSink.
+	seriesSyncMu sync.Mutex
+
 	// startMu guards started and cancel.
 	startMu sync.Mutex
 	started bool
@@ -137,17 +142,51 @@ func (e *eventBroadcasterImpl) Shutdown() {
 
 // refreshExistingEventSeries refresh events TTL
 func (e *eventBroadcasterImpl) refreshExistingEventSeries(ctx context.Context) {
-	// TODO: Investigate whether lock contention won't be a problem
+	e.seriesSyncMu.Lock()
+	defer e.seriesSyncMu.Unlock()
 	e.mu.Lock()
-	defer e.mu.Unlock()
+	toRefresh := make([]eventKey, 0, len(e.eventCache))
 	for isomorphicKey, event := range e.eventCache {
 		if event.Series != nil {
-			if recordedEvent, retry := recordEvent(ctx, e.sink, event); !retry {
-				if recordedEvent != nil {
-					e.eventCache[isomorphicKey] = recordedEvent
-				}
-			}
+			toRefresh = append(toRefresh, isomorphicKey)
 		}
+	}
+	e.mu.Unlock()
+
+	for _, key := range toRefresh {
+		// Avoid unnecessary API calls after cancellation.
+		if ctx.Err() != nil {
+			return
+		}
+		// Deep-copy the event just before recording it, so the API call
+		// carries the most recent observations without holding the lock
+		// during the call.
+		e.mu.Lock()
+		cachedEvent, ok := e.eventCache[key]
+		if !ok || cachedEvent.Series == nil {
+			e.mu.Unlock()
+			continue
+		}
+		event := cachedEvent.DeepCopy()
+		e.mu.Unlock()
+
+		recordedEvent, retry := recordEvent(ctx, e.sink, event)
+		if retry || recordedEvent == nil || recordedEvent.Series == nil {
+			continue
+		}
+		e.mu.Lock()
+		// The cached event may have been updated, finished, or replaced by a
+		// new isomorphic series while the lock was released. Compare the
+		// event identity so only an entry that still belongs to the same
+		// series is refreshed, and keep the most recent observations.
+		if cachedEvent, ok := e.eventCache[key]; ok && cachedEvent.Name == event.Name && cachedEvent.Series != nil {
+			if cachedEvent.Series.Count > recordedEvent.Series.Count {
+				recordedEvent.Series.Count = cachedEvent.Series.Count
+				recordedEvent.Series.LastObservedTime = cachedEvent.Series.LastObservedTime
+			}
+			e.eventCache[key] = recordedEvent
+		}
+		e.mu.Unlock()
 	}
 }
 
@@ -155,19 +194,52 @@ func (e *eventBroadcasterImpl) refreshExistingEventSeries(ctx context.Context) {
 // - write final count to the apiserver
 // - delete a singleton event (i.e. series field is nil) from the cache
 func (e *eventBroadcasterImpl) finishSeries(ctx context.Context) {
-	// TODO: Investigate whether lock contention won't be a problem
+	e.seriesSyncMu.Lock()
+	defer e.seriesSyncMu.Unlock()
 	e.mu.Lock()
-	defer e.mu.Unlock()
+	toFinish := make([]eventKey, 0, len(e.eventCache))
 	for isomorphicKey, event := range e.eventCache {
 		eventSerie := event.Series
 		if eventSerie != nil {
 			if eventSerie.LastObservedTime.Time.Before(time.Now().Add(-finishTime)) {
-				if _, retry := recordEvent(ctx, e.sink, event); !retry {
-					delete(e.eventCache, isomorphicKey)
-				}
+				toFinish = append(toFinish, isomorphicKey)
 			}
 		} else if event.EventTime.Time.Before(time.Now().Add(-finishTime)) {
 			delete(e.eventCache, isomorphicKey)
+		}
+	}
+	e.mu.Unlock()
+
+	for _, key := range toFinish {
+		// Avoid unnecessary API calls after cancellation.
+		if ctx.Err() != nil {
+			return
+		}
+		// Deep-copy the event just before recording it, so the final count
+		// is as recent as possible without holding the lock during the call.
+		e.mu.Lock()
+		cachedEvent, ok := e.eventCache[key]
+		if !ok || cachedEvent.Series == nil ||
+			!cachedEvent.Series.LastObservedTime.Time.Before(time.Now().Add(-finishTime)) {
+			// The entry was removed, replaced by a singleton event, or the
+			// series was observed again while the lock was released.
+			e.mu.Unlock()
+			continue
+		}
+		event := cachedEvent.DeepCopy()
+		e.mu.Unlock()
+
+		if _, retry := recordEvent(ctx, e.sink, event); !retry {
+			e.mu.Lock()
+			// The cached event may have been replaced by a new isomorphic
+			// series while the lock was released. Compare the event identity
+			// and only delete an entry that still belongs to the same series
+			// and was not observed again, otherwise keep aggregating it.
+			if cachedEvent, ok := e.eventCache[key]; ok && cachedEvent.Name == event.Name &&
+				cachedEvent.Series != nil && cachedEvent.Series.Count <= event.Series.Count {
+				delete(e.eventCache, key)
+			}
+			e.mu.Unlock()
 		}
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
+++ b/staging/src/k8s.io/client-go/tools/events/eventseries_test.go
@@ -35,6 +35,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/klog/v2/ktesting"
+	testclocks "k8s.io/utils/clock/testing"
 )
 
 type testEventSeriesSink struct {
@@ -415,5 +416,440 @@ func TestRefreshExistingEventSeries(t *testing.T) {
 		case <-time.After(wait.ForeverTestTimeout):
 			t.Fatalf("timeout after %v", wait.ForeverTestTimeout)
 		}
+	}
+}
+
+// newCachedSeriesEvent creates an Event with a Series and adds it to the
+// broadcaster's cache, returning the Event and its cache key.
+func newCachedSeriesEvent(t *testing.T, eventBroadcaster *eventBroadcasterImpl, lastObservedTime time.Time) (*eventsv1.Event, eventKey) {
+	t.Helper()
+	hostname, _ := os.Hostname()
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "baz",
+			UID:       "bar",
+		},
+	}
+	regarding, err := ref.GetPartialReference(scheme.Scheme, testPod, ".spec.containers[1]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	related, err := ref.GetPartialReference(scheme.Scheme, testPod, ".spec.containers[0]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, "k8s.io/kube-foo").(*recorderImplLogger)
+	cachedEvent := recorder.makeEvent(regarding, related, metav1.MicroTime{Time: time.Now()}, nil, v1.EventTypeNormal, "test", "some verbose message: 1", "eventTest", "eventTest-"+hostname, "started")
+	cachedEvent.Series = &eventsv1.EventSeries{
+		Count:            10,
+		LastObservedTime: metav1.MicroTime{Time: lastObservedTime},
+	}
+	key := getKey(cachedEvent)
+	eventBroadcaster.mu.Lock()
+	defer eventBroadcaster.mu.Unlock()
+	eventBroadcaster.eventCache[key] = cachedEvent
+	return cachedEvent, key
+}
+
+// TestRefreshExistingEventSeriesConcurrentCacheUpdate verifies that
+// refreshExistingEventSeries only updates a cache entry that still belongs to
+// the same series after the lock was released for the API call, and that it
+// keeps the most recent observations recorded while the call was in flight.
+func TestRefreshExistingEventSeriesConcurrentCacheUpdate(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	observedAgainTime := metav1.MicroTime{Time: time.Now().Add(time.Minute)}
+
+	table := []struct {
+		name string
+		// mutate runs while the API call is in flight, i.e. with the
+		// broadcaster's lock released, and simulates a concurrent recorder.
+		mutate func(e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event)
+		verify func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event)
+	}{
+		{
+			name: "cache entry replaced by a new isomorphic series is not overwritten",
+			mutate: func(e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				replacement := original.DeepCopy()
+				replacement.Name = original.Name + "-replacement"
+				replacement.ResourceVersion = ""
+				replacement.Series = &eventsv1.EventSeries{Count: 2, LastObservedTime: observedAgainTime}
+				e.eventCache[key] = replacement
+			},
+			verify: func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				cached, exists := e.eventCache[key]
+				if !exists {
+					t.Fatal("expected the replacement series to remain in the cache")
+				}
+				if cached.Name != original.Name+"-replacement" {
+					t.Errorf("expected cache to hold the replacement series %q, but got %q", original.Name+"-replacement", cached.Name)
+				}
+				if cached.ResourceVersion != "" {
+					t.Errorf("expected the replacement series to be untouched, but got ResourceVersion %q from the recorded event", cached.ResourceVersion)
+				}
+				if cached.Series == nil || cached.Series.Count != 2 {
+					t.Errorf("expected the replacement series to keep Count 2, but got %v", cached.Series)
+				}
+			},
+		},
+		{
+			name: "cache entry observed again keeps the most recent observations",
+			mutate: func(e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				e.eventCache[key].Series.Count = 11
+				e.eventCache[key].Series.LastObservedTime = observedAgainTime
+			},
+			verify: func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				cached, exists := e.eventCache[key]
+				if !exists {
+					t.Fatal("expected the series to remain in the cache")
+				}
+				if cached.Name != original.Name {
+					t.Errorf("expected cache to hold series %q, but got %q", original.Name, cached.Name)
+				}
+				if cached.ResourceVersion != "recorded" {
+					t.Errorf("expected cache to be updated with the recorded event, but got ResourceVersion %q", cached.ResourceVersion)
+				}
+				if cached.Series == nil || cached.Series.Count != 11 {
+					t.Errorf("expected the refreshed series to keep Count 11, but got %v", cached.Series)
+				}
+				if cached.Series != nil && !cached.Series.LastObservedTime.Equal(&observedAgainTime) {
+					t.Errorf("expected the refreshed series to keep LastObservedTime %v, but got %v", observedAgainTime, cached.Series.LastObservedTime)
+				}
+			},
+		},
+		{
+			name: "cache entry finished while refreshing is not re-added",
+			mutate: func(e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				delete(e.eventCache, key)
+			},
+			verify: func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				if cached, exists := e.eventCache[key]; exists {
+					t.Errorf("expected the finished series to stay out of the cache, but got %v", cached)
+				}
+			},
+		},
+		{
+			name: "cache entry replaced by a singleton event is not overwritten",
+			mutate: func(e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				replacement := original.DeepCopy()
+				replacement.Name = original.Name + "-singleton"
+				replacement.Series = nil
+				e.eventCache[key] = replacement
+			},
+			verify: func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				cached, exists := e.eventCache[key]
+				if !exists {
+					t.Fatal("expected the singleton event to remain in the cache")
+				}
+				if cached.Name != original.Name+"-singleton" || cached.Series != nil {
+					t.Errorf("expected cache to hold the untouched singleton event, but got %v", cached)
+				}
+			},
+		},
+	}
+	for _, item := range table {
+		t.Run(item.name, func(t *testing.T) {
+			var eventBroadcaster *eventBroadcasterImpl
+			var original *eventsv1.Event
+			var key eventKey
+			patches := 0
+			testEvents := testEventSeriesSink{
+				OnPatch: func(event *eventsv1.Event, patch []byte) (*eventsv1.Event, error) {
+					patches++
+					if event.Name != original.Name {
+						t.Errorf("expected to patch series %q, but got %q", original.Name, event.Name)
+					}
+					eventBroadcaster.mu.Lock()
+					defer eventBroadcaster.mu.Unlock()
+					item.mutate(eventBroadcaster, key, original)
+					recorded := event.DeepCopy()
+					recorded.ResourceVersion = "recorded"
+					return recorded, nil
+				},
+			}
+			eventBroadcaster = newBroadcaster(&testEvents, 0, map[eventKey]*eventsv1.Event{}).(*eventBroadcasterImpl)
+			original, key = newCachedSeriesEvent(t, eventBroadcaster, time.Now())
+
+			eventBroadcaster.refreshExistingEventSeries(ctx)
+
+			if patches != 1 {
+				t.Errorf("expected exactly one patch request, but got %d", patches)
+			}
+			eventBroadcaster.mu.Lock()
+			defer eventBroadcaster.mu.Unlock()
+			if len(eventBroadcaster.eventCache) > 1 {
+				t.Errorf("expected at most one cache entry, but got %d", len(eventBroadcaster.eventCache))
+			}
+			item.verify(t, eventBroadcaster, key, original)
+		})
+	}
+}
+
+// TestFinishSeriesConcurrentCacheUpdate verifies that finishSeries only
+// deletes a cache entry that still belongs to the same series and was not
+// observed again after the lock was released for the API call.
+func TestFinishSeriesConcurrentCacheUpdate(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	observedAgainTime := metav1.MicroTime{Time: time.Now()}
+
+	table := []struct {
+		name string
+		// mutate runs while the API call is in flight, i.e. with the
+		// broadcaster's lock released, and simulates a concurrent recorder.
+		mutate func(e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event)
+		verify func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event)
+	}{
+		{
+			name: "unchanged series is deleted",
+			mutate: func(e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+			},
+			verify: func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				if cached, exists := e.eventCache[key]; exists {
+					t.Errorf("expected the finished series to be deleted from the cache, but got %v", cached)
+				}
+			},
+		},
+		{
+			name: "cache entry replaced by a new isomorphic series is not deleted",
+			mutate: func(e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				replacement := original.DeepCopy()
+				replacement.Name = original.Name + "-replacement"
+				replacement.Series = &eventsv1.EventSeries{Count: 2, LastObservedTime: observedAgainTime}
+				e.eventCache[key] = replacement
+			},
+			verify: func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				cached, exists := e.eventCache[key]
+				if !exists {
+					t.Fatal("expected the replacement series to remain in the cache")
+				}
+				if cached.Name != original.Name+"-replacement" {
+					t.Errorf("expected cache to hold the replacement series %q, but got %q", original.Name+"-replacement", cached.Name)
+				}
+				if cached.Series == nil || cached.Series.Count != 2 {
+					t.Errorf("expected the replacement series to keep Count 2, but got %v", cached.Series)
+				}
+			},
+		},
+		{
+			name: "cache entry observed again is not deleted",
+			mutate: func(e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				e.eventCache[key].Series.Count = 11
+				e.eventCache[key].Series.LastObservedTime = observedAgainTime
+			},
+			verify: func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				cached, exists := e.eventCache[key]
+				if !exists {
+					t.Fatal("expected the series observed again to remain in the cache")
+				}
+				if cached.Name != original.Name {
+					t.Errorf("expected cache to hold series %q, but got %q", original.Name, cached.Name)
+				}
+				if cached.Series == nil || cached.Series.Count != 11 {
+					t.Errorf("expected the series to keep Count 11, but got %v", cached.Series)
+				}
+			},
+		},
+		{
+			name: "cache entry replaced by a singleton event is not deleted",
+			mutate: func(e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				replacement := original.DeepCopy()
+				replacement.Name = original.Name + "-singleton"
+				replacement.Series = nil
+				e.eventCache[key] = replacement
+			},
+			verify: func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				cached, exists := e.eventCache[key]
+				if !exists {
+					t.Fatal("expected the singleton event to remain in the cache")
+				}
+				if cached.Name != original.Name+"-singleton" || cached.Series != nil {
+					t.Errorf("expected cache to hold the untouched singleton event, but got %v", cached)
+				}
+			},
+		},
+	}
+	for _, item := range table {
+		t.Run(item.name, func(t *testing.T) {
+			var eventBroadcaster *eventBroadcasterImpl
+			var original *eventsv1.Event
+			var key eventKey
+			patches := 0
+			testEvents := testEventSeriesSink{
+				OnPatch: func(event *eventsv1.Event, patch []byte) (*eventsv1.Event, error) {
+					patches++
+					if event.Name != original.Name {
+						t.Errorf("expected to patch series %q, but got %q", original.Name, event.Name)
+					}
+					if event.Series == nil || event.Series.Count != 10 {
+						t.Errorf("expected to record the final Count 10, but got %v", event.Series)
+					}
+					eventBroadcaster.mu.Lock()
+					defer eventBroadcaster.mu.Unlock()
+					item.mutate(eventBroadcaster, key, original)
+					return event, nil
+				},
+			}
+			eventBroadcaster = newBroadcaster(&testEvents, 0, map[eventKey]*eventsv1.Event{}).(*eventBroadcasterImpl)
+			original, key = newCachedSeriesEvent(t, eventBroadcaster, time.Now().Add(-finishTime-time.Minute))
+
+			eventBroadcaster.finishSeries(ctx)
+
+			if patches != 1 {
+				t.Errorf("expected exactly one patch request, but got %d", patches)
+			}
+			eventBroadcaster.mu.Lock()
+			defer eventBroadcaster.mu.Unlock()
+			if len(eventBroadcaster.eventCache) > 1 {
+				t.Errorf("expected at most one cache entry, but got %d", len(eventBroadcaster.eventCache))
+			}
+			item.verify(t, eventBroadcaster, key, original)
+		})
+	}
+}
+
+// TestSeriesHousekeepingWithConcurrentRecordToSink verifies that events
+// recorded through recordToSink while finishSeries or
+// refreshExistingEventSeries are in the middle of an API call are neither
+// blocked by that call nor lost: an isomorphic event increments the cached
+// series and prevents finishSeries from deleting it, and a non-isomorphic
+// event is recorded right away.
+func TestSeriesHousekeepingWithConcurrentRecordToSink(t *testing.T) {
+	_, ctx := ktesting.NewTestContext(t)
+	observedAgainTime := time.Now().Add(time.Minute)
+
+	table := []struct {
+		name             string
+		lastObservedTime time.Time
+		housekeeping     func(e *eventBroadcasterImpl, ctx context.Context)
+		verify           func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event)
+	}{
+		{
+			name:             "finishSeries does not delete a series observed while patching",
+			lastObservedTime: time.Now().Add(-finishTime - time.Minute),
+			housekeeping:     (*eventBroadcasterImpl).finishSeries,
+			verify: func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				cached, exists := e.eventCache[key]
+				if !exists {
+					t.Fatal("expected the series observed while patching to remain in the cache")
+				}
+				if cached.Name != original.Name {
+					t.Errorf("expected cache to hold series %q, but got %q", original.Name, cached.Name)
+				}
+				if cached.Series == nil || cached.Series.Count != 11 {
+					t.Errorf("expected the series to have Count 11, but got %v", cached.Series)
+				}
+			},
+		},
+		{
+			name:             "refreshExistingEventSeries keeps observations recorded while patching",
+			lastObservedTime: time.Now(),
+			housekeeping:     (*eventBroadcasterImpl).refreshExistingEventSeries,
+			verify: func(t *testing.T, e *eventBroadcasterImpl, key eventKey, original *eventsv1.Event) {
+				cached, exists := e.eventCache[key]
+				if !exists {
+					t.Fatal("expected the series to remain in the cache")
+				}
+				if cached.Name != original.Name {
+					t.Errorf("expected cache to hold series %q, but got %q", original.Name, cached.Name)
+				}
+				if cached.ResourceVersion != "recorded" {
+					t.Errorf("expected cache to be updated with the recorded event, but got ResourceVersion %q", cached.ResourceVersion)
+				}
+				if cached.Series == nil || cached.Series.Count != 11 {
+					t.Errorf("expected the refreshed series to have Count 11, but got %v", cached.Series)
+				}
+				if cached.Series != nil && !cached.Series.LastObservedTime.Time.Equal(observedAgainTime) {
+					t.Errorf("expected the refreshed series to keep LastObservedTime %v, but got %v", observedAgainTime, cached.Series.LastObservedTime)
+				}
+			},
+		},
+	}
+	for _, item := range table {
+		t.Run(item.name, func(t *testing.T) {
+			patchStarted := make(chan struct{})
+			releasePatch := make(chan struct{})
+			createdEvent := make(chan *eventsv1.Event, 1)
+			patches := 0
+			testEvents := testEventSeriesSink{
+				OnCreate: func(event *eventsv1.Event) (*eventsv1.Event, error) {
+					createdEvent <- event
+					return event, nil
+				},
+				OnPatch: func(event *eventsv1.Event, patch []byte) (*eventsv1.Event, error) {
+					patches++
+					close(patchStarted)
+					<-releasePatch
+					recorded := event.DeepCopy()
+					recorded.ResourceVersion = "recorded"
+					return recorded, nil
+				},
+			}
+			eventBroadcaster := newBroadcaster(&testEvents, 0, map[eventKey]*eventsv1.Event{}).(*eventBroadcasterImpl)
+			original, key := newCachedSeriesEvent(t, eventBroadcaster, item.lastObservedTime)
+
+			housekeepingDone := make(chan struct{})
+			go func() {
+				defer close(housekeepingDone)
+				item.housekeeping(eventBroadcaster, ctx)
+			}()
+			select {
+			case <-patchStarted:
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Fatalf("timeout after %v waiting for the patch request", wait.ForeverTestTimeout)
+			}
+
+			// While the API call is in flight, record an isomorphic event and
+			// an unrelated event. Neither must wait for the API call to end.
+			isomorphicEvent := original.DeepCopy()
+			isomorphicEvent.Name = original.Name + "-isomorphic"
+			isomorphicEvent.Series = nil
+			otherEvent := original.DeepCopy()
+			otherEvent.Name = original.Name + "-other"
+			otherEvent.Reason = "other"
+			otherEvent.Series = nil
+			recordingDone := make(chan struct{})
+			go func() {
+				defer close(recordingDone)
+				eventBroadcaster.recordToSink(ctx, isomorphicEvent, testclocks.NewFakeClock(observedAgainTime))
+				eventBroadcaster.recordToSink(ctx, otherEvent, testclocks.NewFakeClock(observedAgainTime))
+			}()
+			select {
+			case <-recordingDone:
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Fatalf("timeout after %v: recordToSink was blocked by the in-flight API call", wait.ForeverTestTimeout)
+			}
+			select {
+			case created := <-createdEvent:
+				if created.Name != otherEvent.Name {
+					t.Errorf("expected the unrelated event %q to be created, but got %q", otherEvent.Name, created.Name)
+				}
+			default:
+				t.Error("expected the unrelated event to be created while the API call was in flight")
+			}
+
+			close(releasePatch)
+			select {
+			case <-housekeepingDone:
+			case <-time.After(wait.ForeverTestTimeout):
+				t.Fatalf("timeout after %v waiting for housekeeping to finish", wait.ForeverTestTimeout)
+			}
+
+			eventBroadcaster.mu.Lock()
+			defer eventBroadcaster.mu.Unlock()
+			if patches != 1 {
+				t.Errorf("expected exactly one patch request, but got %d", patches)
+			}
+			if len(createdEvent) != 0 {
+				t.Errorf("expected exactly one create request, but got %d more", len(createdEvent))
+			}
+			if len(eventBroadcaster.eventCache) != 2 {
+				t.Errorf("expected the series and the unrelated event in the cache, but got %d entries", len(eventBroadcaster.eventCache))
+			}
+			otherCached, exists := eventBroadcaster.eventCache[getKey(otherEvent)]
+			if !exists || otherCached.Series != nil {
+				t.Errorf("expected the unrelated event to be cached as a singleton, but got %v", otherCached)
+			}
+			item.verify(t, eventBroadcaster, key, original)
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Moves event API calls outside the broadcaster lock to prevent a slow apiserver from blocking new event processing.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
