### PR TITLE
namespace: requeue when deleted objects still list

### DIFF
--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -208,6 +208,10 @@ const (
 	operationList             operation = "list"
 	// assume a default estimate for finalizers to complete when found on items pending deletion.
 	finalizerEstimateSeconds = int64(15)
+	// remaining items with no finalizers are typically still draining from storage
+	// after a background DeleteCollection. Requeue quickly instead of treating
+	// this as a hard failure (which hits the workqueue rate limiter).
+	storageDrainEstimateSeconds = int64(2)
 )
 
 // operationKey is an entry in a cache.
@@ -481,11 +485,15 @@ func (d *namespacedResourcesDeleter) deleteAllContentForGroupVersionResource(
 		}, nil
 	}
 
-	// nothing reported a finalizer, so something was unexpected as it should have been deleted.
+	// Remaining items with no finalizers are typically still draining from
+	// storage after DeleteCollection (background/async). Treat as an estimated
+	// wait so the controller requeues with AddAfter instead of exponential
+	// backoff via AddRateLimited.
+	logger.V(5).Info("Namespace controller - items remaining without finalizers", "namespace", namespace, "resource", gvr, "items", len(unstructuredList.Items))
 	return gvrDeletionMetadata{
-		finalizerEstimateSeconds: estimate,
+		finalizerEstimateSeconds: storageDrainEstimateSeconds,
 		numRemaining:             len(unstructuredList.Items),
-	}, fmt.Errorf("unexpected items still remain in namespace: %s for gvr: %v", namespace, gvr)
+	}, nil
 }
 
 type allGVRDeletionMetadata struct {

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -485,10 +485,18 @@ func (d *namespacedResourcesDeleter) deleteAllContentForGroupVersionResource(
 		}, nil
 	}
 
-	// Remaining items with no finalizers are typically still draining from
-	// storage after DeleteCollection (background/async). Treat as an estimated
-	// wait so the controller requeues with AddAfter instead of exponential
-	// backoff via AddRateLimited.
+	// Remaining items with no finalizers are storage drain only when delete
+	// actually marked them for deletion. Objects with no deletionTimestamp
+	// never had the delete take effect; keep that as a hard failure so the
+	// worker AddRateLimited and NamespaceDeletionContentFailure still fire.
+	for _, item := range unstructuredList.Items {
+		if ts := item.GetDeletionTimestamp(); ts == nil || ts.IsZero() {
+			return gvrDeletionMetadata{
+				finalizerEstimateSeconds: estimate,
+				numRemaining:             len(unstructuredList.Items),
+			}, fmt.Errorf("unexpected items still remain in namespace: %s for gvr: %v", namespace, gvr)
+		}
+	}
 	logger.V(5).Info("Namespace controller - items remaining without finalizers", "namespace", namespace, "resource", gvr, "items", len(unstructuredList.Items))
 	return gvrDeletionMetadata{
 		finalizerEstimateSeconds: storageDrainEstimateSeconds,

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -467,25 +467,31 @@ func TestDeleteEncounters404(t *testing.T) {
 }
 
 func TestDeleteRemainingItems(t *testing.T) {
+	now := metav1.Now()
 	tests := []struct {
-		name         string
-		finalizers   []string
-		wantEstimate int64
+		name               string
+		finalizers         []string
+		deletionTimestamp  *metav1.Time
+		wantEstimate       int64
+		wantContentFailure bool
 	}{
 		{
-			name:         "no finalizers, still listed after delete",
-			finalizers:   nil,
-			wantEstimate: storageDrainEstimateSeconds,
+			name:              "terminating, no finalizers: storage drain",
+			deletionTimestamp: &now,
+			wantEstimate:      storageDrainEstimateSeconds,
 		},
 		{
 			name:         "finalizers remaining",
 			finalizers:   []string{"example.com/cleanup"},
 			wantEstimate: finalizerEstimateSeconds,
 		},
+		{
+			name:               "no deletionTimestamp and no finalizers: delete did not take effect",
+			wantContentFailure: true,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			now := metav1.Now()
 			nsName := "test"
 			ns := &v1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: nsName, ResourceVersion: "1", DeletionTimestamp: &now},
@@ -499,9 +505,10 @@ func TestDeleteRemainingItems(t *testing.T) {
 					Items: []runtime.RawExtension{{
 						Object: &metav1.PartialObjectMetadata{
 							ObjectMeta: metav1.ObjectMeta{
-								Name:       "lingering",
-								Namespace:  nsName,
-								Finalizers: tc.finalizers,
+								Name:              "lingering",
+								Namespace:         nsName,
+								Finalizers:        tc.finalizers,
+								DeletionTimestamp: tc.deletionTimestamp,
 							},
 						},
 					}},
@@ -522,20 +529,34 @@ func TestDeleteRemainingItems(t *testing.T) {
 			d := NewNamespacedResourcesDeleter(ctx, mockClient.CoreV1().Namespaces(), mockMetadataClient, mockClient.CoreV1(), resourcesFn, v1.FinalizerKubernetes)
 
 			err := d.Delete(ctx, nsName)
-			remaining, ok := err.(*ResourcesRemainingError)
-			if !ok {
-				t.Fatalf("Delete() error = %v (%T), want ResourcesRemainingError", err, err)
-			}
-			if remaining.Estimate != tc.wantEstimate {
-				t.Errorf("Estimate = %d, want %d", remaining.Estimate, tc.wantEstimate)
-			}
-
 			got, getErr := mockClient.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
 			if getErr != nil {
 				t.Fatalf("Get namespace: %v", getErr)
 			}
 			if len(got.Spec.Finalizers) == 0 {
 				t.Fatal("namespace was finalized while content remained")
+			}
+
+			if tc.wantContentFailure {
+				if _, ok := err.(*ResourcesRemainingError); ok {
+					t.Fatalf("Delete() = %v, want a content-deletion failure not ResourcesRemainingError", err)
+				}
+				if err == nil || !strings.Contains(err.Error(), "unexpected items still remain") {
+					t.Fatalf("Delete() error = %v, want unexpected items still remain", err)
+				}
+				cond := getCondition(got.Status.Conditions, v1.NamespaceDeletionContentFailure)
+				if cond == nil || cond.Status != v1.ConditionTrue {
+					t.Fatalf("NamespaceDeletionContentFailure = %v, want True", cond)
+				}
+				return
+			}
+
+			remaining, ok := err.(*ResourcesRemainingError)
+			if !ok {
+				t.Fatalf("Delete() error = %v (%T), want ResourcesRemainingError", err, err)
+			}
+			if remaining.Estimate != tc.wantEstimate {
+				t.Errorf("Estimate = %d, want %d", remaining.Estimate, tc.wantEstimate)
 			}
 			if cond := getCondition(got.Status.Conditions, v1.NamespaceDeletionContentFailure); cond != nil && cond.Status == v1.ConditionTrue {
 				t.Errorf("NamespaceDeletionContentFailure = True (%q), want not a content-deletion failure", cond.Message)

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -465,3 +465,81 @@ func TestDeleteEncounters404(t *testing.T) {
 		t.Error("ns2: expected delete-collection -> list to verify 0 items")
 	}
 }
+
+func TestDeleteRemainingItems(t *testing.T) {
+	tests := []struct {
+		name         string
+		finalizers   []string
+		wantEstimate int64
+	}{
+		{
+			name:         "no finalizers, still listed after delete",
+			finalizers:   nil,
+			wantEstimate: storageDrainEstimateSeconds,
+		},
+		{
+			name:         "finalizers remaining",
+			finalizers:   []string{"example.com/cleanup"},
+			wantEstimate: finalizerEstimateSeconds,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			now := metav1.Now()
+			nsName := "test"
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: nsName, ResourceVersion: "1", DeletionTimestamp: &now},
+				Spec:       v1.NamespaceSpec{Finalizers: []v1.FinalizerName{"kubernetes"}},
+				Status:     v1.NamespaceStatus{Phase: v1.NamespaceTerminating},
+			}
+			mockClient := fake.NewSimpleClientset(ns)
+			mockMetadataClient := metadatafake.NewSimpleMetadataClient(metadatafake.NewTestScheme())
+			mockMetadataClient.PrependReactor("list", "configmaps", func(action core.Action) (bool, runtime.Object, error) {
+				return true, &metav1.List{
+					Items: []runtime.RawExtension{{
+						Object: &metav1.PartialObjectMetadata{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:       "lingering",
+								Namespace:  nsName,
+								Finalizers: tc.finalizers,
+							},
+						},
+					}},
+				}, nil
+			})
+			resourcesFn := func() ([]*metav1.APIResourceList, error) {
+				return []*metav1.APIResourceList{{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{{
+						Name:       "configmaps",
+						Namespaced: true,
+						Kind:       "ConfigMap",
+						Verbs:      []string{"get", "list", "delete", "deletecollection", "create", "update"},
+					}},
+				}}, nil
+			}
+			_, ctx := ktesting.NewTestContext(t)
+			d := NewNamespacedResourcesDeleter(ctx, mockClient.CoreV1().Namespaces(), mockMetadataClient, mockClient.CoreV1(), resourcesFn, v1.FinalizerKubernetes)
+
+			err := d.Delete(ctx, nsName)
+			remaining, ok := err.(*ResourcesRemainingError)
+			if !ok {
+				t.Fatalf("Delete() error = %v (%T), want ResourcesRemainingError", err, err)
+			}
+			if remaining.Estimate != tc.wantEstimate {
+				t.Errorf("Estimate = %d, want %d", remaining.Estimate, tc.wantEstimate)
+			}
+
+			got, getErr := mockClient.CoreV1().Namespaces().Get(ctx, nsName, metav1.GetOptions{})
+			if getErr != nil {
+				t.Fatalf("Get namespace: %v", getErr)
+			}
+			if len(got.Spec.Finalizers) == 0 {
+				t.Fatal("namespace was finalized while content remained")
+			}
+			if cond := getCondition(got.Status.Conditions, v1.NamespaceDeletionContentFailure); cond != nil && cond.Status == v1.ConditionTrue {
+				t.Errorf("NamespaceDeletionContentFailure = True (%q), want not a content-deletion failure", cond.Message)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/sig api-machinery

#### What this PR does / why we need it:

Partial change for the namespace-controller cleanup bottlenecks described in https://github.com/kubernetes/kubernetes/issues/141615 (item 5 in that issue: `"unexpected items still remain"` on async deletes).

When `DeleteCollection` has already been issued, leftover objects with **no finalizers** are typically still draining from storage. That used to be a generic error, so the worker called `AddRateLimited` (exponential backoff, shared 10 QPS bucket) and set `NamespaceDeletionContentFailure`.

This PR treats that case like remaining finalizers: return a short estimate (`storageDrainEstimateSeconds = 2`) and no error so `Delete` returns `ResourcesRemainingError` and the worker `AddAfter`s instead.

Not in this PR (still tracked on #141615): discovery caching, concurrent GVR deletion, per-namespace rate limiting, pod head-of-line blocking (intentional per KEP-5080).

#### Which issue(s) this PR is related to:

Related to #141615

#### Special notes for your reviewer:

How to reproduce / verify:

1. Unit test (this slice):

```
go test ./pkg/controller/namespace/deletion -count=1 -run TestDeleteRemainingItems
```

- leftover ConfigMap, no finalizers → `ResourcesRemainingError` with estimate 2, namespace **not** finalized, no `NamespaceDeletionContentFailure=True`
- leftover object **with** a finalizer → estimate 15 (existing path)

Without this change, the no-finalizer case returned `unexpected items still remain in namespace: ...`.

2. Cluster smoke (timing-dependent; etcd lag after `DeleteCollection`):

```
kubectl create ns ns-drain-repro
for i in $(seq 1 50); do
  kubectl -n ns-drain-repro create cm cm-$i --from-literal=k=v
done
kubectl delete ns ns-drain-repro --wait=false
kubectl get ns ns-drain-repro -o yaml
```

Before: controller-manager logs `unexpected items still remain` and `NamespaceDeletionContentFailure`. After: `NamespaceContentRemaining` and a short requeue, no content-deletion failure for this case.

The issue also has a larger integration sketch (`TestConcurrentNamespaceCleanupPressure`) for the other bottlenecks; that is out of scope here.

#### Does this PR introduce a user-facing change?

```release-note
The namespace controller no longer treats leftover namespaced objects without finalizers as a hard deletion failure. Those objects are treated as still draining from storage and the namespace is requeued after a short wait instead of exponential backoff.
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

```docs

```