### PR TITLE
Fix preemptor stuck when async preemption produces no deletion event

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpreemption/default_preemption_test.go
@@ -3785,11 +3785,11 @@ func TestPreEnqueue(t *testing.T) {
 			finishPreemption := make(chan struct{})
 
 			p.Executor.PreemptPod = func(ctx context.Context, c preemption.Candidate, preemptor preemption.ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error) {
-				if !tt.features.EnableAsyncPreemption {
-					return false, nil
+				if tt.features.EnableAsyncPreemption {
+					<-finishPreemption
 				}
-				<-finishPreemption
-				return false, nil
+				// Keep activation out of this test so it only exercises the PreEnqueue gate.
+				return true, nil
 			}
 
 			// Fill the cycle state

--- a/pkg/scheduler/framework/preemption/executor.go
+++ b/pkg/scheduler/framework/preemption/executor.go
@@ -86,7 +86,7 @@ type Executor struct {
 	lastVictimsPendingPreemption map[types.UID]pendingVictim
 
 	// PreemptPod is a function that actually preempts a specific Pod. It returns true
-	// when the victim was preempted only in scheduler memory, without a delete call.
+	// when a successful delete call will produce a deletion event for the victim.
 	// This is exposed to be replaced during tests.
 	PreemptPod func(ctx context.Context, c Candidate, preemptor ExecutorPreemptor, victim *v1.Pod, pluginName string) (bool, error)
 }
@@ -157,7 +157,7 @@ func NewExecutor(fh fwk.Handle, fts feature.Features) *Executor {
 
 		fh.EventRecorder().WithLogger(logger).Eventf(victim, preemptor.Obj(), v1.EventTypeNormal, "Preempted", "Preempting", eventMessage)
 
-		return preemptedInMemory, nil
+		return !preemptedInMemory, nil
 	}
 
 	return e
@@ -219,7 +219,7 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 
 	errCh := parallelize.NewResultChannel[error]()
 	// PreEnqueue only watches the last victim for completion, so activate when that victim won't emit a deletion event.
-	preemptedLastVictimInMemory := false
+	lastVictimWillProduceDeletionEvent := true
 	preemptPod := func(index int) {
 		victim := victimPods[index]
 		if _, err := e.PreemptPod(ctx, c, preemptor, victim, pluginName); err != nil {
@@ -245,7 +245,7 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 			metrics.PreemptionGoroutinesExecutionTotal.WithLabelValues(result).Inc()
 		}()
 		defer func() {
-			if result == metrics.GoroutineResultError || preemptedLastVictimInMemory {
+			if result == metrics.GoroutineResultError || !lastVictimWillProduceDeletionEvent {
 				// When API call isn't successful or no victim deletion event will be produced, the preemptor's
 				// Pods may get stuck in the unschedulable pod pool in the worst case.
 				e.fh.Activate(logger, preemptor.Pods())
@@ -294,12 +294,12 @@ func (e *Executor) prepareCandidateAsync(c Candidate, preemptor ExecutorPreempto
 			e.lastVictimsPendingPreemption[preemptor.UID()] = pendingVictim{namespace: lastVictim.Namespace, name: lastVictim.Name}
 			e.mu.Unlock()
 
-			preemptedInMemory, err := e.PreemptPod(ctx, c, preemptor, lastVictim, pluginName)
+			willProduceDeletionEvent, err := e.PreemptPod(ctx, c, preemptor, lastVictim, pluginName)
 			if err != nil {
 				utilruntime.HandleErrorWithContext(ctx, err, "Error occurred during async preemption of the last victim")
 				result = metrics.GoroutineResultError
-			} else if preemptedInMemory {
-				preemptedLastVictimInMemory = true
+			} else {
+				lastVictimWillProduceDeletionEvent = willProduceDeletionEvent
 			}
 		}
 		e.mu.Lock()

--- a/pkg/scheduler/framework/preemption/executor_test.go
+++ b/pkg/scheduler/framework/preemption/executor_test.go
@@ -444,6 +444,7 @@ func TestPrepareCandidate(t *testing.T) {
 			nodeNames:             []string{node1Name},
 			expectedStatus:        nil,
 			expectedPreemptingMap: sets.New(types.UID("preemptor")),
+			expectedActivatedPods: map[string]*v1.Pod{preemptor.Name: preemptor},
 		},
 		{
 			name: "one victim with same condition",
@@ -1526,12 +1527,13 @@ func TestPreemptPod(t *testing.T) {
 					preemptor = &compositePodGroupExecutorPreemptor{cpg: preemptorCompositePodGroup, pods: preemptorPods}
 				}
 
-				preemptedInMemory, err := pe.PreemptPod(ctx, &candidate{name: "fake-node"}, preemptor, victimPod, "test-plugin")
+				willProduceDeletionEvent, err := pe.PreemptPod(ctx, &candidate{name: "fake-node"}, preemptor, victimPod, "test-plugin")
 				if err != nil {
 					t.Fatal(err)
 				}
-				if preemptedInMemory != (tt.addVictimToPrebind || tt.addVictimToWaiting) {
-					t.Errorf("PreemptPod() preemptedInMemory = %v, want %v", preemptedInMemory, tt.addVictimToPrebind || tt.addVictimToWaiting)
+				wantDeletionEvent := !tt.addVictimToPrebind && !tt.addVictimToWaiting
+				if willProduceDeletionEvent != wantDeletionEvent {
+					t.Errorf("PreemptPod() willProduceDeletionEvent = %v, want %v", willProduceDeletionEvent, wantDeletionEvent)
 				}
 				if tt.expectCancel {
 					if victimCtx.Err() == nil {

--- a/test/integration/scheduler/preemption/asyncframework/async_framework.go
+++ b/test/integration/scheduler/preemption/asyncframework/async_framework.go
@@ -150,6 +150,8 @@ type Step struct {
 	// WaitForPodsDeleted waits for the specified pods to be deleted from the cluster.
 	// The value is the array of Pod indexes representing the order of Pod creation.
 	WaitForPodsDeleted []int
+	// DeletePod deletes a Pod by name and waits until it is gone from the API and informer.
+	DeletePod string
 }
 
 // AsyncPreemptionStepRunnerConfig is a configuration for running async preemption test steps.
@@ -193,6 +195,8 @@ func RunAsyncPreemptionSteps(testCtx *testutils.TestContext, t *testing.T, steps
 			testCtx.Scheduler.SchedulingQueue.MoveAllToActiveOrBackoffQueue(config.Logger, framework.EventUnschedulableTimeout, nil, nil, nil)
 		case len(step.WaitForPodsDeleted) != 0:
 			waitForPodsDeleted(testCtx, t, step.WaitForPodsDeleted, config.CreatedPods, config.ClientSet)
+		case step.DeletePod != "":
+			deletePod(testCtx, t, step.DeletePod, config.ClientSet)
 		}
 	}
 }
@@ -352,6 +356,41 @@ func registerDelayedPreemptionPlugin(registry *frameworkruntime.Registry, preemp
 		return preemptionPlugin, nil
 	})
 	return delayedPreemptionPluginName, func() *defaultpreemption.DefaultPreemption { return preemptionPlugin }, err
+}
+
+func deletePod(testCtx *testutils.TestContext, t *testing.T, podName string, cs kubernetes.Interface) {
+	gracePeriod := int64(0)
+	if err := cs.CoreV1().Pods(testCtx.NS.Name).Delete(testCtx.Ctx, podName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}); err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("Failed to delete Pod %q: %v", podName, err)
+	}
+	// Wait until the Pod is fully gone from the API so a later PreemptPod call observes NotFound
+	// and reports that it will not produce a deletion event.
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(ctx context.Context) (bool, error) {
+		_, err := cs.CoreV1().Pods(testCtx.NS.Name).Get(ctx, podName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Failed to wait for pod %s to be deleted: %v", podName, err)
+	}
+	// Wait for the informer as well so AssignedPodDelete has been delivered to the scheduling queue
+	// while the preemptor is still gated.
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(_ context.Context) (bool, error) {
+		_, err := testCtx.InformerFactory.Core().V1().Pods().Lister().Pods(testCtx.NS.Name).Get(podName)
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Failed to wait for pod %s deletion to propagate to the informer: %v", podName, err)
+	}
 }
 
 func waitForPodsDeleted(testCtx *testutils.TestContext, t *testing.T, podIndexes []int, createdPods []*v1.Pod, cs kubernetes.Interface) {

--- a/test/integration/scheduler/preemption/podgroup/podgrouppreemption_test.go
+++ b/test/integration/scheduler/preemption/podgroup/podgrouppreemption_test.go
@@ -3338,6 +3338,79 @@ func TestPodGroupAsyncPreemption(t *testing.T) {
 			},
 		},
 		{
+			// Victim deletion events that arrive while the preemptor is gated are consumed
+			// without activating it. Completing preemption then produces no new deletion event
+			// (victims are already gone), so the executor must activate the preemptor itself.
+			// Two victims are required: with a single victim, lastVictimsPendingPreemption is
+			// populated before PreemptPod blocks, so deleting that victim would ungate the
+			// preemptor via PreEnqueue and the test would pass even without Activate.
+			Name: "preemptor is activated when async preemption produces no deletion event",
+			Steps: []asyncframework.Step{
+				{
+					Name:       "create Node",
+					CreateNode: "node",
+				},
+				{
+					Name: "create first victim",
+					CreatePod: &asyncframework.CreatePod{
+						Pod: st.MakePod().Name("victim-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Node("node").Container("image").ZeroTerminationGracePeriod().Priority(1).Obj(),
+					},
+				},
+				{
+					Name: "create second victim",
+					CreatePod: &asyncframework.CreatePod{
+						Pod: st.MakePod().Name("victim-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Node("node").Container("image").ZeroTerminationGracePeriod().Priority(1).Obj(),
+					},
+				},
+				{
+					Name: "create pod group for preemptor",
+					CreatePodGroup: &asyncframework.CreatePodGroup{
+						PodGroup: st.MakePodGroup().Name("pg-preemptor").MinCount(1).Priority(100).Obj(),
+					},
+				},
+				{
+					Name: "create a preemptor Pod",
+					CreatePod: &asyncframework.CreatePod{
+						Pod: st.MakePod().Name("preemptor").Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Container("image").Priority(100).PodGroupName("pg-preemptor").Obj(),
+					},
+				},
+				{
+					Name: "schedule the preemptor Pod",
+					SchedulePodGroup: &asyncframework.SchedulePodGroup{
+						PodGroupName:        "pg-preemptor",
+						ExpectUnschedulable: true,
+					},
+				},
+				{
+					Name:            "check the preemptor Pod is gated",
+					PodGatedInQueue: "preemptor",
+				},
+				{
+					Name:                 "check the preemptor Pod making the preemption API calls",
+					PodRunningPreemption: new(2),
+				},
+				{
+					Name:      "delete first victim while preemption is in flight",
+					DeletePod: "victim-1",
+				},
+				{
+					Name:      "delete second victim while preemption is in flight",
+					DeletePod: "victim-2",
+				},
+				{
+					Name:               "complete the preemption; executor must activate the preemptor",
+					CompletePreemption: "pg-preemptor",
+				},
+				{
+					Name: "schedule the preemptor Pod after victims were deleted externally",
+					SchedulePodGroup: &asyncframework.SchedulePodGroup{
+						PodGroupName:  "pg-preemptor",
+						ExpectSuccess: true,
+					},
+				},
+			},
+		},
+		{
 			Name: "gated preemptor is eventually scheduled even if victim deletion doesn't raise queue hints",
 			Steps: []asyncframework.Step{
 				{

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -43,8 +43,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	configtesting "k8s.io/kubernetes/pkg/scheduler/apis/config/testing"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
-	preemptionframework "k8s.io/kubernetes/pkg/scheduler/framework/preemption"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testfwk "k8s.io/kubernetes/test/integration/framework"
@@ -1634,6 +1632,73 @@ func TestAsyncPreemption(t *testing.T) {
 			},
 		},
 		{
+			// Victim deletion events that arrive while the preemptor is gated are consumed
+			// without activating it. Completing preemption then produces no new deletion event
+			// (victims are already gone), so the executor must activate the preemptor itself.
+			// Two victims are required: with a single victim, lastVictimsPendingPreemption is
+			// populated before PreemptPod blocks, so deleting that victim would ungate the
+			// preemptor via PreEnqueue and the test would pass even without Activate.
+			Name: "preemptor is activated when async preemption produces no deletion event",
+			Steps: []asyncframework.Step{
+				{
+					Name:       "create Node",
+					CreateNode: "node",
+				},
+				{
+					Name: "create first victim",
+					CreatePod: &asyncframework.CreatePod{
+						Pod: st.MakePod().Name("victim-1").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Node("node").Container("image").ZeroTerminationGracePeriod().Priority(1).Obj(),
+					},
+				},
+				{
+					Name: "create second victim",
+					CreatePod: &asyncframework.CreatePod{
+						Pod: st.MakePod().Name("victim-2").Req(map[v1.ResourceName]string{v1.ResourceCPU: "2"}).Node("node").Container("image").ZeroTerminationGracePeriod().Priority(1).Obj(),
+					},
+				},
+				{
+					Name: "create a preemptor Pod",
+					CreatePod: &asyncframework.CreatePod{
+						Pod: st.MakePod().Name("preemptor").Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Container("image").Priority(100).Obj(),
+					},
+				},
+				{
+					Name: "schedule the preemptor Pod",
+					SchedulePod: &asyncframework.SchedulePod{
+						PodName:             "preemptor",
+						ExpectUnschedulable: true,
+					},
+				},
+				{
+					Name:            "check the preemptor Pod is gated",
+					PodGatedInQueue: "preemptor",
+				},
+				{
+					Name:                 "check the preemptor Pod making the preemption API calls",
+					PodRunningPreemption: new(2),
+				},
+				{
+					Name:      "delete first victim while preemption is in flight",
+					DeletePod: "victim-1",
+				},
+				{
+					Name:      "delete second victim while preemption is in flight",
+					DeletePod: "victim-2",
+				},
+				{
+					Name:               "complete the preemption; executor must activate the preemptor",
+					CompletePreemption: "preemptor",
+				},
+				{
+					Name: "schedule the preemptor Pod after victims were deleted externally",
+					SchedulePod: &asyncframework.SchedulePod{
+						PodName:       "preemptor",
+						ExpectSuccess: true,
+					},
+				},
+			},
+		},
+		{
 			Name: "gated preemptor is eventually scheduled even if victim deletion doesn't raise queue hints",
 			Steps: []asyncframework.Step{
 				{
@@ -1902,132 +1967,6 @@ func TestAsyncPreemption(t *testing.T) {
 			}
 			asyncframework.RunAsyncPreemptionSteps(testCtx, t, test.Steps, config)
 		})
-	}
-}
-
-func TestAsyncPreemptionRequeuesAfterDeletionEventConsumedInFlight(t *testing.T) {
-	preemptionDoneChannels := &sync.Map{}
-	blockBindingChannel := make(chan struct{})
-	defer close(blockBindingChannel)
-
-	testCtx, preemptionPlugin, cs := asyncframework.InitTestForAsyncPreemption(t, asyncframework.AsyncPreemptionTestConfig{
-		PreemptionDoneChannels: preemptionDoneChannels,
-		BlockBindingChannel:    blockBindingChannel,
-	})
-	logger, _ := ktesting.NewTestContext(t)
-	if testCtx.Scheduler.APIDispatcher != nil {
-		testCtx.Scheduler.APIDispatcher.Run(logger)
-		defer testCtx.Scheduler.APIDispatcher.Close()
-	}
-	testCtx.Scheduler.SchedulingQueue.Run(logger)
-	defer testCtx.Scheduler.SchedulingQueue.Close()
-
-	node := st.MakeNode().Name("node").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj()
-	if _, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
-		t.Fatalf("Failed to create Node %q: %v", node.Name, err)
-	}
-	if err := testutils.WaitForNodesInCache(testCtx.Ctx, testCtx.Scheduler, 1); err != nil {
-		t.Fatal(err)
-	}
-
-	victim := st.MakePod().Name("victim").Namespace(testCtx.NS.Name).Node(node.Name).
-		Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Container("image").ZeroTerminationGracePeriod().Priority(1).Obj()
-	victim, err := cs.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, victim, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Failed to create victim Pod: %v", err)
-	}
-	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(context.Context) (bool, error) {
-		_, err := testCtx.Scheduler.Cache.GetPod(victim)
-		return err == nil, nil
-	}); err != nil {
-		t.Fatalf("Victim Pod did not reach the scheduler cache: %v", err)
-	}
-
-	preemptor := st.MakePod().Name("preemptor").Namespace(testCtx.NS.Name).
-		Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Container("image").Priority(100).Obj()
-	preemptor, err = cs.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, preemptor, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Failed to create preemptor Pod: %v", err)
-	}
-	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(context.Context) (bool, error) {
-		for _, pod := range testCtx.Scheduler.SchedulingQueue.PodsInActiveQ() {
-			if pod.UID == preemptor.UID {
-				return true, nil
-			}
-		}
-		return false, nil
-	}); err != nil {
-		t.Fatalf("Preemptor Pod did not reach the active queue: %v", err)
-	}
-
-	preemptPodStarted := make(chan struct{})
-	allowPreemptPodToFinish := make(chan struct{})
-	var preemptPodStartedOnce sync.Once
-	preemptionPlugin.Executor.PreemptPod = func(_ context.Context, _ preemptionframework.Candidate, _ preemptionframework.ExecutorPreemptor, _ *v1.Pod, _ string) (bool, error) {
-		preemptPodStartedOnce.Do(func() { close(preemptPodStarted) })
-		<-allowPreemptPodToFinish
-		// Simulate the redundant preemption finding that the victim was already deleted.
-		return false, nil
-	}
-
-	failureHandlerStarted := make(chan struct{})
-	allowFailureHandlerToFinish := make(chan struct{})
-	var failureHandlerStartedOnce sync.Once
-	originalFailureHandler := testCtx.Scheduler.FailureHandler
-	testCtx.Scheduler.FailureHandler = func(ctx context.Context, f schedulerframework.Framework, podInfo *schedulerframework.QueuedPodInfo, status *fwk.Status, nominatingInfo *fwk.NominatingInfo, start time.Time) {
-		failureHandlerStartedOnce.Do(func() { close(failureHandlerStarted) })
-		<-allowFailureHandlerToFinish
-		originalFailureHandler(ctx, f, podInfo, status, nominatingInfo, start)
-	}
-
-	var releasePreemptionOnce sync.Once
-	releasePreemption := func() { releasePreemptionOnce.Do(func() { close(allowPreemptPodToFinish) }) }
-	defer releasePreemption()
-	var releaseFailureHandlerOnce sync.Once
-	releaseFailureHandler := func() { releaseFailureHandlerOnce.Do(func() { close(allowFailureHandlerToFinish) }) }
-	defer releaseFailureHandler()
-
-	schedulingCycleDone := make(chan struct{})
-	go func() {
-		defer close(schedulingCycleDone)
-		testCtx.Scheduler.ScheduleOne(testCtx.Ctx)
-	}()
-
-	for name, ch := range map[string]<-chan struct{}{
-		"async preemption": preemptPodStarted,
-		"failure handling": failureHandlerStarted,
-	} {
-		select {
-		case <-ch:
-		case <-time.After(wait.ForeverTestTimeout):
-			t.Fatalf("Timed out waiting for %s to start", name)
-		}
-	}
-
-	// Record the earlier victim deletion while this retry cycle is in flight. The failure handler then
-	// consumes that event while async preemption is still pending, so PreEnqueue gates the preemptor.
-	testCtx.Scheduler.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, schedulerframework.EventAssignedPodDelete, victim, nil, nil)
-	releaseFailureHandler()
-	select {
-	case <-schedulingCycleDone:
-	case <-time.After(wait.ForeverTestTimeout):
-		t.Fatal("Timed out waiting for the scheduling cycle to finish")
-	}
-	if !asyncframework.PodInUnschedulablePodPool(t, testCtx.Scheduler.SchedulingQueue, preemptor.Name) {
-		t.Fatal("Expected the preemptor to be gated in the unschedulable pool while async preemption is pending")
-	}
-
-	// No new deletion event follows the redundant preemption. Completion itself must activate the preemptor.
-	releasePreemption()
-	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(context.Context) (bool, error) {
-		for _, pod := range testCtx.Scheduler.SchedulingQueue.PodsInActiveQ() {
-			if pod.UID == preemptor.UID {
-				return true, nil
-			}
-		}
-		return false, nil
-	}); err != nil {
-		t.Fatalf("Preemptor was not activated after no-op async preemption completed: %v", err)
 	}
 }
 

--- a/test/integration/scheduler/preemption/preemption_test.go
+++ b/test/integration/scheduler/preemption/preemption_test.go
@@ -43,6 +43,8 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 	configtesting "k8s.io/kubernetes/pkg/scheduler/apis/config/testing"
+	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+	preemptionframework "k8s.io/kubernetes/pkg/scheduler/framework/preemption"
 	frameworkruntime "k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 	st "k8s.io/kubernetes/pkg/scheduler/testing"
 	testfwk "k8s.io/kubernetes/test/integration/framework"
@@ -1900,6 +1902,132 @@ func TestAsyncPreemption(t *testing.T) {
 			}
 			asyncframework.RunAsyncPreemptionSteps(testCtx, t, test.Steps, config)
 		})
+	}
+}
+
+func TestAsyncPreemptionRequeuesAfterDeletionEventConsumedInFlight(t *testing.T) {
+	preemptionDoneChannels := &sync.Map{}
+	blockBindingChannel := make(chan struct{})
+	defer close(blockBindingChannel)
+
+	testCtx, preemptionPlugin, cs := asyncframework.InitTestForAsyncPreemption(t, asyncframework.AsyncPreemptionTestConfig{
+		PreemptionDoneChannels: preemptionDoneChannels,
+		BlockBindingChannel:    blockBindingChannel,
+	})
+	logger, _ := ktesting.NewTestContext(t)
+	if testCtx.Scheduler.APIDispatcher != nil {
+		testCtx.Scheduler.APIDispatcher.Run(logger)
+		defer testCtx.Scheduler.APIDispatcher.Close()
+	}
+	testCtx.Scheduler.SchedulingQueue.Run(logger)
+	defer testCtx.Scheduler.SchedulingQueue.Close()
+
+	node := st.MakeNode().Name("node").Capacity(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Obj()
+	if _, err := cs.CoreV1().Nodes().Create(testCtx.Ctx, node, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Failed to create Node %q: %v", node.Name, err)
+	}
+	if err := testutils.WaitForNodesInCache(testCtx.Ctx, testCtx.Scheduler, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	victim := st.MakePod().Name("victim").Namespace(testCtx.NS.Name).Node(node.Name).
+		Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Container("image").ZeroTerminationGracePeriod().Priority(1).Obj()
+	victim, err := cs.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, victim, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create victim Pod: %v", err)
+	}
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(context.Context) (bool, error) {
+		_, err := testCtx.Scheduler.Cache.GetPod(victim)
+		return err == nil, nil
+	}); err != nil {
+		t.Fatalf("Victim Pod did not reach the scheduler cache: %v", err)
+	}
+
+	preemptor := st.MakePod().Name("preemptor").Namespace(testCtx.NS.Name).
+		Req(map[v1.ResourceName]string{v1.ResourceCPU: "4"}).Container("image").Priority(100).Obj()
+	preemptor, err = cs.CoreV1().Pods(testCtx.NS.Name).Create(testCtx.Ctx, preemptor, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create preemptor Pod: %v", err)
+	}
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(context.Context) (bool, error) {
+		for _, pod := range testCtx.Scheduler.SchedulingQueue.PodsInActiveQ() {
+			if pod.UID == preemptor.UID {
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Preemptor Pod did not reach the active queue: %v", err)
+	}
+
+	preemptPodStarted := make(chan struct{})
+	allowPreemptPodToFinish := make(chan struct{})
+	var preemptPodStartedOnce sync.Once
+	preemptionPlugin.Executor.PreemptPod = func(_ context.Context, _ preemptionframework.Candidate, _ preemptionframework.ExecutorPreemptor, _ *v1.Pod, _ string) (bool, error) {
+		preemptPodStartedOnce.Do(func() { close(preemptPodStarted) })
+		<-allowPreemptPodToFinish
+		// Simulate the redundant preemption finding that the victim was already deleted.
+		return false, nil
+	}
+
+	failureHandlerStarted := make(chan struct{})
+	allowFailureHandlerToFinish := make(chan struct{})
+	var failureHandlerStartedOnce sync.Once
+	originalFailureHandler := testCtx.Scheduler.FailureHandler
+	testCtx.Scheduler.FailureHandler = func(ctx context.Context, f schedulerframework.Framework, podInfo *schedulerframework.QueuedPodInfo, status *fwk.Status, nominatingInfo *fwk.NominatingInfo, start time.Time) {
+		failureHandlerStartedOnce.Do(func() { close(failureHandlerStarted) })
+		<-allowFailureHandlerToFinish
+		originalFailureHandler(ctx, f, podInfo, status, nominatingInfo, start)
+	}
+
+	var releasePreemptionOnce sync.Once
+	releasePreemption := func() { releasePreemptionOnce.Do(func() { close(allowPreemptPodToFinish) }) }
+	defer releasePreemption()
+	var releaseFailureHandlerOnce sync.Once
+	releaseFailureHandler := func() { releaseFailureHandlerOnce.Do(func() { close(allowFailureHandlerToFinish) }) }
+	defer releaseFailureHandler()
+
+	schedulingCycleDone := make(chan struct{})
+	go func() {
+		defer close(schedulingCycleDone)
+		testCtx.Scheduler.ScheduleOne(testCtx.Ctx)
+	}()
+
+	for name, ch := range map[string]<-chan struct{}{
+		"async preemption": preemptPodStarted,
+		"failure handling": failureHandlerStarted,
+	} {
+		select {
+		case <-ch:
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Fatalf("Timed out waiting for %s to start", name)
+		}
+	}
+
+	// Record the earlier victim deletion while this retry cycle is in flight. The failure handler then
+	// consumes that event while async preemption is still pending, so PreEnqueue gates the preemptor.
+	testCtx.Scheduler.SchedulingQueue.MoveAllToActiveOrBackoffQueue(logger, schedulerframework.EventAssignedPodDelete, victim, nil, nil)
+	releaseFailureHandler()
+	select {
+	case <-schedulingCycleDone:
+	case <-time.After(wait.ForeverTestTimeout):
+		t.Fatal("Timed out waiting for the scheduling cycle to finish")
+	}
+	if !asyncframework.PodInUnschedulablePodPool(t, testCtx.Scheduler.SchedulingQueue, preemptor.Name) {
+		t.Fatal("Expected the preemptor to be gated in the unschedulable pool while async preemption is pending")
+	}
+
+	// No new deletion event follows the redundant preemption. Completion itself must activate the preemptor.
+	releasePreemption()
+	if err := wait.PollUntilContextTimeout(testCtx.Ctx, 50*time.Millisecond, wait.ForeverTestTimeout, false, func(context.Context) (bool, error) {
+		for _, pod := range testCtx.Scheduler.SchedulingQueue.PodsInActiveQ() {
+			if pod.UID == preemptor.UID {
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Preemptor was not activated after no-op async preemption completed: %v", err)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:

#### Which issue(s) this PR is related to:
Fixes #141694


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed a five-minute scheduling delay when an asynchronous preemption victim was already deleted.
```
