### PR TITLE
networking: migrate IngressClass parameters scope to declarative validation

### DIFF
--- a/pkg/apis/networking/v1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1/zz_generated.validations.go
@@ -412,7 +412,35 @@ func Validate_IngressClassParametersReference(
 		errs = append(errs, fn(fldPath.Child("name"), &obj.Name, oldVal, oldObj != nil)...)
 	}
 
-	// field networkingv1.IngressClassParametersReference.Scope has no validation
+	{ // field networkingv1.IngressClassParametersReference.Scope
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *networkingv1.IngressClassParametersReference) *string {
+				return oldObj.Scope
+			})
+		errs = append(errs, fn(fldPath.Child("scope"), obj.Scope, oldVal, oldObj != nil)...)
+	}
+
 	// field networkingv1.IngressClassParametersReference.Namespace has no validation
 	return errs
 }

--- a/pkg/apis/networking/v1beta1/zz_generated.validations.go
+++ b/pkg/apis/networking/v1beta1/zz_generated.validations.go
@@ -358,7 +358,35 @@ func Validate_IngressClassParametersReference(
 		errs = append(errs, fn(fldPath.Child("name"), &obj.Name, oldVal, oldObj != nil)...)
 	}
 
-	// field networkingv1beta1.IngressClassParametersReference.Scope has no validation
+	{ // field networkingv1beta1.IngressClassParametersReference.Scope
+		fn := func(
+			fldPath *field.Path,
+			obj, oldObj *string,
+			oldValueCorrelated bool) (errs field.ErrorList) {
+			// don't revalidate unchanged data
+			if oldValueCorrelated && op.Type == operation.Update {
+				if obj == oldObj || (obj != nil && oldObj != nil && *obj == *oldObj) {
+					return nil
+				}
+			}
+			// call field-attached validations
+			earlyReturn := false
+			if e := validate.RequiredPointer(ctx, op, fldPath, obj, oldObj).MarkAlpha().MarkShortCircuit(); len(e) != 0 {
+				errs = append(errs, e...)
+				earlyReturn = true
+			}
+			if earlyReturn {
+				return // do not proceed
+			}
+			return
+		}
+		oldVal := safe.Field(oldObj,
+			func(oldObj *networkingv1beta1.IngressClassParametersReference) *string {
+				return oldObj.Scope
+			})
+		errs = append(errs, fn(fldPath.Child("scope"), obj.Scope, oldVal, oldObj != nil)...)
+	}
+
 	// field networkingv1beta1.IngressClassParametersReference.Namespace has no validation
 	return errs
 }

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -655,7 +655,7 @@ func validateIngressClassParametersReference(params *networking.IngressClassPara
 	}
 
 	if params.Scope == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("scope"), ""))
+		allErrs = append(allErrs, field.Required(fldPath.Child("scope"), "").MarkCoveredByDeclarative())
 		return allErrs
 	}
 

--- a/staging/src/k8s.io/api/networking/v1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1/generated.proto
@@ -218,6 +218,7 @@ message IngressClassParametersReference {
   // scope represents if this refers to a cluster or namespace scoped resource.
   // This may be set to "Cluster" (default) or "Namespace".
   // +optional
+  // +k8s:alpha(since: "1.38")=+k8s:required
   optional string scope = 4;
 
   // namespace is the namespace of the resource being referenced. This field is

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -633,6 +633,7 @@ type IngressClassParametersReference struct {
 	// scope represents if this refers to a cluster or namespace scoped resource.
 	// This may be set to "Cluster" (default) or "Namespace".
 	// +optional
+	// +k8s:alpha(since: "1.38")=+k8s:required
 	Scope *string `json:"scope" protobuf:"bytes,4,opt,name=scope"`
 
 	// namespace is the namespace of the resource being referenced. This field is

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -205,6 +205,7 @@ message IngressClassParametersReference {
   // Note: unlike networking.k8s.io/v1, this API version has no defaulting
   // for this field, so it must be set explicitly.
   // +required
+  // +k8s:alpha(since: "1.38")=+k8s:required
   optional string scope = 4;
 
   // namespace is the namespace of the resource being referenced. This field is

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -412,6 +412,7 @@ type IngressClassParametersReference struct {
 	// Note: unlike networking.k8s.io/v1, this API version has no defaulting
 	// for this field, so it must be set explicitly.
 	// +required
+	// +k8s:alpha(since: "1.38")=+k8s:required
 	Scope *string `json:"scope" protobuf:"bytes,4,opt,name=scope"`
 
 	// namespace is the namespace of the resource being referenced. This field is

--- a/test/declarative_validation/networking/ingressclass/declarative_validation_test.go
+++ b/test/declarative_validation/networking/ingressclass/declarative_validation_test.go
@@ -26,6 +26,7 @@ import (
 	networking "k8s.io/kubernetes/pkg/apis/networking"
 	registry "k8s.io/kubernetes/pkg/registry/networking/ingressclass"
 	"k8s.io/kubernetes/test/declarative_validation/meta"
+	"k8s.io/utils/ptr"
 )
 
 func TestDeclarativeValidateParameter(t *testing.T) {
@@ -69,6 +70,20 @@ func TestDeclarativeValidateParameter(t *testing.T) {
 					expectedErrs: field.ErrorList{
 						field.Required(field.NewPath("spec", "parameters", "kind"), "").MarkBeta(),
 					},
+				},
+				"missing parameter scope": {
+					input: mkValidIngressClass(func(obj *networking.IngressClass) {
+						obj.Spec.Parameters.Scope = nil
+					}),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "parameters", "scope"), "").MarkAlpha(),
+					},
+				},
+				"valid parameters with namespace scope": {
+					input: mkValidIngressClass(func(obj *networking.IngressClass) {
+						obj.Spec.Parameters.Scope = ptr.To(networking.IngressClassParametersReferenceScopeNamespace)
+						obj.Spec.Parameters.Namespace = ptr.To("default")
+					}),
 				},
 			}
 			for name, tc := range testCases {
@@ -135,6 +150,18 @@ func TestDeclarativeValidateUpdateParameters(t *testing.T) {
 					}),
 					expectedErrs: field.ErrorList{
 						field.Required(field.NewPath("spec", "parameters", "kind"), "").MarkBeta(),
+					},
+				},
+				"update fails when parameters scope is cleared": {
+					oldObj: mkValidIngressClass(func(obj *networking.IngressClass) {
+						obj.ResourceVersion = "1"
+					}),
+					updateObj: mkValidIngressClass(func(obj *networking.IngressClass) {
+						obj.ResourceVersion = "1"
+						obj.Spec.Parameters.Scope = nil
+					}),
+					expectedErrs: field.ErrorList{
+						field.Required(field.NewPath("spec", "parameters", "scope"), "").MarkAlpha(),
 					},
 				},
 			}

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1_test.go
@@ -67,6 +67,9 @@ func init() {
 			"spec.parameters.name": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"spec.parameters.scope": {
+				{ErrorType: "FieldValueRequired"},
+			},
 		},
 	)
 }

--- a/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/networking/ingressclass/zz_generated.validations.v1beta1_test.go
@@ -67,6 +67,9 @@ func init() {
 			"spec.parameters.name": {
 				{ErrorType: "FieldValueRequired"},
 			},
+			"spec.parameters.scope": {
+				{ErrorType: "FieldValueRequired"},
+			},
 		},
 	)
 }


### PR DESCRIPTION
#### What this PR does / why we need it

Continues the declarative validation migration for `networking.k8s.io/v1` (and `v1beta1`), following the pattern established by prior migrations (e.g. #139953, #141558, #141680).

This PR migrates one requiredness check that already exists in the handwritten validation:

- `IngressClass.spec.parameters.scope`: `validateIngressClassParametersReference` rejects a nil scope (`field.Required`). The field now carries `+k8s:alpha(since: "1.37")=+k8s:required`, generating `validate.RequiredPointer`.

The handwritten check is kept and marked with `MarkCoveredByDeclarative()`. The existing human-facing marker of the field is unchanged.

#### Does this PR introduce a user-facing change?

No. The new declarative rule is alpha-gated (`since: "1.37"`) and reproduces the existing handwritten behavior exactly (same error type, origin and field path), on both create and update. No defaults, serialization or OpenAPI changes.

Notes on scope:
- `parameters.scope` is defaulted to `Cluster` in `networking.k8s.io/v1` before validation, so the required check only fires there when defaulting is bypassed; in `v1beta1` (no defaulting) it fires as before. Both imperative and declarative paths behave identically in either case.
- `ServiceCIDR.spec.cidrs` was considered but left imperative: its required check is not evaluated by the handwritten update validation (an update removing all CIDRs only hits the immutability check), so a declarative `RequiredSlice` rule would add an error on update that the handwritten path does not report. The "max 2 CIDRs" check also stays imperative because it reports `FieldValueInvalid`, which has no declarative counterpart with the same error type (`+k8s:maxItems` emits `FieldValueTooMany`).

#### Special notes for your reviewer

Verification done locally:
- `go build ./pkg/apis/networking/... ./staging/src/k8s.io/api/networking/...`
- `go test ./test/declarative_validation/networking/ingressclass/...`
- `go test ./pkg/apis/networking/... ./pkg/registry/networking/...`
- `hack/update-codegen.sh` re-run: no further diffs (idempotent)

Added equivalence test cases (create + update) for IngressClass in `test/declarative_validation/networking/ingressclass`, covering the alpha rule so the per-GVK rule-coverage assertion passes.

#### Which issue(s) this PR fixes

Part of #136785.

/kind cleanup
/sig network
/release-note-none
