### PR TITLE
docs: specify ECDSA signature encoding

### DIFF
--- a/staging/src/k8s.io/externaljwt/apis/v1/api.proto
+++ b/staging/src/k8s.io/externaljwt/apis/v1/api.proto
@@ -63,6 +63,8 @@ service ExternalJWTSigner {
     string header = 1;
   
     // The signature for the JWT.
+    // For ECDSA algorithms, the signature must be encoded according to RFC 7518
+    // section 3.4 using the fixed-length R || S (IEEE P1363) format, not ASN.1 DER.
     // Already wrapped in URL-safe base64, exactly as it appears in the final segment of the JWT.
     string signature = 2;
   }


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does

Clarifies the required ECDSA signature encoding for `ExternalJWTSigner.SignJWTResponse.signature`.

ECDSA signatures must use the fixed-length `R || S` (IEEE P1363) format specified by RFC 7518 section 3.4, rather than ASN.1 DER encoding.

This makes the API contract explicit for external signer implementations.

#### Why this is needed

The existing documentation specifies that the signature is URL-safe base64 encoded, but does not specify the underlying ECDSA signature encoding. This can lead to externally generated JWT signatures being rejected during verification.

Fixes #141669
