### PR TITLE
tokencleaner: migrate to contextual logging APIs

### DIFF
--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/names"
 	"k8s.io/kubernetes/pkg/controller/bootstrap"
 )
@@ -68,6 +69,7 @@ func newTokenCleanerController(ctx context.Context, controllerContext Controller
 	}
 
 	tcc, err := bootstrap.NewTokenCleaner(
+		klog.FromContext(ctx),
 		client,
 		controllerContext.InformerFactory.Core().V1().Secrets(),
 		bootstrap.DefaultTokenCleanerOptions(),

--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -73,7 +73,7 @@ type TokenCleaner struct {
 }
 
 // NewTokenCleaner returns a new *NewTokenCleaner.
-func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInformer, options TokenCleanerOptions) (*TokenCleaner, error) {
+func NewTokenCleaner(logger klog.Logger, cl clientset.Interface, secrets coreinformers.SecretInformer, options TokenCleanerOptions) (*TokenCleaner, error) {
 	e := &TokenCleaner{
 		client:               cl,
 		secretLister:         secrets.Lister(),
@@ -87,31 +87,37 @@ func NewTokenCleaner(cl clientset.Interface, secrets coreinformers.SecretInforme
 		),
 	}
 
-	secrets.Informer().AddEventHandlerWithResyncPeriod(
+	_, err := secrets.Informer().AddEventHandlerWithOptions(
 		cache.FilteringResourceEventHandler{
 			FilterFunc: func(obj interface{}) bool {
 				switch t := obj.(type) {
 				case *v1.Secret:
 					return t.Type == bootstrapapi.SecretTypeBootstrapToken && t.Namespace == e.tokenSecretNamespace
 				default:
-					utilruntime.HandleError(fmt.Errorf("object passed to %T that is not expected: %T", e, obj))
+					utilruntime.HandleErrorWithLogger(logger, nil, "Unexpected object type passed to TokenCleaner event handler", "type", fmt.Sprintf("%T", obj))
 					return false
 				}
 			},
 			Handler: cache.ResourceEventHandlerFuncs{
-				AddFunc:    e.enqueueSecrets,
-				UpdateFunc: func(oldSecret, newSecret interface{}) { e.enqueueSecrets(newSecret) },
+				AddFunc:    func(obj interface{}) { e.enqueueSecrets(logger, obj) },
+				UpdateFunc: func(oldSecret, newSecret interface{}) { e.enqueueSecrets(logger, newSecret) },
 			},
 		},
-		options.SecretResync,
+		cache.HandlerOptions{
+			Logger:       &logger,
+			ResyncPeriod: &options.SecretResync,
+		},
 	)
+	if err != nil {
+		return nil, fmt.Errorf("could not add Secret event handler: %w", err)
+	}
 
 	return e, nil
 }
 
 // Run runs controller loops and returns when they are done
 func (tc *TokenCleaner) Run(ctx context.Context) {
-	defer utilruntime.HandleCrash()
+	defer utilruntime.HandleCrashWithContext(ctx)
 
 	logger := klog.FromContext(ctx)
 	logger.Info("Starting token cleaner controller")
@@ -133,10 +139,10 @@ func (tc *TokenCleaner) Run(ctx context.Context) {
 	<-ctx.Done()
 }
 
-func (tc *TokenCleaner) enqueueSecrets(obj interface{}) {
+func (tc *TokenCleaner) enqueueSecrets(logger klog.Logger, obj interface{}) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {
-		utilruntime.HandleError(err)
+		utilruntime.HandleErrorWithLogger(logger, err, "Couldn't get key for object", "object", obj)
 		return
 	}
 	tc.queue.Add(key)
@@ -158,7 +164,7 @@ func (tc *TokenCleaner) processNextWorkItem(ctx context.Context) bool {
 
 	if err := tc.syncFunc(ctx, key); err != nil {
 		tc.queue.AddRateLimited(key)
-		utilruntime.HandleError(fmt.Errorf("Sync %v failed with : %v", key, err))
+		utilruntime.HandleErrorWithContext(ctx, err, "Sync failed", "key", key)
 		return true
 	}
 
@@ -213,7 +219,7 @@ func (tc *TokenCleaner) evalSecret(ctx context.Context, o interface{}) {
 	} else if ttl > 0 {
 		key, err := controller.KeyFunc(o)
 		if err != nil {
-			utilruntime.HandleError(err)
+			utilruntime.HandleErrorWithLogger(logger, err, "Couldn't get key for object", "object", o)
 			return
 		}
 		tc.queue.AddAfter(key, ttl)

--- a/pkg/controller/bootstrap/tokencleaner_test.go
+++ b/pkg/controller/bootstrap/tokencleaner_test.go
@@ -28,15 +28,17 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	"k8s.io/klog/v2/ktesting"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
-func newTokenCleaner() (*TokenCleaner, *fake.Clientset, coreinformers.SecretInformer, error) {
+func newTokenCleaner(t *testing.T) (*TokenCleaner, *fake.Clientset, coreinformers.SecretInformer, error) {
+	logger, _ := ktesting.NewTestContext(t)
 	options := DefaultTokenCleanerOptions()
 	cl := fake.NewSimpleClientset()
 	informerFactory := informers.NewSharedInformerFactory(cl, options.SecretResync)
 	secrets := informerFactory.Core().V1().Secrets()
-	tcc, err := NewTokenCleaner(cl, secrets, options)
+	tcc, err := NewTokenCleaner(logger, cl, secrets, options)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -44,7 +46,7 @@ func newTokenCleaner() (*TokenCleaner, *fake.Clientset, coreinformers.SecretInfo
 }
 
 func TestCleanerNoExpiration(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}
@@ -60,7 +62,7 @@ func TestCleanerNoExpiration(t *testing.T) {
 }
 
 func TestCleanerExpired(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}
@@ -85,7 +87,7 @@ func TestCleanerExpired(t *testing.T) {
 }
 
 func TestCleanerNotExpired(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}
@@ -102,7 +104,8 @@ func TestCleanerNotExpired(t *testing.T) {
 }
 
 func TestCleanerExpiredAt(t *testing.T) {
-	cleaner, cl, secrets, err := newTokenCleaner()
+	logger, _ := ktesting.NewTestContext(t)
+	cleaner, cl, secrets, err := newTokenCleaner(t)
 	if err != nil {
 		t.Fatalf("error creating TokenCleaner: %v", err)
 	}
@@ -110,7 +113,7 @@ func TestCleanerExpiredAt(t *testing.T) {
 	secret := newTokenSecret("tokenID", "tokenSecret")
 	addSecretExpiration(secret, timeString(2*time.Second))
 	secrets.Informer().GetIndexer().Add(secret)
-	cleaner.enqueueSecrets(secret)
+	cleaner.enqueueSecrets(logger, secret)
 	expected := []core.Action{}
 	verifyFunc := func() {
 		cleaner.processNextWorkItem(context.TODO())


### PR DESCRIPTION
## Summary
- Migrates `pkg/controller/bootstrap/tokencleaner.go` to the contextual-logging-aware APIs: `AddEventHandlerWithOptions` instead of `AddEventHandlerWithResyncPeriod`, and `HandleErrorWithLogger`/`HandleErrorWithContext`/`HandleCrashWithContext` instead of `HandleError`/`HandleCrash`.
- `NewTokenCleaner` now takes a `klog.Logger` as its first argument, following the same pattern already used by other migrated controllers (e.g. `pvprotection.NewPVProtectionController`).
- Updates the sole caller in `cmd/kube-controller-manager/app/bootstrap.go` and the controller's unit tests accordingly.

Contributes to #126379

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/controller/bootstrap/...`
- [x] `go vet ./pkg/controller/bootstrap/... ./cmd/kube-controller-manager/...`

## Does this PR introduce a user-facing change?
```release-note
NONE
```

## AI usage disclosure
AI (Claude Code) was used to help resolve a rebase conflict against master (an unrelated change had landed on `tokencleaner.go` in the meantime) and to add this release-note section. The author reviewed and is responsible for all submitted changes; see `CONTRIBUTING.md`.
