### PR TITLE
validation-gen: declare TooLong for the resource format validators

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
+++ b/staging/src/k8s.io/code-generator/cmd/validation-gen/validators/format.go
@@ -119,10 +119,18 @@ func getFormatValidationFunction(format string) (FunctionGen, error) {
 			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-prefixed-label-key", ""}), nil
 	case "k8s-resource-fully-qualified-name":
 		return Function(formatTagName, DefaultFlags, resourceFullyQualifiedNameValidator).
-			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-resource-fully-qualified-name", ""}), nil
+			WithEmits(
+				Emission{field.ErrorTypeInvalid, "format=k8s-resource-fully-qualified-name", ""},
+				// The domain and name parts carry their own length limits.
+				Emission{field.ErrorTypeTooLong, "format=k8s-resource-fully-qualified-name", ""},
+			), nil
 	case "k8s-resource-pool-name":
 		return Function(formatTagName, DefaultFlags, resourcePoolNameValidator).
-			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-resource-pool-name", ""}), nil
+			WithEmits(
+				Emission{field.ErrorTypeInvalid, "format=k8s-resource-pool-name", ""},
+				// The name as a whole is limited to 253 characters.
+				Emission{field.ErrorTypeTooLong, "format=k8s-resource-pool-name", ""},
+			), nil
 	case "k8s-short-name":
 		return Function(formatTagName, DefaultFlags, shortNameValidator).
 			WithEmits(Emission{field.ErrorTypeInvalid, "format=k8s-short-name", ""}), nil

--- a/test/declarative_validation/resource/resourceclaim/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceclaim/declarative_validation_test.go
@@ -508,6 +508,12 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("distinctAttribute"), "nodomain", "a fully qualified name must be a domain and a name separated by a slash").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
+		"distinct attribute with long name": {
+			input: mkValidResourceClaim(tweakDistinctAttribute("domain/" + strings.Repeat("a", 33))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(field.NewPath("spec", "devices", "constraints").Index(0).Child("distinctAttribute"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
+			},
+		},
 
 		"valid exactly derived attributes, valid name": {
 			input: mkValidResourceClaim(tweakExactlyDerivedAttributeName("derived/attribute")),
@@ -517,6 +523,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "derivedAttributes").Index(0).Child("name"), "invalid name", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')").WithOrigin("format=k8s-resource-fully-qualified-name"),
 				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid name", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
+			},
+		},
+		"invalid exactly derived attributes, long name": {
+			input: mkValidResourceClaim(tweakExactlyDerivedAttributeName("domain/" + strings.Repeat("a", 33))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(field.NewPath("spec", "devices", "requests").Index(0).Child("exactly", "derivedAttributes").Index(0).Child("name"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.TooLong(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"invalid exactly derived attributes, empty name": {
@@ -550,6 +563,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("derivedAttributes").Index(0).Child("name"), "invalid name", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')").WithOrigin("format=k8s-resource-fully-qualified-name"),
 				field.Invalid(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid name", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
+			},
+		},
+		"invalid firstAvailable derived attributes, long name": {
+			input: mkValidResourceClaim(tweakFirstAvailableDerivedAttributeName("domain/" + strings.Repeat("a", 33))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(field.NewPath("spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("derivedAttributes").Index(0).Child("name"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.TooLong(field.NewPath("spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"invalid firstAvailable derived attributes, empty name": {

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1_test.go
@@ -83,9 +83,11 @@ func init() {
 			},
 			"spec.devices.constraints[*].distinctAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.constraints[*].matchAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.constraints[*].requests": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -111,6 +113,7 @@ func init() {
 			"spec.devices.requests[*].exactly.derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.requests[*].exactly.selectors": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -143,6 +146,7 @@ func init() {
 			"spec.devices.requests[*].firstAvailable[*].derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.requests[*].firstAvailable[*].deviceClassName": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},
@@ -199,6 +203,7 @@ func init() {
 			"status.allocation.devices.results[*].pool": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-pool-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-pool-name"},
 			},
 			"status.allocation.devices.results[*].shareID": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-uuid"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta1_test.go
@@ -83,9 +83,11 @@ func init() {
 			},
 			"spec.devices.constraints[*].distinctAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.constraints[*].matchAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.constraints[*].requests": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -111,6 +113,7 @@ func init() {
 			"spec.devices.requests[*].derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.requests[*].firstAvailable": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -130,6 +133,7 @@ func init() {
 			"spec.devices.requests[*].firstAvailable[*].derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.requests[*].firstAvailable[*].deviceClassName": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},
@@ -199,6 +203,7 @@ func init() {
 			"status.allocation.devices.results[*].pool": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-pool-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-pool-name"},
 			},
 			"status.allocation.devices.results[*].shareID": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-uuid"},

--- a/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaim/zz_generated.validations.v1beta2_test.go
@@ -83,9 +83,11 @@ func init() {
 			},
 			"spec.devices.constraints[*].distinctAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.constraints[*].matchAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.constraints[*].requests": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -111,6 +113,7 @@ func init() {
 			"spec.devices.requests[*].exactly.derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.requests[*].exactly.selectors": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -143,6 +146,7 @@ func init() {
 			"spec.devices.requests[*].firstAvailable[*].derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.devices.requests[*].firstAvailable[*].deviceClassName": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},
@@ -199,6 +203,7 @@ func init() {
 			"status.allocation.devices.results[*].pool": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-pool-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-pool-name"},
 			},
 			"status.allocation.devices.results[*].shareID": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-uuid"},

--- a/test/declarative_validation/resource/resourceclaimtemplate/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/declarative_validation_test.go
@@ -402,10 +402,22 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", "").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
+		"match attribute with long name": {
+			input: mkValidResourceClaimTemplate(tweakMatchAttribute("domain/" + strings.Repeat("a", 33))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
+			},
+		},
 		"invalid distinct attribute": {
 			input: mkValidResourceClaimTemplate(tweakDistinctAttribute("nodomain")),
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("distinctAttribute"), "nodomain", "a fully qualified name must be a domain and a name separated by a slash").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
+			},
+		},
+		"distinct attribute with long name": {
+			input: mkValidResourceClaimTemplate(tweakDistinctAttribute("domain/" + strings.Repeat("a", 33))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("distinctAttribute"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 
@@ -417,6 +429,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "derivedAttributes").Index(0).Child("name"), "invalid name", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')").WithOrigin("format=k8s-resource-fully-qualified-name"),
 				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid name", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
+			},
+		},
+		"invalid exactly derived attributes, long name": {
+			input: mkValidResourceClaimTemplate(tweakExactlyDerivedAttributeName("domain/" + strings.Repeat("a", 33))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("exactly", "derivedAttributes").Index(0).Child("name"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.TooLong(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"invalid exactly derived attributes, empty name": {
@@ -450,6 +469,13 @@ func testDeclarativeValidate(t *testing.T, apiVersion string) {
 			expectedErrs: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("derivedAttributes").Index(0).Child("name"), "invalid name", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')").WithOrigin("format=k8s-resource-fully-qualified-name"),
 				field.Invalid(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "invalid name", "name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')").WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
+			},
+		},
+		"invalid firstAvailable derived attributes, long name": {
+			input: mkValidResourceClaimTemplate(tweakFirstAvailableDerivedAttributeName("domain/" + strings.Repeat("a", 33))),
+			expectedErrs: field.ErrorList{
+				field.TooLong(field.NewPath("spec", "spec", "devices", "requests").Index(0).Child("firstAvailable").Index(0).Child("derivedAttributes").Index(0).Child("name"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name"),
+				field.TooLong(field.NewPath("spec", "spec", "devices", "constraints").Index(0).Child("matchAttribute"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name").MarkBeta(),
 			},
 		},
 		"invalid firstAvailable derived attributes, empty name": {

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1_test.go
@@ -80,9 +80,11 @@ func init() {
 			},
 			"spec.spec.devices.constraints[*].distinctAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.constraints[*].matchAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.constraints[*].requests": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -108,6 +110,7 @@ func init() {
 			"spec.spec.devices.requests[*].exactly.derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.requests[*].exactly.selectors": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -140,6 +143,7 @@ func init() {
 			"spec.spec.devices.requests[*].firstAvailable[*].derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.requests[*].firstAvailable[*].deviceClassName": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta1_test.go
@@ -80,9 +80,11 @@ func init() {
 			},
 			"spec.spec.devices.constraints[*].distinctAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.constraints[*].matchAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.constraints[*].requests": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -108,6 +110,7 @@ func init() {
 			"spec.spec.devices.requests[*].derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.requests[*].firstAvailable": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -127,6 +130,7 @@ func init() {
 			"spec.spec.devices.requests[*].firstAvailable[*].derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.requests[*].firstAvailable[*].deviceClassName": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},

--- a/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceclaimtemplate/zz_generated.validations.v1beta2_test.go
@@ -80,9 +80,11 @@ func init() {
 			},
 			"spec.spec.devices.constraints[*].distinctAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.constraints[*].matchAttribute": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.constraints[*].requests": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -108,6 +110,7 @@ func init() {
 			"spec.spec.devices.requests[*].exactly.derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.requests[*].exactly.selectors": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -140,6 +143,7 @@ func init() {
 			"spec.spec.devices.requests[*].firstAvailable[*].derivedAttributes[*].name": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.spec.devices.requests[*].firstAvailable[*].deviceClassName": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name"},

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/declarative_validation_test.go
@@ -74,6 +74,11 @@ func TestDeclarativeValidate(t *testing.T) {
 			input:        mkValidRPSR(setPoolName("invalid pool!")),
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("spec", "poolName"), nil, "").WithOrigin("format=k8s-resource-pool-name")},
 		},
+		"pool name too long": {
+			// +k8s:format=k8s-resource-pool-name (standard DV)
+			input:        mkValidRPSR(setPoolName(strings.Repeat("a", 126) + "/" + strings.Repeat("b", 127))),
+			expectedErrs: field.ErrorList{field.TooLong(field.NewPath("spec", "poolName"), "", 253).WithOrigin("format=k8s-resource-pool-name")},
+		},
 		"valid partitionTypeAttribute": {
 			// +k8s:ifEnabled(DRAPartitionableDevicesType)=+k8s:optional
 			input: mkValidRPSR(func(r *resource.ResourcePoolStatusRequest) {
@@ -88,6 +93,14 @@ func TestDeclarativeValidate(t *testing.T) {
 			}),
 			enablePartitionTypeAttr: true,
 			expectedErrs:            field.ErrorList{field.Invalid(field.NewPath("spec", "defaultPartitionTypeAttribute"), nil, "").WithOrigin("format=k8s-resource-fully-qualified-name")},
+		},
+		"partitionTypeAttribute name too long": {
+			// +k8s:ifEnabled(DRAPartitionableDevicesType)=+k8s:format=k8s-resource-fully-qualified-name
+			input: mkValidRPSR(func(r *resource.ResourcePoolStatusRequest) {
+				r.Spec.DefaultPartitionTypeAttribute = new("gpu.example.com/" + strings.Repeat("a", 33))
+			}),
+			enablePartitionTypeAttr: true,
+			expectedErrs:            field.ErrorList{field.TooLong(field.NewPath("spec", "defaultPartitionTypeAttribute"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name")},
 		},
 		"partitionTypeAttribute without domain": {
 			// A bare name is a valid attribute key but not a valid reference:
@@ -249,6 +262,16 @@ func TestDeclarativeValidateStatusUpdate(t *testing.T) {
 				s.Pools = []resource.PoolStatus{pool}
 			})),
 			expectedErrs: field.ErrorList{field.Invalid(field.NewPath("status", "pools").Index(0).Child("poolName"), nil, "").WithOrigin("format=k8s-resource-pool-name")},
+		},
+		"pool poolName too long": {
+			// +k8s:format=k8s-resource-pool-name (standard DV)
+			oldObj: mkValidRPSRForUpdate(),
+			updateObj: mkValidRPSRForUpdate(withStatus(func(s *resource.ResourcePoolStatusRequestStatus) {
+				pool := mkValidPoolStatus()
+				pool.PoolName = strings.Repeat("a", 126) + "/" + strings.Repeat("b", 127)
+				s.Pools = []resource.PoolStatus{pool}
+			})),
+			expectedErrs: field.ErrorList{field.TooLong(field.NewPath("status", "pools").Index(0).Child("poolName"), "", 253).WithOrigin("format=k8s-resource-pool-name")},
 		},
 		"pool nil optional fields valid": {
 			// Device count fields are optional (may be unset when validationError is set)

--- a/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
+++ b/test/declarative_validation/resource/resourcepoolstatusrequest/zz_generated.validations.v1alpha3_test.go
@@ -67,6 +67,7 @@ func init() {
 			"spec.defaultPartitionTypeAttribute": {
 				{ErrorType: "FieldValueForbidden"},
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.driver": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-long-name-caseless"},
@@ -79,6 +80,7 @@ func init() {
 			},
 			"spec.poolName": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-pool-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-pool-name"},
 			},
 			"status.conditions": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},
@@ -148,6 +150,7 @@ func init() {
 			"status.pools[*].poolName": {
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-pool-name"},
 				{ErrorType: "FieldValueRequired"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-pool-name"},
 			},
 			"status.pools[*].resourceSliceCount": {
 				{ErrorType: "FieldValueInvalid", Origin: "minimum"},

--- a/test/declarative_validation/resource/resourceslice/declarative_validation_test.go
+++ b/test/declarative_validation/resource/resourceslice/declarative_validation_test.go
@@ -298,6 +298,16 @@ func TestDeclarativeValidate(t *testing.T) {
 						field.Invalid(field.NewPath("spec", "partitionTypeAttribute"), nil, "").WithOrigin("format=k8s-resource-fully-qualified-name"),
 					},
 				},
+				"invalid: partitionTypeAttribute name too long": {
+					input: mkResourceSliceWithDevices(
+						tweakDeviceCounter(counters("valid-key")),
+						tweakPartitionTypeAttribute(resource.FullyQualifiedName("gpu.example.com/"+strings.Repeat("a", 33))),
+					),
+					enablePartitionTypeAttr: true,
+					expectedErrs: field.ErrorList{
+						field.TooLong(field.NewPath("spec", "partitionTypeAttribute"), "", 32).WithOrigin("format=k8s-resource-fully-qualified-name"),
+					},
+				},
 				// A bare name is a valid attribute key but not a valid reference:
 				// the domain is required so the attribute is unambiguous.
 				"invalid: partitionTypeAttribute without domain": {

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1_test.go
@@ -110,6 +110,7 @@ func init() {
 			"spec.partitionTypeAttribute": {
 				{ErrorType: "FieldValueForbidden"},
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.sharedCounters": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta1_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta1_test.go
@@ -110,6 +110,7 @@ func init() {
 			"spec.partitionTypeAttribute": {
 				{ErrorType: "FieldValueForbidden"},
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.sharedCounters": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},

--- a/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta2_test.go
+++ b/test/declarative_validation/resource/resourceslice/zz_generated.validations.v1beta2_test.go
@@ -110,6 +110,7 @@ func init() {
 			"spec.partitionTypeAttribute": {
 				{ErrorType: "FieldValueForbidden"},
 				{ErrorType: "FieldValueInvalid", Origin: "format=k8s-resource-fully-qualified-name"},
+				{ErrorType: "FieldValueTooLong", Origin: "format=k8s-resource-fully-qualified-name"},
 			},
 			"spec.sharedCounters": {
 				{ErrorType: "FieldValueTooMany", Origin: "maxItems"},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`k8s-resource-pool-name` and `k8s-resource-fully-qualified-name` each declare a
single `Emission{ErrorTypeInvalid, ...}`, but both runtime validators also return
`field.TooLong`:

- `ResourcePoolName` reports the 253 character limit on the whole name.
- `ResourceFullyQualifiedName` reports the 63 character domain limit and the 32
  character name limit, through `validateCIdentifier`.

`Emission` is documented as "must match what the runtime function emits", and
`AssertDeclarativeCoverage` is declared minus observed, so a rule that is never
declared can never be required. The `TooLong` branch of both formats has been
exempt from the guardrail added in #138872. `resourceclaim` happens to assert one
of them today on `constraints[0].matchAttribute`; deleting that case would not
have failed anything.

Declaring the missing emissions left eleven field paths uncovered:

| kind | uncovered paths |
| --- | --- |
| ResourceClaim | `constraints[*].distinctAttribute`, and both `derivedAttributes[*].name` paths |
| ResourceClaimTemplate | those three, plus `constraints[*].matchAttribute` |
| ResourcePoolStatusRequest | `spec.defaultPartitionTypeAttribute`, `spec.poolName`, `status.pools[*].poolName` |
| ResourceSlice | `spec.partitionTypeAttribute` |

This adds a case for each.

The declaration is the side that is wrong, not the runtime. The handwritten
validators these mirror, `validatePoolName` and `validateCIdentifier` in
`pkg/apis/resource/validation`, report the same limits as `TooLong`, so making the
declarative side emit `Invalid` instead would introduce a real mismatch.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Same shape as #139333, which corrected the `+k8s:update` declarations against what
the runtime emits. As in that PR there is no unit test under `validators/`, since
nothing there asserts `Emits` today. The check is the guardrail itself: with the
`format.go` hunk applied and the test cases dropped, all four packages fail with
the uncovered-rule list above.

A check that compared every format's declared emissions against what its runtime
function actually returns would catch this class rather than these two instances,
but it needs a way to drive each function with failing input, so it belongs in its
own PR.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/assign @jpbetz
/cc @yongruilin
