### PR TITLE
Unstructuctured/PartialObjectMeta: Allow to initialize with basic object and type meta

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	cbor "k8s.io/apimachinery/pkg/runtime/serializer/cbor/direct"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
@@ -273,6 +274,80 @@ func ResetObjectMetaForStatus(meta, existingMeta Object) {
 	// managedFields must be preserved since it's been modified to
 	// track changed fields in the status update.
 	//meta.SetManagedFields(existingMeta.GetManagedFields())
+}
+
+// WithAPIVersion sets the apiVersion and returns obj, which allows an object with
+// type information to be constructed in a single expression:
+//
+//	obj := (&metav1.PartialObjectMetadata{}).WithAPIVersion("v1").WithKind("Pod")
+func (obj *PartialObjectMetadata) WithAPIVersion(version string) *PartialObjectMetadata {
+	obj.APIVersion = version
+	return obj
+}
+
+// WithKind sets the kind and returns obj, which allows an object with type
+// information to be constructed in a single expression:
+//
+//	obj := (&metav1.PartialObjectMetadata{}).WithAPIVersion("v1").WithKind("Pod")
+func (obj *PartialObjectMetadata) WithKind(kind string) *PartialObjectMetadata {
+	obj.Kind = kind
+	return obj
+}
+
+// WithName sets the name and returns obj, which allows an object with type and
+// identity information to be constructed in a single expression:
+//
+//	obj := (&metav1.PartialObjectMetadata{}).WithGroupVersionKind(gvk).WithNamespace("ns").WithName("n")
+func (obj *PartialObjectMetadata) WithName(name string) *PartialObjectMetadata {
+	obj.Name = name
+	return obj
+}
+
+// WithNamespace sets the namespace and returns obj, which allows an object with type
+// and identity information to be constructed in a single expression:
+//
+//	obj := (&metav1.PartialObjectMetadata{}).WithGroupVersionKind(gvk).WithNamespace("ns").WithName("n")
+func (obj *PartialObjectMetadata) WithNamespace(namespace string) *PartialObjectMetadata {
+	obj.Namespace = namespace
+	return obj
+}
+
+// WithGroupVersionKind sets the apiVersion and kind from gvk and returns obj, which
+// allows an object with type information to be constructed in a single expression:
+//
+//	obj := (&metav1.PartialObjectMetadata{}).WithGroupVersionKind(gvk)
+func (obj *PartialObjectMetadata) WithGroupVersionKind(gvk schema.GroupVersionKind) *PartialObjectMetadata {
+	obj.APIVersion = gvk.GroupVersion().String()
+	obj.Kind = gvk.Kind
+	return obj
+}
+
+// WithAPIVersion sets the apiVersion and returns obj, which allows a list object with
+// type information to be constructed in a single expression:
+//
+//	list := (&metav1.PartialObjectMetadataList{}).WithAPIVersion("v1").WithKind("PodList")
+func (obj *PartialObjectMetadataList) WithAPIVersion(version string) *PartialObjectMetadataList {
+	obj.APIVersion = version
+	return obj
+}
+
+// WithKind sets the kind and returns obj, which allows a list object with type
+// information to be constructed in a single expression:
+//
+//	list := (&metav1.PartialObjectMetadataList{}).WithAPIVersion("v1").WithKind("PodList")
+func (obj *PartialObjectMetadataList) WithKind(kind string) *PartialObjectMetadataList {
+	obj.Kind = kind
+	return obj
+}
+
+// WithGroupVersionKind sets the apiVersion and kind from gvk and returns obj, which
+// allows a list object with type information to be constructed in a single expression:
+//
+//	list := (&metav1.PartialObjectMetadataList{}).WithGroupVersionKind(gvk)
+func (obj *PartialObjectMetadataList) WithGroupVersionKind(gvk schema.GroupVersionKind) *PartialObjectMetadataList {
+	obj.APIVersion = gvk.GroupVersion().String()
+	obj.Kind = gvk.Kind
+	return obj
 }
 
 // MarshalJSON implements json.Marshaler

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/randfill"
 )
@@ -479,5 +480,59 @@ func TestFieldsV1UnmarshalCBOR(t *testing.T) {
 				t.Errorf("unexpected diff:\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestPartialObjectMetadataWithTypeMeta(t *testing.T) {
+	obj := (&PartialObjectMetadata{}).WithAPIVersion("apps/v1").WithKind("Deployment")
+	if obj.APIVersion != "apps/v1" {
+		t.Errorf("apiVersion: got %q, want %q", obj.APIVersion, "apps/v1")
+	}
+	if obj.Kind != "Deployment" {
+		t.Errorf("kind: got %q, want %q", obj.Kind, "Deployment")
+	}
+}
+
+func TestPartialObjectMetadataWithGroupVersionKind(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	obj := (&PartialObjectMetadata{}).WithGroupVersionKind(gvk)
+	if obj.APIVersion != "apps/v1" {
+		t.Errorf("apiVersion: got %q, want %q", obj.APIVersion, "apps/v1")
+	}
+	if obj.Kind != "Deployment" {
+		t.Errorf("kind: got %q, want %q", obj.Kind, "Deployment")
+	}
+	if got := obj.GroupVersionKind(); got != gvk {
+		t.Errorf("GroupVersionKind: got %v, want %v", got, gvk)
+	}
+}
+
+func TestPartialObjectMetadataWithIdentity(t *testing.T) {
+	gvk := schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
+	obj := (&PartialObjectMetadata{}).WithGroupVersionKind(gvk).WithNamespace("ns").WithName("n")
+	if obj.Namespace != "ns" {
+		t.Errorf("namespace: got %q, want %q", obj.Namespace, "ns")
+	}
+	if obj.Name != "n" {
+		t.Errorf("name: got %q, want %q", obj.Name, "n")
+	}
+	if got := obj.GroupVersionKind(); got != gvk {
+		t.Errorf("GroupVersionKind: got %v, want %v", got, gvk)
+	}
+}
+
+func TestPartialObjectMetadataListWithTypeMeta(t *testing.T) {
+	gvk := schema.GroupVersionKind{Version: "v1", Kind: "PodList"}
+	list := (&PartialObjectMetadataList{}).WithGroupVersionKind(gvk)
+	if got := list.GroupVersionKind(); got != gvk {
+		t.Errorf("GroupVersionKind: got %v, want %v", got, gvk)
+	}
+
+	list = (&PartialObjectMetadataList{}).WithAPIVersion("v1").WithKind("PodList")
+	if list.APIVersion != "v1" {
+		t.Errorf("apiVersion: got %q, want %q", list.APIVersion, "v1")
+	}
+	if list.Kind != "PodList" {
+		t.Errorf("kind: got %q, want %q", list.Kind, "PodList")
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -227,12 +227,30 @@ func (u *Unstructured) SetAPIVersion(version string) {
 	u.setNestedField(version, "apiVersion")
 }
 
+// WithAPIVersion sets the apiVersion and returns u, which allows an object with
+// type information to be constructed in a single expression:
+//
+//	obj := (&unstructured.Unstructured{}).WithAPIVersion("v1").WithKind("Pod")
+func (u *Unstructured) WithAPIVersion(version string) *Unstructured {
+	u.SetAPIVersion(version)
+	return u
+}
+
 func (u *Unstructured) GetKind() string {
 	return getNestedString(u.Object, "kind")
 }
 
 func (u *Unstructured) SetKind(kind string) {
 	u.setNestedField(kind, "kind")
+}
+
+// WithKind sets the kind and returns u, which allows an object with type
+// information to be constructed in a single expression:
+//
+//	obj := (&unstructured.Unstructured{}).WithAPIVersion("v1").WithKind("Pod")
+func (u *Unstructured) WithKind(kind string) *Unstructured {
+	u.SetKind(kind)
+	return u
 }
 
 func (u *Unstructured) GetNamespace() string {
@@ -257,6 +275,24 @@ func (u *Unstructured) SetName(name string) {
 		return
 	}
 	u.setNestedField(name, "metadata", "name")
+}
+
+// WithName sets the name and returns u, which allows an object with type and
+// identity information to be constructed in a single expression:
+//
+//	obj := (&unstructured.Unstructured{}).WithGroupVersionKind(gvk).WithNamespace("ns").WithName("n")
+func (u *Unstructured) WithName(name string) *Unstructured {
+	u.SetName(name)
+	return u
+}
+
+// WithNamespace sets the namespace and returns u, which allows an object with type
+// and identity information to be constructed in a single expression:
+//
+//	obj := (&unstructured.Unstructured{}).WithGroupVersionKind(gvk).WithNamespace("ns").WithName("n")
+func (u *Unstructured) WithNamespace(namespace string) *Unstructured {
+	u.SetNamespace(namespace)
+	return u
 }
 
 func (u *Unstructured) GetGenerateName() string {
@@ -425,6 +461,15 @@ func (u *Unstructured) SetAnnotations(annotations map[string]string) {
 func (u *Unstructured) SetGroupVersionKind(gvk schema.GroupVersionKind) {
 	u.SetAPIVersion(gvk.GroupVersion().String())
 	u.SetKind(gvk.Kind)
+}
+
+// WithGroupVersionKind sets the apiVersion and kind from gvk and returns u, which
+// allows an object with type information to be constructed in a single expression:
+//
+//	obj := (&unstructured.Unstructured{}).WithGroupVersionKind(gvk)
+func (u *Unstructured) WithGroupVersionKind(gvk schema.GroupVersionKind) *Unstructured {
+	u.SetGroupVersionKind(gvk)
+	return u
 }
 
 func (u *Unstructured) GroupVersionKind() schema.GroupVersionKind {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list.go
@@ -153,12 +153,30 @@ func (u *UnstructuredList) SetAPIVersion(version string) {
 	u.setNestedField(version, "apiVersion")
 }
 
+// WithAPIVersion sets the apiVersion and returns u, which allows a list object with
+// type information to be constructed in a single expression:
+//
+//	list := (&unstructured.UnstructuredList{}).WithAPIVersion("v1").WithKind("PodList")
+func (u *UnstructuredList) WithAPIVersion(version string) *UnstructuredList {
+	u.SetAPIVersion(version)
+	return u
+}
+
 func (u *UnstructuredList) GetKind() string {
 	return getNestedString(u.Object, "kind")
 }
 
 func (u *UnstructuredList) SetKind(kind string) {
 	u.setNestedField(kind, "kind")
+}
+
+// WithKind sets the kind and returns u, which allows a list object with type
+// information to be constructed in a single expression:
+//
+//	list := (&unstructured.UnstructuredList{}).WithAPIVersion("v1").WithKind("PodList")
+func (u *UnstructuredList) WithKind(kind string) *UnstructuredList {
+	u.SetKind(kind)
+	return u
 }
 
 func (u *UnstructuredList) GetResourceVersion() string {
@@ -200,6 +218,15 @@ func (u *UnstructuredList) SetRemainingItemCount(c *int64) {
 func (u *UnstructuredList) SetGroupVersionKind(gvk schema.GroupVersionKind) {
 	u.SetAPIVersion(gvk.GroupVersion().String())
 	u.SetKind(gvk.Kind)
+}
+
+// WithGroupVersionKind sets the apiVersion and kind from gvk and returns u, which
+// allows a list object with type information to be constructed in a single expression:
+//
+//	list := (&unstructured.UnstructuredList{}).WithGroupVersionKind(gvk)
+func (u *UnstructuredList) WithGroupVersionKind(gvk schema.GroupVersionKind) *UnstructuredList {
+	u.SetGroupVersionKind(gvk)
+	return u
 }
 
 func (u *UnstructuredList) GroupVersionKind() schema.GroupVersionKind {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
@@ -37,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	cborserializer "k8s.io/apimachinery/pkg/runtime/serializer/cbor"
 	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -473,4 +474,52 @@ func anyEqual(t *testing.T, a, b interface{}) bool {
 		t.Fatalf("unexpected value %v of type %T", a, a)
 	}
 	return true
+}
+
+func TestUnstructuredWithTypeMeta(t *testing.T) {
+	obj := (&unstructured.Unstructured{}).WithAPIVersion("apps/v1").WithKind("Deployment")
+	if got := obj.GetAPIVersion(); got != "apps/v1" {
+		t.Errorf("apiVersion: got %q, want %q", got, "apps/v1")
+	}
+	if got := obj.GetKind(); got != "Deployment" {
+		t.Errorf("kind: got %q, want %q", got, "Deployment")
+	}
+}
+
+func TestUnstructuredWithGroupVersionKind(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+	obj := (&unstructured.Unstructured{}).WithGroupVersionKind(gvk)
+	if got := obj.GroupVersionKind(); got != gvk {
+		t.Errorf("GroupVersionKind: got %v, want %v", got, gvk)
+	}
+}
+
+func TestUnstructuredWithIdentity(t *testing.T) {
+	gvk := schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
+	obj := (&unstructured.Unstructured{}).WithGroupVersionKind(gvk).WithNamespace("ns").WithName("n")
+	if got := obj.GetNamespace(); got != "ns" {
+		t.Errorf("namespace: got %q, want %q", got, "ns")
+	}
+	if got := obj.GetName(); got != "n" {
+		t.Errorf("name: got %q, want %q", got, "n")
+	}
+	if got := obj.GroupVersionKind(); got != gvk {
+		t.Errorf("GroupVersionKind: got %v, want %v", got, gvk)
+	}
+}
+
+func TestUnstructuredListWithTypeMeta(t *testing.T) {
+	gvk := schema.GroupVersionKind{Version: "v1", Kind: "PodList"}
+	list := (&unstructured.UnstructuredList{}).WithGroupVersionKind(gvk)
+	if got := list.GroupVersionKind(); got != gvk {
+		t.Errorf("GroupVersionKind: got %v, want %v", got, gvk)
+	}
+
+	list = (&unstructured.UnstructuredList{}).WithAPIVersion("v1").WithKind("PodList")
+	if got := list.GetAPIVersion(); got != "v1" {
+		t.Errorf("apiVersion: got %q, want %q", got, "v1")
+	}
+	if got := list.GetKind(); got != "PodList" {
+		t.Errorf("kind: got %q, want %q", got, "PodList")
+	}
 }


### PR DESCRIPTION
Unstructured and PartialObjectMeta currently always have to be constructed like this:
```
u := &unstructured.Unstructured{}
u.SetGroupVersionKind(gvk)
```

because the setters are all part of the `metav1.Object` interface so they can not return the object.

Add `With` methods to allow doing this in a single expression:
```
u := (&unstructured.Unstructured).WithGroupVersionKind(gvk).WithName("foo")
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup
/sig api-machinery

#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
