### PR TITLE
apiserver/storage/etcd3/testserver: retry StartEtcd on EADDRINUSE

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server.go
@@ -17,12 +17,14 @@ limitations under the License.
 package testserver
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
 	"os"
 	"strconv"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -34,7 +36,8 @@ import (
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
 )
 
-// getAvailablePort returns a TCP port that is available for binding.
+// getAvailablePorts returns a desired count of TCP ports
+// that are available for binding.
 func getAvailablePorts(count int) ([]int, error) {
 	ports := []int{}
 	for i := 0; i < count; i++ {
@@ -49,6 +52,28 @@ func getAvailablePorts(count int) ([]int, error) {
 	return ports, nil
 }
 
+// assignAvailablePorts assigns client and peer URLs to a cfg
+func assignAvailablePorts(cfg *embed.Config) error {
+	ports, err := getAvailablePorts(2)
+	if err != nil {
+		return err
+	}
+
+	// Only the port is replaced, so that a scheme or host the caller set before
+	// starting the server survives a retry.
+	setPort := func(urls []url.URL, port int) {
+		for i := range urls {
+			urls[i].Host = net.JoinHostPort(urls[i].Hostname(), strconv.Itoa(port))
+		}
+	}
+	setPort(cfg.ListenClientUrls, ports[0])
+	setPort(cfg.AdvertiseClientUrls, ports[0])
+	setPort(cfg.ListenPeerUrls, ports[1])
+	setPort(cfg.AdvertisePeerUrls, ports[1])
+	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
+	return nil
+}
+
 // NewTestConfig returns a configuration for an embedded etcd server.
 // The configuration is based on embed.NewConfig(), with the following adjustments:
 //   - sets UnsafeNoFsync = true to improve test performance (only reasonable in a test-only
@@ -61,18 +86,9 @@ func NewTestConfig(t testing.TB) *embed.Config {
 
 	cfg.UnsafeNoFsync = true
 
-	ports, err := getAvailablePorts(2)
-	if err != nil {
+	if err := assignAvailablePorts(cfg); err != nil {
 		t.Fatal(err)
 	}
-	clientURL := url.URL{Scheme: "http", Host: net.JoinHostPort("localhost", strconv.Itoa(ports[0]))}
-	peerURL := url.URL{Scheme: "http", Host: net.JoinHostPort("localhost", strconv.Itoa(ports[1]))}
-
-	cfg.ListenPeerUrls = []url.URL{peerURL}
-	cfg.AdvertisePeerUrls = []url.URL{peerURL}
-	cfg.ListenClientUrls = []url.URL{clientURL}
-	cfg.AdvertiseClientUrls = []url.URL{clientURL}
-	cfg.InitialCluster = cfg.InitialClusterFromName(cfg.Name)
 
 	cfg.ZapLoggerBuilder = embed.NewZapLoggerBuilder(zaptest.NewLogger(t, zaptest.Level(zapcore.ErrorLevel)).Named("etcd-server"))
 	cfg.Dir = t.TempDir()
@@ -80,7 +96,39 @@ func NewTestConfig(t testing.TB) *embed.Config {
 	return cfg
 }
 
+// maxStartAttempts bounds how many times startEtcd retries with a fresh set of
+// ports before giving up.
+const maxStartAttempts = 3
+
 var autoPortLock sync.Mutex
+
+// startEtcd starts an embedded etcd server.
+// Port assignment is subject to a race condition
+// between assignment and binding, so we retry a few times.
+func startEtcd(t testing.TB, cfg *embed.Config) (*embed.Config, *embed.Etcd, error) {
+	t.Helper()
+
+	autoPortLock.Lock()
+	defer autoPortLock.Unlock()
+
+	if cfg == nil {
+		cfg = NewTestConfig(t)
+	}
+
+	for attempt := 1; ; attempt++ {
+		e, err := embed.StartEtcd(cfg)
+		if err == nil {
+			return cfg, e, nil
+		}
+		if attempt >= maxStartAttempts || !errors.Is(err, syscall.EADDRINUSE) {
+			return cfg, nil, err
+		}
+		t.Logf("etcd failed to bind on attempt %d of %d, retrying with new ports: %v", attempt, maxStartAttempts, err)
+		if err := assignAvailablePorts(cfg); err != nil {
+			return cfg, nil, err
+		}
+	}
+}
 
 // RunEtcd starts an embedded etcd server with the provided config
 // (or NewTestConfig(t) if nil), and returns a client connected to the server.
@@ -88,14 +136,7 @@ var autoPortLock sync.Mutex
 func RunEtcd(t testing.TB, cfg *embed.Config) *kubernetes.Client {
 	t.Helper()
 
-	if cfg == nil {
-		// if we have to autopick free ports, lock until we successfully start the server on the ports we chose
-		autoPortLock.Lock()
-		defer autoPortLock.Unlock()
-		cfg = NewTestConfig(t)
-	}
-
-	e, err := embed.StartEtcd(cfg)
+	cfg, e, err := startEtcd(t, cfg)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/testserver/test_server_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testserver
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"go.etcd.io/etcd/server/v3/embed"
+)
+
+// TestRunEtcdRecoversFromTakenPort claims a port that was selected for etcd
+// before it gets a chance to bind, reproducing what happens when another
+// process takes the port first, and verifies that RunEtcd recovers instead of
+// failing the test. Both listeners are covered because etcd binds the peer
+// listener before the client one, so either can be the one that loses the race.
+func TestRunEtcdRecoversFromTakenPort(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		addr func(cfg *embed.Config) string
+	}{
+		{name: "client", addr: func(cfg *embed.Config) string { return cfg.ListenClientUrls[0].Host }},
+		{name: "peer", addr: func(cfg *embed.Config) string { return cfg.ListenPeerUrls[0].Host }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := NewTestConfig(t)
+			taken := tc.addr(cfg)
+
+			l, err := net.Listen("tcp", taken)
+			if err != nil {
+				t.Fatalf("failed to claim %s: %v", taken, err)
+			}
+			defer func() { _ = l.Close() }()
+
+			client := RunEtcd(t, cfg)
+
+			if got := tc.addr(cfg); got == taken {
+				t.Errorf("etcd is still configured to listen on the claimed address %s", taken)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			if _, err := client.KV.Get(ctx, "/registry"); err != nil {
+				t.Fatalf("etcd did not serve requests after moving to a new port: %v", err)
+			}
+		})
+	}
+}
+
+// TestAssignAvailablePortsPreservesURLs verifies that reassigning ports leaves
+// the rest of the URL alone. Callers such as the storagebackend TLS test switch
+// the scheme of the URLs returned by NewTestConfig to https, and that has to
+// survive a retry.
+func TestAssignAvailablePortsPreservesURLs(t *testing.T) {
+	cfg := NewTestConfig(t)
+	for i := range cfg.ListenClientUrls {
+		cfg.ListenClientUrls[i].Scheme = "https"
+	}
+	clientPort := cfg.ListenClientUrls[0].Port()
+	peerPort := cfg.ListenPeerUrls[0].Port()
+
+	if err := assignAvailablePorts(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := cfg.ListenClientUrls[0].Scheme, "https"; got != want {
+		t.Errorf("client URL scheme = %q, want %q", got, want)
+	}
+	if got, want := cfg.ListenClientUrls[0].Hostname(), "localhost"; got != want {
+		t.Errorf("client URL hostname = %q, want %q", got, want)
+	}
+	if got := cfg.ListenClientUrls[0].Port(); got == clientPort {
+		t.Errorf("client port was not reassigned, still %q", got)
+	}
+	if got := cfg.ListenPeerUrls[0].Port(); got == peerPort {
+		t.Errorf("peer port was not reassigned, still %q", got)
+	}
+	if cfg.ListenClientUrls[0].Port() == cfg.ListenPeerUrls[0].Port() {
+		t.Error("client and peer listeners must not be assigned the same port")
+	}
+	if got, want := cfg.InitialCluster, cfg.AdvertisePeerUrls[0].String(); !strings.Contains(got, want) {
+		t.Errorf("InitialCluster = %q, want it to reference the reassigned peer URL %q", got, want)
+	}
+}


### PR DESCRIPTION
Observed on kubernetes/kubernetes#141661:
listen tcp 127.0.0.1:40671: bind: address already in use

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

This PR adds retries to etcd start in tests to account for EADDRINUSE scenarios during port binding.

Observed https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/141661/pull-kubernetes-unit/2093460307929206784

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
