### PR TITLE
kubectl top pod: add field-selector example for filtering by node

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -86,7 +86,10 @@ var (
 		kubectl top pod POD_NAME --containers
 
 		# Show metrics for the pods defined by label name=myLabel
-		kubectl top pod -l name=myLabel`))
+		kubectl top pod -l name=myLabel
+
+		# Show metrics for all pods on a specific node
+		kubectl top pod -A --field-selector spec.nodeName=NODE_NAME`))
 )
 
 func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericiooptions.IOStreams) *cobra.Command {


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds a help example for the existing `--field-selector` path:

```
kubectl top pod -A --field-selector spec.nodeName=NODE_NAME
```

This is **not** a new `--node` flag.

#141581 proposed `--node` and was closed because #139107 already made `spec.nodeName` filtering work via `--field-selector`. Help/docs still only show namespace, `--containers`, and `-l`, so users keep requesting `--node`. This PR only documents the existing flag.

#### Which issue(s) this PR is related to:

Follow-up to #139107 / #141581
Related: https://github.com/kubernetes/kubectl/issues/1874
Related: https://redhat.atlassian.net/browse/OCPBUGS-114874

#### Special notes for your reviewer:

No behavior change. Example-only. Please do not close as a duplicate of #141581 — that PR added a flag; this one documents the approach SIG CLI already chose.

#### Does this PR introduce a user-facing change?

```release-note
kubectl top pod: add example for filtering metrics by node with --field-selector
```

Made with [Cursor](https://cursor.com)