### PR TITLE
test/e2e/network: Give hostNetwork configs dedicated ports

### DIFF
--- a/test/e2e/common/network/networking.go
+++ b/test/e2e/common/network/networking.go
@@ -84,7 +84,7 @@ var _ = SIGDescribe("Networking", func() {
 		*/
 		framework.ConformanceIt("should function for intra-pod communication: http", f.WithNodeConformance(), func(ctx context.Context) {
 			config := e2enetwork.NewCoreNetworkingTestConfig(ctx, f, false)
-			checkPodToPodConnectivity(ctx, config, "http", e2enetwork.EndpointHTTPPort)
+			checkPodToPodConnectivity(ctx, config, "http", config.EndpointHTTPPort)
 		})
 
 		/*
@@ -95,7 +95,7 @@ var _ = SIGDescribe("Networking", func() {
 		*/
 		framework.ConformanceIt("should function for intra-pod communication: udp", f.WithNodeConformance(), func(ctx context.Context) {
 			config := e2enetwork.NewCoreNetworkingTestConfig(ctx, f, false)
-			checkPodToPodConnectivity(ctx, config, "udp", e2enetwork.EndpointUDPPort)
+			checkPodToPodConnectivity(ctx, config, "udp", config.EndpointUDPPort)
 		})
 
 		/*
@@ -108,7 +108,7 @@ var _ = SIGDescribe("Networking", func() {
 		framework.ConformanceIt("should function for node-pod communication: http [LinuxOnly]", f.WithNodeConformance(), func(ctx context.Context) {
 			config := e2enetwork.NewCoreNetworkingTestConfig(ctx, f, true)
 			for _, endpointPod := range config.EndpointPods {
-				err := config.DialFromNode(ctx, "http", endpointPod.Status.PodIP, e2enetwork.EndpointHTTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+				err := config.DialFromNode(ctx, "http", endpointPod.Status.PodIP, config.EndpointHTTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
 				if err != nil {
 					framework.Failf("Error dialing HTTP node to pod %v", err)
 				}
@@ -125,7 +125,7 @@ var _ = SIGDescribe("Networking", func() {
 		framework.ConformanceIt("should function for node-pod communication: udp [LinuxOnly]", f.WithNodeConformance(), func(ctx context.Context) {
 			config := e2enetwork.NewCoreNetworkingTestConfig(ctx, f, true)
 			for _, endpointPod := range config.EndpointPods {
-				err := config.DialFromNode(ctx, "udp", endpointPod.Status.PodIP, e2enetwork.EndpointUDPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+				err := config.DialFromNode(ctx, "udp", endpointPod.Status.PodIP, config.EndpointUDPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
 				if err != nil {
 					framework.Failf("Error dialing UDP from node to pod: %v", err)
 				}
@@ -134,14 +134,14 @@ var _ = SIGDescribe("Networking", func() {
 
 		f.It("should function for intra-pod communication: sctp [LinuxOnly]", feature.SCTPConnectivity, func(ctx context.Context) {
 			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.EnableSCTP)
-			checkPodToPodConnectivity(ctx, config, "sctp", e2enetwork.EndpointSCTPPort)
+			checkPodToPodConnectivity(ctx, config, "sctp", config.EndpointSCTPPort)
 		})
 
 		f.It("should function for node-pod communication: sctp [LinuxOnly]", feature.SCTPConnectivity, func(ctx context.Context) {
 			ginkgo.Skip("Skipping SCTP node to pod test until DialFromNode supports SCTP #96482")
 			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.EnableSCTP)
 			for _, endpointPod := range config.EndpointPods {
-				err := config.DialFromNode(ctx, "sctp", endpointPod.Status.PodIP, e2enetwork.EndpointSCTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
+				err := config.DialFromNode(ctx, "sctp", endpointPod.Status.PodIP, config.EndpointSCTPPort, config.MaxTries, 0, sets.NewString(endpointPod.Name))
 				if err != nil {
 					framework.Failf("Error dialing SCTP from node to pod: %v", err)
 				}

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -50,23 +50,24 @@ import (
 )
 
 const (
-	// EndpointHTTPPort is the default endpoint HTTP port for testing. Code
-	// operating on a NetworkingTestConfig should read config.EndpointHTTPPort
-	// instead, which accounts for host network endpoints.
-	EndpointHTTPPort = 8083
-	// EndpointUDPPort is the default endpoint UDP port for testing. See
-	// EndpointHTTPPort.
-	EndpointUDPPort = 8081
-	// EndpointSCTPPort is the default endpoint SCTP port for testing. See
-	// EndpointHTTPPort.
-	EndpointSCTPPort = 8082
-	// hostNetworkEndpointHTTPPort, hostNetworkEndpointUDPPort and
-	// hostNetworkEndpointSCTPPort are the endpoint ports used when the endpoint
-	// pods run with HostNetwork=true. They must not overlap with the pod network
-	// endpoint ports above; see setEndpointPorts for why.
-	hostNetworkEndpointHTTPPort = 8093
-	hostNetworkEndpointUDPPort  = 8091
-	hostNetworkEndpointSCTPPort = 8092
+	// endpointHTTPPort is the HTTP port of pod network endpoint pods. Code
+	// operating on a NetworkingTestConfig must read config.EndpointHTTPPort
+	// rather than this constant, because host network endpoints listen
+	// somewhere else; see setEndpointPorts.
+	endpointHTTPPort = 8083
+	// endpointUDPPort is the UDP port of pod network endpoint pods. See endpointHTTPPort.
+	endpointUDPPort = 8081
+	// endpointSCTPPort is the SCTP port of pod network endpoint pods. See endpointHTTPPort.
+	endpointSCTPPort = 8082
+	// hostNetworkEndpointPortBase is the first port of the range reserved for
+	// host network endpoint pods, which need a set of ports per concurrently
+	// running test config; see setEndpointPorts. The range sits above the ports
+	// the node components bind and below the NodePort and ephemeral ranges, so
+	// nothing else on the node claims it.
+	hostNetworkEndpointPortBase = 11000
+	// hostNetworkEndpointPortRange is how many ports (http, udp, sctp) each
+	// host network test config reserves.
+	hostNetworkEndpointPortRange = 3
 	// testContainerHTTPPort is the test container http port.
 	testContainerHTTPPort = 9080
 	// ClusterHTTPPort is a cluster HTTP port for testing.
@@ -216,8 +217,8 @@ type NetworkingTestConfig struct {
 	// SecondaryNodeIP it's an ExternalIP of the secondary IP family if the node has one,
 	// or an InternalIP if not, for usein nodePort testing.
 	SecondaryNodeIP string
-	// The http/udp/sctp ports the endpoint pods listen on. These differ between
-	// pod network and host network endpoints; see setEndpointPorts.
+	// The http/udp/sctp ports the endpoint pods listen on. Host network
+	// endpoints get a set of ports of their own; see setEndpointPorts.
 	EndpointHTTPPort int
 	EndpointUDPPort  int
 	EndpointSCTPPort int
@@ -825,15 +826,29 @@ func (config *NetworkingTestConfig) CreateService(ctx context.Context, serviceSp
 	return createdService
 }
 
+// hostNetworkEndpointPorts returns the http, udp and sctp ports reserved for the
+// host network endpoint pods of the config running on the given ginkgo parallel
+// process, which is 1-indexed.
+func hostNetworkEndpointPorts(parallelProcess int) (int, int, int) {
+	base := hostNetworkEndpointPortBase + hostNetworkEndpointPortRange*(parallelProcess-1)
+	return base, base + 1, base + 2
+}
+
 // setEndpointPorts selects the ports the endpoint pods listen on.
+//
+// Pod network endpoints listen inside a network namespace of their own, so every
+// test config can reuse the same well-known ports without reaching any other
+// config.
+//
+// Host network endpoints need unique ports for each parallel process
+// to avoid colliding with other parallel test processes.
 func (config *NetworkingTestConfig) setEndpointPorts() {
-	config.EndpointHTTPPort = EndpointHTTPPort
-	config.EndpointUDPPort = EndpointUDPPort
-	config.EndpointSCTPPort = EndpointSCTPPort
 	if config.EndpointsHostNetwork {
-		config.EndpointHTTPPort = hostNetworkEndpointHTTPPort
-		config.EndpointUDPPort = hostNetworkEndpointUDPPort
-		config.EndpointSCTPPort = hostNetworkEndpointSCTPPort
+		config.EndpointHTTPPort, config.EndpointUDPPort, config.EndpointSCTPPort = hostNetworkEndpointPorts(ginkgo.GinkgoParallelProcess())
+	} else { // pod network endpoints case
+		config.EndpointHTTPPort = endpointHTTPPort
+		config.EndpointUDPPort = endpointUDPPort
+		config.EndpointSCTPPort = endpointSCTPPort
 	}
 }
 

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -50,12 +50,23 @@ import (
 )
 
 const (
-	// EndpointHTTPPort is an endpoint HTTP port for testing.
+	// EndpointHTTPPort is the default endpoint HTTP port for testing. Code
+	// operating on a NetworkingTestConfig should read config.EndpointHTTPPort
+	// instead, which accounts for host network endpoints.
 	EndpointHTTPPort = 8083
-	// EndpointUDPPort is an endpoint UDP port for testing.
+	// EndpointUDPPort is the default endpoint UDP port for testing. See
+	// EndpointHTTPPort.
 	EndpointUDPPort = 8081
-	// EndpointSCTPPort is an endpoint SCTP port for testing.
+	// EndpointSCTPPort is the default endpoint SCTP port for testing. See
+	// EndpointHTTPPort.
 	EndpointSCTPPort = 8082
+	// hostNetworkEndpointHTTPPort, hostNetworkEndpointUDPPort and
+	// hostNetworkEndpointSCTPPort are the endpoint ports used when the endpoint
+	// pods run with HostNetwork=true. They must not overlap with the pod network
+	// endpoint ports above; see setEndpointPorts for why.
+	hostNetworkEndpointHTTPPort = 8093
+	hostNetworkEndpointUDPPort  = 8091
+	hostNetworkEndpointSCTPPort = 8092
 	// testContainerHTTPPort is the test container http port.
 	testContainerHTTPPort = 9080
 	// ClusterHTTPPort is a cluster HTTP port for testing.
@@ -205,6 +216,11 @@ type NetworkingTestConfig struct {
 	// SecondaryNodeIP it's an ExternalIP of the secondary IP family if the node has one,
 	// or an InternalIP if not, for usein nodePort testing.
 	SecondaryNodeIP string
+	// The http/udp/sctp ports the endpoint pods listen on. These differ between
+	// pod network and host network endpoints; see setEndpointPorts.
+	EndpointHTTPPort int
+	EndpointUDPPort  int
+	EndpointSCTPPort int
 	// The http/udp/sctp nodePorts of the Service.
 	NodeHTTPPort int
 	NodeUDPPort  int
@@ -232,7 +248,7 @@ func (config *NetworkingTestConfig) DialFromEndpointContainer(ctx context.Contex
 			dialCmd = echoNodename
 		}
 	}
-	return config.DialFromContainer(ctx, protocol, dialCmd, config.EndpointPods[0].Status.PodIP, targetIP, EndpointHTTPPort, targetPort, maxTries, minTries, expectedEps)
+	return config.DialFromContainer(ctx, protocol, dialCmd, config.EndpointPods[0].Status.PodIP, targetIP, config.EndpointHTTPPort, targetPort, maxTries, minTries, expectedEps)
 }
 
 // DialFromTestContainer executes a curl via kubectl exec in a test container. Returns an error to be handled by the caller.
@@ -591,8 +607,8 @@ func (config *NetworkingTestConfig) executeCurlCmd(ctx context.Context, cmd stri
 func (config *NetworkingTestConfig) createNetShellPodSpec(podName, hostname string) *v1.Pod {
 	netexecArgs := []string{
 		"netexec",
-		fmt.Sprintf("--http-port=%d", EndpointHTTPPort),
-		fmt.Sprintf("--udp-port=%d", EndpointUDPPort),
+		fmt.Sprintf("--http-port=%d", config.EndpointHTTPPort),
+		fmt.Sprintf("--udp-port=%d", config.EndpointUDPPort),
 	}
 	// In case of hostnetwork endpoints, we want to bind the udp listener to specific ip addresses.
 	// In order to cover legacy AND dualstack, we pass both the host ip and the two pod ips. Agnhost
@@ -610,7 +626,7 @@ func (config *NetworkingTestConfig) createNetShellPodSpec(podName, hostname stri
 		ProbeHandler: v1.ProbeHandler{
 			HTTPGet: &v1.HTTPGetAction{
 				Path: "/healthz",
-				Port: intstr.IntOrString{IntVal: EndpointHTTPPort},
+				Port: intstr.IntOrString{IntVal: int32(config.EndpointHTTPPort)},
 			},
 		},
 	}
@@ -633,11 +649,11 @@ func (config *NetworkingTestConfig) createNetShellPodSpec(podName, hostname stri
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "http",
-							ContainerPort: EndpointHTTPPort,
+							ContainerPort: int32(config.EndpointHTTPPort),
 						},
 						{
 							Name:          "udp",
-							ContainerPort: EndpointUDPPort,
+							ContainerPort: int32(config.EndpointUDPPort),
 							Protocol:      v1.ProtocolUDP,
 						},
 					},
@@ -652,10 +668,10 @@ func (config *NetworkingTestConfig) createNetShellPodSpec(podName, hostname stri
 	}
 	// we want sctp to be optional as it will load the sctp kernel module
 	if config.SCTPEnabled {
-		pod.Spec.Containers[0].Args = append(pod.Spec.Containers[0].Args, fmt.Sprintf("--sctp-port=%d", EndpointSCTPPort))
+		pod.Spec.Containers[0].Args = append(pod.Spec.Containers[0].Args, fmt.Sprintf("--sctp-port=%d", config.EndpointSCTPPort))
 		pod.Spec.Containers[0].Ports = append(pod.Spec.Containers[0].Ports, v1.ContainerPort{
 			Name:          "sctp",
-			ContainerPort: EndpointSCTPPort,
+			ContainerPort: int32(config.EndpointSCTPPort),
 			Protocol:      v1.ProtocolSCTP,
 		})
 	}
@@ -736,8 +752,8 @@ func (config *NetworkingTestConfig) createNodePortServiceSpec(svcName string, se
 		Spec: v1.ServiceSpec{
 			Type: v1.ServiceTypeNodePort,
 			Ports: []v1.ServicePort{
-				{Port: ClusterHTTPPort, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt32(EndpointHTTPPort)},
-				{Port: ClusterUDPPort, Name: "udp", Protocol: v1.ProtocolUDP, TargetPort: intstr.FromInt32(EndpointUDPPort)},
+				{Port: ClusterHTTPPort, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt32(int32(config.EndpointHTTPPort))},
+				{Port: ClusterUDPPort, Name: "udp", Protocol: v1.ProtocolUDP, TargetPort: intstr.FromInt32(int32(config.EndpointUDPPort))},
 			},
 			Selector:        selector,
 			SessionAffinity: sessionAffinity,
@@ -745,7 +761,7 @@ func (config *NetworkingTestConfig) createNodePortServiceSpec(svcName string, se
 	}
 
 	if config.SCTPEnabled {
-		res.Spec.Ports = append(res.Spec.Ports, v1.ServicePort{Port: ClusterSCTPPort, Name: "sctp", Protocol: v1.ProtocolSCTP, TargetPort: intstr.FromInt32(EndpointSCTPPort)})
+		res.Spec.Ports = append(res.Spec.Ports, v1.ServicePort{Port: ClusterSCTPPort, Name: "sctp", Protocol: v1.ProtocolSCTP, TargetPort: intstr.FromInt32(int32(config.EndpointSCTPPort))})
 	}
 	if config.DualStackEnabled {
 		requireDual := v1.IPFamilyPolicyRequireDualStack
@@ -809,9 +825,23 @@ func (config *NetworkingTestConfig) CreateService(ctx context.Context, serviceSp
 	return createdService
 }
 
+// setEndpointPorts selects the ports the endpoint pods listen on.
+func (config *NetworkingTestConfig) setEndpointPorts() {
+	config.EndpointHTTPPort = EndpointHTTPPort
+	config.EndpointUDPPort = EndpointUDPPort
+	config.EndpointSCTPPort = EndpointSCTPPort
+	if config.EndpointsHostNetwork {
+		config.EndpointHTTPPort = hostNetworkEndpointHTTPPort
+		config.EndpointUDPPort = hostNetworkEndpointUDPPort
+		config.EndpointSCTPPort = hostNetworkEndpointSCTPPort
+	}
+}
+
 // setupCore sets up the pods and core test config
 // mainly for simplified node e2e setup
 func (config *NetworkingTestConfig) setupCore(ctx context.Context, selector map[string]string) {
+	config.setEndpointPorts()
+
 	ginkgo.By("Creating the service pods in kubernetes")
 	podName := "netserver"
 	config.EndpointPods = config.createNetProxyPods(ctx, podName, selector)

--- a/test/e2e/framework/network/utils_test.go
+++ b/test/e2e/framework/network/utils_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package network
+
+import "testing"
+
+func TestSetEndpointPorts(t *testing.T) {
+	podNetwork := &NetworkingTestConfig{}
+	podNetwork.setEndpointPorts()
+
+	hostNetwork := &NetworkingTestConfig{EndpointsHostNetwork: true}
+	hostNetwork.setEndpointPorts()
+
+	if podNetwork.EndpointHTTPPort != EndpointHTTPPort ||
+		podNetwork.EndpointUDPPort != EndpointUDPPort ||
+		podNetwork.EndpointSCTPPort != EndpointSCTPPort {
+		t.Errorf("pod network endpoints should keep the default ports, got http=%d udp=%d sctp=%d",
+			podNetwork.EndpointHTTPPort, podNetwork.EndpointUDPPort, podNetwork.EndpointSCTPPort)
+	}
+
+	// Host network endpoints bind their listeners in the node's network
+	// namespace, so any port they share with pod network endpoints lets one
+	// test config answer a concurrently running config's dials.
+	// xref: https://issues.k8s.io/131370
+	podNetworkPorts := map[int]string{
+		podNetwork.EndpointHTTPPort: "http",
+		podNetwork.EndpointUDPPort:  "udp",
+		podNetwork.EndpointSCTPPort: "sctp",
+	}
+	for _, hostPort := range []int{hostNetwork.EndpointHTTPPort, hostNetwork.EndpointUDPPort, hostNetwork.EndpointSCTPPort} {
+		if name, shared := podNetworkPorts[hostPort]; shared {
+			t.Errorf("host network endpoints must not reuse pod network endpoint port %d (%s)", hostPort, name)
+		}
+	}
+}

--- a/test/e2e/framework/network/utils_test.go
+++ b/test/e2e/framework/network/utils_test.go
@@ -16,34 +16,69 @@ limitations under the License.
 
 package network
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/onsi/ginkgo/v2"
+)
 
 func TestSetEndpointPorts(t *testing.T) {
 	podNetwork := &NetworkingTestConfig{}
 	podNetwork.setEndpointPorts()
 
-	hostNetwork := &NetworkingTestConfig{EndpointsHostNetwork: true}
-	hostNetwork.setEndpointPorts()
-
-	if podNetwork.EndpointHTTPPort != EndpointHTTPPort ||
-		podNetwork.EndpointUDPPort != EndpointUDPPort ||
-		podNetwork.EndpointSCTPPort != EndpointSCTPPort {
-		t.Errorf("pod network endpoints should keep the default ports, got http=%d udp=%d sctp=%d",
+	if podNetwork.EndpointHTTPPort != endpointHTTPPort ||
+		podNetwork.EndpointUDPPort != endpointUDPPort ||
+		podNetwork.EndpointSCTPPort != endpointSCTPPort {
+		t.Errorf("pod network endpoints should keep the well-known ports, got http=%d udp=%d sctp=%d",
 			podNetwork.EndpointHTTPPort, podNetwork.EndpointUDPPort, podNetwork.EndpointSCTPPort)
 	}
 
-	// Host network endpoints bind their listeners in the node's network
-	// namespace, so any port they share with pod network endpoints lets one
-	// test config answer a concurrently running config's dials.
-	// xref: https://issues.k8s.io/131370
-	podNetworkPorts := map[int]string{
-		podNetwork.EndpointHTTPPort: "http",
-		podNetwork.EndpointUDPPort:  "udp",
-		podNetwork.EndpointSCTPPort: "sctp",
+	hostNetwork := &NetworkingTestConfig{EndpointsHostNetwork: true}
+	hostNetwork.setEndpointPorts()
+
+	wantHTTP, wantUDP, wantSCTP := hostNetworkEndpointPorts(ginkgo.GinkgoParallelProcess())
+	if hostNetwork.EndpointHTTPPort != wantHTTP ||
+		hostNetwork.EndpointUDPPort != wantUDP ||
+		hostNetwork.EndpointSCTPPort != wantSCTP {
+		t.Errorf("host network endpoints should take the ports reserved for this process, want http=%d udp=%d sctp=%d, got http=%d udp=%d sctp=%d",
+			wantHTTP, wantUDP, wantSCTP,
+			hostNetwork.EndpointHTTPPort, hostNetwork.EndpointUDPPort, hostNetwork.EndpointSCTPPort)
 	}
-	for _, hostPort := range []int{hostNetwork.EndpointHTTPPort, hostNetwork.EndpointUDPPort, hostNetwork.EndpointSCTPPort} {
-		if name, shared := podNetworkPorts[hostPort]; shared {
-			t.Errorf("host network endpoints must not reuse pod network endpoint port %d (%s)", hostPort, name)
+}
+
+// TestHostNetworkEndpointPortsAreUnique covers the property that keeps host
+// network endpoints from answering dials meant for someone else: the endpoint
+// pods of one config listen on every node, so no two configs that can run at the
+// same time may claim a port, and none of them may claim a pod network port.
+// xref: https://issues.k8s.io/131370
+func TestHostNetworkEndpointPortsAreUnique(t *testing.T) {
+	// The start of the default service-node-port-range. Host network endpoints
+	// have to stay clear of it, and of the ephemeral range above it, or the
+	// node may already be using the port they try to bind.
+	const nodePortRangeStart = 30000
+	// Far wider than the parallelism any job runs with, so that the range still
+	// holds if jobs get wider.
+	const parallelProcesses = 256
+
+	podNetworkPorts := map[int]string{
+		endpointHTTPPort: "http",
+		endpointUDPPort:  "udp",
+		endpointSCTPPort: "sctp",
+	}
+	owner := make(map[int]int, parallelProcesses*hostNetworkEndpointPortRange)
+	for process := 1; process <= parallelProcesses; process++ {
+		httpPort, udpPort, sctpPort := hostNetworkEndpointPorts(process)
+		for _, port := range []int{httpPort, udpPort, sctpPort} {
+			if name, shared := podNetworkPorts[port]; shared {
+				t.Errorf("process %d claims pod network %s port %d", process, name, port)
+			}
+			if previous, taken := owner[port]; taken {
+				t.Errorf("process %d claims port %d, already held by process %d", process, port, previous)
+			}
+			if port >= nodePortRangeStart {
+				t.Errorf("process %d claims port %d, which is inside the default NodePort range", process, port)
+			}
+			owner[port] = process
 		}
 	}
 }

--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -622,9 +622,10 @@ var _ = common.SIGDescribe(feature.IPv6DualStack, func() {
 			config.DialEchoFromTestContainer(ctx, "udp", config.SecondaryClusterIP, e2enetwork.ClusterUDPPort, config.MaxTries, 0, message)
 		})
 
-		// if the endpoints pods use hostNetwork, several tests can't run in parallel
-		// because the pods will try to acquire the same port in the host.
-		// We run the test in serial, to avoid port conflicts.
+		// The endpoint pods run with hostNetwork, so their listeners bind in the
+		// node's network namespace rather than one of their own. setEndpointPorts
+		// gives each parallel process its own endpoint ports, so this test can run
+		// alongside the others without them answering each other's dials.
 		ginkgo.It("should function for service endpoints using hostNetwork", func(ctx context.Context) {
 			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.EnableDualStack, e2enetwork.UseHostNetwork, e2enetwork.EndpointsUseHostNetwork)
 

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -465,9 +465,10 @@ var _ = common.SIGDescribe("Networking", func() {
 			}
 		})
 
-		// if the endpoints pods use hostNetwork, several tests can't run in parallel
-		// because the pods will try to acquire the same port in the host.
-		// We run the test in serial, to avoid port conflicts.
+		// The endpoint pods run with hostNetwork, so their listeners bind in the
+		// node's network namespace rather than one of their own. setEndpointPorts
+		// gives each parallel process its own endpoint ports, so this test can run
+		// alongside the others without them answering each other's dials.
 		ginkgo.It("should function for service endpoints using hostNetwork", func(ctx context.Context) {
 			config := e2enetwork.NewNetworkingTestConfig(ctx, f, e2enetwork.UseHostNetwork, e2enetwork.EndpointsUseHostNetwork)
 

--- a/test/e2e/network/util.go
+++ b/test/e2e/network/util.go
@@ -226,7 +226,7 @@ func createSecondNodePortService(ctx context.Context, f *framework.Framework, co
 					Port:       e2enetwork.ClusterHTTPPort,
 					Name:       "http",
 					Protocol:   v1.ProtocolTCP,
-					TargetPort: intstr.FromInt32(e2enetwork.EndpointHTTPPort),
+					TargetPort: intstr.FromInt32(int32(config.EndpointHTTPPort)),
 				},
 			},
 			Selector: config.NodePortService.Spec.Selector,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake
/sig network

#### What this PR does / why we need it:

Every networking test config uses the same endpoint port: EndpointHTTPPort = 8083 , passed unconditionally in createNetShellPodSpec . For pod-network configs that's fine, each listener sits in its own netns. But the hostNetwork variant puts an identical 8083 listener in the node's netns, bound to 0.0.0.0 (wildcard).

Example failing run:

- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/141503/pull-kubernetes-e2e-gce/2092991476374966272

In the example failing run, nettest-1302 (pod network) deleted netserver-0, but kube-proxy hadn't removed the endpoint yet. So the dial to the ClusterIP was still DNAT'd to the deleted pod's IP. Concurrently, nettest-829 (a hostNetwork config) had a wildcard-bound listener on that same node and answered, returning the node name.

I see 2 possible test fixes:
1. Bind the hostNetwork listeners to their own addresses — same thing we did for UDP in PRs #98883 and #98884.
2. Give hostNetwork configs dedicated ports so they no longer share 8083/8081/8082 with pod-network configs.

This PR implements *2*.

To clarify this PR is based on the conclusion that these flakes originate in the test code and not the k/k networking stack itself.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

Related to #131370

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
