### PR TITLE
batch: graduate CronJob schedule validation

### DIFF
--- a/pkg/apis/batch/v1/zz_generated.validations.go
+++ b/pkg/apis/batch/v1/zz_generated.validations.go
@@ -153,7 +153,7 @@ func Validate_CronJobSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/batch/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.validations.go
@@ -136,7 +136,7 @@ func Validate_CronJobSpec(
 			}
 			// call field-attached validations
 			earlyReturn := false
-			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkBeta().MarkShortCircuit(); len(e) != 0 {
+			if e := validate.RequiredValue(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
 				errs = append(errs, e...)
 				earlyReturn = true
 			}

--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -887,9 +887,7 @@ func ValidateCronJobUpdate(job, oldJob *batch.CronJob, opts apivalidation.PodVal
 func validateCronJobSpec(spec, oldSpec *batch.CronJobSpec, fldPath *field.Path, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if len(spec.Schedule) == 0 {
-		allErrs = append(allErrs, field.Required(fldPath.Child("schedule"), "").MarkCoveredByDeclarative())
-	} else {
+	if len(spec.Schedule) != 0 {
 		allowTZInSchedule := false
 		if oldSpec != nil {
 			allowTZInSchedule = strings.Contains(oldSpec.Schedule, "TZ")

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -2997,22 +2997,7 @@ func TestValidateCronJob(t *testing.T) {
 				},
 			},
 		},
-		"spec.schedule: Required value": {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "mycronjob",
-				Namespace: metav1.NamespaceDefault,
-				UID:       types.UID("1a2b3c"),
-			},
-			Spec: batch.CronJobSpec{
-				Schedule:          "",
-				ConcurrencyPolicy: batch.AllowConcurrent,
-				JobTemplate: batch.JobTemplateSpec{
-					Spec: batch.JobSpec{
-						Template: validPodTemplateSpec,
-					},
-				},
-			},
-		},
+
 		"spec.timeZone: timeZone must be nil or non-empty string": {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "mycronjob",

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -64,7 +64,7 @@ message CronJobList {
 message CronJobSpec {
   // The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:required
   optional string schedule = 1;
 
   // The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -790,7 +790,7 @@ type CronJobSpec struct {
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:required
 	Schedule string `json:"schedule" protobuf:"bytes,1,opt,name=schedule"`
 
 	// The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/staging/src/k8s.io/api/batch/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1beta1/generated.proto
@@ -64,7 +64,7 @@ message CronJobList {
 message CronJobSpec {
   // The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
   // +required
-  // +k8s:beta(since: "1.37")=+k8s:required
+  // +k8s:required
   optional string schedule = 1;
 
   // The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/staging/src/k8s.io/api/batch/v1beta1/types.go
+++ b/staging/src/k8s.io/api/batch/v1beta1/types.go
@@ -87,7 +87,7 @@ type CronJobSpec struct {
 
 	// The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
 	// +required
-	// +k8s:beta(since: "1.37")=+k8s:required
+	// +k8s:required
 	Schedule string `json:"schedule" protobuf:"bytes,1,opt,name=schedule"`
 
 	// The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.

--- a/test/declarative_validation/batch/cronjob/declarative_validation_test.go
+++ b/test/declarative_validation/batch/cronjob/declarative_validation_test.go
@@ -64,7 +64,7 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 		"schedule: empty": {
 			input: mkCronJob(tweakSchedule("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "schedule"), "").MarkBeta(),
+				field.Required(field.NewPath("spec", "schedule"), ""),
 			},
 		},
 		"jobTemplate.spec.maxFailedIndexes set without backoffLimitPerIndex": {
@@ -272,7 +272,7 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			old:    mkCronJob(),
 			update: mkCronJob(tweakSchedule("")),
 			expectedErrs: field.ErrorList{
-				field.Required(field.NewPath("spec", "schedule"), "").MarkBeta(),
+				field.Required(field.NewPath("spec", "schedule"), ""),
 			},
 		},
 		"valid unchanged scheduling": {


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does

Graduates the `CronJobSpec.schedule` required validation from beta to stable declarative validation.

- Removes the `+k8s:beta(since: "1.37")=+k8s:required` lifecycle wrapper from `CronJobSpec.schedule`.
- Removes the redundant handwritten `MarkCoveredByDeclarative()` validation now that the field is covered by declarative validation.
- Removes the corresponding handwritten validation test for the legacy validation path.
- Regenerates the declarative validation code for `batch/v1` and `batch/v1beta1`.
- Removes the beta marker from the corresponding declarative validation test expectations.
- Updates the generated protobuf comments for `batch/v1` and `batch/v1beta1`.

This follows the declarative validation graduation pattern used by the other API types in the current graduation effort.

Related to #141532

## Tests

- `make test WHAT=./pkg/apis/batch/validation` — 243 tests passed
- `make test WHAT=./pkg/api/testing` — 1687 tests passed, 165 skipped
- `git diff --check`

## Does this PR introduce a user-facing change?

```release-note
None