### PR TITLE
Automated cherry pick of #141489: [kube-proxy/winkernel] Guard against load balancers without port mappings

### DIFF
--- a/pkg/proxy/winkernel/hns.go
+++ b/pkg/proxy/winkernel/hns.go
@@ -400,8 +400,14 @@ func (hns hns) getAllLoadBalancers() (map[loadBalancerIdentifier]*loadBalancerIn
 	}
 	loadBalancers := make(map[loadBalancerIdentifier]*(loadBalancerInfo))
 	for _, lb := range lbs {
-		isIPv6 := (lb.Flags & LoadBalancerFlagsIPv6) == LoadBalancerFlagsIPv6
+		// PortMappings is populated by HNS and can be empty, for example when a load
+		// balancer is partially created. Such an entry cannot be keyed by port.
+		if len(lb.PortMappings) == 0 {
+			klog.V(2).InfoS("Skipping load balancer with no port mappings", "hnsLbID", lb.Id)
+			continue
+		}
 		portMap := lb.PortMappings[0]
+		isIPv6 := (lb.Flags & LoadBalancerFlagsIPv6) == LoadBalancerFlagsIPv6
 		// Compute hash from backends (endpoint IDs)
 		hash, err := hashEndpoints(lb.HostComputeEndpoints)
 		if err != nil {

--- a/pkg/proxy/winkernel/hns_test.go
+++ b/pkg/proxy/winkernel/hns_test.go
@@ -989,6 +989,56 @@ func TestCreateOrReplaceLoadbalancer_FileAlreadyExistsNoMatchingLB(t *testing.T)
 	assert.Nil(t, lb)
 }
 
+func TestGetAllLoadBalancers_SkipsLoadBalancersWithoutPortMappings(t *testing.T) {
+	testCases := []struct {
+		name         string
+		portMappings []hcn.LoadBalancerPortMapping
+	}{
+		{
+			name:         "nil port mappings",
+			portMappings: nil,
+		},
+		{
+			name:         "empty port mappings",
+			portMappings: []hcn.LoadBalancerPortMapping{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcnMock := getHcnMock("L2Bridge")
+			hns := hns{hcn: hcnMock}
+
+			hcnMock.PopulateRawQueriedLoadbalancer(&hcn.HostComputeLoadBalancer{
+				Id:           "LBID-malformed",
+				FrontendVIPs: []string{serviceVip},
+				PortMappings: tc.portMappings,
+			})
+			hcnMock.PopulateQueriedLoadbalancers("LBID-valid", serviceVip, protocol, internalPort, externalPort, false, "EPID-1")
+
+			loadBalancers, err := hns.getAllLoadBalancers()
+			assert.NoError(t, err)
+
+			hnsIDs := make([]string, 0, len(loadBalancers))
+			for _, lb := range loadBalancers {
+				hnsIDs = append(hnsIDs, lb.hnsID)
+			}
+			assert.ElementsMatch(t, []string{"LBID-valid"}, hnsIDs)
+		})
+	}
+}
+
+func TestGetAllLoadBalancers_AllLoadBalancersWithoutPortMappings(t *testing.T) {
+	hcnMock := getHcnMock("L2Bridge")
+	hns := hns{hcn: hcnMock}
+
+	hcnMock.PopulateRawQueriedLoadbalancer(&hcn.HostComputeLoadBalancer{Id: "LBID-malformed"})
+
+	loadBalancers, err := hns.getAllLoadBalancers()
+	assert.NoError(t, err)
+	assert.Empty(t, loadBalancers)
+}
+
 func TestDeleteLoadBalancer_NotFound(t *testing.T) {
 	hcnMock := getHcnMock("L2Bridge")
 	hns := hns{hcn: hcnMock}

--- a/pkg/proxy/winkernel/testing/hcnutils_mock.go
+++ b/pkg/proxy/winkernel/testing/hcnutils_mock.go
@@ -126,6 +126,12 @@ func (hcnObj HcnMock) PopulateQueriedLoadbalancers(lbID, vip string, protocol ui
 	loadbalancerMap[lbID] = lb
 }
 
+// PopulateRawQueriedLoadbalancer injects a load balancer into the mocked HNS state verbatim,
+// bypassing the validation CreateLoadBalancer performs.
+func (hcnObj HcnMock) PopulateRawQueriedLoadbalancer(lb *hcn.HostComputeLoadBalancer) {
+	loadbalancerMap[lb.Id] = lb
+}
+
 func (hcnObj HcnMock) GetNetworkByName(networkName string) (*hcn.HostComputeNetwork, error) {
 	return hcnObj.network, nil
 }


### PR DESCRIPTION
Cherry pick of #141489 on release-1.37.

#141489: [kube-proxy/winkernel] Guard against load balancers without port mappings

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Fixed a panic in the Windows kube-proxy (winkernel) that could terminate kube-proxy when
an HNS load balancer without port mappings was enumerated.
```