### PR TITLE
fix: capture entity type before requeue to avoid data race in Update 

### DIFF
--- a/pkg/scheduler/backend/queue/scheduling_queue.go
+++ b/pkg/scheduler/backend/queue/scheduling_queue.go
@@ -950,11 +950,15 @@ func (p *PriorityQueue) addToPodGroupIfExists(logger klog.Logger, pInfo *framewo
 	}
 	rootInfo := entity.(*framework.QueuedPodGroupInfo)
 	rootInfo.AddPod(pInfo)
+	// Capture the root type and references before requeueing. Once the root is added to
+	// activeQ, it can be popped and processed before this goroutine logs the update.
+	rootType, rootRef := rootInfo.Type(), klog.KObj(rootInfo)
+	podRef := klog.KObj(pInfo)
 	queue := p.requeueEntityWithQueueingStrategy(logger, rootInfo, strategy, framework.EventUnscheduledPodAdd.Label())
 	if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
 		p.activeQ.broadcast()
 	}
-	logger.V(5).Info("Pod added to existing root group info", "rootType", rootInfo.Type(), "root", klog.KObj(rootInfo), "pod", klog.KObj(pInfo), "queue", queue)
+	logger.V(5).Info("Pod added to existing root group info", "rootType", rootType, "root", rootRef, "pod", podRef, "queue", queue)
 	return true
 }
 
@@ -1426,14 +1430,14 @@ func (p *PriorityQueue) Update(ctx context.Context, oldPod, newPod *v1.Pod) {
 		// Plugins have to implement a QueueingHint for Pod/Update event
 		// if the rejection from them could be resolved by updating unscheduled Pods itself.
 		for _, evt := range events {
-			// Here, the entityRef is captured for logging, to prevent a data race that can occur in the logger below,
-			// where a pod re-queued to activeQ in requeueEntityWithQueueingStrategy is popped and processed quickly enough,
-			// so the write in its failure handler overwrites the pod object in PodInfo, which is accessed for logging.
-			entityRef := klog.KObj(entity)
+			// Capture the entity type and reference before requeueing. Once the entity is added to activeQ,
+			// it can be popped and processed before this goroutine logs the update. The scheduling cycle can
+			// then mutate fields accessed by Type and KObj.
+			entityType, entityRef := entity.Type(), klog.KObj(entity)
 			hint := p.isEntityWorthRequeuing(logger, entity, evt, oldPod, newPod, nil)
 			queue := p.requeueEntityWithQueueingStrategy(logger, entity, hint, evt.Label())
 			if queue != unschedulableQ {
-				logger.V(5).Info("Entity moved to an internal scheduling queue because the Pod is updated", "type", entity.Type(), "entity", entityRef, "pod", klog.KObj(newPod), "event", evt.Label(), "queue", queue)
+				logger.V(5).Info("Entity moved to an internal scheduling queue because the Pod is updated", "type", entityType, "entity", entityRef, "pod", klog.KObj(newPod), "event", evt.Label(), "queue", queue)
 			}
 			if queue == activeQ || (p.isPopFromBackoffQEnabled && queue == backoffQ) {
 				p.activeQ.broadcast()


### PR DESCRIPTION
…logging



#### What type of PR is this?
/kind flake


#### What this PR does / why we need it:
quick fix for the data race

#### Which issue(s) this PR is related to:

Fixes #141653


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```


#### AI usage disclosure:

Yes, comment are generated by AI.
