### PR TITLE
Remove debug logs from node declared features validation test

### DIFF
--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -32752,9 +32752,6 @@ func TestValidateNodeDeclaredFeatures(t *testing.T) {
 					} else {
 						found := false
 						for _, err := range errs {
-							t.Logf("DEBUG: tc.expectedErrType: %v err.Type:%v err.Field :%v  tc.expectedErrPath:%v", tc.expectedErrType, err.Type, err.Field, tc.expectedErrPath)
-							t.Logf("DEBUG: err.Type == tc.expectedErrType:%v err.Field == tc.expectedErrPath:%v", err.Type == tc.expectedErrType, err.Field == tc.expectedErrPath)
-							t.Logf("DEBUG: tc.expectedErrMsg: %v err.Error() :%v contains:%v", tc.expectedErrMsg, err.Error(), strings.Contains(err.Error(), tc.expectedErrMsg))
 							if tc.expectedErrType != "" && err.Type == tc.expectedErrType && err.Field == tc.expectedErrPath {
 								if tc.expectedErrMsg != "" && strings.Contains(err.Error(), tc.expectedErrMsg) {
 									found = true


### PR DESCRIPTION
Fixes #141665.

Removes the leftover DEBUG t.Logf calls from TestValidateNodeDeclaredFeatures so passing verbose test runs stay clean.