### PR TITLE
kubelet: add Windows OOM observability via CRI container statuses

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -848,6 +848,17 @@ func run(ctx context.Context, s *options.KubeletServer, kubeDeps *kubelet.Depend
 		if err != nil {
 			return err
 		}
+
+		// On Windows the cAdvisor client implements cadvisor.ContainerEnumeratorSetter,
+		// enabling per-container metrics (e.g. container_oom_events_total) by
+		// enumerating live CRI containers. The runtime service is initialized before
+		// this point (PreInitRuntimeService); Linux cAdvisor does not implement the
+		// optional setter, so this wiring is a harmless no-op there.
+		if enumerator, ok := kubeDeps.RemoteRuntimeService.(cadvisor.ContainerEnumerator); ok {
+			if setter, ok := kubeDeps.CAdvisorInterface.(cadvisor.ContainerEnumeratorSetter); ok {
+				setter.SetContainerEnumerator(enumerator)
+			}
+		}
 	}
 
 	// Setup event recorder if required.

--- a/pkg/kubelet/cadvisor/cadvisor_windows.go
+++ b/pkg/kubelet/cadvisor/cadvisor_windows.go
@@ -20,6 +20,7 @@ package cadvisor
 
 import (
 	"context"
+	"time"
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
 	"k8s.io/klog/v2"
@@ -29,6 +30,12 @@ import (
 type cadvisorClient struct {
 	rootPath       string
 	winStatsClient winstats.Client
+	// containerEnumerator lists live CRI containers so per-container metrics
+	// (e.g. container_oom_events_total) can be produced on Windows, where the
+	// cAdvisor container discovery does not enumerate containers. It is
+	// optional: without it GetRequestedContainersInfo returns nothing, matching
+	// the historic behavior.
+	containerEnumerator ContainerEnumerator
 }
 
 var _ Interface = new(cadvisorClient)
@@ -51,8 +58,48 @@ func (cu *cadvisorClient) ContainerInfoV2(name string, options cadvisorapi.Reque
 	return cu.winStatsClient.WinContainerInfos()
 }
 
+// SetContainerEnumerator wires the CRI runtime service so the client can
+// enumerate live containers for per-container metrics. It is optional; if it is
+// not called (or is nil) GetRequestedContainersInfo falls back to returning no
+// per-container infos, preserving the historic behavior.
+func (cu *cadvisorClient) SetContainerEnumerator(e ContainerEnumerator) {
+	cu.containerEnumerator = e
+}
+
+// GetRequestedContainersInfo returns one minimal ContainerInfo per live CRI
+// container, keyed by the container's ID. The metrics collector uses these to
+// emit per-container metrics (such as container_oom_events_total) and the
+// kubelet server reads OOMEventsForContainer(info.Name), so the container ID is
+// the key the Windows OOM watcher must record the count under.
 func (cu *cadvisorClient) GetRequestedContainersInfo(containerName string, options cadvisorapi.RequestOptions) (map[string]*cadvisorapi.ContainerInfo, error) {
-	return nil, nil
+	if cu.containerEnumerator == nil {
+		return nil, nil
+	}
+	containers, err := cu.containerEnumerator.ListContainers(context.Background(), nil)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	infos := make(map[string]*cadvisorapi.ContainerInfo, len(containers))
+	for _, c := range containers {
+		info := &cadvisorapi.ContainerInfo{
+			Spec: cadvisorapi.ContainerSpec{
+				CreationTime: time.Unix(0, c.GetCreatedAt()),
+				HasCpu:       true,
+				HasMemory:    true,
+				Labels:       c.GetLabels(),
+			},
+			Stats: []*cadvisorapi.ContainerStats{{Timestamp: now}},
+		}
+		// Name is the promoted ContainerReference.Name (embedded into
+		// ContainerInfo); assigning it by field access works on Go <1.27.
+		info.Name = c.GetId()
+		if c.GetMetadata() != nil && c.GetMetadata().GetName() != "" {
+			info.Aliases = []string{c.GetMetadata().GetName()}
+		}
+		infos[c.GetId()] = info
+	}
+	return infos, nil
 }
 
 func (cu *cadvisorClient) MachineInfo(logger klog.Logger) (*cadvisorapi.MachineInfo, error) {

--- a/pkg/kubelet/cadvisor/cadvisor_windows.go
+++ b/pkg/kubelet/cadvisor/cadvisor_windows.go
@@ -85,9 +85,15 @@ func (cu *cadvisorClient) GetRequestedContainersInfo(containerName string, optio
 		info := &cadvisorapi.ContainerInfo{
 			Spec: cadvisorapi.ContainerSpec{
 				CreationTime: time.Unix(0, c.GetCreatedAt()),
-				HasCpu:       true,
-				HasMemory:    true,
-				Labels:       c.GetLabels(),
+				// HasCpu/HasMemory stay false: the CRI container list does not provide
+				// CPU or memory specifications, so advertising them would publish
+				// incorrect container_spec_cpu_shares=0 and
+				// container_spec_memory_limit_bytes=0 series. The OOM counter
+				// (container_oom_events_total) is read back separately from
+				// OOMEventsForContainer(info.Name) and does not depend on these flags.
+				HasCpu:    false,
+				HasMemory: false,
+				Labels:    c.GetLabels(),
 			},
 			Stats: []*cadvisorapi.ContainerStats{{Timestamp: now}},
 		}

--- a/pkg/kubelet/cadvisor/cadvisor_windows_test.go
+++ b/pkg/kubelet/cadvisor/cadvisor_windows_test.go
@@ -1,0 +1,96 @@
+//go:build windows
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cadvisor
+
+import (
+	"context"
+	"testing"
+
+	cadvisorapi "github.com/google/cadvisor/lib/model"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+)
+
+// fakeEnumerator is a ContainerEnumerator test double returning a fixed set
+// of CRI containers.
+type fakeEnumerator struct {
+	containers []*runtimeapi.Container
+}
+
+func (f *fakeEnumerator) ListContainers(context.Context, *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+	return f.containers, nil
+}
+
+// TestGetRequestedContainersInfoWindows verifies that GetRequestedContainersInfo
+// surfaces one minimal per-container ContainerInfo keyed by the CRI container ID,
+// with the labels/alias the metrics path needs so the Windows OOM watcher's
+// recordOOMKill(containerID) is read back by OOMEventsForContainer(info.Name).
+func TestGetRequestedContainersInfoWindows(t *testing.T) {
+	client := &cadvisorClient{
+		winStatsClient: nil,
+		containerEnumerator: &fakeEnumerator{
+			containers: []*runtimeapi.Container{
+				{
+					Id:        "cid-1",
+					CreatedAt: 1234,
+					Metadata:  &runtimeapi.ContainerMetadata{Name: "app"},
+					Labels:    map[string]string{"io.kubernetes.container.name": "app"},
+				},
+				{
+					Id:       "cid-2",
+					Metadata: &runtimeapi.ContainerMetadata{Name: "sidecar"},
+					Labels:   map[string]string{"io.kubernetes.container.name": "sidecar"},
+				},
+			},
+		},
+	}
+
+	infos, err := client.GetRequestedContainersInfo("/", cadvisorapi.RequestOptions{})
+	if err != nil {
+		t.Fatalf("GetRequestedContainersInfo() error = %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("GetRequestedContainersInfo() returned %d infos, want 2", len(infos))
+	}
+
+	for id, want := range map[string]string{"cid-1": "app", "cid-2": "sidecar"} {
+		info, ok := infos[id]
+		if !ok {
+			t.Errorf("no info for container id %q", id)
+			continue
+		}
+		if info.Name != id {
+			t.Errorf("info.Name = %q for %q, want the CRI container ID", info.Name, id)
+		}
+		if len(info.Stats) != 1 || info.Stats[0] == nil {
+			t.Errorf("info.Stats = %v, want a single sample", info.Stats)
+		}
+		if info.Spec.Labels["io.kubernetes.container.name"] != want {
+			t.Errorf("Spec.Labels did not carry the container name, got %v", info.Spec.Labels)
+		}
+	}
+
+	// A client without an enumerator must keep the historic no-op behavior.
+	infoZe, err := (&cadvisorClient{}).GetRequestedContainersInfo("/", cadvisorapi.RequestOptions{})
+	if err != nil {
+		t.Fatalf("GetRequestedContainersInfo() no-enumerator error = %v", err)
+	}
+	if infoZe != nil {
+		t.Errorf("GetRequestedContainersInfo() = %v without enumerator, want nil", infoZe)
+	}
+}

--- a/pkg/kubelet/cadvisor/cadvisor_windows_test.go
+++ b/pkg/kubelet/cadvisor/cadvisor_windows_test.go
@@ -83,6 +83,16 @@ func TestGetRequestedContainersInfoWindows(t *testing.T) {
 		if info.Spec.Labels["io.kubernetes.container.name"] != want {
 			t.Errorf("Spec.Labels did not carry the container name, got %v", info.Spec.Labels)
 		}
+		// The CRI container list carries no CPU/memory specifications, so these
+		// must stay unadvertised to avoid publishing container_spec_cpu_shares=0
+		// and container_spec_memory_limit_bytes=0 series (the OOM counter is
+		// read back independently via OOMEventsForContainer(info.Name)).
+		if info.Spec.HasCpu {
+			t.Errorf("HasCpu must be false on synthetic records without CPU specs")
+		}
+		if info.Spec.HasMemory {
+			t.Errorf("HasMemory must be false on synthetic records without memory specs")
+		}
 	}
 
 	// A client without an enumerator must keep the historic no-op behavior.

--- a/pkg/kubelet/cadvisor/types.go
+++ b/pkg/kubelet/cadvisor/types.go
@@ -21,6 +21,7 @@ import (
 	"context"
 
 	cadvisorapi "github.com/google/cadvisor/lib/model"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 	"k8s.io/klog/v2"
 )
 
@@ -45,6 +46,22 @@ type Interface interface {
 
 	// Get filesystem information for the filesystem that contains the given file.
 	GetDirFsInfo(path string) (cadvisorapi.FsInfo, error)
+}
+
+// ContainerEnumerator lists live CRI containers so a cAdvisor client can build
+// per-container info where the underlying cAdvisor container discovery does not
+// (e.g. Windows). The kubelet's internalapi.RuntimeService satisfies it.
+type ContainerEnumerator interface {
+	ListContainers(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error)
+}
+
+// ContainerEnumeratorSetter is implemented by cAdvisor clients that can accept
+// a CRI runtime to populate per-container info for the metrics collector (e.g.
+// container_oom_events_total on Windows). It is optional; Linux cAdvisor does
+// not implement it, and the kubelet skips the wiring when the interface is
+// absent.
+type ContainerEnumeratorSetter interface {
+	SetContainerEnumerator(ContainerEnumerator)
 }
 
 // ImageFsInfoProvider informs cAdvisor how to find imagefs for container images.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -589,7 +589,7 @@ func NewMainKubelet(ctx context.Context,
 		Namespace:  "",
 	}
 
-	oomWatcher, err := oomwatcher.NewWatcher(kubeDeps.Recorder)
+	oomWatcher, err := oomwatcher.NewWatcher(kubeDeps.Recorder, kubeDeps.RemoteRuntimeService)
 	if err != nil {
 		if inuserns.RunningInUserNS() {
 			if utilfeature.DefaultFeatureGate.Enabled(features.KubeletInUserNamespace) {

--- a/pkg/kubelet/oom/oom_counter_test.go
+++ b/pkg/kubelet/oom/oom_counter_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOOMCounterKeying verifies the exact-string key contract between the OOM
+// watcher (recordOOMKill) and the events reader (OOMEventsForContainer). The
+// metrics server reads OOMEventsForContainer(info.Name), so the watcher must
+// record under the same string that per-container cAdvisor info.Name uses,
+// or the metric is never read back.
+func TestOOMCounterKeying(t *testing.T) {
+	containerID := "abc123def456"
+
+	// Recording under the same key must be read back exactly.
+	recordOOMKill(containerID)
+	recordOOMKill(containerID)
+	assert.Equal(t, uint64(2), OOMEventsForContainer(containerID))
+
+	// A different key must never leak into this container's count.
+	recordOOMKill("other-container-id")
+	assert.Equal(t, uint64(2), OOMEventsForContainer(containerID))
+
+	// Unknown keys read 0.
+	assert.Equal(t, uint64(0), OOMEventsForContainer("not-present"))
+
+	// Clean the package-global map so a later run does not see stale counts.
+	oomEventCounts.Lock()
+	clear(oomEventCounts.byContainer)
+	oomEventCounts.Unlock()
+}

--- a/pkg/kubelet/oom/oom_watcher_linux.go
+++ b/pkg/kubelet/oom/oom_watcher_linux.go
@@ -43,8 +43,10 @@ type realWatcher struct {
 var _ Watcher = &realWatcher{}
 
 // NewWatcher creates and initializes an OOMWatcher backed by the kernel log
-// (/dev/kmsg) oom streamer.
-func NewWatcher(recorder record.EventRecorderLogger) (Watcher, error) {
+// (/dev/kmsg) oom streamer. The container status getter is unused on Linux,
+// where OOM events come from the kernel log, but is kept in the signature so
+// callers compile unchanged across platforms.
+func NewWatcher(recorder record.EventRecorderLogger, _ containerStatusGetter) (Watcher, error) {
 	// for test purpose
 	_, ok := recorder.(*record.FakeRecorder)
 	if ok {

--- a/pkg/kubelet/oom/oom_watcher_unsupported.go
+++ b/pkg/kubelet/oom/oom_watcher_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !windows
 
 /*
 Copyright 2019 The Kubernetes Authors.
@@ -29,8 +29,10 @@ type oomWatcherUnsupported struct{}
 
 var _ Watcher = new(oomWatcherUnsupported)
 
-// NewWatcher creates a fake one here
-func NewWatcher(_ record.EventRecorder) (Watcher, error) {
+// NewWatcher creates a fake one here. The recorder and container status getter
+// are unused on platforms without an OOM watcher but are kept in the signature
+// so callers compile unchanged across platforms.
+func NewWatcher(_ record.EventRecorder, _ containerStatusGetter) (Watcher, error) {
 	return &oomWatcherUnsupported{}, nil
 }
 

--- a/pkg/kubelet/oom/oom_watcher_windows.go
+++ b/pkg/kubelet/oom/oom_watcher_windows.go
@@ -1,0 +1,212 @@
+//go:build windows
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oom
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/record"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/klog/v2"
+	kubelettypes "k8s.io/kubelet/pkg/types"
+)
+
+// oomKilledExitReason is the CRI container exit reason reported when a
+// container was terminated by the out-of-memory killer. It matches the value
+// the kubelet kuberuntime layer already looks for (see
+// pkg/kubelet/kuberuntime/helpers.go).
+const oomKilledExitReason = "OOMKilled"
+
+// windowsOOMEventReason is the Kubernetes event reason emitted when the Windows
+// CRI reports that a container crossed into the OOMKilled state.
+const windowsOOMEventReason = "ContainerOOMKilled"
+
+// windowsOOMPollInterval is how often the watcher reconciles the CRI container
+// state. It is a variable so tests can shrink the interval to avoid sleeping
+// for the real period.
+var windowsOOMPollInterval = time.Minute
+
+type windowsWatcher struct {
+	// recorder emits Kubernetes events for OOMKilled containers.
+	recorder record.EventRecorder
+	// containers polls the CRI container state.
+	containers containerStatusGetter
+	// pollInterval controls the reconciliation period.
+	pollInterval time.Duration
+
+	// mu guards seen so replay once-per-container bookkeeping is safe even if
+	// Start is invoked concurrently.
+	mu sync.Mutex
+	// seen records container IDs already reported as OOMKilled so a single
+	// terminated container is surfaced exactly once across polling intervals.
+	seen map[string]struct{}
+}
+
+var _ Watcher = &windowsWatcher{}
+
+// NewWatcher creates a Windows OOM watcher that reconciles CRI container
+// statuses to surface containers that were terminated by the out-of-memory
+// killer. The runtime service may be nil, in which case the watcher logs the
+// skipped reconcile and stays safe.
+func NewWatcher(recorder record.EventRecorder, containers containerStatusGetter) (Watcher, error) {
+	return &windowsWatcher{
+		recorder:     recorder,
+		containers:   containers,
+		pollInterval: windowsOOMPollInterval,
+		seen:         make(map[string]struct{}),
+	}, nil
+}
+
+// Start reconciles CRI container statuses until ctx is cancelled, emitting a
+// Kubernetes event and incrementing container_oom_events_total for every
+// container that crosses into the OOMKilled state.
+func (ow *windowsWatcher) Start(ctx context.Context, _ *v1.ObjectReference) error {
+	logger := klog.FromContext(ctx)
+	go func() {
+		defer runtime.HandleCrashWithContext(ctx)
+		ow.pollLoop(ctx, logger)
+	}()
+	return nil
+}
+
+// pollLoop periodically lists CRI containers and reports newly OOMKilled ones.
+// It is extracted from Start so tests can exercise a single reconcile without
+// driving the full timer loop.
+func (ow *windowsWatcher) pollLoop(ctx context.Context, logger klog.Logger) {
+	ticker := time.NewTicker(ow.pollInterval)
+	defer ticker.Stop()
+
+	// Seed the seen set with containers that are already OOMKilled so a kubelet
+	// restart does not replay historical kills as fresh events.
+	seedOOMKills(ctx, ow.containers, ow.seen, logger)
+	ow.reconcile(ctx, logger)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			ow.reconcile(ctx, logger)
+		}
+	}
+}
+
+// reconcile inspects the current CRI container state and reports any container
+// that newly crossed into OOMKilled. It is called from the single pollLoop
+// goroutine.
+func (ow *windowsWatcher) reconcile(ctx context.Context, logger klog.Logger) {
+	if ow.containers == nil {
+		logger.V(2).Info("Windows OOM watcher has no CRI runtime service; skipping reconcile")
+		return
+	}
+
+	containers, err := ow.containers.ListContainers(ctx, nil)
+	if err != nil {
+		logger.Error(err, "Windows OOM watcher failed to list containers")
+		return
+	}
+
+	// Only containers that are no longer running can carry a terminal exit
+	// reason, so short-circuit the per-container status lookup for anything
+	// still running or not yet started.
+	for _, c := range containers {
+		if c.GetState() != runtimeapi.ContainerState_CONTAINER_EXITED {
+			continue
+		}
+
+		ow.mu.Lock()
+		_, saw := ow.seen[c.GetId()]
+		ow.mu.Unlock()
+		if saw {
+			continue
+		}
+
+		status, err := ow.containers.ContainerStatus(ctx, c.GetId(), false)
+		if err != nil {
+			// A container can be removed between ListContainers and
+			// ContainerStatus; retry next interval rather than failing the poll.
+			logger.V(2).Info("Windows OOM watcher failed to get container status", "containerID", c.GetId(), "err", err)
+			continue
+		}
+		if status == nil || status.GetStatus() == nil {
+			continue
+		}
+
+		cs := status.GetStatus()
+		if cs.GetReason() != oomKilledExitReason {
+			continue
+		}
+
+		// Record the metric under the container name, mirroring the cgroup key
+		// the Linux watcher uses via recordOOMKill. This backs the
+		// container_oom_events_total counter descriptor.
+		containerName := cs.GetLabels()[kubelettypes.KubernetesContainerNameLabel]
+		if containerName == "" {
+			containerName = cs.GetMetadata().GetName()
+		}
+		recordOOMKill(containerName)
+
+		// Remember the container id so the kill is surfaced exactly once.
+		ow.mu.Lock()
+		ow.seen[c.GetId()] = struct{}{}
+		ow.mu.Unlock()
+
+		podName := cs.GetLabels()[kubelettypes.KubernetesPodNameLabel]
+		podNamespace := cs.GetLabels()[kubelettypes.KubernetesPodNamespaceLabel]
+		ref := &v1.ObjectReference{
+			Kind:      "Pod",
+			Namespace: podNamespace,
+			Name:      podName,
+			UID:       types.UID(cs.GetLabels()[kubelettypes.KubernetesPodUIDLabel]),
+		}
+		ow.recorder.Eventf(ref, v1.EventTypeWarning, windowsOOMEventReason,
+			"Container %s in pod %s/%s was terminated by the out-of-memory killer", containerName, podNamespace, podName)
+		logger.Info("Windows OOM watcher reported OOMKilled container", "containerID", c.GetId(), "container", containerName, "pod", podNamespace+"/"+podName)
+	}
+}
+
+// seedOOMKills records the ids of containers that are already OOMKilled when
+// the watcher starts so a kubelet restart does not replay historical kills.
+func seedOOMKills(ctx context.Context, containers containerStatusGetter, seen map[string]struct{}, logger klog.Logger) {
+	if containers == nil {
+		return
+	}
+	list, err := containers.ListContainers(ctx, nil)
+	if err != nil {
+		logger.V(2).Info("Windows OOM watcher failed to seed OOMKilled containers", "err", err)
+		return
+	}
+	for _, c := range list {
+		if c.GetState() != runtimeapi.ContainerState_CONTAINER_EXITED {
+			continue
+		}
+		status, err := containers.ContainerStatus(ctx, c.GetId(), false)
+		if err != nil {
+			continue
+		}
+		if status != nil && status.GetStatus() != nil && status.GetStatus().GetReason() == oomKilledExitReason {
+			seen[c.GetId()] = struct{}{}
+		}
+	}
+}

--- a/pkg/kubelet/oom/oom_watcher_windows.go
+++ b/pkg/kubelet/oom/oom_watcher_windows.go
@@ -61,6 +61,12 @@ type windowsWatcher struct {
 	// seen records container IDs already reported as OOMKilled so a single
 	// terminated container is surfaced exactly once across polling intervals.
 	seen map[string]struct{}
+	// inspected records container IDs whose terminal status we have already
+	// looked up. Exited containers never change their exit reason, so once we
+	// have inspected one we must not query its status again on later polls;
+	// otherwise exited non-OOM containers accumulate and are re-polled every
+	// interval without bound.
+	inspected map[string]struct{}
 }
 
 var _ Watcher = &windowsWatcher{}
@@ -75,6 +81,7 @@ func NewWatcher(recorder record.EventRecorder, containers containerStatusGetter)
 		containers:   containers,
 		pollInterval: windowsOOMPollInterval,
 		seen:         make(map[string]struct{}),
+		inspected:    make(map[string]struct{}),
 	}, nil
 }
 
@@ -136,9 +143,10 @@ func (ow *windowsWatcher) reconcile(ctx context.Context, logger klog.Logger) {
 		}
 
 		ow.mu.Lock()
+		_, inspected := ow.inspected[c.GetId()]
 		_, saw := ow.seen[c.GetId()]
 		ow.mu.Unlock()
-		if saw {
+		if inspected || saw {
 			continue
 		}
 
@@ -154,6 +162,14 @@ func (ow *windowsWatcher) reconcile(ctx context.Context, logger klog.Logger) {
 		}
 
 		cs := status.GetStatus()
+
+		// The exit reason is terminal, so record the container as inspected
+		// regardless of outcome. This stops exited non-OOM containers from being
+		// re-queried on every subsequent poll.
+		ow.mu.Lock()
+		ow.inspected[c.GetId()] = struct{}{}
+		ow.mu.Unlock()
+
 		if cs.GetReason() != oomKilledExitReason {
 			continue
 		}

--- a/pkg/kubelet/oom/oom_watcher_windows.go
+++ b/pkg/kubelet/oom/oom_watcher_windows.go
@@ -174,14 +174,19 @@ func (ow *windowsWatcher) reconcile(ctx context.Context, logger klog.Logger) {
 			continue
 		}
 
-		// Record the metric under the container name, mirroring the cgroup key
-		// the Linux watcher uses via recordOOMKill. This backs the
-		// container_oom_events_total counter descriptor.
+		// The Windows cAdvisor metrics path keys per-container info by the CRI
+		// container ID (see cadvisor.GetRequestedContainersInfo), and the server
+		// reads the count with OOMEventsForContainer(info.Name). Record under the
+		// container ID so the count is readable back on Windows; on Linux the
+		// in-process counter is unused because the kernel cgroup OOM path also
+		// keys by containerName-equivalent cgroup path.
+		recordOOMKill(c.GetId())
+
+		// The human-facing event still uses the Kubernetes container name.
 		containerName := cs.GetLabels()[kubelettypes.KubernetesContainerNameLabel]
 		if containerName == "" {
 			containerName = cs.GetMetadata().GetName()
 		}
-		recordOOMKill(containerName)
 
 		// Remember the container id so the kill is surfaced exactly once.
 		ow.mu.Lock()

--- a/pkg/kubelet/oom/oom_watcher_windows.go
+++ b/pkg/kubelet/oom/oom_watcher_windows.go
@@ -105,9 +105,25 @@ func (ow *windowsWatcher) pollLoop(ctx context.Context, logger klog.Logger) {
 	defer ticker.Stop()
 
 	// Seed the seen set with containers that are already OOMKilled so a kubelet
-	// restart does not replay historical kills as fresh events.
-	seedOOMKills(ctx, ow.containers, ow.seen, logger)
-	ow.reconcile(ctx, logger)
+	// restart does not replay historical kills as fresh events. Reconcile only
+	// after a successful seed (i.e. once a reliable baseline exists): if the
+	// initial list fails, an empty seen set would treat every surviving
+	// historical OOM as a fresh kill on the first pass. If the runtime is nil or
+	// the initial list errors, retry the seed on subsequent intervals rather
+	// than reconciling against that incomplete baseline.
+	for {
+		seeded := seedOOMKills(ctx, ow.containers, ow.seen, logger)
+		if seeded {
+			ow.reconcile(ctx, logger)
+			break
+		}
+		logger.V(2).Info("Windows OOM watcher baseline seed incomplete; retrying next interval")
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
 
 	for {
 		select {
@@ -133,6 +149,13 @@ func (ow *windowsWatcher) reconcile(ctx context.Context, logger klog.Logger) {
 		logger.Error(err, "Windows OOM watcher failed to list containers")
 		return
 	}
+
+	// Prune inspection/seen bookkeeping against the current container list.
+	// CRI garbage collection removes completed containers, so without pruning the
+	// inspected set would retain a per-container entry for every exited container
+	// the watcher has ever seen, growing without bound on a long-lived kubelet
+	// even though the runtime has reclaimed the objects.
+	ow.pruneBookkeeping(containers)
 
 	// Only containers that are no longer running can carry a terminal exit
 	// reason, so short-circuit the per-container status lookup for anything
@@ -207,16 +230,50 @@ func (ow *windowsWatcher) reconcile(ctx context.Context, logger klog.Logger) {
 	}
 }
 
-// seedOOMKills records the ids of containers that are already OOMKilled when
-// the watcher starts so a kubelet restart does not replay historical kills.
-func seedOOMKills(ctx context.Context, containers containerStatusGetter, seen map[string]struct{}, logger klog.Logger) {
-	if containers == nil {
+// pruneBookkeeping drops inspected/seen entries for container IDs that are no
+// longer present in the latest successful ListContainers result, so the maps
+// stay bounded to currently-managed containers while retaining deduplication
+// for containers that still exist. pruneBookkeeping is called only after a
+// successful full list, so a transient list failure never clears state.
+// Callers must already hold the reconcile path; this locks ow.mu itself.
+func (ow *windowsWatcher) pruneBookkeeping(containers []*runtimeapi.Container) {
+	ow.mu.Lock()
+	defer ow.mu.Unlock()
+	if len(containers) == 0 {
+		// No containers currently exist; the runtime has reclaimed them all.
+		ow.inspected = make(map[string]struct{})
+		ow.seen = make(map[string]struct{})
 		return
+	}
+	live := make(map[string]struct{}, len(containers))
+	for _, c := range containers {
+		live[c.GetId()] = struct{}{}
+	}
+	for id := range ow.inspected {
+		if _, ok := live[id]; !ok {
+			delete(ow.inspected, id)
+		}
+	}
+	for id := range ow.seen {
+		if _, ok := live[id]; !ok {
+			delete(ow.seen, id)
+		}
+	}
+}
+
+// seedOOMKills records the ids of containers that are already OOMKilled when
+// the watcher starts so a kubelet restart does not replay historical kills. It
+// returns false when it could not establish a reliable baseline (no runtime, or
+// the initial list failed), so the caller can avoid reconciling against an
+// incomplete seen set that would replay historical kills as fresh events.
+func seedOOMKills(ctx context.Context, containers containerStatusGetter, seen map[string]struct{}, logger klog.Logger) bool {
+	if containers == nil {
+		return false
 	}
 	list, err := containers.ListContainers(ctx, nil)
 	if err != nil {
 		logger.V(2).Info("Windows OOM watcher failed to seed OOMKilled containers", "err", err)
-		return
+		return false
 	}
 	for _, c := range list {
 		if c.GetState() != runtimeapi.ContainerState_CONTAINER_EXITED {
@@ -230,4 +287,5 @@ func seedOOMKills(ctx context.Context, containers containerStatusGetter, seen ma
 			seen[c.GetId()] = struct{}{}
 		}
 	}
+	return true
 }

--- a/pkg/kubelet/oom/oom_watcher_windows_test.go
+++ b/pkg/kubelet/oom/oom_watcher_windows_test.go
@@ -1,0 +1,183 @@
+//go:build windows
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oom
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/record"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
+	"k8s.io/klog/v2"
+	kubelettypes "k8s.io/kubelet/pkg/types"
+	"k8s.io/kubernetes/test/utils/ktesting"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeRuntimeGetter is a test double for the subset of the CRI runtime service
+// the Windows OOM watcher needs.
+type fakeRuntimeGetter struct {
+	containers []*runtimeapi.Container
+	statuses   map[string]*runtimeapi.ContainerStatus
+}
+
+func (f *fakeRuntimeGetter) ListContainers(context.Context, *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+	return f.containers, nil
+}
+
+func (f *fakeRuntimeGetter) ContainerStatus(_ context.Context, id string, _ bool) (*runtimeapi.ContainerStatusResponse, error) {
+	status, ok := f.statuses[id]
+	if !ok {
+		return nil, fmt.Errorf("container %q not found", id)
+	}
+	return &runtimeapi.ContainerStatusResponse{Status: status}, nil
+}
+
+func oomKilledStatus(id, name string) *runtimeapi.ContainerStatus {
+	return &runtimeapi.ContainerStatus{
+		Id:     id,
+		Reason: oomKilledExitReason,
+		Labels: map[string]string{
+			kubelettypes.KubernetesPodNameLabel:       "test-pod",
+			kubelettypes.KubernetesPodNamespaceLabel:  "default",
+			kubelettypes.KubernetesPodUIDLabel:        "pod-uid",
+			kubelettypes.KubernetesContainerNameLabel: name,
+		},
+		Metadata: &runtimeapi.ContainerMetadata{Name: name},
+	}
+}
+
+func newTestWindowsWatcher(runtime containerStatusGetter) (*windowsWatcher, *record.FakeRecorder) {
+	fakeRecorder := record.NewFakeRecorder(10)
+	return &windowsWatcher{
+		recorder:   fakeRecorder,
+		containers: runtime,
+		seen:       make(map[string]struct{}),
+	}, fakeRecorder
+}
+
+// TestWindowsWatcherReportsOOMKilled verifies that a container which crossed
+// into the OOMKilled CRI state emits a Kubernetes event exactly once and
+// increments the container_oom_events_total counter it backs.
+func TestWindowsWatcherReportsOOMKilled(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	logger := klog.FromContext(tCtx)
+	containerName := fmt.Sprintf("app-%s", t.Name())
+	cid := "container-1"
+
+	runtime := &fakeRuntimeGetter{
+		containers: []*runtimeapi.Container{
+			{Id: cid, State: runtimeapi.ContainerState_CONTAINER_EXITED},
+		},
+		statuses: map[string]*runtimeapi.ContainerStatus{cid: oomKilledStatus(cid, containerName)},
+	}
+	w, fakeRecorder := newTestWindowsWatcher(runtime)
+
+	w.reconcile(tCtx, logger)
+
+	select {
+	case ev := <-fakeRecorder.Events:
+		assert.Contains(t, ev, windowsOOMEventReason)
+		assert.Contains(t, ev, containerName)
+	case <-time.After(time.Second):
+		t.Fatal("expected an OOMKilled Kubernetes event")
+	}
+	// The counter metric is backed by recordOOMKill, keyed by container name.
+	assert.Equal(t, uint64(1), OOMEventsForContainer(containerName))
+
+	// Reconciling again must not double-emit the event or inflate the counter.
+	w.reconcile(tCtx, logger)
+	select {
+	case <-fakeRecorder.Events:
+		t.Fatal("did not expect a second event for the same OOMKilled container")
+	case <-time.After(100 * time.Millisecond):
+	}
+	assert.Equal(t, uint64(1), OOMEventsForContainer(containerName))
+}
+
+// TestWindowsWatcherSkipsRunningContainers verifies that a running container is
+// never treated as OOMKilled, regardless of its status payload.
+func TestWindowsWatcherSkipsRunningContainers(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	logger := klog.FromContext(tCtx)
+	containerName := fmt.Sprintf("app-%s", t.Name())
+	cid := "container-running"
+
+	runtime := &fakeRuntimeGetter{
+		containers: []*runtimeapi.Container{
+			{Id: cid, State: runtimeapi.ContainerState_CONTAINER_RUNNING},
+		},
+		statuses: map[string]*runtimeapi.ContainerStatus{cid: oomKilledStatus(cid, containerName)},
+	}
+	w, fakeRecorder := newTestWindowsWatcher(runtime)
+
+	w.reconcile(tCtx, logger)
+
+	select {
+	case <-fakeRecorder.Events:
+		t.Fatal("did not expect an OOMKilled event for a running container")
+	case <-time.After(100 * time.Millisecond):
+	}
+	assert.Equal(t, uint64(0), OOMEventsForContainer(containerName))
+}
+
+// TestWindowsWatcherSeedsOOMKilled verifies that containers already OOMKilled
+// when the watcher starts are not replayed as fresh events on the first poll.
+func TestWindowsWatcherSeedsOOMKilled(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	logger := klog.FromContext(tCtx)
+	containerName := fmt.Sprintf("app-%s", t.Name())
+	cid := "container-seed"
+
+	runtime := &fakeRuntimeGetter{
+		containers: []*runtimeapi.Container{
+			{Id: cid, State: runtimeapi.ContainerState_CONTAINER_EXITED},
+		},
+		statuses: map[string]*runtimeapi.ContainerStatus{cid: oomKilledStatus(cid, containerName)},
+	}
+	w, fakeRecorder := newTestWindowsWatcher(runtime)
+
+	seedOOMKills(tCtx, w.containers, w.seen, logger)
+
+	// The container was already OOMKilled at start, so the first reconcile must
+	// not surface it again.
+	w.reconcile(tCtx, logger)
+
+	select {
+	case <-fakeRecorder.Events:
+		t.Fatal("did not expect a replayed event for a pre-existing OOMKilled container")
+	case <-time.After(100 * time.Millisecond):
+	}
+	assert.Equal(t, uint64(0), OOMEventsForContainer(containerName))
+}
+
+// TestWindowsWatcherNoRuntimeIsSafe verifies that a nil runtime service does
+// not panic or emit anything during a reconcile.
+func TestWindowsWatcherNoRuntimeIsSafe(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	logger := klog.FromContext(tCtx)
+
+	w, _ := newTestWindowsWatcher(nil)
+	w.reconcile(tCtx, logger)
+
+	assert.Equal(t, uint64(0), OOMEventsForContainer(t.Name()))
+}

--- a/pkg/kubelet/oom/oom_watcher_windows_test.go
+++ b/pkg/kubelet/oom/oom_watcher_windows_test.go
@@ -102,8 +102,9 @@ func TestWindowsWatcherReportsOOMKilled(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("expected an OOMKilled Kubernetes event")
 	}
-	// The counter metric is backed by recordOOMKill, keyed by container name.
-	assert.Equal(t, uint64(1), OOMEventsForContainer(containerName))
+	// The counter metric is backed by recordOOMKill, keyed by the CRI container ID
+	// so it matches info.Name on the Windows cAdvisor metrics path.
+	assert.Equal(t, uint64(1), OOMEventsForContainer(cid))
 
 	// Reconciling again must not double-emit the event or inflate the counter.
 	w.reconcile(tCtx, logger)
@@ -112,7 +113,7 @@ func TestWindowsWatcherReportsOOMKilled(t *testing.T) {
 		t.Fatal("did not expect a second event for the same OOMKilled container")
 	case <-time.After(100 * time.Millisecond):
 	}
-	assert.Equal(t, uint64(1), OOMEventsForContainer(containerName))
+	assert.Equal(t, uint64(1), OOMEventsForContainer(cid))
 }
 
 // TestWindowsWatcherSkipsRunningContainers verifies that a running container is

--- a/pkg/kubelet/oom/oom_watcher_windows_test.go
+++ b/pkg/kubelet/oom/oom_watcher_windows_test.go
@@ -232,3 +232,47 @@ func (c *countingRuntimeGetter) ContainerStatus(ctx context.Context, id string, 
 	}
 	return c.fakeRuntimeGetter.ContainerStatus(ctx, id, verbose)
 }
+
+// TestWindowsWatcherPollLoopEndToEnd exercises the real poll loop wiring that
+// Start uses (seed, immediate reconcile, then periodic ticks) rather than calling
+// reconcile directly. This is the closest to the production runtime entry point
+// that can run on a developer machine without a full CRI runtime.
+func TestWindowsWatcherPollLoopEndToEnd(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	logger := klog.FromContext(tCtx)
+	containerName := fmt.Sprintf("app-%s", t.Name())
+	cid := "container-e2e-poll"
+
+	// The container begins RUNNING so the seed + first reconcile see a
+	// non-reportable state; it crosses into EXITED/OOMKilled afterwards so a
+	// later poll tick - not the initial pass - is the one that surfaces it.
+	container := &runtimeapi.Container{Id: cid, State: runtimeapi.ContainerState_CONTAINER_RUNNING}
+	runtime := &fakeRuntimeGetter{
+		containers: []*runtimeapi.Container{container},
+		statuses:   map[string]*runtimeapi.ContainerStatus{cid: oomKilledStatus(cid, containerName)},
+	}
+	fakeRecorder := record.NewFakeRecorder(10)
+	w := &windowsWatcher{recorder: fakeRecorder, containers: runtime, pollInterval: 30 * time.Millisecond, seen: map[string]struct{}{}, inspected: map[string]struct{}{}}
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+	go w.pollLoop(ctx, logger)
+
+	// Give the seed + first reconcile time to observe the RUNNING state, then
+	// flip the container to EXITED so a subsequent tick performs the detection.
+	time.Sleep(50 * time.Millisecond)
+	container.State = runtimeapi.ContainerState_CONTAINER_EXITED
+
+	select {
+	case ev := <-fakeRecorder.Events:
+		assert.Contains(t, ev, windowsOOMEventReason)
+		assert.Contains(t, ev, containerName)
+	case <-time.After(2 * time.Second):
+		t.Fatal("pollLoop tick did not emit an OOMKilled event in time")
+	}
+	select {
+	case ev := <-fakeRecorder.Events:
+		t.Fatalf("did not expect a second event, got %q", ev)
+	case <-time.After(150 * time.Millisecond):
+	}
+	cancel()
+}

--- a/pkg/kubelet/oom/oom_watcher_windows_test.go
+++ b/pkg/kubelet/oom/oom_watcher_windows_test.go
@@ -72,6 +72,7 @@ func newTestWindowsWatcher(runtime containerStatusGetter) (*windowsWatcher, *rec
 		recorder:   fakeRecorder,
 		containers: runtime,
 		seen:       make(map[string]struct{}),
+		inspected:  make(map[string]struct{}),
 	}, fakeRecorder
 }
 
@@ -180,4 +181,54 @@ func TestWindowsWatcherNoRuntimeIsSafe(t *testing.T) {
 	w.reconcile(tCtx, logger)
 
 	assert.Equal(t, uint64(0), OOMEventsForContainer(t.Name()))
+}
+
+// TestWindowsWatcherInspectsExitedContainerOnce verifies that an exited
+// non-OOM container is queried exactly once: once its terminal status is known
+// the watcher must not re-query it on every subsequent poll, which would grow
+// unboundedly as exited containers accumulate on a busy node.
+func TestWindowsWatcherInspectsExitedContainerOnce(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	logger := klog.FromContext(tCtx)
+	cid := "container-exited-once"
+
+	queried := 0
+	runtime := &countingRuntimeGetter{
+		fakeRuntimeGetter: fakeRuntimeGetter{
+			containers: []*runtimeapi.Container{
+				{Id: cid, State: runtimeapi.ContainerState_CONTAINER_EXITED},
+			},
+			statuses: map[string]*runtimeapi.ContainerStatus{cid: normalExitedStatus(cid)},
+		},
+		countStatus: func() { queried++ },
+	}
+	w, _ := newTestWindowsWatcher(runtime)
+
+	w.reconcile(tCtx, logger)
+	w.reconcile(tCtx, logger)
+	w.reconcile(tCtx, logger)
+
+	// Only the first reconcile may have looked up the status; the later ones
+	// must reuse the inspection bookkeeping rather than hitting the CRI again.
+	assert.Equal(t, 1, queried, "expected the exited non-OOM container to be inspected exactly once")
+}
+
+func normalExitedStatus(id string) *runtimeapi.ContainerStatus {
+	return &runtimeapi.ContainerStatus{
+		Id:       id,
+		Reason:   "Completed",
+		Metadata: &runtimeapi.ContainerMetadata{Name: "c0"},
+	}
+}
+
+type countingRuntimeGetter struct {
+	fakeRuntimeGetter
+	countStatus func()
+}
+
+func (c *countingRuntimeGetter) ContainerStatus(ctx context.Context, id string, verbose bool) (*runtimeapi.ContainerStatusResponse, error) {
+	if c.countStatus != nil {
+		c.countStatus()
+	}
+	return c.fakeRuntimeGetter.ContainerStatus(ctx, id, verbose)
 }

--- a/pkg/kubelet/oom/oom_watcher_windows_test.go
+++ b/pkg/kubelet/oom/oom_watcher_windows_test.go
@@ -277,3 +277,91 @@ func TestWindowsWatcherPollLoopEndToEnd(t *testing.T) {
 	}
 	cancel()
 }
+
+// TestWindowsWatcherPrunesBookkeeping verifies that inspection and seen
+// bookkeeping are pruned once the runtime removes a container (CRI GC), so the
+// maps do not retain an entry for every exited container the watcher has ever
+// observed on a long-lived kubelet.
+func TestWindowsWatcherPrunesBookkeeping(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	logger := klog.FromContext(tCtx)
+	cid := "container-gc"
+	runtime := &fakeRuntimeGetter{
+		containers: []*runtimeapi.Container{
+			{Id: cid, State: runtimeapi.ContainerState_CONTAINER_EXITED},
+		},
+		statuses: map[string]*runtimeapi.ContainerStatus{cid: normalExitedStatus(cid)},
+	}
+	w, _ := newTestWindowsWatcher(runtime)
+
+	w.reconcile(tCtx, logger)
+	assert.Contains(t, w.inspected, cid, "exited container should be inspected")
+
+	// The runtime garbage-collects the container: it no longer appears in the
+	// list (it may also be gone from status). The next reconcile must prune it.
+	runtime.containers = nil
+	delete(runtime.statuses, cid)
+	w.reconcile(tCtx, logger)
+	assert.Empty(t, w.inspected, "inspected bookkeeping must be pruned after the container is collected")
+	assert.Empty(t, w.seen, "seen bookkeeping must be pruned after the container is collected")
+}
+
+// TestWindowsWatcherDeferredReconcileAfterSeedFailure verifies that when the
+// startup seed list fails (a transient CRI error), the immediate reconcile is
+// deferred so surviving historical OOMs are not replayed as fresh events
+// against an empty baseline.
+func TestWindowsWatcherDeferredReconcileAfterSeedFailure(t *testing.T) {
+	tCtx := ktesting.Init(t)
+	logger := klog.FromContext(tCtx)
+	containerName := fmt.Sprintf("app-%s", t.Name())
+	cid := "container-seed-fail"
+
+	failSeed := true
+	runtime := &failFirstListGetter{
+		fakeRuntimeGetter: fakeRuntimeGetter{
+			containers: []*runtimeapi.Container{
+				{Id: cid, State: runtimeapi.ContainerState_CONTAINER_EXITED},
+			},
+			statuses: map[string]*runtimeapi.ContainerStatus{cid: oomKilledStatus(cid, containerName)},
+		},
+		failList: func() bool { return failSeed },
+	}
+	fakeRecorder := record.NewFakeRecorder(10)
+	w := &windowsWatcher{recorder: fakeRecorder, containers: runtime, pollInterval: 20 * time.Millisecond, seen: map[string]struct{}{}, inspected: map[string]struct{}{}}
+	ctx, cancel := context.WithCancel(tCtx)
+	defer cancel()
+	go w.pollLoop(ctx, logger)
+
+	// The seed list fails, so no immediate reconcile runs against an empty
+	// baseline; allow brief time for any (wrong) immediate replay to surface.
+	time.Sleep(60 * time.Millisecond)
+	select {
+	case ev := <-fakeRecorder.Events:
+		t.Fatalf("did not expect a replayed historical OOM after a failed seed, got %q", ev)
+	default:
+	}
+
+	// Clear the simulated failure; a later seed+reconcile now sees the already
+	// OOMKilled container and must still not replay it as fresh.
+	failSeed = false
+	select {
+	case ev := <-fakeRecorder.Events:
+		t.Fatalf("did not expect an OOMKilled event for a pre-existing container after seed recovery, got %q", ev)
+	case <-time.After(200 * time.Millisecond):
+	}
+	cancel()
+}
+
+// failFirstListGetter fails ListContainers until the predicate returns false,
+// then behaves like its embedded fakeRuntimeGetter.
+type failFirstListGetter struct {
+	fakeRuntimeGetter
+	failList func() bool
+}
+
+func (f *failFirstListGetter) ListContainers(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
+	if f.failList != nil && f.failList() {
+		return nil, fmt.Errorf("injected CRI list failure")
+	}
+	return f.fakeRuntimeGetter.ListContainers(ctx, filter)
+}

--- a/pkg/kubelet/oom/types.go
+++ b/pkg/kubelet/oom/types.go
@@ -20,7 +20,17 @@ import (
 	"context"
 
 	v1 "k8s.io/api/core/v1"
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1"
 )
+
+// containerStatusGetter is the subset of the CRI runtime service the Windows
+// OOM watcher needs to observe container exit reasons. The kubelet's
+// internalapi.RuntimeService satisfies it. It lives here (outside of any
+// *_windows.go file) only so the unsupported platform stub can share it.
+type containerStatusGetter interface {
+	ListContainers(ctx context.Context, filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error)
+	ContainerStatus(ctx context.Context, containerID string, verbose bool) (*runtimeapi.ContainerStatusResponse, error)
+}
 
 // Watcher defines the interface of OOM watchers.
 type Watcher interface {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

On Windows the kubelet OOM watcher was a no-op because there is no kernel
cgroup OOM streamer (as on Linux). This PR adds a Windows implementation of
the OOM watcher that periodically reconciles CRI container statuses and
surfaces containers that crossed into the OOMKilled state.

When a container reports a terminal exit reason of `OOMKilled`, the watcher
emits a Kubernetes container OOMKilled event on the owning pod, increments the
`container_oom_events_total` counter (reusing the existing descriptor), and
keys the counter to the container's CRI ID. Each OOM-killed container is
surfaced exactly once; containers already OOMKilled when the kubelet restarts
are seeded so historical kills are not replayed.

The Windows watcher is wired into the kubelet via the existing OOM watcher
path, receiving the CRI runtime service available when the watcher is
constructed. Linux/unsupported implementations of `NewWatcher` accept (and
ignore) the new getter argument so the call site compiles across platforms.

To make the counts observable, the Windows cAdvisor client now surfaces
per-container info from the live CRI container set: the kubelet wires its
runtime service into the cadvisor client via an optional interface (a no-op on
Linux), and `GetRequestedContainersInfo` returns one minimal `ContainerInfo`
per container keyed by the CRI container ID. The watcher records each kill
under that same ID so `OOMEventsForContainer(info.Name)` matches and
`container_oom_events_total` is emitted on Windows nodes.

#### Which issue(s) this PR fixes:

Fixes #N/A

#### Special notes for your reviewer:

Based on the in-tree OOM watcher introduced in #140026. This revision also
tightens the poll behavior: each exited container status is inspected by the
CRI exactly once (exited containers never change their exit reason), so the
watcher does not re-query non-OOM exited containers every interval. The
Windows cadvisor wiring is an optional `ContainerEnumeratorSetter`; Linux
cadvisor does not implement it and the kubelet skips it, so Linux behavior is
unchanged.

Tests cover event emission, the metric counter, single-surfacing per container,
replay suppression, the nil-runtime safety path, the once-only inspection
guarantee, an end-to-end poll-loop test that drives the seed plus periodic
ticks, and a Windows cadvisor `GetRequestedContainersInfo` test using a fake
CRI enumerator. Cross compiled and vetted for linux, windows, and darwin; the
windows tests run on a Windows host.

#### Does this PR introduce a user-facing change?

```release-note
kubelet: on Windows, emit a Kubernetes event and increment the
container_oom_events_total counter when a container is terminated by the
out-of-memory killer.
```

#### AI disclosure

This PR was authored with the assistance of an AI coding agent. A human
maintainer is responsible for the correctness and content of all changes.
