### PR TITLE
Automated cherry pick of #141296: Fix windows backslash escaping

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec.go
@@ -73,7 +73,9 @@ func (p localPath) StripSlashes() localPath {
 }
 
 func isRelative(base, target localPath) bool {
-	relative, err := filepath.Rel(base.String(), target.String())
+	baseNormalized := strings.ReplaceAll(stripTrailingSlash(base.String()), `\`, "/")
+	targetNormalized := strings.ReplaceAll(stripTrailingSlash(target.String()), `\`, "/")
+	relative, err := filepath.Rel(baseNormalized, targetNormalized)
 	if err != nil {
 		return false
 	}
@@ -141,11 +143,18 @@ func stripLeadingSlash(file string) string {
 // stripPathShortcuts removes any leading or trailing "../" from a given path
 func stripPathShortcuts(p string) string {
 	newPath := p
-	trimmed := strings.TrimPrefix(newPath, "../")
+	trimmedPosix := strings.TrimPrefix(newPath, "../")
 
-	for trimmed != newPath {
-		newPath = trimmed
-		trimmed = strings.TrimPrefix(newPath, "../")
+	for trimmedPosix != newPath {
+		newPath = trimmedPosix
+		trimmedPosix = strings.TrimPrefix(newPath, "../")
+	}
+
+	trimmedWindows := strings.TrimPrefix(newPath, `..\`)
+
+	for trimmedWindows != newPath {
+		newPath = trimmedWindows
+		trimmedWindows = strings.TrimPrefix(newPath, `..\`)
 	}
 
 	// trim leftover {".", ".."}
@@ -153,7 +162,7 @@ func stripPathShortcuts(p string) string {
 		newPath = ""
 	}
 
-	if len(newPath) > 0 && string(newPath[0]) == "/" {
+	if len(newPath) > 0 && (string(newPath[0]) == "/" || string(newPath[0]) == `\`) {
 		return newPath[1:]
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cp
 
 import "testing"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec_test.go
@@ -1,0 +1,152 @@
+package cp
+
+import "testing"
+
+func TestIsRelative(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		base     string
+		expected bool
+	}{
+		{
+			name:     "test single path shortcut prefix",
+			input:    "../foo/bar",
+			base:     "../",
+			expected: true,
+		},
+		{
+			name:     "test single path shortcut prefix (Windows)",
+			input:    `..\foo\bar`,
+			base:     `..\`,
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts",
+			input:    "../../foo/bar",
+			base:     "../",
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts (Windows)",
+			input:    `..\..\foo\bar`,
+			base:     `..\`,
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts with absolute path",
+			input:    "/tmp/one/two/../../foo/bar",
+			base:     "/",
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts with absolute path (Windows)",
+			input:    `\tmp\one\two\..\..\foo\bar`,
+			base:     `\`,
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory",
+			input:    "../../",
+			base:     "../",
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory (Windows)",
+			input:    `..\..\`,
+			base:     `..\`,
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory and no trailing slash",
+			input:    "../..",
+			base:     "../",
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory and no trailing slash (Windows)",
+			input:    `..\..`,
+			base:     `..\`,
+			expected: false,
+		},
+		{
+			name:     "test multiple path shortcuts with absolute path and filename containing leading dots",
+			input:    "/tmp/one/two/../../foo/..bar",
+			base:     "/",
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts with absolute path and filename containing leading dots (Windows)",
+			input:    `\tmp\one\two\..\..\foo\..bar`,
+			base:     `\`,
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory and filename containing leading dots",
+			input:    "../...foo",
+			base:     "../",
+			expected: true,
+		},
+		{
+			name:     "test multiple path shortcuts with no named directory and filename containing leading dots (Windows)",
+			input:    `..\...foo`,
+			base:     `..\`,
+			expected: true,
+		},
+		{
+			name:     "test filename containing leading dots",
+			input:    "/...foo",
+			base:     "/",
+			expected: true,
+		},
+		{
+			name:     "test root directory",
+			input:    "/",
+			base:     "/",
+			expected: true,
+		},
+		{
+			name:     "test root directory (Windows)",
+			input:    `\`,
+			base:     `\`,
+			expected: true,
+		},
+		{
+			name:     "test basic relative path",
+			input:    "/a/b/c",
+			base:     "/a",
+			expected: true,
+		},
+		{
+			name:     "test basic relative path (Windows)",
+			input:    `\a\b\c`,
+			base:     `\a`,
+			expected: true,
+		},
+		{
+			name:     "test basic non relative path",
+			input:    "/a/b/c",
+			base:     "/f",
+			expected: false,
+		},
+		{
+			name:     "test basic non relative path (Windows)",
+			input:    `\a\b\c`,
+			base:     `\f`,
+			expected: false,
+		},
+		{
+			name:     "test mix of Windows base and linux input",
+			input:    `\a\b\c`,
+			base:     `/f`,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		result := isRelative(newLocalPath(test.base), newLocalPath(test.input))
+		if result != test.expected {
+			t.Errorf("%s: %t, saw: %t", test.name, test.expected, result)
+		}
+	}
+}


### PR DESCRIPTION
Cherry pick of #141296 on release-1.36.

#141296: Fix windows backslash escaping

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
NONE
```