### PR TITLE
Use /healthz for e2e NodePort Health Check Test

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -3949,8 +3949,9 @@ var _ = common.SIGDescribe("Services", func() {
 		}
 
 		checkOneHealthCheck := func(nodeIP string, expectResponse bool, expectStatus string, deadline time.Time) {
-			// "-i" means to return the HTTP headers in the response
-			cmd := fmt.Sprintf("curl -g -i -s --connect-timeout 3 http://%s/", net.JoinHostPort(nodeIP, hcNodePortStr))
+			// "-i" means to return the HTTP headers in the response. We request /healthz because that is the path
+			// the ESIPP design specifies for healthCheckNodePort, and the one the rest of the suite already uses.
+			cmd := fmt.Sprintf("curl -g -i -s --connect-timeout 3 http://%s/healthz", net.JoinHostPort(nodeIP, hcNodePortStr))
 			err := wait.PollUntilContextTimeout(ctx, framework.Poll, time.Until(deadline), true, func(ctx context.Context) (bool, error) {
 				out, err := e2eoutput.RunHostCmd(namespace, execPod.Name, cmd)
 				if !expectResponse {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/kind failing-test
/kind regression

#### What this PR does / why we need it:

FYI @danwinship @aojea 

The `healthCheckNodePort` [design specifies `/healthz`](https://github.com/kubernetes/design-proposals-archive/blob/acc25e14ca83dfda4f66d8cb1f1b491f26e78ffe/network/external-lb-source-ip-preservation.md#traffic-steering-using-health-checks), and every other health check assertion in the e2e suite uses that path. kube-proxy accepts requests on any path, but that permissive routing behavior isn't part of the documented contract.

This changes the remaining `/` assertion to `/healthz` so the test checks the specified endpoint and works with implementations that route health checks explicitly.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

https://github.com/cloudnativelabs/kube-router/issues/2006

#### Special notes for your reviewer:

The e2e tests didn't always test `/` for this test, it appears that this change came from the work done on this PR: https://github.com/kubernetes/kubernetes/pull/125222

When the harness was changed from `config.GetResponseFromTestContainer()` to `curl`:

* Before: https://github.com/kubernetes/kubernetes/pull/125222/changes#diff-7997b2b19d3ef4dd0257c8edf9a87cc579b2c244012ff5b054aa3e4ad7b748e2L1300
* After: https://github.com/kubernetes/kubernetes/pull/125222/changes#diff-2191f4f175779dcfa927c21f8fc225d9d031000f516d17babb42d645f3100a9cR4000

As part of the PRs review, this change was never mentioned which is what originally made me think it was unintentional.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Other doc]: https://github.com/kubernetes/design-proposals-archive/blob/acc25e14ca83dfda4f66d8cb1f1b491f26e78ffe/network/external-lb-source-ip-preservation.md
```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->

YES. I used AI to track down this problem of the e2e tests failing via kube-router.
