### PR TITLE
Automated cherry pick of #141489: [kube-proxy/winkernel] Guard against load balancers without port mappings

### DIFF
--- a/pkg/proxy/winkernel/hns.go
+++ b/pkg/proxy/winkernel/hns.go
@@ -347,8 +347,14 @@ func (hns hns) getAllLoadBalancers() (map[loadBalancerIdentifier]*loadBalancerIn
 	}
 	loadBalancers := make(map[loadBalancerIdentifier]*(loadBalancerInfo))
 	for _, lb := range lbs {
-		isIPv6 := (lb.Flags & LoadBalancerFlagsIPv6) == LoadBalancerFlagsIPv6
+		// PortMappings is populated by HNS and can be empty, for example when a load
+		// balancer is partially created. Such an entry cannot be keyed by port.
+		if len(lb.PortMappings) == 0 {
+			klog.V(2).InfoS("Skipping load balancer with no port mappings", "hnsLbID", lb.Id)
+			continue
+		}
 		portMap := lb.PortMappings[0]
+		isIPv6 := (lb.Flags & LoadBalancerFlagsIPv6) == LoadBalancerFlagsIPv6
 		// Compute hash from backends (endpoint IDs)
 		hash, err := hashEndpoints(lb.HostComputeEndpoints)
 		if err != nil {

--- a/pkg/proxy/winkernel/hns_test.go
+++ b/pkg/proxy/winkernel/hns_test.go
@@ -724,3 +724,64 @@ func createTestNetwork() (*hcn.HostComputeNetwork, error) {
 
 	return network.Create()
 }
+
+func TestGetAllLoadBalancers_SkipsLoadBalancersWithoutPortMappings(t *testing.T) {
+	testCases := []struct {
+		name         string
+		portMappings []hcn.LoadBalancerPortMapping
+	}{
+		{
+			name:         "nil port mappings",
+			portMappings: nil,
+		},
+		{
+			name:         "empty port mappings",
+			portMappings: []hcn.LoadBalancerPortMapping{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hcnMock := getHcnMock("L2Bridge")
+			hns := hns{hcn: hcnMock}
+
+			hcnMock.PopulateRawQueriedLoadbalancer(&hcn.HostComputeLoadBalancer{
+				Id:           "LBID-malformed",
+				FrontendVIPs: []string{serviceVip},
+				PortMappings: tc.portMappings,
+			})
+			hcnMock.PopulateRawQueriedLoadbalancer(&hcn.HostComputeLoadBalancer{
+				Id:                   "LBID-valid",
+				FrontendVIPs:         []string{serviceVip},
+				HostComputeEndpoints: []string{"EPID-1"},
+				PortMappings: []hcn.LoadBalancerPortMapping{
+					{
+						Protocol:     uint32(protocol),
+						InternalPort: internalPort,
+						ExternalPort: externalPort,
+					},
+				},
+			})
+
+			loadBalancers, err := hns.getAllLoadBalancers()
+			assert.NoError(t, err)
+
+			hnsIDs := make([]string, 0, len(loadBalancers))
+			for _, lb := range loadBalancers {
+				hnsIDs = append(hnsIDs, lb.hnsID)
+			}
+			assert.ElementsMatch(t, []string{"LBID-valid"}, hnsIDs)
+		})
+	}
+}
+
+func TestGetAllLoadBalancers_AllLoadBalancersWithoutPortMappings(t *testing.T) {
+	hcnMock := getHcnMock("L2Bridge")
+	hns := hns{hcn: hcnMock}
+
+	hcnMock.PopulateRawQueriedLoadbalancer(&hcn.HostComputeLoadBalancer{Id: "LBID-malformed"})
+
+	loadBalancers, err := hns.getAllLoadBalancers()
+	assert.NoError(t, err)
+	assert.Empty(t, loadBalancers)
+}

--- a/pkg/proxy/winkernel/testing/hcnutils_mock.go
+++ b/pkg/proxy/winkernel/testing/hcnutils_mock.go
@@ -96,6 +96,12 @@ func (hcnObj HcnMock) PopulateQueriedEndpoints(epId, hnsId, ipAddress, mac strin
 	endpointMap[endpoint.Name] = endpoint
 }
 
+// PopulateRawQueriedLoadbalancer injects a load balancer into the mocked HNS state verbatim,
+// bypassing the validation CreateLoadBalancer performs.
+func (hcnObj HcnMock) PopulateRawQueriedLoadbalancer(lb *hcn.HostComputeLoadBalancer) {
+	loadbalancerMap[lb.Id] = lb
+}
+
 func (hcnObj HcnMock) GetNetworkByName(networkName string) (*hcn.HostComputeNetwork, error) {
 	return hcnObj.network, nil
 }


### PR DESCRIPTION
Cherry pick of #141489 on release-1.36.

#141489: [kube-proxy/winkernel] Guard against load balancers without port mappings

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug

#### Note on tests
The production fix (hns.go) is a clean cherry-pick. The unit tests were adapted to the release-1.36 test harness: the valid load balancer is injected via `PopulateRawQueriedLoadbalancer` (added by this change) rather than `PopulateQueriedLoadbalancers`, which is not present on release-1.36 (introduced later by #139503). Verified locally: `go test ./pkg/proxy/winkernel/` passes, and the new tests panic with `index out of range` without the fix.

```release-note
Fixed a panic in the Windows kube-proxy (winkernel) that could terminate kube-proxy when an HNS load balancer without port mappings was enumerated.
```
