### PR TITLE
Show Terminating status for StatefulSets in kubectl get

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -239,6 +239,7 @@ func AddHandlers(h printers.PrintHandler) {
 	statefulSetColumnDefinitions := []metav1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Ready", Type: "string", Description: "Number of the pod with ready state"},
+		{Name: "Status", Type: "string", Description: "Status of the stateful set."},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 		{Name: "Containers", Type: "string", Priority: 1, Description: "Names of each container in the template."},
 		{Name: "Images", Type: "string", Priority: 1, Description: "Images referenced by each container in the template."},
@@ -1607,7 +1608,11 @@ func printStatefulSet(obj *apps.StatefulSet, options printers.GenerateOptions) (
 	desiredReplicas := obj.Spec.Replicas
 	readyReplicas := obj.Status.ReadyReplicas
 	createTime := translateTimestampSince(obj.CreationTimestamp)
-	row.Cells = append(row.Cells, obj.Name, fmt.Sprintf("%d/%d", int64(readyReplicas), int64(desiredReplicas)), createTime)
+	status := "Active"
+	if obj.ObjectMeta.DeletionTimestamp != nil {
+		status = "Terminating"
+	}
+	row.Cells = append(row.Cells, obj.Name, fmt.Sprintf("%d/%d", int64(readyReplicas), int64(desiredReplicas)), status, createTime)
 	if options.Wide {
 		names, images := layoutContainerCells(obj.Spec.Template.Spec.Containers)
 		row.Cells = append(row.Cells, names, images)

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -5154,8 +5154,8 @@ func TestPrintStatefulSet(t *testing.T) {
 				},
 			},
 			options: printers.GenerateOptions{},
-			// Columns: Name, Ready, Age
-			expected: []metav1.TableRow{{Cells: []interface{}{"test1", "2/5", "0s"}}},
+			// Columns: Name, Ready, Status, Age
+			expected: []metav1.TableRow{{Cells: []interface{}{"test1", "2/5", "Active", "0s"}}},
 		},
 		// Generate options "Wide"; includes containers and images.
 		{
@@ -5187,8 +5187,38 @@ func TestPrintStatefulSet(t *testing.T) {
 				},
 			},
 			options: printers.GenerateOptions{Wide: true},
-			// Columns: Name, Ready, Age, Containers, Images
-			expected: []metav1.TableRow{{Cells: []interface{}{"test1", "2/5", "0s", "fake-container1,fake-container2", "fake-image1,fake-image2"}}},
+			// Columns: Name, Ready, Status, Age, Containers, Images
+			expected: []metav1.TableRow{{Cells: []interface{}{"test1", "2/5", "Active", "0s", "fake-container1,fake-container2", "fake-image1,fake-image2"}}},
+		},
+		// A stateful set being deleted reports Terminating.
+		{
+			statefulSet: apps.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test1",
+					CreationTimestamp: metav1.Time{Time: time.Now().Add(1.9e9)},
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Spec: apps.StatefulSetSpec{
+					Replicas: 5,
+					Template: api.PodTemplateSpec{
+						Spec: api.PodSpec{
+							Containers: []api.Container{
+								{
+									Name:  "fake-container1",
+									Image: "fake-image1",
+								},
+							},
+						},
+					},
+				},
+				Status: apps.StatefulSetStatus{
+					Replicas:      5,
+					ReadyReplicas: 2,
+				},
+			},
+			options: printers.GenerateOptions{},
+			// Columns: Name, Ready, Status, Age
+			expected: []metav1.TableRow{{Cells: []interface{}{"test1", "2/5", "Terminating", "0s"}}},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

`kubectl get sts` gives no indication that a StatefulSet is being deleted. When deletion is blocked by a finalizer, which is common with operators, a terminating StatefulSet renders identically to a healthy one:

```
NAME   READY   AGE
web    1/1     8d      <- actually stuck terminating
```

The only signal today is a non-nil `metadata.deletionTimestamp`, so users have to drop to `-o yaml` or `describe` to find out. For Pod, PersistentVolume and PersistentVolumeClaim, terminating state is already visible in `kubectl get`.

This adds a `Status` column to StatefulSet, following the pattern already used by `printPod`, `printJob`, `printPersistentVolume` and `printPersistentVolumeClaim`:

```
NAME   READY   STATUS        AGE
web    0/1     Terminating   8d
api    1/1     Active        8d
```

The column is placed between `Ready` and `Age`, matching the order Pod uses.

#### Why `Active` and not `Running`

StatefulSet has no `status.phase` and no relevant conditions, so a `Status` column has to supply a value for the non-terminating case.

`Active` matches Namespace, which is the one other resource whose status is genuinely binary between existing and being deleted. It asserts only that the object is not being deleted, which is exactly what the check establishes.

`Running` was the alternative, but it makes a claim about the workload that this code never verifies, and it visibly contradicts the `Ready` column:

```
NAME   READY   STATUS    AGE
web    0/0     Running   8d     <- replicas: 0, nothing is running
api    0/5     Running   8d     <- all pods CrashLoopBackOff
```

Since `Ready` already reports health, a `Status` column that disagrees with it would be worse than no column.

A previous attempt at this issue, #119559, derived a richer vocabulary (Terminating / Updating / Scaling / Ready / Unknown) from `CurrentRevision` vs `UpdateRevision` and `ObservedGeneration`. That PR was closed by the stale bot rather than rejected, but the cost of the approach is visible in its own test diff: an ordinary healthy StatefulSet began rendering as `Unknown`. This PR deliberately keeps the vocabulary minimal to avoid that.

#### Which issue(s) this PR is related to:

Fixes kubernetes/kubectl#1444

#### Special notes for your reviewer:

Deployment, DaemonSet and ReplicaSet have the same gap, none of them check `DeletionTimestamp`. I kept this PR to StatefulSet to match the issue title and to limit the default-output change to one resource. Happy to follow up with the other three if you would prefer them consistent.

Note the compatibility impact, called out in the release note: this shifts column positions, so scripts doing `kubectl get sts | awk '{print $3}'` now get `STATUS` where they previously got `AGE`.

`printStatefulSetList` delegates to `printStatefulSet` and needed no change. Two existing cases in `TestPrintStatefulSet` were updated for the new column, and a third was added covering a StatefulSet with `DeletionTimestamp` set.

#### Does this PR introduce a user-facing change?

```release-note
kubectl get statefulset now includes a STATUS column, showing `Terminating` while the StatefulSet is being deleted and `Active` otherwise. Note that this adds a column to the default output, so scripts that parse `kubectl get statefulset` by column position need updating: the third column is now STATUS rather than AGE.
```
