### PR TITLE
kubelet: implement Windows process-count stats for pidlimit

### DIFF
--- a/pkg/kubelet/stats/pidlimit/pidlimit_unsupported.go
+++ b/pkg/kubelet/stats/pidlimit/pidlimit_unsupported.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !windows
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/pkg/kubelet/stats/pidlimit/pidlimit_windows.go
+++ b/pkg/kubelet/stats/pidlimit/pidlimit_windows.go
@@ -1,0 +1,78 @@
+//go:build windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pidlimit
+
+import (
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+)
+
+// Stats provides basic information about max and current process count.
+func Stats() (*statsapi.RlimitStats, error) {
+	rlimit := &statsapi.RlimitStats{}
+
+	// Windows has no kernel pid knob equivalent to Linux' kernel.pid_max, so
+	// report the observed system-wide process count as both the current count
+	// and the node limit. This makes the pid.available eviction signal
+	// computable on Windows without a config-provided ceiling (pod-max-pids is
+	// applied per cgroup on Linux only).
+	count, err := currentProcessCount()
+	if err != nil {
+		return nil, err
+	}
+	rlimit.NumOfRunningProcesses = &count
+	rlimit.MaxPID = &count
+
+	rlimit.Time = v1.NewTime(time.Now())
+
+	return rlimit, nil
+}
+
+// currentProcessCount enumerates all processes on the system via
+// NtQuerySystemInformation and returns how many are currently running.
+func currentProcessCount() (int64, error) {
+	// NtQuerySystemInformation reports STATUS_INFO_LENGTH_MISMATCH when the
+	// buffer is too small, so grow it until the enumeration fits.
+	bufSize := 1024 * 1024
+	for {
+		buf := make([]byte, bufSize)
+		var retLen uint32
+		err := windows.NtQuerySystemInformation(windows.SystemProcessInformation, unsafe.Pointer(&buf[0]), uint32(len(buf)), &retLen)
+		if err != nil && err != windows.STATUS_INFO_LENGTH_MISMATCH {
+			return 0, err
+		}
+		if err == nil {
+			count := int64(0)
+			proc := (*windows.SYSTEM_PROCESS_INFORMATION)(unsafe.Pointer(&buf[0]))
+			for {
+				count++
+				if proc.NextEntryOffset == 0 {
+					return count, nil
+				}
+				proc = (*windows.SYSTEM_PROCESS_INFORMATION)(unsafe.Pointer(uintptr(unsafe.Pointer(proc)) + uintptr(proc.NextEntryOffset)))
+			}
+		}
+		bufSize *= 2
+	}
+}

--- a/pkg/kubelet/stats/pidlimit/pidlimit_windows.go
+++ b/pkg/kubelet/stats/pidlimit/pidlimit_windows.go
@@ -28,21 +28,24 @@ import (
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 )
 
-// Stats provides basic information about max and current process count.
+// Stats reports the current system-wide process count on Windows.
+//
+// Unlike Linux, Windows has no kernel pid knob equivalent to kernel.pid_max,
+// so there is no real ceiling to report. MaxPID is deliberately left unset:
+// fabricating one (for example mirroring the current process count) would make
+// the pid.available eviction signal (MaxPID - NumOfRunningProcesses) always
+// evaluate to 0 and permanently drive the node into NodePIDPressure, evicting
+// pods. Leaving MaxPID nil keeps pid.available eviction unsupported on
+// Windows, matching the behavior for other non-Linux platforms, while still
+// surfacing the live process count for observability.
 func Stats() (*statsapi.RlimitStats, error) {
 	rlimit := &statsapi.RlimitStats{}
 
-	// Windows has no kernel pid knob equivalent to Linux' kernel.pid_max, so
-	// report the observed system-wide process count as both the current count
-	// and the node limit. This makes the pid.available eviction signal
-	// computable on Windows without a config-provided ceiling (pod-max-pids is
-	// applied per cgroup on Linux only).
 	count, err := currentProcessCount()
 	if err != nil {
 		return nil, err
 	}
 	rlimit.NumOfRunningProcesses = &count
-	rlimit.MaxPID = &count
 
 	rlimit.Time = v1.NewTime(time.Now())
 

--- a/pkg/kubelet/stats/pidlimit/pidlimit_windows_test.go
+++ b/pkg/kubelet/stats/pidlimit/pidlimit_windows_test.go
@@ -36,10 +36,13 @@ func TestStats(t *testing.T) {
 	stats, err := Stats()
 	require.NoError(t, err)
 	require.NotNil(t, stats)
-	require.NotNil(t, stats.MaxPID)
 	require.NotNil(t, stats.NumOfRunningProcesses)
-	// Windows has no kernel pid cap, so MaxPID mirrors the observed process
-	// count, which keeps the pid.available eviction signal computable.
-	assert.Equal(t, *stats.MaxPID, *stats.NumOfRunningProcesses)
-	assert.Greater(t, *stats.MaxPID, int64(0))
+	assert.Greater(t, *stats.NumOfRunningProcesses, int64(0))
+
+	// Windows has no kernel pid_max knob, so there is no ceiling to report.
+	// MaxPID must stay nil: fabricating it (e.g. mirroring the process count)
+	// would make pid.available (MaxPID - NumOfRunningProcesses) always resolve
+	// to 0 and permanently pressure the node, so pid eviction stays unsupported
+	// on Windows.
+	assert.Nil(t, stats.MaxPID)
 }

--- a/pkg/kubelet/stats/pidlimit/pidlimit_windows_test.go
+++ b/pkg/kubelet/stats/pidlimit/pidlimit_windows_test.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pidlimit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCurrentProcessCount(t *testing.T) {
+	count, err := currentProcessCount()
+	require.NoError(t, err)
+	// At minimum the test process itself must be enumerated.
+	assert.Greater(t, count, int64(0))
+}
+
+func TestStats(t *testing.T) {
+	stats, err := Stats()
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	require.NotNil(t, stats.MaxPID)
+	require.NotNil(t, stats.NumOfRunningProcesses)
+	// Windows has no kernel pid cap, so MaxPID mirrors the observed process
+	// count, which keeps the pid.available eviction signal computable.
+	assert.Equal(t, *stats.MaxPID, *stats.NumOfRunningProcesses)
+	assert.Greater(t, *stats.MaxPID, int64(0))
+}


### PR DESCRIPTION
What this PR does / why we need it:
On Windows, `pidlimit.Stats()` (from `pkg/kubelet/stats/pidlimit`) returned `nil, nil`
via the `!linux` fallback, so the kubelet never reported node PID
statistics on Windows.

This PR adds a Windows-specific implementation
(`pkg/kubelet/stats/pidlimit/pidlimit_windows.go`) that enumerates the
system process table via the Win32 `NtQuerySystemInformation` API and
reports the current process count in `NumOfRunningProcesses`, which is
now surfaced in the node summary for observability. The `!linux`
fallback is narrowed to `!linux && !windows` so the two `Stats()`
implementations do not collide on Windows.

Why `MaxPID` is left unset: Windows has no kernel PID cap equivalent to
Linux' `kernel.pid_max`, so there is no real ceiling to report.
Fabricating one (for example mirroring the observed process count) would
make the `pid.available` eviction signal always evaluate to 0 and
permanently drive a healthy node into `NodePIDPressure` and evict pods.
Leaving `MaxPID` unset keeps `pid.available` eviction unsupported on
Windows, matching the behavior for other non-Linux platforms, while the
live process count is still reported for observability.

Which issue(s) this PR fixes:
Not tracked as an issue.

Special notes for your reviewer:
- `MaxPID` is intentionally left unset. This follows review feedback (see
  the resolved review thread) that setting it to the observed process count
  broke `pid.available` computation.
- `NumOfRunningProcesses` on Windows is a process count (Linux reports a
  thread count); it is informational only on Windows.

#### Does this PR introduce a user-facing change?
```release-note
- kubelet: surface the node process count on Windows for observability (informational only).
```

#### AI-generated content
This change and description were prepared with AI assistance and reviewed by an engineer before submission. No @mentions or 'fixes #' in commit.
