### PR TITLE
Add CPG performance tests in scheduler_perf

### DIFF
--- a/test/integration/scheduler_perf/cpg/cpg_test.go
+++ b/test/integration/scheduler_perf/cpg/cpg_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cpg
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	_ "k8s.io/component-base/logs/json/register"
+	perf "k8s.io/kubernetes/test/integration/scheduler_perf"
+)
+
+func TestMain(m *testing.M) {
+	if err := perf.InitTests(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	m.Run()
+}
+
+// TestSchedulerPerf runs integration tests for multi-level workload scheduling with CompositePodGroup,
+// covering basic scheduling policies, gang scheduling policies, preemption, and topology-aware scheduling (TAS).
+func TestSchedulerPerf(t *testing.T) {
+	perf.RunIntegrationPerfScheduling(t, "performance-config.yaml", perf.WithPodsSchedulingTimeout(50*time.Minute))
+}
+
+// BenchmarkPerfScheduling runs performance benchmarks measuring scheduling throughput for CompositePodGroup
+// workloads across multi-level basic, gang, preemption, and TAS policies.
+func BenchmarkPerfScheduling(b *testing.B) {
+	perf.RunBenchmarkPerfScheduling(b, "performance-config.yaml", "cpg", nil, perf.WithPodsSchedulingTimeout(50*time.Minute))
+}

--- a/test/integration/scheduler_perf/cpg/performance-config.yaml
+++ b/test/integration/scheduler_perf/cpg/performance-config.yaml
@@ -1,0 +1,894 @@
+# The following labels are used in this file:
+#
+# - integration-test: test cases to run as the integration test.
+# - performance: test cases to run in the performance test.
+# - short: supplemental label for the above two labels (must not used alone), which literally means short execution time test cases.
+
+# 2LevelCompositePodGroupBasicScheduling benchmarks scheduling throughput when both CompositePodGroup
+# and its child PodGroups use basic policy (spec.schedulingPolicy.basic), allowing
+# pods and groups to be scheduled independently without quorum.
+- name: 2LevelCompositePodGroupBasicScheduling
+  featureGates:
+    GenericWorkload: true
+    TopologyAwareWorkloadScheduling: true
+    CompositePodGroup: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createNamespaces
+    prefix: cpg-basic-ns
+    count: 1
+  - opcode: createCompositePodGroups
+    # Create composite pod groups with basic scheduling policy.
+    countParam: $initRootCPG
+    namespace: cpg-basic-ns-0
+    templatePath: templates/cpg-basic.yaml
+  - opcode: createPodGroups
+    # Create child pod groups with basic scheduling policy referencing parent CPG.
+    countParam: $initPodGroups
+    namespace: cpg-basic-ns-0
+    templatePath: templates/podgroup-basic.yaml
+    templateParams:
+      podGroupsPerCompositePodGroup: $podGroupsPerCompositePodGroup
+  - opcode: createPods
+    # Create pods belonging to child pod groups according to their indices.
+    countParam: $initPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: cpg-basic-ns-0
+    podTemplatePath: templates/basic-pod.yaml
+    collectMetrics: true
+    templateParams:
+      podsPerGroup: $podsPerGroup
+  workloads:
+  - name: 10Nodes_2Trees_2Level_4PodGroups_12Pods
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      initRootCPG: 2
+      initPodGroups: 4
+      podGroupsPerCompositePodGroup: 2
+      podsPerGroup: 3
+  - name: 100Nodes_4Trees_2Level_8PodGroups_24Pods
+    labels: [integration-test]
+    params:
+      initNodes: 100
+      initRootCPG: 4
+      initPodGroups: 8
+      podGroupsPerCompositePodGroup: 2
+      podsPerGroup: 3
+  - name: 5000Nodes_4Trees_2Level_16PodGroups_8000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 4
+      initPodGroups: 16
+      podGroupsPerCompositePodGroup: 4
+      podsPerGroup: 500
+  - name: 5000Nodes_4Trees_2Level_16PodGroups_12000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 4
+      initPodGroups: 16
+      podGroupsPerCompositePodGroup: 4
+      podsPerGroup: 750
+  - name: 5000Nodes_4Trees_2Level_16PodGroups_16000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 4
+      initPodGroups: 16
+      podGroupsPerCompositePodGroup: 4
+      podsPerGroup: 1000
+  - name: 5000Nodes_2Trees_2Level_64PodGroups_6400Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 64
+      podGroupsPerCompositePodGroup: 32
+      podsPerGroup: 100
+  - name: 5000Nodes_2Trees_2Level_128PodGroups_12800Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 128
+      podGroupsPerCompositePodGroup: 64
+      podsPerGroup: 100
+  - name: 5000Nodes_2Trees_2Level_256PodGroups_25600Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 256
+      podGroupsPerCompositePodGroup: 128
+      podsPerGroup: 100
+
+# 2LevelCompositePodGroupGangScheduling benchmarks all-or-nothing scheduling throughput of CompositePodGroups
+# where both the CPG (minGroupCount) and child PodGroups (minCount) enforce gang quorum.
+- name: 2LevelCompositePodGroupGangScheduling
+  featureGates:
+    GenericWorkload: true
+    TopologyAwareWorkloadScheduling: true
+    CompositePodGroup: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createNamespaces
+    prefix: cpg-gang-ns
+    count: 1
+  - opcode: createCompositePodGroups
+    # Create composite pod groups with gang scheduling policy and minGroupCount.
+    countParam: $initRootCPG
+    namespace: cpg-gang-ns-0
+    templatePath: templates/cpg-gang.yaml
+    templateParams:
+      minGroupCount: $podGroupsPerCompositePodGroup
+      priority: 1000
+  - opcode: createPodGroups
+    # Create child pod groups with gang scheduling policy, referencing parent CPG.
+    countParam: $initPodGroups
+    namespace: cpg-gang-ns-0
+    templatePath: templates/podgroup-gang.yaml
+    templateParams:
+      parentPrefix: cpg
+      podGroupsPerCompositePodGroup: $podGroupsPerCompositePodGroup
+      minCount: $minCount
+      priority: 1000
+  - opcode: createPods
+    # Create pods with reference to the child pod groups according to their indices.
+    countParam: $initPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: cpg-gang-ns-0
+    podTemplatePath: templates/gang-pod.yaml
+    collectMetrics: true
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      priority: 1000
+      cpuRequest: 100m
+  workloads:
+  - name: 10Nodes_2Trees_2Level_4PodGroups_12Pods
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      initRootCPG: 2
+      initPodGroups: 4
+      podGroupsPerCompositePodGroup: 2
+      minCount: 3
+      podsPerGroup: 3
+  - name: 100Nodes_4Trees_2Level_8PodGroups_24Pods
+    labels: [integration-test]
+    params:
+      initNodes: 100
+      initRootCPG: 4
+      initPodGroups: 8
+      podGroupsPerCompositePodGroup: 2
+      minCount: 3
+      podsPerGroup: 3
+  - name: 5000Nodes_4Trees_2Level_16PodGroups_8000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 4
+      initPodGroups: 16
+      podGroupsPerCompositePodGroup: 4
+      minCount: 500
+      podsPerGroup: 500
+  - name: 5000Nodes_4Trees_2Level_16PodGroups_12000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 4
+      initPodGroups: 16
+      podGroupsPerCompositePodGroup: 4
+      minCount: 750
+      podsPerGroup: 750
+  - name: 5000Nodes_4Trees_2Level_16PodGroups_16000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 4
+      initPodGroups: 16
+      podGroupsPerCompositePodGroup: 4
+      minCount: 1000
+      podsPerGroup: 1000
+  - name: 5000Nodes_2Trees_2Level_64PodGroups_6400Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 64
+      podGroupsPerCompositePodGroup: 32
+      minCount: 100
+      podsPerGroup: 100
+  - name: 5000Nodes_2Trees_2Level_128PodGroups_12800Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 128
+      podGroupsPerCompositePodGroup: 64
+      minCount: 100
+      podsPerGroup: 100
+  - name: 5000Nodes_2Trees_2Level_256PodGroups_25600Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 256
+      podGroupsPerCompositePodGroup: 128
+      minCount: 100
+      podsPerGroup: 100
+
+# 2LevelCompositePodGroupPreemptionBasic benchmarks preemption where a high-priority CPG and its child PodGroups
+# preempt standalone, un-grouped low-priority pods.
+#
+# Standard node capacity is 4000m CPU. Low-priority pods request 40m CPU each.
+# Preemptor gang pods request 3970m CPU each, forcing eviction of all low-priority pods on the node.
+- name: 2LevelCompositePodGroupPreemptionBasic
+  featureGates:
+    GenericWorkload: true
+    TopologyAwareWorkloadScheduling: true
+    CompositePodGroup: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createNamespaces
+    prefix: cpg-preempt
+    count: 2
+  - opcode: createPods
+    countParam: $initPods
+    podTemplatePath: templates/pod-low-priority.yaml
+    namespace: cpg-preempt-1
+    templateParams:
+      nodesCount: $initNodes
+      podsCount: $initPods
+  - opcode: createCompositePodGroups
+    countParam: $initRootCPG
+    namespace: cpg-preempt-0
+    templatePath: templates/cpg-gang.yaml
+    templateParams:
+      priority: 1000
+      minGroupCount: $podGroupsPerCompositePodGroup
+  - opcode: createPodGroups
+    countParam: $initPodGroups
+    namespace: cpg-preempt-0
+    templatePath: templates/podgroup-gang.yaml
+    templateParams:
+      parentPrefix: cpg
+      podGroupsPerCompositePodGroup: $podGroupsPerCompositePodGroup
+      priority: 1000
+      minCount: $minCount
+  - opcode: createPods
+    collectMetrics: true
+    countParam: $initPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: cpg-preempt-0
+    podTemplatePath: templates/gang-pod.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      cpuRequest: $gangCpuRequest
+      priority: 1000
+  workloads:
+  - name: 2Nodes_1PreemptorCPG_2Groups_2Pods_Evicting_10InitPods
+    labels: [short, integration-test]
+    params:
+      initNodes: 2
+      initPods: 10
+      initRootCPG: 1
+      initPodGroups: 2
+      podGroupsPerCompositePodGroup: 2
+      minCount: 1
+      podsPerGroup: 1
+      gangCpuRequest: 3970m
+  - name: 100Nodes_1PreemptorCPG_10Groups_100Pods_Evicting_1000InitPods
+    labels: [performance]
+    params:
+      initNodes: 100
+      initPods: 1000
+      initRootCPG: 1
+      initPodGroups: 10
+      podGroupsPerCompositePodGroup: 10
+      minCount: 10
+      podsPerGroup: 10
+      gangCpuRequest: 3970m
+  - name: 100Nodes_10PreemptorCPGs_20Groups_100Pods_Evicting_1000InitPods
+    labels: [performance]
+    params:
+      initNodes: 100
+      initPods: 1000
+      initRootCPG: 10
+      initPodGroups: 20
+      podGroupsPerCompositePodGroup: 2
+      minCount: 5
+      podsPerGroup: 5
+      gangCpuRequest: 3970m
+
+# 2LevelCompositePodGroupSchedulingWithPreemption benchmarks hierarchical preemption where a high-priority CPG (priority 9999999)
+# preempts lower-priority CPGs (priority 1000) and their child PodGroups.
+#
+# Standard node capacity is 4000m CPU. Low-priority gang pods request 600m CPU (priority 1000).
+# High-priority gang pods request 3500m CPU (priority 9999999), forcing eviction of low-priority
+# CPG member pods across the nodes.
+- name: 2LevelCompositePodGroupSchedulingWithPreemption
+  featureGates:
+    GenericWorkload: true
+    TopologyAwareWorkloadScheduling: true
+    CompositePodGroup: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createNamespaces
+    prefix: cpg-preempt
+    count: 2
+  - opcode: createCompositePodGroups
+    countParam: $lowPriorityCPGs
+    namespace: cpg-preempt-1
+    templatePath: templates/cpg-gang.yaml
+    templateParams:
+      priority: 1000
+      minGroupCount: $podGroupsPerCompositePodGroup
+  - opcode: createPodGroups
+    countParam: $lowPriorityGroups
+    namespace: cpg-preempt-1
+    templatePath: templates/podgroup-gang.yaml
+    templateParams:
+      parentPrefix: cpg
+      podGroupsPerCompositePodGroup: $podGroupsPerCompositePodGroup
+      priority: 1000
+      minCount: $minCount
+  - opcode: createPods
+    countParam: $lowPriorityGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: cpg-preempt-1
+    podTemplatePath: templates/gang-pod.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      cpuRequest: $lowPriorityCpuRequest
+      hostPortBase: 8000
+      priority: 1000
+  - opcode: createCompositePodGroups
+    countParam: $highPriorityCPGs
+    namespace: cpg-preempt-0
+    templatePath: templates/cpg-gang.yaml
+    templateParams:
+      priority: 9999999
+      minGroupCount: $podGroupsPerCompositePodGroup
+  - opcode: createPodGroups
+    countParam: $highPriorityGroups
+    namespace: cpg-preempt-0
+    templatePath: templates/podgroup-gang.yaml
+    templateParams:
+      parentPrefix: cpg
+      podGroupsPerCompositePodGroup: $podGroupsPerCompositePodGroup
+      priority: 9999999
+      minCount: $minCount
+  - opcode: createPods
+    collectMetrics: true
+    countParam: $highPriorityGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: cpg-preempt-0
+    podTemplatePath: templates/gang-pod.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      cpuRequest: $highPriorityCpuRequest
+      hostPortBase: 9000
+      priority: 9999999
+  workloads:
+  - name: 2Nodes_1PreemptorCPG_2Groups_2Pods_Evicting_2LowPriorityCPGs
+    labels: [short, integration-test]
+    params:
+      initNodes: 2
+      lowPriorityCPGs: 2
+      lowPriorityGroups: 4
+      highPriorityCPGs: 1
+      highPriorityGroups: 2
+      podGroupsPerCompositePodGroup: 2
+      minCount: 1
+      podsPerGroup: 1
+      lowPriorityCpuRequest: 600m
+      highPriorityCpuRequest: 3500m
+  - name: 100Nodes_1PreemptorCPG_10Groups_100Pods_Evicting_5LowPriorityCPGs
+    labels: [performance]
+    params:
+      initNodes: 100
+      lowPriorityCPGs: 5
+      lowPriorityGroups: 50
+      highPriorityCPGs: 1
+      highPriorityGroups: 10
+      podGroupsPerCompositePodGroup: 10
+      minCount: 10
+      podsPerGroup: 10
+      lowPriorityCpuRequest: 600m
+      highPriorityCpuRequest: 3500m
+  - name: 100Nodes_10PreemptorCPGs_20Groups_100Pods_Evicting_50LowPriorityCPGs
+    labels: [performance]
+    params:
+      initNodes: 100
+      lowPriorityCPGs: 50
+      lowPriorityGroups: 100
+      highPriorityCPGs: 10
+      highPriorityGroups: 20
+      podGroupsPerCompositePodGroup: 2
+      minCount: 5
+      podsPerGroup: 5
+      lowPriorityCpuRequest: 600m
+      highPriorityCpuRequest: 3500m
+
+# 2LevelCompositePodGroupPreemptionAndAffinityConstraints benchmarks high-priority CPG preemption under pod affinity constraints.
+#
+# Standard node capacity is 4000m CPU. High-priority anchor pods (priority 9999999) are spread 1 per node via hostPort.
+# Low-priority victim pods (priority 0) fill remaining node capacity. Preemptor gang pods (priority 8888888)
+# have required podAffinity to anchor pods and request 3970m CPU, forcing preemption of co-located low-priority pods on target nodes.
+- name: 2LevelCompositePodGroupPreemptionAndAffinityConstraints
+  featureGates:
+    GenericWorkload: true
+    TopologyAwareWorkloadScheduling: true
+    CompositePodGroup: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createNamespaces
+    prefix: cpg-preempt
+    count: 3
+  # create high priority anchor pods
+  - opcode: createPods
+    countParam: $initNodes
+    podTemplatePath: templates/pod-anchor-high-priority.yaml
+    namespace: cpg-preempt-2
+    templateParams:
+      nodesCount: $initNodes
+      podsCount: $initNodes
+  # create low priority pods that will be preempted
+  - opcode: createPods
+    countParam: $initPods
+    podTemplatePath: templates/pod-low-priority.yaml
+    namespace: cpg-preempt-1
+    templateParams:
+      nodesCount: $initNodes
+      podsCount: $initPods
+  - opcode: createCompositePodGroups
+    countParam: $initRootCPG
+    namespace: cpg-preempt-0
+    templatePath: templates/cpg-gang.yaml
+    templateParams:
+      priority: 8888888
+      minGroupCount: $podGroupsPerCompositePodGroup
+  - opcode: createPodGroups
+    countParam: $initPodGroups
+    namespace: cpg-preempt-0
+    templatePath: templates/podgroup-gang.yaml
+    templateParams:
+      parentPrefix: cpg
+      podGroupsPerCompositePodGroup: $podGroupsPerCompositePodGroup
+      priority: 8888888
+      minCount: $minCount
+  - opcode: createPods
+    collectMetrics: true
+    countParam: $initPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: cpg-preempt-0
+    podTemplatePath: templates/pod-gang-affinity.yaml
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      priority: 8888888
+  workloads:
+  - name: 2Nodes_1PreemptorCPG_2Groups_2Pods_Evicting_10InitPods
+    labels: [short, integration-test]
+    params:
+      initNodes: 2
+      initPods: 10
+      initRootCPG: 1
+      initPodGroups: 2
+      podGroupsPerCompositePodGroup: 2
+      minCount: 1
+      podsPerGroup: 1
+  - name: 100Nodes_1PreemptorCPG_10Groups_100Pods_Evicting_1000InitPods
+    labels: [performance]
+    params:
+      initNodes: 100
+      initPods: 1000
+      initRootCPG: 1
+      initPodGroups: 10
+      podGroupsPerCompositePodGroup: 10
+      minCount: 10
+      podsPerGroup: 10
+  - name: 100Nodes_10PreemptorCPGs_20Groups_100Pods_Evicting_1000InitPods
+    labels: [performance]
+    params:
+      initNodes: 100
+      initPods: 1000
+      initRootCPG: 10
+      initPodGroups: 20
+      podGroupsPerCompositePodGroup: 2
+      minCount: 5
+      podsPerGroup: 5
+
+# 2LevelCompositePodGroupWithTopologyAwareScheduling benchmarks hierarchical topology-aware scheduling (TAS).
+#
+# Enforces a two-tier topology constraint: the root CPG requires all member groups to fit within
+# the same zone (topology.kubernetes.io/zone), while child PodGroups require member pods to fit
+# within the same rack (topology.kubernetes.io/rack).
+- name: 2LevelCompositePodGroupWithTopologyAwareScheduling
+  featureGates:
+    GenericWorkload: true
+    TopologyAwareWorkloadScheduling: true
+    CompositePodGroup: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+    nodeTemplatePath: templates/tas-node.yaml
+  - opcode: createNamespaces
+    prefix: cpg-tas-ns
+    count: 1
+  - opcode: createCompositePodGroups
+    # Create composite pod groups with zone topology constraint and gang scheduling policy.
+    countParam: $initRootCPG
+    namespace: cpg-tas-ns-0
+    templatePath: templates/cpg-tas.yaml
+    templateParams:
+      minGroupCount: $podGroupsPerCompositePodGroup
+  - opcode: createPodGroups
+    # Create child pod groups with rack topology constraint and gang scheduling policy, referencing parent CPG.
+    countParam: $initPodGroups
+    namespace: cpg-tas-ns-0
+    templatePath: templates/podgroup-tas.yaml
+    templateParams:
+      podGroupsPerCompositePodGroup: $podGroupsPerCompositePodGroup
+      minCount: $minCount
+  - opcode: createPods
+    # Create pods with reference to the child pod groups according to their indices.
+    countParam: $initPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: cpg-tas-ns-0
+    podTemplatePath: templates/tas-pod.yaml
+    collectMetrics: true
+    templateParams:
+      podsPerGroup: $podsPerGroup
+  workloads:
+  - name: 10Nodes_2Trees_2Level_4PodGroups_12Pods
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      initRootCPG: 2
+      initPodGroups: 4
+      podGroupsPerCompositePodGroup: 2
+      minCount: 3
+      podsPerGroup: 3
+  - name: 5000Nodes_2Trees_2Level_8PodGroups_4000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 8
+      podGroupsPerCompositePodGroup: 4
+      minCount: 500
+      podsPerGroup: 500
+  - name: 5000Nodes_2Trees_2Level_8PodGroups_6000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 8
+      podGroupsPerCompositePodGroup: 4
+      minCount: 750
+      podsPerGroup: 750
+  - name: 5000Nodes_2Trees_2Level_8PodGroups_8000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 8
+      podGroupsPerCompositePodGroup: 4
+      minCount: 1000
+      podsPerGroup: 1000
+  - name: 5000Nodes_2Trees_2Level_64PodGroups_6400Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 64
+      podGroupsPerCompositePodGroup: 32
+      minCount: 100
+      podsPerGroup: 100
+  - name: 5000Nodes_2Trees_2Level_128PodGroups_12800Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 128
+      podGroupsPerCompositePodGroup: 64
+      minCount: 100
+      podsPerGroup: 100
+  - name: 5000Nodes_2Trees_2Level_256PodGroups_25600Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initPodGroups: 256
+      podGroupsPerCompositePodGroup: 128
+      minCount: 100
+      podsPerGroup: 100
+
+# 3LevelCompositePodGroupScheduling benchmarks scheduling throughput for 3-level CPG hierarchies.
+# These typically represent JobSets.
+- name: 3LevelCompositePodGroupScheduling
+  featureGates:
+    GenericWorkload: true
+    TopologyAwareWorkloadScheduling: true
+    CompositePodGroup: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createNamespaces
+    prefix: cpg-3level-ns
+    count: 1
+  - opcode: createCompositePodGroups
+    # Level 1: Root CompositePodGroups
+    countParam: $initRootCPG
+    namespace: cpg-3level-ns-0
+    templatePath: templates/cpg-gang.yaml
+    templateParams:
+      minGroupCount: $compositePodGroupsPerParent
+      priority: 1000
+  - opcode: createCompositePodGroups
+    # Level 2: Children CompositePodGroups referencing root
+    countParam: $initLevel2CPGs
+    namespace: cpg-3level-ns-0
+    templatePath: templates/cpg-child-gang.yaml
+    templateParams:
+      namePrefix: cpg-level2
+      parentPrefix: cpg
+      compositePodGroupsPerParent: $compositePodGroupsPerParent
+      minGroupCount: $podGroupsPerCompositePodGroup
+      priority: 1000
+  - opcode: createPodGroups
+    # Level 3: Leaf PodGroups referencing their parent CompositePodGroups in level 2
+    countParam: $initPodGroups
+    namespace: cpg-3level-ns-0
+    templatePath: templates/podgroup-gang.yaml
+    templateParams:
+      parentPrefix: cpg-level2
+      podGroupsPerCompositePodGroup: $podGroupsPerCompositePodGroup
+      minCount: $minCount
+      priority: 1000
+  - opcode: createPods
+    # Pods belonging to leaf PodGroups
+    countParam: $initPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: cpg-3level-ns-0
+    podTemplatePath: templates/gang-pod.yaml
+    collectMetrics: true
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      priority: 1000
+      cpuRequest: 100m
+  workloads:
+  - name: 10Nodes_2Trees_3Level_16PodGroups_48Pods
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initPodGroups: 16
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 4
+      minCount: 3
+      podsPerGroup: 3
+  - name: 5000Nodes_2Trees_3Level_16PodGroups_8000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initPodGroups: 16
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 4
+      minCount: 500
+      podsPerGroup: 500
+  - name: 5000Nodes_2Trees_3Level_16PodGroups_12000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initPodGroups: 16
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 4
+      minCount: 750
+      podsPerGroup: 750
+  - name: 5000Nodes_2Trees_3Level_16PodGroups_16000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initPodGroups: 16
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 4
+      minCount: 1000
+      podsPerGroup: 1000
+  - name: 5000Nodes_2Trees_3Level_64PodGroups_6400Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initPodGroups: 64
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 16
+      minCount: 100
+      podsPerGroup: 100
+  - name: 5000Nodes_2Trees_3Level_128PodGroups_12800Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initPodGroups: 128
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 32
+      minCount: 100
+      podsPerGroup: 100
+  - name: 5000Nodes_2Trees_3Level_256PodGroups_25600Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initPodGroups: 256
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 64
+      minCount: 100
+      podsPerGroup: 100
+
+# 4LevelCompositePodGroupScheduling benchmarks scheduling throughput for 4-level CPG hierarchies.
+# These typically represent Disaggregated Sets.
+- name: 4LevelCompositePodGroupScheduling
+  featureGates:
+    GenericWorkload: true
+    TopologyAwareWorkloadScheduling: true
+    CompositePodGroup: true
+  workloadTemplate:
+  - opcode: createNodes
+    countParam: $initNodes
+  - opcode: createNamespaces
+    prefix: cpg-4level-ns
+    count: 1
+  - opcode: createCompositePodGroups
+    # Level 1: Root CompositePodGroups
+    countParam: $initRootCPG
+    namespace: cpg-4level-ns-0
+    templatePath: templates/cpg-gang.yaml
+    templateParams:
+      minGroupCount: $compositePodGroupsPerParent
+      priority: 1000
+  - opcode: createCompositePodGroups
+    # Level 2: Children CompositePodGroups referencing root
+    countParam: $initLevel2CPGs
+    namespace: cpg-4level-ns-0
+    templatePath: templates/cpg-child-gang.yaml
+    templateParams:
+      namePrefix: cpg-level2
+      parentPrefix: cpg
+      compositePodGroupsPerParent: $compositePodGroupsPerParent
+      minGroupCount: $compositePodGroupsPerParent
+      priority: 1000
+  - opcode: createCompositePodGroups
+    # Level 3: Children CompositePodGroups referencing their parents in level 2
+    countParam: $initLevel3CPGs
+    namespace: cpg-4level-ns-0
+    templatePath: templates/cpg-child-gang.yaml
+    templateParams:
+      namePrefix: cpg-level3
+      parentPrefix: cpg-level2
+      compositePodGroupsPerParent: $compositePodGroupsPerParent
+      minGroupCount: $podGroupsPerCompositePodGroup
+      priority: 1000
+  - opcode: createPodGroups
+    # Level 4: Leaf PodGroups referencing their parent CompositePodGroups in level 3
+    countParam: $initPodGroups
+    namespace: cpg-4level-ns-0
+    templatePath: templates/podgroup-gang.yaml
+    templateParams:
+      parentPrefix: cpg-level3
+      podGroupsPerCompositePodGroup: $podGroupsPerCompositePodGroup
+      minCount: $minCount
+      priority: 1000
+  - opcode: createPods
+    # Pods belonging to leaf PodGroups
+    countParam: $initPodGroups
+    countMultiplierParam: $podsPerGroup
+    namespace: cpg-4level-ns-0
+    podTemplatePath: templates/gang-pod.yaml
+    collectMetrics: true
+    templateParams:
+      podsPerGroup: $podsPerGroup
+      priority: 1000
+      cpuRequest: 100m
+  workloads:
+  - name: 10Nodes_2Trees_4Level_32PodGroups_96Pods
+    labels: [integration-test, short]
+    params:
+      initNodes: 10
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initLevel3CPGs: 8
+      initPodGroups: 32
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 4
+      minCount: 3
+      podsPerGroup: 3
+  - name: 5000Nodes_2Trees_4Level_32PodGroups_16000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initLevel3CPGs: 8
+      initPodGroups: 32
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 4
+      minCount: 500
+      podsPerGroup: 500
+  - name: 5000Nodes_2Trees_4Level_32PodGroups_24000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initLevel3CPGs: 8
+      initPodGroups: 32
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 4
+      minCount: 750
+      podsPerGroup: 750
+  - name: 5000Nodes_2Trees_4Level_32PodGroups_32000Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initLevel3CPGs: 8
+      initPodGroups: 32
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 4
+      minCount: 1000
+      podsPerGroup: 1000
+  - name: 5000Nodes_2Trees_4Level_64PodGroups_6400Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initLevel3CPGs: 8
+      initPodGroups: 64
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 8
+      minCount: 100
+      podsPerGroup: 100
+  - name: 5000Nodes_2Trees_4Level_128PodGroups_12800Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initLevel3CPGs: 8
+      initPodGroups: 128
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 16
+      minCount: 100
+      podsPerGroup: 100
+  - name: 5000Nodes_2Trees_4Level_256PodGroups_25600Pods
+    labels: [performance]
+    params:
+      initNodes: 5000
+      initRootCPG: 2
+      initLevel2CPGs: 4
+      initLevel3CPGs: 8
+      initPodGroups: 256
+      compositePodGroupsPerParent: 2
+      podGroupsPerCompositePodGroup: 32
+      minCount: 100
+      podsPerGroup: 100

--- a/test/integration/scheduler_perf/cpg/templates/basic-pod.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/basic-pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-cpg-basic-pod-{{.Index}}
+spec:
+  schedulingGroup:
+    podGroupName: basic-group-{{DivideInt .Index .podsPerGroup}}
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi

--- a/test/integration/scheduler_perf/cpg/templates/cpg-basic.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/cpg-basic.yaml
@@ -1,0 +1,10 @@
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: CompositePodGroup
+metadata:
+  name: cpg-{{.Index}}
+spec:
+  workloadRef:
+    workloadName: cpg-workload
+    templateName: cpg-template
+  schedulingPolicy:
+    basic: {}

--- a/test/integration/scheduler_perf/cpg/templates/cpg-child-gang.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/cpg-child-gang.yaml
@@ -1,0 +1,13 @@
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: CompositePodGroup
+metadata:
+  name: {{.namePrefix}}-{{.Index}}
+spec:
+  parentCompositePodGroupName: {{.parentPrefix}}-{{DivideInt .Index .compositePodGroupsPerParent}}
+  workloadRef:
+    workloadName: cpg-workload
+    templateName: cpg-template
+  priority: {{.priority}}
+  schedulingPolicy:
+    gang:
+      minGroupCount: {{.minGroupCount}}

--- a/test/integration/scheduler_perf/cpg/templates/cpg-gang.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/cpg-gang.yaml
@@ -1,0 +1,12 @@
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: CompositePodGroup
+metadata:
+  name: cpg-{{.Index}}
+spec:
+  workloadRef:
+    workloadName: cpg-workload
+    templateName: cpg-template
+  priority: {{.priority}}
+  schedulingPolicy:
+    gang:
+      minGroupCount: {{.minGroupCount}}

--- a/test/integration/scheduler_perf/cpg/templates/cpg-tas.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/cpg-tas.yaml
@@ -1,0 +1,14 @@
+apiVersion: scheduling.k8s.io/v1alpha3
+kind: CompositePodGroup
+metadata:
+  name: cpg-{{.Index}}
+spec:
+  workloadRef:
+    workloadName: cpg-workload
+    templateName: cpg-template
+  schedulingPolicy:
+    gang:
+      minGroupCount: {{.minGroupCount}}
+  schedulingConstraints:
+    topology:
+    - key: topology.kubernetes.io/zone

--- a/test/integration/scheduler_perf/cpg/templates/gang-pod.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/gang-pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-cpg-gang-pod-{{.Index}}
+spec:
+  priority: {{.priority}}
+  schedulingGroup:
+    podGroupName: gang-group-{{DivideInt .Index .podsPerGroup}}
+  terminationGracePeriodSeconds: 0
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause
+    resources:
+      requests:
+        cpu: {{.cpuRequest}}
+        memory: 100Mi

--- a/test/integration/scheduler_perf/cpg/templates/pod-anchor-high-priority.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/pod-anchor-high-priority.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-anchor-{{.Index}}-
+  labels:
+    app: blue
+    label1: value1
+    label2: value2
+    label3: value3
+    label4: value4
+spec:
+  priority: 9999999
+  terminationGracePeriodSeconds: 0
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause
+    ports:
+    - containerPort: 80
+      # hostPort is configured with a formula based on .Index and the number of pods per node
+      # to guarantee that anchor pods are evenly distributed/spread across all nodes in the cluster.
+      hostPort: {{AddInt 7000 (Mod .Index (DivideInt .podsCount .nodesCount))}}
+    resources:
+      requests:
+        cpu: 10m
+        memory: 100Mi

--- a/test/integration/scheduler_perf/cpg/templates/pod-gang-affinity.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/pod-gang-affinity.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-gang-{{.Index}}
+spec:
+  priority: {{.priority}}
+  schedulingGroup:
+    podGroupName: gang-group-{{DivideInt .Index .podsPerGroup}}
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app: blue
+            label1: value1
+            label2: value2
+            label3: value3
+            label4: value4
+        topologyKey: kubernetes.io/hostname
+        namespaceSelector: {}
+  terminationGracePeriodSeconds: 0
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause
+    resources:
+      requests:
+        cpu: 3970m
+        memory: 500Mi

--- a/test/integration/scheduler_perf/cpg/templates/pod-low-priority.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/pod-low-priority.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: pod-low-priority-{{.Index}}-
+  labels:
+    app: blue
+    label1: value1
+    label2: value2
+    label3: value3
+    label4: value4
+spec:
+  priority: 0
+  terminationGracePeriodSeconds: 0
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause
+    ports:
+    - containerPort: 80
+      hostPort: {{AddInt 8000 (Mod .Index (DivideInt .podsCount .nodesCount))}}
+    resources:
+      requests:
+        cpu: 40m
+        memory: 100Mi

--- a/test/integration/scheduler_perf/cpg/templates/podgroup-basic.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/podgroup-basic.yaml
@@ -1,0 +1,11 @@
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PodGroup
+metadata:
+  name: basic-group-{{.Index}}
+spec:
+  parentCompositePodGroupName: cpg-{{DivideInt .Index .podGroupsPerCompositePodGroup}}
+  workloadRef:
+    workloadName: cpg-workload
+    templateName: pg-template
+  schedulingPolicy:
+    basic: {}

--- a/test/integration/scheduler_perf/cpg/templates/podgroup-gang.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/podgroup-gang.yaml
@@ -1,0 +1,13 @@
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PodGroup
+metadata:
+  name: gang-group-{{.Index}}
+spec:
+  parentCompositePodGroupName: {{.parentPrefix}}-{{DivideInt .Index .podGroupsPerCompositePodGroup}}
+  workloadRef:
+    workloadName: cpg-workload
+    templateName: pg-template
+  priority: {{.priority}}
+  schedulingPolicy:
+    gang:
+      minCount: {{.minCount}}

--- a/test/integration/scheduler_perf/cpg/templates/podgroup-tas.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/podgroup-tas.yaml
@@ -1,0 +1,15 @@
+apiVersion: scheduling.k8s.io/v1beta1
+kind: PodGroup
+metadata:
+  name: gang-group-{{.Index}}
+spec:
+  parentCompositePodGroupName: cpg-{{DivideInt .Index .podGroupsPerCompositePodGroup}}
+  workloadRef:
+    workloadName: cpg-workload
+    templateName: pg-template
+  schedulingPolicy:
+    gang:
+      minCount: {{.minCount}}
+  schedulingConstraints:
+    topology:
+    - key: topology.kubernetes.io/rack

--- a/test/integration/scheduler_perf/cpg/templates/tas-node.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/tas-node.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Node
+metadata:
+  name: node-{{.Index}}
+  labels:
+    kubernetes.io/hostname: node-{{.Index}}
+    # Topology hierarchy: 1 zone per 1,000 nodes, 1 rack per 100 nodes (10 racks per zone).
+    topology.kubernetes.io/zone: zone-{{DivideInt .Index 1000}}
+    topology.kubernetes.io/rack: rack-{{DivideInt .Index 100}}
+status:
+  capacity:
+    cpu: "4"
+    memory: 32Gi
+    pods: "110"
+  allocatable:
+    cpu: "4"
+    memory: 32Gi
+    pods: "110"
+  phase: Running
+  conditions:
+  - type: Ready
+    status: "True"

--- a/test/integration/scheduler_perf/cpg/templates/tas-pod.yaml
+++ b/test/integration/scheduler_perf/cpg/templates/tas-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-cpg-tas-pod-{{.Index}}
+spec:
+  schedulingGroup:
+    podGroupName: gang-group-{{DivideInt .Index .podsPerGroup}}
+  terminationGracePeriodSeconds: 0
+  containers:
+  - image: registry.k8s.io/pause:3.10.1
+    name: pause
+    resources:
+      requests:
+        cpu: 100m
+        memory: 100Mi

--- a/test/integration/scheduler_perf/executor.go
+++ b/test/integration/scheduler_perf/executor.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -46,6 +47,7 @@ import (
 	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	coreinformers "k8s.io/client-go/informers/core/v1"
+	schedulingv1alpha3informers "k8s.io/client-go/informers/scheduling/v1alpha3"
 	schedulinginformers "k8s.io/client-go/informers/scheduling/v1beta1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/restmapper"
@@ -68,6 +70,7 @@ type WorkloadExecutor struct {
 	numPodsScheduledPerNamespace map[string]int
 	podInformer                  coreinformers.PodInformer
 	podGroupInformer             schedulinginformers.PodGroupInformer
+	compositePodGroupInformer    schedulingv1alpha3informers.CompositePodGroupInformer
 	throughputErrorMargin        float64
 	testCase                     *testCase
 	workload                     *Workload
@@ -100,6 +103,8 @@ func (e *WorkloadExecutor) runOp(tCtx ktesting.TContext, op realOp, opIndex int)
 		return e.runSleepOp(tCtx, concreteOp)
 	case *createPodGroups:
 		return e.runCreatePodGroupsOp(tCtx, concreteOp)
+	case *createCompositePodGroups:
+		return e.runCreateCompositePodGroupsOp(tCtx, concreteOp)
 	case *startCollectingMetricsOp:
 		return e.runStartCollectingMetricsOp(tCtx, opIndex, concreteOp)
 	case *stopCollectingMetricsOp:
@@ -248,6 +253,78 @@ func (e *WorkloadExecutor) createPodGroupWithRetry(tCtx ktesting.TContext, obj *
 	defer cancel()
 	for {
 		_, err := tCtx.Client().SchedulingV1beta1().PodGroups(namespace).Create(ctx, obj, metav1.CreateOptions{
+			FieldValidation: "Strict",
+		})
+
+		if err == nil {
+			return nil
+		}
+
+		// Fail fast on non-retriable client errors (invalid specs, bad requests, forbidden access).
+		if apierrors.IsInvalid(err) || apierrors.IsBadRequest(err) || apierrors.IsForbidden(err) {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s: timed out (%w) while creating %q, last error was: %w", templatePath, context.Cause(ctx), klog.KObj(obj), err)
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+// runCreateCompositePodGroupsOp executes the createCompositePodGroups operation.
+// It creates the configured number of CompositePodGroups from a template and
+// then waits for them to be visible in the scheduler's informer cache.
+// This ensures that subsequent operations (like creating PodGroups that reference these CompositePodGroups) won't fail due to cache lag.
+func (e *WorkloadExecutor) runCreateCompositePodGroupsOp(tCtx ktesting.TContext, op *createCompositePodGroups) error {
+	if err := createNamespaceIfNotPresent(tCtx, op.Namespace, &e.numPodsScheduledPerNamespace); err != nil {
+		return err
+	}
+
+	tCtx.Logf("creating %d CompositePodGroups in namespace %q", op.Count, op.Namespace)
+
+	for index := range op.Count {
+		env := make(map[string]any)
+		maps.Copy(env, op.TemplateParams)
+		env["Index"] = index
+
+		obj := &schedulingv1alpha3.CompositePodGroup{}
+		if _, err := getSpecFromTextTemplateFile(op.TemplatePath, env, obj); err != nil {
+			return fmt.Errorf("%s: %w", op.TemplatePath, err)
+		}
+
+		if err := e.createCompositePodGroupWithRetry(tCtx, obj, op.Namespace, op.TemplatePath); err != nil {
+			return err
+		}
+	}
+
+	// Wait for composite pod groups to be visible in the scheduler's informer cache.
+	// It times out after 10 seconds if the condition is not met.
+	tCtx.Logf("waiting for %d CompositePodGroups in namespace %q", op.Count, op.Namespace)
+	err := wait.PollUntilContextTimeout(tCtx, 100*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		compositePodGroups, err := e.compositePodGroupInformer.Lister().CompositePodGroups(op.Namespace).List(labels.Everything())
+		if err != nil {
+			return false, err
+		}
+		if len(compositePodGroups) >= op.Count {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for CompositePodGroups to be cached: %w", err)
+	}
+
+	return nil
+}
+
+func (e *WorkloadExecutor) createCompositePodGroupWithRetry(tCtx ktesting.TContext, obj *schedulingv1alpha3.CompositePodGroup, namespace, templatePath string) error {
+	ctx, cancel := context.WithTimeout(tCtx, 20*time.Second)
+
+	defer cancel()
+	for {
+		_, err := tCtx.Client().SchedulingV1alpha3().CompositePodGroups(namespace).Create(ctx, obj, metav1.CreateOptions{
 			FieldValidation: "Strict",
 		})
 

--- a/test/integration/scheduler_perf/executor_test.go
+++ b/test/integration/scheduler_perf/executor_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "k8s.io/api/core/v1"
+	schedulingv1alpha3 "k8s.io/api/scheduling/v1alpha3"
 	schedulingapi "k8s.io/api/scheduling/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,6 +35,7 @@ import (
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	"k8s.io/kubernetes/test/utils/client-go/ktesting"
 	"k8s.io/utils/ptr"
 )
@@ -470,19 +472,7 @@ func TestRunOp(t *testing.T) {
 			verifyFuncs: []verifyFunc{
 				verifyCount(2),
 				verifyNamespaceCreated("namespace-0"),
-				verifyObj(
-					&schedulingapi.PodGroup{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "namespace-0",
-						},
-						Spec: schedulingapi.PodGroupSpec{
-							SchedulingPolicy: schedulingapi.PodGroupSchedulingPolicy{
-								Gang: &schedulingapi.GangSchedulingPolicy{
-									MinCount: 3,
-								},
-							},
-						},
-					}),
+				verifyObj(st.MakePodGroup().Namespace("namespace-0").MinCount(3).Obj()),
 			},
 		},
 		{
@@ -515,6 +505,50 @@ func TestRunOp(t *testing.T) {
 			},
 			expectedFailure: true,
 		},
+		{
+			name: "Create CompositePodGroups",
+			op: &createCompositePodGroups{
+				Opcode:       createCompositePodGroupsOpcode,
+				Namespace:    "namespace-0",
+				TemplatePath: *newCompositePodGroupTemplateFile(t, "namespace-0"),
+				Count:        2,
+			},
+			verifyFuncs: []verifyFunc{
+				verifyCount(2),
+				verifyNamespaceCreated("namespace-0"),
+				verifyObj(st.MakeCompositePodGroup().Namespace("namespace-0").MinGroupCount(2).Obj()),
+			},
+		},
+		{
+			name: "Create CompositePodGroups with Invalid Template Path",
+			op: &createCompositePodGroups{
+				Opcode:       createCompositePodGroupsOpcode,
+				Namespace:    "namespace-0",
+				TemplatePath: "non-existent-file.yaml",
+				Count:        1,
+			},
+			expectedFailure: true,
+		},
+		{
+			name: "Create CompositePodGroups with empty namespace",
+			op: &createCompositePodGroups{
+				Opcode:       createCompositePodGroupsOpcode,
+				Namespace:    "",
+				TemplatePath: *newCompositePodGroupTemplateFile(t, ""),
+				Count:        1,
+			},
+			expectedFailure: true,
+		},
+		{
+			name: "Create CompositePodGroups with zero count",
+			op: &createCompositePodGroups{
+				Opcode:       createCompositePodGroupsOpcode,
+				Namespace:    "namespace-0",
+				TemplatePath: *newCompositePodGroupTemplateFile(t, "namespace-0"),
+				Count:        0,
+			},
+			expectedFailure: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -527,6 +561,8 @@ func TestRunOp(t *testing.T) {
 			podInformer := informerFactory.Core().V1().Pods()
 			podGroupInformer := informerFactory.Scheduling().V1beta1().PodGroups()
 			podGroupInformer.Informer()
+			compositePodGroupInformer := informerFactory.Scheduling().V1alpha3().CompositePodGroups()
+			compositePodGroupInformer.Informer()
 			informerFactory.Start(tCtx.Done())
 			informerFactory.WaitForCacheSync(tCtx.Done())
 
@@ -536,9 +572,10 @@ func TestRunOp(t *testing.T) {
 				testCase: &testCase{
 					DefaultPodTemplatePath: newPodTemplateFile(t, "namespace-0"),
 				},
-				podInformer:      podInformer,
-				podGroupInformer: podGroupInformer,
-				workload:         tt.workload,
+				podInformer:               podInformer,
+				podGroupInformer:          podGroupInformer,
+				compositePodGroupInformer: compositePodGroupInformer,
+				workload:                  tt.workload,
 			}
 
 			opToRun := tt.op
@@ -613,6 +650,14 @@ func verifyCount(expectedCount int) verifyFunc {
 			}
 			if got := len(pgs.Items); got != expectedCount {
 				return fmt.Errorf("unexpected pod group count: got %d, want %d", got, expectedCount)
+			}
+		case *createCompositePodGroups:
+			cpgs, err := tCtx.Client().SchedulingV1alpha3().CompositePodGroups(concreteOp.Namespace).List(tCtx, metav1.ListOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to list composite pod groups: %w", err)
+			}
+			if got := len(cpgs.Items); got != expectedCount {
+				return fmt.Errorf("unexpected composite pod group count: got %d, want %d", got, expectedCount)
 			}
 		default:
 			return fmt.Errorf("verifyCount doesn't support this operation type: %T", op)
@@ -806,6 +851,34 @@ func verifyObj(expectedObj any) verifyFunc {
 			}
 			got = gotPodGroups
 			want = wantPodGroups
+		case *createCompositePodGroups:
+			expectedCompositePodGroupTemplate, ok := expectedObj.(*schedulingv1alpha3.CompositePodGroup)
+			if !ok {
+				return fmt.Errorf("expectedObj must be *schedulingv1alpha3.CompositePodGroup when op is *createCompositePodGroups, got %T", expectedObj)
+			}
+
+			namespace := expectedCompositePodGroupTemplate.Namespace
+			if namespace == "" {
+				return fmt.Errorf("expectedCompositePodGroupTemplate.Namespace must be set")
+			}
+
+			compositePodGroupsList, listErr := tCtx.Client().SchedulingV1alpha3().CompositePodGroups(namespace).List(tCtx, metav1.ListOptions{})
+			if listErr != nil {
+				return fmt.Errorf("failed to list composite pod groups: %w", listErr)
+			}
+			gotCompositePodGroups := compositePodGroupsList.Items
+
+			wantCompositePodGroups := make([]schedulingv1alpha3.CompositePodGroup, len(gotCompositePodGroups))
+			for i := range gotCompositePodGroups {
+				wantCompositePodGroups[i] = *expectedCompositePodGroupTemplate
+			}
+
+			cmpOpts = []cmp.Option{
+				cmpopts.EquateEmpty(),
+				cmpOptsIgnoreObjectMeta,
+			}
+			got = gotCompositePodGroups
+			want = wantCompositePodGroups
 		default:
 			return fmt.Errorf("verifyObj doesn't support this operation type for cmp.Diff: %T", opDetails)
 		}
@@ -843,7 +916,7 @@ func createObjTemplateFile(t *testing.T, obj any) *string {
 	}()
 
 	switch obj := obj.(type) {
-	case *v1.Node, *v1.Pod, *v1.PersistentVolume, *v1.PersistentVolumeClaim, *schedulingapi.PodGroup:
+	case *v1.Node, *v1.Pod, *v1.PersistentVolume, *v1.PersistentVolumeClaim, *schedulingapi.PodGroup, *schedulingv1alpha3.CompositePodGroup:
 		if err := json.NewEncoder(f).Encode(obj); err != nil {
 			t.Fatalf("Failed to encode the template to %s: %v", templateFile, err)
 		}
@@ -1134,20 +1207,13 @@ func newPodTemplateFile(t *testing.T, namespace string) *string {
 }
 
 func newPodGroupTemplateFile(t *testing.T, namespace string) *string {
-	pg := &schedulingapi.PodGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "gang-{{.Index}}",
-			Namespace: namespace,
-		},
-		Spec: schedulingapi.PodGroupSpec{
-			SchedulingPolicy: schedulingapi.PodGroupSchedulingPolicy{
-				Gang: &schedulingapi.GangSchedulingPolicy{
-					MinCount: 3,
-				},
-			},
-		},
-	}
+	pg := st.MakePodGroup().Name("gang-{{.Index}}").Namespace(namespace).MinCount(3).Obj()
 	return createObjTemplateFile(t, pg)
+}
+
+func newCompositePodGroupTemplateFile(t *testing.T, namespace string) *string {
+	cpg := st.MakeCompositePodGroup().Name("cpg-{{.Index}}").Namespace(namespace).MinGroupCount(2).Obj()
+	return createObjTemplateFile(t, cpg)
 }
 
 func newPersistentVolumeTemplateFile(t *testing.T) *string {

--- a/test/integration/scheduler_perf/operations.go
+++ b/test/integration/scheduler_perf/operations.go
@@ -681,6 +681,10 @@ type createPodGroups struct {
 	Count int
 	// CountParam is the name of the parameter that determines the count.
 	CountParam string
+	// Template parameter for multiplying CountParam. It is used when total number of podgroups
+	// is defined by number of podgroups per set of composite podgroups for multiple sets of composite podgroups.
+	// Optional.
+	CountMultiplierParam string
 }
 
 func (cpg *createPodGroups) isValid(allowParameterization bool) error {
@@ -710,6 +714,13 @@ func (cpg createPodGroups) patchParams(w *Workload) (realOp, error) {
 			return nil, err
 		}
 		cpg.Count = count
+		if cpg.CountMultiplierParam != "" {
+			multiplier, err := w.Params.get(cpg.CountMultiplierParam[1:])
+			if err != nil {
+				return nil, err
+			}
+			cpg.Count *= multiplier
+		}
 	}
 	if len(cpg.TemplateParams) > 0 {
 		var err error
@@ -719,6 +730,70 @@ func (cpg createPodGroups) patchParams(w *Workload) (realOp, error) {
 		}
 	}
 	return &cpg, cpg.isValid(false)
+}
+
+// createCompositePodGroups defines an op where CompositePodGroups get created from a YAML template
+// then waits for them to be visible in the scheduler's informer cache.
+type createCompositePodGroups struct {
+	// Must match createCompositePodGroupsOpcode.
+	Opcode operationCode
+	// Namespace the objects should be created in.
+	Namespace string
+	// Path to spec file describing the CompositePodGroup to create.
+	TemplatePath string
+	// Params to be passed to the template.
+	TemplateParams map[string]any
+	// Count determines how many CompositePodGroups get created.
+	Count int
+	// CountParam is the name of the parameter that determines the count.
+	CountParam string
+	// CountMultiplierParam is optional template parameter for multiplying CountParam.
+	CountMultiplierParam string
+}
+
+func (ccpg *createCompositePodGroups) isValid(allowParameterization bool) error {
+	if ccpg.TemplatePath == "" {
+		return fmt.Errorf("templatePath must be set")
+	}
+	if ccpg.Namespace == "" {
+		return fmt.Errorf("namespace must be set")
+	}
+	if !isValidCount(allowParameterization, ccpg.Count, ccpg.CountParam) {
+		return fmt.Errorf("invalid Count=%d / CountParam=%q", ccpg.Count, ccpg.CountParam)
+	}
+	if !allowParameterization && ccpg.Count < 1 {
+		return fmt.Errorf("count must be greater than 0, got %d", ccpg.Count)
+	}
+	return nil
+}
+
+func (ccpg *createCompositePodGroups) collectsMetrics() bool {
+	return false
+}
+
+func (ccpg createCompositePodGroups) patchParams(w *Workload) (realOp, error) {
+	if ccpg.CountParam != "" {
+		count, err := w.Params.get(ccpg.CountParam[1:])
+		if err != nil {
+			return nil, err
+		}
+		ccpg.Count = count
+		if ccpg.CountMultiplierParam != "" {
+			multiplier, err := w.Params.get(ccpg.CountMultiplierParam[1:])
+			if err != nil {
+				return nil, err
+			}
+			ccpg.Count *= multiplier
+		}
+	}
+	if len(ccpg.TemplateParams) > 0 {
+		var err error
+		ccpg.TemplateParams, err = resolveTemplateParams(ccpg.TemplateParams, w)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &ccpg, ccpg.isValid(false)
 }
 
 // startCollectingMetricsOp defines an op that starts metrics collectors.

--- a/test/integration/scheduler_perf/scheduler_perf.go
+++ b/test/integration/scheduler_perf/scheduler_perf.go
@@ -61,23 +61,24 @@ import (
 type operationCode string
 
 const (
-	allocResourceClaimsOpcode    operationCode = "allocResourceClaims"
-	createAnyOpcode              operationCode = "createAny"
-	createNodesOpcode            operationCode = "createNodes"
-	createNamespacesOpcode       operationCode = "createNamespaces"
-	createPodsOpcode             operationCode = "createPods"
-	createPodSetsOpcode          operationCode = "createPodSets"
-	deletePodsOpcode             operationCode = "deletePods"
-	createResourceClaimsOpcode   operationCode = "createResourceClaims"
-	churnOpcode                  operationCode = "churn"
-	updateAnyOpcode              operationCode = "updateAny"
-	barrierOpcode                operationCode = "barrier"
-	sleepOpcode                  operationCode = "sleep"
-	startCollectingMetricsOpcode operationCode = "startCollectingMetrics"
-	stopCollectingMetricsOpcode  operationCode = "stopCollectingMetrics"
-	createPodGroupsOpcode        operationCode = "createPodGroups"
-	startCollectingProfileOpcode operationCode = "startCollectingProfile"
-	stopCollectingProfileOpcode  operationCode = "stopCollectingProfile"
+	allocResourceClaimsOpcode      operationCode = "allocResourceClaims"
+	createAnyOpcode                operationCode = "createAny"
+	createNodesOpcode              operationCode = "createNodes"
+	createNamespacesOpcode         operationCode = "createNamespaces"
+	createPodsOpcode               operationCode = "createPods"
+	createPodSetsOpcode            operationCode = "createPodSets"
+	deletePodsOpcode               operationCode = "deletePods"
+	createResourceClaimsOpcode     operationCode = "createResourceClaims"
+	churnOpcode                    operationCode = "churn"
+	updateAnyOpcode                operationCode = "updateAny"
+	barrierOpcode                  operationCode = "barrier"
+	sleepOpcode                    operationCode = "sleep"
+	startCollectingMetricsOpcode   operationCode = "startCollectingMetrics"
+	stopCollectingMetricsOpcode    operationCode = "stopCollectingMetrics"
+	createPodGroupsOpcode          operationCode = "createPodGroups"
+	createCompositePodGroupsOpcode operationCode = "createCompositePodGroups"
+	startCollectingProfileOpcode   operationCode = "startCollectingProfile"
+	stopCollectingProfileOpcode    operationCode = "stopCollectingProfile"
 )
 
 const (
@@ -514,23 +515,24 @@ type op struct {
 // which op we're decoding at runtime.
 func (op *op) UnmarshalJSON(b []byte) error {
 	possibleOps := map[operationCode]realOp{
-		allocResourceClaimsOpcode:    &allocResourceClaimsOp{},
-		createAnyOpcode:              &createAny{},
-		createNodesOpcode:            &createNodesOp{},
-		createNamespacesOpcode:       &createNamespacesOp{},
-		createPodsOpcode:             &createPodsOp{},
-		createPodSetsOpcode:          &createPodSetsOp{},
-		deletePodsOpcode:             &deletePodsOp{},
-		createResourceClaimsOpcode:   &createResourceClaimsOp{},
-		churnOpcode:                  &churnOp{},
-		updateAnyOpcode:              &updateAny{},
-		barrierOpcode:                &barrierOp{},
-		sleepOpcode:                  &sleepOp{},
-		startCollectingMetricsOpcode: &startCollectingMetricsOp{},
-		stopCollectingMetricsOpcode:  &stopCollectingMetricsOp{},
-		createPodGroupsOpcode:        &createPodGroups{},
-		startCollectingProfileOpcode: &startCollectingProfileOp{},
-		stopCollectingProfileOpcode:  &stopCollectingProfileOp{},
+		allocResourceClaimsOpcode:      &allocResourceClaimsOp{},
+		createAnyOpcode:                &createAny{},
+		createNodesOpcode:              &createNodesOp{},
+		createNamespacesOpcode:         &createNamespacesOp{},
+		createPodsOpcode:               &createPodsOp{},
+		createPodSetsOpcode:            &createPodSetsOp{},
+		deletePodsOpcode:               &deletePodsOp{},
+		createResourceClaimsOpcode:     &createResourceClaimsOp{},
+		churnOpcode:                    &churnOp{},
+		updateAnyOpcode:                &updateAny{},
+		barrierOpcode:                  &barrierOp{},
+		sleepOpcode:                    &sleepOp{},
+		startCollectingMetricsOpcode:   &startCollectingMetricsOp{},
+		stopCollectingMetricsOpcode:    &stopCollectingMetricsOp{},
+		createPodGroupsOpcode:          &createPodGroups{},
+		createCompositePodGroupsOpcode: &createCompositePodGroups{},
+		startCollectingProfileOpcode:   &startCollectingProfileOp{},
+		stopCollectingProfileOpcode:    &stopCollectingProfileOp{},
 		// TODO(#94601): add a delete nodes op to simulate scaling behaviour?
 	}
 	// First determine the opcode using lenient decoding (= ignore extra fields).
@@ -1130,6 +1132,7 @@ func runWorkload(tCtx ktesting.TContext, tc *testCase, w *Workload, topicName st
 		numPodsScheduledPerNamespace: make(map[string]int),
 		podInformer:                  podInformer,
 		podGroupInformer:             informerFactory.Scheduling().V1beta1().PodGroups(),
+		compositePodGroupInformer:    informerFactory.Scheduling().V1alpha3().CompositePodGroups(),
 		throughputErrorMargin:        throughputErrorMargin,
 		testCase:                     tc,
 		workload:                     w,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/sig-scheduling

#### What this PR does / why we need it:

Adding performance tests for CPG in scheduler_perf.

### Test cases include:
* Multi-level CompositePodGroup scheduling with gang and basic policies
* Multi-level CompositePodGroup scheduling with preemptions
* Multi-level CompositePodGroup scheduling with TAS

### Changes include:
- Adding new operations to create CompositePodGroups.

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```