### PR TITLE
scheduler: remove persistent volume testing dependency

### DIFF
--- a/pkg/scheduler/.import-restrictions
+++ b/pkg/scheduler/.import-restrictions
@@ -8,8 +8,6 @@ rules:
     allowedPrefixes: [ "" ]
   - selectorRegexp: ^k8s[.]io/kubernetes/pkg/controller$
     allowedPrefixes: [ "" ]
-  - selectorRegexp: ^k8s[.]io/kubernetes/pkg/controller/volume/persistentvolume/testing$
-    allowedPrefixes: [ "" ]
   - selectorRegexp: ^k8s[.]io/kubernetes/pkg/features$
     allowedPrefixes: [ "" ]
   - selectorRegexp: ^k8s[.]io/kubernetes/test/utils/image$

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -28,11 +28,12 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	storageinformers "k8s.io/client-go/informers/storage/v1"
@@ -44,7 +45,6 @@ import (
 	"k8s.io/klog/v2/ktesting"
 	_ "k8s.io/klog/v2/ktesting/init"
 	"k8s.io/kubernetes/pkg/controller"
-	pvtesting "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/testing"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/feature"
 )
 
@@ -85,16 +85,15 @@ var (
 	pvBoundGeneric        = makeTestPV("pv-bound", "node1", "1G", "1", correctGenericPVC, waitClass)
 
 	// PVs for manual binding
-	pvNode1a                   = makeTestPV("pv-node1a", "node1", "5G", "1", nil, waitClass)
-	pvNode1b                   = makeTestPV("pv-node1b", "node1", "10G", "1", nil, waitClass)
-	pvNode1c                   = makeTestPV("pv-node1b", "node1", "5G", "1", nil, waitClass)
-	pvNode2                    = makeTestPV("pv-node2", "node2", "1G", "1", nil, waitClass)
-	pvBound                    = makeTestPV("pv-bound", "node1", "1G", "1", boundPVC, waitClass)
-	pvNode1aBound              = makeTestPV("pv-node1a", "node1", "5G", "1", unboundPVC, waitClass)
-	pvNode1bBound              = makeTestPV("pv-node1b", "node1", "10G", "1", unboundPVC2, waitClass)
-	pvNode1bBoundHigherVersion = makeTestPV("pv-node1b", "node1", "10G", "2", unboundPVC2, waitClass)
-	pvBoundImmediate           = makeTestPV("pv-bound-immediate", "node1", "1G", "1", immediateBoundPVC, immediateClass)
-	pvBoundImmediateNode2      = makeTestPV("pv-bound-immediate", "node2", "1G", "1", immediateBoundPVC, immediateClass)
+	pvNode1a              = makeTestPV("pv-node1a", "node1", "5G", "1", nil, waitClass)
+	pvNode1b              = makeTestPV("pv-node1b", "node1", "10G", "1", nil, waitClass)
+	pvNode1c              = makeTestPV("pv-node1b", "node1", "5G", "1", nil, waitClass)
+	pvNode2               = makeTestPV("pv-node2", "node2", "1G", "1", nil, waitClass)
+	pvBound               = makeTestPV("pv-bound", "node1", "1G", "1", boundPVC, waitClass)
+	pvNode1aBound         = makeTestPV("pv-node1a", "node1", "5G", "1", unboundPVC, waitClass)
+	pvNode1bBound         = makeTestPV("pv-node1b", "node1", "10G", "1", unboundPVC2, waitClass)
+	pvBoundImmediate      = makeTestPV("pv-bound-immediate", "node1", "1G", "1", immediateBoundPVC, immediateClass)
+	pvBoundImmediateNode2 = makeTestPV("pv-bound-immediate", "node2", "1G", "1", immediateBoundPVC, immediateClass)
 
 	// PVs for CSI migration
 	migrationPVBound             = makeTestPVForCSIMigration(zone1Labels, boundMigrationPVC, true)
@@ -133,7 +132,6 @@ var (
 
 type testEnv struct {
 	client                  clientset.Interface
-	reactor                 *pvtesting.VolumeReactor
 	binder                  SchedulerVolumeBinder
 	internalBinder          *volumeBinder
 	internalPodInformer     coreinformers.PodInformer
@@ -147,20 +145,14 @@ type testEnv struct {
 	internalCSIStorageCapacityInformer storageinformers.CSIStorageCapacityInformer
 }
 
+type apiUpdateError struct {
+	resource string
+	name     string
+}
+
 func newTestBinder(t *testing.T, ctx context.Context) *testEnv {
-	client := &fake.Clientset{}
+	client := fake.NewClientset()
 	logger := klog.FromContext(ctx)
-	reactor := pvtesting.NewVolumeReactor(ctx, client, nil, nil, nil)
-	// TODO refactor all tests to use real watch mechanism, see #72327
-	client.AddWatchReactor("*", func(action k8stesting.Action) (handled bool, ret watch.Interface, err error) {
-		gvr := action.GetResource()
-		ns := action.GetNamespace()
-		watch, err := reactor.Watch(logger, gvr, ns)
-		if err != nil {
-			return false, nil, err
-		}
-		return true, watch, nil
-	})
 	informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 
 	podInformer := informerFactory.Core().V1().Pods()
@@ -266,7 +258,6 @@ func newTestBinder(t *testing.T, ctx context.Context) *testEnv {
 
 	return &testEnv{
 		client:                  client,
-		reactor:                 reactor,
 		binder:                  binder,
 		internalBinder:          internalBinder,
 		internalPodInformer:     podInformer,
@@ -278,6 +269,33 @@ func newTestBinder(t *testing.T, ctx context.Context) *testEnv {
 		internalCSIDriverInformer:          csiDriverInformer,
 		internalCSIStorageCapacityInformer: csiStorageCapacityInformer,
 	}
+}
+
+func (env *testEnv) addAPIUpdateConflictReactor(t *testing.T, updateError *apiUpdateError) {
+	t.Helper()
+	if updateError == nil {
+		return
+	}
+
+	fakeClient, ok := env.client.(*fake.Clientset)
+	if !ok {
+		t.Fatalf("client is not a fake clientset")
+	}
+	fakeClient.PrependReactor("update", updateError.resource, func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updateAction, ok := action.(k8stesting.UpdateAction)
+		if !ok {
+			return false, nil, nil
+		}
+		object, objectOK := updateAction.GetObject().(metav1.Object)
+		if !objectOK || object.GetName() != updateError.name {
+			return false, nil, nil
+		}
+		return true, nil, apierrors.NewConflict(
+			action.GetResource().GroupResource(),
+			updateError.name,
+			fmt.Errorf("simulated resource version conflict"),
+		)
+	})
 }
 
 func (env *testEnv) initNodes(cachedNodes []*v1.Node) {
@@ -307,30 +325,46 @@ func (env *testEnv) addCSIStorageCapacities(capacities []*storagev1.CSIStorageCa
 }
 
 func (env *testEnv) initClaims(t *testing.T, cachedPVCs []*v1.PersistentVolumeClaim, apiPVCs []*v1.PersistentVolumeClaim) {
+	// Seed the tracker directly so setup does not emit watch events before the test action.
+	fakeClient := env.client.(*fake.Clientset)
 	for _, pvc := range cachedPVCs {
 		if err := env.internalPVCInformer.Informer().GetIndexer().Add(pvc); err != nil {
 			t.Fatalf("error adding PVC %s/%s to cache: %v", pvc.Namespace, pvc.Name, err)
 		}
 		if apiPVCs == nil {
-			env.reactor.AddClaim(pvc)
+			err := fakeClient.Tracker().Add(pvc.DeepCopy())
+			if err != nil {
+				t.Fatalf("failed to add PVC %s/%s to fake client: %v", pvc.Namespace, pvc.Name, err)
+			}
 		}
 	}
 	for _, pvc := range apiPVCs {
-		env.reactor.AddClaim(pvc)
+		err := fakeClient.Tracker().Add(pvc.DeepCopy())
+		if err != nil {
+			t.Fatalf("failed to add PVC %s/%s to fake client: %v", pvc.Namespace, pvc.Name, err)
+		}
 	}
 }
 
 func (env *testEnv) initVolumes(t *testing.T, cachedPVs []*v1.PersistentVolume, apiPVs []*v1.PersistentVolume) {
+	// Seed the tracker directly so setup does not emit watch events before the test action.
+	fakeClient := env.client.(*fake.Clientset)
 	for _, pv := range cachedPVs {
 		if err := env.internalPVInformer.Informer().GetIndexer().Add(pv); err != nil {
 			t.Fatalf("error adding PV %s to cache: %v", pv.Name, err)
 		}
 		if apiPVs == nil {
-			env.reactor.AddVolume(pv)
+			err := fakeClient.Tracker().Add(pv.DeepCopy())
+			if err != nil {
+				t.Fatalf("failed to add PV %q to fake client: %v", pv.Name, err)
+			}
 		}
 	}
 	for _, pv := range apiPVs {
-		env.reactor.AddVolume(pv)
+		err := fakeClient.Tracker().Add(pv.DeepCopy())
+		if err != nil {
+			t.Fatalf("failed to add PV %q to fake client: %v", pv.Name, err)
+		}
 	}
 }
 
@@ -542,9 +576,37 @@ func (env *testEnv) validateBind(
 		}
 	}
 
-	// Check reactor for API updates
-	if err := env.reactor.CheckVolumes(expectedAPIPVs); err != nil {
-		t.Errorf("API reactor validation failed: %v", err)
+	// Check API objects updated by the binder.
+	apiPVs, err := env.client.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Errorf("failed to list PersistentVolumes: %v", err)
+		return
+	}
+
+	expectedMap := make(map[string]*v1.PersistentVolume, len(expectedAPIPVs))
+	for _, pv := range expectedAPIPVs {
+		pv := pv.DeepCopy()
+		pv.ResourceVersion = ""
+		pv.ManagedFields = nil
+		if pv.Spec.ClaimRef != nil {
+			pv.Spec.ClaimRef.ResourceVersion = ""
+		}
+		expectedMap[pv.Name] = pv
+	}
+
+	gotMap := make(map[string]*v1.PersistentVolume, len(apiPVs.Items))
+	for i := range apiPVs.Items {
+		pv := apiPVs.Items[i].DeepCopy()
+		pv.ResourceVersion = ""
+		pv.ManagedFields = nil
+		if pv.Spec.ClaimRef != nil {
+			pv.Spec.ClaimRef.ResourceVersion = ""
+		}
+		gotMap[pv.Name] = pv
+	}
+
+	if diff := cmp.Diff(expectedMap, gotMap); diff != "" {
+		t.Errorf("API PersistentVolume check failed (-want, +got):\n%s", diff)
 	}
 }
 
@@ -569,9 +631,31 @@ func (env *testEnv) validateProvision(
 		}
 	}
 
-	// Check reactor for API updates
-	if err := env.reactor.CheckClaims(expectedAPIPVCs); err != nil {
-		t.Errorf("API reactor validation failed: %v", err)
+	// Check API objects updated by the binder.
+	apiPVCs, err := env.client.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		t.Errorf("failed to list PersistentVolumeClaims: %v", err)
+		return
+	}
+
+	expectedMap := make(map[string]*v1.PersistentVolumeClaim, len(expectedAPIPVCs))
+	for _, pvc := range expectedAPIPVCs {
+		pvc := pvc.DeepCopy()
+		pvc.ResourceVersion = ""
+		pvc.ManagedFields = nil
+		expectedMap[getPVCName(pvc)] = pvc
+	}
+
+	gotMap := make(map[string]*v1.PersistentVolumeClaim, len(apiPVCs.Items))
+	for i := range apiPVCs.Items {
+		pvc := apiPVCs.Items[i].DeepCopy()
+		pvc.ResourceVersion = ""
+		pvc.ManagedFields = nil
+		gotMap[getPVCName(pvc)] = pvc
+	}
+
+	if diff := cmp.Diff(expectedMap, gotMap); diff != "" {
+		t.Errorf("API PersistentVolumeClaim check failed (-want, +got):\n%s", diff)
 	}
 }
 
@@ -1443,6 +1527,9 @@ func TestBindAPIUpdate(t *testing.T) {
 		// if nil, use cachedPVCs
 		apiPVCs []*v1.PersistentVolumeClaim
 
+		// API update error to inject, if any.
+		apiUpdateError *apiUpdateError
+
 		// Expected return values
 		shouldFail  bool
 		expectedPVs []*v1.PersistentVolume
@@ -1488,11 +1575,13 @@ func TestBindAPIUpdate(t *testing.T) {
 			provisionedPVCs: []*v1.PersistentVolumeClaim{},
 		},
 		"api-update-failed": {
+			apiUpdateError: &apiUpdateError{
+				resource: "persistentvolumes",
+				name:     "pv-node1b",
+			},
 			bindings:        []*BindingInfo{makeBinding(unboundPVC, pvNode1aBound), makeBinding(unboundPVC2, pvNode1bBound)},
 			cachedPVs:       []*v1.PersistentVolume{pvNode1a, pvNode1b},
-			apiPVs:          []*v1.PersistentVolume{pvNode1a, pvNode1bBoundHigherVersion},
 			expectedPVs:     []*v1.PersistentVolume{pvNode1aBound, pvNode1b},
-			expectedAPIPVs:  []*v1.PersistentVolume{pvNode1aBound, pvNode1bBoundHigherVersion},
 			provisionedPVCs: []*v1.PersistentVolumeClaim{},
 			shouldFail:      true,
 		},
@@ -1503,23 +1592,27 @@ func TestBindAPIUpdate(t *testing.T) {
 			expectedPVCs:    []*v1.PersistentVolumeClaim{addProvisionAnn(provisionedPVC)},
 		},
 		"provision-api-update-failed": {
+			apiUpdateError: &apiUpdateError{
+				resource: "persistentvolumeclaims",
+				name:     "provisioned-pvc2",
+			},
 			bindings:        []*BindingInfo{},
 			provisionedPVCs: []*v1.PersistentVolumeClaim{addProvisionAnn(provisionedPVC), addProvisionAnn(provisionedPVC2)},
 			cachedPVCs:      []*v1.PersistentVolumeClaim{provisionedPVC, provisionedPVC2},
-			apiPVCs:         []*v1.PersistentVolumeClaim{provisionedPVC, provisionedPVCHigherVersion},
 			expectedPVCs:    []*v1.PersistentVolumeClaim{addProvisionAnn(provisionedPVC), provisionedPVC2},
-			expectedAPIPVCs: []*v1.PersistentVolumeClaim{addProvisionAnn(provisionedPVC), provisionedPVCHigherVersion},
 			shouldFail:      true,
 		},
 		"binding-succeed, provision-api-update-failed": {
+			apiUpdateError: &apiUpdateError{
+				resource: "persistentvolumeclaims",
+				name:     "provisioned-pvc2",
+			},
 			bindings:        []*BindingInfo{makeBinding(unboundPVC, pvNode1aBound)},
 			cachedPVs:       []*v1.PersistentVolume{pvNode1a},
 			expectedPVs:     []*v1.PersistentVolume{pvNode1aBound},
 			provisionedPVCs: []*v1.PersistentVolumeClaim{addProvisionAnn(provisionedPVC), addProvisionAnn(provisionedPVC2)},
 			cachedPVCs:      []*v1.PersistentVolumeClaim{provisionedPVC, provisionedPVC2},
-			apiPVCs:         []*v1.PersistentVolumeClaim{provisionedPVC, provisionedPVCHigherVersion},
 			expectedPVCs:    []*v1.PersistentVolumeClaim{addProvisionAnn(provisionedPVC), provisionedPVC2},
-			expectedAPIPVCs: []*v1.PersistentVolumeClaim{addProvisionAnn(provisionedPVC), provisionedPVCHigherVersion},
 			shouldFail:      true,
 		},
 	}
@@ -1543,6 +1636,7 @@ func TestBindAPIUpdate(t *testing.T) {
 		testEnv.initVolumes(t, scenario.cachedPVs, scenario.apiPVs)
 		testEnv.initClaims(t, scenario.cachedPVCs, scenario.apiPVCs)
 		testEnv.assumeVolumes(t, "node1", pod, scenario.bindings, scenario.provisionedPVCs)
+		testEnv.addAPIUpdateConflictReactor(t, scenario.apiUpdateError)
 
 		// Execute
 		err := testEnv.internalBinder.bindAPIUpdate(ctx, pod, scenario.bindings, scenario.provisionedPVCs)
@@ -1915,6 +2009,8 @@ func TestBindPodVolumes(t *testing.T) {
 		apiPV  *v1.PersistentVolume
 		apiPVC *v1.PersistentVolumeClaim
 
+		apiUpdateError *apiUpdateError
+
 		// This function runs with a delay of 5 seconds
 		delayFunc func(t *testing.T, ctx context.Context, testEnv *testEnv, pod *v1.Pod, pvs []*v1.PersistentVolume, pvcs []*v1.PersistentVolumeClaim)
 
@@ -1974,11 +2070,15 @@ func TestBindPodVolumes(t *testing.T) {
 			},
 		},
 		"bound-by-pv-controller-before-bind": {
-			initPVs:    []*v1.PersistentVolume{pvNode1a},
-			initPVCs:   []*v1.PersistentVolumeClaim{unboundPVC},
-			binding:    makeBinding(unboundPVC, pvNode1aBound),
-			apiPV:      pvNode1aBound,
-			apiPVC:     boundPVCNode1a,
+			initPVs:  []*v1.PersistentVolume{pvNode1a},
+			initPVCs: []*v1.PersistentVolumeClaim{unboundPVC},
+			binding:  makeBinding(unboundPVC, pvNode1aBound),
+			apiPV:    pvNode1aBound,
+			apiPVC:   boundPVCNode1a,
+			apiUpdateError: &apiUpdateError{
+				resource: "persistentvolumes",
+				name:     pvNode1a.Name,
+			},
 			shouldFail: true, // bindAPIUpdate will fail because API conflict
 		},
 		"pod-deleted-after-time": {
@@ -2081,6 +2181,7 @@ func TestBindPodVolumes(t *testing.T) {
 				t.Fatalf("failed to update PVC %q", getPVCName(scenario.apiPVC))
 			}
 		}
+		testEnv.addAPIUpdateConflictReactor(t, scenario.apiUpdateError)
 
 		if scenario.delayFunc != nil {
 			go func(scenario scenarioType) {

--- a/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/binder_test.go
@@ -325,7 +325,8 @@ func (env *testEnv) addCSIStorageCapacities(capacities []*storagev1.CSIStorageCa
 }
 
 func (env *testEnv) initClaims(t *testing.T, cachedPVCs []*v1.PersistentVolumeClaim, apiPVCs []*v1.PersistentVolumeClaim) {
-	// Seed the tracker directly so setup does not emit watch events before the test action.
+	// Seed API state in the tracker. Because the informer is already running,
+	// tracker changes are delivered asynchronously through its watch.
 	fakeClient := env.client.(*fake.Clientset)
 	for _, pvc := range cachedPVCs {
 		if err := env.internalPVCInformer.Informer().GetIndexer().Add(pvc); err != nil {
@@ -347,7 +348,8 @@ func (env *testEnv) initClaims(t *testing.T, cachedPVCs []*v1.PersistentVolumeCl
 }
 
 func (env *testEnv) initVolumes(t *testing.T, cachedPVs []*v1.PersistentVolume, apiPVs []*v1.PersistentVolume) {
-	// Seed the tracker directly so setup does not emit watch events before the test action.
+	// Seed API state in the tracker. Because the informer is already running,
+	// tracker changes are delivered asynchronously through its watch.
 	fakeClient := env.client.(*fake.Clientset)
 	for _, pv := range cachedPVs {
 		if err := env.internalPVInformer.Informer().GetIndexer().Add(pv); err != nil {
@@ -412,18 +414,36 @@ func (env *testEnv) updateClaims(ctx context.Context, pvcs []*v1.PersistentVolum
 	})
 }
 
-func (env *testEnv) deleteVolumes(t *testing.T, pvs []*v1.PersistentVolume) {
+func (env *testEnv) deleteVolumes(t *testing.T, ctx context.Context, pvs []*v1.PersistentVolume) {
 	for _, pv := range pvs {
-		if err := env.internalPVInformer.Informer().GetIndexer().Delete(pv); err != nil {
-			t.Fatalf("Error deleting PV %s: %v", pv.Name, err)
+		if err := env.client.CoreV1().PersistentVolumes().Delete(ctx, pv.Name, metav1.DeleteOptions{}); err != nil {
+			t.Fatalf("failed to delete PV %q: %v", pv.Name, err)
+		}
+		if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, cacheUpdateTimeout, true, func(ctx context.Context) (bool, error) {
+			_, err := env.internalBinder.pvCache.GetAPIObj(pv.Name)
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}); err != nil {
+			t.Fatalf("failed waiting for PV %q deletion to reach informer cache: %v", pv.Name, err)
 		}
 	}
 }
 
-func (env *testEnv) deleteClaims(t *testing.T, pvcs []*v1.PersistentVolumeClaim) {
+func (env *testEnv) deleteClaims(t *testing.T, ctx context.Context, pvcs []*v1.PersistentVolumeClaim) {
 	for _, pvc := range pvcs {
-		if err := env.internalPVCInformer.Informer().GetIndexer().Delete(pvc); err != nil {
-			t.Fatalf("Error deleting PVC %s/%s: %v", pvc.Namespace, pvc.Name, err)
+		if err := env.client.CoreV1().PersistentVolumeClaims(pvc.Namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{}); err != nil {
+			t.Fatalf("failed to delete PVC %q: %v", getPVCName(pvc), err)
+		}
+		if err := wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, cacheUpdateTimeout, true, func(ctx context.Context) (bool, error) {
+			_, err := env.internalBinder.pvcCache.GetAPIObj(getPVCName(pvc))
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}); err != nil {
+			t.Fatalf("failed waiting for PVC %q deletion to reach informer cache: %v", getPVCName(pvc), err)
 		}
 	}
 }
@@ -1834,14 +1854,14 @@ func TestCheckBindings(t *testing.T) {
 
 		// Before execute
 		if scenario.deletePVs {
-			testEnv.deleteVolumes(t, scenario.initPVs)
+			testEnv.deleteVolumes(t, ctx, scenario.initPVs)
 		} else {
 			if err := testEnv.updateVolumes(ctx, scenario.apiPVs); err != nil {
 				t.Errorf("Failed to update PVs: %v", err)
 			}
 		}
 		if scenario.deletePVCs {
-			testEnv.deleteClaims(t, scenario.initPVCs)
+			testEnv.deleteClaims(t, ctx, scenario.initPVCs)
 		} else {
 			if err := testEnv.updateClaims(ctx, scenario.apiPVCs); err != nil {
 				t.Errorf("Failed to update PVCs: %v", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This removes the scheduler test dependency on `pkg/controller/volume/persistentvolume/testing`.

- Uses the fake client tracker to seed PV/PVC API state.
- Uses `fake.Clientset.PrependReactor()` to inject API update conflicts.
- Validates all API PVs/PVCs directly from the fake client.
- Removes the stale scheduler import allow-list entry.

#### Which issue(s) this PR fixes:

Fixes #141498

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### AI assistance

AI assistance was used to inspect and explain the existing test setup, implement the focused test refactor, and run verification. I reviewed the changes and remain responsible for all submitted code in accordance with `CONTRIBUTING.md`.