### PR TITLE
test/scheduler: more retries for TestEndpointHandlers

### DIFF
--- a/test/integration/scheduler/serving/endpoints_test.go
+++ b/test/integration/scheduler/serving/endpoints_test.go
@@ -28,9 +28,11 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
 	apiserverfeat "k8s.io/apiserver/pkg/features"
 	flagzv1alpha1 "k8s.io/apiserver/pkg/server/flagz/api/v1alpha1"
 	flagzv1beta1 "k8s.io/apiserver/pkg/server/flagz/api/v1beta1"
@@ -48,6 +50,20 @@ import (
 	kubeschedulertesting "k8s.io/kubernetes/cmd/kube-scheduler/app/testing"
 	"k8s.io/kubernetes/test/integration/framework"
 )
+
+const (
+	// handlerSyncPollInterval governs how often to poll for retry.
+	handlerSyncPollInterval = 100 * time.Millisecond
+	// handlerSyncTimeout is how long to wait for the scheduler to become ready.
+	handlerSyncTimeout = 5 * time.Second
+)
+
+// handlerSyncBackoff gives the scheduler time to report ready.
+var handlerSyncBackoff = wait.Backoff{
+	Duration: handlerSyncPollInterval,
+	Factor:   1.0,
+	Steps:    int(handlerSyncTimeout / handlerSyncPollInterval),
+}
 
 func TestEndpointHandlers(t *testing.T) {
 	server, configStr, _, err := startTestAPIServer(t)
@@ -166,7 +182,7 @@ func TestEndpointHandlers(t *testing.T) {
 			}
 
 			err = retry.OnError(
-				retry.DefaultBackoff,
+				handlerSyncBackoff,
 				func(err error) bool {
 					// the endpoint /readyz/sched-handler-sync needs some time to finish
 					// the initialization, so we need to retry


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

This PR adds more retries to `TestEndpointHandlers` because it seems that tests are occasionally flaking due to the scheduler taking longer than 300ms or so to come up healthy. Specifically, we will retry every 100ms up to 50 times (5s).

Ref:

- https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/141661/pull-kubernetes-integration/2093460305391652864

In the above test run, it failed after ~340ms because the test's retry budget expired, not because anything in the scheduler failed. At that point the scheduler's handlers were still syncing and had logged no errors. Handler sync completed in 3–47ms in the sibling subtests of the same run, so this was an outlier, and the logs don't show whether it was stuck or merely slow. Since a healthy scheduler can plausibly need longer than 340ms, I think there's a good chance we can safely increase the retry tolerance and get rid of flakes.

No changes were made to the error matching that triggers a retry (e.g., "handlers are not fully synchronized"), so increasing the retry tolerance doesn't introduce additional permissiveness for additional errors.

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
