### PR TITLE
Migrate Job non-negative spec fields to declarative validation

### DIFF
--- a/pkg/apis/batch/v1/zz_generated.validations.go
+++ b/pkg/apis/batch/v1/zz_generated.validations.go
@@ -440,13 +440,163 @@ func Validate_JobSpec(
 		errs = append(errs, e...)
 	}
 
-	// field batchv1.JobSpec.Parallelism has no validation
-	// field batchv1.JobSpec.Completions has no validation
-	// field batchv1.JobSpec.ActiveDeadlineSeconds has no validation
+	{ // field batchv1.JobSpec.Parallelism
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *batchv1.JobSpec) *int32 {
+				return oldObj.Parallelism
+			})
+		errs = append(errs, fn(fldPath.Child("parallelism"), obj.Parallelism, oldVal, oldObj != nil)...)
+	}
+
+	{ // field batchv1.JobSpec.Completions
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *batchv1.JobSpec) *int32 {
+				return oldObj.Completions
+			})
+		errs = append(errs, fn(fldPath.Child("completions"), obj.Completions, oldVal, oldObj != nil)...)
+	}
+
+	{ // field batchv1.JobSpec.ActiveDeadlineSeconds
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int64,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *batchv1.JobSpec) *int64 {
+				return oldObj.ActiveDeadlineSeconds
+			})
+		errs = append(errs, fn(fldPath.Child("activeDeadlineSeconds"), obj.ActiveDeadlineSeconds, oldVal, oldObj != nil)...)
+	}
+
 	// field batchv1.JobSpec.PodFailurePolicy has no validation
 	// field batchv1.JobSpec.SuccessPolicy has no validation
-	// field batchv1.JobSpec.BackoffLimit has no validation
-	// field batchv1.JobSpec.BackoffLimitPerIndex has no validation
+
+	{ // field batchv1.JobSpec.BackoffLimit
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *batchv1.JobSpec) *int32 {
+				return oldObj.BackoffLimit
+			})
+		errs = append(errs, fn(fldPath.Child("backoffLimit"), obj.BackoffLimit, oldVal, oldObj != nil)...)
+	}
+
+	{ // field batchv1.JobSpec.BackoffLimitPerIndex
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *batchv1.JobSpec) *int32 {
+				return oldObj.BackoffLimitPerIndex
+			})
+		errs = append(errs, fn(fldPath.Child("backoffLimitPerIndex"), obj.BackoffLimitPerIndex, oldVal, oldObj != nil)...)
+	}
 
 	{ // field batchv1.JobSpec.MaxFailedIndexes
 		fn := func(
@@ -466,6 +616,9 @@ func Validate_JobSpec(
 			}
 			if earlyReturn {
 				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
 			}
 			return
 		}
@@ -501,7 +654,37 @@ func Validate_JobSpec(
 		errs = append(errs, fn(fldPath.Child("template"), &obj.Template, oldVal, oldObj != nil)...)
 	}
 
-	// field batchv1.JobSpec.TTLSecondsAfterFinished has no validation
+	{ // field batchv1.JobSpec.TTLSecondsAfterFinished
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *int32,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.OptionalPointer(ctx, op, fldPath, obj, oldObj).MarkShortCircuit(); len(e) != 0 {
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			if e := validate.Minimum(ctx, op, fldPath, obj, oldObj, 0).MarkAlpha(); len(e) != 0 {
+				errs = append(errs, e...)
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *batchv1.JobSpec) *int32 {
+				return oldObj.TTLSecondsAfterFinished
+			})
+		errs = append(errs, fn(fldPath.Child("ttlSecondsAfterFinished"), obj.TTLSecondsAfterFinished, oldVal, oldObj != nil)...)
+	}
+
 	// field batchv1.JobSpec.CompletionMode has no validation
 	// field batchv1.JobSpec.Suspend has no validation
 	// field batchv1.JobSpec.PodReplacementPolicy has no validation

--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -202,25 +202,25 @@ func validateJobSpec(spec, oldSpec *batch.JobSpec, fldPath *field.Path, opts api
 	allErrs := field.ErrorList{}
 
 	if spec.Parallelism != nil {
-		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.Parallelism), fldPath.Child("parallelism"))...)
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.Parallelism), fldPath.Child("parallelism")).MarkCoveredByDeclarative()...)
 	}
 	if spec.Completions != nil {
-		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.Completions), fldPath.Child("completions"))...)
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.Completions), fldPath.Child("completions")).MarkCoveredByDeclarative()...)
 	}
 	if spec.ActiveDeadlineSeconds != nil {
-		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.ActiveDeadlineSeconds), fldPath.Child("activeDeadlineSeconds"))...)
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.ActiveDeadlineSeconds), fldPath.Child("activeDeadlineSeconds")).MarkCoveredByDeclarative()...)
 	}
 	if spec.BackoffLimit != nil {
-		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.BackoffLimit), fldPath.Child("backoffLimit"))...)
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.BackoffLimit), fldPath.Child("backoffLimit")).MarkCoveredByDeclarative()...)
 	}
 	if spec.TTLSecondsAfterFinished != nil {
-		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.TTLSecondsAfterFinished), fldPath.Child("ttlSecondsAfterFinished"))...)
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.TTLSecondsAfterFinished), fldPath.Child("ttlSecondsAfterFinished")).MarkCoveredByDeclarative()...)
 	}
 	if spec.BackoffLimitPerIndex != nil {
-		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.BackoffLimitPerIndex), fldPath.Child("backoffLimitPerIndex"))...)
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.BackoffLimitPerIndex), fldPath.Child("backoffLimitPerIndex")).MarkCoveredByDeclarative()...)
 	}
 	if spec.MaxFailedIndexes != nil {
-		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.MaxFailedIndexes), fldPath.Child("maxFailedIndexes"))...)
+		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.MaxFailedIndexes), fldPath.Child("maxFailedIndexes")).MarkCoveredByDeclarative()...)
 		if spec.BackoffLimitPerIndex == nil {
 			allErrs = append(allErrs, field.Required(fldPath.Child("backoffLimitPerIndex"), "when maxFailedIndexes is specified").WithOrigin("dependentRequired").MarkCoveredByDeclarative())
 		}

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -3336,6 +3336,57 @@ func TestValidateCronJob(t *testing.T) {
 				},
 			},
 		},
+		"spec.jobTemplate.spec.backoffLimit:must be greater than or equal to 0": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mycronjob",
+				Namespace: metav1.NamespaceDefault,
+				UID:       types.UID("1a2b3c"),
+			},
+			Spec: batch.CronJobSpec{
+				Schedule:          "* * * * ?",
+				ConcurrencyPolicy: batch.AllowConcurrent,
+				JobTemplate: batch.JobTemplateSpec{
+					Spec: batch.JobSpec{
+						BackoffLimit: &negative,
+						Template:     validPodTemplateSpec,
+					},
+				},
+			},
+		},
+		"spec.jobTemplate.spec.backoffLimitPerIndex:must be greater than or equal to 0": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mycronjob",
+				Namespace: metav1.NamespaceDefault,
+				UID:       types.UID("1a2b3c"),
+			},
+			Spec: batch.CronJobSpec{
+				Schedule:          "* * * * ?",
+				ConcurrencyPolicy: batch.AllowConcurrent,
+				JobTemplate: batch.JobTemplateSpec{
+					Spec: batch.JobSpec{
+						BackoffLimitPerIndex: &negative,
+						Template:             validPodTemplateSpec,
+					},
+				},
+			},
+		},
+		"spec.jobTemplate.spec.maxFailedIndexes:must be greater than or equal to 0": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mycronjob",
+				Namespace: metav1.NamespaceDefault,
+				UID:       types.UID("1a2b3c"),
+			},
+			Spec: batch.CronJobSpec{
+				Schedule:          "* * * * ?",
+				ConcurrencyPolicy: batch.AllowConcurrent,
+				JobTemplate: batch.JobTemplateSpec{
+					Spec: batch.JobSpec{
+						MaxFailedIndexes: &negative,
+						Template:         validPodTemplateSpec,
+					},
+				},
+			},
+		},
 	}
 
 	for k, v := range errorCases {

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -247,6 +247,8 @@ message JobSpec {
   // i.e. when the work left to do is less than max parallelism.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
   // +optional
+  // +k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
   optional int32 parallelism = 1;
 
   // Specifies the desired number of successfully finished pods the
@@ -256,6 +258,8 @@ message JobSpec {
   // pod signals the success of the job.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
   // +optional
+  // +k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
   optional int32 completions = 2;
 
   // Specifies the duration in seconds relative to the startTime that the job
@@ -264,6 +268,8 @@ message JobSpec {
   // update), this timer will effectively be stopped and reset when the Job is
   // resumed again.
   // +optional
+  // +k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
   optional int64 activeDeadlineSeconds = 3;
 
   // Specifies the policy of handling failed pods. In particular, it allows to
@@ -290,6 +296,8 @@ message JobSpec {
   // Defaults to 6, unless backoffLimitPerIndex (only Indexed Job) is specified.
   // When backoffLimitPerIndex is specified, backoffLimit defaults to 2147483647.
   // +optional
+  // +k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
   optional int32 backoffLimit = 7;
 
   // Specifies the limit for the number of retries within an
@@ -299,6 +307,8 @@ message JobSpec {
   // be set when Job's completionMode=Indexed, and the Pod's restart
   // policy is Never. The field is immutable.
   // +optional
+  // +k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
   optional int32 backoffLimitPerIndex = 12;
 
   // Specifies the maximal number of failed indexes before marking the Job as
@@ -311,6 +321,7 @@ message JobSpec {
   // less than or equal to 10^4 when is completions greater than 10^5.
   // +optional
   // +k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
   // +k8s:alpha(since: "1.37")=+k8s:dependentRequired("backoffLimitPerIndex")
   optional int32 maxFailedIndexes = 13;
 
@@ -346,6 +357,8 @@ message JobSpec {
   // the Job won't be automatically deleted. If this field is set to zero,
   // the Job becomes eligible to be deleted immediately after it finishes.
   // +optional
+  // +k8s:optional
+  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
   optional int32 ttlSecondsAfterFinished = 8;
 
   // completionMode specifies how Pod completions are tracked. It can be

--- a/staging/src/k8s.io/api/batch/v1/generated.proto
+++ b/staging/src/k8s.io/api/batch/v1/generated.proto
@@ -248,7 +248,7 @@ message JobSpec {
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
   // +optional
   // +k8s:optional
-  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
+  // +k8s:alpha(since: "1.38")=+k8s:minimum=0
   optional int32 parallelism = 1;
 
   // Specifies the desired number of successfully finished pods the
@@ -259,7 +259,7 @@ message JobSpec {
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
   // +optional
   // +k8s:optional
-  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
+  // +k8s:alpha(since: "1.38")=+k8s:minimum=0
   optional int32 completions = 2;
 
   // Specifies the duration in seconds relative to the startTime that the job
@@ -269,7 +269,7 @@ message JobSpec {
   // resumed again.
   // +optional
   // +k8s:optional
-  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
+  // +k8s:alpha(since: "1.38")=+k8s:minimum=0
   optional int64 activeDeadlineSeconds = 3;
 
   // Specifies the policy of handling failed pods. In particular, it allows to
@@ -297,7 +297,7 @@ message JobSpec {
   // When backoffLimitPerIndex is specified, backoffLimit defaults to 2147483647.
   // +optional
   // +k8s:optional
-  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
+  // +k8s:alpha(since: "1.38")=+k8s:minimum=0
   optional int32 backoffLimit = 7;
 
   // Specifies the limit for the number of retries within an
@@ -308,7 +308,7 @@ message JobSpec {
   // policy is Never. The field is immutable.
   // +optional
   // +k8s:optional
-  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
+  // +k8s:alpha(since: "1.38")=+k8s:minimum=0
   optional int32 backoffLimitPerIndex = 12;
 
   // Specifies the maximal number of failed indexes before marking the Job as
@@ -321,7 +321,7 @@ message JobSpec {
   // less than or equal to 10^4 when is completions greater than 10^5.
   // +optional
   // +k8s:optional
-  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
+  // +k8s:alpha(since: "1.38")=+k8s:minimum=0
   // +k8s:alpha(since: "1.37")=+k8s:dependentRequired("backoffLimitPerIndex")
   optional int32 maxFailedIndexes = 13;
 
@@ -358,7 +358,7 @@ message JobSpec {
   // the Job becomes eligible to be deleted immediately after it finishes.
   // +optional
   // +k8s:optional
-  // +k8s:alpha(since: "1.37")=+k8s:minimum=0
+  // +k8s:alpha(since: "1.38")=+k8s:minimum=0
   optional int32 ttlSecondsAfterFinished = 8;
 
   // completionMode specifies how Pod completions are tracked. It can be

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -310,6 +310,8 @@ type JobSpec struct {
 	// i.e. when the work left to do is less than max parallelism.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
 	// +optional
+	// +k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
 	Parallelism *int32 `json:"parallelism,omitempty" protobuf:"varint,1,opt,name=parallelism"`
 
 	// Specifies the desired number of successfully finished pods the
@@ -319,6 +321,8 @@ type JobSpec struct {
 	// pod signals the success of the job.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
 	// +optional
+	// +k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
 	Completions *int32 `json:"completions,omitempty" protobuf:"varint,2,opt,name=completions"`
 
 	// Specifies the duration in seconds relative to the startTime that the job
@@ -327,6 +331,8 @@ type JobSpec struct {
 	// update), this timer will effectively be stopped and reset when the Job is
 	// resumed again.
 	// +optional
+	// +k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
 	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty" protobuf:"varint,3,opt,name=activeDeadlineSeconds"`
 
 	// Specifies the policy of handling failed pods. In particular, it allows to
@@ -353,6 +359,8 @@ type JobSpec struct {
 	// Defaults to 6, unless backoffLimitPerIndex (only Indexed Job) is specified.
 	// When backoffLimitPerIndex is specified, backoffLimit defaults to 2147483647.
 	// +optional
+	// +k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
 	BackoffLimit *int32 `json:"backoffLimit,omitempty" protobuf:"varint,7,opt,name=backoffLimit"`
 
 	// Specifies the limit for the number of retries within an
@@ -362,6 +370,8 @@ type JobSpec struct {
 	// be set when Job's completionMode=Indexed, and the Pod's restart
 	// policy is Never. The field is immutable.
 	// +optional
+	// +k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
 	BackoffLimitPerIndex *int32 `json:"backoffLimitPerIndex,omitempty" protobuf:"varint,12,opt,name=backoffLimitPerIndex"`
 
 	// Specifies the maximal number of failed indexes before marking the Job as
@@ -374,6 +384,7 @@ type JobSpec struct {
 	// less than or equal to 10^4 when is completions greater than 10^5.
 	// +optional
 	// +k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
 	// +k8s:alpha(since: "1.37")=+k8s:dependentRequired("backoffLimitPerIndex")
 	MaxFailedIndexes *int32 `json:"maxFailedIndexes,omitempty" protobuf:"varint,13,opt,name=maxFailedIndexes"`
 
@@ -414,6 +425,8 @@ type JobSpec struct {
 	// the Job won't be automatically deleted. If this field is set to zero,
 	// the Job becomes eligible to be deleted immediately after it finishes.
 	// +optional
+	// +k8s:optional
+	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty" protobuf:"varint,8,opt,name=ttlSecondsAfterFinished"`
 
 	// completionMode specifies how Pod completions are tracked. It can be

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -311,7 +311,7 @@ type JobSpec struct {
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
 	// +optional
 	// +k8s:optional
-	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
+	// +k8s:alpha(since: "1.38")=+k8s:minimum=0
 	Parallelism *int32 `json:"parallelism,omitempty" protobuf:"varint,1,opt,name=parallelism"`
 
 	// Specifies the desired number of successfully finished pods the
@@ -322,7 +322,7 @@ type JobSpec struct {
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
 	// +optional
 	// +k8s:optional
-	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
+	// +k8s:alpha(since: "1.38")=+k8s:minimum=0
 	Completions *int32 `json:"completions,omitempty" protobuf:"varint,2,opt,name=completions"`
 
 	// Specifies the duration in seconds relative to the startTime that the job
@@ -332,7 +332,7 @@ type JobSpec struct {
 	// resumed again.
 	// +optional
 	// +k8s:optional
-	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
+	// +k8s:alpha(since: "1.38")=+k8s:minimum=0
 	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty" protobuf:"varint,3,opt,name=activeDeadlineSeconds"`
 
 	// Specifies the policy of handling failed pods. In particular, it allows to
@@ -360,7 +360,7 @@ type JobSpec struct {
 	// When backoffLimitPerIndex is specified, backoffLimit defaults to 2147483647.
 	// +optional
 	// +k8s:optional
-	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
+	// +k8s:alpha(since: "1.38")=+k8s:minimum=0
 	BackoffLimit *int32 `json:"backoffLimit,omitempty" protobuf:"varint,7,opt,name=backoffLimit"`
 
 	// Specifies the limit for the number of retries within an
@@ -371,7 +371,7 @@ type JobSpec struct {
 	// policy is Never. The field is immutable.
 	// +optional
 	// +k8s:optional
-	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
+	// +k8s:alpha(since: "1.38")=+k8s:minimum=0
 	BackoffLimitPerIndex *int32 `json:"backoffLimitPerIndex,omitempty" protobuf:"varint,12,opt,name=backoffLimitPerIndex"`
 
 	// Specifies the maximal number of failed indexes before marking the Job as
@@ -384,7 +384,7 @@ type JobSpec struct {
 	// less than or equal to 10^4 when is completions greater than 10^5.
 	// +optional
 	// +k8s:optional
-	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
+	// +k8s:alpha(since: "1.38")=+k8s:minimum=0
 	// +k8s:alpha(since: "1.37")=+k8s:dependentRequired("backoffLimitPerIndex")
 	MaxFailedIndexes *int32 `json:"maxFailedIndexes,omitempty" protobuf:"varint,13,opt,name=maxFailedIndexes"`
 
@@ -426,7 +426,7 @@ type JobSpec struct {
 	// the Job becomes eligible to be deleted immediately after it finishes.
 	// +optional
 	// +k8s:optional
-	// +k8s:alpha(since: "1.37")=+k8s:minimum=0
+	// +k8s:alpha(since: "1.38")=+k8s:minimum=0
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty" protobuf:"varint,8,opt,name=ttlSecondsAfterFinished"`
 
 	// completionMode specifies how Pod completions are tracked. It can be

--- a/test/declarative_validation/batch/cronjob/declarative_validation_test.go
+++ b/test/declarative_validation/batch/cronjob/declarative_validation_test.go
@@ -79,6 +79,51 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				tweakJobTemplateBackoffLimitPerIndex(ptr.To[int32](1)),
 			),
 		},
+		"jobTemplate.spec.parallelism negative": {
+			input: mkCronJob(tweakJobTemplateParallelism(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "jobTemplate", "spec", "parallelism"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"jobTemplate.spec.completions negative": {
+			input: mkCronJob(tweakJobTemplateCompletions(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "jobTemplate", "spec", "completions"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"jobTemplate.spec.activeDeadlineSeconds negative": {
+			input: mkCronJob(tweakJobTemplateActiveDeadlineSeconds(ptr.To[int64](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "jobTemplate", "spec", "activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"jobTemplate.spec.backoffLimit negative": {
+			input: mkCronJob(tweakJobTemplateBackoffLimit(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "jobTemplate", "spec", "backoffLimit"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"jobTemplate.spec.backoffLimitPerIndex negative": {
+			input: mkCronJob(tweakJobTemplateBackoffLimitPerIndex(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "jobTemplate", "spec", "backoffLimitPerIndex"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"jobTemplate.spec.maxFailedIndexes negative": {
+			input: mkCronJob(
+				tweakJobTemplateBackoffLimitPerIndex(ptr.To[int32](1)),
+				tweakJobTemplateMaxFailedIndexes(ptr.To[int32](-1)),
+			),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "jobTemplate", "spec", "maxFailedIndexes"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"jobTemplate.spec.ttlSecondsAfterFinished negative": {
+			input: mkCronJob(tweakJobTemplateTTLSecondsAfterFinished(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "jobTemplate", "spec", "ttlSecondsAfterFinished"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
 		"valid with basic scheduling policy": {
 			input:                 mkCronJob(tweakJobSchedulingBasic()),
 			enableWorkloadWithJob: true,
@@ -560,9 +605,39 @@ func tweakSchedule(schedule string) func(*batch.CronJob) {
 	}
 }
 
+func tweakJobTemplateParallelism(v *int32) func(*batch.CronJob) {
+	return func(job *batch.CronJob) {
+		job.Spec.JobTemplate.Spec.Parallelism = v
+	}
+}
+
+func tweakJobTemplateCompletions(v *int32) func(*batch.CronJob) {
+	return func(job *batch.CronJob) {
+		job.Spec.JobTemplate.Spec.Completions = v
+	}
+}
+
+func tweakJobTemplateActiveDeadlineSeconds(v *int64) func(*batch.CronJob) {
+	return func(job *batch.CronJob) {
+		job.Spec.JobTemplate.Spec.ActiveDeadlineSeconds = v
+	}
+}
+
+func tweakJobTemplateBackoffLimit(v *int32) func(*batch.CronJob) {
+	return func(job *batch.CronJob) {
+		job.Spec.JobTemplate.Spec.BackoffLimit = v
+	}
+}
+
 func tweakJobTemplateMaxFailedIndexes(v *int32) func(*batch.CronJob) {
 	return func(job *batch.CronJob) {
 		job.Spec.JobTemplate.Spec.MaxFailedIndexes = v
+	}
+}
+
+func tweakJobTemplateTTLSecondsAfterFinished(v *int32) func(*batch.CronJob) {
+	return func(job *batch.CronJob) {
+		job.Spec.JobTemplate.Spec.TTLSecondsAfterFinished = v
 	}
 }
 

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1_test.go
@@ -61,8 +61,24 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.jobTemplate.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
+			"spec.jobTemplate.spec.backoffLimit": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.jobTemplate.spec.backoffLimitPerIndex": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 				{ErrorType: "FieldValueRequired", Origin: "dependentRequired"},
+			},
+			"spec.jobTemplate.spec.completions": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
+			"spec.jobTemplate.spec.maxFailedIndexes": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
+			"spec.jobTemplate.spec.parallelism": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
 			"spec.jobTemplate.spec.scheduling": {
 				{ErrorType: "FieldValueForbidden"},
@@ -127,6 +143,9 @@ func init() {
 			},
 			"spec.jobTemplate.spec.template.spec.tolerations[*].key": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"spec.jobTemplate.spec.ttlSecondsAfterFinished": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
 			"spec.schedule": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/batch/cronjob/zz_generated.validations.v1beta1_test.go
@@ -61,8 +61,24 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.jobTemplate.spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
+			"spec.jobTemplate.spec.backoffLimit": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.jobTemplate.spec.backoffLimitPerIndex": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 				{ErrorType: "FieldValueRequired", Origin: "dependentRequired"},
+			},
+			"spec.jobTemplate.spec.completions": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
+			"spec.jobTemplate.spec.maxFailedIndexes": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
+			"spec.jobTemplate.spec.parallelism": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
 			"spec.jobTemplate.spec.scheduling": {
 				{ErrorType: "FieldValueForbidden"},
@@ -127,6 +143,9 @@ func init() {
 			},
 			"spec.jobTemplate.spec.template.spec.tolerations[*].key": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"spec.jobTemplate.spec.ttlSecondsAfterFinished": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
 			"spec.schedule": {
 				{ErrorType: "FieldValueRequired"},

--- a/test/declarative_validation/batch/job/declarative_validation_test.go
+++ b/test/declarative_validation/batch/job/declarative_validation_test.go
@@ -73,6 +73,48 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				field.Required(field.NewPath("spec", "backoffLimitPerIndex"), "").WithOrigin("dependentRequired").MarkAlpha(),
 			},
 		},
+		"negative parallelism": {
+			input: mkJob(tweakParallelism(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "parallelism"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"negative completions": {
+			input: mkJob(tweakCompletions(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "completions"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"negative activeDeadlineSeconds": {
+			input: mkJob(tweakActiveDeadlineSeconds(ptr.To[int64](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "activeDeadlineSeconds"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"negative backoffLimit": {
+			input: mkJob(tweakBackoffLimit(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "backoffLimit"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"negative backoffLimitPerIndex": {
+			input: mkJob(tweakBackoffLimitPerIndex(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "backoffLimitPerIndex"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"negative maxFailedIndexes": {
+			input: mkJob(tweakBackoffLimitPerIndex(ptr.To[int32](1)), tweakMaxFailedIndexes(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "maxFailedIndexes"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"negative ttlSecondsAfterFinished": {
+			input: mkJob(tweakTTLSecondsAfterFinished(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "ttlSecondsAfterFinished"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
 		"valid with basic scheduling policy": {
 			input:                 mkJob(setBasicPolicy()),
 			enableWorkloadWithJob: true,
@@ -294,6 +336,20 @@ func testDeclarativeValidateUpdate(t *testing.T, apiVersion string) {
 			enableWorkloadWithJob: true,
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "scheduling", "schedulingPolicy", "gang", "minCount"), nil, "").WithOrigin("minimum"),
+			},
+		},
+		"updating parallelism to negative": {
+			old:    mkJob(setResourceVersion("1"), tweakParallelism(ptr.To[int32](5))),
+			update: mkJob(setResourceVersion("1"), tweakParallelism(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "parallelism"), nil, "").WithOrigin("minimum").MarkAlpha(),
+			},
+		},
+		"updating backoffLimit to negative": {
+			old:    mkJob(setResourceVersion("1"), tweakBackoffLimit(ptr.To[int32](3))),
+			update: mkJob(setResourceVersion("1"), tweakBackoffLimit(ptr.To[int32](-1))),
+			expectedErrs: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "backoffLimit"), nil, "").WithOrigin("minimum").MarkAlpha(),
 			},
 		},
 		"adding scheduling after creation is immutable": {
@@ -546,6 +602,36 @@ func addResourceClaims(claims ...schedulingv1alpha3.WorkloadPodGroupResourceClai
 			setGangPolicy(4)(job)
 		}
 		job.Spec.Scheduling.ResourceClaims = append(job.Spec.Scheduling.ResourceClaims, claims...)
+	}
+}
+
+func tweakParallelism(v *int32) func(*batch.Job) {
+	return func(job *batch.Job) {
+		job.Spec.Parallelism = v
+	}
+}
+
+func tweakCompletions(v *int32) func(*batch.Job) {
+	return func(job *batch.Job) {
+		job.Spec.Completions = v
+	}
+}
+
+func tweakActiveDeadlineSeconds(v *int64) func(*batch.Job) {
+	return func(job *batch.Job) {
+		job.Spec.ActiveDeadlineSeconds = v
+	}
+}
+
+func tweakBackoffLimit(v *int32) func(*batch.Job) {
+	return func(job *batch.Job) {
+		job.Spec.BackoffLimit = v
+	}
+}
+
+func tweakTTLSecondsAfterFinished(v *int32) func(*batch.Job) {
+	return func(job *batch.Job) {
+		job.Spec.TTLSecondsAfterFinished = v
 	}
 }
 

--- a/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/batch/job/zz_generated.validations.v1_test.go
@@ -61,8 +61,24 @@ func init() {
 			"metadata.uid": {
 				{ErrorType: "FieldValueInvalid", Origin: "immutable"},
 			},
+			"spec.activeDeadlineSeconds": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
+			"spec.backoffLimit": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
 			"spec.backoffLimitPerIndex": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 				{ErrorType: "FieldValueRequired", Origin: "dependentRequired"},
+			},
+			"spec.completions": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
+			"spec.maxFailedIndexes": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
+			},
+			"spec.parallelism": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
 			"spec.scheduling": {
 				{ErrorType: "FieldValueForbidden"},
@@ -127,6 +143,9 @@ func init() {
 			},
 			"spec.template.spec.tolerations[*].key": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-label-key"},
+			},
+			"spec.ttlSecondsAfterFinished": {
+				{ErrorType: "FieldValueInvalid", Origin: "minimum"},
 			},
 		},
 	)


### PR DESCRIPTION
#### What this PR does / why we need it

Part of the declarative validation migration. This migrates the seven non-negative field checks in `JobSpec` to declarative validation:

- `spec.parallelism`
- `spec.completions`
- `spec.activeDeadlineSeconds`
- `spec.backoffLimit`
- `spec.backoffLimitPerIndex`
- `spec.maxFailedIndexes`
- `spec.ttlSecondsAfterFinished`

The rules are added as `+k8s:alpha(since: "1.37")=+k8s:minimum=0` tags (with `+k8s:optional` requiredness markers) in `staging/src/k8s.io/api/batch/v1/types.go`, and the corresponding imperative `ValidateNonnegativeField` calls in `validateJobSpec` are marked with `MarkCoveredByDeclarative` so the cross-check keeps both sides in sync. The imperative and declarative errors are identical in type, origin (`minimum`) and message (`must be greater than or equal to 0`).

#### Special notes for your reviewer

- `CronJob` embeds `JobSpec` in `spec.jobTemplate`, so the generated rules apply there too. The imperative path already shares `validateJobSpec` via `ValidateJobTemplateSpec`, so behavior is unchanged; I only added the negative-value equivalence test cases the coverage harness requires for the CronJob path.
- Test-only additions besides the tags: create and update cases in `test/declarative_validation/batch/job` and create cases in `test/declarative_validation/batch/cronjob`.
- Verified locally: `pkg/apis/batch/...`, `pkg/registry/batch/...` and `test/declarative_validation/batch/...` all pass, and a second `hack/update-codegen.sh` run produces no further diff.

#### Does this PR introduce a user-facing change?

NONE

/kind cleanup
/sig apps