### PR TITLE
[WIP] client-go: experimental low-memory informer cache store (bytecache)

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/bytecache/arena.go
+++ b/staging/src/k8s.io/client-go/tools/cache/bytecache/arena.go
@@ -1,0 +1,115 @@
+//go:build linux && amd64 && !race
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package bytecache is a prototype of an informer-style object cache that
+// stores objects as serialized bytes in an mmap-ed file instead of as live
+// Go objects on the heap.
+//
+// The file is mapped twice with MAP_SHARED:
+//   - rw: PROT_READ|PROT_WRITE — only the store's write path touches this.
+//   - ro: PROT_READ — everything handed out to readers aliases this mapping,
+//     so a stray write is a hardware fault, not silent corruption.
+//
+// Because both mappings are MAP_SHARED views of the same file, they are backed
+// by the same physical pages in the page cache: a write through rw is
+// immediately visible through ro, and the kernel may write pages back to the
+// file and evict them under memory pressure (no swap required — the file
+// itself is the backing store).
+package bytecache
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Arena is an append-only allocator over a twice-mapped file.
+type Arena struct {
+	f   *os.File
+	rw  []byte // PROT_READ|PROT_WRITE MAP_SHARED
+	ro  []byte // PROT_READ MAP_SHARED — same pages as rw
+	off int
+}
+
+func NewArena(path string, size int) (*Arena, error) {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	// Sparse file: pages are allocated lazily as we write.
+	if err := f.Truncate(int64(size)); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	rw, err := syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_SHARED)
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("rw mmap: %w", err)
+	}
+	ro, err := syscall.Mmap(int(f.Fd()), 0, size, syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		_ = syscall.Munmap(rw)
+		_ = f.Close()
+		return nil, fmt.Errorf("ro mmap: %w", err)
+	}
+	return &Arena{f: f, rw: rw, ro: ro}, nil
+}
+
+// Bump reserves size bytes at the given alignment and returns the offset.
+func (a *Arena) Bump(size, align int) (int, error) {
+	off := (a.off + align - 1) &^ (align - 1)
+	if off+size > len(a.rw) {
+		return 0, fmt.Errorf("arena full (%d used of %d)", a.off, len(a.rw))
+	}
+	a.off = off + size
+	return off, nil
+}
+
+// Reset discards all allocations (benchmark convenience; a real store needs
+// compaction instead).
+func (a *Arena) Reset() { a.off = 0 }
+
+// Alloc copies b into the arena and returns its offset.
+// Append-only: updates write a new copy; reclaiming dead space is a
+// compaction problem left out of the prototype.
+func (a *Arena) Alloc(b []byte) (int, error) {
+	if a.off+len(b) > len(a.rw) {
+		return 0, fmt.Errorf("arena full (%d used of %d)", a.off, len(a.rw))
+	}
+	off := a.off
+	copy(a.rw[off:], b)
+	a.off += len(b)
+	return off, nil
+}
+
+// ReadOnly returns a slice aliasing the read-only mapping. Writing through the
+// result is a segfault by construction.
+func (a *Arena) ReadOnly(off, n int) []byte {
+	return a.ro[off : off+n : off+n]
+}
+
+func (a *Arena) Used() int { return a.off }
+
+func (a *Arena) Close() error {
+	_ = syscall.Munmap(a.ro)
+	_ = syscall.Munmap(a.rw)
+	name := a.f.Name()
+	_ = a.f.Close()
+	_ = os.Remove(name) // may already be unlinked
+	return nil
+}

--- a/staging/src/k8s.io/client-go/tools/cache/bytecache/cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/bytecache/cache.go
@@ -38,22 +38,22 @@ const (
 )
 
 // Enabled reports whether the experimental bytecache store is switched on.
-// Values: "1"/"reloc" (native relocation codec), "proto", "gob".
+// Values: "1"/"reloc" (native relocation codec), "proto", "gob", "0" (off).
+//
+// TEMPORARY (do not merge): defaults ON in proto mode so CI exercises the
+// store; the final default is off.
 func Enabled() bool {
-	v := os.Getenv("KUBE_BYTECACHE")
-	return v != "" && v != "0"
+	return os.Getenv("KUBE_BYTECACHE") != "0"
 }
 
 func kindFromEnv() codecKind {
 	switch os.Getenv("KUBE_BYTECACHE") {
 	case "1", "reloc":
 		return kindReloc
-	case "proto":
-		return kindProto
 	case "gob":
 		return kindGob
 	}
-	return kindReloc
+	return kindProto
 }
 
 func hotBudget() int {

--- a/staging/src/k8s.io/client-go/tools/cache/bytecache/cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/bytecache/cache.go
@@ -1,0 +1,353 @@
+//go:build linux && amd64 && !race
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytecache
+
+import (
+	"container/list"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"sync"
+	"unsafe"
+
+	"k8s.io/klog/v2"
+)
+
+const (
+	// Sparse reservation per store; pages materialize only as written.
+	defaultArenaBytes = 1 << 30
+	// Heap budget for the hot LRU of materialized objects.
+	defaultHotBytes = 16 << 20
+)
+
+// Enabled reports whether the experimental bytecache store is switched on.
+// Values: "1"/"reloc" (native relocation codec), "proto", "gob".
+func Enabled() bool {
+	v := os.Getenv("KUBE_BYTECACHE")
+	return v != "" && v != "0"
+}
+
+func kindFromEnv() codecKind {
+	switch os.Getenv("KUBE_BYTECACHE") {
+	case "1", "reloc":
+		return kindReloc
+	case "proto":
+		return kindProto
+	case "gob":
+		return kindGob
+	}
+	return kindReloc
+}
+
+func hotBudget() int {
+	if v := os.Getenv("KUBE_BYTECACHE_HOT_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultHotBytes
+}
+
+// Cache is a key->object store holding objects at rest in a file-backed mmap
+// arena, with a bounded LRU of materialized heap copies in front and a
+// passthrough mode for objects that cannot be encoded.
+//
+// Locking contract: Set, Delete, and Replace require the caller's write lock;
+// Get, GetTransient, All, Keys, and Len require at least the caller's read
+// lock. The LRU has its own internal lock so Gets may run concurrently.
+type Cache struct {
+	kind        codecKind
+	maxHotBytes int
+	// typeState memoizes the per-type round-trip self-check: the first
+	// object of each type is encoded, decoded, and DeepEqual-verified.
+	// Types the codec cannot faithfully round-trip are blacklisted to
+	// passthrough (e.g. gob silently drops unexported fields).
+	typeState map[reflect.Type]int8 // 0 unknown, 1 ok, 2 bad
+	arena     *Arena
+	codec     *codec
+	degraded  bool // arena setup failed: passthrough everything
+	index     map[string]ent
+
+	lmu      sync.Mutex // guards hot/lru/hotBytes (mutated during read-locked Gets)
+	hot      map[string]*list.Element
+	lru      *list.List
+	hotBytes int
+
+	encoded, passed int
+	warnOnce        sync.Once
+}
+
+type hotEnt struct {
+	key  string
+	obj  interface{}
+	size int
+}
+
+func New() *Cache {
+	return &Cache{
+		kind:        kindFromEnv(),
+		typeState:   map[reflect.Type]int8{},
+		maxHotBytes: hotBudget(),
+		index:       map[string]ent{},
+		hot:         map[string]*list.Element{},
+		lru:         list.New(),
+	}
+}
+
+func (c *Cache) ensureArena() bool {
+	if c.degraded {
+		return false
+	}
+	if c.arena != nil {
+		return true
+	}
+	dir := os.Getenv("KUBE_BYTECACHE_DIR")
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	f, err := os.CreateTemp(dir, "bytecache-*.arena")
+	if err != nil {
+		c.degrade("arena file", err)
+		return false
+	}
+	path := f.Name()
+	_ = f.Close()
+	a, err := NewArena(path, defaultArenaBytes)
+	if err != nil {
+		_ = os.Remove(path)
+		c.degrade("arena mmap", err)
+		return false
+	}
+	// The mapping keeps the file alive; unlink so it never outlives us.
+	_ = os.Remove(path)
+	c.arena = a
+	c.codec = newCodec(a)
+	klog.Background().V(2).Info("bytecache: arena created", "reserveBytes", defaultArenaBytes, "hotBudgetBytes", c.maxHotBytes)
+	return true
+}
+
+func (c *Cache) degrade(what string, err error) {
+	c.degraded = true
+	c.warnOnce.Do(func() {
+		klog.Background().Error(err, "bytecache: falling back to heap storage", "operation", what)
+	})
+}
+
+// encode returns an arena entry, or a passthrough entry if obj cannot be
+// (or should not be) encoded.
+func (c *Cache) encode(obj interface{}) ent {
+	rv := reflect.ValueOf(obj)
+	if rv.Kind() != reflect.Pointer || rv.IsNil() || rv.Type().Elem().Kind() != reflect.Struct {
+		c.passed++
+		return ent{obj: obj}
+	}
+	if !c.ensureArena() {
+		c.passed++
+		return ent{obj: obj}
+	}
+	typ := rv.Type().Elem()
+	if c.typeState[typ] == 2 {
+		c.passed++
+		return ent{obj: obj}
+	}
+	e, err := c.encodeKind(rv, obj)
+	if err != nil {
+		// Unsupported type shape, arena full, etc: store the object itself.
+		c.passed++
+		klog.Background().V(4).Info("bytecache: storing object on heap", "type", fmt.Sprintf("%T", obj), "reason", err)
+		return ent{obj: obj}
+	}
+	if c.typeState[typ] == 0 {
+		// First object of this type: verify the codec round-trips it
+		// faithfully before trusting the encoding for the type.
+		decoded, derr := c.decode(e)
+		if derr != nil || !reflect.DeepEqual(obj, decoded) {
+			c.typeState[typ] = 2
+			klog.Background().Error(derr, "bytecache: codec cannot faithfully round-trip type; storing on heap", "type", typ.String())
+			c.passed++
+			return ent{obj: obj}
+		}
+		c.typeState[typ] = 1
+	}
+	c.encoded++
+	return e
+}
+
+func (c *Cache) encodeKind(rv reflect.Value, obj interface{}) (ent, error) {
+	switch c.kind {
+	case kindProto:
+		return c.encodeProto(obj)
+	case kindGob:
+		return c.encodeGob(obj)
+	default:
+		return c.codec.encode(rv.Type().Elem(), unsafe.Pointer(rv.Pointer()))
+	}
+}
+
+func (c *Cache) decode(e ent) (interface{}, error) {
+	switch c.kind {
+	case kindProto:
+		return c.decodeProto(e)
+	case kindGob:
+		return c.decodeGob(e)
+	default:
+		return c.codec.decode(e)
+	}
+}
+
+// Set stores obj under key (caller holds write lock).
+func (c *Cache) Set(key string, obj interface{}) {
+	c.index[key] = c.encode(obj)
+	c.dropHot(key) // any cached materialization is now stale
+}
+
+// Delete removes key (caller holds write lock).
+func (c *Cache) Delete(key string) {
+	delete(c.index, key)
+	c.dropHot(key)
+}
+
+// Get returns the object for key, using and populating the hot LRU
+// (caller holds at least read lock).
+func (c *Cache) Get(key string) (interface{}, bool) {
+	e, ok := c.index[key]
+	if !ok {
+		return nil, false
+	}
+	if e.typ == nil {
+		return e.obj, true
+	}
+	c.lmu.Lock()
+	if el, hit := c.hot[key]; hit {
+		c.lru.MoveToFront(el)
+		obj := el.Value.(*hotEnt).obj
+		c.lmu.Unlock()
+		return obj, true
+	}
+	c.lmu.Unlock()
+	obj, err := c.decode(e)
+	if err != nil {
+		klog.Background().Error(err, "bytecache: decode failed", "key", key)
+		return nil, false
+	}
+	c.lmu.Lock()
+	if el, hit := c.hot[key]; hit { // raced with another reader; keep theirs
+		c.lru.MoveToFront(el)
+		obj = el.Value.(*hotEnt).obj
+	} else {
+		c.hot[key] = c.lru.PushFront(&hotEnt{key: key, obj: obj, size: e.size})
+		c.hotBytes += e.size
+		for c.hotBytes > c.maxHotBytes && c.lru.Len() > 1 {
+			c.dropHotLocked(c.lru.Back())
+		}
+	}
+	c.lmu.Unlock()
+	return obj, true
+}
+
+// GetTransient returns the object without inserting it into the LRU — for
+// bulk sweeps (List) and internal reads that shouldn't churn the hot set.
+func (c *Cache) GetTransient(key string) (interface{}, bool) {
+	e, ok := c.index[key]
+	if !ok {
+		return nil, false
+	}
+	if e.typ == nil {
+		return e.obj, true
+	}
+	c.lmu.Lock()
+	if el, hit := c.hot[key]; hit {
+		obj := el.Value.(*hotEnt).obj
+		c.lmu.Unlock()
+		return obj, true
+	}
+	c.lmu.Unlock()
+	obj, err := c.decode(e)
+	if err != nil {
+		klog.Background().Error(err, "bytecache: decode failed", "key", key)
+		return nil, false
+	}
+	return obj, true
+}
+
+// All materializes every object (caller holds read lock).
+func (c *Cache) All() []interface{} {
+	out := make([]interface{}, 0, len(c.index))
+	for key := range c.index {
+		if obj, ok := c.GetTransient(key); ok {
+			out = append(out, obj)
+		}
+	}
+	return out
+}
+
+func (c *Cache) Keys() []string {
+	out := make([]string, 0, len(c.index))
+	for key := range c.index {
+		out = append(out, key)
+	}
+	return out
+}
+
+func (c *Cache) Len() int { return len(c.index) }
+
+// Replace swaps in a whole new content set (caller holds write lock). The
+// arena is reset first, so every relist doubles as compaction — safe because
+// consumers only ever hold detached heap copies, never arena pointers.
+func (c *Cache) Replace(items map[string]interface{}) {
+	c.lmu.Lock()
+	c.hot = map[string]*list.Element{}
+	c.lru.Init()
+	c.hotBytes = 0
+	c.lmu.Unlock()
+	if c.arena != nil {
+		c.arena.Reset()
+	}
+	c.index = make(map[string]ent, len(items))
+	for key, obj := range items {
+		c.index[key] = c.encode(obj)
+	}
+}
+
+func (c *Cache) dropHot(key string) {
+	c.lmu.Lock()
+	if el, ok := c.hot[key]; ok {
+		c.dropHotLocked(el)
+	}
+	c.lmu.Unlock()
+}
+
+func (c *Cache) dropHotLocked(el *list.Element) {
+	he := el.Value.(*hotEnt)
+	delete(c.hot, he.key)
+	c.lru.Remove(el)
+	c.hotBytes -= he.size
+}
+
+// Stats returns counters for tests and debugging.
+func (c *Cache) Stats() (encoded, passed, arenaUsed, hotBytes int) {
+	if c.arena != nil {
+		arenaUsed = c.arena.Used()
+	}
+	c.lmu.Lock()
+	hotBytes = c.hotBytes
+	c.lmu.Unlock()
+	return c.encoded, c.passed, arenaUsed, hotBytes
+}

--- a/staging/src/k8s.io/client-go/tools/cache/bytecache/codecs.go
+++ b/staging/src/k8s.io/client-go/tools/cache/bytecache/codecs.go
@@ -1,0 +1,99 @@
+//go:build linux && amd64 && !race
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytecache
+
+// Alternative serialization codecs, selectable for comparison via
+// KUBE_BYTECACHE=proto|gob (KUBE_BYTECACHE=1 or "reloc" selects the native
+// relocation codec). All codecs share the arena-at-rest + hot-LRU structure;
+// only the byte format and materialization cost differ:
+//
+//   reloc: native memory layout + relocation list; decode = memcpy + patch.
+//   proto: gogo protobuf wire bytes; decode = generated Unmarshal. Only for
+//          types with generated marshalers; ~5x denser at rest.
+//   gob:   encoding/gob; requires no generated code, but silently drops
+//          unexported fields (e.g. resource.Quantity's value) and repeats
+//          type descriptors per object — expected to be disqualified by the
+//          per-type self-check; included for honest comparison.
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"reflect"
+)
+
+type codecKind int
+
+const (
+	kindReloc codecKind = iota
+	kindProto
+	kindGob
+)
+
+type protoMessage interface {
+	Marshal() ([]byte, error)
+	Unmarshal([]byte) error
+}
+
+func (c *Cache) encodeProto(obj interface{}) (ent, error) {
+	m, ok := obj.(protoMessage)
+	if !ok {
+		return ent{}, fmt.Errorf("%T has no generated proto marshaler", obj)
+	}
+	b, err := m.Marshal()
+	if err != nil {
+		return ent{}, err
+	}
+	off, err := c.arena.Alloc(b)
+	if err != nil {
+		return ent{}, err
+	}
+	return ent{typ: reflect.TypeOf(obj).Elem(), off: off, size: len(b)}, nil
+}
+
+func (c *Cache) decodeProto(e ent) (interface{}, error) {
+	obj := reflect.New(e.typ).Interface()
+	if err := obj.(protoMessage).Unmarshal(c.arena.ReadOnly(e.off, e.size)); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+func (c *Cache) encodeGob(obj interface{}) (ent, error) {
+	var buf bytes.Buffer
+	// A fresh encoder per object: gob is stream-oriented, so this repeats
+	// the type dictionary in every entry — part of what the comparison is
+	// designed to show.
+	if err := gob.NewEncoder(&buf).Encode(obj); err != nil {
+		return ent{}, err
+	}
+	off, err := c.arena.Alloc(buf.Bytes())
+	if err != nil {
+		return ent{}, err
+	}
+	return ent{typ: reflect.TypeOf(obj).Elem(), off: off, size: buf.Len()}, nil
+}
+
+func (c *Cache) decodeGob(e ent) (interface{}, error) {
+	obj := reflect.New(e.typ).Interface()
+	if err := gob.NewDecoder(bytes.NewReader(c.arena.ReadOnly(e.off, e.size))).Decode(obj); err != nil {
+		return nil, err
+	}
+	return obj, nil
+}

--- a/staging/src/k8s.io/client-go/tools/cache/bytecache/codecs_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/bytecache/codecs_test.go
@@ -1,0 +1,172 @@
+//go:build linux && amd64 && !race
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytecache
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func codecPod(i int) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("pod-%d", i),
+			Namespace: "default",
+			Labels:    map[string]string{"app": fmt.Sprintf("pod-%d", i), "tier": "backend"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: fmt.Sprintf("node-%d", i%100),
+			Containers: []corev1.Container{{
+				Name:  "c",
+				Image: fmt.Sprintf("registry.example.com/app:v%d", i),
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("128Mi"),
+					},
+				},
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, PodIP: "10.0.0.1"},
+	}
+	for e := range 8 {
+		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env,
+			corev1.EnvVar{Name: fmt.Sprintf("E%d", e), Value: fmt.Sprintf("v%d", e)})
+	}
+	return pod
+}
+
+func newCacheKind(t testing.TB, mode string) *Cache {
+	t.Helper()
+	t.Setenv("KUBE_BYTECACHE", mode)
+	return New()
+}
+
+// The self-check must accept reloc and proto for pods, and must blacklist
+// gob: resource.Quantity keeps its value in unexported fields, which gob
+// silently drops.
+func TestCodecSelfCheck(t *testing.T) {
+	for _, tc := range []struct {
+		mode        string
+		wantEncoded bool
+	}{
+		{"1", true},
+		{"proto", true},
+		{"gob", false},
+	} {
+		t.Run(tc.mode, func(t *testing.T) {
+			c := newCacheKind(t, tc.mode)
+			c.Set("k", codecPod(1))
+			encoded, passed, _, _ := c.Stats()
+			if tc.wantEncoded && (encoded != 1 || passed != 0) {
+				t.Fatalf("mode %s: encoded=%d passed=%d, want encoded", tc.mode, encoded, passed)
+			}
+			if !tc.wantEncoded && (encoded != 0 || passed != 1) {
+				t.Fatalf("mode %s: encoded=%d passed=%d, want passthrough (self-check should reject)", tc.mode, encoded, passed)
+			}
+			// Whatever the storage, reads must be faithful.
+			got, ok := c.Get("k")
+			if !ok || !reflect.DeepEqual(codecPod(1), got) {
+				t.Fatalf("mode %s: round-trip mismatch", tc.mode)
+			}
+		})
+	}
+}
+
+// Direct demonstration of gob's lossiness on k8s types (why the self-check
+// exists): without it, Quantities would silently decode as empty.
+func TestGobIsLossyOnQuantities(t *testing.T) {
+	c := newCacheKind(t, "gob")
+	if !c.ensureArena() {
+		t.Fatal("arena")
+	}
+	pod := codecPod(1)
+	e, err := c.encodeGob(pod)
+	if err != nil {
+		t.Fatalf("gob encode unexpectedly failed: %v", err)
+	}
+	decoded, err := c.decodeGob(e)
+	if err != nil {
+		t.Fatalf("gob decode failed: %v", err)
+	}
+	got := decoded.(*corev1.Pod).Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	want := pod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	if got.String() == want.String() {
+		t.Fatalf("expected gob to corrupt Quantity (got %s == want %s); if gob became faithful, update the docs", got.String(), want.String())
+	}
+	t.Logf("gob corrupted Quantity as expected: %q -> %q (size %d bytes vs proto/reloc below)", want.String(), got.String(), e.size)
+}
+
+func TestCodecSizes(t *testing.T) {
+	for _, mode := range []string{"1", "proto", "gob"} {
+		c := newCacheKind(t, mode)
+		if !c.ensureArena() {
+			t.Fatal("arena")
+		}
+		rv := reflect.ValueOf(codecPod(1))
+		e, err := c.encodeKind(rv, rv.Interface())
+		if err != nil {
+			t.Fatalf("%s: %v", mode, err)
+		}
+		extra := 0
+		if mode == "1" {
+			extra = 4 * e.relocN
+		}
+		t.Logf("%-6s %6d bytes/pod at rest (+%d reloc list)", mode, e.size, extra)
+	}
+}
+
+func benchCodec(b *testing.B, mode string, decode bool) {
+	c := newCacheKind(b, mode)
+	if !c.ensureArena() {
+		b.Fatal("arena")
+	}
+	pod := codecPod(1)
+	rv := reflect.ValueOf(pod)
+	e, err := c.encodeKind(rv, pod)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if decode {
+			if _, err := c.decode(e); err != nil {
+				b.Fatal(err)
+			}
+		} else {
+			if _, err := c.encodeKind(rv, pod); err != nil {
+				c.arena.Reset()
+				i--
+			}
+		}
+	}
+}
+
+func BenchmarkEncodeReloc(b *testing.B) { benchCodec(b, "1", false) }
+func BenchmarkEncodeProto(b *testing.B) { benchCodec(b, "proto", false) }
+func BenchmarkEncodeGob(b *testing.B)   { benchCodec(b, "gob", false) }
+func BenchmarkDecodeReloc(b *testing.B) { benchCodec(b, "1", true) }
+func BenchmarkDecodeProto(b *testing.B) { benchCodec(b, "proto", true) }
+func BenchmarkDecodeGob(b *testing.B)   { benchCodec(b, "gob", true) }

--- a/staging/src/k8s.io/client-go/tools/cache/bytecache/copier.go
+++ b/staging/src/k8s.io/client-go/tools/cache/bytecache/copier.go
@@ -1,0 +1,305 @@
+//go:build linux && amd64 && !race
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytecache
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+	"unsafe"
+)
+
+// stringRepr / sliceRepr mirror the runtime headers, but with uintptr data
+// words so that all our stores into arena memory are plain integer stores:
+// no typed pointer writes into the arena means no GC write barriers fire on
+// non-heap addresses.
+type stringRepr struct {
+	data uintptr
+	len  int
+}
+
+type sliceRepr struct {
+	data uintptr
+	len  int
+	cap  int
+}
+
+var locationType = reflect.TypeFor[time.Location]()
+
+// Copier performs a relocating deep-copy of a live Go object graph into an
+// Arena, preserving native memory layout. The copy in the arena is a real Go
+// object: a *T cast of its offset (in the read-only mapping) is directly
+// usable, with zero decode cost.
+//
+// Pointers, strings, and slices are relocated into the arena, with their data
+// pointers rebased to the read-only mapping. Maps cannot live in the arena —
+// their internals are owned by the Go runtime — so each map is rebuilt as a
+// real heap map (whose string keys/values do alias the arena) and returned as
+// an "anchor": because the GC never scans arena memory, the caller must keep
+// anchors alive for as long as the arena object is reachable.
+//
+// Assumes acyclic object graphs (true for k8s API types). *time.Location is
+// shared rather than copied: in practice it points at the runtime's UTC/Local
+// globals.
+type Copier struct {
+	arena   *Arena
+	anchors []any
+	hasPtr  map[reflect.Type]bool
+	// arenaMaps: relocate map internals into the arena via snapshotMap
+	// (version-locked to the runtime's map layout) instead of rebuilding
+	// heap maps that must be anchored.
+	arenaMaps bool
+	// recordRelocs: remember the arena offset of every internal pointer
+	// word written. A block plus its reloc list can then be relocated
+	// anywhere with memcpy + patch — no reflection walk.
+	recordRelocs bool
+	relocs       []int32
+	depth        int
+}
+
+// record notes that the pointer word at p (inside the RW mapping) holds an
+// internal pointer that must be patched if the block is relocated.
+func (c *Copier) record(p unsafe.Pointer) {
+	if !c.recordRelocs {
+		return
+	}
+	off := uintptr(p) - uintptr(unsafe.Pointer(&c.arena.rw[0]))
+	if off >= uintptr(len(c.arena.rw)) {
+		panic("bytecache: reloc recording outside arena (heap-map mode is not relocatable)")
+	}
+	c.relocs = append(c.relocs, int32(off))
+}
+
+func NewCopier(a *Arena) *Copier {
+	return &Copier{arena: a, hasPtr: map[reflect.Type]bool{}}
+}
+
+// NewArenaMapCopier relocates maps into the arena too: no heap anchors at
+// all, and map contents become hardware-read-only like everything else.
+func NewArenaMapCopier(a *Arena) *Copier {
+	c := NewCopier(a)
+	c.arenaMaps = true
+	return c
+}
+
+// Copy relocates the object of type t at src into the arena. It returns the
+// arena offset of the root and the heap anchors (rebuilt maps) that must be
+// kept alive alongside it. The caller must keep the source object alive until
+// Copy returns (it is read through raw pointers).
+func (c *Copier) Copy(t reflect.Type, src unsafe.Pointer) (off int, anchors []any, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("arena copy failed: %v", r)
+		}
+	}()
+	c.anchors = nil
+	off = c.clone(t, src)
+	anchors = c.anchors
+	c.anchors = nil
+	return off, anchors, nil
+}
+
+// clone bump-allocates space for t, memcpys the raw bytes from src, then
+// fixes up any pointer-bearing fields in place.
+func (c *Copier) clone(t reflect.Type, src unsafe.Pointer) int {
+	c.depth++
+	defer func() { c.depth-- }()
+	if c.depth > 512 {
+		panic("object graph too deep (cyclic?)")
+	}
+	size := int(t.Size())
+	off := c.mustBump(size, int(t.Align()))
+	copy(c.arena.rw[off:off+size], unsafe.Slice((*byte)(src), size))
+	if c.hasPointers(t) {
+		c.fixup(t, c.rwAt(off))
+	}
+	return off
+}
+
+func (c *Copier) mustBump(size, align int) int {
+	off, err := c.arena.Bump(size, align)
+	if err != nil {
+		panic(err)
+	}
+	return off
+}
+
+// rwAt is where we write during construction; roAddr is the address readers
+// will use — pointers stored in the arena are rebased onto the RO mapping.
+func (c *Copier) rwAt(off int) unsafe.Pointer { return unsafe.Pointer(&c.arena.rw[off]) }
+func (c *Copier) roAddr(off int) uintptr      { return uintptr(unsafe.Pointer(&c.arena.ro[off])) }
+
+// fixup rewrites the pointer-bearing parts of the value of type t at p
+// (writable memory: either the RW mapping or a heap temporary for map
+// entries), relocating everything it references into the arena.
+func (c *Copier) fixup(t reflect.Type, p unsafe.Pointer) {
+	switch t.Kind() {
+	case reflect.Struct:
+		for f := range t.Fields() {
+			if c.hasPointers(f.Type) {
+				c.fixup(f.Type, unsafe.Add(p, f.Offset))
+			}
+		}
+	case reflect.Array:
+		et := t.Elem()
+		if c.hasPointers(et) {
+			for i := 0; i < t.Len(); i++ {
+				c.fixup(et, unsafe.Add(p, uintptr(i)*et.Size()))
+			}
+		}
+	case reflect.String:
+		h := (*stringRepr)(p)
+		if h.len == 0 {
+			h.data = 0
+			return
+		}
+		off := c.mustBump(h.len, 1)
+		copy(c.arena.rw[off:off+h.len], unsafe.Slice((*byte)(unsafe.Pointer(h.data)), h.len)) //nolint:govet // uintptr captured from memory kept live by the caller; see package doc
+		h.data = c.roAddr(off)
+		c.record(p)
+	case reflect.Slice:
+		h := (*sliceRepr)(p)
+		if h.len == 0 {
+			h.data, h.cap = 0, 0
+			return
+		}
+		et := t.Elem()
+		esz := int(et.Size())
+		off := c.mustBump(esz*h.len, int(et.Align()))
+		copy(c.arena.rw[off:off+esz*h.len], unsafe.Slice((*byte)(unsafe.Pointer(h.data)), esz*h.len)) //nolint:govet // uintptr captured from memory kept live by the caller; see package doc
+		if c.hasPointers(et) {
+			for i := 0; i < h.len; i++ {
+				c.fixup(et, c.rwAt(off+i*esz))
+			}
+		}
+		h.data, h.cap = c.roAddr(off), h.len
+		c.record(p)
+	case reflect.Pointer:
+		pp := (*uintptr)(p)
+		if *pp == 0 {
+			return
+		}
+		et := t.Elem()
+		if et == locationType {
+			return // shared runtime global (time.UTC / time.Local)
+		}
+		*pp = c.roAddr(c.clone(et, unsafe.Pointer(*pp))) //nolint:govet // uintptr captured from memory kept live by the caller; see package doc
+		c.record(p)
+	case reflect.Map:
+		if c.arenaMaps {
+			c.snapshotMap(t, p)
+			return
+		}
+		wp := (*uintptr)(p)
+		if *wp == 0 {
+			return
+		}
+		src := reflect.NewAt(t, p).Elem()
+		dst := reflect.MakeMapWithSize(t, src.Len())
+		it := src.MapRange()
+		for it.Next() {
+			dst.SetMapIndex(c.relocate(it.Key()), c.relocate(it.Value()))
+		}
+		c.anchors = append(c.anchors, dst.Interface())
+		*wp = uintptr(dst.UnsafePointer())
+	case reflect.Interface:
+		// An interface value is (type/itab word, data word). The type word
+		// points at static type metadata in the binary — kept as-is. The
+		// data word is either the value itself (pointer-shaped types: *T,
+		// map, ...) or a pointer to a heap box holding the value.
+		words := (*[2]uintptr)(p)
+		if words[0] == 0 {
+			return // nil interface
+		}
+		v := reflect.NewAt(t, p).Elem().Elem()
+		if !v.IsValid() {
+			return
+		}
+		dt := v.Type()
+		if isDirectIface(dt) {
+			c.fixup(dt, unsafe.Pointer(&words[1]))
+		} else if words[1] != 0 {
+			words[1] = c.roAddr(c.clone(dt, unsafe.Pointer(words[1]))) //nolint:govet // uintptr captured from memory kept live by the caller; see package doc
+			c.record(unsafe.Pointer(&words[1]))
+		}
+	default:
+		// Chan, Func, UnsafePointer: not relocatable.
+		panic(fmt.Sprintf("unsupported kind %v (%v)", t.Kind(), t))
+	}
+}
+
+// isDirectIface reports whether values of t are stored directly in an
+// interface's data word (rather than boxed behind a pointer). Reads the
+// TFlagDirectIface bit from the runtime type descriptor (abi.Type.TFlag at
+// offset 20 on 64-bit, bit 1<<5 as of Go 1.26) — version-locked like the map
+// mirrors, and self-checked at init below. (Case in point on version drift:
+// this bit lived in the Kind_ byte until recently.)
+func isDirectIface(t reflect.Type) bool {
+	type iface struct{ tab, data unsafe.Pointer }
+	tp := (*iface)(unsafe.Pointer(&t)).data
+	return *(*uint8)(unsafe.Add(tp, 20))&(1<<5) != 0
+}
+
+func init() {
+	// The flag is a cached computation of "pointer-shaped": verify our read
+	// of it against known types so layout drift fails loudly at startup.
+	if !isDirectIface(reflect.TypeFor[*int]()) ||
+		!isDirectIface(reflect.TypeFor[map[string]string]()) ||
+		isDirectIface(reflect.TypeFor[string]()) ||
+		isDirectIface(reflect.TypeFor[int64]()) ||
+		isDirectIface(reflect.TypeFor[[]int]()) {
+		panic("bytecache: abi.Type.TFlag direct-iface bit not where we expect; update copier.go mirrors for this Go version")
+	}
+}
+
+// relocate returns a copy of v whose referenced data (string bytes, nested
+// pointers, ...) lives in the arena; the top-level value itself stays on the
+// heap, because it is about to be stored inside a heap map's buckets.
+func (c *Copier) relocate(v reflect.Value) reflect.Value {
+	if !c.hasPointers(v.Type()) {
+		return v
+	}
+	tmp := reflect.New(v.Type())
+	tmp.Elem().Set(v)
+	c.fixup(v.Type(), tmp.UnsafePointer())
+	return tmp.Elem()
+}
+
+func (c *Copier) hasPointers(t reflect.Type) bool {
+	if v, ok := c.hasPtr[t]; ok {
+		return v
+	}
+	var r bool
+	switch t.Kind() {
+	case reflect.Pointer, reflect.Map, reflect.String, reflect.Slice,
+		reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
+		r = true
+	case reflect.Array:
+		r = c.hasPointers(t.Elem())
+	case reflect.Struct:
+		for f := range t.Fields() {
+			if c.hasPointers(f.Type) {
+				r = true
+				break
+			}
+		}
+	}
+	c.hasPtr[t] = r
+	return r
+}

--- a/staging/src/k8s.io/client-go/tools/cache/bytecache/doc.go
+++ b/staging/src/k8s.io/client-go/tools/cache/bytecache/doc.go
@@ -1,0 +1,35 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package bytecache is an EXPERIMENTAL storage backend for informer caches.
+//
+// Objects at rest are relocated into a file-backed, read-only-mapped memory
+// arena: they cost no Go heap objects, are invisible to the GC and the GOGC
+// pacer, and cold pages can be evicted by the kernel (no swap required).
+// Get materializes objects into self-contained heap []byte blocks via a
+// recorded relocation list (memcpy + pointer patch, ~3µs for a typical pod),
+// fronted by a bounded LRU so hot reads are a pointer return. Consumers hold
+// ordinary GC-traced pointers; block lifetime is managed by the GC through
+// interior-pointer reachability.
+//
+// The implementation mirrors Go runtime internals (Swiss map layout,
+// interface representation) and is gated to amd64, non-race builds; any
+// object it cannot encode is stored as a plain heap pointer (passthrough),
+// so behavior degrades to the status quo rather than failing.
+//
+// Enabled via KUBE_BYTECACHE=1. See KUBE_BYTECACHE_HOT_BYTES and
+// KUBE_BYTECACHE_DIR to tune the per-store hot budget and arena location.
+package bytecache

--- a/staging/src/k8s.io/client-go/tools/cache/bytecache/maparena.go
+++ b/staging/src/k8s.io/client-go/tools/cache/bytecache/maparena.go
@@ -1,0 +1,191 @@
+//go:build linux && amd64 && !race
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytecache
+
+// Arena-resident Go maps via snapshot relocation.
+//
+// We never reimplement map hashing or insertion. A map built normally by the
+// runtime is a valid, self-contained pointer graph: Map struct -> directory
+// -> tables -> group arrays. We bit-copy that graph into the arena and rebase
+// the internal pointers. Two properties make the copy remain a valid map for
+// the runtime's own READ paths (mapaccess, len, range):
+//
+//  1. The hash seed is a field of the Map struct, so it travels with the copy.
+//  2. Go's hash functions hash key *contents*, not addresses, so relocating
+//     string keys into the arena does not change any hash: every ctrl byte
+//     and probe sequence stays correct.
+//
+// Writes are a different story: mapassign/mapdelete/clear would write to the
+// Map struct and groups — which live in the read-only mapping, so a buggy
+// consumer's map write becomes an immediate hardware fault. That closes the
+// mutation-protection hole that heap-anchored maps had.
+//
+// This file mirrors internal runtime layouts (Go 1.24+ Swiss maps, amd64) and
+// is therefore version-locked; layout drift is caught by VerifyMapLayout-style
+// round-trip checks rather than discovered in production.
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+// rtMapType mirrors internal/abi.MapType. The leading embedded abi.Type is
+// opaque padding: we only read the map-specific tail fields.
+type rtMapType struct {
+	_         [48]byte // abi.Type on 64-bit
+	key       unsafe.Pointer
+	elem      unsafe.Pointer
+	group     unsafe.Pointer
+	hasher    func(unsafe.Pointer, uintptr) uintptr
+	groupSize uintptr
+	slotSize  uintptr
+	elemOff   uintptr
+	flags     uint32
+}
+
+const (
+	rtMapIndirectKey  = 1 << 2 // abi.MapIndirectKey
+	rtMapIndirectElem = 1 << 3 // abi.MapIndirectElem
+)
+
+// rtMap mirrors internal/runtime/maps.Map, with pointer fields as uintptr so
+// every store we do is a plain integer store (no GC write barriers on arena
+// addresses, and no shading of stale arena bytes).
+type rtMap struct {
+	used              uint64
+	seed              uintptr
+	dirPtr            uintptr
+	dirLen            int
+	globalDepth       uint8
+	globalShift       uint8
+	writing           uint8
+	tombstonePossible bool
+	clearSeq          uint64
+}
+
+// rtTable mirrors internal/runtime/maps.table.
+type rtTable struct {
+	used       uint16
+	capacity   uint16
+	growthLeft uint16
+	localDepth uint8
+	index      int
+	groupsData uintptr // groupsReference.data
+	lengthMask uint64  // groupsReference.lengthMask
+}
+
+func mapTypeFor(t reflect.Type) *rtMapType {
+	type iface struct{ tab, data unsafe.Pointer }
+	return (*rtMapType)((*iface)(unsafe.Pointer(&t)).data)
+}
+
+// copyRaw bump-allocates and byte-copies size bytes from src.
+func (c *Copier) copyRaw(src uintptr, size, align int) int {
+	off := c.mustBump(size, align)
+	copy(c.arena.rw[off:off+size], unsafe.Slice((*byte)(unsafe.Pointer(src)), size)) //nolint:govet // uintptr captured from memory kept live by the caller; see package doc
+	return off
+}
+
+// snapshotMap relocates the map whose word is at p into the arena.
+func (c *Copier) snapshotMap(t reflect.Type, p unsafe.Pointer) {
+	wp := (*uintptr)(p)
+	if *wp == 0 {
+		return
+	}
+	mt := mapTypeFor(t)
+	// Layout sanity checks; a Go version whose maps we don't understand
+	// panics out of Copy as an error instead of corrupting memory.
+	slotsBase := int(mt.groupSize) - 8*int(mt.slotSize)
+	if slotsBase != 8 || mt.elemOff >= mt.slotSize {
+		panic(fmt.Sprintf("unexpected swiss map layout for %v: groupSize=%d slotSize=%d elemOff=%d",
+			t, mt.groupSize, mt.slotSize, mt.elemOff))
+	}
+
+	mOff := c.copyRaw(*wp, int(unsafe.Sizeof(rtMap{})), 8)
+	m := (*rtMap)(c.rwAt(mOff))
+	switch {
+	case m.dirPtr == 0:
+		// Empty map that never allocated. Nothing further to relocate.
+	case m.dirLen == 0:
+		// Small-map optimization: dirPtr points directly at a single group.
+		m.dirPtr = c.roAddr(c.snapshotGroups(mt, t, m.dirPtr, 1))
+		c.record(unsafe.Pointer(&m.dirPtr))
+	default:
+		// dirPtr -> [dirLen]*table; entries may repeat (extendible hashing),
+		// so relocate each distinct table exactly once.
+		dOff := c.copyRaw(m.dirPtr, m.dirLen*8, 8)
+		dir := unsafe.Slice((*uintptr)(c.rwAt(dOff)), m.dirLen)
+		moved := make(map[uintptr]uintptr, m.dirLen)
+		for i, tp := range dir {
+			np, ok := moved[tp]
+			if !ok {
+				tOff := c.copyRaw(tp, int(unsafe.Sizeof(rtTable{})), 8)
+				tb := (*rtTable)(c.rwAt(tOff))
+				tb.groupsData = c.roAddr(c.snapshotGroups(mt, t, tb.groupsData, int(tb.lengthMask)+1))
+				c.record(unsafe.Pointer(&tb.groupsData))
+				np = c.roAddr(tOff)
+				moved[tp] = np
+			}
+			dir[i] = np
+			c.record(unsafe.Pointer(&dir[i]))
+		}
+		m.dirPtr = c.roAddr(dOff)
+		c.record(unsafe.Pointer(&m.dirPtr))
+	}
+	*wp = c.roAddr(mOff)
+	c.record(p)
+}
+
+// snapshotGroups relocates an array of n slot groups and fixes up the keys
+// and elems of every present slot. Empty/deleted slots are zeroed so no stale
+// heap pointers are carried into the arena.
+func (c *Copier) snapshotGroups(mt *rtMapType, t reflect.Type, data uintptr, n int) int {
+	gOff := c.copyRaw(data, n*int(mt.groupSize), 8)
+	kt, et := t.Key(), t.Elem()
+	kPtr, ePtr := c.hasPointers(kt), c.hasPointers(et)
+	kInd, eInd := mt.flags&rtMapIndirectKey != 0, mt.flags&rtMapIndirectElem != 0
+	for g := range n {
+		base := gOff + g*int(mt.groupSize)
+		ctrls := *(*uint64)(c.rwAt(base))
+		for s := range 8 {
+			slotOff := base + 8 + s*int(mt.slotSize)
+			if byte(ctrls>>(8*s))&0x80 != 0 { // empty or deleted
+				clear(c.arena.rw[slotOff : slotOff+int(mt.slotSize)])
+				continue
+			}
+			c.fixupSlot(kt, kPtr, kInd, slotOff)
+			c.fixupSlot(et, ePtr, eInd, slotOff+int(mt.elemOff))
+		}
+	}
+	return gOff
+}
+
+func (c *Copier) fixupSlot(t reflect.Type, hasPtr, indirect bool, off int) {
+	if indirect {
+		// Slot holds a pointer to the key/elem (types > 128 bytes).
+		pp := (*uintptr)(c.rwAt(off))
+		*pp = c.roAddr(c.clone(t, unsafe.Pointer(*pp))) //nolint:govet // uintptr captured from memory kept live by the caller; see package doc
+		c.record(unsafe.Pointer(pp))
+		return
+	}
+	if hasPtr {
+		c.fixup(t, c.rwAt(off))
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/bytecache/reloc.go
+++ b/staging/src/k8s.io/client-go/tools/cache/bytecache/reloc.go
@@ -1,0 +1,86 @@
+//go:build linux && amd64 && !race
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytecache
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+)
+
+// ent describes one stored object: either an arena-resident block plus its
+// relocation list, or a passthrough heap object (typ == nil).
+type ent struct {
+	typ                         reflect.Type
+	off, size, relocOff, relocN int
+	obj                         interface{} // passthrough only
+}
+
+// codec encodes objects of any pointer-to-struct type into the arena and
+// materializes detached heap copies back out.
+type codec struct {
+	arena  *Arena
+	copier *Copier
+}
+
+func newCodec(a *Arena) *codec {
+	c := NewArenaMapCopier(a) // self-contained blocks (maps included)
+	c.recordRelocs = true
+	return &codec{arena: a, copier: c}
+}
+
+func (c *codec) encode(typ reflect.Type, src unsafe.Pointer) (ent, error) {
+	c.copier.relocs = c.copier.relocs[:0]
+	off, anchors, err := c.copier.Copy(typ, src)
+	if err != nil {
+		return ent{}, err
+	}
+	if len(anchors) != 0 {
+		return ent{}, fmt.Errorf("bytecache: unexpected heap anchors")
+	}
+	size := c.arena.Used() - off
+	e := ent{typ: typ, off: off, size: size, relocN: len(c.copier.relocs)}
+	if e.relocN > 0 {
+		e.relocOff, err = c.arena.Bump(4*e.relocN, 4)
+		if err != nil {
+			return ent{}, err
+		}
+		dst := unsafe.Slice((*int32)(unsafe.Pointer(&c.arena.rw[e.relocOff])), e.relocN)
+		for i, r := range c.copier.relocs {
+			dst[i] = r - int32(off) // block-relative
+		}
+	}
+	return e, nil
+}
+
+// decode materializes a detached, self-contained heap copy: one []byte
+// allocation, one memcpy, and a patch of each recorded pointer word. The
+// returned object holds no arena pointers; its lifetime belongs to the GC.
+func (c *codec) decode(e ent) (interface{}, error) {
+	block := make([]byte, e.size)
+	copy(block, c.arena.ro[e.off:e.off+e.size])
+	delta := uintptr(unsafe.Pointer(&block[0])) - uintptr(unsafe.Pointer(&c.arena.ro[e.off]))
+	if e.relocN > 0 {
+		rel := unsafe.Slice((*int32)(unsafe.Pointer(&c.arena.ro[e.relocOff])), e.relocN)
+		for _, r := range rel {
+			*(*uintptr)(unsafe.Pointer(&block[r])) += delta
+		}
+	}
+	return reflect.NewAt(e.typ, unsafe.Pointer(&block[0])).Interface(), nil
+}

--- a/staging/src/k8s.io/client-go/tools/cache/bytecache_footprint_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/bytecache_footprint_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache_test
+
+// Memory footprint measurement for informer caches — run with:
+//
+//	go test -run TestInformerCacheMemoryFootprint -v ./tools/cache/
+//
+// Measures heap attributable to a real SharedIndexInformer at rest, with the
+// default threadSafeMap and with the experimental bytecache store
+// (KUBE_BYTECACHE=1). There is no other in-tree measurement of informer
+// memory footprint today.
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	fcache "k8s.io/client-go/tools/cache/testing"
+)
+
+func footprintPod(i int) *corev1.Pod {
+	name := fmt.Sprintf("workload-%d", i)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: fmt.Sprintf("team-%d", i%50),
+			UID:       "11111111-2222-3333-4444-555555555555",
+			Labels: map[string]string{
+				"app":                         name,
+				"pod-template-hash":           "5f7b8c9d",
+				"app.kubernetes.io/name":      name,
+				"topology.kubernetes.io/zone": "us-east-1a",
+			},
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/last-applied-configuration": `{"apiVersion":"v1","kind":"Pod","metadata":{"labels":{"app":"x"}},"spec":{"containers":[{"image":"nginx","name":"nginx"}]}}`,
+				"prometheus.io/scrape":                             "true",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:           fmt.Sprintf("node-%d", i%500),
+			ServiceAccountName: "default",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: fmt.Sprintf("10.%d.%d.%d", i%250, (i/250)%250, i%250),
+		},
+	}
+	for c := range 2 {
+		container := corev1.Container{
+			Name:  fmt.Sprintf("container-%d", c),
+			Image: fmt.Sprintf("registry.example.com/app/%s:v1.%d", name, c),
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+			},
+		}
+		for e := range 8 {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name:  fmt.Sprintf("APP_SETTING_%d", e),
+				Value: fmt.Sprintf("value-%d-%d", c, e),
+			})
+		}
+		pod.Spec.Containers = append(pod.Spec.Containers, container)
+	}
+	return pod
+}
+
+func TestInformerCacheMemoryFootprint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("footprint measurement, skipped in short mode")
+	}
+	const n = 20000
+	for _, mode := range []string{"0", "1", "proto", "gob"} {
+		name := "default"
+		switch mode {
+		case "1":
+			name = "bytecache-reloc"
+		case "proto", "gob":
+			name = "bytecache-" + mode
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("KUBE_BYTECACHE", mode)
+
+			source := fcache.NewFakeControllerSource()
+			defer source.Shutdown()
+			for i := range n {
+				source.Add(footprintPod(i))
+			}
+			runtime.GC()
+			runtime.GC()
+			var base runtime.MemStats
+			runtime.ReadMemStats(&base)
+
+			informer := cache.NewSharedIndexInformer(source, &corev1.Pod{}, 0,
+				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			stop := make(chan struct{})
+			defer close(stop)
+			go informer.Run(stop)
+			if !cache.WaitForCacheSync(stop, informer.HasSynced) {
+				t.Fatal("sync failed")
+			}
+			if err := wait.PollUntilContextTimeout(context.Background(), 100*time.Millisecond, 30*time.Second, true,
+				func(context.Context) (bool, error) {
+					return len(informer.GetStore().ListKeys()) == n, nil
+				}); err != nil {
+				t.Fatalf("never saw %d keys: %v", n, err)
+			}
+
+			// Exercise the read path a consumer would.
+			obj, ok, err := informer.GetStore().GetByKey("team-7/workload-7")
+			if err != nil || !ok {
+				t.Fatalf("get: %v %v", ok, err)
+			}
+			pod := obj.(*corev1.Pod)
+			if pod.Labels["app"] != "workload-7" || len(pod.Spec.Containers[0].Env) != 8 {
+				t.Fatal("bad pod content")
+			}
+			byNS, err := informer.GetIndexer().ByIndex(cache.NamespaceIndex, "team-7")
+			if err != nil || len(byNS) != n/50 {
+				t.Fatalf("ByIndex: %d, %v", len(byNS), err)
+			}
+
+			runtime.GC()
+			runtime.GC()
+			var after runtime.MemStats
+			runtime.ReadMemStats(&after)
+			start := time.Now()
+			for range 3 {
+				runtime.GC()
+			}
+			gcTime := time.Since(start) / 3
+			t.Logf("%s: informer-attributable heap %+.1f MB, heapObjects %+d, full GC %v",
+				name, float64(after.HeapAlloc-base.HeapAlloc)/1e6,
+				int64(after.HeapObjects)-int64(base.HeapObjects), gcTime)
+		})
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
@@ -523,6 +523,9 @@ func (c *threadSafeMap) Resync() error {
 }
 
 func NewThreadSafeStore(indexers Indexers, indices Indices, opts ...ThreadSafeStoreOption) ThreadSafeStore {
+	if store := newArenaThreadSafeStoreOrNil(indexers, indices, opts...); store != nil {
+		return store
+	}
 	store := &threadSafeMap{
 		items: map[string]interface{}{},
 		index: &storeIndex{

--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_arena.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_arena.go
@@ -1,0 +1,281 @@
+//go:build linux && amd64 && !race
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientgofeaturegate "k8s.io/client-go/features"
+	"k8s.io/client-go/tools/cache/bytecache"
+)
+
+// newArenaThreadSafeStoreOrNil returns the experimental bytecache-backed
+// ThreadSafeStore when KUBE_BYTECACHE=1, and nil otherwise (callers fall
+// back to the default threadSafeMap). See the bytecache package docs.
+func newArenaThreadSafeStoreOrNil(indexers Indexers, indices Indices, opts ...ThreadSafeStoreOption) ThreadSafeStore {
+	if !bytecache.Enabled() {
+		return nil
+	}
+	// Options are typed against threadSafeMap; harvest them via a throwaway.
+	tmp := &threadSafeMap{}
+	for _, opt := range opts {
+		opt(tmp)
+	}
+	metrics := tmp.metrics
+	if metrics == nil {
+		metrics = newStoreMetrics(InformerNameAndResource{}, noopInformerMetricsProvider{})
+	}
+	return &arenaThreadSafeMap{
+		cache:   bytecache.New(),
+		index:   &storeIndex{indexers: indexers, indices: indices},
+		metrics: metrics,
+	}
+}
+
+// arenaThreadSafeMap mirrors threadSafeMap's semantics over a bytecache.Cache.
+// Objects returned by Get/List are materialized copies sharing the informer
+// contract: treat them as read-only. Unlike threadSafeMap, Get is not
+// guaranteed to return pointer-identical objects across calls.
+type arenaThreadSafeMap struct {
+	lock    sync.RWMutex
+	cache   *bytecache.Cache
+	index   *storeIndex
+	rv      string
+	metrics *storeMetrics
+}
+
+var _ ThreadSafeStore = &arenaThreadSafeMap{}
+var _ ThreadSafeStoreWithTransaction = &arenaThreadSafeMap{}
+
+func (c *arenaThreadSafeMap) Transaction(txns ...ThreadSafeStoreTransaction) {
+	if len(txns) == 0 {
+		return
+	}
+	finalObj := txns[len(txns)-1].Object
+	rv, rvErr := rvFromObject(finalObj)
+	rvInt, parseErr := parseRVForMetricsWithTruncation(rv)
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for _, txn := range txns {
+		switch txn.Type {
+		case TransactionTypeAdd, TransactionTypeUpdate:
+			c.updateLocked(txn.Key, txn.Object)
+		case TransactionTypeDelete:
+			c.deleteLocked(txn.Key)
+		}
+	}
+	if rvErr == nil {
+		c.rv = rv
+		if parseErr == nil {
+			c.metrics.storeResourceVersion.Set(float64(rvInt))
+		}
+	}
+}
+
+func (c *arenaThreadSafeMap) Add(key string, obj interface{}) {
+	c.Update(key, obj)
+}
+
+func (c *arenaThreadSafeMap) Update(key string, obj interface{}) {
+	rv, rvErr := rvFromObject(obj)
+	rvInt, parseErr := parseRVForMetricsWithTruncation(rv)
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.updateLocked(key, obj)
+	if rvErr == nil {
+		c.rv = rv
+		if parseErr == nil {
+			c.metrics.storeResourceVersion.Set(float64(rvInt))
+		}
+	}
+}
+
+func (c *arenaThreadSafeMap) updateLocked(key string, obj interface{}) {
+	var oldObject interface{}
+	if len(c.index.indexers) > 0 {
+		// Materialize the previous version so indices can be unwound; the
+		// index funcs only look at values, so a copy is equivalent.
+		oldObject, _ = c.cache.GetTransient(key)
+	}
+	c.cache.Set(key, obj)
+	c.index.updateIndices(oldObject, obj, key)
+}
+
+func (c *arenaThreadSafeMap) Delete(key string) {
+	c.DeleteWithObject(key, nil)
+}
+
+func (c *arenaThreadSafeMap) DeleteWithObject(key string, obj interface{}) {
+	var rv string
+	var rvInt int64
+	var rvErr, parseErr error
+	if obj != nil {
+		rv, rvErr = rvFromObject(obj)
+		rvInt, parseErr = parseRVForMetricsWithTruncation(rv)
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.deleteLocked(key)
+	if obj != nil && rvErr == nil {
+		c.rv = rv
+		if parseErr == nil {
+			c.metrics.storeResourceVersion.Set(float64(rvInt))
+		}
+	}
+}
+
+func (c *arenaThreadSafeMap) deleteLocked(key string) {
+	if obj, exists := c.cache.GetTransient(key); exists {
+		c.index.updateIndices(obj, nil, key)
+		c.cache.Delete(key)
+	}
+}
+
+func (c *arenaThreadSafeMap) Get(key string) (interface{}, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.cache.Get(key)
+}
+
+func (c *arenaThreadSafeMap) List() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.cache.All()
+}
+
+func (c *arenaThreadSafeMap) ListKeys() []string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.cache.Keys()
+}
+
+func (c *arenaThreadSafeMap) Replace(items map[string]interface{}, resourceVersion string) {
+	var rvInt int64
+	var parseErr error
+	if resourceVersion != "" {
+		rvInt, parseErr = parseRVForMetricsWithTruncation(resourceVersion)
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Replace(items)
+	c.rv = resourceVersion
+	if parseErr == nil {
+		c.metrics.storeResourceVersion.Set(float64(rvInt))
+	}
+	c.index.reset()
+	for key, item := range items {
+		c.index.updateIndices(nil, item, key)
+	}
+}
+
+func (c *arenaThreadSafeMap) Index(indexName string, obj interface{}) ([]interface{}, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	storeKeySet, err := c.index.getKeysFromIndex(indexName, obj)
+	if err != nil {
+		return nil, err
+	}
+	list := make([]interface{}, 0, storeKeySet.Len())
+	for storeKey := range storeKeySet {
+		if item, ok := c.cache.Get(storeKey); ok {
+			list = append(list, item)
+		}
+	}
+	return list, nil
+}
+
+func (c *arenaThreadSafeMap) ByIndex(indexName, indexedValue string) ([]interface{}, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	set, err := c.index.getKeysByIndex(indexName, indexedValue)
+	if err != nil {
+		return nil, err
+	}
+	list := make([]interface{}, 0, set.Len())
+	for key := range set {
+		if item, ok := c.cache.Get(key); ok {
+			list = append(list, item)
+		}
+	}
+	return list, nil
+}
+
+func (c *arenaThreadSafeMap) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	set, err := c.index.getKeysByIndex(indexName, indexedValue)
+	if err != nil {
+		return nil, err
+	}
+	return sets.List(set), nil
+}
+
+func (c *arenaThreadSafeMap) ListIndexFuncValues(indexName string) []string {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.index.getIndexValues(indexName)
+}
+
+func (c *arenaThreadSafeMap) GetIndexers() Indexers {
+	return c.index.indexers
+}
+
+func (c *arenaThreadSafeMap) AddIndexers(newIndexers Indexers) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if err := c.index.addIndexers(newIndexers); err != nil {
+		return err
+	}
+	for _, key := range c.cache.Keys() {
+		item, ok := c.cache.GetTransient(key)
+		if !ok {
+			continue
+		}
+		for name := range newIndexers {
+			c.index.updateSingleIndex(name, nil, item, key)
+		}
+	}
+	return nil
+}
+
+func (c *arenaThreadSafeMap) Resync() error { return nil }
+
+func (c *arenaThreadSafeMap) LastStoreSyncResourceVersion() string {
+	if !clientgofeaturegate.FeatureGates().Enabled(clientgofeaturegate.AtomicFIFO) {
+		return ""
+	}
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.rv
+}
+
+func (c *arenaThreadSafeMap) Bookmark(rv string) {
+	var rvInt int64
+	var parseErr error
+	if rv != "" {
+		rvInt, parseErr = parseRVForMetricsWithTruncation(rv)
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.rv = rv
+	if parseErr == nil {
+		c.metrics.storeResourceVersion.Set(float64(rvInt))
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_arena_stub.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_arena_stub.go
@@ -1,0 +1,26 @@
+//go:build !linux || !amd64 || race
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+// The experimental bytecache store depends on amd64 runtime layouts and is
+// incompatible with checkptr (-race); on excluded builds KUBE_BYTECACHE is
+// ignored and the default threadSafeMap is used.
+func newArenaThreadSafeStoreOrNil(indexers Indexers, indices Indices, opts ...ThreadSafeStoreOption) ThreadSafeStore {
+	return nil
+}

--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_test.go
@@ -27,6 +27,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
+// newThreadSafeMapForTest constructs the default threadSafeMap directly:
+// these tests exercise its internals, independent of KUBE_BYTECACHE.
+func newThreadSafeMapForTest(indexers Indexers, indices Indices) *threadSafeMap {
+	return &threadSafeMap{
+		items:   map[string]interface{}{},
+		index:   &storeIndex{indexers: indexers, indices: indices},
+		metrics: newStoreMetrics(InformerNameAndResource{}, noopInformerMetricsProvider{}),
+	}
+}
+
 func TestThreadSafeStoreDeleteRemovesEmptySetsFromIndex(t *testing.T) {
 	testIndexer := "testIndexer"
 
@@ -38,7 +48,7 @@ func TestThreadSafeStoreDeleteRemovesEmptySetsFromIndex(t *testing.T) {
 	}
 
 	indices := Indices{}
-	store := NewThreadSafeStore(indexers, indices).(*threadSafeMap)
+	store := newThreadSafeMapForTest(indexers, indices)
 
 	testKey := "testKey"
 
@@ -72,7 +82,7 @@ func TestThreadSafeStoreAddKeepsNonEmptySetPostDeleteFromIndex(t *testing.T) {
 	}
 
 	indices := Indices{}
-	store := NewThreadSafeStore(indexers, indices).(*threadSafeMap)
+	store := newThreadSafeMapForTest(indexers, indices)
 
 	store.Add("retain", "retain")
 	store.Add("delete", "delete")
@@ -108,7 +118,7 @@ func TestThreadSafeStoreIndexingFunctionsWithMultipleValues(t *testing.T) {
 	}
 
 	indices := Indices{}
-	store := NewThreadSafeStore(indexers, indices).(*threadSafeMap)
+	store := newThreadSafeMapForTest(indexers, indices)
 
 	store.Add("key1", "foo")
 	store.Add("key2", "bar")
@@ -169,14 +179,14 @@ func TestThreadSafeStoreIndexingFunctionsWithMultipleValues(t *testing.T) {
 
 func TestThreadSafeStoreRV(t *testing.T) {
 	t.Run("Initial state", func(t *testing.T) {
-		store := NewThreadSafeStore(Indexers{}, Indices{}).(*threadSafeMap)
+		store := newThreadSafeMapForTest(Indexers{}, Indices{})
 		if rv := store.LastStoreSyncResourceVersion(); rv != "" {
 			t.Errorf("Expected initial RV to be \"\", got %q", rv)
 		}
 	})
 
 	t.Run("Add Update and Delete", func(t *testing.T) {
-		store := NewThreadSafeStore(Indexers{}, Indices{}).(*threadSafeMap)
+		store := newThreadSafeMapForTest(Indexers{}, Indices{})
 
 		// Add obj with RV "10"
 		store.Add("key1", &metav1.ObjectMeta{ResourceVersion: "10"})
@@ -250,7 +260,7 @@ func TestThreadSafeStoreRV(t *testing.T) {
 	})
 
 	t.Run("Replace", func(t *testing.T) {
-		store := NewThreadSafeStore(Indexers{}, Indices{}).(*threadSafeMap)
+		store := newThreadSafeMapForTest(Indexers{}, Indices{})
 		store.Add("key1", &metav1.ObjectMeta{ResourceVersion: "10"})
 
 		if rv := store.LastStoreSyncResourceVersion(); rv != "10" {
@@ -270,7 +280,7 @@ func TestThreadSafeStoreRV(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		store := NewThreadSafeStore(Indexers{}, Indices{}).(*threadSafeMap)
+		store := newThreadSafeMapForTest(Indexers{}, Indices{})
 		store.Add("key1", &metav1.ObjectMeta{ResourceVersion: "10"})
 
 		if rv := store.LastStoreSyncResourceVersion(); rv != "10" {
@@ -296,7 +306,7 @@ func BenchmarkIndexer(b *testing.B) {
 	}
 
 	indices := Indices{}
-	store := NewThreadSafeStore(indexers, indices).(*threadSafeMap)
+	store := newThreadSafeMapForTest(indexers, indices)
 
 	// The following benchmark imitates what is happening in indexes
 	// used in storage layer, where indexing is mostly static (e.g.

--- a/test/integration/bytecache/footprint_test.go
+++ b/test/integration/bytecache/footprint_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytecache
+
+// Informer cache memory footprint against a REAL apiserver: pods created via
+// the API carry defaulting, managedFields, and status as production objects
+// do. One informer per KUBE_BYTECACHE mode syncs the same 10k pods; we
+// measure the heap attributable to each.
+//
+//	go test -v -timeout 30m ./test/integration/bytecache/
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+const (
+	nPods   = 10000
+	nsName  = "footprint"
+	workers = 64
+)
+
+func apiPod(i int) *corev1.Pod {
+	name := fmt.Sprintf("workload-%d", i)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"app":                         name,
+				"pod-template-hash":           "5f7b8c9d",
+				"app.kubernetes.io/name":      name,
+				"topology.kubernetes.io/zone": "us-east-1a",
+			},
+			Annotations: map[string]string{
+				"kubectl.kubernetes.io/last-applied-configuration": `{"apiVersion":"v1","kind":"Pod","metadata":{"labels":{"app":"x"}},"spec":{"containers":[{"image":"nginx","name":"nginx"}]}}`,
+				"prometheus.io/scrape":                             "true",
+			},
+		},
+		Spec: corev1.PodSpec{NodeName: fmt.Sprintf("node-%d", i%500)},
+	}
+	for c := range 2 {
+		container := corev1.Container{
+			Name:  fmt.Sprintf("container-%d", c),
+			Image: fmt.Sprintf("registry.example.com/app/%s:v1.%d", name, c),
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("128Mi"),
+				},
+			},
+		}
+		for e := range 8 {
+			container.Env = append(container.Env, corev1.EnvVar{
+				Name: fmt.Sprintf("APP_SETTING_%d", e), Value: fmt.Sprintf("value-%d-%d", c, e),
+			})
+		}
+		pod.Spec.Containers = append(pod.Spec.Containers, container)
+	}
+	return pod
+}
+
+func TestInformerFootprintAgainstAPIServer(t *testing.T) {
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, framework.DefaultTestServerFlags(), framework.SharedEtcd())
+	defer server.TearDownFn()
+
+	config := restclient.CopyConfig(server.ClientConfig)
+	config.QPS = 2000
+	config.Burst = 4000
+	client := kubernetes.NewForConfigOrDie(config)
+	ctx := context.Background()
+
+	if _, err := client.CoreV1().Namespaces().Create(ctx,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}, metav1.CreateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("creating %d pods via the API...", nPods)
+	start := time.Now()
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for w := range workers {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := w; i < nPods; i += workers {
+				if _, err := client.CoreV1().Pods(nsName).Create(ctx, apiPod(i), metav1.CreateOptions{}); err != nil {
+					select {
+					case errCh <- err:
+					default:
+					}
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
+	}
+	t.Logf("created %d pods in %v", nPods, time.Since(start))
+
+	for _, mode := range []string{"0", "1", "proto"} {
+		name := map[string]string{"0": "default", "1": "reloc", "proto": "proto"}[mode]
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("KUBE_BYTECACHE", mode)
+			runtime.GC()
+			runtime.GC()
+			var base runtime.MemStats
+			runtime.ReadMemStats(&base)
+
+			lw := cache.NewListWatchFromClient(client.CoreV1().RESTClient(), "pods", nsName, fields.Everything())
+			informer := cache.NewSharedIndexInformer(lw, &corev1.Pod{}, 0,
+				cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+			stop := make(chan struct{})
+			go informer.Run(stop)
+			if !cache.WaitForCacheSync(stop, informer.HasSynced) {
+				close(stop)
+				t.Fatal("sync failed")
+			}
+			if err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, time.Minute, true,
+				func(context.Context) (bool, error) {
+					return len(informer.GetStore().ListKeys()) == nPods, nil
+				}); err != nil {
+				close(stop)
+				t.Fatalf("never saw %d keys: %v", nPods, err)
+			}
+
+			obj, ok, err := informer.GetStore().GetByKey(nsName + "/workload-7")
+			if err != nil || !ok {
+				close(stop)
+				t.Fatalf("get: %v %v", ok, err)
+			}
+			pod := obj.(*corev1.Pod)
+			if pod.Labels["app"] != "workload-7" || len(pod.ManagedFields) == 0 {
+				close(stop)
+				t.Fatalf("unexpected pod content (managedFields=%d)", len(pod.ManagedFields))
+			}
+
+			runtime.GC()
+			runtime.GC()
+			var after runtime.MemStats
+			runtime.ReadMemStats(&after)
+			gcStart := time.Now()
+			for range 3 {
+				runtime.GC()
+			}
+			gcTime := time.Since(gcStart) / 3
+			t.Logf("%-8s heap %+7.1f MB, heapObjects %+9d, full GC %v (managedFields present: %d entries on sample pod)",
+				name, float64(after.HeapAlloc-base.HeapAlloc)/1e6,
+				int64(after.HeapObjects)-int64(base.HeapObjects), gcTime, len(pod.ManagedFields))
+
+			close(stop)
+		})
+	}
+}

--- a/test/integration/bytecache/main_test.go
+++ b/test/integration/bytecache/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bytecache
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}


### PR DESCRIPTION
Opening as a draft to gather feedback on whether this direction is worth pursuing (KEP to follow if so).

**What type of PR is this?**

/kind feature
/sig api-machinery

**What this PR does / why we need it**:

**WIP / RFC**: an experimental informer cache store that moves cached objects off the Go heap. Opt-in via `KUBE_BYTECACHE=1`, default off, zero behavior change otherwise. 

### Problem

Informer caches hold every watched object as a live Go object graph on the heap. In large clusters this is often the dominant memory cost of controllers.  Because these are pointer-rich objects, they also make garbage-collection expensive.

### Design

Objects in the informer cache are stored as `[]byte` (we have a few options here).  We store them in an mmaped file: this does not need to be visited by GC, and does not mess up the GOGC calculation.  The pages are evictable by the kernel under memory pressure, even if swap is not configured ( 🎉  )

`Get()` returns an object.  The different codecs have different strategies here.  I investigated whether we could simply return a pointer to the mmaped-file, the problem (that I haven't cracked) is that garbage collection becomes tricky.  I think it is solvable with go runtime changes, but that's probably a future discussion.

Three codecs are included for comparison, selectable via the env var:

| codec | encode | decode (miss) | at rest/pod | notes |
|---|---|---|---|---|
| `reloc` (=`1`) | 9.3µs, 0 allocs | 0.8µs, 1 alloc | 3,067B | native layout; works for **any** type incl. `unstructured` (CRDs) |
| `proto` | 2.1µs | 3.0µs, 42 allocs | **303B** | generated marshalers only; 10× denser at rest |
| `gob` | 284µs | 598µs | 17,295B | **disqualified**: silently corrupts `resource.Quantity` (unexported fields); included to show why, and to demonstrate the self-check |


### Numbers

Against a real kube-apiserver, 10k pods created through the API (managedFields, defaulting, status intact), measured per mode in `test/integration/bytecache`:

| mode | informer-attributable heap | heap objects |
|---|---|---|
| current | +89.4 MB | +889,225 |
| reloc | **+2.2 MB** | **+10,071** |
| proto | +2.2 MB | +10,524 |



### Known caveats / questions for discussion

* Get/List is slower (the pointer cast approach takes about 0.1µs, so maybe 20x - 100x slower).  It's still very fast, but it might be noticeable on a controller restart.
* We should decide whether we want proto or the reloc code.  The reloc code is cool, I think, but I would be much more comfortable if we baked it into the go runtime.


**Does this PR introduce a user-facing change?**

```release-note
NONE
```

