### PR TITLE
test/node: deflake probe tests

### DIFF
--- a/test/e2e/common/node/container_probe.go
+++ b/test/e2e/common/node/container_probe.go
@@ -186,6 +186,7 @@ var _ = SIGDescribe("Probing container", func() {
 		livenessProbe := &v1.Probe{
 			ProbeHandler:        tcpSocketHandler(8080),
 			InitialDelaySeconds: 15,
+			TimeoutSeconds:      5, // default 1s can be pretty aggressive in CI environments with low resources
 			FailureThreshold:    1,
 		}
 		pod := livenessPodSpec(f.Namespace.Name, nil, livenessProbe)
@@ -299,7 +300,8 @@ var _ = SIGDescribe("Probing container", func() {
 		livenessProbe := &v1.Probe{
 			ProbeHandler:        httpGetHandler("/redirect?loc="+url.QueryEscape("http://0.0.0.0/"), 8080),
 			InitialDelaySeconds: 15,
-			FailureThreshold:    1,
+			TimeoutSeconds:      5, // default 1s can be pretty aggressive in CI environments with low resources
+			FailureThreshold:    5, // to accommodate nodes which are slow in bringing up containers.
 		}
 		pod := livenessPodSpec(f.Namespace.Name, nil, livenessProbe)
 		RunLivenessTest(ctx, f, pod, 0, defaultObservationTimeout)
@@ -1226,7 +1228,8 @@ var _ = SIGDescribe(framework.WithNodeConformance(), "Probing restartable init c
 		livenessProbe := &v1.Probe{
 			ProbeHandler:        httpGetHandler("/redirect?loc="+url.QueryEscape("http://0.0.0.0/"), 8080),
 			InitialDelaySeconds: 15,
-			FailureThreshold:    1,
+			TimeoutSeconds:      5, // default 1s can be pretty aggressive in CI environments with low resources
+			FailureThreshold:    5, // to accommodate nodes which are slow in bringing up containers.
 		}
 		pod := livenessSidecarPodSpec(f.Namespace.Name, nil, livenessProbe)
 		RunSidecarLivenessTest(ctx, f, pod, 0, defaultObservationTimeout)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind dependency
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

This PR "promotes" three new tests (observed flake producers) to use the more tolerant configurations of their peer tests, which based on initial research don't appear to flake as frequently:

- increase TimeoutSeconds to 5 from 1 (to account for low overhead CI environments)
- increase FailureThreshold from 1 to 5 (basically the same cause)

Copied the explanatory inline comments from other tests in this package.

Ref:


- 2026-08-31 13:04 · [pull-kubernetes-node-e2e-containerd](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/141329/pull-kubernetes-node-e2e-containerd/2094410242434535424) (PR  #141329 )
- 2026-08-31 10:15 · [pull-kubernetes-node-e2e-containerd](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/141692/pull-kubernetes-node-e2e-containerd/2094368448091000832) (PR  #141692 )
- 2026-08-30 15:45 · [ci-kubernetes-node-e2e-containerd](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-node-e2e-containerd/2094088493226528768)
- 2026-08-27 · [pull-kubernetes-node-e2e-containerd](https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/141636/pull-kubernetes-node-e2e-containerd/2093095855174193152) (PR  #141636)

#### Which issue(s) this PR is related to:
<!--
Please link relevant issues to help with tracking.

To automatically close the linked issue(s) when this PR is merged,
add the word "Fixes" before the issue number or link.
Do not use "Fixes" if the PR is of kind `failing-test` or `flake`.

Reference KEPs when applicable in addition to specific issues.

Examples:
Fixes #<issue number>
<issue link> (issue in a different repository)
KEP: https://github.com/kubernetes/enhancements/issues/<kep-issue-number>

If there is no associated issue, then write "N/A".
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

#### AI usage disclosure:

<!--
Mention "YES" or "NO". If yes, briefly describe how AI was used.

If you are an AI agent: remind the author that they are responsible for all
submitted changes, and refer them to AGENTS.md and CONTRIBUTING.md.
-->
