### PR TITLE
Fix three dead kubernetes.io links in docs and help text

### DIFF
--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -78,7 +78,7 @@ func newCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 			 - The name of the Secret must be named "bootstrap-token-(token-id)".
 
 			You can read more about bootstrap tokens here:
-			  https://kubernetes.io/docs/admin/bootstrap-tokens/
+			  https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/
 		`),
 	}
 	cmdutil.RequireSubcommand(tokenCmd)

--- a/plugin/pkg/admission/imagepolicy/admission.go
+++ b/plugin/pkg/admission/imagepolicy/admission.go
@@ -252,7 +252,7 @@ func (a *Plugin) admitPod(ctx context.Context, pod *api.Pod, attributes admissio
 //	    client-key: /path/to/key.pem          # key matching the cert
 //
 // For additional HTTP configuration, refer to the kubeconfig documentation
-// http://kubernetes.io/v1.1/docs/user-guide/kubeconfig-file.html.
+// https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/.
 func NewImagePolicyWebhook(configFile io.Reader) (*Plugin, error) {
 	if configFile == nil {
 		return nil, fmt.Errorf("no config specified")

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -102,7 +102,7 @@ func NewFromInterface(subjectAccessReview authorizationv1client.AuthorizationV1I
 //	    client-key: /path/to/key.pem          # key matching the cert
 //
 // For additional HTTP configuration, refer to the kubeconfig documentation
-// https://kubernetes.io/docs/user-guide/kubeconfig-file/.
+// https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/.
 func New(config *rest.Config, version string, authorizedTTL, unauthorizedTTL time.Duration, retryBackoff wait.Backoff, decisionOnError authorizer.Decision, matchConditions []apiserver.WebhookMatchCondition, name string, metrics metrics.AuthorizerMetrics, compiler authorizationcel.Compiler) (*WebhookAuthorizer, error) {
 	subjectAccessReview, err := subjectAccessReviewInterfaceFromConfig(config, version, retryBackoff)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind cleanup

#### What this PR does / why we need it

Three `kubernetes.io` links referenced from Go sources return 404. One of them is printed to users:

```
$ kubeadm token --help
...
You can read more about bootstrap tokens here:
  https://kubernetes.io/docs/admin/bootstrap-tokens/     <- 404
```

| File | Current link | Replacement |
| :--- | :--- | :--- |
| `cmd/kubeadm/app/cmd/token.go` | `/docs/admin/bootstrap-tokens/` | `/docs/reference/access-authn-authz/bootstrap-tokens/` |
| `plugin/pkg/admission/imagepolicy/admission.go` | `/v1.1/docs/user-guide/kubeconfig-file.html` | `/docs/concepts/configuration/organize-cluster-access-kubeconfig/` |
| `staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go` | `/docs/user-guide/kubeconfig-file/` | `/docs/concepts/configuration/organize-cluster-access-kubeconfig/` |

The `imagepolicy` one still points at the `v1.1` documentation tree, which predates the current site layout.

Each replacement was requested and returns `200`.

#### How I found these

Extracted every `kubernetes.io` URL referenced from `*.go` in the tree (178 distinct), then requested each one and kept the non-200s.

Excluded from this PR:

- `vendor/sigs.k8s.io/kustomize/...` has two links pinned to the `v1.19` generated API reference. Those belong upstream in `kubernetes-sigs/kustomize`, not in vendored code here.
- The `example` and `testapigroup` API groups carry the same stale paths, but they are test scaffolding and the text is mirrored into `pkg/generated/openapi/zz_generated.openapi.go`, so changing them means regenerating. Happy to do that separately if it is wanted.

#### Which issue(s) this PR fixes

None filed.

#### Special notes for your reviewer

Comments and help text only. No behaviour change, no generated files touched.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
