### PR TITLE
kubelet: cap Windows usageNanoCores at node CPU capacity

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -953,7 +953,7 @@ func (p *criStatsProvider) getContainerUsageNanoCores(stats *runtimeapi.Containe
 
 	// Bypass the cache if the CRI implementation specified the UsageNanoCores.
 	if stats.Cpu != nil && stats.Cpu.UsageNanoCores != nil {
-		return &stats.Cpu.UsageNanoCores.Value
+		return p.capUsageNanoCores(&stats.Cpu.UsageNanoCores.Value)
 	}
 
 	p.mutex.RLock()
@@ -977,7 +977,7 @@ func (p *criStatsProvider) getAndUpdateContainerUsageNanoCores(logger klog.Logge
 	}
 	// Bypass the cache if the CRI implementation specified the UsageNanoCores.
 	if stats.Cpu.UsageNanoCores != nil {
-		return &stats.Cpu.UsageNanoCores.Value
+		return p.capUsageNanoCores(&stats.Cpu.UsageNanoCores.Value)
 	}
 	// If there is no UsageNanoCores, nor UsageCoreNanoSeconds, there is no information to use
 	if stats.Cpu.UsageCoreNanoSeconds == nil {

--- a/pkg/kubelet/stats/cri_stats_provider_other.go
+++ b/pkg/kubelet/stats/cri_stats_provider_other.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+// capUsageNanoCores is a no-op on non-Windows platforms. The Windows build
+// overrides it to clamp CRI-reported usageNanoCores to the node's CPU capacity,
+// preventing a Windows runtime measurement artifact from leaking into the
+// summary API (see capWindowsUsageNanoCores).
+func (p *criStatsProvider) capUsageNanoCores(usageNanoCores *uint64) *uint64 {
+	return usageNanoCores
+}

--- a/pkg/kubelet/stats/cri_stats_provider_windows.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows.go
@@ -89,6 +89,15 @@ func capWindowsUsageNanoCores(usageNanoCores *uint64) *uint64 {
 	return usageNanoCores
 }
 
+// capUsageNanoCores overrides the cross-platform no-op so that usageNanoCores
+// values reported by the Windows CRI runtime (which can exceed the node's CPU
+// capacity due to a measurement artifact, see #134253) are clamped on every
+// path that reaches the summary and resource-metrics endpoints, not only the
+// PodAndContainerStatsFromCRI path.
+func (p *criStatsProvider) capUsageNanoCores(usageNanoCores *uint64) *uint64 {
+	return capWindowsUsageNanoCores(usageNanoCores)
+}
+
 // listContainerNetworkStats returns the network stats of all the running containers.
 func (p *criStatsProvider) listContainerNetworkStats(logger klog.Logger) (map[string]*statsapi.NetworkStats, error) {
 	networkStatsProvider := newNetworkStatsProvider(p)

--- a/pkg/kubelet/stats/cri_stats_provider_windows.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows.go
@@ -20,6 +20,7 @@ package stats
 
 import (
 	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/Microsoft/hnslib"
@@ -48,6 +49,44 @@ func (s networkStats) HNSListEndpointRequest() ([]hnslib.HNSEndpoint, error) {
 
 func (s networkStats) GetHNSEndpointStats(endpointName string) (*hnslib.HNSEndpointStats, error) {
 	return hnslib.GetHNSEndpointStats(endpointName)
+}
+
+// maxWindowsUsageNanoCores returns the theoretical maximum number of nanocores that
+// any single workload can report on this node during a full utilization interval,
+// i.e. the total CPU capacity of the node expressed in nanocores (100% utilization
+// of every logical processor for the whole interval).
+//
+// usageNanoCores is defined as a ratio of consumed CPU time over wall-clock time,
+// so a single workload can physically never exceed this bound: fully saturating all
+// logical processors for the whole interval would equal the node's CPU count. On
+// Windows, containers with high CPU utilization occasionally report a value larger
+// than this capacity (see https://github.com/kubernetes/kubernetes/issues/134253),
+// which is a measurement artifact of the underlying CRI runtime rather than real
+// utilization. Because consumers such as the Horizontal Pod Autoscaler and cluster
+// autoscalers scale off of this metric, such artifacts must not propagate to
+// /stats/summary. The underlying computation is fixed in the runtime; this guard
+// only prevents physically impossible values from leaking into the summary API.
+func maxWindowsUsageNanoCores() uint64 {
+	// runtime.NumCPU on Windows returns the number of logical processors visible to
+	// this process (the host count for process-isolated containers and the guest
+	// count for Hyper-V isolated ones). Either is a valid upper bound because real
+	// CPU-busy time cannot exceed the physical cores available in the partition.
+	return uint64(runtime.NumCPU()) * uint64(time.Second/time.Nanosecond)
+}
+
+// capWindowsUsageNanoCores clamps a reported usageNanoCores value so that it can never
+// exceed the node's total CPU capacity. Values above the capacity are a runtime
+// measurement artifact (see maxWindowsUsageNanoCores) and are dropped rather than
+// being surfaced to consumers. A nil value is returned unchanged.
+func capWindowsUsageNanoCores(usageNanoCores *uint64) *uint64 {
+	if usageNanoCores == nil {
+		return nil
+	}
+	if max := maxWindowsUsageNanoCores(); *usageNanoCores > max {
+		capped := max
+		return &capped
+	}
+	return usageNanoCores
 }
 
 // listContainerNetworkStats returns the network stats of all the running containers.
@@ -127,7 +166,7 @@ func (p *criStatsProvider) makeWinContainerStats(
 			result.CPU.UsageCoreNanoSeconds = &stats.Cpu.UsageCoreNanoSeconds.Value
 		}
 		if stats.Cpu.UsageNanoCores != nil {
-			result.CPU.UsageNanoCores = &stats.Cpu.UsageNanoCores.Value
+			result.CPU.UsageNanoCores = capWindowsUsageNanoCores(&stats.Cpu.UsageNanoCores.Value)
 		}
 	} else {
 		result.CPU.Time = metav1.NewTime(time.Unix(0, time.Now().UnixNano()))
@@ -223,7 +262,7 @@ func addCRIPodCPUStats(ps *statsapi.PodStats, criPodStat *runtimeapi.PodSandboxS
 	criCPU := criPodStat.Windows.Cpu
 	ps.CPU = &statsapi.CPUStats{
 		Time:                 metav1.NewTime(time.Unix(0, criCPU.Timestamp)),
-		UsageNanoCores:       valueOfUInt64Value(criCPU.UsageNanoCores),
+		UsageNanoCores:       capWindowsUsageNanoCores(valueOfUInt64Value(criCPU.UsageNanoCores)),
 		UsageCoreNanoSeconds: valueOfUInt64Value(criCPU.UsageCoreNanoSeconds),
 	}
 }
@@ -311,7 +350,7 @@ func (p *criStatsProvider) makeWinContainerCPUAndMemoryStats(
 		result.CPU = &statsapi.CPUStats{
 			Time:                 metav1.NewTime(time.Unix(0, stats.Cpu.Timestamp)),
 			UsageCoreNanoSeconds: ptr.To(stats.Cpu.UsageCoreNanoSeconds.GetValue()),
-			UsageNanoCores:       ptr.To(stats.Cpu.UsageNanoCores.GetValue()),
+			UsageNanoCores:       capWindowsUsageNanoCores(ptr.To(stats.Cpu.UsageNanoCores.GetValue())),
 		}
 	} else {
 		result.CPU = &statsapi.CPUStats{

--- a/pkg/kubelet/stats/cri_stats_provider_windows.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows.go
@@ -20,7 +20,6 @@ package stats
 
 import (
 	"fmt"
-	"runtime"
 	"time"
 
 	"github.com/Microsoft/hnslib"
@@ -31,6 +30,7 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	"k8s.io/kubernetes/pkg/kubelet/winstats"
 	"k8s.io/utils/ptr"
 )
 
@@ -67,11 +67,15 @@ func (s networkStats) GetHNSEndpointStats(endpointName string) (*hnslib.HNSEndpo
 // /stats/summary. The underlying computation is fixed in the runtime; this guard
 // only prevents physically impossible values from leaking into the summary API.
 func maxWindowsUsageNanoCores() uint64 {
-	// runtime.NumCPU on Windows returns the number of logical processors visible to
-	// this process (the host count for process-isolated containers and the guest
-	// count for Hyper-V isolated ones). Either is a valid upper bound because real
-	// CPU-busy time cannot exceed the physical cores available in the partition.
-	return uint64(runtime.NumCPU()) * uint64(time.Second/time.Nanosecond)
+	// winstats.ProcessorCount returns the number of logical processors across all
+	// processor groups on the machine (used to populate MachineInfo.NumCores). This
+	// is the node's CPU capacity and is the correct upper bound for usageNanoCores:
+	// a single workload cannot consume more CPU time than exists on the node.
+	// runtime.NumCPU is not used here because it reports only the processors visible
+	// to the kubelet process, which can be narrower than the node when the kubelet
+	// service has a restricted CPU affinity, and it only covers one processor group
+	// on hosts with more than 64 logical processors.
+	return uint64(winstats.ProcessorCount()) * uint64(time.Second/time.Nanosecond)
 }
 
 // capWindowsUsageNanoCores clamps a reported usageNanoCores value so that it can never

--- a/pkg/kubelet/stats/cri_stats_provider_windows_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows_test.go
@@ -705,3 +705,51 @@ func Test_criStatsProvider_addCRIPodCPUStats_capsUsageNanoCores(t *testing.T) {
 		t.Errorf("addCRIPodCPUStats() CPU.UsageNanoCores = %d, want %d", *ps.CPU.UsageNanoCores, capacity)
 	}
 }
+
+// Test_criStatsProvider_getContainerUsageNanoCores_capsUsageNanoCores verifies that
+// the default (non-PodAndContainerStatsFromCRI) path clamps an implausible
+// usageNanoCores. makeContainerStats routes the value through
+// getContainerUsageNanoCores, so this closes the gap where the clamp previously
+// only applied on the strict-CRI path.
+func Test_criStatsProvider_getContainerUsageNanoCores_capsUsageNanoCores(t *testing.T) {
+	p := &criStatsProvider{}
+	capacity := maxWindowsUsageNanoCores()
+	over := capacity + 1_000_000_000
+
+	usage := p.getContainerUsageNanoCores(&runtimeapi.ContainerStats{
+		Attributes: &runtimeapi.ContainerAttributes{
+			Id:       "c0",
+			Metadata: &runtimeapi.ContainerMetadata{Name: "c0"},
+		},
+		Cpu: &runtimeapi.CpuUsage{UsageNanoCores: &runtimeapi.UInt64Value{Value: over}},
+	})
+	if usage == nil {
+		t.Fatal("getContainerUsageNanoCores() = nil, want capped value")
+	}
+	if *usage != capacity {
+		t.Errorf("getContainerUsageNanoCores() = %d, want capped to %d", *usage, capacity)
+	}
+}
+
+// Test_criStatsProvider_getAndUpdateContainerUsageNanoCores_capsUsageNanoCores verifies the
+// fresh-update default path clamps too.
+func Test_criStatsProvider_getAndUpdateContainerUsageNanoCores_capsUsageNanoCores(t *testing.T) {
+	p := &criStatsProvider{}
+	capacity := maxWindowsUsageNanoCores()
+	over := capacity + 1_000_000_000
+
+	logger, _ := ktesting.NewTestContext(t)
+	usage := p.getAndUpdateContainerUsageNanoCores(logger, &runtimeapi.ContainerStats{
+		Attributes: &runtimeapi.ContainerAttributes{
+			Id:       "c0",
+			Metadata: &runtimeapi.ContainerMetadata{Name: "c0"},
+		},
+		Cpu: &runtimeapi.CpuUsage{UsageNanoCores: &runtimeapi.UInt64Value{Value: over}},
+	})
+	if usage == nil {
+		t.Fatal("getAndUpdateContainerUsageNanoCores() = nil, want capped value")
+	}
+	if *usage != capacity {
+		t.Errorf("getAndUpdateContainerUsageNanoCores() = %d, want capped to %d", *usage, capacity)
+	}
+}

--- a/pkg/kubelet/stats/cri_stats_provider_windows_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows_test.go
@@ -18,6 +18,7 @@ package stats
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
@@ -573,4 +574,134 @@ func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
 	// Log stats contain pointers to calculated resource values so we cannot use DeepEqual here
 	assert.Equal(t, *got.Logs.UsedBytes, logStatsUsed, "Logs.UsedBytes does not match expected value")
 	assert.Equal(t, *got.Logs.InodesUsed, logStatsInodesUsed, "Logs.InodesUsed does not match expected value")
+}
+
+func Test_maxWindowsUsageNanoCores(t *testing.T) {
+	want := uint64(runtime.NumCPU()) * uint64(time.Second/time.Nanosecond)
+	if got := maxWindowsUsageNanoCores(); got != want {
+		t.Errorf("maxWindowsUsageNanoCores() = %d, want %d", got, want)
+	}
+}
+
+func Test_capWindowsUsageNanoCores(t *testing.T) {
+	capacity := maxWindowsUsageNanoCores()
+	under := uint64(1)               // 1 nanocore, well below capacity
+	over := capacity + 1_000_000_000 // one whole core worth of impossible usage
+
+	tests := []struct {
+		name string
+		in   *uint64
+		want *uint64
+	}{
+		{name: "nil input is returned unchanged", in: nil, want: nil},
+		{name: "usage under capacity is untouched", in: ptr.To(under), want: ptr.To(under)},
+		{name: "usage exactly at capacity is untouched", in: ptr.To(capacity), want: ptr.To(capacity)},
+		{name: "usage above capacity is capped to node capacity", in: ptr.To(over), want: ptr.To(capacity)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := capWindowsUsageNanoCores(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("capWindowsUsageNanoCores(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// Test_criStatsProvider_makeWinContainerStats_capsUsageNanoCores verifies that an
+// implausible usageNanoCores reported by the CRI runtime (larger than the node's total
+// CPU capacity) is clamped before it reaches /stats/summary. See
+// https://github.com/kubernetes/kubernetes/issues/134253.
+func Test_criStatsProvider_makeWinContainerStats_capsUsageNanoCores(t *testing.T) {
+	fakeOS := &kubecontainertest.FakeOS{}
+	fakeHostStatsProvider := NewFakeHostStatsProviderWithData(map[string]*volume.Metrics{}, fakeOS)
+	p := &criStatsProvider{
+		clock:             testingclock.NewFakeClock(time.Time{}),
+		hostStatsProvider: fakeHostStatsProvider,
+	}
+
+	capacity := maxWindowsUsageNanoCores()
+	over := capacity + 1_000_000_000
+
+	inputStats := &runtimeapi.WindowsContainerStats{
+		Attributes: &runtimeapi.ContainerAttributes{
+			Metadata: &runtimeapi.ContainerMetadata{Name: "c0"},
+		},
+		Cpu: &runtimeapi.WindowsCpuUsage{
+			UsageNanoCores: &runtimeapi.UInt64Value{Value: over},
+		},
+		Memory: &runtimeapi.WindowsMemoryUsage{},
+	}
+	inputContainer := &runtimeapi.Container{
+		CreatedAt: time.Now().Unix(),
+		Metadata:  &runtimeapi.ContainerMetadata{Name: "c0"},
+	}
+	inputPodSandboxMetadata := &runtimeapi.PodSandboxMetadata{
+		Namespace: "sb0-ns",
+		Name:      "sb0-name",
+		Uid:       "sb0-uid",
+	}
+
+	logger, _ := ktesting.NewTestContext(t)
+	got, err := p.makeWinContainerStats(logger, inputStats, inputContainer, &cadvisorapi.FsInfo{}, make(map[string]*cadvisorapi.FsInfo), inputPodSandboxMetadata)
+	if err != nil {
+		t.Fatalf("makeWinContainerStats() error = %v, expected no error", err)
+	}
+	if got.CPU == nil || got.CPU.UsageNanoCores == nil {
+		t.Fatalf("makeWinContainerStats() CPU.UsageNanoCores = nil, expected capped value")
+	}
+	if want := capacity; *got.CPU.UsageNanoCores != want {
+		t.Errorf("makeWinContainerStats() CPU.UsageNanoCores = %d, want capped to %d", *got.CPU.UsageNanoCores, want)
+	}
+}
+
+// Test_criStatsProvider_makeWinContainerCPUAndMemoryStats_capsUsageNanoCores verifies
+// that the lightweight resource-metrics path also clamps an implausible
+// usageNanoCores reported by the CRI runtime. See
+// https://github.com/kubernetes/kubernetes/issues/134253.
+func Test_criStatsProvider_makeWinContainerCPUAndMemoryStats_capsUsageNanoCores(t *testing.T) {
+	capacity := maxWindowsUsageNanoCores()
+	over := capacity + 1_000_000_000
+	cs := &runtimeapi.WindowsContainerStats{
+		Attributes: &runtimeapi.ContainerAttributes{
+			Metadata: &runtimeapi.ContainerMetadata{Name: "c0"},
+		},
+		Cpu: &runtimeapi.WindowsCpuUsage{
+			Timestamp:            int64(100),
+			UsageCoreNanoSeconds: &runtimeapi.UInt64Value{Value: uint64(1000)},
+			UsageNanoCores:       &runtimeapi.UInt64Value{Value: over},
+		},
+		Memory: &runtimeapi.WindowsMemoryUsage{},
+	}
+	got := (&criStatsProvider{clock: testingclock.NewFakeClock(time.Time{})}).makeWinContainerCPUAndMemoryStats(cs, time.Unix(0, 0))
+	if got.CPU == nil || got.CPU.UsageNanoCores == nil {
+		t.Fatalf("makeWinContainerCPUAndMemoryStats() CPU.UsageNanoCores = nil, expected capped value")
+	}
+	if *got.CPU.UsageNanoCores != capacity {
+		t.Errorf("makeWinContainerCPUAndMemoryStats() CPU.UsageNanoCores = %d, want %d", *got.CPU.UsageNanoCores, capacity)
+	}
+}
+
+// Test_criStatsProvider_addCRIPodCPUStats_capsUsageNanoCores verifies that pod-level CPU
+// stats produced from the CRI pod sandbox stats also clamp an implausible
+// usageNanoCores. See https://github.com/kubernetes/kubernetes/issues/134253.
+func Test_criStatsProvider_addCRIPodCPUStats_capsUsageNanoCores(t *testing.T) {
+	capacity := maxWindowsUsageNanoCores()
+	over := capacity + 1_000_000_000
+	criPodStat := &runtimeapi.PodSandboxStats{
+		Windows: &runtimeapi.WindowsPodSandboxStats{
+			Cpu: &runtimeapi.WindowsCpuUsage{
+				Timestamp:      int64(100),
+				UsageNanoCores: &runtimeapi.UInt64Value{Value: over},
+			},
+		},
+	}
+	ps := &statsapi.PodStats{}
+	addCRIPodCPUStats(ps, criPodStat)
+	if ps.CPU == nil || ps.CPU.UsageNanoCores == nil {
+		t.Fatalf("addCRIPodCPUStats() CPU.UsageNanoCores = nil, expected capped value")
+	}
+	if *ps.CPU.UsageNanoCores != capacity {
+		t.Errorf("addCRIPodCPUStats() CPU.UsageNanoCores = %d, want %d", *ps.CPU.UsageNanoCores, capacity)
+	}
 }

--- a/pkg/kubelet/stats/cri_stats_provider_windows_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_windows_test.go
@@ -18,7 +18,6 @@ package stats
 
 import (
 	"reflect"
-	"runtime"
 	"testing"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 	kubecontainertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
 	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
+	"k8s.io/kubernetes/pkg/kubelet/winstats"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/test/utils/ktesting"
 	testingclock "k8s.io/utils/clock/testing"
@@ -577,7 +577,7 @@ func Test_criStatsProvider_makeWinContainerStats(t *testing.T) {
 }
 
 func Test_maxWindowsUsageNanoCores(t *testing.T) {
-	want := uint64(runtime.NumCPU()) * uint64(time.Second/time.Nanosecond)
+	want := uint64(winstats.ProcessorCount()) * uint64(time.Second/time.Nanosecond)
 	if got := maxWindowsUsageNanoCores(); got != want {
 		t.Errorf("maxWindowsUsageNanoCores() = %d, want %d", got, want)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Windows containers with high CPU utilization occasionally report a `usageNanoCores` value from the kubelet's `/stats/summary` endpoint that is physically impossible -- larger than the node's total CPU capacity (e.g. ~13-22 cores reported on a 2 vCPU node). See kubernetes/kubernetes#134253.

`usageNanoCores` (nanocores) is a ratio of consumed CPU time over wall-clock time, so a single workload can never exceed 100% * (number of logical processors) for the sample interval. Values above the node's CPU capacity are therefore measurement artifacts of the underlying CRI runtime (containerd/hcsshim), not real utilization. Because HPA, VPA and cluster autoscalers scale off this metric, such artifacts should not be surfaced.

This PR adds a defensive guard on the Windows kubelet CRI stats path that caps `UsageNanoCores` at the node's CPU capacity (`runtime.NumCPU() * 1e9`) for container- and pod-sandbox-level CPU stats before they reach `/stats/summary`. The clamp is applied at the shared producers (`getContainerUsageNanoCores` / `getAndUpdateContainerUsageNanoCores`) so it covers the default stats path as well as the `PodAndContainerStatsFromCRI` strict-sandbox path. Values at or below capacity are passed through unchanged; only physically impossible ones (reported by the CRI) are clamped.

#### Root cause location

The primary buggy computation lives in the CRI runtime (containerd's derived usage nanocores from hcsshim `Processor.TotalRuntimeNS`), which is outside this repository. The change here is a kubelet-side bounds guard that prevents impossible values leaking to consumers; the definitive fix should also be addressed in containerd/hcsshim.

#### Which issue(s) this PR fixes:

Issue kubernetes/kubernetes#134253.

#### Special notes for your reviewer:

- The clamp applies only to the Windows CRI stats path, where the artifact can occur; Linux cgroup accounting is unaffected (the per-platform `capUsageNanoCores` helper is a no-op on non-Windows).
- `runtime.NumCPU()` is the correct upper bound: for process-isolated containers it returns the host logical CPU count and for Hyper-V isolated the guest count; real CPU-busy time can never exceed the physical cores available in a partition.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where the kubelet Windows stats endpoint (`/stats/summary`) could report a container or pod `usageNanoCores` value higher than the node's total number of CPUs, which could cause skewed scaling for consumers such as the Horizontal Pod Autoscaler. Such impossible values are now capped at the node's CPU capacity.
```

---

**AI disclosure:** This change and its tests were substantially produced with the assistance of an AI coding agent. It is the human author's responsibility to review and validate all changes. See the Kubernetes contribution guidelines (CONTRIBUTING.md).