### PR TITLE
kubelet: improve init container startup status visibility

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -2526,20 +2526,55 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 		oldStatuses[status.Name] = status
 	}
 
+	isInitContainerCompleted := func(container *v1.Container, oldStatus *v1.ContainerStatus, cStatus *kubecontainer.Status) bool {
+		if cStatus != nil {
+			if cStatus.State == kubecontainer.ContainerStateExited && cStatus.ExitCode == 0 {
+				return true
+			}
+			if podutil.IsRestartableInitContainer(container) && cStatus.State == kubecontainer.ContainerStateRunning {
+				return true
+			}
+		}
+		if oldStatus != nil {
+			if oldStatus.State.Terminated != nil && oldStatus.State.Terminated.ExitCode == 0 {
+				return true
+			}
+			if podutil.IsRestartableInitContainer(container) && oldStatus.State.Running != nil {
+				return true
+			}
+		}
+		return false
+	}
+
 	// Set all container statuses to default waiting state
 	statuses := make(map[string]*v1.ContainerStatus, len(containers))
 	defaultWaitingState := v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: ContainerCreating}}
-	if hasInitContainers {
+	if hasInitContainers && !isInitContainer {
 		defaultWaitingState = v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: PodInitializing}}
 	}
 
 	supportsRRO := kl.runtimeClassSupportsRecursiveReadOnlyMounts(logger, pod)
 
+	currentStatuses := make(map[string]*kubecontainer.Status, len(podStatus.ContainerStatuses))
+	for _, cs := range podStatus.ContainerStatuses {
+		currentStatuses[cs.Name] = cs
+	}
+
+	foundActiveInitContainer := false
 	for _, container := range containers {
+		state := defaultWaitingState
+		if isInitContainer {
+			if !foundActiveInitContainer {
+				state = v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: ContainerCreating}}
+			} else {
+				state = v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: PodInitializing}}
+			}
+		}
+
 		status := &v1.ContainerStatus{
 			Name:  container.Name,
 			Image: container.Image,
-			State: defaultWaitingState,
+			State: state,
 		}
 		// status.VolumeMounts cannot be propagated from kubecontainer.Status
 		// because the CRI API is unaware of the volume names.
@@ -2578,6 +2613,17 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 			}
 		}
 		statuses[container.Name] = status
+
+		if isInitContainer {
+			cStatus := currentStatuses[container.Name]
+			var oldStatusPtr *v1.ContainerStatus
+			if found {
+				oldStatusPtr = &oldStatus
+			}
+			if !isInitContainerCompleted(&container, oldStatusPtr, cStatus) {
+				foundActiveInitContainer = true
+			}
+		}
 	}
 
 	for _, container := range containers {
@@ -2637,10 +2683,7 @@ func (kl *Kubelet) convertToAPIContainerStatuses(ctx context.Context, pod *v1.Po
 		status := statuses[container.Name]
 		// If the status we're about to write indicates the default, the Waiting status will force this pod back into Pending.
 		// That isn't true, we know the pod was previously running.
-		isDefaultWaitingStatus := status.State.Waiting != nil && status.State.Waiting.Reason == ContainerCreating
-		if hasInitContainers {
-			isDefaultWaitingStatus = status.State.Waiting != nil && status.State.Waiting.Reason == PodInitializing
-		}
+		isDefaultWaitingStatus := status.State.Waiting != nil && (status.State.Waiting.Reason == ContainerCreating || status.State.Waiting.Reason == PodInitializing)
 		if !isDefaultWaitingStatus {
 			// the status was written, don't override
 			continue

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -3840,6 +3840,18 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 		},
 		RestartPolicy: v1.RestartPolicyAlways,
 	}
+	desiredStateWithMultipleInitContainers := v1.PodSpec{
+		NodeName: "machine",
+		InitContainers: []v1.Container{
+			{Name: "init-0"},
+			{Name: "init-1"},
+			{Name: "init-2"},
+		},
+		Containers: []v1.Container{
+			{Name: "containerA"},
+		},
+		RestartPolicy: v1.RestartPolicyAlways,
+	}
 	now := metav1.Now()
 
 	tests := []struct {
@@ -4182,7 +4194,7 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 					Name: "sidecar-1",
 					State: v1.ContainerState{
 						Waiting: &v1.ContainerStateWaiting{
-							Reason:  "PodInitializing",
+							Reason:  "ContainerCreating",
 							Message: "",
 						},
 					},
@@ -4190,6 +4202,79 @@ func TestConvertToAPIContainerStatuses(t *testing.T) {
 			},
 			hasInitContainers: true,
 			isInitContainer:   true,
+		},
+		{
+			name: "Multiple init containers at startup: active init container gets ContainerCreating, subsequent get PodInitializing",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-pod"},
+				Spec:       desiredStateWithMultipleInitContainers,
+				Status: v1.PodStatus{
+					InitContainerStatuses: []v1.ContainerStatus{},
+					ContainerStatuses:     []v1.ContainerStatus{},
+				},
+			},
+			currentStatus:     &kubecontainer.PodStatus{},
+			previousStatus:    []v1.ContainerStatus{},
+			containers:        desiredStateWithMultipleInitContainers.InitContainers,
+			hasInitContainers: true,
+			isInitContainer:   true,
+			expected: []v1.ContainerStatus{
+				{
+					Name:  "init-0",
+					State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "ContainerCreating"}},
+				},
+				{
+					Name:  "init-1",
+					State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "PodInitializing"}},
+				},
+				{
+					Name:  "init-2",
+					State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "PodInitializing"}},
+				},
+			},
+		},
+		{
+			name: "Multiple init containers: init-0 completed, init-1 gets ContainerCreating, init-2 gets PodInitializing",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-pod"},
+				Spec:       desiredStateWithMultipleInitContainers,
+				Status: v1.PodStatus{
+					InitContainerStatuses: []v1.ContainerStatus{},
+					ContainerStatuses:     []v1.ContainerStatus{},
+				},
+			},
+			currentStatus: &kubecontainer.PodStatus{
+				ContainerStatuses: []*kubecontainer.Status{
+					{
+						ID:       kubecontainer.ContainerID{ID: "init-0-id"},
+						Name:     "init-0",
+						State:    kubecontainer.ContainerStateExited,
+						ExitCode: 0,
+					},
+				},
+			},
+			previousStatus:    []v1.ContainerStatus{},
+			containers:        desiredStateWithMultipleInitContainers.InitContainers,
+			hasInitContainers: true,
+			isInitContainer:   true,
+			expected: []v1.ContainerStatus{
+				{
+					Name: "init-0",
+					State: v1.ContainerState{
+						Terminated: &v1.ContainerStateTerminated{
+							ExitCode: 0,
+						},
+					},
+				},
+				{
+					Name:  "init-1",
+					State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "ContainerCreating"}},
+				},
+				{
+					Name:  "init-2",
+					State: v1.ContainerState{Waiting: &v1.ContainerStateWaiting{Reason: "PodInitializing"}},
+				},
+			},
 		},
 	}
 	featuregatetesting.SetFeatureGatesDuringTest(t, utilfeature.DefaultFeatureGate, featuregatetesting.FeatureOverrides{

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2182,12 +2182,11 @@ func TestGenerateAPIPodStatusWithReasonCache(t *testing.T) {
 		Namespace: pod.Namespace,
 	}
 	tests := []struct {
-		containers    []v1.Container
-		statuses      []*kubecontainer.Status
-		reasons       map[string]error
-		oldStatuses   []v1.ContainerStatus
-		expectedState map[string]v1.ContainerState
-		// Only set expectedInitState when it is different from expectedState
+		containers                   []v1.Container
+		statuses                     []*kubecontainer.Status
+		reasons                      map[string]error
+		oldStatuses                  []v1.ContainerStatus
+		expectedState                map[string]v1.ContainerState
 		expectedInitState            map[string]v1.ContainerState
 		expectedLastTerminationState map[string]v1.ContainerState
 	}{
@@ -2211,7 +2210,7 @@ func TestGenerateAPIPodStatusWithReasonCache(t *testing.T) {
 			},
 			expectedInitState: map[string]v1.ContainerState{
 				"without-old-record": {Waiting: &v1.ContainerStateWaiting{
-					Reason: PodInitializing,
+					Reason: ContainerCreating,
 				}},
 				"with-old-record": {Waiting: &v1.ContainerStateWaiting{
 					Reason: PodInitializing,

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -1387,6 +1387,29 @@ func TestPrintPod(t *testing.T) {
 			[]metav1.TableRow{{Cells: []interface{}{"test6", "1/2", "Running", "6", "<unknown>"}}},
 		},
 		{
+			// Test pod has 1 init container in ContainerCreating state
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-init-creating"},
+				Spec:       api.PodSpec{InitContainers: make([]api.Container, 1), Containers: make([]api.Container, 1)},
+				Status: api.PodStatus{
+					Phase: "podPhase",
+					InitContainerStatuses: []api.ContainerStatus{
+						{
+							Ready: false,
+							State: api.ContainerState{Waiting: &api.ContainerStateWaiting{Reason: "ContainerCreating"}},
+						},
+					},
+					ContainerStatuses: []api.ContainerStatus{
+						{
+							Ready: false,
+							State: api.ContainerState{Waiting: &api.ContainerStateWaiting{Reason: "PodInitializing"}},
+						},
+					},
+				},
+			},
+			[]metav1.TableRow{{Cells: []interface{}{"test-init-creating", "0/1", "Init:ContainerCreating", "0", "<unknown>"}}},
+		},
+		{
 			// Test pod has 1 init container restarting and 1 container not running
 			api.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "test7"},


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Improves startup status visibility for init containers.

Previously, `kubelet` set the default waiting state for all containers to `PodInitializing` when `hasInitContainers` was true. This caused `initContainerStatuses` to report `waiting.reason: PodInitializing` and `kubectl get pod` to display `Init:0/N` even while an init container's image was being pulled or the container was being created (`ContainerCreating`).

This PR updates `convertToAPIContainerStatuses` to set the default waiting reason for init containers to `ContainerCreating`, while preserving `PodInitializing` for regular containers waiting on init container completion. This allows `kubectl get pod` to report `Init:ContainerCreating` and accurately surface init container lifecycle stages.

#### Which issue(s) this PR is related to:
Fixes #141686

#### Special notes for your reviewer:
- `pkg/kubelet/kubelet_pods.go`: `convertToAPIContainerStatuses` now checks `hasInitContainers && !isInitContainer` before setting `PodInitializing`.
- `pkg/printers/internalversion/printers_test.go`: Added test cases for init container waiting reasons like `Init:ContainerCreating`.

#### Does this PR introduce a user-facing change?
```release-note
kubelet: improved init container startup visibility by setting the initial waiting state of init containers to `ContainerCreating` instead of `PodInitializing`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
- Issue: https://github.com/kubernetes/kubernetes/issues/141686

#### AI usage disclosure:
YES, an AI coding assistant was used to help trace container status generation in `pkg/kubelet`, update unit tests, and format the PR description.
