### PR TITLE
Skip containerfs.inodesFree eviction threshold when inode thresholds are not configured

### DIFF
--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -241,11 +241,9 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 			softContainerFsDisk = idx
 		}
 		if threshold.Signal == evictionapi.SignalContainerFsInodesFree && isHardEvictionThreshold(threshold) {
-			err = errors.Join(fmt.Errorf("found containerfs.inodesFree for hard eviction. ignoring"))
 			hardContainerFsINodes = idx
 		}
 		if threshold.Signal == evictionapi.SignalContainerFsInodesFree && !isHardEvictionThreshold(threshold) {
-			err = errors.Join(fmt.Errorf("found containerfs.inodesFree for soft eviction. ignoring"))
 			softContainerFsINodes = idx
 		}
 	}
@@ -276,30 +274,41 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 				GracePeriod: softNodeFsDisk.GracePeriod,
 			})
 		}
-		if hardContainerFsINodes != -1 {
-			thresholds[hardContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, Operator: hardNodeINodeDisk.Operator, Value: hardNodeINodeDisk.Value, MinReclaim: hardNodeINodeDisk.MinReclaim,
+		// Only add the containerfs inode thresholds if the source nodefs inode
+		// thresholds are present. On platforms where inodes are not supported
+		// (e.g. Windows), the nodefs.inodesFree threshold is not configured and
+		// deriving containerfs.inodesFree from an empty threshold would leave a
+		// signal that the eviction manager can never observe (spamming the log).
+		if hardNodeINodeDisk.Signal != "" {
+			if hardContainerFsINodes != -1 {
+				err = errors.Join(err, fmt.Errorf("found containerfs.inodesFree for hard eviction. ignoring"))
+				thresholds[hardContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, Operator: hardNodeINodeDisk.Operator, Value: hardNodeINodeDisk.Value, MinReclaim: hardNodeINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:     evictionapi.SignalContainerFsInodesFree,
+					Operator:   hardNodeINodeDisk.Operator,
+					Value:      hardNodeINodeDisk.Value,
+					MinReclaim: hardNodeINodeDisk.MinReclaim,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:     evictionapi.SignalContainerFsInodesFree,
-				Operator:   hardNodeINodeDisk.Operator,
-				Value:      hardNodeINodeDisk.Value,
-				MinReclaim: hardNodeINodeDisk.MinReclaim,
-			})
 		}
-		if softContainerFsINodes != -1 {
-			thresholds[softContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softNodeINodeDisk.GracePeriod, Operator: softNodeINodeDisk.Operator, Value: softNodeINodeDisk.Value, MinReclaim: softNodeINodeDisk.MinReclaim,
+		if softNodeINodeDisk.Signal != "" {
+			if softContainerFsINodes != -1 {
+				err = errors.Join(err, fmt.Errorf("found containerfs.inodesFree for soft eviction. ignoring"))
+				thresholds[softContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softNodeINodeDisk.GracePeriod, Operator: softNodeINodeDisk.Operator, Value: softNodeINodeDisk.Value, MinReclaim: softNodeINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:      evictionapi.SignalContainerFsInodesFree,
+					Operator:    softNodeINodeDisk.Operator,
+					Value:       softNodeINodeDisk.Value,
+					MinReclaim:  softNodeINodeDisk.MinReclaim,
+					GracePeriod: softNodeINodeDisk.GracePeriod,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:      evictionapi.SignalContainerFsInodesFree,
-				Operator:    softNodeINodeDisk.Operator,
-				Value:       softNodeINodeDisk.Value,
-				MinReclaim:  softNodeINodeDisk.MinReclaim,
-				GracePeriod: softNodeINodeDisk.GracePeriod,
-			})
 		}
 	}
 	// Separate image filesystem case
@@ -329,30 +338,41 @@ func UpdateContainerFsThresholds(thresholds []evictionapi.Threshold, imageFs, se
 				GracePeriod: softImageFsDisk.GracePeriod,
 			})
 		}
-		if hardContainerFsINodes != -1 {
-			thresholds[hardContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: hardImageINodeDisk.GracePeriod, Operator: hardImageINodeDisk.Operator, Value: hardImageINodeDisk.Value, MinReclaim: hardImageINodeDisk.MinReclaim,
+		// Only add the containerfs inode thresholds if the source imagefs inode
+		// thresholds are present. On platforms where inodes are not supported
+		// (e.g. Windows), the imagefs.inodesFree threshold is not configured and
+		// deriving containerfs.inodesFree from an empty threshold would leave a
+		// signal that the eviction manager can never observe (spamming the log).
+		if hardImageINodeDisk.Signal != "" {
+			if hardContainerFsINodes != -1 {
+				err = errors.Join(err, fmt.Errorf("found containerfs.inodesFree for hard eviction. ignoring"))
+				thresholds[hardContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: hardImageINodeDisk.GracePeriod, Operator: hardImageINodeDisk.Operator, Value: hardImageINodeDisk.Value, MinReclaim: hardImageINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:     evictionapi.SignalContainerFsInodesFree,
+					Operator:   hardImageINodeDisk.Operator,
+					Value:      hardImageINodeDisk.Value,
+					MinReclaim: hardImageINodeDisk.MinReclaim,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:     evictionapi.SignalContainerFsInodesFree,
-				Operator:   hardImageINodeDisk.Operator,
-				Value:      hardImageINodeDisk.Value,
-				MinReclaim: hardImageINodeDisk.MinReclaim,
-			})
 		}
-		if softContainerFsINodes != -1 {
-			thresholds[softContainerFsINodes] = evictionapi.Threshold{
-				Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softImageINodeDisk.GracePeriod, Operator: softImageINodeDisk.Operator, Value: softImageINodeDisk.Value, MinReclaim: softImageINodeDisk.MinReclaim,
+		if softImageINodeDisk.Signal != "" {
+			if softContainerFsINodes != -1 {
+				err = errors.Join(err, fmt.Errorf("found containerfs.inodesFree for soft eviction. ignoring"))
+				thresholds[softContainerFsINodes] = evictionapi.Threshold{
+					Signal: evictionapi.SignalContainerFsInodesFree, GracePeriod: softImageINodeDisk.GracePeriod, Operator: softImageINodeDisk.Operator, Value: softImageINodeDisk.Value, MinReclaim: softImageINodeDisk.MinReclaim,
+				}
+			} else {
+				thresholds = append(thresholds, evictionapi.Threshold{
+					Signal:      evictionapi.SignalContainerFsInodesFree,
+					Operator:    softImageINodeDisk.Operator,
+					Value:       softImageINodeDisk.Value,
+					MinReclaim:  softImageINodeDisk.MinReclaim,
+					GracePeriod: softImageINodeDisk.GracePeriod,
+				})
 			}
-		} else {
-			thresholds = append(thresholds, evictionapi.Threshold{
-				Signal:      evictionapi.SignalContainerFsInodesFree,
-				Operator:    softImageINodeDisk.Operator,
-				Value:       softImageINodeDisk.Value,
-				MinReclaim:  softImageINodeDisk.MinReclaim,
-				GracePeriod: softImageINodeDisk.GracePeriod,
-			})
 		}
 	}
 	return thresholds, err

--- a/pkg/kubelet/eviction/helpers_test.go
+++ b/pkg/kubelet/eviction/helpers_test.go
@@ -2180,6 +2180,7 @@ func TestAddContainerFsThresholds(t *testing.T) {
 		expectedContainerFsINodesHard evictionapi.Threshold
 		expectedContainerFsINodesSoft evictionapi.Threshold
 		expectErr                     bool
+		expectNoContainerFsInodes     bool
 		thresholdList                 []evictionapi.Threshold
 	}{
 		{
@@ -3116,6 +3117,219 @@ func TestAddContainerFsThresholds(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:               "single filesystem; no inode thresholds (Windows-like)",
+			imageFs:                   false,
+			containerFs:               false,
+			expectNoContainerFsInodes: true,
+			expectedContainerFsHard: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("100Mi"),
+				},
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+			},
+			expectedContainerFsSoft: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("200Mi"),
+				},
+				GracePeriod: gracePeriod,
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+			},
+			thresholdList: []evictionapi.Threshold{
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("100Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("200Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("100Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("300Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("2Gi"),
+					},
+				},
+			},
+		},
+		{
+			description:               "image filesystem; no inode thresholds (Windows-like)",
+			imageFs:                   true,
+			containerFs:               false,
+			expectNoContainerFsInodes: true,
+			expectedContainerFsHard: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("150Mi"),
+				},
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1.5Gi"),
+				},
+			},
+			expectedContainerFsSoft: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("300Mi"),
+				},
+				GracePeriod: gracePeriod,
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("3Gi"),
+				},
+			},
+			thresholdList: []evictionapi.Threshold{
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("100Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("200Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("150Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1.5Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("300Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("3Gi"),
+					},
+				},
+			},
+		},
+		{
+			description:               "split image and container filesystem; no inode thresholds (Windows-like)",
+			imageFs:                   true,
+			containerFs:               true,
+			expectNoContainerFsInodes: true,
+			expectedContainerFsHard: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("100Mi"),
+				},
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+			},
+			expectedContainerFsSoft: evictionapi.Threshold{
+				Signal:   evictionapi.SignalContainerFsAvailable,
+				Operator: evictionapi.OpLessThan,
+				Value: evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("200Mi"),
+				},
+				GracePeriod: gracePeriod,
+				MinReclaim: &evictionapi.ThresholdValue{
+					Quantity: quantityMustParse("1Gi"),
+				},
+			},
+			thresholdList: []evictionapi.Threshold{
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("100Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalNodeFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("200Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("150Mi"),
+					},
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("1.5Gi"),
+					},
+				},
+				{
+					Signal:   evictionapi.SignalImageFsAvailable,
+					Operator: evictionapi.OpLessThan,
+					Value: evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("300Mi"),
+					},
+					GracePeriod: gracePeriod,
+					MinReclaim: &evictionapi.ThresholdValue{
+						Quantity: quantityMustParse("3Gi"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -3142,12 +3356,18 @@ func TestAddContainerFsThresholds(t *testing.T) {
 					softContainerFsMatch = idx
 				}
 				if val.Signal == evictionapi.SignalContainerFsInodesFree && isHardEvictionThreshold(val) {
+					if testCase.expectNoContainerFsInodes {
+						t.Fatalf("did not expect hard containerfs.inodesFree but found one")
+					}
 					if !reflect.DeepEqual(val, testCase.expectedContainerFsINodesHard) {
 						t.Fatalf("want %v got %v", testCase.expectedContainerFsINodesHard, val)
 					}
 					hardContainerFsINodesMatch = idx
 				}
 				if val.Signal == evictionapi.SignalContainerFsInodesFree && !isHardEvictionThreshold(val) {
+					if testCase.expectNoContainerFsInodes {
+						t.Fatalf("did not expect soft containerfs.inodesFree but found one")
+					}
 					if !reflect.DeepEqual(val, testCase.expectedContainerFsINodesSoft) {
 						t.Fatalf("want %v got %v", testCase.expectedContainerFsINodesSoft, val)
 					}
@@ -3160,11 +3380,13 @@ func TestAddContainerFsThresholds(t *testing.T) {
 			if softContainerFsMatch == -1 {
 				t.Fatalf("did not find soft containerfs.available")
 			}
-			if hardContainerFsINodesMatch == -1 {
-				t.Fatalf("did not find hard containerfs.inodesfree")
-			}
-			if softContainerFsINodesMatch == -1 {
-				t.Fatalf("did not find soft containerfs.inodesfree")
+			if !testCase.expectNoContainerFsInodes {
+				if hardContainerFsINodesMatch == -1 {
+					t.Fatalf("did not find hard containerfs.inodesFree")
+				}
+				if softContainerFsINodesMatch == -1 {
+					t.Fatalf("did not find soft containerfs.inodesFree")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

On Windows, inodes are not supported and the default eviction configuration does not include `nodefs.inodesFree` / `imagefs.inodesFree` thresholds. However, `UpdateContainerFsThresholds` unconditionally adds `containerfs.inodesFree` thresholds derived from those (absent) source thresholds. Since the Windows container runtime never reports inode statistics, `makeSignalObservations` never creates an observation for `containerfs.inodesFree`, so the eviction manager logs frequently:

```
I0213 04:51:38.888080    1532 helpers.go:940] "Eviction manager: no observation found for eviction signal" signal="containerfs.inodesFree"
```

This PR guards the `containerfs.inodesFree` threshold generation so that hard/soft containerfs inode thresholds are only added when the source inode thresholds (`nodefs.inodesFree` or `imagefs.inodesFree`) are actually configured. On platforms that do not support inodes (e.g. Windows) the signal is no longer created, which stops the log spam. This follows the same approach previously used to address `nodefs.inodesFree` in the eviction defaults.

Both code paths in `UpdateContainerFsThresholds` are covered:
- Single / split filesystem path (containerfs = nodefs): guard on `hardNodeINodeDisk.Signal != ""` / `softNodeINodeDisk.Signal != ""`.
- Separate image filesystem path (containerfs = imagefs): guard on `hardImageINodeDisk.Signal != ""` / `softImageINodeDisk.Signal != ""`.

#### Which optional links

Related issue: kubernetes/kubernetes#130142

#### Special notes for reviewers

This is the same class of bug that was previously fixed for `nodefs.inodesFree` in kubernetes/kubernetes#67709. The `containerfs.inodesFree` signal was introduced later and did not carry the same guard.

#### AI usage disclosure

This change was developed with the assistance of an AI coding agent. The agent analyzed the eviction manager code paths, identified the unconditional `containerfs.inodesFree` threshold generation on inode-unaware platforms, and produced the fix and tests. The human author (via this PR) is responsible for reviewing and validating all submitted changes; per the project's contributing guidelines, please review `CONTRIBUTING.md`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed kubelet eviction manager logging frequent spurious "no observation found for eviction signal containerfs.inodesFree" messages on Windows nodes, where inodes are not supported.
```
