### PR TITLE
Add a suggested FlowSchema for kube-proxy

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
@@ -70,6 +70,7 @@ var (
 	}
 	SuggestedFlowSchemas = []*flowcontrol.FlowSchema{
 		SuggestedFlowSchemaSystemNodes,               // references "system" priority-level
+		SuggestedFlowSchemaKubeProxy,                 // references "system" priority-level
 		SuggestedFlowSchemaSystemNodeHigh,            // references "node-high" priority-level
 		SuggestedFlowSchemaProbes,                    // references "exempt" priority-level
 		SuggestedFlowSchemaSystemLeaderElection,      // references "leader-election" priority-level
@@ -334,6 +335,24 @@ var (
 		flowcontrol.FlowDistinguisherMethodByUserType,
 		flowcontrol.PolicyRulesWithSubjects{
 			Subjects: groups(user.NodesGroup), // the nodes group
+			ResourceRules: []flowcontrol.ResourcePolicyRule{resourceRule(
+				[]string{flowcontrol.VerbAll},
+				[]string{flowcontrol.APIGroupAll},
+				[]string{flowcontrol.ResourceAll},
+				[]string{flowcontrol.NamespaceEvery},
+				true)},
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.NonResourceAll}),
+			},
+		},
+	)
+	SuggestedFlowSchemaKubeProxy = newFlowSchema(
+		"kube-proxy", "system", 600,
+		flowcontrol.FlowDistinguisherMethodByUserType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: users(user.KubeProxy),
 			ResourceRules: []flowcontrol.ResourcePolicyRule{resourceRule(
 				[]string{flowcontrol.VerbAll},
 				[]string{flowcontrol.APIGroupAll},

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/match_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/match_test.go
@@ -19,11 +19,13 @@ package flowcontrol
 import (
 	"fmt"
 	"math/rand"
+	"sort"
 	"testing"
 
 	flowcontrol "k8s.io/api/flowcontrol/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	fcboot "k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	fcfmt "k8s.io/apiserver/pkg/util/flowcontrol/format"
@@ -328,5 +330,55 @@ func checkRules(t *testing.T, expectMatch bool, digest RequestDigest, rules []fl
 		if expectMatch != actualMatch {
 			t.Errorf("expectMatch=%v, actualMatch=%v, digest=%#+v, fs=%s", expectMatch, actualMatch, digest, fcfmt.Fmt(fs))
 		}
+	}
+}
+
+// TestSuggestedFlowSchemasMatchKubeProxy checks that a request from kube-proxy is
+// matched by a suggested FlowSchema that references the "system" priority level.
+// The bootstrap configuration documents "system" as the priority level "for the
+// system components that affects self-maintenance of the cluster ... including
+// kubelet and kube-proxy", but kube-proxy authenticates as the user
+// system:kube-proxy rather than as a member of the system:nodes group, so before
+// the kube-proxy FlowSchema existed it fell through to "global-default".
+func TestSuggestedFlowSchemasMatchKubeProxy(t *testing.T) {
+	// The request kube-proxy issues on startup, as reported in
+	// https://github.com/kubernetes/kubernetes/issues/105370.
+	digest := RequestDigest{
+		RequestInfo: &request.RequestInfo{
+			IsResourceRequest: true,
+			Verb:              "list",
+			APIGroup:          "",
+			APIVersion:        "v1",
+			Resource:          "nodes",
+			Namespace:         "",
+		},
+		User: &user.DefaultInfo{
+			Name:   user.KubeProxy,
+			Groups: []string{user.AllAuthenticated},
+		},
+	}
+
+	schemas := make([]*flowcontrol.FlowSchema, len(fcboot.SuggestedFlowSchemas))
+	copy(schemas, fcboot.SuggestedFlowSchemas)
+	sort.SliceStable(schemas, func(i, j int) bool {
+		return schemas[i].Spec.MatchingPrecedence < schemas[j].Spec.MatchingPrecedence
+	})
+
+	var matched *flowcontrol.FlowSchema
+	for _, schema := range schemas {
+		if matchesFlowSchema(digest, schema) {
+			matched = schema
+			break
+		}
+	}
+
+	if matched == nil {
+		t.Fatalf("no suggested FlowSchema matched a request from %q", user.KubeProxy)
+	}
+	if got, want := matched.Name, "kube-proxy"; got != want {
+		t.Errorf("request from %q matched FlowSchema %q, want %q", user.KubeProxy, got, want)
+	}
+	if got, want := matched.Spec.PriorityLevelConfiguration.Name, "system"; got != want {
+		t.Errorf("request from %q was assigned priority level %q, want %q", user.KubeProxy, got, want)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

The bootstrap configuration describes the `system` priority level as the one for "the system components that affects self-maintenance of the cluster and the availability of those running pods in the cluster, including kubelet and kube-proxy" (`bootstrap/default.go:48-50`). Only kubelet reaches it. `SuggestedFlowSchemaSystemNodes` selects the `system:nodes` group, and kube-proxy authenticates as the user `system:kube-proxy`, so it matches no suggested schema and falls through to `global-default`, where ordinary workload traffic goes. The audit lines in #105370 show this directly: `apf_pl="global-default" apf_fs="global-default" apf_fd="system:kube-proxy"`.

That puts kube-proxy in the same queue as user workloads. When `global-default` saturates, its node and EndpointSlice reads queue behind them, which can delay Service programming on every node.

This adds a `kube-proxy` FlowSchema selecting that user and referencing `system`, at precedence 600, between `system-nodes` (500) and `kube-controller-manager` (800).

**This changes default APF configuration, so please read it as an API surface change.** Every cluster gains a suggested FlowSchema named `kube-proxy` on upgrade, and kube-proxy traffic moves from `global-default` to `system`.

#### Which issue(s) this PR is related to:

Fixes #105370

#### Special notes for your reviewer:

The issue expects `workload-low` or `workload-high`. I chose `system` because the in-tree comment names kube-proxy explicitly, but that comment may just be stale. If sig-api-machinery reads it the other way the level is a one-line change.

I fixed only kube-proxy of the four components listed. `node-problem-detector` and `konnectivity-server` authenticate as deployment-specific ServiceAccounts with no well-known username, so no bootstrap schema can select them reliably. `glbc` lives in kubernetes/ingress-gce, as @aojea noted on the issue.

The test routes a real request digest through `matchesFlowSchema` in precedence order rather than asserting the struct exists, so it fails with the reported symptom when the source change is reverted:

```
$ go test -run TestSuggestedFlowSchemasMatchKubeProxy ./staging/src/k8s.io/apiserver/pkg/util/flowcontrol/
    match_test.go:379: request from "system:kube-proxy" matched FlowSchema "global-default", want "kube-proxy"
    match_test.go:382: request from "system:kube-proxy" was assigned priority level "global-default", want "system"
FAIL
```

Both packages I touched pass with the change, including under `-race`.

#### Does this PR introduce a user-facing change?

```release-note
A suggested FlowSchema named `kube-proxy` is added to the default API Priority and Fairness configuration. Requests from the `system:kube-proxy` user are now assigned to the `system` priority level rather than `global-default`.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```

#### AI usage disclosure:

YES. I used Claude Code to find my way around the APF bootstrap config and to draft both the FlowSchema and its test. It ran the suites too. I reviewed the change and am responsible for it.
