### PR TITLE
Refactor flags and options in `kubectl top` cmd

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
@@ -81,8 +81,8 @@ func NewCmdTop(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Com
 	}
 
 	// create subcommands
-	cmd.AddCommand(NewCmdTopNode(f, nil, streams))
-	cmd.AddCommand(NewCmdTopPod(f, nil, streams))
+	cmd.AddCommand(NewCmdTopNode(f, streams))
+	cmd.AddCommand(NewCmdTopPod(f, streams))
 
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -90,10 +90,8 @@ func NewTopNodeFlags(streams genericiooptions.IOStreams) *TopNodeFlags {
 	}
 }
 
-func NewCmdTopNode(f cmdutil.Factory, flags *TopNodeFlags, streams genericiooptions.IOStreams) *cobra.Command {
-	if flags == nil {
-		flags = NewTopNodeFlags(streams)
-	}
+func NewCmdTopNode(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	flags := NewTopNodeFlags(streams)
 
 	cmd := &cobra.Command{
 		Use:                   "node [NAME | -l label]",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node.go
@@ -19,6 +19,8 @@ package top
 import (
 	"context"
 	"errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -38,15 +40,26 @@ import (
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 )
 
-// TopNodeOptions contains all the options for running the top-node cli command.
-type TopNodeOptions struct {
-	ResourceName       string
+// TopNodeFlags directly reflect the information that CLI is gathering via flags.
+type TopNodeFlags struct {
 	Selector           string
 	SortBy             string
 	NoHeaders          bool
 	UseProtocolBuffers bool
 	ShowCapacity       bool
 	ShowSwap           bool
+
+	genericiooptions.IOStreams
+}
+
+// TopNodeOptions contains all the options for running the top-node cli command.
+type TopNodeOptions struct {
+	ResourceName string
+	Selector     string
+	SortBy       string
+	NoHeaders    bool
+	ShowCapacity bool
+	ShowSwap     bool
 
 	NodeClient      corev1client.CoreV1Interface
 	Printer         *metricsutil.TopCmdPrinter
@@ -70,12 +83,16 @@ var (
 		  kubectl top node NODE_NAME`))
 )
 
-func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericiooptions.IOStreams) *cobra.Command {
-	if o == nil {
-		o = &TopNodeOptions{
-			IOStreams:          streams,
-			UseProtocolBuffers: true,
-		}
+func NewTopNodeFlags(streams genericiooptions.IOStreams) *TopNodeFlags {
+	return &TopNodeFlags{
+		IOStreams:          streams,
+		UseProtocolBuffers: true,
+	}
+}
+
+func NewCmdTopNode(f cmdutil.Factory, flags *TopNodeFlags, streams genericiooptions.IOStreams) *cobra.Command {
+	if flags == nil {
+		flags = NewTopNodeFlags(streams)
 	}
 
 	cmd := &cobra.Command{
@@ -86,52 +103,68 @@ func NewCmdTopNode(f cmdutil.Factory, o *TopNodeOptions, streams genericiooption
 		Example:               topNodeExample,
 		ValidArgsFunction:     completion.ResourceNameCompletionFunc(f, "node"),
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			o, err := flags.ToOptions(f, args)
+			cmdutil.CheckErr(err)
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.RunTopNode())
 		},
 		Aliases: []string{"nodes", "no"},
 	}
-	cmdutil.AddLabelSelectorFlagVar(cmd, &o.Selector)
-	cmd.Flags().StringVar(&o.SortBy, "sort-by", o.SortBy, "If non-empty, sort nodes list using specified field. The field can be either 'cpu' or 'memory'.")
-	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers")
-	cmd.Flags().BoolVar(&o.UseProtocolBuffers, "use-protocol-buffers", o.UseProtocolBuffers, "Enables using protocol-buffers to access Metrics API.")
-	cmd.Flags().BoolVar(&o.ShowCapacity, "show-capacity", o.ShowCapacity, "Print node resources based on Capacity instead of Allocatable(default) of the nodes.")
-	cmd.Flags().BoolVar(&o.ShowSwap, "show-swap", o.ShowSwap, "Print node resources related to swap memory.")
+	flags.AddFlags(cmd)
 
 	return cmd
 }
 
-func (o *TopNodeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+// AddFlags registers flags for a cli
+func (flags *TopNodeFlags) AddFlags(cmd *cobra.Command) {
+	cmdutil.AddLabelSelectorFlagVar(cmd, &flags.Selector)
+	cmd.Flags().StringVar(&flags.SortBy, "sort-by", flags.SortBy, "If non-empty, sort nodes list using specified field. The field can be either 'cpu' or 'memory'.")
+	cmd.Flags().BoolVar(&flags.NoHeaders, "no-headers", flags.NoHeaders, "If present, print output without headers")
+	cmd.Flags().BoolVar(&flags.UseProtocolBuffers, "use-protocol-buffers", flags.UseProtocolBuffers, "Enables using protocol-buffers to access Metrics API.")
+	cmd.Flags().BoolVar(&flags.ShowCapacity, "show-capacity", flags.ShowCapacity, "Print node resources based on Capacity instead of Allocatable(default) of the nodes.")
+	cmd.Flags().BoolVar(&flags.ShowSwap, "show-swap", flags.ShowSwap, "Print node resources related to swap memory.")
+}
+
+// ToOptions converts from CLI inputs to runtime inputs
+func (flags *TopNodeFlags) ToOptions(f cmdutil.Factory, args []string) (*TopNodeOptions, error) {
+	o := &TopNodeOptions{
+		Selector:     flags.Selector,
+		SortBy:       flags.SortBy,
+		NoHeaders:    flags.NoHeaders,
+		ShowCapacity: flags.ShowCapacity,
+		ShowSwap:     flags.ShowSwap,
+		IOStreams:    flags.IOStreams,
+	}
+
 	if len(args) == 1 {
 		o.ResourceName = args[0]
 	} else if len(args) > 1 {
-		return cmdutil.UsageErrorf(cmd, "%s", cmd.Use)
+		return nil, fmt.Errorf("unexpected arguments: %v", args[1:])
 	}
 
 	clientset, err := f.KubernetesClientSet()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	o.DiscoveryClient = clientset.DiscoveryClient
 
 	config, err := f.ToRESTConfig()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if o.UseProtocolBuffers {
+	if flags.UseProtocolBuffers {
 		config.ContentType = "application/vnd.kubernetes.protobuf"
 	}
 	o.MetricsClient, err = metricsclientset.NewForConfig(config)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	o.NodeClient = clientset.CoreV1()
 
 	o.Printer = metricsutil.NewTopCmdPrinter(o.Out, o.ShowSwap)
-	return nil
+	return o, nil
 }
 
 func (o *TopNodeOptions) Validate() error {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_node_test.go
@@ -241,14 +241,14 @@ func runTopNodeTest(t *testing.T, opts runTopNodeOpts) string {
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 	streams, _, buf, _ := genericiooptions.NewTestIOStreams()
 
-	cmd := NewCmdTopNode(tf, nil, streams)
-	cmdOptions := &TopNodeOptions{
+	cmdFlags := &TopNodeFlags{
 		IOStreams: streams,
 		Selector:  opts.selector,
 		SortBy:    opts.sortBy,
 		ShowSwap:  opts.showSwap,
 	}
-	if err := cmdOptions.Complete(tf, cmd, opts.cmdArgs); err != nil {
+	cmdOptions, err := cmdFlags.ToOptions(tf, opts.cmdArgs)
+	if err != nil {
 		t.Fatal(err)
 	}
 	cmdOptions.MetricsClient = opts.fakeMetrics

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -114,10 +114,8 @@ func NewTopPodFlags(streams genericiooptions.IOStreams) *TopPodFlags {
 	}
 }
 
-func NewCmdTopPod(f cmdutil.Factory, flags *TopPodFlags, streams genericiooptions.IOStreams) *cobra.Command {
-	if flags == nil {
-		flags = NewTopPodFlags(streams)
-	}
+func NewCmdTopPod(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	flags := NewTopPodFlags(streams)
 
 	cmd := &cobra.Command{
 		Use:                   "pod [NAME | -l label]",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -43,9 +43,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
-type TopPodOptions struct {
-	ResourceName       string
-	Namespace          string
+// TopPodFlags directly reflect the information that CLI is gathering via flags.
+type TopPodFlags struct {
 	LabelSelector      string
 	FieldSelector      string
 	SortBy             string
@@ -55,6 +54,21 @@ type TopPodOptions struct {
 	UseProtocolBuffers bool
 	Sum                bool
 	ShowSwap           bool
+
+	genericiooptions.IOStreams
+}
+
+type TopPodOptions struct {
+	ResourceName    string
+	Namespace       string
+	LabelSelector   string
+	FieldSelector   string
+	SortBy          string
+	AllNamespaces   bool
+	PrintContainers bool
+	NoHeaders       bool
+	Sum             bool
+	ShowSwap        bool
 
 	PodClient       corev1client.PodsGetter
 	Printer         *metricsutil.TopCmdPrinter
@@ -92,12 +106,17 @@ var (
 		kubectl top pod -A --field-selector spec.nodeName=NODE_NAME`))
 )
 
-func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericiooptions.IOStreams) *cobra.Command {
-	if o == nil {
-		o = &TopPodOptions{
-			IOStreams:          streams,
-			UseProtocolBuffers: true,
-		}
+// NewTopPodFlags returns a default TopPodFlags
+func NewTopPodFlags(streams genericiooptions.IOStreams) *TopPodFlags {
+	return &TopPodFlags{
+		IOStreams:          streams,
+		UseProtocolBuffers: true,
+	}
+}
+
+func NewCmdTopPod(f cmdutil.Factory, flags *TopPodFlags, streams genericiooptions.IOStreams) *cobra.Command {
+	if flags == nil {
+		flags = NewTopPodFlags(streams)
 	}
 
 	cmd := &cobra.Command{
@@ -108,58 +127,77 @@ func NewCmdTopPod(f cmdutil.Factory, o *TopPodOptions, streams genericiooptions.
 		Example:               topPodExample,
 		ValidArgsFunction:     completion.ResourceNameCompletionFunc(f, "pod"),
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(o.Complete(f, cmd, args))
+			o, err := flags.ToOptions(f, args)
+			cmdutil.CheckErr(err)
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.RunTopPod())
 		},
 		Aliases: []string{"pods", "po"},
 	}
-	cmdutil.AddLabelSelectorFlagVar(cmd, &o.LabelSelector)
-	cmd.Flags().StringVar(&o.FieldSelector, "field-selector", o.FieldSelector, "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
-	cmd.Flags().StringVar(&o.SortBy, "sort-by", o.SortBy, "If non-empty, sort pods list using specified field. The field can be either 'cpu' or 'memory'.")
-	cmd.Flags().BoolVar(&o.PrintContainers, "containers", o.PrintContainers, "If present, print usage of containers within a pod.")
-	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
-	cmd.Flags().BoolVar(&o.NoHeaders, "no-headers", o.NoHeaders, "If present, print output without headers.")
-	cmd.Flags().BoolVar(&o.UseProtocolBuffers, "use-protocol-buffers", o.UseProtocolBuffers, "Enables using protocol-buffers to access Metrics API.")
-	cmd.Flags().BoolVar(&o.Sum, "sum", o.Sum, "Print the sum of the resource usage")
-	cmd.Flags().BoolVar(&o.ShowSwap, "show-swap", o.ShowSwap, "Print pod resources related to swap memory.")
+	flags.AddFlags(cmd)
 	return cmd
 }
 
-func (o *TopPodOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
-	var err error
+// AddFlags registers flags for a cli
+func (flags *TopPodFlags) AddFlags(cmd *cobra.Command) {
+	cmdutil.AddLabelSelectorFlagVar(cmd, &flags.LabelSelector)
+	cmd.Flags().StringVar(&flags.FieldSelector, "field-selector", flags.FieldSelector, "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
+	cmd.Flags().StringVar(&flags.SortBy, "sort-by", flags.SortBy, "If non-empty, sort pods list using specified field. The field can be either 'cpu' or 'memory'.")
+	cmd.Flags().BoolVar(&flags.PrintContainers, "containers", flags.PrintContainers, "If present, print usage of containers within a pod.")
+	cmd.Flags().BoolVarP(&flags.AllNamespaces, "all-namespaces", "A", flags.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	cmd.Flags().BoolVar(&flags.NoHeaders, "no-headers", flags.NoHeaders, "If present, print output without headers.")
+	cmd.Flags().BoolVar(&flags.UseProtocolBuffers, "use-protocol-buffers", flags.UseProtocolBuffers, "Enables using protocol-buffers to access Metrics API.")
+	cmd.Flags().BoolVar(&flags.Sum, "sum", flags.Sum, "Print the sum of the resource usage")
+	cmd.Flags().BoolVar(&flags.ShowSwap, "show-swap", flags.ShowSwap, "Print pod resources related to swap memory.")
+}
+
+// ToOptions converts from CLI inputs to runtime inputs
+func (flags *TopPodFlags) ToOptions(f cmdutil.Factory, args []string) (*TopPodOptions, error) {
+	o := &TopPodOptions{
+		LabelSelector:   flags.LabelSelector,
+		FieldSelector:   flags.FieldSelector,
+		SortBy:          flags.SortBy,
+		AllNamespaces:   flags.AllNamespaces,
+		PrintContainers: flags.PrintContainers,
+		NoHeaders:       flags.NoHeaders,
+		Sum:             flags.Sum,
+		ShowSwap:        flags.ShowSwap,
+		IOStreams:       flags.IOStreams,
+	}
+
 	if len(args) == 1 {
 		o.ResourceName = args[0]
 	} else if len(args) > 1 {
-		return cmdutil.UsageErrorf(cmd, "%s", cmd.Use)
+		return nil, fmt.Errorf("unexpected arguments: %v", args[1:])
 	}
 
+	var err error
 	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	clientset, err := f.KubernetesClientSet()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	o.DiscoveryClient = clientset.DiscoveryClient
 	config, err := f.ToRESTConfig()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if o.UseProtocolBuffers {
+	if flags.UseProtocolBuffers {
 		config.ContentType = "application/vnd.kubernetes.protobuf"
 	}
 	o.MetricsClient, err = metricsclientset.NewForConfig(config)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	o.PodClient = clientset.CoreV1()
 
 	o.Printer = metricsutil.NewTopCmdPrinter(o.Out, o.ShowSwap)
-	return nil
+	return o, nil
 }
 
 func (o *TopPodOptions) Validate() error {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
@@ -104,7 +104,7 @@ const (
 func TestTopPod(t *testing.T) {
 	testCases := []struct {
 		name               string
-		options            *TopPodOptions
+		options            *TopPodFlags
 		args               []string
 		expectedPods       []string
 		expectedContainers []string
@@ -125,7 +125,7 @@ func TestTopPod(t *testing.T) {
 	}{
 		{
 			name:            "all namespaces",
-			options:         &TopPodOptions{AllNamespaces: true},
+			options:         &TopPodFlags{AllNamespaces: true},
 			namespaces:      []string{testNS, "secondtestns", "thirdtestns"},
 			listsNamespaces: true,
 		},
@@ -140,17 +140,17 @@ func TestTopPod(t *testing.T) {
 		},
 		{
 			name:       "pod with label selector",
-			options:    &TopPodOptions{LabelSelector: "key=value"},
+			options:    &TopPodFlags{LabelSelector: "key=value"},
 			namespaces: []string{testNS, testNS},
 		},
 		{
 			name:       "pod with field selector",
-			options:    &TopPodOptions{FieldSelector: "key=value"},
+			options:    &TopPodFlags{FieldSelector: "key=value"},
 			namespaces: []string{testNS, testNS},
 		},
 		{
 			name:    "pod with container metrics",
-			options: &TopPodOptions{PrintContainers: true},
+			options: &TopPodFlags{PrintContainers: true},
 			args:    []string{"pod1"},
 			expectedContainers: []string{
 				"container1-1",
@@ -161,19 +161,19 @@ func TestTopPod(t *testing.T) {
 		},
 		{
 			name:         "pod sort by cpu",
-			options:      &TopPodOptions{SortBy: "cpu"},
+			options:      &TopPodFlags{SortBy: "cpu"},
 			expectedPods: []string{"pod2", "pod3", "pod1"},
 			namespaces:   []string{testNS, testNS, testNS},
 		},
 		{
 			name:         "pod sort by memory",
-			options:      &TopPodOptions{SortBy: "memory"},
+			options:      &TopPodFlags{SortBy: "memory"},
 			expectedPods: []string{"pod2", "pod3", "pod1"},
 			namespaces:   []string{testNS, testNS, testNS},
 		},
 		{
 			name:    "container sort by cpu",
-			options: &TopPodOptions{PrintContainers: true, SortBy: "cpu"},
+			options: &TopPodFlags{PrintContainers: true, SortBy: "cpu"},
 			expectedContainers: []string{
 				"container2-3",
 				"container2-2",
@@ -187,7 +187,7 @@ func TestTopPod(t *testing.T) {
 		},
 		{
 			name:    "container sort by memory",
-			options: &TopPodOptions{PrintContainers: true, SortBy: "memory"},
+			options: &TopPodFlags{PrintContainers: true, SortBy: "memory"},
 			expectedContainers: []string{
 				"container2-3",
 				"container2-2",
@@ -201,13 +201,13 @@ func TestTopPod(t *testing.T) {
 		},
 		{
 			name:            "with swap",
-			options:         &TopPodOptions{AllNamespaces: true, ShowSwap: true},
+			options:         &TopPodFlags{AllNamespaces: true, ShowSwap: true},
 			namespaces:      []string{testNS, "secondtestns", "thirdtestns"},
 			listsNamespaces: true,
 		},
 		{
 			name:              "swap values",
-			options:           &TopPodOptions{ShowSwap: true},
+			options:           &TopPodFlags{ShowSwap: true},
 			namespaces:        []string{testNS, testNS, testNS},
 			expectedSwapBytes: map[string]string{"pod1": "4Mi", "pod2": "0Mi", "pod3": "3Mi"},
 		},
@@ -215,7 +215,7 @@ func TestTopPod(t *testing.T) {
 			// The metrics API returns all three pods, while the pod list
 			// endpoint only returns pod1, so the client must drop pod2 and pod3.
 			name:                "pod with field selector filtering metrics",
-			options:             &TopPodOptions{FieldSelector: "spec.nodeName=node-a"},
+			options:             &TopPodFlags{FieldSelector: "spec.nodeName=node-a"},
 			namespaces:          []string{testNS, testNS, testNS},
 			extraPaths:          onlyPod1ListResponse,
 			expectedInOutput:    []string{"pod1"},
@@ -223,7 +223,7 @@ func TestTopPod(t *testing.T) {
 		},
 		{
 			name:           "no resources found in all namespaces",
-			options:        &TopPodOptions{AllNamespaces: true},
+			options:        &TopPodFlags{AllNamespaces: true},
 			extraPaths:     emptyPodListResponse,
 			expectedOutput: new(""),
 			expectedErr:    new("No resources found\n"),
@@ -411,7 +411,7 @@ func emptyPodListResponse(req *http.Request) (*http.Response, error) {
 type runTopPodOpts struct {
 	apisBody    string
 	fakeMetrics *metricsfake.Clientset
-	options     *TopPodOptions
+	options     *TopPodFlags
 	cmdArgs     []string
 	extraPaths  func(req *http.Request) (*http.Response, error)
 }
@@ -448,16 +448,16 @@ func runTopPodTest(t *testing.T, opts runTopPodOpts) (stdout string, stderr stri
 	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
 	streams, _, buf, errbuf := genericiooptions.NewTestIOStreams()
 
-	cmd := NewCmdTopPod(tf, nil, streams)
-	var cmdOptions *TopPodOptions
+	var cmdFlags *TopPodFlags
 	if opts.options != nil {
-		cmdOptions = opts.options
+		cmdFlags = opts.options
 	} else {
-		cmdOptions = &TopPodOptions{}
+		cmdFlags = &TopPodFlags{}
 	}
-	cmdOptions.IOStreams = streams
+	cmdFlags.IOStreams = streams
 
-	if err := cmdOptions.Complete(tf, cmd, opts.cmdArgs); err != nil {
+	cmdOptions, err := cmdFlags.ToOptions(tf, opts.cmdArgs)
+	if err != nil {
 		t.Fatal(err)
 	}
 	cmdOptions.MetricsClient = opts.fakeMetrics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind dependency

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR decouples the command options from the input flags. The input flags from the command are then translated to options which are further used while running the command.

#### Which issue(s) this PR is related to:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
