### PR TITLE
dra: reject negative counter quantities in validation and allocator

### DIFF
--- a/pkg/apis/resource/validation/validation.go
+++ b/pkg/apis/resource/validation/validation.go
@@ -1605,8 +1605,11 @@ func isFractionalQuantity(q apiresource.Quantity) bool {
 }
 
 func validateDeviceCounter(counter resource.Counter, fldPath *field.Path) field.ErrorList {
-	// Any parsed quantity is valid.
-	return nil
+	var allErrs field.ErrorList
+	if counter.Value.Sign() < 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("value"), counter.Value.String(), "must be greater than or equal to 0"))
+	}
+	return allErrs
 }
 
 func validateQualifiedName(name resource.QualifiedName, fldPath *field.Path) field.ErrorList {

--- a/pkg/apis/resource/validation/validation_resourceslice_test.go
+++ b/pkg/apis/resource/validation/validation_resourceslice_test.go
@@ -1465,6 +1465,18 @@ func TestValidateResourceSlice(t *testing.T) {
 				return slice
 			}(),
 		},
+		"negative-counter-in-counter-set": {
+			wantFailures: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "sharedCounters").Index(0).Child("counters").Key("memory").Child("value"), "-1Gi", "must be greater than or equal to 0"),
+			},
+			slice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSliceWithSharedCounters(goodName, goodName, driverName, 1)
+				slice.Spec.SharedCounters[0].Counters = map[string]resourceapi.Counter{
+					"memory": {Value: resource.MustParse("-1Gi")},
+				}
+				return slice
+			}(),
+		},
 		"missing-name-counterset-consumes-counter": {
 			wantFailures: field.ErrorList{
 				field.Required(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counterSet"), "").MarkCoveredByDeclarative(),
@@ -1521,6 +1533,23 @@ func TestValidateResourceSlice(t *testing.T) {
 				slice.Spec.Devices[0].ConsumesCounters = []resourceapi.DeviceCounterConsumption{
 					{
 						CounterSet: "counterset-0",
+					},
+				}
+				return slice
+			}(),
+		},
+		"negative-counter-consumes-counter": {
+			wantFailures: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "devices").Index(0).Child("consumesCounters").Index(0).Child("counters").Key("memory").Child("value"), "-1Gi", "must be greater than or equal to 0"),
+			},
+			slice: func() *resourceapi.ResourceSlice {
+				slice := testResourceSlice(goodName, goodName, driverName, 1)
+				slice.Spec.Devices[0].ConsumesCounters = []resourceapi.DeviceCounterConsumption{
+					{
+						CounterSet: "counterset-0",
+						Counters: map[string]resourceapi.Counter{
+							"memory": {Value: resource.MustParse("-1Gi")},
+						},
 					},
 				}
 				return slice

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/experimental/pools_experimental.go
@@ -352,6 +352,11 @@ func getAndValidateCounterSets(slices []*draapi.ResourceSlice) (map[draapi.Uniqu
 			if _, found := counterSets[counterSet.Name]; found {
 				return nil, fmt.Errorf("duplicate counter set name %s", counterSet.Name)
 			}
+			for counterName, counter := range counterSet.Counters {
+				if counter.Value.Sign() < 0 {
+					return nil, fmt.Errorf("counter %s in counter set %s has negative value %v", counterName, counterSet.Name, counter.Value)
+				}
+			}
 			counterSets[counterSet.Name] = &counterSet
 		}
 	}
@@ -383,9 +388,12 @@ func validateDeviceCounterConsumption(counterSets map[draapi.UniqueString]*draap
 					return fmt.Errorf("counter set %s not found", deviceCounterConsumption.CounterSet)
 				}
 
-				for counterName := range deviceCounterConsumption.Counters {
+				for counterName, counter := range deviceCounterConsumption.Counters {
 					if _, found := counterSet.Counters[counterName]; !found {
 						return fmt.Errorf("counter %s not found in counter set %s", counterName, counterSet.Name)
+					}
+					if counter.Value.Sign() < 0 {
+						return fmt.Errorf("consumed counter %s in counter set %s has negative value %v", counterName, deviceCounterConsumption.CounterSet, counter.Value)
 					}
 				}
 			}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/incubating/pools_incubating.go
@@ -352,6 +352,11 @@ func getAndValidateCounterSets(slices []*draapi.ResourceSlice) (map[draapi.Uniqu
 			if _, found := counterSets[counterSet.Name]; found {
 				return nil, fmt.Errorf("duplicate counter set name %s", counterSet.Name)
 			}
+			for counterName, counter := range counterSet.Counters {
+				if counter.Value.Sign() < 0 {
+					return nil, fmt.Errorf("counter %s in counter set %s has negative value %v", counterName, counterSet.Name, counter.Value)
+				}
+			}
 			counterSets[counterSet.Name] = &counterSet
 		}
 	}
@@ -383,9 +388,12 @@ func validateDeviceCounterConsumption(counterSets map[draapi.UniqueString]*draap
 					return fmt.Errorf("counter set %s not found", deviceCounterConsumption.CounterSet)
 				}
 
-				for counterName := range deviceCounterConsumption.Counters {
+				for counterName, counter := range deviceCounterConsumption.Counters {
 					if _, found := counterSet.Counters[counterName]; !found {
 						return fmt.Errorf("counter %s not found in counter set %s", counterName, counterSet.Name)
+					}
+					if counter.Value.Sign() < 0 {
+						return fmt.Errorf("consumed counter %s in counter set %s has negative value %v", counterName, deviceCounterConsumption.CounterSet, counter.Value)
 					}
 				}
 			}

--- a/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/pools_stable.go
+++ b/staging/src/k8s.io/dynamic-resource-allocation/structured/internal/stable/pools_stable.go
@@ -319,6 +319,11 @@ func getAndValidateCounterSets(slices []*draapi.ResourceSlice) (map[draapi.Uniqu
 			if _, found := counterSets[counterSet.Name]; found {
 				return nil, fmt.Errorf("duplicate counter set name %s", counterSet.Name)
 			}
+			for counterName, counter := range counterSet.Counters {
+				if counter.Value.Sign() < 0 {
+					return nil, fmt.Errorf("counter %s in counter set %s has negative value %v", counterName, counterSet.Name, counter.Value)
+				}
+			}
 			counterSets[counterSet.Name] = &counterSet
 		}
 	}
@@ -350,9 +355,12 @@ func validateDeviceCounterConsumption(counterSets map[draapi.UniqueString]*draap
 					return fmt.Errorf("counter set %s not found", deviceCounterConsumption.CounterSet)
 				}
 
-				for counterName := range deviceCounterConsumption.Counters {
+				for counterName, counter := range deviceCounterConsumption.Counters {
 					if _, found := counterSet.Counters[counterName]; !found {
 						return fmt.Errorf("counter %s not found in counter set %s", counterName, counterSet.Name)
+					}
+					if counter.Value.Sign() < 0 {
+						return fmt.Errorf("consumed counter %s in counter set %s has negative value %v", counterName, deviceCounterConsumption.CounterSet, counter.Value)
 					}
 				}
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig node
/wg device-management

#### What this PR does / why we need it:

In Dynamic Resource Allocation (DRA), `validateDeviceCounter` previously accepted negative quantities in `spec.sharedCounters` and `spec.devices[*].consumesCounters`. When the structured allocator calculates available capacity on a shared counter set, subtracting negative consumption amounts effectively increases the available capacity, allowing devices to overcommit physical resources.

This PR:
1. Rejects negative counter quantities in `validateDeviceCounter` (`pkg/apis/resource/validation/validation.go`).
2. Adds defensive validation in `getAndValidateCounterSets` and `validateDeviceCounterConsumption` within the structured allocator (`internal/stable`, `internal/incubating`, `internal/experimental`) to fail closed on malformed/stored ResourceSlices containing negative counters.
3. Adds unit test scenarios in `pkg/apis/resource/validation/validation_resourceslice_test.go`.

#### Which issue(s) this PR fixes:

Fixes #141216

#### Special notes for your reviewer:

AI assistance disclosure: Claude / Antigravity was used to assist in identifying and formulating the sign validation check, allocator defensive guards, and table-driven unit tests.

#### Does this PR introduce a user-facing change?

```release-note
Rejected negative counter quantities in ResourceSlice device counter validation and structured allocator pool validation.
```
