### PR TITLE
Measure coverage of storage tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/etcd3"
 	etcd3testing "k8s.io/apiserver/pkg/storage/etcd3/testing"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
+	"k8s.io/apiserver/pkg/storage/testing/coverage"
 	"k8s.io/apiserver/pkg/storage/value"
 	"k8s.io/apiserver/pkg/storage/value/encrypt/identity"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -259,6 +260,14 @@ func TestListPaging(t *testing.T) {
 }
 
 func TestLists(t *testing.T) {
+	var tracker *coverage.CoverageTracker
+	if coverage.IsEnabled() {
+		tracker = coverage.NewTracker()
+		t.Cleanup(func() {
+			t.Log(tracker.FormatScorecard(coverage.SectionList))
+		})
+	}
+
 	for _, listFromCacheSnapshot := range []bool{true, false} {
 		t.Run(fmt.Sprintf("ListFromCacheSnapshot=%v", listFromCacheSnapshot), func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ListFromCacheSnapshot, listFromCacheSnapshot)
@@ -266,21 +275,24 @@ func TestLists(t *testing.T) {
 				t.Parallel()
 				ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 				t.Cleanup(terminate)
-				storagetesting.RunTestList(ctx, t, cacher, compactStore(cacher, server.V3Client.Client), true, server.V3Client.Kubernetes.(*storagetesting.KubernetesRecorder))
+				wrappedStore := coverage.Wrap(cacher, tracker)
+				storagetesting.RunTestList(ctx, t, wrappedStore, compactStore(cacher, server.V3Client.Client), true, server.V3Client.Kubernetes.(*storagetesting.KubernetesRecorder))
 			})
 
 			t.Run("ConsistentList", func(t *testing.T) {
 				t.Parallel()
 				ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 				t.Cleanup(terminate)
-				storagetesting.RunTestConsistentList(ctx, t, cacher, increaseRVFunc(server.V3Client.Client), true, true, listFromCacheSnapshot)
+				wrappedStore := coverage.Wrap(cacher, tracker)
+				storagetesting.RunTestConsistentList(ctx, t, wrappedStore, increaseRVFunc(server.V3Client.Client), true, true, listFromCacheSnapshot)
 			})
 
 			t.Run("GetListNonRecursive", func(t *testing.T) {
 				t.Parallel()
 				ctx, cacher, server, terminate := testSetupWithEtcdServer(t)
 				t.Cleanup(terminate)
-				storagetesting.RunTestGetListNonRecursive(ctx, t, increaseRVFunc(server.V3Client.Client), cacher)
+				wrappedStore := coverage.Wrap(cacher, tracker)
+				storagetesting.RunTestGetListNonRecursive(ctx, t, increaseRVFunc(server.V3Client.Client), wrappedStore)
 			})
 		})
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -54,6 +54,7 @@ import (
 	etcdfeature "k8s.io/apiserver/pkg/storage/feature"
 	storagemetrics "k8s.io/apiserver/pkg/storage/metrics"
 	storagetesting "k8s.io/apiserver/pkg/storage/testing"
+	"k8s.io/apiserver/pkg/storage/testing/coverage"
 	"k8s.io/apiserver/pkg/storage/value"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -341,13 +342,22 @@ func TestTransformationFailure(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
+	var tracker *coverage.CoverageTracker
+	if coverage.IsEnabled() {
+		tracker = coverage.NewTracker()
+		t.Cleanup(func() {
+			t.Log(tracker.FormatScorecard(coverage.SectionList))
+		})
+	}
+
 	for _, rangeStream := range []bool{false, true} {
 		t.Run(fmt.Sprintf("rangeStream=%v", rangeStream), func(t *testing.T) {
 			featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.EtcdRangeStream, rangeStream)
 			resetFeatureSupportCheckerDuringTest(t)
 			ctx, store, client := testSetup(t)
+			wrappedStore := coverage.Wrap(store, tracker)
 			kvRecorder := client.KV.(*storagetesting.KVRecorder)
-			storagetesting.RunTestList(ctx, t, store, compactStorage(store, client.Client), false, client.Kubernetes.(*storagetesting.KubernetesRecorder))
+			storagetesting.RunTestList(ctx, t, wrappedStore, compactStorage(store, client.Client), false, client.Kubernetes.(*storagetesting.KubernetesRecorder))
 			streamReads := kvRecorder.GetStreamReadsAndReset()
 			if rangeStream && streamReads == 0 {
 				t.Error("expected lists to be served by RangeStream")

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/categories.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/categories.go
@@ -1,0 +1,248 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+// Category defines an individual API state category tracked in the coverage matrix.
+type Category string
+
+const (
+	// =========================================================================
+	// 1. GET CATEGORIES (16 categories)
+	// =========================================================================
+	CategoryGetRVQuorumLatest Category = "Get RV: Quorum / Latest (\"\")"
+	CategoryGetRVCacheAny     Category = "Get RV: Cache-Any (\"0\")"
+	CategoryGetRVPastSnapshot Category = "Get RV: Past Committed Snapshot"
+	CategoryGetRVFuture       Category = "Get RV: Future / Too Large"
+	CategoryGetRVCompacted    Category = "Get RV: Compacted / Too Old"
+	CategoryGetRVMalformed    Category = "Get RV: Malformed (\"abc\")"
+
+	CategoryGetKeyExisting            Category = "Get Key: Existing Object"
+	CategoryGetKeyNonExisting         Category = "Get Key: Non-Existing Object"
+	CategoryGetOptIgnoreNotFoundTrue  Category = "Get Option: IgnoreNotFound (true)"
+	CategoryGetOptIgnoreNotFoundFalse Category = "Get Option: IgnoreNotFound (false)"
+
+	CategoryGetOutcomeFound           Category = "Get Outcome: Found Object"
+	CategoryGetOutcomeNotFound        Category = "Get Outcome: NotFound (404)"
+	CategoryGetOutcomeIgnoredNotFound Category = "Get Outcome: Ignored NotFound (nil, err=nil)"
+	CategoryGetOutcomeErrTooLarge     Category = "Get Outcome: Err TooLarge"
+	CategoryGetOutcomeErrTooOld       Category = "Get Outcome: Err TooOld / Expired"
+	CategoryGetOutcomeErrInvalid      Category = "Get Outcome: Err Invalid / Parse"
+
+	// =========================================================================
+	// 2. LIST CATEGORIES (29 categories)
+	// =========================================================================
+	CategoryListRVQuorumLatest Category = "List RV: Quorum / Latest (\"\")"
+	CategoryListRVCacheAny     Category = "List RV: Cache-Any (\"0\")"
+	CategoryListRVPastSnapshot Category = "List RV: Past Committed Snapshot"
+	CategoryListRVFuture       Category = "List RV: Future / Too Large"
+	CategoryListRVCompacted    Category = "List RV: Compacted / Too Old"
+	CategoryListRVMalformed    Category = "List RV: Malformed (\"abc\")"
+
+	CategoryListMatchUnset    Category = "List Match: Unset"
+	CategoryListMatchExact    Category = "List Match: Exact"
+	CategoryListMatchNotOlder Category = "List Match: NotOlderThan"
+	CategoryListMatchInvalid  Category = "List Match: Invalid"
+
+	CategoryListPagingUnpaged   Category = "List Pagination: Unpaged"
+	CategoryListPagingInitChunk Category = "List Pagination: Initial Chunk (Limit > 0)"
+	CategoryListPagingContinued Category = "List Pagination: Continue Token Drained"
+	CategoryListPagingConflict  Category = "List Pagination: RV + Continue Conflict"
+
+	CategoryListScopeRoot      Category = "List Scope: Root Prefix (/pods/)"
+	CategoryListScopeSubtree   Category = "List Scope: Subtree Namespace (/pods/nsX/)"
+	CategoryListScopeSingleKey Category = "List Scope: Non-Recursive Key"
+
+	CategoryListFilterEverything Category = "List Filter: Unfiltered (Everything)"
+	CategoryListFilterLabelMatch Category = "List Filter: Label Selector"
+	CategoryListFilterFieldMatch Category = "List Filter: Field Selector"
+	CategoryListFilterZeroMatch  Category = "List Filter: Zero Match Filter"
+
+	CategoryListOutcomeSuccessFull  Category = "List Outcome: Success Full"
+	CategoryListOutcomeSuccessPaged Category = "List Outcome: Success Paged"
+	CategoryListOutcomeSuccessEmpty Category = "List Outcome: Success Empty"
+	CategoryListOutcomeErrTooLarge  Category = "List Outcome: Err TooLarge"
+	CategoryListOutcomeErrTooOld    Category = "List Outcome: Err TooOld / Expired"
+	CategoryListOutcomeErrInvalid   Category = "List Outcome: Err Invalid / Parse"
+
+	// =========================================================================
+	// 3. WATCH CATEGORIES (18 categories)
+	// =========================================================================
+	CategoryWatchModeStandardLive     Category = "Watch Mode: Standard Live Stream (RV != \"\")"
+	CategoryWatchModeFromZeroHistory  Category = "Watch Mode: History Stream (RV = \"0\" / \"1\")"
+	CategoryWatchModeWatchListInitial Category = "Watch Mode: WatchList Snapshot (SendInitialEvents)"
+	CategoryWatchModeHistoricalRV     Category = "Watch Mode: Historical Stream (RV = \"R\")"
+	CategoryWatchModeCompactedRV      Category = "Watch Mode: Compacted Stream"
+
+	CategoryWatchScopeRootPrefix Category = "Watch Scope: Root Prefix (/pods/)"
+	CategoryWatchScopeSubtree    Category = "Watch Scope: Subtree Namespace (/pods/nsX/)"
+	CategoryWatchScopeSingleKey  Category = "Watch Scope: Single Key"
+
+	CategoryWatchFilterEverything Category = "Watch Filter: Unfiltered (Everything)"
+	CategoryWatchFilterLabelMatch Category = "Watch Filter: Label Selector"
+	CategoryWatchFilterFieldMatch Category = "Watch Filter: Field Selector"
+
+	CategoryWatchEventAdded    Category = "Watch Event: Added (Create / Filter Enter)"
+	CategoryWatchEventModified Category = "Watch Event: Modified (Update in Filter)"
+	CategoryWatchEventDeleted  Category = "Watch Event: Deleted (Delete / Filter Exit)"
+
+	CategoryWatchBookmarkInitialEnd  Category = "Watch Bookmark: initial-events-end"
+	CategoryWatchBookmarkProgress    Category = "Watch Bookmark: Progress / Quiescent"
+	CategoryWatchOutcomeEventStream  Category = "Watch Outcome: Continuous Event Delivery"
+	CategoryWatchOutcomeCompactedErr Category = "Watch Outcome: Err TooOld / 410 Gone"
+
+	// =========================================================================
+	// 4. MUTATION CATEGORIES (17 categories)
+	// =========================================================================
+	CategoryMutCreate Category = "Mutation Op: Create"
+	CategoryMutUpdate Category = "Mutation Op: Update"
+	CategoryMutDelete Category = "Mutation Op: Delete"
+
+	CategoryMutPrecondNone       Category = "Precondition: None (Unconditional)"
+	CategoryMutPrecondMatchingRV Category = "Precondition: Matching ResourceVersion"
+	CategoryMutPrecondStaleRV    Category = "Precondition: Stale / Mismatched RV"
+
+	CategoryMutUpdateMutating         Category = "Update Path: Mutating State Change"
+	CategoryMutUpdateShortCircuit     Category = "Update Path: Short-Circuit / No-Op"
+	CategoryMutUpdateUpsert           Category = "Update Path: Upsert (IgnoreNotFound)"
+	CategoryMutUpdateCachedObj        Category = "Update Path: CachedObject Suggestion"
+	CategoryMutDeleteValidationReject Category = "Delete Path: Admission Validation Reject"
+	CategoryMutDeleteNotFound         Category = "Delete Path: Key Not Found"
+
+	CategoryMutOutcomeSuccess     Category = "Mutation Outcome: Success"
+	CategoryMutOutcomeKeyConflict Category = "Mutation Outcome: Key Already Exists (409)"
+	CategoryMutOutcomeNotFound    Category = "Mutation Outcome: Key Not Found (404)"
+	CategoryMutOutcomePrecondFail Category = "Mutation Outcome: Precondition Failed"
+	CategoryMutOutcomeRejectFail  Category = "Mutation Outcome: Validation Rejected"
+)
+
+// Section represents a group of related API state categories (Get, List, Watch, Mutation).
+type Section string
+
+const (
+	SectionGet                Section = "Get"
+	SectionList               Section = "List"
+	SectionWatch              Section = "Watch"
+	SectionCreateUpdateDelete Section = "Create / Update / Delete"
+)
+
+// SectionGroup groups categories under a section for structured reporting.
+type SectionGroup struct {
+	Section    Section
+	Categories []Category
+}
+
+// SectionCategories groups categories by method family for structured reporting.
+var SectionCategories = []SectionGroup{
+	{
+		Section: SectionGet,
+		Categories: []Category{
+			CategoryGetRVQuorumLatest,
+			CategoryGetRVCacheAny,
+			CategoryGetRVPastSnapshot,
+			CategoryGetRVFuture,
+			CategoryGetRVCompacted,
+			CategoryGetRVMalformed,
+			CategoryGetKeyExisting,
+			CategoryGetKeyNonExisting,
+			CategoryGetOptIgnoreNotFoundTrue,
+			CategoryGetOptIgnoreNotFoundFalse,
+			CategoryGetOutcomeFound,
+			CategoryGetOutcomeNotFound,
+			CategoryGetOutcomeIgnoredNotFound,
+			CategoryGetOutcomeErrTooLarge,
+			CategoryGetOutcomeErrTooOld,
+			CategoryGetOutcomeErrInvalid,
+		},
+	},
+	{
+		Section: SectionList,
+		Categories: []Category{
+			CategoryListRVQuorumLatest,
+			CategoryListRVCacheAny,
+			CategoryListRVPastSnapshot,
+			CategoryListRVFuture,
+			CategoryListRVCompacted,
+			CategoryListRVMalformed,
+			CategoryListMatchUnset,
+			CategoryListMatchExact,
+			CategoryListMatchNotOlder,
+			CategoryListMatchInvalid,
+			CategoryListPagingUnpaged,
+			CategoryListPagingInitChunk,
+			CategoryListPagingContinued,
+			CategoryListPagingConflict,
+			CategoryListScopeRoot,
+			CategoryListScopeSubtree,
+			CategoryListScopeSingleKey,
+			CategoryListFilterEverything,
+			CategoryListFilterLabelMatch,
+			CategoryListFilterFieldMatch,
+			CategoryListFilterZeroMatch,
+			CategoryListOutcomeSuccessFull,
+			CategoryListOutcomeSuccessPaged,
+			CategoryListOutcomeSuccessEmpty,
+			CategoryListOutcomeErrTooLarge,
+			CategoryListOutcomeErrTooOld,
+			CategoryListOutcomeErrInvalid,
+		},
+	},
+	{
+		Section: SectionWatch,
+		Categories: []Category{
+			CategoryWatchModeStandardLive,
+			CategoryWatchModeFromZeroHistory,
+			CategoryWatchModeWatchListInitial,
+			CategoryWatchModeHistoricalRV,
+			CategoryWatchModeCompactedRV,
+			CategoryWatchScopeRootPrefix,
+			CategoryWatchScopeSubtree,
+			CategoryWatchScopeSingleKey,
+			CategoryWatchFilterEverything,
+			CategoryWatchFilterLabelMatch,
+			CategoryWatchFilterFieldMatch,
+			CategoryWatchEventAdded,
+			CategoryWatchEventModified,
+			CategoryWatchEventDeleted,
+			CategoryWatchBookmarkInitialEnd,
+			CategoryWatchBookmarkProgress,
+			CategoryWatchOutcomeEventStream,
+			CategoryWatchOutcomeCompactedErr,
+		},
+	},
+	{
+		Section: SectionCreateUpdateDelete,
+		Categories: []Category{
+			CategoryMutCreate,
+			CategoryMutUpdate,
+			CategoryMutDelete,
+			CategoryMutPrecondNone,
+			CategoryMutPrecondMatchingRV,
+			CategoryMutPrecondStaleRV,
+			CategoryMutUpdateMutating,
+			CategoryMutUpdateShortCircuit,
+			CategoryMutUpdateUpsert,
+			CategoryMutUpdateCachedObj,
+			CategoryMutDeleteValidationReject,
+			CategoryMutDeleteNotFound,
+			CategoryMutOutcomeSuccess,
+			CategoryMutOutcomeKeyConflict,
+			CategoryMutOutcomeNotFound,
+			CategoryMutOutcomePrecondFail,
+			CategoryMutOutcomeRejectFail,
+		},
+	},
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/storage.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/storage.go
@@ -1,0 +1,153 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"context"
+	"flag"
+	"reflect"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+var (
+	coverageFlag    bool
+	overrideEnabled *bool
+	overrideMu      sync.RWMutex
+)
+
+func init() {
+	flag.BoolVar(&coverageFlag, "storage-coverage", false, "Enable storage API state coverage tracking and reporting")
+}
+
+func SetEnabled(enabled *bool) {
+	overrideMu.Lock()
+	defer overrideMu.Unlock()
+	overrideEnabled = enabled
+}
+
+func IsEnabled() bool {
+	overrideMu.RLock()
+	if overrideEnabled != nil {
+		defer overrideMu.RUnlock()
+		return *overrideEnabled
+	}
+	overrideMu.RUnlock()
+	return coverageFlag
+}
+
+// CoverageStorage transparently wraps a storage.Interface to intercept and classify all invocations.
+type CoverageStorage struct {
+	storage.Interface
+	tracker *CoverageTracker
+}
+
+func Wrap(store storage.Interface, tracker *CoverageTracker) storage.Interface {
+	if !IsEnabled() || tracker == nil {
+		return store
+	}
+	return &CoverageStorage{
+		Interface: store,
+		tracker:   tracker,
+	}
+}
+
+// Tracker returns the underlying CoverageTracker.
+func (s *CoverageStorage) Tracker() *CoverageTracker {
+	if s == nil {
+		return nil
+	}
+	return s.tracker
+}
+
+func (s *CoverageStorage) Versioner() storage.Versioner {
+	return s.Interface.Versioner()
+}
+
+func (s *CoverageStorage) Create(ctx context.Context, key string, obj, out runtime.Object, ttl uint64) error {
+	err := s.Interface.Create(ctx, key, obj, out, ttl)
+	s.tracker.RecordCreate(key, obj, out, ttl, err)
+	return err
+}
+
+func (s *CoverageStorage) Delete(ctx context.Context, key string, out runtime.Object, preconditions *storage.Preconditions, validateDeletion storage.ValidateObjectFunc, cachedExistingObject runtime.Object, opts storage.DeleteOptions) error {
+	validateReject := false
+	wrappedValidate := validateDeletion
+	if validateDeletion != nil {
+		wrappedValidate = func(ctx context.Context, obj runtime.Object) error {
+			vErr := validateDeletion(ctx, obj)
+			if vErr != nil {
+				validateReject = true
+			}
+			return vErr
+		}
+	}
+
+	err := s.Interface.Delete(ctx, key, out, preconditions, wrappedValidate, cachedExistingObject, opts)
+	s.tracker.RecordDelete(key, preconditions, validateReject, err)
+	return err
+}
+
+func (s *CoverageStorage) Watch(ctx context.Context, key string, opts storage.ListOptions) (watch.Interface, error) {
+	w, err := s.Interface.Watch(ctx, key, opts)
+	s.tracker.RecordWatch(key, opts, err)
+	if err != nil {
+		return nil, err
+	}
+	return newCoverageWatcher(w, key, opts, s.tracker), nil
+}
+
+func (s *CoverageStorage) Get(ctx context.Context, key string, opts storage.GetOptions, objPtr runtime.Object) error {
+	err := s.Interface.Get(ctx, key, opts, objPtr)
+	s.tracker.RecordGet(key, opts, objPtr, err)
+	return err
+}
+
+func (s *CoverageStorage) GetList(ctx context.Context, key string, opts storage.ListOptions, listObj runtime.Object) error {
+	err := s.Interface.GetList(ctx, key, opts, listObj)
+	s.tracker.RecordGetList(key, opts, listObj, err)
+	return err
+}
+
+func (s *CoverageStorage) GuaranteedUpdate(ctx context.Context, key string, destination runtime.Object, ignoreNotFound bool, preconditions *storage.Preconditions, tryUpdate storage.UpdateFunc, cachedExistingObject runtime.Object) error {
+	isShortCircuit := false
+	isMutating := false
+
+	wrappedUpdate := func(existing runtime.Object, res storage.ResponseMeta) (runtime.Object, *uint64, error) {
+		newObj, ttl, err := tryUpdate(existing, res)
+		if err != nil {
+			return nil, nil, err
+		}
+		if existing != nil && reflect.DeepEqual(existing, newObj) {
+			isShortCircuit = true
+		} else {
+			isMutating = true
+		}
+		return newObj, ttl, nil
+	}
+
+	err := s.Interface.GuaranteedUpdate(ctx, key, destination, ignoreNotFound, preconditions, wrappedUpdate, cachedExistingObject)
+	s.tracker.RecordUpdate(key, ignoreNotFound, preconditions, isMutating, isShortCircuit, cachedExistingObject != nil, err)
+	return err
+}
+
+func (s *CoverageStorage) ReadinessCheck() error {
+	return s.Interface.ReadinessCheck()
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/tracker.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/tracker.go
@@ -1,0 +1,397 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+// CoverageTracker collects and classifies operations against the 80 API state matrix.
+type CoverageTracker struct {
+	mu        sync.Mutex
+	versioner storage.Versioner
+	counts    map[Category]int64
+}
+
+// NewTracker creates a new thread-safe coverage tracker.
+func NewTracker() *CoverageTracker {
+	counts := make(map[Category]int64)
+	for _, sec := range SectionCategories {
+		for _, category := range sec.Categories {
+			counts[category] = 0
+		}
+	}
+	return &CoverageTracker{
+		versioner: storage.APIObjectVersioner{},
+		counts:    counts,
+	}
+}
+
+func (t *CoverageTracker) inc(cat Category) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.counts[cat]++
+}
+
+func (t *CoverageTracker) RecordGet(key string, opts storage.GetOptions, out runtime.Object, err error) {
+	// 1. RV Classification
+	switch opts.ResourceVersion {
+	case "":
+		t.inc(CategoryGetRVQuorumLatest)
+	case "0":
+		t.inc(CategoryGetRVCacheAny)
+	case "abc", "invalid":
+		t.inc(CategoryGetRVMalformed)
+	default:
+		if rv, parseErr := t.versioner.ParseResourceVersion(opts.ResourceVersion); parseErr == nil {
+			if rv > 1000000 {
+				t.inc(CategoryGetRVFuture)
+			} else {
+				t.inc(CategoryGetRVPastSnapshot)
+			}
+		} else {
+			t.inc(CategoryGetRVMalformed)
+		}
+	}
+
+	// 2. Options
+	if opts.IgnoreNotFound {
+		t.inc(CategoryGetOptIgnoreNotFoundTrue)
+	} else {
+		t.inc(CategoryGetOptIgnoreNotFoundFalse)
+	}
+
+	// 3. Outcomes
+	if err == nil {
+		if out != nil {
+			t.inc(CategoryGetKeyExisting)
+			t.inc(CategoryGetOutcomeFound)
+		} else {
+			t.inc(CategoryGetKeyNonExisting)
+			t.inc(CategoryGetOutcomeIgnoredNotFound)
+		}
+	} else {
+		if storage.IsNotFound(err) || apierrors.IsNotFound(err) {
+			t.inc(CategoryGetKeyNonExisting)
+			t.inc(CategoryGetOutcomeNotFound)
+		} else if storage.IsTooLargeResourceVersion(err) {
+			t.inc(CategoryGetOutcomeErrTooLarge)
+		} else if apierrors.IsResourceExpired(err) {
+			t.inc(CategoryGetRVCompacted)
+			t.inc(CategoryGetOutcomeErrTooOld)
+		} else if storage.IsInvalidObj(err) || apierrors.IsBadRequest(err) {
+			t.inc(CategoryGetOutcomeErrInvalid)
+		}
+	}
+}
+
+func (t *CoverageTracker) RecordGetList(key string, opts storage.ListOptions, out runtime.Object, err error) {
+	// 1. RV Classification
+	switch opts.ResourceVersion {
+	case "":
+		t.inc(CategoryListRVQuorumLatest)
+	case "0":
+		t.inc(CategoryListRVCacheAny)
+	case "abc", "invalid":
+		t.inc(CategoryListRVMalformed)
+	default:
+		if rv, parseErr := t.versioner.ParseResourceVersion(opts.ResourceVersion); parseErr == nil {
+			if rv > 1000000 {
+				t.inc(CategoryListRVFuture)
+			} else {
+				t.inc(CategoryListRVPastSnapshot)
+			}
+		} else {
+			t.inc(CategoryListRVMalformed)
+		}
+	}
+
+	// 2. Match Mode
+	switch opts.ResourceVersionMatch {
+	case "":
+		t.inc(CategoryListMatchUnset)
+	case metav1.ResourceVersionMatchExact:
+		t.inc(CategoryListMatchExact)
+	case metav1.ResourceVersionMatchNotOlderThan:
+		t.inc(CategoryListMatchNotOlder)
+	default:
+		t.inc(CategoryListMatchInvalid)
+	}
+
+	// 3. Pagination
+	limit := opts.Predicate.Limit
+	continueToken := opts.Predicate.Continue
+	if limit == 0 && continueToken == "" {
+		t.inc(CategoryListPagingUnpaged)
+	} else if limit > 0 && continueToken == "" {
+		t.inc(CategoryListPagingInitChunk)
+	} else if continueToken != "" {
+		t.inc(CategoryListPagingContinued)
+	}
+	if continueToken != "" && opts.ResourceVersion != "" && opts.ResourceVersion != "0" {
+		t.inc(CategoryListPagingConflict)
+	}
+
+	// 4. Scope
+	trimmed := strings.Trim(key, "/")
+	parts := strings.Split(trimmed, "/")
+	if !opts.Recursive {
+		t.inc(CategoryListScopeSingleKey)
+	} else if len(parts) <= 1 || trimmed == "pods" {
+		t.inc(CategoryListScopeRoot)
+	} else {
+		t.inc(CategoryListScopeSubtree)
+	}
+
+	// 5. Predicate / Filters
+	if opts.Predicate.Empty() {
+		t.inc(CategoryListFilterEverything)
+	}
+	if opts.Predicate.Label != nil && !opts.Predicate.Label.Empty() {
+		t.inc(CategoryListFilterLabelMatch)
+	}
+	if opts.Predicate.Field != nil && !opts.Predicate.Field.Empty() {
+		t.inc(CategoryListFilterFieldMatch)
+	}
+
+	// 6. Outcomes
+	if err == nil {
+		itemCount := 0
+		if listObj, ok := out.(metav1.ListInterface); ok {
+			_ = listObj
+		}
+		if list, listErr := meta.ExtractList(out); listErr == nil {
+			itemCount = len(list)
+		}
+		if continueToken != "" || limit > 0 {
+			t.inc(CategoryListOutcomeSuccessPaged)
+		} else if itemCount > 0 {
+			t.inc(CategoryListOutcomeSuccessFull)
+		} else {
+			t.inc(CategoryListOutcomeSuccessEmpty)
+			t.inc(CategoryListFilterZeroMatch)
+		}
+	} else {
+		if storage.IsTooLargeResourceVersion(err) {
+			t.inc(CategoryListOutcomeErrTooLarge)
+		} else if apierrors.IsResourceExpired(err) {
+			t.inc(CategoryListRVCompacted)
+			t.inc(CategoryListOutcomeErrTooOld)
+		} else if storage.IsInvalidObj(err) || apierrors.IsBadRequest(err) {
+			t.inc(CategoryListOutcomeErrInvalid)
+		}
+	}
+}
+
+func (t *CoverageTracker) RecordWatch(key string, opts storage.ListOptions, err error) {
+	if opts.SendInitialEvents != nil && *opts.SendInitialEvents {
+		t.inc(CategoryWatchModeWatchListInitial)
+	} else if opts.ResourceVersion == "" {
+		t.inc(CategoryWatchModeStandardLive)
+	} else if opts.ResourceVersion == "0" || opts.ResourceVersion == "1" {
+		t.inc(CategoryWatchModeFromZeroHistory)
+	} else {
+		t.inc(CategoryWatchModeHistoricalRV)
+	}
+
+	trimmed := strings.Trim(key, "/")
+	parts := strings.Split(trimmed, "/")
+	if !opts.Recursive {
+		t.inc(CategoryWatchScopeSingleKey)
+	} else if len(parts) <= 1 || trimmed == "pods" {
+		t.inc(CategoryWatchScopeRootPrefix)
+	} else {
+		t.inc(CategoryWatchScopeSubtree)
+	}
+
+	if opts.Predicate.Empty() {
+		t.inc(CategoryWatchFilterEverything)
+	}
+	if opts.Predicate.Label != nil && !opts.Predicate.Label.Empty() {
+		t.inc(CategoryWatchFilterLabelMatch)
+	}
+	if opts.Predicate.Field != nil && !opts.Predicate.Field.Empty() {
+		t.inc(CategoryWatchFilterFieldMatch)
+	}
+
+	if err != nil {
+		if apierrors.IsResourceExpired(err) {
+			t.inc(CategoryWatchModeCompactedRV)
+			t.inc(CategoryWatchOutcomeCompactedErr)
+		}
+	}
+}
+
+func (t *CoverageTracker) RecordWatchEvent(ev watch.Event) {
+	switch ev.Type {
+	case watch.Added:
+		t.inc(CategoryWatchEventAdded)
+		t.inc(CategoryWatchOutcomeEventStream)
+	case watch.Modified:
+		t.inc(CategoryWatchEventModified)
+		t.inc(CategoryWatchOutcomeEventStream)
+	case watch.Deleted:
+		t.inc(CategoryWatchEventDeleted)
+		t.inc(CategoryWatchOutcomeEventStream)
+	case watch.Bookmark:
+		isInitialEventsEnd := false
+		if metaObj, ok := ev.Object.(metav1.Object); ok {
+			if metaObj.GetAnnotations() != nil && metaObj.GetAnnotations()["k8s.io/initial-events-end"] == "true" {
+				isInitialEventsEnd = true
+			}
+		}
+		if isInitialEventsEnd {
+			t.inc(CategoryWatchBookmarkInitialEnd)
+		} else {
+			t.inc(CategoryWatchBookmarkProgress)
+		}
+	case watch.Error:
+		t.inc(CategoryWatchOutcomeCompactedErr)
+	}
+}
+
+func (t *CoverageTracker) RecordCreate(key string, obj runtime.Object, out runtime.Object, ttl uint64, err error) {
+	t.inc(CategoryMutCreate)
+	t.inc(CategoryMutPrecondNone)
+	if err == nil {
+		t.inc(CategoryMutOutcomeSuccess)
+	} else if storage.IsExist(err) || apierrors.IsAlreadyExists(err) {
+		t.inc(CategoryMutOutcomeKeyConflict)
+	} else if storage.IsInvalidObj(err) || apierrors.IsInvalid(err) {
+		t.inc(CategoryMutOutcomePrecondFail)
+	}
+}
+
+func (t *CoverageTracker) RecordUpdate(key string, ignoreNotFound bool, preconds *storage.Preconditions, isMutating bool, isShortCircuit bool, hasCachedObj bool, err error) {
+	t.inc(CategoryMutUpdate)
+
+	if preconds == nil {
+		t.inc(CategoryMutPrecondNone)
+	} else if preconds.ResourceVersion != nil {
+		if *preconds.ResourceVersion == "1" {
+			t.inc(CategoryMutPrecondStaleRV)
+		} else {
+			t.inc(CategoryMutPrecondMatchingRV)
+		}
+	}
+
+	if ignoreNotFound {
+		t.inc(CategoryMutUpdateUpsert)
+	}
+	if hasCachedObj {
+		t.inc(CategoryMutUpdateCachedObj)
+	}
+	if isShortCircuit {
+		t.inc(CategoryMutUpdateShortCircuit)
+	} else if isMutating {
+		t.inc(CategoryMutUpdateMutating)
+	}
+
+	if err == nil {
+		t.inc(CategoryMutOutcomeSuccess)
+	} else if storage.IsNotFound(err) || apierrors.IsNotFound(err) {
+		t.inc(CategoryMutOutcomeNotFound)
+	} else if storage.IsConflict(err) || storage.IsInvalidObj(err) || apierrors.IsConflict(err) {
+		t.inc(CategoryMutOutcomePrecondFail)
+	}
+}
+
+func (t *CoverageTracker) RecordDelete(key string, preconds *storage.Preconditions, validateReject bool, err error) {
+	t.inc(CategoryMutDelete)
+
+	if preconds == nil {
+		t.inc(CategoryMutPrecondNone)
+	} else if preconds.ResourceVersion != nil {
+		t.inc(CategoryMutPrecondMatchingRV)
+	}
+
+	if validateReject {
+		t.inc(CategoryMutDeleteValidationReject)
+	}
+
+	if err == nil {
+		t.inc(CategoryMutOutcomeSuccess)
+	} else if storage.IsNotFound(err) || apierrors.IsNotFound(err) {
+		t.inc(CategoryMutDeleteNotFound)
+		t.inc(CategoryMutOutcomeNotFound)
+	} else if storage.IsInvalidObj(err) {
+		t.inc(CategoryMutOutcomeRejectFail)
+	} else if storage.IsConflict(err) {
+		t.inc(CategoryMutOutcomePrecondFail)
+	}
+}
+
+// FormatScorecard renders the category matrix report as formatted plain text.
+// If sections are provided, only those sections are included in the report.
+func (t *CoverageTracker) FormatScorecard(sections ...Section) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	filter := make(map[Section]bool, len(sections))
+	for _, s := range sections {
+		filter[s] = true
+	}
+
+	var sb strings.Builder
+	sb.WriteString("\n========================================================================\n")
+	sb.WriteString("              KUBERNETES STORAGE API STATE COVERAGE SCORECARD            \n")
+	sb.WriteString("========================================================================\n")
+	sb.WriteString(fmt.Sprintf("%-50s | %8s | %s\n", "API State Category", "Hits", "Status"))
+	sb.WriteString("---------------------------------------------------+----------+---------\n")
+
+	totalCategories := 0
+	coveredCategories := 0
+
+	for _, sec := range SectionCategories {
+		if len(filter) > 0 && !filter[sec.Section] {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf(">>> %s\n", sec.Section))
+		sb.WriteString("---------------------------------------------------+----------+---------\n")
+		for _, cat := range sec.Categories {
+			totalCategories++
+			count := t.counts[cat]
+			status := "[ ] Missing"
+			if count > 0 {
+				coveredCategories++
+				status = fmt.Sprintf("[✓] Covered (%d)", count)
+			}
+			sb.WriteString(fmt.Sprintf("%-50s | %8d | %s\n", cat, count, status))
+		}
+		sb.WriteString("---------------------------------------------------+----------+---------\n")
+	}
+
+	pct := 0.0
+	if totalCategories > 0 {
+		pct = (float64(coveredCategories) / float64(totalCategories)) * 100.0
+	}
+
+	sb.WriteString("========================================================================\n")
+	sb.WriteString(fmt.Sprintf("TOTAL API STATES COVERED: %d / %d (%.1f%%)\n", coveredCategories, totalCategories, pct))
+	sb.WriteString("========================================================================\n")
+
+	return sb.String()
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/coverage/watcher.go
@@ -1,0 +1,63 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+type coverageWatcher struct {
+	underlying watch.Interface
+	key        string
+	opts       storage.ListOptions
+	tracker    *CoverageTracker
+	resultCh   chan watch.Event
+	stopOnce   sync.Once
+}
+
+func newCoverageWatcher(underlying watch.Interface, key string, opts storage.ListOptions, tracker *CoverageTracker) watch.Interface {
+	cw := &coverageWatcher{
+		underlying: underlying,
+		key:        key,
+		opts:       opts,
+		tracker:    tracker,
+		resultCh:   make(chan watch.Event),
+	}
+
+	go func() {
+		defer close(cw.resultCh)
+		for ev := range underlying.ResultChan() {
+			tracker.RecordWatchEvent(ev)
+			cw.resultCh <- ev
+		}
+	}()
+
+	return cw
+}
+
+func (w *coverageWatcher) Stop() {
+	w.stopOnce.Do(func() {
+		w.underlying.Stop()
+	})
+}
+
+func (w *coverageWatcher) ResultChan() <-chan watch.Event {
+	return w.resultCh
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/store_tests.go
@@ -650,7 +650,7 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 
 	getAttrs := func(obj runtime.Object) (labels.Set, fields.Set, error) {
 		pod := obj.(*example.Pod)
-		return nil, fields.Set{"metadata.name": pod.Name, "spec.nodeName": pod.Spec.NodeName}, nil
+		return labels.Set(pod.Labels), fields.Set{"metadata.name": pod.Name, "spec.nodeName": pod.Spec.NodeName}, nil
 	}
 	// Compact and increase RV to test consistent List.
 	compact(ctx, t, createdPods[0].ResourceVersion)
@@ -1422,6 +1422,44 @@ func RunTestList(ctx context.Context, t *testing.T, store storage.Interface, com
 			rv:          list.ResourceVersion,
 			rvMatch:     metav1.ResourceVersionMatchNotOlderThan,
 			expectedOut: []example.Pod{},
+		},
+		{
+			name:   "filter with label selector matching multiple items",
+			prefix: "/pods/",
+			pred: storage.SelectionPredicate{
+				Field: fields.Everything(),
+				Label: labels.SelectorFromSet(map[string]string{"app": "foo"}),
+			},
+			expectedOut: []example.Pod{*createdPods[2], *createdPods[4]},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				return nil
+			},
+		},
+		{
+			name:   "filter with label selector and pagination",
+			prefix: "/pods/",
+			pred: storage.SelectionPredicate{
+				Field: fields.Everything(),
+				Label: labels.SelectorFromSet(map[string]string{"app": "foo"}),
+				Limit: 1,
+			},
+			expectedOut:    []example.Pod{*createdPods[2]},
+			expectContinue: true,
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				return nil
+			},
+		},
+		{
+			name:   "filter with label selector matching zero items",
+			prefix: "/pods/",
+			pred: storage.SelectionPredicate{
+				Field: fields.Everything(),
+				Label: labels.SelectorFromSet(map[string]string{"app": "nonexistent"}),
+			},
+			expectedOut: []example.Pod{},
+			expectCacherRequestsToEtcd: func() []RecordedList {
+				return nil
+			},
 		},
 		{
 			name:        "test consistent List",
@@ -2478,12 +2516,12 @@ func seedMultiLevelData(ctx context.Context, store storage.Interface) (initialRV
 	//   - third/
 	//  |         - barfoo
 	//  |         - foo
-	barFirst := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "first", Name: "bar"}}
-	barSecond := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "second", Name: "bar"}}
-	fooSecond := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "second", Name: "foo"}}
-	bazSecond := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "second", Name: "baz"}}
-	barfooThird := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "third", Name: "barfoo"}}
-	fooThird := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "third", Name: "foo"}}
+	barFirst := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "first", Name: "bar", Labels: map[string]string{"app": "bar", "env": "prod"}}}
+	barSecond := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "second", Name: "bar", Labels: map[string]string{"app": "bar", "env": "prod"}}}
+	fooSecond := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "second", Name: "foo", Labels: map[string]string{"app": "foo", "env": "prod"}}}
+	bazSecond := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "second", Name: "baz", Labels: map[string]string{"app": "baz"}}}
+	barfooThird := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "third", Name: "barfoo", Labels: map[string]string{"app": "barfoo", "env": "dev"}}}
+	fooThird := &example.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "third", Name: "foo", Labels: map[string]string{"app": "foo", "env": "dev"}}}
 
 	preset := []struct {
 		key       string


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/pull/141729
```
        ========================================================================
                      KUBERNETES STORAGE API STATE COVERAGE SCORECARD            
        ========================================================================
        API State Category                                 |     Hits | Status
        ---------------------------------------------------+----------+---------
        >>> List
        ---------------------------------------------------+----------+---------
        List RV: Quorum / Latest ("")                      |       80 | [✓] Covered (80)
        List RV: Cache-Any ("0")                           |       20 | [✓] Covered (20)
        List RV: Past Committed Snapshot                   |      102 | [✓] Covered (102)
        List RV: Future / Too Large                        |        4 | [✓] Covered (4)
        List RV: Compacted / Too Old                       |        6 | [✓] Covered (6)
        List RV: Malformed ("abc")                         |        4 | [✓] Covered (4)
        List Match: Unset                                  |      112 | [✓] Covered (112)
        List Match: Exact                                  |       58 | [✓] Covered (58)
        List Match: NotOlderThan                           |       36 | [✓] Covered (36)
        List Match: Invalid                                |        4 | [✓] Covered (4)
        List Pagination: Unpaged                           |      110 | [✓] Covered (110)
        List Pagination: Initial Chunk (Limit > 0)         |       60 | [✓] Covered (60)
        List Pagination: Continue Token Drained            |       40 | [✓] Covered (40)
        List Pagination: RV + Continue Conflict            |        2 | [✓] Covered (2)
        List Scope: Root Prefix (/pods/)                   |      120 | [✓] Covered (120)
        List Scope: Subtree Namespace (/pods/nsX/)         |       66 | [✓] Covered (66)
        List Scope: Non-Recursive Key                      |       24 | [✓] Covered (24)
        List Filter: Unfiltered (Everything)               |      160 | [✓] Covered (160)
        List Filter: Label Selector                        |        6 | [✓] Covered (6)
        List Filter: Field Selector                        |       44 | [✓] Covered (44)
        List Filter: Zero Match Filter                     |       28 | [✓] Covered (28)
        List Outcome: Success Full                         |       64 | [✓] Covered (64)
        List Outcome: Success Paged                        |       92 | [✓] Covered (92)
        List Outcome: Success Empty                        |       28 | [✓] Covered (28)
        List Outcome: Err TooLarge                         |        6 | [✓] Covered (6)
        List Outcome: Err TooOld / Expired                 |        6 | [✓] Covered (6)
        List Outcome: Err Invalid / Parse                  |       10 | [✓] Covered (10)
        ---------------------------------------------------+----------+---------
        ========================================================================
        TOTAL API STATES COVERED: 27 / 27 (100.0%)
        ========================================================================
```

Prototype of automatic semantic coverage reporting for storage.
       
```release-note
NONE
```

```

#### AI usage disclosure:

Yes, AI was used to generate code to classify the requests. I read the code and rewrote some interfaces and cleaned part of code. Still need to cleanup more.
